### PR TITLE
Spells: Fix Warriors' Bloodthirst

### DIFF
--- a/sql/updates/world/2011_10_06_01_world_spell_linked_spell.sql
+++ b/sql/updates/world/2011_10_06_01_world_spell_linked_spell.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 23881;
+INSERT INTO `spell_linked_spell` VALUES (23881, 55970, 0, 'Bloodthirst');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8845,12 +8845,6 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
                 CastSpell(this, 70721, true);
             break;
         }
-        // Bloodthirst (($m/100)% of max health)
-        case 23880:
-        {
-            basepoints0 = int32(CountPctFromMaxHealth(triggerAmount));
-            break;
-        }
         // Shamanistic Rage triggered spell
         case 30824:
         {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1282,15 +1282,6 @@ void Spell::EffectDummy(SpellEffIndex effIndex)
                 m_damage += CalculatePctF(damage, m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
                 return;
             }
-            switch (m_spellInfo->Id)
-            {
-                // Bloodthirst
-                case 23881:
-                {
-                    m_caster->CastCustomSpell(unitTarget, 23885, &damage, NULL, NULL, true, NULL);
-                    return;
-                }
-            }
             break;
         case SPELLFAMILY_WARLOCK:
             // Life Tap


### PR DESCRIPTION
Cleanup hacky and broken Bloodthirst trigger -- in wrong place and with wrong target -- and move it to DB where it belongs.

Also fix Bloodthirst ability to have a crit chance on its heal effect, thanks Chaplain for that.
