### PR TITLE
Fixes Mojo Volley still being cast after boss death.

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -280,6 +280,7 @@ class boss_drakkari_elemental : public CreatureScript
                     if (Creature* colossus = Unit::GetCreature(*me, instance->GetData64(DATA_DRAKKARI_COLOSSUS)))
                         killer->Kill(colossus);
                 }
+                me->RemoveAura(SPELL_MOJO_VALLEY); // fixes mojo volley still being cast after death
             }
 
             void UpdateAI(const uint32 diff)


### PR DESCRIPTION
Mojo volley aura will no longer be on the player after boss is dead.
