### PR TITLE
Core/Spells: Bladestorm (fix immunities and removal of aura when switching between weapons)

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22224,6 +22224,12 @@ void Player::RemoveItemDependentAurasAndCasts(Item* pItem)
             continue;
         }
 
+        if (aura->GetId() == 46924)
+        {
+            ++itr;
+            continue;
+        }
+
         // no alt item, remove aura, restart check
         RemoveOwnedAura(itr);
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16560,6 +16560,9 @@ void Unit::KnockbackFrom(float x, float y, float speedXY, float speedZ)
     }
     else
     {
+        // Bladestorm
+        if (player->HasAura(46924))
+            return;
         float vcos, vsin;
         GetSinCos(x, y, vsin, vcos);
 


### PR DESCRIPTION
``` sql
DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 46924;
INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
(46924, -13810, 2, 'Bladestorm immune at Frost Trap'),
(46924, -51514, 2, 'Bladestorm immune at Hex'),
(46924, -116, 2, 'Bladestorm immune at FrostBolt'),
(46924, -45524, 2, 'Bladestorm immune at Chains of Ice'),
(46924, -68766, 2, 'Bladestorm immune at Desecration'),
(46924, -58617, 2, 'Bladestorm immune at Glyph of Heart Strike'),
(46924, -605, 2, 'Bladestorm immune at Mind Control');
```

also needed to fix immunities
