### PR TITLE
The Val'kyr Twins Clean up and Implements

### DIFF
--- a/sql/updates/world/2011_08_24_00_world_spell_script_names.sql
+++ b/sql/updates/world/2011_08_24_00_world_spell_script_names.sql
@@ -1,0 +1,15 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (67590,67602,67603,67604,65684,67176,67177,67178,65686,67222,67223,67224);
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`)
+VALUES
+(67590, 'spell_powering_up'),
+(67602, 'spell_powering_up'),
+(67603, 'spell_powering_up'),
+(67604, 'spell_powering_up'),
+(65684, 'spell_valkyr_essences'),
+(67176, 'spell_valkyr_essences'),
+(67177, 'spell_valkyr_essences'),
+(67178, 'spell_valkyr_essences'),
+(67222, 'spell_valkyr_essences'),
+(65686, 'spell_valkyr_essences'),
+(67223, 'spell_valkyr_essences'),
+(67224, 'spell_valkyr_essences');

--- a/sql/updates/world/2011_09_01_00_world_conditions.sql
+++ b/sql/updates/world/2011_09_01_00_world_conditions.sql
@@ -1,0 +1,10 @@
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `ConditionTypeOrReference` = 18 AND `SourceEntry` IN (65875,67303,67304,67305,65876,67306,67307,67308) ;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 0, 65875, 0, 18, 1, 34497, 2, 0, '', 'Twins Pact - Dark'),
+(13, 0, 67303, 0, 18, 1, 34497, 2, 0, '', 'Twins Pact - Dark'),
+(13, 0, 67304, 0, 18, 1, 34497, 2, 0, '', 'Twins Pact - Dark'),
+(13, 0, 67305, 0, 18, 1, 34497, 2, 0, '', 'Twins Pact - Dark'),
+(13, 0, 65876, 0, 18, 1, 34496, 2, 0, '', 'Twins Pact - Light'),
+(13, 0, 67306, 0, 18, 1, 34496, 2, 0, '', 'Twins Pact - Light'),
+(13, 0, 67307, 0, 18, 1, 34496, 2, 0, '', 'Twins Pact - Light'),
+(13, 0, 67308, 0, 18, 1, 34496, 2, 0, '', 'Twins Pact - Light');

--- a/sql/updates/world/2011_09_01_01_spell_script_names.sql
+++ b/sql/updates/world/2011_09_01_01_spell_script_names.sql
@@ -1,0 +1,10 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (65879,65916,67244,67245,67246,67248,67249,67250);
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(65879, 'spell_power_of_the_twins'),
+(65916, 'spell_power_of_the_twins'),
+(67244, 'spell_power_of_the_twins'),
+(67245, 'spell_power_of_the_twins'),
+(67246, 'spell_power_of_the_twins'),
+(67248, 'spell_power_of_the_twins'),
+(67249, 'spell_power_of_the_twins'),
+(67250, 'spell_power_of_the_twins');

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -53,9 +53,6 @@ enum Equipment
 
 enum Summons
 {
-    NPC_DARK_ESSENCE     = 34567,
-    NPC_LIGHT_ESSENCE    = 34568,
-
     NPC_UNLEASHED_DARK   = 34628,
     NPC_UNLEASHED_LIGHT  = 34630,
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -204,7 +204,6 @@ struct boss_twin_baseAI : public ScriptedAI
             case 1:
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_OOC_NOT_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 me->SetReactState(REACT_AGGRESSIVE);
-                me->SetInCombatWithZone();
                 break;
         }
     }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -251,18 +251,6 @@ struct boss_twin_baseAI : public ScriptedAI
         Summons.Despawn(summoned);
     }
 
-    void HealReceived(Unit* healer, uint32& heal)
-    {
-        if(healer->GetEntry() == me->GetEntry())
-        {
-            if (Creature* pSister = GetSister())
-            {
-                heal = uint32(heal/2);
-                healer->DealHeal(pSister, heal);
-            }
-        }
-    }
-
     void SummonColorballs(uint8 quantity)
     {
         float x0 = ToCCommonLoc[1].GetPositionX(), y0 = ToCCommonLoc[1].GetPositionY(), r = 47.0f;

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -830,7 +830,7 @@ class spell_power_of_the_twins : public SpellScriptLoader
                 if (InstanceScript* instance = GetCaster()->GetInstanceScript())
                 {
                     if (Creature* Valk = ObjectAccessor::GetCreature(*GetCaster(), instance->GetData64(GetCaster()->GetEntry())))
-                        Valk->AI()->EnableDualWield(true);
+                        CAST_AI(boss_twin_baseAI, Valk->AI())->EnableDualWield(true);
                 }
             }
 
@@ -839,7 +839,7 @@ class spell_power_of_the_twins : public SpellScriptLoader
                 if (InstanceScript* instance = GetCaster()->GetInstanceScript())
                 {
                     if (Creature* Valk = ObjectAccessor::GetCreature(*GetCaster(), instance->GetData64(GetCaster()->GetEntry())))
-                        Valk->AI()->EnableDualWield(false);
+                        CAST_AI(boss_twin_baseAI, Valk->AI())->EnableDualWield(false);
                 }
             }
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -86,6 +86,7 @@ enum BossSpells
     SPELL_DARK_SURGE            = 65768,
     SPELL_DARK_SHIELD           = 65874,
     SPELL_DARK_TWIN_PACT        = 65875,
+    SPELL_POWER_TWINS           = 65879,
     SPELL_DARK_VORTEX           = 66058,
     SPELL_DARK_TOUCH            = 67282,
 
@@ -360,10 +361,13 @@ struct boss_twin_baseAI : public ScriptedAI
             case 2: // Shield+Pact
                 if (m_uiSpecialAbilityTimer <= uiDiff)
                 {
-                    if (Creature* pSister = GetSister())
-                        pSister->AI()->DoAction(ACTION_PACT);
                     DoScriptText(EMOTE_SHIELD, me);
                     DoScriptText(SAY_SHIELD, me);
+                    if (Creature* pSister = GetSister())
+                    {
+                        pSister->AI()->DoAction(ACTION_PACT);
+                        pSister->CastSpell(pSister, SPELL_POWER_TWINS, false);
+                    }
                     DoCast(me, m_uiShieldSpellId);
                     DoCast(me, m_uiTwinPactSpellId);
                     m_uiStage = 0;

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -44,10 +44,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
             std::string SaveDataBuffer;
             bool   NeedSave;
 
-            uint32 DataDamageTwin;
-            uint32 FjolaCasting;
-            uint32 EydisCasting;
-
             uint64 BarrentGUID;
             uint64 TirionGUID;
             uint64 FizzlebangGUID;
@@ -368,11 +364,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                                 break;
                         }
                         break;
-                    case DATA_HEALTH_TWIN_SHARED:
-                        DataDamageTwin = data;
-                        data = NOT_STARTED;
-                        break;
-
                     //Achievements
                     case DATA_SNOBOLD_COUNT:
                         if (data == INCREASE)
@@ -584,8 +575,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                                 break;
                         };
                         return EventNPCId;
-                    case DATA_HEALTH_TWIN_SHARED:
-                        return DataDamageTwin;
                     default:
                         break;
                 }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.cpp
@@ -745,24 +745,36 @@ class npc_tirion_toc : public CreatureScript
                             break;
                         case 4010:
                             DoScriptText(SAY_STAGE_3_02, me);
-                            m_pInstance->DoUseDoorOrButton(m_pInstance->GetData64(GO_MAIN_GATE_DOOR));
+                            if(Creature* pTemp = me->SummonCreature(NPC_LIGHTBANE, ToCCommonLoc[3].GetPositionX(), ToCCommonLoc[3].GetPositionY(), ToCCommonLoc[3].GetPositionZ(), 5, TEMPSUMMON_CORPSE_TIMED_DESPAWN, DESPAWN_TIME))
+                            {
+                                pTemp->SetVisible(false);
+                                pTemp->SetReactState(REACT_PASSIVE);
+                                pTemp->SummonCreature(NPC_LIGHT_ESSENCE, TwinValkyrsLoc[0].GetPositionX(), TwinValkyrsLoc[0].GetPositionY(), TwinValkyrsLoc[0].GetPositionZ());
+                                pTemp->SummonCreature(NPC_LIGHT_ESSENCE, TwinValkyrsLoc[1].GetPositionX(), TwinValkyrsLoc[1].GetPositionY(), TwinValkyrsLoc[1].GetPositionZ());
+                            }
+                            if(Creature* pTemp = me->SummonCreature(NPC_DARKBANE, ToCCommonLoc[4].GetPositionX(), ToCCommonLoc[4].GetPositionY(), ToCCommonLoc[4].GetPositionZ(), 5, TEMPSUMMON_CORPSE_TIMED_DESPAWN, DESPAWN_TIME))
+                            {
+                                pTemp->SetVisible(false);
+                                pTemp->SetReactState(REACT_PASSIVE);
+                                pTemp->SummonCreature(NPC_DARK_ESSENCE, TwinValkyrsLoc[2].GetPositionX(), TwinValkyrsLoc[2].GetPositionY(), TwinValkyrsLoc[2].GetPositionZ());
+                                pTemp->SummonCreature(NPC_DARK_ESSENCE, TwinValkyrsLoc[3].GetPositionX(), TwinValkyrsLoc[3].GetPositionY(), TwinValkyrsLoc[3].GetPositionZ());
+                            }
                             m_uiUpdateTimer = 3000;
                             m_pInstance->SetData(TYPE_EVENT, 4015);
                             break;
                         case 4015:
-                            me->SummonCreature(NPC_LIGHTBANE, ToCCommonLoc[3].GetPositionX(), ToCCommonLoc[3].GetPositionY(), ToCCommonLoc[3].GetPositionZ(), 5, TEMPSUMMON_CORPSE_TIMED_DESPAWN, DESPAWN_TIME);
+                            m_pInstance->DoUseDoorOrButton(m_pInstance->GetData64(GO_MAIN_GATE_DOOR));
                             if (Creature* pTemp = Unit::GetCreature((*me), m_pInstance->GetData64(NPC_LIGHTBANE)))
                             {
                                 pTemp->GetMotionMaster()->MovePoint(0, ToCCommonLoc[6].GetPositionX(), ToCCommonLoc[6].GetPositionY(), ToCCommonLoc[6].GetPositionZ());
                                 pTemp->AddUnitMovementFlag(MOVEMENTFLAG_WALKING);
-                                me->SetReactState(REACT_PASSIVE);
+                                pTemp->SetVisible(true);
                             }
-                            me->SummonCreature(NPC_DARKBANE, ToCCommonLoc[4].GetPositionX(), ToCCommonLoc[4].GetPositionY(), ToCCommonLoc[4].GetPositionZ(), 5, TEMPSUMMON_CORPSE_TIMED_DESPAWN, DESPAWN_TIME);
                             if (Creature* pTemp = Unit::GetCreature((*me), m_pInstance->GetData64(NPC_DARKBANE)))
                             {
                                 pTemp->GetMotionMaster()->MovePoint(0, ToCCommonLoc[7].GetPositionX(), ToCCommonLoc[7].GetPositionY(), ToCCommonLoc[7].GetPositionZ());
                                 pTemp->AddUnitMovementFlag(MOVEMENTFLAG_WALKING);
-                                me->SetReactState(REACT_PASSIVE);
+                                pTemp->SetVisible(true);
                             }
                             m_uiUpdateTimer = 5000;
                             m_pInstance->SetData(TYPE_EVENT, 4016);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.h
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.h
@@ -22,8 +22,6 @@ enum
     TYPE_EVENT_NPC              = 102,
     TYPE_NORTHREND_BEASTS       = 103,
 
-    DATA_HEALTH_TWIN_SHARED     = 201,
-
     DATA_SNOBOLD_COUNT                   = 301,
     DATA_MISTRESS_OF_PAIN_COUNT          = 302,
     DATA_TRIBUTE_TO_IMMORTALITY_ELEGIBLE = 303,

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.h
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.h
@@ -208,6 +208,9 @@ enum eCreature
     NPC_LIGHTBANE               = 34497,
     NPC_DARKBANE                = 34496,
 
+    NPC_DARK_ESSENCE            = 34567,
+    NPC_LIGHT_ESSENCE           = 34568,
+
     NPC_ANUBARAK                = 34564,
 };
 


### PR DESCRIPTION
How can see there much function hardcoded in orinal script.
Here the list of changes i made:

```
      * First Commit:
          - Cleaned wrong hardcoded "DamageTaken" and use default Essence spells
          - Cleaned wrong hardcoded "Health Sharing" and use Emphaty Spells
          - Removed unused variables FjolaCasting - EydisCasting in instance script

      * Second Commit:
          - Implement Powering Up Spell
          - Fix Essence Spells to cast Surge of Speed on abrosb.

      * Third Commit:
          - Implement Power of the Twin's Spell

      * Fourth Commit:
          - Cleaned wrong hardcoded "Healing" and use default Twin's Touch spells

      * Fifth Commit:
          - Implement Dual Wield on Power of the Twins spells.

      * Seventh Commit:
          - Do not enter in combat on start.
```
