### PR TITLE
Crashfix: GetInstanceScript() if target is NULL in achievement_defenseles

### DIFF
--- a/src/server/scripts/Northrend/VioletHold/boss_cyanigosa.cpp
+++ b/src/server/scripts/Northrend/VioletHold/boss_cyanigosa.cpp
@@ -168,6 +168,9 @@ class achievement_defenseless : public AchievementCriteriaScript
 
         bool OnCheck(Player* /*player*/, Unit* target)
         {
+            if(!target)
+                return false;
+
             InstanceScript* instance = target->GetInstanceScript();
             if (!instance)
                 return false;


### PR DESCRIPTION
Crashfix: GetInstanceScript() if target is NULL in achievement_defenseless
