### PR TITLE
Scripts/Brd: Fix learning of Dark Iron Smelting.

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -56,7 +56,7 @@ public:
                 break;
             case GOSSIP_ACTION_INFO_DEF+11:
                 player->CLOSE_GOSSIP_MENU();
-                creature->CastSpell(player, SPELL_LEARN_SMELT, false);
+                player->CastSpell(player, SPELL_LEARN_SMELT, false);
                 break;
             case GOSSIP_ACTION_INFO_DEF+2:
                 player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_ITEM_TEACH_3, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 22);


### PR DESCRIPTION
Spell is selfcast.
Player should cast it and not npc.
