### PR TITLE
Core/Spells: Fixed Survival of the Fittest armor increase bonus while in Dire Bear or Bear form.

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1562,7 +1562,7 @@ void AuraEffect::HandleShapeshiftBoosts(Unit* target, bool apply) const
                     // Survival of the Fittest
                     if (AuraEffect const* aurEff = target->GetAuraEffect(SPELL_AURA_MOD_TOTAL_STAT_PERCENTAGE, SPELLFAMILY_DRUID, 961, 0))
                     {
-                        int32 bp = 100 + aurEff->GetSpellInfo()->Effects[EFFECT_2].CalcValue();
+                        int32 bp = aurEff->GetSpellInfo()->Effects[EFFECT_2].CalcValue();
                         target->CastCustomSpell(target, 62069, &bp, NULL, NULL, true, 0, this);
                     }
                 break;


### PR DESCRIPTION
Core/Spells: Fixed Survival of the Fittest armor increase bonus while in Dire Bear or Bear form. Closes #2724

1) Armor while in dire bear form : 13205
2) .aura 33856 (Survival of the Fittest Rank3)
3) Demorph and remorph into dire bear form
4) Armor value is now : 17475

17475 / 13205 = 1.3233623...

I think this is rather correct, may need to drop CalcValue() call and use directly the BasePoint.
