### PR TITLE
Fix problems with charges

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -41,6 +41,7 @@ class AuraEffect
         Aura * GetBase() const { return m_base; }
         void GetTargetList(std::list<Unit*> & targetList) const;
         void GetApplicationList(std::list<AuraApplication*> & applicationList) const;
+        SpellModifier* GetSpellModifier() const { return m_spellmod; }
 
         SpellEntry const* GetSpellProto() const { return m_spellProto; }
         uint32 GetId() const { return m_spellProto->Id; }

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -831,6 +831,11 @@ bool Aura::ModStackAmount(int32 num, AuraRemoveMode removeMode)
 
         // reset charges
         SetCharges(CalcMaxCharges());
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+            if (AuraEffect* aurEff = GetEffect(i))
+                if ((aurEff->GetAuraType() == SPELL_AURA_ADD_FLAT_MODIFIER) || (aurEff->GetAuraType() == SPELL_AURA_ADD_PCT_MODIFIER))
+                    if (SpellModifier* mod = aurEff->GetSpellModifier())
+                        mod->charges = GetCharges();
     }
     SetNeedClientUpdateForTargets();
     return false;


### PR DESCRIPTION
Core/Auras: Fix problem with aura charges introduced on 42a20f1 with the reuse of existing aura objects on aura reapply.

Closes #2039 and #2211
