### PR TITLE
Scripts/BT: Typo fix

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
@@ -1413,7 +1413,7 @@ public:
 
                     for (uint8 i = 0; i < 2; ++i)
 
-                        Instance->HandleGameObject(DoorGUID[i], false);
+                        instance->HandleGameObject(DoorGUID[i], false);
                     // JustCreated = false;
                 }else
                 { // open all doors, raid wiped


### PR DESCRIPTION
Fix for typo in the Illidan script introduced in c7251a2b3952389da3a78ad1d1be72fe11f55923
