### PR TITLE
Update damage percent reduction raid buffs to 3.3.5a

### DIFF
--- a/sql/updates/world/2011_11_12_00_world_spell_group.sql
+++ b/sql/updates/world/2011_11_12_00_world_spell_group.sql
@@ -1,0 +1,3 @@
+UPDATE `spell_group` SET `spell_id`=63944 WHERE `spell_id`=47930 LIMIT 1; -- Removes Grace and adds Renewed Hope
+UPDATE `spell_group` SET `spell_id`=-1007 WHERE `id`=1092 AND `spell_id`=20911 LIMIT 1; -- Adds Greater Blessing of Sanctuary
+UPDATE `spell_group_stack_rules` SET `stack_rule`=3 WHERE `group_id`=1093 LIMIT 1;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10892,12 +10892,6 @@ bool Unit::isSpellCrit(Unit* victim, SpellInfo const* spellProto, SpellSchoolMas
                             if (victim->HasAura(6788))
                                 crit_chance+=(*i)->GetAmount();
                             break;
-                        case   21: // Test of Faith
-                        case 6935:
-                        case 6918:
-                            if (victim->HealthBelowPct(50))
-                                crit_chance+=(*i)->GetAmount();
-                            break;
                         default:
                             break;
                     }
@@ -11121,11 +11115,6 @@ uint32 Unit::SpellHealingBonus(Unit* victim, SpellInfo const* spellProto, uint32
             case 4953:
             case 3736: // Hateful Totem of the Third Wind / Increased Lesser Healing Wave / LK Arena (4/5/6) Totem of the Third Wind / Savage Totem of the Third Wind
                 DoneTotal += (*i)->GetAmount();
-                break;
-            case 7997: // Renewed Hope
-            case 7998:
-                if (victim->HasAura(6788))
-                    AddPctN(DoneTotalMod, (*i)->GetAmount());
                 break;
             case   21: // Test of Faith
             case 6935:
@@ -11750,11 +11739,6 @@ void Unit::MeleeDamageBonus(Unit* victim, uint32 *pdamage, WeaponAttackType attT
                     float mod = victim->ToPlayer()->GetRatingBonusValue(CR_CRIT_TAKEN_MELEE) * (-8.0f);
                     AddPctF(TakenTotalMod, std::max(mod, float((*i)->GetAmount())));
                 }
-                break;
-            // Ebon Plague
-            case 1933:
-                if ((*i)->GetMiscValue() & (spellProto ? spellProto->GetSchoolMask() : 0))
-                    AddPctN(TakenTotalMod, (*i)->GetAmount());
                 break;
         }
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11751,18 +11751,6 @@ void Unit::MeleeDamageBonus(Unit* victim, uint32 *pdamage, WeaponAttackType attT
                     AddPctF(TakenTotalMod, std::max(mod, float((*i)->GetAmount())));
                 }
                 break;
-            // Blessing of Sanctuary
-            // Greater Blessing of Sanctuary
-            case 19:
-            case 1804:
-            {
-                if ((*i)->GetSpellInfo()->SpellFamilyName != SPELLFAMILY_PALADIN)
-                    continue;
-
-                if ((*i)->GetMiscValue() & (spellProto ? spellProto->GetSchoolMask() : 0))
-                    AddPctN(TakenTotalMod, (*i)->GetAmount());
-                break;
-            }
             // Ebon Plague
             case 1933:
                 if ((*i)->GetMiscValue() & (spellProto ? spellProto->GetSchoolMask() : 0))

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3484,6 +3484,9 @@ void SpellMgr::LoadDbcDataCorrections()
             case 25899: // Greater Blessing of Sanctuary
                 spellInfo->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
                 break;
+            case 63944: // Renewed Hope
+                spellInfo->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
+                break;
             default:
                 break;
         }

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3480,6 +3480,10 @@ void SpellMgr::LoadDbcDataCorrections()
             case 72405: // Broken Frostmourne
                 spellInfo->EffectRadiusIndex[1] = EFFECT_RADIUS_200_YARDS;   // 200yd
                 break;
+            case 20911: // Blessing of Sanctuary
+            case 25899: // Greater Blessing of Sanctuary
+                spellInfo->EffectApplyAuraName[0] = SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN;
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
**Blessing of Sanctuary**
- 3% damage redution was not working on spell damage; fixed.

**Renewed Hope**
- 3% damage redution was not working; fixed.
- was also increasing healing on target (dunno why); removed.

**Test of Faith**
- since 3.1.0 no longer increases crit; updated.

**Grace**
- effect changed in 3.1.0: now can stack with Sanctuary; updated.

**Ebon Plague**
- there was some code that became obsolete with 89bae3b51c5208931bb3b409f8092e07c55b80e3; removed.

Also updated tables `spell_group` and `spell_group_stack_rules`
