### PR TITLE
Fix target level at resist chance calculation

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1595,7 +1595,7 @@ void Unit::CalcAbsorbResist(Unit* victim, SpellSchoolMask schoolMask, DamageEffe
 
         static uint32 const BOSS_LEVEL = 83;
         static float const BOSS_RESISTANCE_CONSTANT = 510.0f;
-        uint32 level = getLevel();
+        uint32 level = victim->getLevel();
         float resistanceConstant = 0.0f;
 
         if (level == BOSS_LEVEL)


### PR DESCRIPTION
I believe that even after the changes from the last commit, there is still a bug left in the code. My suggestion is to change the level used to determine a constant for the resist chance calculation to the level of the target- instead of using the caster level.
