### PR TITLE
Trial of the Crusader

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
@@ -495,7 +495,7 @@ public:
         {
             if (!UpdateVictim()) return;
 
-            if (m_uiNatureGraspTimer <= uiDiff)
+			if (m_uiNatureGraspTimer <= uiDiff)
             {
                 DoCast(me, SPELL_NATURE_GRASP);
                 m_uiNatureGraspTimer = urand(40*IN_MILLISECONDS, 80*IN_MILLISECONDS);
@@ -525,19 +525,19 @@ public:
 							DoCast(me, SPELL_LIFEBLOOM);
                         break;
                     case 1:
-                        if (Unit* target = DoSelectLowestHpFriendly(60.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(60.0f))
 							DoCast(target, SPELL_NOURISH);
 						else
 							DoCast(me, SPELL_NOURISH);
                         break;
                     case 2:
-                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
 							DoCast(target, SPELL_REGROWTH);
 						else
 							DoCast(me, SPELL_REGROWTH);
                         break;
                     case 3:
-                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
 							DoCast(target, SPELL_REJUVENATION);
 						else
 							DoCast(me, SPELL_REJUVENATION);
@@ -632,17 +632,17 @@ public:
 							DoCast(me, SPELL_HEALING_WAVE);
                         break;
                     case 2:
-                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
 							DoCast(target, SPELL_RIPTIDE);
 						else
 							DoCast(me, SPELL_RIPTIDE);
                         break;
                     case 3:
-                        if (Unit* target = SelectEnemyCaster(false))
+						if (Unit* target = SelectEnemyCaster(false))
 							DoCast(target, SPELL_EARTH_SHOCK);
                         break;
                     case 4:
-                        DoCast(me, SPELL_SPIRIT_CLEANSE);
+						DoCast(me, SPELL_SPIRIT_CLEANSE);
                         break;
                     case 5:
                         if (Unit* target = SelectRandomFriendlyMissingBuff(SPELL_EARTH_SHIELD))
@@ -755,7 +755,7 @@ public:
 							DoCast(me, SPELL_FLASH_OF_LIGHT);
                         break;
                     case 2: case 3:
-                        if (Unit* target = DoSelectLowestHpFriendly(60.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(60.0f))
 							DoCast(target, SPELL_HOLY_LIGHT);
 						else
 							DoCast(me, SPELL_HOLY_LIGHT);
@@ -825,19 +825,19 @@ public:
                 switch (urand(0, 5))
                 {
                     case 0:
-                         if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
 							DoCast(target, SPELL_RENEW);
 						else
 							DoCast(me, SPELL_RENEW);
                         break;
                     case 1:
-                         if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
 							DoCast(target, SPELL_SHIELD);
 						else
 							DoCast(me, SPELL_SHIELD);
                         break;
                     case 2: case 3:
-                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
 							DoCast(target, SPELL_FLASH_HEAL);
 						else
 							DoCast(me, SPELL_FLASH_HEAL);
@@ -949,20 +949,20 @@ public:
                 switch (urand(0, 4))
                 {
                     case 0: case 1:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
-                            DoCast(target, SPELL_MIND_FLAY);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
+							DoCast(target, SPELL_MIND_FLAY);
                         break;
                     case 2:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
-                            DoCast(target, SPELL_VAMPIRIC_TOUCH);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
+							DoCast(target, SPELL_VAMPIRIC_TOUCH);
                         break;
                    case 3:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
-                            DoCast(target, SPELL_SW_PAIN);
-                        break;
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
+							DoCast(target, SPELL_SW_PAIN);
+						break;
                    case 4:
-                        if (Unit* target = urand(0, 1) ? SelectTarget(SELECT_TARGET_RANDOM, 0) : DoSelectLowestHpFriendly(40.0f))
-                            DoCast(target, SPELL_DISPEL);
+						if (Unit* target = urand(0, 1) ? SelectTarget(SELECT_TARGET_RANDOM, 0) : DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_DISPEL);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -1070,8 +1070,8 @@ public:
                         DoCastVictim(SPELL_CURSE_OF_AGONY);
                         break;
                     case 5:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
-                            DoCast(target, SPELL_CURSE_OF_EXHAUSTION);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+							DoCast(target, SPELL_CURSE_OF_EXHAUSTION);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -1178,15 +1178,15 @@ public:
                 {
                     case 0:
 						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
-                        DoCast(target, SPELL_ARCANE_BARRAGE);
+							DoCast(target, SPELL_ARCANE_BARRAGE);
                         break;
                     case 1:
 						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0, true))
-                        DoCast(target, SPELL_ARCANE_BLAST);
+							DoCast(target, SPELL_ARCANE_BLAST);
                         break;
                     case 2:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0F, true))
-                        DoCast(target, SPELL_FROSTBOLT);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0F, true))
+							DoCast(target, SPELL_FROSTBOLT);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -1306,7 +1306,7 @@ public:
 							DoCast(target, SPELL_EXPLOSIVE_SHOT);
                         break;
                     case 3:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 35.0f, true))
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 35.0f, true))
 							DoCast(target, SPELL_AIMED_SHOT);
                         break;
                 }
