### PR TITLE
Core/Spells: Bladestorm (fix immunities and removal of aura when switching between weapons)

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16562,6 +16562,8 @@ void Unit::KnockbackFrom(float x, float y, float speedXY, float speedZ)
     }
     else
     {
+        if (player->HasAura(46924))
+            return;
         float vcos, vsin;
         GetSinCos(x, y, vsin, vcos);
 

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -248,7 +248,7 @@ bool MapManager::CanPlayerEnter(uint32 mapid, Player* player, bool loginCheck)
             instaceIdToCheck = save->GetInstanceId();
 
         // instanceId can never be 0 - will not be found
-        if (!player->CheckInstanceCount(instaceIdToCheck))
+        if (!player->CheckInstanceCount(instaceIdToCheck) && !player->isDead())
         {
             player->SendTransferAborted(mapid, TRANSFER_ABORT_TOO_MANY_INSTANCES);
             return false;


### PR DESCRIPTION
DELETE FROM `spell_linked_spell` where `spell_trigger` in (46924);
INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
('46924', '-13810', '2', 'Bladestorm immune at Frost Trap'),
('46924', '-51514', '2', 'Bladestorm immune at Hex'),
('46924', '-116', '2', 'Bladestorm immune at FrostBolt'),
('46924', '-45524', '2', 'Bladestorm immune at Chains of Ice'),
('46924', '-68766', '2', 'Bladestorm immune at Desecration'),
('46924', '-58617', '2', 'Bladestorm immune at Glyph of Heart Strike');

also needed for immunities :]
