### PR TITLE
Achievement: "Snakes. Why'd It Have To Be Snakes?"

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_slad_ran.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_slad_ran.cpp
@@ -92,8 +92,7 @@ public:
 
         uint8 uiPhase;
 
-        bool snakesAchievement;
-
+        std::set<uint64> lWrappedPlayers;
         SummonList lSummons;
 
         InstanceScript* instance;
@@ -105,7 +104,7 @@ public:
             uiVenomBoltTimer = 15*IN_MILLISECONDS;
             uiSpawnTimer = 5*IN_MILLISECONDS;
             uiPhase = 0;
-            snakesAchievement = true;
+            lWrappedPlayers.clear();
 
             lSummons.DespawnAll();
 
@@ -194,18 +193,15 @@ public:
             lSummons.Summon(summoned);
         }
 
-        void SetData(uint32 type, uint32 /*data*/)
+        void SetGUID(uint64 guid, int32 type)
         {
             if (type == DATA_SNAKES_WHYD_IT_HAVE_TO_BE_SNAKES)
-                snakesAchievement = false;
+                lWrappedPlayers.insert(guid);
         }
 
-        uint32 GetData(uint32 type)
+        bool WasWrapped(uint64 guid)
         {
-            if (type == DATA_SNAKES_WHYD_IT_HAVE_TO_BE_SNAKES)
-                return snakesAchievement ? 1 : 0;
-
-            return 0;
+            return lWrappedPlayers.count(guid);
         }
     };
 
@@ -252,7 +248,7 @@ public:
 
                     if (TempSummon* _me = me->ToTempSummon())
                         if (Creature* sladran = _me->GetSummoner()->ToCreature())
-                            sladran->AI()->SetData(DATA_SNAKES_WHYD_IT_HAVE_TO_BE_SNAKES, 0);
+                            sladran->AI()->SetGUID(target->GetGUID() ,DATA_SNAKES_WHYD_IT_HAVE_TO_BE_SNAKES);
 
                     me->DespawnOrUnsummon();
                 }
@@ -309,15 +305,13 @@ class achievement_snakes_whyd_it_have_to_be_snakes : public AchievementCriteriaS
         {
         }
 
-        bool OnCheck(Player* /*player*/, Unit* target)
+        bool OnCheck(Player* player, Unit* target)
         {
             if (!target)
                 return false;
 
-            if (Creature* sladran = target->ToCreature())
-                if (sladran->AI()->GetData(DATA_SNAKES_WHYD_IT_HAVE_TO_BE_SNAKES))
-                    return true;
-
+            if (boss_slad_ran::boss_slad_ranAI* sladRanAI = CAST_AI(boss_slad_ran::boss_slad_ranAI, target->GetAI()))
+                return !sladRanAI->WasWrapped(player->GetGUID());
             return false;
         }
 };


### PR DESCRIPTION
The following SQL is also necessary.

``` sql
DELETE FROM `disables` WHERE entry = 7363 AND sourceType = 4;
DELETE FROM `achievement_criteria_data` WHERE `type` = 11 AND `criteria_id` = 7363;
INSERT INTO `achievement_criteria_data` VALUES
(7363, 11, 0, 0, 'achievement_snakes_whyd_it_have_to_be_snakes');
```

Changes added:
- Add spell [Snake Wrap](http://www.wowhead.com/spell=55126) to [Slad'ran Constrictor](http://www.wowhead.com/npc=29713) AI, that should be casted on a player when a single [Grip of Slad'ran](http://www.wowhead.com/spell=55093) application reaches 5 stacks.
- Achievement [Snakes. Why'd It Have To Be Snakes?](http://www.wowhead.com/achievement=2058), directly linked with previous change.
- Despawn all summons when boss dies.
