### PR TITLE
Restore working .pdump load 

### DIFF
--- a/src/server/game/Tools/PlayerDump.cpp
+++ b/src/server/game/Tools/PlayerDump.cpp
@@ -520,11 +520,11 @@ DumpReturn PlayerDumpReader::LoadDump(const std::string& file, uint32 account, s
                     ROLLBACK(DUMP_FILE_BROKEN);
 
                 const char null[5] = "NULL";
-                if (!changenth(line, 68, null))             // characters.deleteInfos_Account
+                if (!changenth(line, 69, null))             // characters.deleteInfos_Account
                     ROLLBACK(DUMP_FILE_BROKEN);
-                if (!changenth(line, 69, null))             // characters.deleteInfos_Name
+                if (!changenth(line, 70, null))             // characters.deleteInfos_Name
                     ROLLBACK(DUMP_FILE_BROKEN);
-                if (!changenth(line, 70, null))             // characters.deleteDate
+                if (!changenth(line, 71, null))             // characters.deleteDate
                     ROLLBACK(DUMP_FILE_BROKEN);
                 break;
             }


### PR DESCRIPTION
The .pdump load command was returning an SQL error when executed due to the new column added in 76fe596160e31d0c3214, grantableLevels. The deleteInfo_\* fields starting positions wasn't updated, so the NULL filling was wrong, trying to assign NULL to grantableLevels, generating the SQL error.

If you want to reproduce the error on 2bf545db62ae13ed2a0d :
1. Do a .pdump write of a randon character.
2. Do a .pdump load of the previous created file.
3. See the error :
   
   ERROR: [1048] Column 'grantableLevels' cannot be null
   Unhandled MySQL errno 1048. Unexpected behaviour possible.
   [Warning] Transaction aborted. 1610 queries not executed.
