### PR TITLE
Core/Mechanics: Cap armorPen to maxArmorPen

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1584,7 +1584,7 @@ uint32 Unit::CalcArmorReducedDamage(Unit* victim, const uint32 damage, SpellInfo
         // Figure out how much armor do we ignore
         float armorPen = CalculatePctF(maxArmorPen, ToPlayer()->GetRatingBonusValue(CR_ARMOR_PENETRATION));
         // Got the value, apply it
-        armor -= armorPen;
+        armor -= std::min(armorPen, maxArmorPen);
     }
 
     if (armor < 0.0f)


### PR DESCRIPTION
_ToPlayer()->GetRatingBonusValue(CR_ARMOR_PENETRATION)_ may return a value greater than 100.0f (100%), which results in a _armorPen_ larger than _maxArmorPen_.
This change enforces the cap of maxArmorPen.
