### PR TITLE
Spells: Fix Warriors' Bloodthirst

### DIFF
--- a/sql/updates/world/2011_10_07_01_world_misc.sql
+++ b/sql/updates/world/2011_10_07_01_world_misc.sql
@@ -1,0 +1,9 @@
+-- 23881 Bloodthirst (damage spell)
+-- 23885 Bloodthirst (buff)
+-- 23880 Bloodthirst (triggered heal)
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 23881;
+INSERT INTO `spell_linked_spell` VALUES (23881, 23885, 0, 'Bloodthirst');
+
+DELETE FROM `spell_bonus_data` WHERE `entry` = 23880;
+INSERT INTO `spell_bonus_data` VALUES (23880, 0, -1, -1, -1, 'Bloodthirst');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8845,12 +8845,6 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
                 CastSpell(this, 70721, true);
             break;
         }
-        // Bloodthirst (($m/100)% of max health)
-        case 23880:
-        {
-            basepoints0 = int32(CountPctFromMaxHealth(triggerAmount));
-            break;
-        }
         // Shamanistic Rage triggered spell
         case 30824:
         {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1282,15 +1282,6 @@ void Spell::EffectDummy(SpellEffIndex effIndex)
                 m_damage += CalculatePctF(damage, m_caster->GetTotalAttackPowerValue(BASE_ATTACK));
                 return;
             }
-            switch (m_spellInfo->Id)
-            {
-                // Bloodthirst
-                case 23881:
-                {
-                    m_caster->CastCustomSpell(unitTarget, 23885, &damage, NULL, NULL, true, NULL);
-                    return;
-                }
-            }
             break;
         case SPELLFAMILY_WARLOCK:
             // Life Tap

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2921,6 +2921,14 @@ void SpellMgr::LoadDbcDataCorrections()
 
         switch (spellInfo->Id)
         {
+            case 23880: // Bloodthirst
+                spellInfo->Effect[EFFECT_0] = SPELL_EFFECT_HEAL_PCT;
+                spellInfo->EffectBasePoints[EFFECT_0] = 0; // 1%
+                // make it capable of crit as magic effect using spell crit chance
+                spellInfo->AttributesEx2 &= ~SPELL_ATTR2_CANT_CRIT;
+                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+                spellInfo->SchoolMask = SPELL_SCHOOL_MASK_HOLY;
+                break;
             case 42835: // Spout
                 spellInfo->Effect[0] = 0; // remove damage effect, only anim is needed
                 break;


### PR DESCRIPTION
- Cleanup hacky and malfunctioning hardcoded triggers and formulas
- Move the trigger to DB where it belongs
- Change DBC data to correspond the correct WoTLK behaviour
