### PR TITLE
Rotface should only cast Mutated Infection on one player.

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
@@ -193,8 +193,6 @@ class boss_rotface : public CreatureScript
                         case EVENT_MUTATED_INFECTION:
                         {
                             Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 0.0f, true, -MUTATED_INFECTION);
-                            if (!target)
-                                target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0.0f, true, -MUTATED_INFECTION);
                             if (target)
                             {
                                 me->CastCustomSpell(SPELL_MUTATED_INFECTION, SPELLVALUE_MAX_TARGETS, 1, target, false);


### PR DESCRIPTION
This way Rotface will only cast Mutated Infection on one player instead of two.