@@ -1402,15 +1402,15 @@ public:
 							DoCast(target, SPELL_MOONFIRE);
                         break;
                     case 2:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
 							DoCast(target, SPELL_INSECT_SWARM);
                         break;
                     case 3:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
 							DoCast(target, SPELL_STARFIRE);
                         break;
                     case 4: case 5: case 6:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
 							DoCast(target, SPELL_WRATH);
                         break;
                 }
@@ -1618,8 +1618,8 @@ public:
 
             if (m_uiStrangulateTimer <= uiDiff)
             {
-                if (Unit* target = SelectEnemyCaster(false))
-                    DoCast(target, SPELL_STRANGULATE);
+				if (Unit* target = SelectEnemyCaster(false))
+					DoCast(target, SPELL_STRANGULATE);
                 m_uiStrangulateTimer = urand(10*IN_MILLISECONDS, 90*IN_MILLISECONDS);
             } else m_uiStrangulateTimer -= uiDiff;
 
@@ -1637,8 +1637,8 @@ public:
 
             if (m_uiDeathGripTimer <= uiDiff)
             {
-                if (me->IsInRange(me->getVictim(), 10.0f, 30.0f, false))
-                    DoCastVictim(SPELL_DEATH_GRIP);
+				if (me->IsInRange(me->getVictim(), 10.0f, 30.0f, false))
+					DoCastVictim(SPELL_DEATH_GRIP);
                 m_uiDeathGripTimer = urand(5*IN_MILLISECONDS, 15*IN_MILLISECONDS);
             } else m_uiDeathGripTimer -= uiDiff;
 
@@ -1719,8 +1719,8 @@ public:
 
             if (m_uiShadowstepTimer <= uiDiff)
             {
-                if (me->IsInRange(me->getVictim(), 10.0f, 40.0f))
-                    DoCastVictim(SPELL_SHADOWSTEP);
+				if (me->IsInRange(me->getVictim(), 10.0f, 40.0f))
+					DoCastVictim(SPELL_SHADOWSTEP);
                 m_uiShadowstepTimer = urand(10*IN_MILLISECONDS, 80*IN_MILLISECONDS);
             } else m_uiShadowstepTimer -= uiDiff;
 
@@ -1940,8 +1940,8 @@ public:
 
             if (m_uiRepentanceTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 20.0f, true))
-                    DoCast(target, SPELL_REPENTANCE);
+				if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 20.0f, true))
+					DoCast(target, SPELL_REPENTANCE);
                 m_uiRepentanceTimer = 60*IN_MILLISECONDS;
             } else m_uiRepentanceTimer -= uiDiff;
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
@@ -24,8 +24,7 @@ SDCategory: Crusader Coliseum
 EndScriptData */
 
 // Known bugs:
-// All - untested
-// Pets aren't being summoned by their masters
+// The Champions are not using all of their abilities.
 
 #include "ScriptPCH.h"
 #include "trial_of_the_crusader.h"
