### PR TITLE
Core/Spells: Fixed Aspect of the Beast

### DIFF
--- a/sql/updates/world/2011_XX_XX_XX_world_spell_script_names.sql
+++ b/sql/updates/world/2011_XX_XX_XX_world_spell_script_names.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=13161;
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(13161, 'spell_hun_aspect_of_the_beast');

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -174,7 +174,7 @@ enum UnitStandFlags
 {
     UNIT_STAND_FLAGS_UNK1         = 0x01,
     UNIT_STAND_FLAGS_CREEP        = 0x02,
-    UNIT_STAND_FLAGS_UNK3         = 0x04,
+    UNIT_STAND_FLAGS_UNTRACKABLE  = 0x04,
     UNIT_STAND_FLAGS_UNK4         = 0x08,
     UNIT_STAND_FLAGS_UNK5         = 0x10,
     UNIT_STAND_FLAGS_ALL          = 0xFF
@@ -185,7 +185,7 @@ enum UnitBytes1_Flags
 {
     UNIT_BYTE1_FLAG_ALWAYS_STAND = 0x01,
     UNIT_BYTE1_FLAG_UNK_2        = 0x02,
-    UNIT_BYTE1_FLAG_UNTRACKABLE  = 0x04,
+    UNIT_BYTE1_FLAG_UNK_3        = 0x04,
     UNIT_BYTE1_FLAG_ALL          = 0xFF
 };
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2751,13 +2751,13 @@ void AuraEffect::HandleAuraUntrackable(AuraApplication const* aurApp, uint8 mode
     Unit* target = aurApp->GetTarget();
 
     if (apply)
-        target->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_UNTRACKABLE);
+        target->SetByteFlag(UNIT_FIELD_BYTES_1, 2, UNIT_STAND_FLAGS_UNTRACKABLE);
     else
     {
         // do not remove unit flag if there are more than this auraEffect of that kind on unit on unit
         if (target->HasAuraType(GetAuraType()))
             return;
-        target->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_UNTRACKABLE);
+        target->RemoveByteFlag(UNIT_FIELD_BYTES_1, 2, UNIT_STAND_FLAGS_UNTRACKABLE);
     }
 }
 

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -39,6 +39,58 @@ enum HunterSpells
     HUNTER_SPELL_CHIMERA_SHOT_SERPENT            = 53353,
     HUNTER_SPELL_CHIMERA_SHOT_VIPER              = 53358,
     HUNTER_SPELL_CHIMERA_SHOT_SCORPID            = 53359,
+    HUNTER_SPELL_ASPECT_OF_THE_BEAST_PET         = 61669,
+};
+
+// 13161 Aspect of the Beast
+class spell_hun_aspect_of_the_beast : public SpellScriptLoader
+{
+public:
+    spell_hun_aspect_of_the_beast() : SpellScriptLoader("spell_hun_aspect_of_the_beast") { }
+
+    class spell_hun_aspect_of_the_beast_AuraScript : public AuraScript
+    {
+        PrepareAuraScript(spell_hun_aspect_of_the_beast_AuraScript)
+        bool Validate(SpellInfo const* /*entry*/)
+        {
+            if (!sSpellMgr->GetSpellInfo(HUNTER_SPELL_ASPECT_OF_THE_BEAST_PET))
+                return false;
+            return true;
+        }
+        
+        void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+        {
+            if (!GetCaster())
+                return;
+
+            Unit* caster = GetCaster();
+            if (caster->ToPlayer())
+                if (Pet* pet = caster->ToPlayer()->GetPet())
+                    pet->RemoveAurasDueToSpell(HUNTER_SPELL_ASPECT_OF_THE_BEAST_PET);
+        }
+
+        void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+        {
+            if (!GetCaster())
+                return;
+
+            Unit* caster = GetCaster();
+            if (caster->ToPlayer())
+                if (Pet* pet = caster->ToPlayer()->GetPet())
+                    caster->CastSpell(caster, HUNTER_SPELL_ASPECT_OF_THE_BEAST_PET, true);
+        }
+
+        void Register()
+        {
+            AfterEffectApply += AuraEffectApplyFn(spell_hun_aspect_of_the_beast_AuraScript::OnApply, EFFECT_0, SPELL_AURA_UNTRACKABLE, AURA_EFFECT_HANDLE_REAL);
+            AfterEffectRemove += AuraEffectRemoveFn(spell_hun_aspect_of_the_beast_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_UNTRACKABLE, AURA_EFFECT_HANDLE_REAL);
+        }
+    };
+
+    AuraScript *GetAuraScript() const
+    {
+        return new spell_hun_aspect_of_the_beast_AuraScript();
+    }
 };
 
 // 53209 Chimera Shot
@@ -512,6 +564,7 @@ public:
 
 void AddSC_hunter_spell_scripts()
 {
+    new spell_hun_aspect_of_the_beast();
     new spell_hun_chimera_shot();
     new spell_hun_invigoration();
     new spell_hun_last_stand_pet();


### PR DESCRIPTION
Core/Spells: Fixed Aspect of the Beast making the caster and his pet untrackable and the pet's Attack Power bonus.

I couldn't use `spell_linked_spell`. Type 2 does break the spell by also « aura - ing » the player, thus making him a little overpowered under precision aura. Type 1 did work but it didn't remove the aspect when I switched to another aspect or simply right-clicked the aspect of the beast

Thanks to Shauren and QAston for their hints about the unit flag.
