### PR TITLE
Store pendingInstanceId instead of pointer of instance save, because pointer may become invalid. Fix #2987.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1754,7 +1754,7 @@ void Player::Update(uint32 p_time)
         if (_pendingBindTimer <= p_time)
         {
             // Player left the instance
-            if (_pendingBind->GetInstanceId() == GetInstanceId())
+            if (_pendingBindId == GetInstanceId())
                 BindToInstance();
             SetPendingBind(NULL, 0);
         }
@@ -18021,10 +18021,14 @@ InstancePlayerBind* Player::BindToInstance(InstanceSave* save, bool permanent, b
 
 void Player::BindToInstance()
 {
+    InstanceSave* mapSave = sInstanceSaveMgr->GetInstanceSave(_pendingBindId);
+    if(!mapSave) //it seems sometimes mapSave is NULL, but I did not check why
+        return;
+
     WorldPacket data(SMSG_INSTANCE_SAVE_CREATED, 4);
     data << uint32(0);
     GetSession()->SendPacket(&data);
-    BindToInstance(_pendingBind, true);
+    BindToInstance(mapSave, true);
 }
 
 void Player::SendRaidInfo()

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2373,8 +2373,8 @@ class Player : public Unit, public GridObject<Player>
         void UnbindInstance(BoundInstancesMap::iterator &itr, Difficulty difficulty, bool unload = false);
         InstancePlayerBind* BindToInstance(InstanceSave* save, bool permanent, bool load = false);
         void BindToInstance();
-        void SetPendingBind(InstanceSave* save, uint32 bindTimer) { _pendingBind = save; _pendingBindTimer = bindTimer; }
-        bool HasPendingBind() const { return _pendingBind != NULL; }
+        void SetPendingBind(uint32 instanceId, uint32 bindTimer) { _pendingBindId = instanceId; _pendingBindTimer = bindTimer; }
+        bool HasPendingBind() const { return _pendingBindId > 0; }
         void SendRaidInfo();
         void SendSavedInstances();
         static void ConvertInstancesToGroup(Player* player, Group* group, bool switchLeader);
@@ -2802,7 +2802,7 @@ class Player : public Unit, public GridObject<Player>
         uint32 m_timeSyncServer;
 
         InstanceTimeMap _instanceResetTimes;
-        InstanceSave* _pendingBind;
+        uint32 _pendingBindId;
         uint32 _pendingBindTimer;
 };
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2361,7 +2361,7 @@ bool InstanceMap::Add(Player* player)
                             data << uint32(i_data ? i_data->GetCompletedEncounterMask() : 0);
                             data << uint8(0);
                             player->GetSession()->SendPacket(&data);
-                            player->SetPendingBind(mapSave, 60000);
+                            player->SetPendingBind(mapSave->GetInstanceId(), 60000);
                         }
                     }
                 }


### PR DESCRIPTION
Store pendingInstanceId instead of pointer of instance save, because pointer may become invalid. Fix #2987.
