### PR TITLE
Сheck quest conditions in effect QuestComplete

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5907,6 +5907,10 @@ void Spell::EffectQuestComplete(SpellEffIndex effIndex)
     uint32 quest_id = m_spellInfo->EffectMiscValue[effIndex];
     if (quest_id)
     {
+        Quest* pQuest = sObjectMgr->GetQuestTemplate(quest_id);
+        if (!pQuest || !pPlayer->CanTakeQuest(pQuest, false))
+            return;
+
         uint16 log_slot = pPlayer->FindQuestSlot(quest_id);
         if (log_slot < MAX_QUEST_LOG_SIZE)
             pPlayer->AreaExploredOrEventHappens(quest_id);


### PR DESCRIPTION
Now spells with effect EffectQuestComplete allow complete quests without check quest conditions, require disabled quests. In result on the battleground, players get the quests for both factions.