@@ -520,16 +519,28 @@ public:
                 switch (urand(0, 4))
                 {
                     case 0:
-                        DoCast(me, SPELL_LIFEBLOOM);
+						if (Unit* target = DoSelectLowestHpFriendly(60.0f))
+							DoCast(target, SPELL_LIFEBLOOM);
+						else
+							DoCast(me, SPELL_LIFEBLOOM);
                         break;
                     case 1:
-                        DoCast(me, SPELL_NOURISH);
+                        if (Unit* target = DoSelectLowestHpFriendly(60.0f))
+							DoCast(target, SPELL_NOURISH);
+						else
+							DoCast(me, SPELL_NOURISH);
                         break;
                     case 2:
-                        DoCast(me, SPELL_REGROWTH);
+                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_REGROWTH);
+						else
+							DoCast(me, SPELL_REGROWTH);
                         break;
                     case 3:
-                        DoCast(me, SPELL_REJUVENATION);
+                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_REJUVENATION);
+						else
+							DoCast(me, SPELL_REJUVENATION);
                         break;
                     case 4:
                         if (Creature* target = SelectRandomFriendlyMissingBuff(SPELL_THORNS))
@@ -615,13 +626,20 @@ public:
                 switch (urand(0, 5))
                 {
                     case 0: case 1:
-                        DoCast(me, SPELL_HEALING_WAVE);
+						if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_HEALING_WAVE);
+						else
+							DoCast(me, SPELL_HEALING_WAVE);
                         break;
                     case 2:
-                        DoCast(me, SPELL_RIPTIDE);
+                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_RIPTIDE);
+						else
+							DoCast(me, SPELL_RIPTIDE);
                         break;
                     case 3:
-                        DoCast(me, SPELL_EARTH_SHOCK);
+                        if (Unit* target = SelectEnemyCaster(false))
+							DoCast(target, SPELL_EARTH_SHOCK);
                         break;
                     case 4:
                         DoCast(me, SPELL_SPIRIT_CLEANSE);
@@ -731,13 +749,20 @@ public:
                 switch (urand(0, 4))
                 {
                     case 0: case 1:
-                        DoCast(me, SPELL_FLASH_OF_LIGHT);
+						if (Unit* target = DoSelectLowestHpFriendly(60.0f))
+							DoCast(target, SPELL_FLASH_OF_LIGHT);
+						else
+							DoCast(me, SPELL_FLASH_OF_LIGHT);
                         break;
                     case 2: case 3:
-                        DoCast(me, SPELL_HOLY_LIGHT);
+                        if (Unit* target = DoSelectLowestHpFriendly(60.0f))
+							DoCast(target, SPELL_HOLY_LIGHT);
+						else
+							DoCast(me, SPELL_HOLY_LIGHT);
                         break;
                     case 4:
-                        DoCast(me, SPELL_CLEANSE);
+						// Unsure what to use for this so left it as cleanse his/herself
+						DoCast(me, SPELL_CLEANSE);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -800,20 +825,30 @@ public:
                 switch (urand(0, 5))
                 {
                     case 0:
-                        DoCast(me, SPELL_RENEW);
+                         if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_RENEW);
+						else
+							DoCast(me, SPELL_RENEW);
                         break;
                     case 1:
-                        DoCast(me, SPELL_SHIELD);
+                         if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_SHIELD);
+						else
+							DoCast(me, SPELL_SHIELD);
                         break;
                     case 2: case 3:
-                        DoCast(me, SPELL_FLASH_HEAL);
+                        if (Unit* target = DoSelectLowestHpFriendly(40.0f))
+							DoCast(target, SPELL_FLASH_HEAL);
+						else
+							DoCast(me, SPELL_FLASH_HEAL);
                         break;
                     case 4:
                         if (Unit* target = urand(0, 1) ? SelectTarget(SELECT_TARGET_RANDOM, 0) : DoSelectLowestHpFriendly(40.0f))
                             DoCast(target, SPELL_DISPEL);
                         break;
                     case 5:
