### PR TITLE
Do not call AddObjectToRemoveList(Pet*) in Map::MoveAllCreaturesInMoveList(). Fix #2892.

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -824,9 +824,17 @@ void Map::MoveAllCreaturesInMoveList()
         }
         else
         {
+            //AddObjectToRemoveList(Pet*) should only be called in Pet::Remove
+            //This may happen when a player just logs in and a pet moves to a nearby unloaded cell
+            //To avoid this, we can load nearby cells when player log in
+            //But this check is always needed to ensure safety
+            if (c->isPet())
+            {
+                ((Pet*)c)->Remove(PET_SAVE_NOT_IN_SLOT, true);
+            }
             // if creature can't be move in new cell/grid (not loaded) move it to repawn cell/grid
             // creature coordinates will be updated and notifiers send
-            if (!CreatureRespawnRelocation(c))
+            else if (!CreatureRespawnRelocation(c))
             {
                 // ... or unload (if respawn grid also not loaded)
                 #ifdef TRINITY_DEBUG

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -824,23 +824,24 @@ void Map::MoveAllCreaturesInMoveList()
         }
         else
         {
-            //AddObjectToRemoveList(Pet*) should only be called in Pet::Remove
-            //This may happen when a player just logs in and a pet moves to a nearby unloaded cell
-            //To avoid this, we can load nearby cells when player log in
-            //But this check is always needed to ensure safety
-            if (c->isPet())
-            {
-                ((Pet*)c)->Remove(PET_SAVE_NOT_IN_SLOT, true);
-            }
             // if creature can't be move in new cell/grid (not loaded) move it to repawn cell/grid
             // creature coordinates will be updated and notifiers send
-            else if (!CreatureRespawnRelocation(c))
+            if (!CreatureRespawnRelocation(c))
             {
                 // ... or unload (if respawn grid also not loaded)
                 #ifdef TRINITY_DEBUG
                     sLog->outDebug(LOG_FILTER_MAPS, "Creature (GUID: %u Entry: %u) cannot be move to unloaded respawn grid.", c->GetGUIDLow(), c->GetEntry());
                 #endif
-                AddObjectToRemoveList(c);
+                //AddObjectToRemoveList(Pet*) should only be called in Pet::Remove
+                //This may happen when a player just logs in and a pet moves to a nearby unloaded cell
+                //To avoid this, we can load nearby cells when player log in
+                //But this check is always needed to ensure safety
+                //TODO: pets will disappear if this is outside CreatureRespawnRelocation
+                //need to check why pet is frequently relocated to an unloaded cell
+                if (c->isPet())
+                    ((Pet*)c)->Remove(PET_SAVE_NOT_IN_SLOT, true);
+                else
+                    AddObjectToRemoveList(c);
             }
         }
 
@@ -933,8 +934,8 @@ bool Map::CreatureRespawnRelocation(Creature *c)
         c->UpdateObjectVisibility(false);
         return true;
     }
-    else
-        return false;
+
+    return false;
 }
 
 bool Map::UnloadGrid(const uint32 x, const uint32 y, bool unloadAll)

--- a/src/server/scripts/Northrend/storm_peaks.cpp
+++ b/src/server/scripts/Northrend/storm_peaks.cpp
@@ -558,7 +558,7 @@ public:
     {
         npc_brunnhildar_prisonerAI(Creature* creature) : ScriptedAI(creature) {}
 
-        Unit* drake;
+        uint64 drakeGUID;
         uint16 enter_timer;
         bool hasEmptySeats;
 
@@ -566,14 +566,25 @@ public:
         {
             me->CastSpell(me, SPELL_ICE_PRISON, true);
             enter_timer = 0;
-            drake = NULL;
+            drakeGUID = 0;
             hasEmptySeats = false;
         }
 
         void UpdateAI(const uint32 diff)
         {
+            //TODO: not good script
+            if (!drakeGUID)
+                return;
+
+            Creature* drake = Unit::GetCreature(*me, drakeGUID);
+            if (!drake)
+            {
+                drakeGUID = 0;
+                return;
+            }
+
             // drake unsummoned, passengers dropped
-            if (drake && !me->IsOnVehicle(drake) && !hasEmptySeats)
+            if (!me->IsOnVehicle(drake) && !hasEmptySeats)
                 me->ForcedDespawn(3000);
 
             if (enter_timer <= 0)
@@ -593,8 +604,15 @@ public:
 
         void MoveInLineOfSight(Unit* unit)
         {
-            if (!unit || !drake)
+            if (!unit || !drakeGUID)
                 return;
+
+            Creature* drake = Unit::GetCreature(*me, drakeGUID);
+            if (!drake)
+            {
+                drakeGUID = 0;
+                return;
+            }
 
             if (!me->IsOnVehicle(drake) && !me->HasAura(SPELL_ICE_PRISON))
             {
@@ -651,7 +669,7 @@ public:
             enter_timer = 500;
 
             if (hitter->IsVehicle())
-                drake = hitter;
+                drakeGUID = hitter->GetGUID();
             else
                 return;
 


### PR DESCRIPTION
Do not call AddObjectToRemoveList(Pet*) in Map::MoveAllCreaturesInMoveList(). Fix #2892.
