### PR TITLE
Scripts/IcecrownCitadel: Hack Valithria Dreamwalker EncounterState until 

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -554,6 +554,7 @@ class instance_icecrown_citadel : public InstanceMapScript
                         }
                         break;
                     case DATA_BLOOD_QUEEN_LANA_THEL:
+                        SetBossState(DATA_VALITHRIA_DREAMWALKER, state);    // TEMP HACK UNTIL VALITHRIA DREAMWALKER SCRIPTED
                         HandleGameObject(BloodwingSigilGUID, state != DONE);
                         if (instance->IsHeroic())
                         {


### PR DESCRIPTION
Scripts/IcecrownCitadel: Hack Valithria Dreamwalker EncounterState until it will be scripted to can reach Sindragosa's Lair
