### PR TITLE
Core/Spells: Misery talent should be activated by Mind Flay

### DIFF
--- a/sql/updates/world/2011_10_24_00_world_spell_proc_event.sql
+++ b/sql/updates/world/2011_10_24_00_world_spell_proc_event.sql
@@ -1,0 +1,1 @@
+UPDATE `spell_proc_event` SET `SpellFamilyMask2`=64 WHERE `entry`=33193;


### PR DESCRIPTION
Priest's Misery talent should be activated (and refreshed) by Mind Flay as per:
http://www.wowwiki.com/Misery

also reported here:
https://github.com/TrinityCore/TrinityCore/issues/3565
