### PR TITLE
Core/Spells: Add visual to Defend spells depending on the number of charges.

### DIFF
--- a/sql/updates/world/2011_08_22_00_world_spell_script_names.sql
+++ b/sql/updates/world/2011_08_22_00_world_spell_script_names.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE spell_id IN (62552, 62719, 66482);
+INSERT INTO `spell_script_names` VALUES
+(62552, 'spell_gen_defend'),
+(62719, 'spell_gen_defend'),
+(66482, 'spell_gen_defend');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1180,7 +1180,7 @@ class spell_gen_magic_rooster : public SpellScriptLoader
         }
 };
 
-enum eDefendVisual
+enum DefendVisualSpells
 {
     SPELL_VISUAL_SHIELD_1 = 63130,
     SPELL_VISUAL_SHIELD_2 = 63131,


### PR DESCRIPTION
Defend spells from the Argent Tournament related vehicles have a visual effect that changes depending on the number of charges of Defend on the owner.

This behaviour can be clearly observed here.
http://www.youtube.com/watch?v=BqcbS62r8eU&feature=player_detailpage#t=42s
