### PR TITLE
Don't send StartTravel with MoveJump. Fixes client display of jumping eff

### DIFF
--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -58,7 +58,7 @@ bool PointMovementGenerator<T>::Update(T &unit, const uint32 diff)
         arrived = true;
         return false;
     }
-    else if (!unit.HasUnitState(UNIT_STAT_MOVE))
+    else if (!unit.HasUnitState(UNIT_STAT_MOVE) && !unit.HasUnitState(UNIT_STAT_JUMPING))
     {
         i_destinationHolder.StartTravel(traveller);
     }


### PR DESCRIPTION
Don't send StartTravel with MoveJump. Fixes client display of jumping effects.
Was broken with https://github.com/TrinityCore/TrinityCore/commit/04bb2f4a1707b57d5b5d5af3910ffb690cd8117d, should now work again.
