### PR TITLE
Traps and Basic Campfire ignoring unattackable flags.

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -808,6 +808,9 @@ namespace Trinity
                 if (u->GetTypeId() == TYPEID_UNIT && ((Creature*)u)->isTotem())
                     return false;
 
+                if(!u->isTargetableForAttack(false))
+                    return false;
+
                 return i_obj->IsWithinDistInMap(u, i_range) && !i_funit->IsFriendlyTo(u);
             }
         private:


### PR DESCRIPTION
Hunter (damaging) traps and Basic campfire are making creatures with unattackable flags enter in combat with the caster.

rev: 0f9fc672d55435fdc8b7e32c21423e1ec2cbe605

How to reproduce:
1. Create an alliance character.
2. Learn Basic Campfire (spell 818).
3. Teleport to Dalaran.
4. Get really close to a Sunreaver Guardian Mage (npc 29255)
5. Cast Basic Campfire (spell 818)
6. See how you enter in combat with the npc (he doesn't attack you)

Another example with the same alliance character.
1. Find Backbiter (npc 32751), patrolling arround Dalaran.
2. Cast Basic Campfire in the middle of his route and wait for him to pass near the Fire.
3. See how the NPC starts attacking you.

This behaviour is repeatable with any creature with unattackable flags and can be used for exploiting scripts relying in this flags.
