### PR TITLE
Core/Spells: Tricks of the Trade (fix entier spell. aggro now removed af...

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6482,6 +6482,16 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                     triggered_spell_id = 32747;
                     break;
                 }
+                case 57934: // Tricks of the Trade
+                {
+                    Unit* redirectTarget = GetMisdirectionTarget();
+                    RemoveAura(57934);
+                    if (!redirectTarget)
+                        break;
+                    redirectTarget->CastSpell(this,59628,true);
+                    CastSpell(redirectTarget,57933,true);
+                    break;
+                }
             }
 
             switch (dummySpell->SpellIconID)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4803,6 +4803,10 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                 case 71563:
                     if (Aura* newAura = target->AddAura(71564, target))
                         newAura->SetStackAmount(newAura->GetSpellInfo()->StackAmount);
+                        break;
+                case 59628: // Tricks of the Trade
+                    target->SetReducedThreatPercent(100,caster->GetGUID());
+                    break;
             }
         }
         // AT REMOVE
@@ -4950,6 +4954,15 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                     if (GetId() == 61777)
                         target->CastSpell(target, GetAmount(), true);
                     break;
+                case SPELLFAMILY_ROGUE:
+                    //  Tricks of the trade
+                    switch(GetId())
+                    {
+                        case 59628:
+                        case 57934:
+                            target->SetReducedThreatPercent(0,0);
+                            break;       
+                    }
                 default:
                     break;
             }


### PR DESCRIPTION
...ter buff dissapears, correct buffs are placed on both the rogue and the target, both 15% buff and the second threat modifier buff are working as intended)
