### PR TITLE
Scripts/ICC: Fix Lord Marrowgar Bone Storm

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -564,14 +564,19 @@ class spell_marrowgar_bone_storm : public SpellScriptLoader
         {
             PrepareSpellScript(spell_marrowgar_bone_storm_SpellScript);
 
-            void RecalculateDamage(SpellEffIndex /*effIndex*/)
+            void RecalculateDamage()
             {
-                SetHitDamage(int32(GetHitDamage() / sqrtf(logf(GetHitUnit()->GetExactDist2d(GetCaster())))));
+                if (Unit* caster = GetCaster())
+                {
+                    const float distance = GetHitUnit()->GetExactDist2d(caster);
+                    const int32 damage   = GetHitDamage();
+                    SetHitDamage(int32(damage - (damage * distance / (distance + caster->GetObjectSize() / 2))));
+                }
             }
 
             void Register()
             {
-                OnEffectHitTarget += SpellEffectFn(spell_marrowgar_bone_storm_SpellScript::RecalculateDamage, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+                OnHit += SpellHitFn(spell_marrowgar_bone_storm_SpellScript::RecalculateDamage);
             }
         };
 


### PR DESCRIPTION
- Fix Bone Storm not doing any damage when target is too close to the boss;
- Fix crash from division by zero when distance from the boss is exactly 1.0;
- New damage reduction from distance formula that acts more like described in WoWWiki;
- Fix Bone Storm not reducing damage with distance after commit e949ad3adbfe22c11ec4d731b0fcfb9cc284f064.
