### PR TITLE
[Core/Boss] Fix the HP sharing of Twin Valkyr.

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -276,6 +276,18 @@ struct boss_twin_baseAI : public ScriptedAI
         return Unit::GetCreature((*me), m_instance->GetData64(m_uiSisterNpcId));
     }
 
+    //From wowpedia: For the Twin Val'kyr, Fjola and Edyis both die at the same time (they share hp)
+    void DamageTaken(Unit* who, uint32& uiDamage)
+    {
+        if (who != me) //Redundant check
+            if (Creature* pSister = GetSister())
+            {
+                uiDamage /= 2; //Half damage to first sister...
+                pSister->DealDamage(pSister, uiDamage); //... and half damage to second sister
+                pSister->LowerPlayerDamageReq(uiDamage); //Count toward damage done by players
+            }
+    }
+
     void EnterCombat(Unit* /*who*/)
     {
         me->SetInCombatWithZone();


### PR DESCRIPTION
The Twin Valkyr must share HP. This commit fixes this issue: https://github.com/TrinityCore/TrinityCore/issues/3642
