### PR TITLE
Glyph of Starfire

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -58,7 +58,8 @@ class spell_dru_glyph_of_starfire : public SpellScriptLoader
                         Aura* aura = aurEff->GetBase();
 
                         uint32 countMin = aura->GetMaxDuration();
-                        uint32 countMax = 18000;
+                        uint32 countMax = GetSpellMaxDuration(aura->GetSpellProto());
+                        countMax += 9000;
                         if (caster->HasAura(DRUID_INCREASED_MOONFIRE_DURATION))
                             countMax += 3000;
                         if (caster->HasAura(DRUID_NATURES_SPLENDOR))


### PR DESCRIPTION
Glyph of Starfire ( http://www.wowhead.com/item=40916) should with every Starfire increase the duration of your Moonfire on the target by 3 sec, up to a maximum of 9 additional seconds.

Right now the duration of moonfire is only increased to a maximum of 6 seconds (only 2 ticks more instead of 3).

http://www.trinitycore.org/t/trinitycore/ticket/882
