### PR TITLE
Fix Crash in ProcessQueryCallbacks

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -19041,6 +19041,7 @@ void Player::Customize(uint64 guid, uint8 gender, uint8 skin, uint8 face, uint8 
     player_bytes2 |= facialHair;
 
     CharacterDatabase.PExecute("UPDATE characters SET gender = '%u', playerBytes = '%u', playerBytes2 = '%u' WHERE guid = '%u'", gender, skin | (face << 8) | (hairStyle << 16) | (hairColor << 24), player_bytes2, GUID_LOPART(guid));
+    sWorld->ReloadSingleCharacterNameData(GUID_LOPART(guid));
 }
 
 void Player::SendAttackSwingDeadTarget()

--- a/src/server/game/Server/Protocol/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Server/Protocol/Handlers/CharacterHandler.cpp
@@ -1426,6 +1426,8 @@ void WorldSession::HandleCharCustomize(WorldPacket& recv_data)
     data << uint8(hairColor);
     data << uint8(facialHair);
     SendPacket(&data);
+
+    sWorld->ReloadSingleCharacterNameData(GUID_LOPART(guid));
 }
 
 void WorldSession::HandleEquipmentSetSave(WorldPacket &recv_data)

--- a/src/server/game/Server/Protocol/Handlers/QueryHandler.cpp
+++ b/src/server/game/Server/Protocol/Handlers/QueryHandler.cpp
@@ -56,80 +56,40 @@ void WorldSession::SendNameQueryOpcode(Player* p)
     SendPacket(&data);
 }
 
