### PR TITLE
Scripts/ICC: Fix Professor Putricide's Slime Puddle growth

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3266,6 +3266,9 @@ void SpellMgr::LoadDbcDataCorrections()
             case 70460: // Coldflame Jets (Traps after Saurfang)
                 spellInfo->DurationIndex = 1;   // 10 seconds
                 break;
+            case 70347: // Slime Puddle Grow Stack (Professor Putricide)
+                spellInfo->EffectBasePoints[EFFECT_0] = 9; // 10% instead of 20%
+                break;
             case 71413: // Green Ooze Summon (Professor Putricide)
             case 71414: // Orange Ooze Summon (Professor Putricide)
                 spellInfo->EffectImplicitTargetA[0] = TARGET_DEST_DEST;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -825,12 +825,12 @@ class spell_putricide_slime_puddle : public SpellScriptLoader
                 PreventDefaultAction();
                 if (Unit* caster = GetCaster())
                 {
-                    int32 radiusMod = 4;
+                    int32 radiusMod = 400;
                     if (Aura* size = caster->GetAura(70347))
-                        radiusMod += size->GetStackAmount();
+                        radiusMod += size->GetStackAmount() * 50;
 
                     uint32 triggerSpellId = GetSpellInfo()->Effects[aurEff->GetEffIndex()].TriggerSpell;
-                    caster->CastCustomSpell(triggerSpellId, SPELLVALUE_RADIUS_MOD, radiusMod * 100, caster, true);
+                    caster->CastCustomSpell(triggerSpellId, SPELLVALUE_RADIUS_MOD, radiusMod, caster, true);
                 }
             }
 


### PR DESCRIPTION
Fix Slime Puddle growing way too fast and way too big compared to retail.

I made some videos of it growing and compared to many Professor Putricide strategy videos from Youtube, the TrinityCore Slime Puddle was growing way too fast and reaching impressive sizes making third phase almost impossible, specially for PUGs. Now it seems correct and third phase is a bit more confortable.