-                        DoCast(me, SPELL_MANA_BURN);
+						if (Unit* target = SelectEnemyCaster(false))
+							DoCast(target, SPELL_MANA_BURN);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -914,15 +949,15 @@ public:
                 switch (urand(0, 4))
                 {
                     case 0: case 1:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
                             DoCast(target, SPELL_MIND_FLAY);
                         break;
                     case 2:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
                             DoCast(target, SPELL_VAMPIRIC_TOUCH);
                         break;
                    case 3:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 40.0f, true))
                             DoCast(target, SPELL_SW_PAIN);
                         break;
                    case 4:
@@ -994,7 +1029,7 @@ public:
 
             if (m_uiFearTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 20.0f, true))
                     DoCast(target, SPELL_FEAR);
                 m_uiFearTimer = urand(4*IN_MILLISECONDS, 15*IN_MILLISECONDS);
             } else m_uiFearTimer -= uiDiff;
@@ -1008,7 +1043,7 @@ public:
 
             if (m_uiUnstableAfflictionTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
                     DoCast(target, SPELL_UNSTABLE_AFFLICTION);
                 m_uiUnstableAfflictionTimer = urand(2*IN_MILLISECONDS, 10*IN_MILLISECONDS);
             } else m_uiUnstableAfflictionTimer -= uiDiff;
@@ -1035,7 +1070,7 @@ public:
                         DoCastVictim(SPELL_CURSE_OF_AGONY);
                         break;
                     case 5:
-                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
                             DoCast(target, SPELL_CURSE_OF_EXHAUSTION);
                         break;
                 }
@@ -1079,6 +1114,7 @@ public:
         uint32 m_uiIceBlockTimer;
         uint32 m_uiPolymorphTimer;
         uint32 m_uiCommonTimer;
+		uint32 m_uiArcaneExplosionTimer;
 
         void Reset()
         {
@@ -1088,6 +1124,7 @@ public:
             m_uiIceBlockTimer = urand(0*IN_MILLISECONDS, 360*IN_MILLISECONDS);
             m_uiPolymorphTimer = urand(15*IN_MILLISECONDS, 40*IN_MILLISECONDS);
             m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
+			m_uiArcaneExplosionTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
             SetEquipmentSlots(false, 47524, EQUIP_NO_CHANGE, EQUIP_NO_CHANGE);
         }
 
@@ -1112,6 +1149,15 @@ public:
                 m_uiBlinkTimer = urand(7*IN_MILLISECONDS, 25*IN_MILLISECONDS);
             } else m_uiBlinkTimer -= uiDiff;
 
+			if (m_uiArcaneExplosionTimer <= uiDiff)
+			{
+				if (EnemiesInRange(10.0f) > 2)
+				{
+					DoCast(SPELL_ARCANE_EXPLOSION);
+				}
+				m_uiArcaneExplosionTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
+			} else m_uiArcaneExplosionTimer -= uiDiff;
+
             if (m_uiIceBlockTimer <= uiDiff)
             {
                 if (HealthBelowPct(20))
@@ -1121,7 +1167,7 @@ public:
 
             if (m_uiPolymorphTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
                     DoCast(target, SPELL_POLYMORPH);
                 m_uiPolymorphTimer = urand(15*IN_MILLISECONDS, 40*IN_MILLISECONDS);
             } else m_uiPolymorphTimer -= uiDiff;
@@ -1131,13 +1177,16 @@ public:
                 switch (urand(0, 2))
                 {
                     case 0:
-                        DoCast(me, SPELL_ARCANE_BARRAGE);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+                        DoCast(target, SPELL_ARCANE_BARRAGE);
                         break;
                     case 1:
-                        DoCastVictim(SPELL_ARCANE_BLAST);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0, true))
+                        DoCast(target, SPELL_ARCANE_BLAST);
                         break;
                     case 2:
-                        DoCastVictim(SPELL_FROSTBOLT);
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0F, true))
+                        DoCast(target, SPELL_FROSTBOLT);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -1249,13 +1298,16 @@ public:
                 switch (urand(0, 3))
                 {
                     case 0: case 1:
-                        DoCastVictim(SPELL_SHOOT);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0, true))
+							DoCast(target, SPELL_SHOOT);
                         break;
                     case 2:
