### PR TITLE
Spell: Mark of the Fallen Champion

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8772,7 +8772,7 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
         case 72256:
             // this should be handled by targetAuraSpell, but because 72408 is not passive
             // one failed proc will remove the entire aura
-            CastSpell(NULL, trigger_spell_id, true, NULL, triggeredByAura);
+            CastSpell((Unit*)NULL, trigger_spell_id, true, NULL, triggeredByAura);
             return true;
         case 15337: // Improved Spirit Tap (Rank 1)
         case 15338: // Improved Spirit Tap (Rank 2)


### PR DESCRIPTION
Forcing gcc to use the right overloaded function here.

Gcc seems to be more into GameObjects than in Units, as it chooses `void CastSpell(GameObject *go, uint32 spellId, ...` over one of the `Unit*` ones.

Can provide backtrace if necessary.

Affects #2547 #2284 but should not close them, as there are still some targetAuraSpell problems left, if i recall that right.
