### PR TITLE
Core/Spells: Fixed Swift Retribution talent

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3313,6 +3313,12 @@ void SpellMgr::LoadDbcDataCorrections()
                 spellInfo->EffectImplicitTargetB[0] = TARGET_UNIT_TARGET_ANY;
                 spellInfo->Effect[1] = 0;
                 break;
+            case 53379: // Swift Retribution
+            case 53484:
+            case 53648:
+                spellInfo->EffectSpellClassMask[0] = flag96(0x00000000, 0x00000000, 0x00000020);
+                ++count;
+                break;
             default:
                 break;
         }

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3317,7 +3317,6 @@ void SpellMgr::LoadDbcDataCorrections()
             case 53484:
             case 53648:
                 spellInfo->EffectSpellClassMask[0] = flag96(0x00000000, 0x00000000, 0x00000020);
-                ++count;
                 break;
             default:
                 break;


### PR DESCRIPTION
Core/Spells: Fixed Swift Retribution talent to being applied when any Paladin aura is up instead of only the retribution aura. This change was introduced with patch 3.1.0

Fixes parts of #205
