### PR TITLE
Warlock - Glyph of Seduction

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5731,7 +5731,8 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
             }
             switch(dummySpell->Id)
             {
-                // Glyph of Polymorph
+                // Glyph of Polymorph + Glyph of Seduction
+                case 56250:
                 case 56375:
                 {
                     target->RemoveAurasByType(SPELL_AURA_PERIODIC_DAMAGE, 0, target->GetAura(32409)); // SW:D shall not be removed.


### PR DESCRIPTION
Fixes Warlock's Glyph of Seduction to remove Damage over time effects when seduction is cast.
