### PR TITLE
Icecrown Citadel/Lady Deathwhisper - DaD

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -438,7 +438,7 @@ class boss_lady_deathwhisper : public CreatureScript
                         case EVENT_DEATH_AND_DECAY:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM))
                                 DoCast(target, SPELL_DEATH_AND_DECAY);
-                            events.ScheduleEvent(EVENT_DEATH_AND_DECAY, urand(10000, 12000));
+                            events.ScheduleEvent(EVENT_DEATH_AND_DECAY, urand(20000, 22000));
                             break;
                         case EVENT_DOMINATE_MIND_H:
                             Talk(SAY_DOMINATE_MIND);


### PR DESCRIPTION
*Lady Deathwhisper should not cast DaD so often

Lady Deathwhisper should cast DaD with ~21s from each other. Now her first DaD disappear and she instantly cast new.

Can watch this: http://www.youtube.com/watch?v=JXTE2VJSJS0 for example.
