### PR TITLE
[Core/Spell] Fix cannibalize target selection.

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -363,5 +363,21 @@ bool AnyDeadUnitSpellTargetInRangeCheck::operator()(Creature* u)
         && i_searchObj->IsTargetMatchingCheck(u, i_check);
 }
 
+bool AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck::operator()(Player* u)
+{
+    return AnyDeadUnitSpellTargetInRangeCheck::operator()(u);
+}
+
+bool AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck::operator()(Corpse* u)
+{
+    return AnyDeadUnitSpellTargetInRangeCheck::operator()(u);
+}
+
+bool AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck::operator()(Creature* u)
+{
+    return AnyDeadUnitSpellTargetInRangeCheck::operator()(u)
+        && (u->GetCreatureType() == CREATURE_TYPE_UNDEAD || u->GetCreatureType() == CREATURE_TYPE_HUMANOID);
+}
+
 template void ObjectUpdater::Visit<GameObject>(GameObjectMapType &);
 template void ObjectUpdater::Visit<DynamicObject>(DynamicObjectMapType &);

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -601,6 +601,17 @@ namespace Trinity
             SpellTargetSelectionCheckTypes i_check;
     };
 
+    class AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck : public AnyDeadUnitSpellTargetInRangeCheck
+    {
+        public:
+            AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck(Unit const* searchObj, float range, SpellInfo const* spellInfo, SpellTargetSelectionCheckTypes check)
+                : AnyDeadUnitSpellTargetInRangeCheck(searchObj, range, spellInfo, check) {}
+            bool operator()(Player* u);
+            bool operator()(Corpse* u);
+            bool operator()(Creature* u);
+            template<class NOT_INTERESTED> bool operator()(NOT_INTERESTED*) { return false; }
+    };
+
     // WorldObject do classes
 
     class RespawnDo

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -189,8 +189,8 @@ class spell_gen_cannibalize : public SpellScriptLoader
                 float max_range = GetSpellInfo()->GetMaxRange(false);
                 WorldObject* result = NULL;
                 // search for nearby enemy corpse in range
-                Trinity::AnyDeadUnitSpellTargetInRangeCheck check(caster, max_range, GetSpellInfo(), TARGET_SELECT_CHECK_ENEMY);
-                Trinity::WorldObjectSearcher<Trinity::AnyDeadUnitSpellTargetInRangeCheck> searcher(caster, result, check);
+                Trinity::AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck check(caster, max_range, GetSpellInfo(), TARGET_SELECT_CHECK_ENEMY);
+                Trinity::WorldObjectSearcher<Trinity::AnyDeadUndeadOrHumanoidUnitSpellTargetInRangeCheck> searcher(caster, result, check);
                 caster->GetMap()->VisitFirstFound(caster->m_positionX, caster->m_positionY, max_range, searcher);
                 if (!result)
                     return SPELL_FAILED_NO_EDIBLE_CORPSES;


### PR DESCRIPTION
Taken by the idea of Warpten on this pull request: https://github.com/TrinityCore/TrinityCore/pull/3600.
Actually cannibalize can target every type of dead creature, but it must target only undead or humanoid creatures. SpellInfo::CheckTarget can not be fixed because the spell has not a target, but it takes the nearest corpse.