-                        DoCastVictim(SPELL_EXPLOSIVE_SHOT);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 35.0f, true))
+							DoCast(target, SPELL_EXPLOSIVE_SHOT);
                         break;
                     case 3:
-                        DoCastVictim(SPELL_AIMED_SHOT);
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 35.0f, true))
+							DoCast(target, SPELL_AIMED_SHOT);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -1323,14 +1375,14 @@ public:
 
             if (m_uiCycloneTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 20.0f, true))
                     DoCast(target, SPELL_CYCLONE);
                 m_uiCycloneTimer = urand(5*IN_MILLISECONDS, 40*IN_MILLISECONDS);
             } else m_uiCycloneTimer -= uiDiff;
 
             if (m_uiEntanglingRootsTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
                     DoCast(target, SPELL_ENTANGLING_ROOTS);
                 m_uiEntanglingRootsTimer = urand(5*IN_MILLISECONDS, 40*IN_MILLISECONDS);
             } else m_uiEntanglingRootsTimer -= uiDiff;
@@ -1346,16 +1398,20 @@ public:
                 switch (urand(0, 6))
                 {
                     case 0: case 1:
-                        DoCastVictim(SPELL_MOONFIRE);
+						if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+							DoCast(target, SPELL_MOONFIRE);
                         break;
                     case 2:
-                        DoCastVictim(SPELL_INSECT_SWARM);
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+							DoCast(target, SPELL_INSECT_SWARM);
                         break;
                     case 3:
-                        DoCastVictim(SPELL_STARFIRE);
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+							DoCast(target, SPELL_STARFIRE);
                         break;
                     case 4: case 5: case 6:
-                        DoCastVictim(SPELL_WRATH);
+                        if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30.0f, true))
+							DoCast(target, SPELL_WRATH);
                         break;
                 }
                 m_uiCommonTimer = urand(15*IN_MILLISECONDS, 30*IN_MILLISECONDS);
@@ -1434,9 +1490,12 @@ public:
 
             if (m_uiIntimidatingShoutTimer <= uiDiff)
             {
-                DoCast(me, SPELL_INTIMIDATING_SHOUT);
-                m_uiIntimidatingShoutTimer = urand(10*IN_MILLISECONDS, 60*IN_MILLISECONDS);
-            } else m_uiIntimidatingShoutTimer -= uiDiff;
+				if (EnemiesInRange(10.0f) > 3)
+				{
+					DoCast(SPELL_INTIMIDATING_SHOUT);
+				}
+				m_uiIntimidatingShoutTimer = urand(10*IN_MILLISECONDS, 60*IN_MILLISECONDS);
+			} else m_uiIntimidatingShoutTimer -= uiDiff;
 
             if (m_uiMortalStrikeTimer <= uiDiff)
             {
@@ -1452,13 +1511,14 @@ public:
 
             if (m_uiChargeTimer <= uiDiff)
             {
-                DoCastVictim(SPELL_CHARGE);
+				if (me->IsInRange(me->getVictim(), 8.0f, 25.0f, false))
+					DoCastVictim(SPELL_CHARGE);
                 m_uiChargeTimer = urand(3*IN_MILLISECONDS, 25*IN_MILLISECONDS);
             } else m_uiChargeTimer -= uiDiff;
 
             if (m_uiRetaliationTimer <= uiDiff)
             {
-                DoCastVictim(SPELL_RETALIATION);
+                DoCast(me, SPELL_RETALIATION);
                 m_uiRetaliationTimer = urand(30*IN_MILLISECONDS, 60*IN_MILLISECONDS);
             } else m_uiRetaliationTimer -= uiDiff;
 
@@ -1545,7 +1605,7 @@ public:
 
             if (m_uiChainsOfIceTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 25.0f, true))
                     DoCast(target, SPELL_CHAINS_OF_ICE);
                 m_uiChainsOfIceTimer = urand(5*IN_MILLISECONDS, 15*IN_MILLISECONDS);
             } else m_uiChainsOfIceTimer -= uiDiff;
