### PR TITLE
Spells: Fix Warriors' Bloodthirst

### DIFF
--- a/sql/updates/world/2011_10_06_01_world_spell_linked_spell.sql
+++ b/sql/updates/world/2011_10_06_01_world_spell_linked_spell.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 23881;
+INSERT INTO `spell_linked_spell` VALUES (23881, 23885, 0, 'Bloodthirst');

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1282,15 +1282,6 @@ void Spell::EffectDummy(SpellEffIndex effIndex)
                 m_damage += CalculatePctF(damage, m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
                 return;
             }
-            switch (m_spellInfo->Id)
-            {
-                // Bloodthirst
-                case 23881:
-                {
-                    m_caster->CastCustomSpell(unitTarget, 23885, &damage, NULL, NULL, true, NULL);
-                    return;
-                }
-            }
             break;
         case SPELLFAMILY_WARLOCK:
             // Life Tap


### PR DESCRIPTION
Cleanup hacky and broken Bloodthirst trigger -- in wrong place and with wrong target -- and move it to DB where it belongs.
