### PR TITLE
Crashfix: Added mutex for iThreatList to prevent manipulation within one 

### DIFF
--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -25,6 +25,7 @@
 #include "UnitEvents.h"
 
 #include <list>
+#include <ace/Mutex.h>
 
 //==============================================================
 
@@ -144,6 +145,7 @@ class ThreatContainer
 {
     private:
         std::list<HostileReference*> iThreatList;
+        ACE_Thread_Mutex m_ThreatListMutex;
         bool iDirty;
     protected:
         friend class ThreatManager;

--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -150,8 +150,8 @@ class ThreatContainer
     protected:
         friend class ThreatManager;
 
-        void remove(HostileReference* hostileRef) { iThreatList.remove(hostileRef); }
-        void addReference(HostileReference* hostileRef) { iThreatList.push_back(hostileRef); }
+        void remove(HostileReference* hostileRef) { m_ThreatListMutex.acquire(); iThreatList.remove(hostileRef); m_ThreatListMutex.release(); }
+        void addReference(HostileReference* hostileRef) { m_ThreatListMutex.acquire(); iThreatList.push_back(hostileRef); m_ThreatListMutex.release(); }
         void clearReferences();
 
         // Sort the list if necessary


### PR DESCRIPTION
Crashfix: Added mutex for iThreatList to prevent manipulation within one thread while iterating within another. Unfortunately this can only take care of the functions accessing iThreatList within ThreatContainer. Although the author of the function "getThreatList" hoped that the method will not be used that often, it is now being heavily used throughout the entire code (mostly scripts and AI). A lot of refactoring would be necessary to take care of those entries as well. That said, the crash fix could be successfully tested and takes care of the occasions which happen the most.

Fixes #2396 and possibly #235 and #1491
