### PR TITLE
[Core] Fix the correct exit from the dungeon finder queue.

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -292,6 +292,7 @@ class LFGMgr
         LfgState GetState(uint64 guid);
         const LfgDungeonSet& GetSelectedDungeons(uint64 guid);
         uint32 GetDungeon(uint64 guid, bool asId = true);
+        void SetState(uint64 guid, LfgState state);
         void ClearState(uint64 guid);
         void RemovePlayerData(uint64 guid);
         void RemoveGroupData(uint64 guid);
@@ -304,7 +305,6 @@ class LFGMgr
         uint8 GetRoles(uint64 guid);
         const std::string& GetComment(uint64 gguid);
         void RestoreState(uint64 guid);
-        void SetState(uint64 guid, LfgState state);
         void SetDungeon(uint64 guid, uint32 dungeon);
         void SetSelectedDungeons(uint64 guid, const LfgDungeonSet& dungeons);
         void SetLockedDungeons(uint64 guid, const LfgLockMap& lock);

--- a/src/server/game/DungeonFinding/LFGScripts.cpp
+++ b/src/server/game/DungeonFinding/LFGScripts.cpp
@@ -82,6 +82,7 @@ void LFGScripts::OnRemoveMember(Group* group, uint64 guid, RemoveMethod method, 
     }
 
     sLFGMgr->ClearState(guid);
+    sLFGMgr->SetState(guid, LFG_STATE_NONE);
     if (Player* plr = ObjectAccessor::FindPlayer(guid))
     {
         /*


### PR DESCRIPTION
This change will fix the issue https://github.com/TrinityCore/TrinityCore/issues/3481 because sLFGMgr->ClearState(guid); only restore the previous dungeon finder's state and not set the state to LFG_STATE_NONE.
