### PR TITLE
Fix #2734

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3290,7 +3290,7 @@ void Spell::handle_immediate()
     TakeCastItem();
 
     // handle ammo consumption for Hunter's volley spell
-	if (m_spellInfo->IsRangedWeaponSpell() && m_spellInfo->IsChanneled())
+    if (m_spellInfo->IsRangedWeaponSpell() && m_spellInfo->IsChanneled())
         TakeAmmo();
 
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3289,6 +3289,11 @@ void Spell::handle_immediate()
     // Remove used for cast item if need (it can be already NULL after TakeReagents call
     TakeCastItem();
 
+	// handle ammo consumption for Hunter's volley spell
+	if (IsRangedWeaponSpell(m_spellInfo) && IsChanneledSpell(m_spellInfo))
+		TakeAmmo();
+
+
     if (m_spellState != SPELL_STATE_CASTING)
         finish(true);                                       // successfully finish spell cast (not last in case autorepeat or channel spell)
 }
@@ -6638,6 +6643,10 @@ void Spell::CalculateDamageDoneForAllTargets()
         Unit* unit = m_caster->GetGUID() == target.targetGUID ? m_caster : ObjectAccessor::GetUnit(*m_caster, target.targetGUID);
         if (!unit) // || !unit->isAlive()) do we need to check alive here?
             continue;
+
+		// do not consume ammo anymore for Hunter's volley spell
+		if (IsTriggered() && m_spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && IsAreaOfEffectSpell(m_spellInfo))
+			usesAmmo = false;
 
         if (usesAmmo)
         {

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3289,9 +3289,9 @@ void Spell::handle_immediate()
     // Remove used for cast item if need (it can be already NULL after TakeReagents call
     TakeCastItem();
 
-	// handle ammo consumption for Hunter's volley spell
-	if (IsRangedWeaponSpell(m_spellInfo) && IsChanneledSpell(m_spellInfo))
-		TakeAmmo();
+    // handle ammo consumption for Hunter's volley spell
+	if (m_spellInfo->IsRangedWeaponSpell() && m_spellInfo->IsChanneled())
+        TakeAmmo();
 
 
     if (m_spellState != SPELL_STATE_CASTING)
@@ -6644,9 +6644,9 @@ void Spell::CalculateDamageDoneForAllTargets()
         if (!unit) // || !unit->isAlive()) do we need to check alive here?
             continue;
 
-		// do not consume ammo anymore for Hunter's volley spell
-		if (IsTriggered() && m_spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && IsAreaOfEffectSpell(m_spellInfo))
-			usesAmmo = false;
+        // do not consume ammo anymore for Hunter's volley spell
+        if (IsTriggered() && m_spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && m_spellInfo->IsAOE())
+            usesAmmo = false;
 
         if (usesAmmo)
         {


### PR DESCRIPTION
Fixes ammo consumption for Hunter's Volley
#2734

Although I would like to use a more solid check for this special spell, I had to use checks for hunter, AOE, channel and range to narrow it down to the specific spells. I really did not want to enlist the spell ids as I considered this a bit to hacky. Hunters do have this as there only ranged AOE spell, so the checks should be save also for the future.
