### PR TITLE
Core/Mechanic: Fixed spell penetration from items

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1584,10 +1584,10 @@ void Unit::CalcAbsorbResist(Unit* victim, SpellSchoolMask schoolMask, DamageEffe
     if ((schoolMask & SPELL_SCHOOL_MASK_NORMAL) == 0)
     {
         float baseVictimResistance = float(victim->GetResistance(GetFirstSchoolInMask(schoolMask)));
-        float ignoredResistance = float(GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_TARGET_RESISTANCE, schoolMask));
+        float ignoredResistance = -float(GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_TARGET_RESISTANCE, schoolMask));
         if (Player* player = ToPlayer())
             ignoredResistance += float(player->GetSpellPenetrationItemMod());
-        float victimResistance = baseVictimResistance + ignoredResistance;
+        float victimResistance = baseVictimResistance - ignoredResistance;
 
         static const uint32 BOSS_LEVEL = 83;
         static const float BOSS_RESISTANCE_CONSTANT = 510.0;


### PR DESCRIPTION
Okay I have to explain myself a bit on this one.

The spell penetration granted by items that have it as a stat bonus (not a spell) is a positive value. Gems, as well as enchants, however, are applying auras SPELL_AURA_MOD_TARGET_RESISTANCE and NONE of them in the DBCs have a POSITIVE value.

Okay, now this is going to get a lot theorical.

You target has 120 frost resistance. As a frost mage, you obviously gemmed spell penetration, so, say you have one +25 spell pen gem. That makes you have a SPELL_AURA_MOD_TARGET_RESISTANCE with value = -25.

Computation from the old source: 
float ignoredResistance = float(GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_TARGET_RESISTANCE, schoolMask));
=> ignoredResistance = -25
Your m_spellPenetrationItemMod = 0 since you don't have any item that gives spell pen.
That means that the target's resistance used in computations is 120 + (-25). This is obviously correct.

Now, say you buy the S6 wand that grants 43 spell penetration and keep your +25 spell pen gem. The m_spellPenetrationItemMod then equals +43. Computations lead to:
float ignoredResistance = float(GetTotalAuraModifierByMiscMask(SPELL_AURA_MOD_TARGET_RESISTANCE, schoolMask));
ignoredResistance => -25

ignoredResistance += float(player->GetSpellPenetrationItemMod());
ignoredResistance = -25 + (+43) = 18
As a consequence, the resistance used in computations is now of 120+18. The target gained resistance. HAXX !

This could have been fixed in two different ways:
- fixing the sign of m_spellPenetrationItemMod when changing it, but I felt that this would not be logical.
- Fixing it the way I did.

I'm available on IRC for further informations.
