### PR TITLE
Fix Elemental Oath

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -903,26 +903,6 @@ void AuraEffect::CalculateSpellMod()
                 default:
                     break;
             }
-        case SPELL_AURA_MOD_SPELL_CRIT_CHANCE:
-            switch (GetId())
-            {
-                case 51466: // Elemental oath
-                case 51470: // Elemental oath
-                    // "while Clearcasting from Elemental Focus is active, you deal 5%/10% more spell damage."
-                    if (!m_spellmod)
-                    {
-                        m_spellmod = new SpellModifier(GetBase());
-                        m_spellmod->op = SPELLMOD_EFFECT2;
-                        m_spellmod->type = SPELLMOD_FLAT;
-                        m_spellmod->spellId = GetId();
-                        m_spellmod->mask[1] = 0x0004000;
-                    }
-                    m_spellmod->value = GetBase()->GetUnitOwner()->CalculateSpellDamage(GetBase()->GetUnitOwner(), GetSpellInfo(), 1);
-                    break;
-                default:
-                    break;
-            }
-            break;
         case SPELL_AURA_ADD_FLAT_MODIFIER:
         case SPELL_AURA_ADD_PCT_MODIFIER:
             if (!m_spellmod)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3090,6 +3090,13 @@ void SpellMgr::LoadDbcDataCorrections()
             case 48422:
                 spellInfo->Stances = 1 << (FORM_TREE - 1);
                 break;
+            case 51466: // Elemental Oath (Rank 1)
+            case 51470: // Elemental Oath (Rank 2)
+                spellInfo->Effect[EFFECT_1] = SPELL_EFFECT_APPLY_AURA;
+                spellInfo->EffectApplyAuraName[EFFECT_1] = SPELL_AURA_ADD_FLAT_MODIFIER;
+                spellInfo->EffectMiscValue[EFFECT_1] = SPELLMOD_EFFECT2;
+                spellInfo->EffectSpellClassMask[EFFECT_1] = flag96(0x00000000, 0x00004000, 0x00000000);
+                break;
             case 47569: // Improved Shadowform (Rank 1)
                 // with this spell atrribute aura can be stacked several times
                 spellInfo->Attributes &= ~SPELL_ATTR0_NOT_SHAPESHIFT;


### PR DESCRIPTION
Remove hacky implementation of Elemental Oath
Properly fix it by correcting DBC data
Fix Clearcasting from Elemental Oath damage bonus being displayed twice in Spell ToolTips by damage Addons like DrDamage (displaying 10.25% instead of 5%, 21% instead of 10%)
