### PR TITLE
Some spell and core fixes (quest)

### DIFF
--- a/sql/updates/world/2011_05_09_00_spell_bonus_data.sql
+++ b/sql/updates/world/2011_05_09_00_spell_bonus_data.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_bonus_data` WHERE `entry`=64801;
+INSERT INTO `spell_bonus_data`
+VALUES
+(64801,0.45,0,0,0,'Druid - T8 Restoration 4P Bonus');

--- a/sql/updates/world/2011_05_09_00_spell_proc_event.sql
+++ b/sql/updates/world/2011_05_09_00_spell_proc_event.sql
@@ -1,0 +1,1 @@
+UPDATE `spell_proc_event` SET `SpellFamilyMask1`=65536 WHERE `entry`=70756;

--- a/sql/updates/world/2011_05_09_01_spell_bonus_data.sql
+++ b/sql/updates/world/2011_05_09_01_spell_bonus_data.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_bonus_data` WHERE `entry` IN (34914,64085);
+INSERT INTO `spell_bonus_data` (`entry`,`direct_bonus`,`dot_bonus`,`ap_bonus`,`ap_dot_bonus`,`comments`)
+VALUES
+(34914,0,0.4,0,0,'Priest - Vampiric Touch'),
+(64085,1.2,0,0,0,'Priest - Vampiric Touch');

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1078,6 +1078,21 @@ void Battleground::AddPlayer(Player* plr)
     // add arena specific auras
     if (isArena())
     {
+        plr->ResummonPetTemporaryUnSummonedIfAny();
+        
+        // Removing pet's buffs and debuffs which are not permanent on Arena enter
+        if (Pet* pet = plr->GetPet())
+        {
+            pet->SetHealth(pet->GetMaxHealth());
+
+            Unit::AuraApplicationMap& appliedAuras = pet->GetAppliedAuras();
+            for (Unit::AuraApplicationMap::iterator itr = appliedAuras.begin(); itr != appliedAuras.end(); ++itr)
+                if (AuraApplication* aurApp = itr->second)
+                    if (Aura* aura = aurApp->GetBase())
+                        if (!aura->IsPermanent())
+                            pet->RemoveAura(itr);
+        }
+
         plr->RemoveArenaEnchantments(TEMP_ENCHANTMENT_SLOT);
         if (team == ALLIANCE)                                // gold
         {

--- a/src/server/game/Chat/Commands/Level1.cpp
+++ b/src/server/game/Chat/Commands/Level1.cpp
@@ -830,6 +830,12 @@ bool ChatHandler::HandleGroupSummonCommand(const char* args)
         else
             pl->SaveRecallPosition();
 
+        if (pl->IsMounted())
+        {
+            pl->Unmount();
+            pl->RemoveAurasByType(SPELL_AURA_MOUNTED);
+        }
+
         // before GM
         float x, y, z;
         m_session->GetPlayer()->GetClosePoint(x, y, z, pl->GetObjectSize());

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -20849,8 +20849,9 @@ bool Player::CanReportAfkDueToLimit()
 ///This player has been blamed to be inactive in a battleground
 void Player::ReportedAfkBy(Player* reporter)
 {
-    Battleground *bg = GetBattleground();
-    if (!bg || bg != reporter->GetBattleground() || GetTeam() != reporter->GetTeam())
+    Battleground* bg = GetBattleground();
+    // Battleground also must be in progress!
+    if (!bg || bg != reporter->GetBattleground() || GetTeam() != reporter->GetTeam() || bg->GetStatus() != STATUS_IN_PROGRESS)
         return;
 
     // check if player has 'Idle' or 'Inactive' debuff

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10836,6 +10836,16 @@ bool Unit::isSpellCrit(Unit *pVictim, SpellEntry const *spellProto, SpellSchoolM
                             break;
                         }
                     break;
+                    case SPELLFAMILY_WARRIOR:
+                       // Victory Rush
+                       if (spellProto->SpellFamilyFlags[1] & 0x100)
+                       {
+                           // Glyph of Victory Rush
+                           if (AuraEffect const* aurEff = GetAuraEffect(58382, 0))
+                               crit_chance += aurEff->GetAmount();
+                           break;
+                       }
+                    break;
                     case SPELLFAMILY_PALADIN:
                         // Judgement of Command proc always crits on stunned target
                         if (spellProto->SpellFamilyName == SPELLFAMILY_PALADIN)

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -213,6 +213,26 @@ bool Quest::IsAllowedInRaid() const
     return sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_RAID);
 }
 
+bool Quest::IsQuestReturnItem(uint32 questId) const
+{
+    if (!questId)
+        return false;
+
+    Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+    if (!quest || !quest->SrcItemId)
+        return false;
+
+    ItemTemplate const* item = sObjectMgr->GetItemTemplate(quest->SrcItemId);
+    if (!item || item->StartQuest != questId)
+        return false;
+
+    for (uint8 n = 0; n < 6; n++)
+        if (quest->SrcItemId == quest->ReqItemId[n])
+            return true;
+
+    return false;
+}
+
 uint32 Quest::CalculateHonorGain(uint8 level) const
 {
     if (level > GT_MAX_LEVEL)

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -185,6 +185,7 @@ class Quest
 
         bool HasFlag(uint32 flag) const { return (QuestFlags & flag) != 0; }
         void SetFlag(uint32 flag) { QuestFlags |= flag; }
+        bool IsQuestReturnItem(uint32 quest) const;
 
         // table data accessors:
         uint32 GetQuestId() const { return QuestId; }

--- a/src/server/game/Server/Protocol/Handlers/QuestHandler.cpp
+++ b/src/server/game/Server/Protocol/Handlers/QuestHandler.cpp
@@ -397,22 +397,21 @@ void WorldSession::HandleQuestLogRemoveQuest(WorldPacket& recv_data)
 
     if (slot < MAX_QUEST_LOG_SIZE)
     {
-        if (uint32 quest = _player->GetQuestSlotQuestId(slot))
+        if (uint32 questId = _player->GetQuestSlotQuestId(slot))
         {
-            if (!_player->TakeQuestSourceItem(quest, true))
-                return;                                     // can't un-equip some items, reject quest cancel
-
-            if (const Quest *pQuest = sObjectMgr->GetQuestTemplate(quest))
+            if (Quest const* quest = sObjectMgr->GetQuestTemplate(questId))
             {
-                if (pQuest->HasFlag(QUEST_TRINITY_FLAGS_TIMED))
-                    _player->RemoveTimedQuest(quest);
+                if (quest->HasFlag(QUEST_TRINITY_FLAGS_TIMED))
+                    _player->RemoveTimedQuest(questId);
+                
+                if (!quest->IsQuestReturnItem(questId))
+                    _player->TakeQuestSourceItem(questId, true); // Remove quest src item from player
             }
 
-            _player->TakeQuestSourceItem(quest, true); // remove quest src item from player
-            _player->RemoveActiveQuest(quest);
-            _player->GetAchievementMgr().RemoveTimedAchievement(ACHIEVEMENT_TIMED_TYPE_QUEST, quest);
+            _player->RemoveActiveQuest(questId);
+            _player->GetAchievementMgr().RemoveTimedAchievement(ACHIEVEMENT_TIMED_TYPE_QUEST, questId);
 
-            sLog->outDetail("Player %u abandoned quest %u", _player->GetGUIDLow(), quest);
+            sLog->outDetail("Player %u abandoned quest %u", _player->GetGUIDLow(), questId);
         }
 
         _player->SetQuestSlot(slot, 0);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5912,6 +5912,15 @@ void AuraEffect::HandleAuraDummy(AuraApplication const * aurApp, uint8 mode, boo
                             }
                             break;
                         }
+                        case 43681: // Inactive
+                        {
+                            if (!target || target->GetTypeId() != TYPEID_PLAYER || aurApp->GetRemoveMode() != AURA_REMOVE_BY_EXPIRE)
+                                return;
+                           
+                            if (target->GetMap()->IsBattleground())
+                                target->ToPlayer()->LeaveBattleground();
+                            break;
+                        }
                         case 42783: // Wrath of the Astromancer
                             target->CastSpell(target, GetAmount(), true, NULL, this);
                             break;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5966,13 +5966,13 @@ void AuraEffect::HandleAuraDummy(AuraApplication const * aurApp, uint8 mode, boo
                     }
                     break;
                 case SPELLFAMILY_PRIEST:
-                    // Vampiric Touch
-                    if (m_spellProto->SpellFamilyFlags[1] & 0x0400 && aurApp->GetRemoveMode() == AURA_REMOVE_BY_ENEMY_SPELL)
+                    // Vampiric Touch - dispel damage
+                    // GetEffIndex() needed because of double damage
+                    if (m_spellProto->SpellFamilyFlags[1] & 0x0400 && aurApp->GetRemoveMode() == AURA_REMOVE_BY_ENEMY_SPELL && GetEffIndex() == 0)
                     {
-                        if (AuraEffect const * aurEff = GetBase()->GetEffect(1))
+                        if (AuraEffect const* aurEff = GetBase()->GetEffect(EFFECT_1))
                         {
-                            int32 damage = aurEff->GetAmount()*4;
-                            // backfire damage
+                            int32 damage = aurEff->GetAmount() * 8;
                             target->CastCustomSpell(target, 64085, &damage, NULL, NULL, true, NULL, NULL, GetCasterGUID());
                         }
                     }

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -955,6 +955,20 @@ void Aura::HandleAuraSpecificMods(AuraApplication const * aurApp, Unit * caster,
                         break;
                 }
                 break;
+            case SPELLFAMILY_DRUID:
+                if (!caster)
+                    break;
+                // Rejuvenation
+                if (GetSpellProto()->SpellFamilyFlags[0] & 0x10 && GetEffect(EFFECT_0))
+                {
+                    // Druid T8 Restoration 4P Bonus
+                    if (AuraEffect const* aurEff = caster->GetAuraEffect(64760, EFFECT_0))
+                    {
+                        int32 heal = GetEffect(EFFECT_0)->GetAmount();
+                        caster->CastCustomSpell(target, 64801, &heal, NULL, NULL, true, NULL, GetEffect(EFFECT_0));
+                    }
+                } 
+                break;
             case SPELLFAMILY_MAGE:
                 if (!caster)
                     break;

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1057,6 +1057,7 @@ void Aura::HandleAuraSpecificMods(AuraApplication const * aurApp, Unit * caster,
                     {
                         int32 basepoints0 = aurEff->GetAmount() * GetEffect(0)->GetTotalTicks() * caster->SpellDamageBonus(target, GetSpellProto(), GetEffect(0)->GetAmount(), DOT) / 100;
                         caster->CastCustomSpell(target, 63675, &basepoints0, NULL, NULL, true, NULL, GetEffect(0));
+                        caster->CastCustomSpell(caster, 75999, &basepoints0, NULL, NULL, true, NULL, GetEffect(1));
                     }
                 }
                 // Renew

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1502,6 +1502,15 @@ void Aura::HandleAuraSpecificMods(AuraApplication const * aurApp, Unit * caster,
                     else
                         target->RemoveAurasDueToSpell(64364, GetCasterGUID());
                     break;
+                case 20216:
+                    if (caster->HasAura(70755))
+                    {
+                        if (apply)
+                            caster->CastSpell(caster, 71166, true);
+                        else
+                            caster->RemoveAurasDueToSpell(71166);
+                    }
+                    break;
             }
             break;
         case SPELLFAMILY_DEATHKNIGHT:

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2784,9 +2784,14 @@ void Spell::SelectEffectTargets(uint32 i, uint32 cur)
                 for (Unit::AuraEffectList::const_iterator j = Auras.begin(); j != Auras.end(); ++j)
                     if ((*j)->IsAffectedOnSpell(m_spellInfo))
                         maxTargets += (*j)->GetAmount();
-
-                if (m_spellInfo->Id == 5246) //Intimidating Shout
-                    unitList.remove(m_targets.getUnitTarget());
+                switch (m_spellInfo->Id)
+                {
+                    case 5246: // Intimidating Shout
+                    case 49821: // Mind Sear (Rank 1)
+                    case 53022: // Mind Sear (Rank 2)
+                        unitList.remove(m_targets.getUnitTarget());
+                        break;
+                }
                 Trinity::RandomResizeList(unitList, maxTargets);
             }
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2275,6 +2275,10 @@ void Spell::SpellDamageHeal(SpellEffIndex /*effIndex*/)
             if (!caster->HasAura(54824))
                 unitTarget->RemoveAura(targetAura->GetId(), targetAura->GetCasterGUID());
 
+            // Druid T8 2P Restoration Set Bonus
+            if (caster->HasAura(64756))
+                addhealth = int32(addhealth * 1.1f);
+
             //addhealth += tickheal * tickcount;
             //addhealth = caster->SpellHealingBonus(m_spellInfo, addhealth, HEAL, unitTarget);
         }


### PR DESCRIPTION
First two commits fixes T8 2P & 4P Druid Restoration Set Bonuses
Third fixes double damage and damage itself of backfire Vampiric Touch damage
Forth fixes destroying of items, which start quest and which quest is abbandoned. This however needs more research if the items stay in inventory or the items are destroyed and added again.
Fifth commit fixes proc event of T10 4P Holy Paladin Set Bonus
Sixth commit fixes T10 2P Holy Paladin Set Bonus
