### PR TITLE
Fix Divine Storm

### DIFF
--- a/sql/updates/world/2011_10_11_01_world_spell_script_names.sql
+++ b/sql/updates/world/2011_10_11_01_world_spell_script_names.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 53385;
+INSERT INTO `spell_script_names` VALUES (53385, 'spell_pal_divine_storm');

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1125,9 +1125,13 @@ void Spell::EffectDummy(SpellEffIndex effIndex)
                         return;
                     m_caster->CastCustomSpell(unitTarget, 52752, &damage, NULL, NULL, true);
                     return;
-                case 54171:                                   //Divine Storm
+                case 54171:                                 // Divine Storm
                 {
-                    m_caster->CastCustomSpell(unitTarget, 54172, &damage, 0, 0, true);
+                    if (m_UniqueTargetInfo.size())
+                    {
+                        int32 heal = damage / m_UniqueTargetInfo.size();
+                        m_caster->CastCustomSpell(unitTarget, 54172, &heal, NULL, NULL, true);
+                    }
                     return;
                 }
                 case 58418:                                 // Portal to Orgrimmar
@@ -1354,16 +1358,6 @@ void Spell::EffectDummy(SpellEffIndex effIndex)
             }
             break;
         case SPELLFAMILY_PALADIN:
-            // Divine Storm
-            if (m_spellInfo->SpellFamilyFlags[1] & SPELLFAMILYFLAG1_PALADIN_DIVINESTORM && effIndex == 1)
-            {
-                int32 dmg = CalculatePctN(m_damage, damage);
-                if (!unitTarget)
-                    unitTarget = m_caster;
-                m_caster->CastCustomSpell(unitTarget, 54171, &dmg, 0, 0, true);
-                return;
-            }
-
             switch (m_spellInfo->Id)
             {
                 case 31789:                                 // Righteous Defense (step 1)

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -37,6 +37,10 @@ enum PaladinSpells
     SPELL_BLESSING_OF_LOWER_CITY_PALADIN         = 37879,
     SPELL_BLESSING_OF_LOWER_CITY_PRIEST          = 37880,
     SPELL_BLESSING_OF_LOWER_CITY_SHAMAN          = 37881,
+
+    SPELL_DIVINE_STORM                           = 53385,
+    SPELL_DIVINE_STORM_DUMMY                     = 54171,
+    SPELL_DIVINE_STORM_HEAL                      = 54172,
 };
 
 // 31850 - Ardent Defender
@@ -327,6 +331,40 @@ public:
     }
 };
 
+class spell_pal_divine_storm : public SpellScriptLoader
+{
+public:
+    spell_pal_divine_storm() : SpellScriptLoader("spell_pal_divine_storm") { }
+
+    class spell_pal_divine_storm_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_pal_divine_storm_SpellScript);
+
+        uint32 healPct;
+
+        bool Load()
+        {
+            healPct = GetSpellInfo()->Effects[EFFECT_1].CalcValue(GetCaster());
+            return true;
+        }
+
+        void TriggerHeal()
+        {
+            GetCaster()->CastCustomSpell(SPELL_DIVINE_STORM_DUMMY, SPELLVALUE_BASE_POINT0, (GetHitDamage() * healPct) / 100, GetCaster(), true);
+        }
+
+        void Register()
+        {
+            AfterHit += SpellHitFn(spell_pal_divine_storm_SpellScript::TriggerHeal);
+        }
+    };
+
+    SpellScript* GetSpellScript() const
+    {
+        return new spell_pal_divine_storm_SpellScript();
+    }
+};
+
 void AddSC_paladin_spell_scripts()
 {
     new spell_pal_ardent_defender();
@@ -335,4 +373,5 @@ void AddSC_paladin_spell_scripts()
     new spell_pal_guarded_by_the_light();
     new spell_pal_holy_shock();
     new spell_pal_judgement_of_command();
+    new spell_pal_divine_storm();
 }


### PR DESCRIPTION
Fix healing part of Divine Storm, will now work as intented healing up to 3 party or raid members for a total of 25% (or 40% with Glyph) of the damage caused.

Closes #285