-void WorldSession::SendNameQueryOpcodeFromDB(uint64 guid)
-{
-    QueryResultFuture lFutureResult =
-        CharacterDatabase.AsyncPQuery(
-            !sWorld->getBoolConfig(CONFIG_DECLINED_NAMES_USED) ?
-        //   ------- Query Without Declined Names --------
-        //          0     1     2     3       4
-            "SELECT guid, name, race, gender, class "
-            "FROM characters WHERE guid = '%u'"
-            :
-        //   --------- Query With Declined Names ---------
-        //          0                1     2     3       4
-            "SELECT characters.guid, name, race, gender, class, "
-        //   5         6       7           8             9
-            "genitive, dative, accusative, instrumental, prepositional "
-            "FROM characters LEFT JOIN character_declinedname ON characters.guid = character_declinedname.guid WHERE characters.guid = '%u'",
-            GUID_LOPART(guid)
-        );
-
-    _nameQueryCallbacks.insert(lFutureResult);
-
-// CharacterDatabase.AsyncPQuery(&WorldSession::SendNameQueryOpcodeFromDBCallBack, GetAccountId(),
-}
-
-void WorldSession::SendNameQueryOpcodeFromDBCallBack(QueryResult result)
-{
-    if (!result)
-        return;
-
-    Field* fields = result->Fetch();
-    uint32 guid      = fields[0].GetUInt32();
-    std::string name = fields[1].GetString();
-    uint8 pRace = 0, pGender = 0, pClass = 0;
-    if (name == "")
-        name         = GetTrinityString(LANG_NON_EXIST_CHARACTER);
-    else
-    {
-        pRace        = fields[2].GetUInt8();
-        pGender      = fields[3].GetUInt8();
-        pClass       = fields[4].GetUInt8();
-    }
-                                                            // guess size
-    WorldPacket data(SMSG_NAME_QUERY_RESPONSE, (8+1+1+1+1+1+1+10));
-    data.appendPackGUID(MAKE_NEW_GUID(guid, 0, HIGHGUID_PLAYER));
-    data << uint8(0);                                       // added in 3.1
-    data << name;
-    data << uint8(0);                                       // realm name for cross realm BG usage
-    data << uint8(pRace);                                   // race
-    data << uint8(pGender);                                 // gender
-    data << uint8(pClass);                                  // class
-
-    // if the first declined name field (5) is empty, the rest must be too
-    if (sWorld->getBoolConfig(CONFIG_DECLINED_NAMES_USED) && fields[5].GetString() != "")
-    {
-        data << uint8(1);                                   // is declined
-        for (int i = 5; i < MAX_DECLINED_NAME_CASES+5; ++i)
-            data << fields[i].GetString();
-    }
-    else
-        data << uint8(0);                                   // is not declined
-
-    SendPacket(&data);
-}
-
 void WorldSession::HandleNameQueryOpcode(WorldPacket& recv_data)
 {
     uint64 guid;
 
     recv_data >> guid;
 
+    sLog->outString("HandleNameQueryOpcode %u", guid);
+
     if (Player* pChar = ObjectAccessor::FindPlayer(guid))
         SendNameQueryOpcode(pChar);
     else
-        SendNameQueryOpcodeFromDB(guid);
+    {
+        if (CharacterNameData* cname = sWorld->GetCharacterNameData(guid))
+        {
+            WorldPacket data(SMSG_NAME_QUERY_RESPONSE, 8+1+1+1+1+1+1+10);
+            data.appendPackGUID(guid);
+            data << uint8(0);
+            if (cname->_name == "")
+            {
+                data << std::string(GetTrinityString(LANG_NON_EXIST_CHARACTER));
+                data << uint32(0);
+            }
+            else
+            {
+                data << cname->_name;
+                data << uint8(0);
+                data << uint8(cname->_race);
+                data << uint8(cname->_gender);
+                data << uint8(cname->_class);
+            }
+            data << uint8(0);
+            SendPacket(&data);
+        }
+    }
 }
 
 void WorldSession::HandleQueryTimeOpcode(WorldPacket & /*recv_data*/)

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -984,22 +984,6 @@ void WorldSession::ProcessQueryCallbacks()
 {
     QueryResult result;
 
-    //! HandleNameQueryOpcode
-    while (!_nameQueryCallbacks.is_empty())
-    {
-        QueryResultFuture lResult;
-        ACE_Time_Value timeout = ACE_Time_Value::zero;
-        if (_nameQueryCallbacks.next_readable(lResult, &timeout) != 1)
-           break;
-
-        if (lResult.ready())
-        {
-            lResult.get(result);
-            SendNameQueryOpcodeFromDBCallBack(result);
-            lResult.cancel();
-        }
-    }
-
     //! HandleCharEnumOpcode
     if (_charEnumCallback.ready())
     {

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -279,8 +279,6 @@ class WorldSession
 
         //void SendTestCreatureQueryOpcode(uint32 entry, uint64 guid, uint32 testvalue);
         void SendNameQueryOpcode(Player* p);
-        void SendNameQueryOpcodeFromDB(uint64 guid);
-        void SendNameQueryOpcodeFromDBCallBack(QueryResult result);
 
         void SendTrainerList(uint64 guid);
         void SendTrainerList(uint64 guid, const std::string& strTitle);

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -511,6 +511,14 @@ struct CliCommandHolder
 
 typedef UNORDERED_MAP<uint32, WorldSession*> SessionMap;
 
+struct CharacterNameData
+{
+    std::string _name;
+    uint8 _class;
+    uint8 _race;
+    uint8 _gender;
+};
+
 /// The World
 class World
 {
@@ -729,6 +737,9 @@ class World
 
         bool isEventKillStart;
 
+        CharacterNameData *GetCharacterNameData(uint32 guid);
+        void ReloadSingleCharacterNameData(uint32 guid);
+
         uint32 GetCleaningFlags() const { return m_CleaningFlags; }
         void   SetCleaningFlags(uint32 flags) { m_CleaningFlags = flags; }
     protected:
@@ -816,7 +827,10 @@ class World
 
         std::list<std::string> m_Autobroadcasts;
 
-    private:
+        std::map<uint32, CharacterNameData*> _CharacterNameDataMap;
+        ACE_Thread_Mutex _CharacterNameDataMapMutex;
+        void LoadCharacterNameData();
+
         void ProcessQueryCallbacks();
         ACE_Future_Set<PreparedQueryResult> m_realmCharCallbacks;
 };


### PR DESCRIPTION
Removes ACE_Future_Set and moves all data needed for CMSG_NAME_QUERY to RAM to prevent crash within ACE framework's callback system, should increase speed too.

Solves: #3175, #2136, #1422

Original Author @Kerhong
