### PR TITLE
Core/Spells Disables environmental damage to players which are not attackable by AOE damage

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1244,9 +1244,15 @@ void Player::StopMirrorTimer(MirrorTimerType Type)
     GetSession()->SendPacket(&data);
 }
 
+bool Player::IsImmuneToEnvironmentalDamage()
+{
+	// check for GM and death state included in isAttackableByAOE
+    return (!isAttackableByAOE());
+}
+
 uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
 {
-    if (!isAlive() || isGameMaster())
+    if (IsImmuneToEnvironmentalDamage())
         return 0;
 
     // Absorb, resist some environmental damage type

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1246,7 +1246,7 @@ void Player::StopMirrorTimer(MirrorTimerType Type)
 
 bool Player::IsImmuneToEnvironmentalDamage()
 {
-	// check for GM and death state included in isAttackableByAOE
+    // check for GM and death state included in isAttackableByAOE
     return (!isAttackableByAOE());
 }
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2753,6 +2753,8 @@ class Player : public Unit, public GridObject<Player>
         bool IsHasDelayedTeleport() const { return m_bHasDelayedTeleport; }
         void SetDelayedTeleportFlag(bool setting) { m_bHasDelayedTeleport = setting; }
 
+        bool IsImmuneToEnvironmentalDamage();
+
         void ScheduleDelayedOperation(uint32 operation)
         {
             if (operation < DELAYED_END)


### PR DESCRIPTION
Core/Spells Disables environmental damage to players which are not attackable by AOE damage (e.g. spirit of redemption form of priest)

Fixes #2531
