### PR TITLE
Scripts/ICC: Fix Prince Keleseth encounter

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -419,8 +419,23 @@ class boss_prince_keleseth_icc : public CreatureScript
                     DoZoneInCombat(controller);
 
                 events.ScheduleEvent(EVENT_BERSERK, 600000);
-                events.ScheduleEvent(EVENT_SHADOW_RESONANCE, urand(10000, 15000));
+                events.ScheduleEvent(EVENT_SHADOW_RESONANCE, 1000);
                 events.ScheduleEvent(EVENT_SHADOW_LANCE, 2000);
+            }
+
+            void AttackStart(Unit* who)
+            {
+                if (!who)
+                    return;
+
+                if (me->Attack(who, true))
+                {
+                    me->SetInCombatWith(who);
+                    who->SetInCombatWith(me);
+
+                    DoStartMovement(who, 20.0f);
+                    SetCombatMovement(true);
+                }
             }
 
             void JustDied(Unit* /*killer*/)
@@ -566,7 +581,7 @@ class boss_prince_keleseth_icc : public CreatureScript
                         case EVENT_SHADOW_RESONANCE:
                             Talk(SAY_KELESETH_SPECIAL);
                             DoCast(me, SPELL_SHADOW_RESONANCE);
-                            events.ScheduleEvent(EVENT_SHADOW_RESONANCE, urand(10000, 15000));
+                            events.ScheduleEvent(EVENT_SHADOW_RESONANCE, urand(10000, 12000));
                             break;
                         case EVENT_SHADOW_LANCE:
                             if (_isEmpowered)


### PR DESCRIPTION
Prince Keleseth should summon the first Dark Nucleus right after being pulled. This is crucial for the enconter, or the tanker won't hold much longer or be ready when Prince Keleseth get empowered.
The interval between Dark Nucleus summons can't be that long eigher.
Prince Keleseth should also keep a 20 yards distance from the tanker, unless the player decides to get closer.