@@ -1681,7 +1741,7 @@ public:
 
             if (m_uiBladeFlurryTimer <= uiDiff)
             {
-                DoCastVictim(SPELL_BLADE_FLURRY);
+                DoCast(me, SPELL_BLADE_FLURRY);
                 m_uiBladeFlurryTimer = urand(12*IN_MILLISECONDS, 120*IN_MILLISECONDS);
             } else m_uiBladeFlurryTimer -= uiDiff;
 
@@ -1790,7 +1850,10 @@ public:
 
             if (m_uiEarthShockTimer <= uiDiff)
             {
-                DoCastVictim(SPELL_EARTH_SHOCK_ENH);
+				if (Unit* target = SelectEnemyCaster(false))
+				{
+					DoCast(target, SPELL_EARTH_SHOCK_ENH);
+				}
                 m_uiEarthShockTimer = urand(5*IN_MILLISECONDS, 8*IN_MILLISECONDS);
             } else m_uiEarthShockTimer -= uiDiff;
 
@@ -1846,7 +1909,7 @@ public:
     {
         mob_toc_retro_paladinAI(Creature* creature) : boss_faction_championsAI(creature, AI_MELEE) {}
 
-        uint32 m_uiRepeteanceTimer;
+        uint32 m_uiRepentanceTimer;
         uint32 m_uiCrusaderStrikeTimer;
         uint32 m_uiAvengingWrathTimer;
         uint32 m_uiDivineShieldTimer;
@@ -1856,7 +1919,7 @@ public:
         void Reset()
         {
             boss_faction_championsAI::Reset();
-            m_uiRepeteanceTimer = 60*IN_MILLISECONDS;
+            m_uiRepentanceTimer = 60*IN_MILLISECONDS;
             m_uiCrusaderStrikeTimer = urand(6*IN_MILLISECONDS, 18*IN_MILLISECONDS);
             m_uiAvengingWrathTimer = 180*IN_MILLISECONDS;
             m_uiDivineShieldTimer = urand(0*IN_MILLISECONDS, 360*IN_MILLISECONDS);
@@ -1875,12 +1938,12 @@ public:
         {
             if (!UpdateVictim()) return;
 
-            if (m_uiRepeteanceTimer <= uiDiff)
+            if (m_uiRepentanceTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 20.0f, true))
                     DoCast(target, SPELL_REPENTANCE);
-                m_uiRepeteanceTimer = 60*IN_MILLISECONDS;
-            } else m_uiRepeteanceTimer -= uiDiff;
+                m_uiRepentanceTimer = 60*IN_MILLISECONDS;
+            } else m_uiRepentanceTimer -= uiDiff;
 
             if (m_uiCrusaderStrikeTimer <= uiDiff)
             {
@@ -1890,7 +1953,7 @@ public:
 
             if (m_uiAvengingWrathTimer <= uiDiff)
             {
-                DoCastVictim(SPELL_AVENGING_WRATH);
+                DoCast(me, SPELL_AVENGING_WRATH);
                 m_uiAvengingWrathTimer = 180*IN_MILLISECONDS;
             } else m_uiAvengingWrathTimer -= uiDiff;
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
@@ -68,7 +68,6 @@ enum BossSpells
 {
     SPELL_LEGION_FLAME                = 66197, // player should run away from raid because he triggers Legion Flame
     SPELL_LEGION_FLAME_EFFECT         = 66201, // used by trigger npc
-    SPELL_TOUCH_OF_JARAXXUS           = 66209, // used only in 25H
     SPELL_NETHER_POWER                = 66228, // +20% of spell damage per stack, stackable up to 5/10 times, must be dispelled/stealed
     SPELL_FEL_LIGHTING                = 66528, // jumps to nearby targets
     SPELL_FEL_FIREBALL                = 66532, // does heavy damage to the tank, interruptable
@@ -120,7 +119,6 @@ public:
         uint32 m_uiIncinerateFleshTimer;
         uint32 m_uiNetherPowerTimer;
         uint32 m_uiLegionFlameTimer;
-        uint32 m_uiTouchOfJaraxxusTimer;
         uint32 m_uiSummonNetherPortalTimer;
         uint32 m_uiSummonInfernalEruptionTimer;
 
@@ -134,7 +132,6 @@ public:
             m_uiIncinerateFleshTimer = urand(20*IN_MILLISECONDS, 25*IN_MILLISECONDS);
             m_uiNetherPowerTimer = 40*IN_MILLISECONDS;
             m_uiLegionFlameTimer = 30*IN_MILLISECONDS;
-            m_uiTouchOfJaraxxusTimer = urand(10*IN_MILLISECONDS, 15*IN_MILLISECONDS);
             m_uiSummonNetherPortalTimer = 1*MINUTE*IN_MILLISECONDS;
             m_uiSummonInfernalEruptionTimer = 2*MINUTE*IN_MILLISECONDS;
             Summons.DespawnAll();
@@ -240,12 +237,6 @@ public:
                 m_uiLegionFlameTimer = 30*IN_MILLISECONDS;
             } else m_uiLegionFlameTimer -= uiDiff;
 
-            if (GetDifficulty() == RAID_DIFFICULTY_25MAN_HEROIC && m_uiTouchOfJaraxxusTimer <= uiDiff)
-            {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true))
-                    me->CastCustomSpell(SPELL_TOUCH_OF_JARAXXUS, SPELLVALUE_MAX_TARGETS, 1);
-                m_uiTouchOfJaraxxusTimer = urand(10*IN_MILLISECONDS, 15*IN_MILLISECONDS);
-            } else m_uiTouchOfJaraxxusTimer -= uiDiff;
 
             DoMeleeAttackIfReady();
         }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
