### PR TITLE
[Core/Spell] Fix the Cannibalize's target selection.

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -175,7 +175,9 @@ class CannibalizeClassCheck
             WorldObject* target = object;
             if (Corpse* pCorpse = target->ToCorpse())
                 target = ObjectAccessor::FindPlayer(pCorpse->GetOwnerGUID());
-            else return true; // to avoid some crashes
+
+            if (!target)
+                return true; // to avoid some crashes
 
             if (target->GetTypeId() == TYPEID_PLAYER)
                 return false;

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -172,13 +172,14 @@ class CannibalizeClassCheck
     public:
         bool operator() (WorldObject* object)
         {
-            WorldObject *target = object;
-            if (Corpse *pCorpse = target->ToCorpse())
+            WorldObject* target = object;
+            if (Corpse* pCorpse = target->ToCorpse())
                 target = ObjectAccessor::FindPlayer(pCorpse->GetOwnerGUID());
+            else return true; // to avoid some crashes
 
             if (target->GetTypeId() == TYPEID_PLAYER)
                 return false;
-            else if (Creature *cTarget = target->ToCreature())
+            else if (Creature* cTarget = target->ToCreature())
                 if (cTarget->GetCreatureType()==CREATURE_TYPE_UNDEAD || cTarget->GetCreatureType()==CREATURE_TYPE_HUMANOID)
                     return false;
 


### PR DESCRIPTION
With this fix the Cannibalize's script will check if the target is an humanoid or an undead.
This change will fix this issue: https://github.com/TrinityCore/TrinityCore/issues/3591
