### PR TITLE
Core/Entity: correct args for ACE_ASSERT

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -436,7 +436,7 @@ ChatCommand* ChatHandler::getCommandTable()
             // cache top-level commands
             commandTableCache = (ChatCommand*)malloc(sizeof(ChatCommand) * total);
             memset(commandTableCache, 0, sizeof(ChatCommand) * total);
-            ACE_ASSERT(commandTableCache);
+            ASSERT(commandTableCache);
             size_t added = appendCommandTable(commandTableCache, commandTable);
             for (std::vector<ChatCommand*>::const_iterator it = dynamic.begin(); it != dynamic.end(); ++it)
                 added += appendCommandTable(commandTableCache + added, *it);

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -484,7 +484,8 @@ int WorldSocket::handle_input_header (void)
 {
     ACE_ASSERT (m_RecvWPct == NULL);
 
-    ACE_ASSERT (m_Header.length() == sizeof(ClientPktHeader));
+    size_t headerLen = m_Header.length(); size_t clientPktHeaderLen = sizeof(ClientPktHeader);
+    ACE_ASSERT (headerLen == clientPktHeaderLen);
 
     m_Crypt.DecryptRecv ((uint8*) m_Header.rd_ptr(), sizeof(ClientPktHeader));
 
@@ -517,7 +518,8 @@ int WorldSocket::handle_input_header (void)
     }
     else
     {
-        ACE_ASSERT(m_RecvPct.space() == 0);
+        size_t recvPctSp = m_RecvPct.space();
+        ACE_ASSERT(recvPctSp == 0);
     }
 
     return 0;
@@ -528,8 +530,10 @@ int WorldSocket::handle_input_payload (void)
     // set errno properly here on error !!!
     // now have a header and payload
 
-    ACE_ASSERT (m_RecvPct.space() == 0);
-    ACE_ASSERT (m_Header.space() == 0);
+    size_t recvPctSp = m_RecvPct.space();
+    ACE_ASSERT (recvPctSp == 0);
+    size_t headerSp = m_Header.space();
+    ACE_ASSERT (headerSp == 0);
     ACE_ASSERT (m_RecvWPct != NULL);
 
     const int ret = ProcessIncoming (m_RecvWPct);
@@ -584,7 +588,8 @@ int WorldSocket::handle_input_missing_data (void)
             if (m_Header.space() > 0)
             {
                 // Couldn't receive the whole header this time.
-                ACE_ASSERT (message_block.length() == 0);
+                size_t msgBlockLen = message_block.length();
+                ACE_ASSERT (msgBlockLen == 0);
                 errno = EWOULDBLOCK;
                 return -1;
             }
@@ -618,7 +623,8 @@ int WorldSocket::handle_input_missing_data (void)
             if (m_RecvPct.space() > 0)
             {
                 // Couldn't receive the whole data this time.
-                ACE_ASSERT (message_block.length() == 0);
+                size_t msgBlockLen = message_block.length();
+                ACE_ASSERT (msgBlockLen == 0);
                 errno = EWOULDBLOCK;
                 return -1;
             }

--- a/src/server/shared/Debugging/Errors.h
+++ b/src/server/shared/Debugging/Errors.h
@@ -24,9 +24,9 @@
 #include <ace/Stack_Trace.h>
 
 #define WPAssert( assertion ) { if (!(assertion)) { ACE_Stack_Trace st; sLog->outError( "\n%s:%i in %s ASSERTION FAILED:\n  %s\n%s\n", __FILE__, __LINE__, __FUNCTION__,  #assertion, st.c_str()); assert( #assertion &&0 ); ((void(*)())NULL)();} }
-#define WPError( assertion, errmsg ) if ( ! (assertion) ) { sLog->outError( "%\n%s:%i in %s ERROR:\n  %s\n", __FILE__, __LINE__, __FUNCTION__, (char *)errmsg ); assert( false ); }
-#define WPWarning( assertion, errmsg ) if ( ! (assertion) ) { sLog->outError( "\n%s:%i in %s WARNING:\n  %s\n", __FILE__, __LINE__, __FUNCTION__, (char *)errmsg ); }
-#define WPFatal( assertion, errmsg ) if ( ! (assertion) ) { sLog->outError( "\n%s:%i in %s FATAL ERROR:\n  %s\n", __FILE__, __LINE__, __FUNCTION__, (char *)errmsg ); assert( #assertion &&0 ); abort(); }
+#define WPError( assertion, errmsg ) if (!(assertion)) { sLog->outError( "%\n%s:%i in %s ERROR:\n  %s\n", __FILE__, __LINE__, __FUNCTION__, (char *)errmsg ); assert( false ); }
+#define WPWarning( assertion, errmsg ) if (!(assertion)) { sLog->outError( "\n%s:%i in %s WARNING:\n  %s\n", __FILE__, __LINE__, __FUNCTION__, (char *)errmsg ); }
+#define WPFatal( assertion, errmsg ) if (!(assertion)) { sLog->outError( "\n%s:%i in %s FATAL ERROR:\n  %s\n", __FILE__, __LINE__, __FUNCTION__, (char *)errmsg ); assert( #assertion &&0 ); abort(); }
 
 #define ASSERT WPAssert
 #endif


### PR DESCRIPTION
*ACE_ASSERT (this->next (retv) != 0);  // BAD CODE!
*It must only be used to check values; it may never be used to wrap a function call, or contain any other side effect. That's because the statement will disappear when ACE_NDEBUG is enabled.
