### PR TITLE
Fix vmapassembler

### DIFF
--- a/src/server/collision/Maps/TileAssembler.cpp
+++ b/src/server/collision/Maps/TileAssembler.cpp
@@ -500,7 +500,7 @@ namespace VMAP
         {
             model.setGroupModels(groupsArray);
 
-            std::string worldModelFileName(iSrcDir);
+            std::string worldModelFileName(iDestDir);
             worldModelFileName.push_back('/');
             worldModelFileName.append(pModelFilename).append(".vmo");
             success = model.writeFile(worldModelFileName);


### PR DESCRIPTION
Bug : vmapassembler create vmo files in source folder (Buildings)

http://www.trinitycore.org/f/topic/4138-vmapmanager2-errors
