### PR TITLE
Fixed spellid's from Zul'Gurub encounters High Priest Thekal and Bloodlord Mandokir (&adds).

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -32,12 +32,12 @@ EndScriptData */
 #define SAY_WATCH               -1309018
 #define SAY_WATCH_WHISPER       -1309019                    //is this text for real? easter egg?
 
-#define SPELL_CHARGE            24315
-#define SPELL_CLEAVE            20691
+#define SPELL_CHARGE            24408
+#define SPELL_CLEAVE            7160
 #define SPELL_FEAR              29321
-#define SPELL_WHIRLWIND         24236
-#define SPELL_MORTAL_STRIKE     24573
-#define SPELL_ENRAGE            23537
+#define SPELL_WHIRLWIND         15589
+#define SPELL_MORTAL_STRIKE     16856
+#define SPELL_ENRAGE            24318
 #define SPELL_WATCH             24314
 #define SPELL_LEVEL_UP          24312
 

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
@@ -32,25 +32,25 @@ EndScriptData */
 enum eSpells
 {
     SPELL_MORTALCLEAVE        = 22859,
-    SPELL_SILENCE             = 23207,
-    SPELL_FRENZY              = 23342,
+    SPELL_SILENCE             = 22666,
+    SPELL_FRENZY              = 8269,
     SPELL_FORCEPUNCH          = 24189,
-    SPELL_CHARGE              = 24408,
-    SPELL_ENRAGE              = 23537,
+    SPELL_CHARGE              = 24193,
+    SPELL_ENRAGE              = 8269,
     SPELL_SUMMONTIGERS        = 24183,
     SPELL_TIGER_FORM          = 24169,
     SPELL_RESURRECT           = 24173,                    //We will not use this spell.
 
 //Zealot Lor'Khan Spells
-    SPELL_SHIELD              = 25020,
+    SPELL_SHIELD              = 25045,
     SPELL_BLOODLUST           = 24185,
     SPELL_GREATERHEAL         = 24208,
-    SPELL_DISARM              = 22691,
+    SPELL_DISARM              = 6713,
 
-//Zealot Lor'Khan Spells
+//Zealot Zath Spells
     SPELL_SWEEPINGSTRIKES     = 18765,
-    SPELL_SINISTERSTRIKE      = 15667,
-    SPELL_GOUGE               = 24698,
+    SPELL_SINISTERSTRIKE      = 15581,
+    SPELL_GOUGE               = 12540,
     SPELL_KICK                = 15614,
     SPELL_BLIND               = 21060,
 };


### PR DESCRIPTION
The script uses the wrong ID's which causes heavy damage, Spell ID's taken from WoWHead.
