### PR TITLE
Disable until fixed: Bug abuse spells

### DIFF
--- a/sql/updates/world/2011_10_15_01_world_disables.sql
+++ b/sql/updates/world/2011_10_15_01_world_disables.sql
@@ -1,0 +1,5 @@
+
+DELETE FROM `disables` WHERE `sourceType` = 0 AND `entry` IN (23397, 23398);
+INSERT INTO `disables` VALUES
+    (0, 23397, 3, '', '', 'CURRENTLY A SOURCE OF BUG ABUSE - Allows Warriors to stack Berserker Stance passive auras indefinitely and for use in all stances'),
+    (0, 23398, 3, '', '', 'CURRENTLY A SOURCE OF BUG ABUSE - Allows Druids to stack Cat Form passive auras indefinitely and for use in all stances');


### PR DESCRIPTION
Those spells are cast by the boss Nefarian, in Blackrock Spire. They force the nearby players to shapeshift into a given form/stance with the Boss as caster, causing them to gain the talent passive auras related to that stance having the Boss as caster aswell.
This causes those passive auras to not be removed when the effect fades, making them stack once more every time the spell is cast. A Druid can stack a lot of talent effects increasing his damages to millions.
Couldn't figure any solution by now, but its too problematic to be allowed. Luckly those are the only spells of this kind, and they are not essential so they should be disabled until fixed.
