### PR TITLE
Core/Spells: Fixed spellmodifiers not being correctly restored after a fakecast.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3570,6 +3570,15 @@ void Spell::finish(bool ok)
 
     if (m_spellState == SPELL_STATE_FINISHED)
         return;
+
+    if (Player* modOwner = m_caster->GetSpellModOwner())
+    {
+        if (ok || m_spellState != SPELL_STATE_PREPARING)
+            modOwner->RemoveSpellMods(this);
+        else
+            modOwner->RestoreSpellMods(this);
+    }
+
     m_spellState = SPELL_STATE_FINISHED;
 
     if (m_spellInfo->IsChanneled())


### PR DESCRIPTION
Core/Spells: Fixed spellmodifiers not being correctly restored after a fakecast.

Closes #2704
