### PR TITLE
Make HasAura and RemoveAurasDueToSpell difficulty-compliant for scripts

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3586,6 +3586,10 @@ void Unit::RemoveAura(Aura * aura, AuraRemoveMode mode)
 
 void Unit::RemoveAurasDueToSpell(uint32 spellId, uint64 caster, uint8 reqEffMask, AuraRemoveMode removeMode)
 {
+    // check for spell-difficulty to get rid of helpers in scripts like RAID_MODE
+    SpellEntry const *spellInfo = sSpellStore.LookupEntry(spellId);
+    spellId = sSpellMgr->GetSpellForDifficultyFromSpell(spellInfo, this)->Id;
+
     for (AuraApplicationMap::iterator iter = m_appliedAuras.lower_bound(spellId); iter != m_appliedAuras.upper_bound(spellId);)
     {
         Aura const * aura = iter->second->GetBase();
@@ -4199,6 +4203,9 @@ uint32 Unit::GetAuraCount(uint32 spellId) const
 
 bool Unit::HasAura(uint32 spellId, uint64 casterGUID, uint64 itemCasterGUID, uint8 reqEffMask) const
 {
+    SpellEntry const *spellInfo = sSpellStore.LookupEntry(spellId);
+    spellId = sSpellMgr->GetSpellForDifficultyFromSpell(spellInfo, this)->Id;
+
     if (GetAuraApplication(spellId, casterGUID, itemCasterGUID, reqEffMask))
         return true;
     return false;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3588,7 +3588,8 @@ void Unit::RemoveAurasDueToSpell(uint32 spellId, uint64 caster, uint8 reqEffMask
 {
     // check for spell-difficulty to get rid of helpers in scripts like RAID_MODE
     SpellEntry const *spellInfo = sSpellStore.LookupEntry(spellId);
-    spellId = sSpellMgr->GetSpellForDifficultyFromSpell(spellInfo, this)->Id;
+    if(spellInfo)
+        spellId = sSpellMgr->GetSpellForDifficultyFromSpell(spellInfo, this)->Id;
 
     for (AuraApplicationMap::iterator iter = m_appliedAuras.lower_bound(spellId); iter != m_appliedAuras.upper_bound(spellId);)
     {
@@ -4204,7 +4205,8 @@ uint32 Unit::GetAuraCount(uint32 spellId) const
 bool Unit::HasAura(uint32 spellId, uint64 casterGUID, uint64 itemCasterGUID, uint8 reqEffMask) const
 {
     SpellEntry const *spellInfo = sSpellStore.LookupEntry(spellId);
-    spellId = sSpellMgr->GetSpellForDifficultyFromSpell(spellInfo, this)->Id;
+    if(spellInfo)
+        spellId = sSpellMgr->GetSpellForDifficultyFromSpell(spellInfo, this)->Id;
 
     if (GetAuraApplication(spellId, casterGUID, itemCasterGUID, reqEffMask))
         return true;

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -1052,7 +1052,7 @@ class SpellMgr
         }
 
         // Spell Difficulty data
-        SpellEntry const* GetSpellForDifficultyFromSpell(SpellEntry const* spell, Unit* Caster)
+        SpellEntry const* GetSpellForDifficultyFromSpell(SpellEntry const* spell, const Unit* Caster)
         {
             //spell never can be NULL in this case!
             if (!Caster || !Caster->GetMap() ||  !Caster->GetMap()->IsDungeon())


### PR DESCRIPTION
Should fix issues with garfrost, valkyries in Toc10, and all scripts using those functions without proper helpers (RAID_MODE)
