### PR TITLE
Scripts/ICC: Crash fix. Avoid a division by zero.

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -975,7 +975,7 @@ class spell_sindragosa_s_fury : public SpellScriptLoader
                 uint32 minResistFactor = uint32((resistance / (resistance + 510.0f))* 10.0f) * 2;
                 uint32 randomResist = urand(0, (9 - minResistFactor) * 100)/100 + minResistFactor;
 
-                uint32 damage = (uint32(GetEffectValue()/_targetCount) * randomResist) / 10;
+                uint32 damage = (_targetCount > 0) ? ((uint32(GetEffectValue()/_targetCount) * randomResist) / 10) : 0;
 
                 SpellNonMeleeDamage damageInfo(GetCaster(), GetHitUnit(), GetSpellInfo()->Id, GetSpellInfo()->SchoolMask);
                 damageInfo.damage = damage;


### PR DESCRIPTION
Based on this crash log: http://paste2.org/p/1698874
