### PR TITLE
Fix Bloodthirst

### DIFF
--- a/sql/updates/world/2011_10_08_01_world_misc.sql
+++ b/sql/updates/world/2011_10_08_01_world_misc.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 23881;
+DELETE FROM `spell_bonus_data` WHERE `entry` = 23880;
+INSERT INTO `spell_bonus_data` VALUES (23880, 0, -1, -1, -1, 'Bloodthirst');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8846,12 +8846,6 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
                 CastSpell(this, 70721, true);
             break;
         }
-        // Bloodthirst (($m/100)% of max health)
-        case 23880:
-        {
-            basepoints0 = int32(CountPctFromMaxHealth(triggerAmount));
-            break;
-        }
         // Shamanistic Rage triggered spell
         case 30824:
         {

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2921,6 +2921,20 @@ void SpellMgr::LoadDbcDataCorrections()
 
         switch (spellInfo->Id)
         {
+            case 23880: // Bloodthirst
+                spellInfo->Effect[EFFECT_0] = SPELL_EFFECT_HEAL_PCT;
+                spellInfo->EffectBasePoints[EFFECT_0] = 0; // default to 1%
+                // make it capable of crit as magic effect using spell crit chance
+                spellInfo->AttributesEx2 &= ~SPELL_ATTR2_CANT_CRIT;
+                spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+                spellInfo->SchoolMask = SPELL_SCHOOL_MASK_HOLY;
+                break;
+            case 23881: // Bloodthirst
+                spellInfo->EffectImplicitTargetA[EFFECT_1] = TARGET_UNIT_CASTER;
+                break;
+            case 23885: // Bloodthirst
+                spellInfo->EffectApplyAuraName[EFFECT_0] = SPELL_AURA_PROC_TRIGGER_SPELL_WITH_VALUE;
+                break;
             case 42835: // Spout
                 spellInfo->Effect[0] = 0; // remove damage effect, only anim is needed
                 break;


### PR DESCRIPTION
Adjust DBC data so we no more need a hardcoded formula
Fix healing effect ability to crit as healing spell
Fix Bloodthirst buff recently not working due missing target information
Fix Glyph of Bloodthirst

Closes: #3359 #3414
