### PR TITLE
Scripts/ICC: Fix Shadow Prison

### DIFF
--- a/sql/updates/characters/2011_10_09_00_characters_character_aura.sql
+++ b/sql/updates/characters/2011_10_09_00_characters_character_aura.sql
@@ -1,0 +1,1 @@
+DELETE FROM `character_aura` WHERE `spell` = 73001;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -241,23 +241,7 @@ class boss_blood_council_controller : public CreatureScript
                 }
 
                 if (IsHeroic())
-                {
-                    Map::PlayerList const &PlList = me->GetMap()->GetPlayers();
-                    if (PlList.isEmpty())
-                        return;
-
-                    for (Map::PlayerList::const_iterator i = PlList.begin(); i != PlList.end(); ++i)
-                    {
-                        if (Player* player = i->getSource())
-                        {
-                            if (player->isGameMaster())
-                                continue;
-
-                            if (player->isAlive())
-                                player->AddAura(SPELL_SHADOW_PRISON_DUMMY, player);
-                        }
-                    }
-                }
+                    me->AddAura(SPELL_SHADOW_PRISON_DUMMY, me);
             }
 
             void SetData(uint32 /*type*/, uint32 data)
@@ -297,8 +281,6 @@ class boss_blood_council_controller : public CreatureScript
                         killer->Kill(prince);
                     }
                 }
-
-                instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_SHADOW_PRISON_DUMMY);
             }
 
             void UpdateAI(uint32 const diff)


### PR DESCRIPTION
Fix Shadow Prison implementation, the control aura should not be cast on players.
Fix Shadow Prison aura remaining on players if they leave the instance during the encounter,
causing them to kill all nearby moving enemies including inside battlegrounds.
