### PR TITLE
Core/GameObjects: Damage range of DestructibleGameObjects, after intact state.

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1660,7 +1660,7 @@ void GameObject::SendCustomAnim(uint32 anim)
 
 bool GameObject::IsInRange(float x, float y, float z, float radius) const
 {
-    GameObjectDisplayInfoEntry const* info = sGameObjectDisplayInfoStore.LookupEntry(GetUInt32Value(GAMEOBJECT_DISPLAYID));
+    GameObjectDisplayInfoEntry const* info = sGameObjectDisplayInfoStore.LookupEntry(m_goInfo->displayId);
     if (!info)
         return IsWithinDist3d(x, y, z, radius);
 


### PR DESCRIPTION
Correction of displayID for range calculation, because only in intact state, GameObjectDisplayInfo.dbc have the correct data for range.

Some objetcs have data in others states, others no, you can view this on Wintergrasp Towers (of Fortress), perhaps, most convenient one would be that, if no data in advanced stages of destruction, call the previous data.
