### PR TITLE
Core/Maps: Crash fix.

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2036,6 +2036,12 @@ void Map::RemoveAllObjectsInRemoveList()
         std::set<WorldObject*>::iterator itr = i_objectsToRemove.begin();
         WorldObject* obj = *itr;
 
+        if (!obj)
+        {
+            i_objectsToRemove.erase(itr);
+            continue;
+        }
+        
         switch(obj->GetTypeId())
         {
             case TYPEID_CORPSE:


### PR DESCRIPTION
Prevents access violation caused by NULL obj pointer. Closes #777.