@@ -242,8 +242,8 @@ public:
 
             if (GetDifficulty() == RAID_DIFFICULTY_25MAN_HEROIC && m_uiTouchOfJaraxxusTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
-                    DoCast(target, SPELL_TOUCH_OF_JARAXXUS);
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true))
+                    me->CastCustomSpell(SPELL_TOUCH_OF_JARAXXUS, SPELLVALUE_MAX_TARGETS, 1);
                 m_uiTouchOfJaraxxusTimer = urand(10*IN_MILLISECONDS, 15*IN_MILLISECONDS);
             } else m_uiTouchOfJaraxxusTimer -= uiDiff;
 
@@ -383,7 +383,7 @@ public:
 
             if (m_uiFelStreakTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true))
                     DoCast(target, SPELL_FEL_STREAK);
                 m_uiFelStreakTimer = 30*IN_MILLISECONDS;
             } else m_uiFelStreakTimer -= uiDiff;
@@ -504,14 +504,14 @@ public:
 
             if (m_uiSpinningStrikeTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0, true))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true))
                     DoCast(target, SPELL_SPINNING_STRIKE);
                 m_uiSpinningStrikeTimer = 30*IN_MILLISECONDS;
             } else m_uiSpinningStrikeTimer -= uiDiff;
 
             if (IsHeroic() && m_uiMistressKissTimer <= uiDiff)
             {
-                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0, true))
+                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true))
                     DoCast(target, SPELL_MISTRESS_KISS);
                 m_uiMistressKissTimer = 30*IN_MILLISECONDS;
             } else m_uiMistressKissTimer -= uiDiff;


### PR DESCRIPTION
Lord Jaraxxus:
- Removed Touch of Jaraxxus from the Lord Jaraxxus script. The ability was never noticed on retail.
- Mistress of Pain's  "Mistress Kiss" and "Spinning Strike" abilities will not target pets and totems
- Fel Infernal's "Fel Streak" ability will not target pets or totems.

Faction Champions
- Healers will now properly heal other NPC's as well as themselves
- Caster NPC's will no longer cast their abilities on themselves
- Melee NPC's should now use their abilities correctly.
- Prevented many of the NPC's abilities from targeting totems and pets.
- Added Missing Arcane Explosion ability to the Mage Champions.
