### PR TITLE
[CORE/BOSS] Fix Sapphiron flying phase start.

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
@@ -271,14 +271,18 @@ public:
                             break;
                         }
                         case EVENT_FLIGHT:
-                            phase = PHASE_FLIGHT;
-                            events.SetPhase(PHASE_FLIGHT);
-                            me->SetReactState(REACT_PASSIVE);
-                            me->AttackStop();
-                            float x, y, z, o;
-                            me->GetHomePosition(x, y, z, o);
-                            me->GetMotionMaster()->MovePoint(1, x, y, z);
-                            return;
+                            if (HealthAbovePct(10))
+                            {
+                                phase = PHASE_FLIGHT;
+                                events.SetPhase(PHASE_FLIGHT);
+                                me->SetReactState(REACT_PASSIVE);
+                                me->AttackStop();
+                                float x, y, z, o;
+                                me->GetHomePosition(x, y, z, o);
+                                me->GetMotionMaster()->MovePoint(1, x, y, z);
+                                return;
+                            }
+                            break;
                     }
                 }
 


### PR DESCRIPTION
Sapphiron will enter flying phase only if it's health is above 10%.
From wowhead: "When Sapphiron's health reaches 10%, he will stop flying in the air."
