### PR TITLE
[CORE/SPELL MECHANICS] Fix immunity system for many spells.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11456,14 +11456,17 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo)
                 return true;
     }
 
+    bool immuneToAllEffects = true;
     for (int i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         // State/effect immunities applied by aura expect full spell immunity
         // Ignore effects with mechanic, they are supposed to be checked separately
         if (!spellInfo->Effects[i].Mechanic)
-            if (IsImmunedToSpellEffect(spellInfo, i))
-                return true;
+            if (!IsImmunedToSpellEffect(spellInfo, i))
+                immuneToAllEffects = false;
     }
+    if(immuneToAllEffects) //Return immune only if the target is immune to all spell effects.
+        return true;
 
     if (spellInfo->Id != 42292 && spellInfo->Id !=59752)
     {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11461,7 +11461,7 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo)
     {
         // State/effect immunities applied by aura expect full spell immunity
         // Ignore effects with mechanic, they are supposed to be checked separately
-        if (spellInfo->Effects[i].Mechanic || (!spellInfo->Effects[i].Mechanic && !IsImmunedToSpellEffect(spellInfo, i)))
+        if (spellInfo->Effects[i].Mechanic || !IsImmunedToSpellEffect(spellInfo, i))
             immuneToAllEffects = false;
     }
     if (immuneToAllEffects) //Return immune only if the target is immune to all spell effects.

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11461,9 +11461,8 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo)
     {
         // State/effect immunities applied by aura expect full spell immunity
         // Ignore effects with mechanic, they are supposed to be checked separately
-        if (!spellInfo->Effects[i].Mechanic)
-            if (!IsImmunedToSpellEffect(spellInfo, i))
-                immuneToAllEffects = false;
+        if (spellInfo->Effects[i].Mechanic || (!spellInfo->Effects[i].Mechanic && !IsImmunedToSpellEffect(spellInfo, i)))
+            immuneToAllEffects = false;
     }
     if (immuneToAllEffects) //Return immune only if the target is immune to all spell effects.
         return true;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11465,7 +11465,7 @@ bool Unit::IsImmunedToSpell(SpellInfo const* spellInfo)
             if (!IsImmunedToSpellEffect(spellInfo, i))
                 immuneToAllEffects = false;
     }
-    if(immuneToAllEffects) //Return immune only if the target is immune to all spell effects.
+    if (immuneToAllEffects) //Return immune only if the target is immune to all spell effects.
         return true;
 
     if (spellInfo->Id != 42292 && spellInfo->Id !=59752)

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1562,7 +1562,7 @@ SpellMissInfo Spell::DoSpellHitOnUnit(Unit* unit, const uint32 effectMask, bool 
     }
 
     for (uint32 effectNumber = 0; effectNumber < MAX_SPELL_EFFECTS; ++effectNumber)
-        if (effectMask & (1 << effectNumber))
+        if (effectMask & (1 << effectNumber) && !unit->IsImmunedToSpellEffect(m_spellInfo, effectNumber)) //Handle effect only if the target isn't immune.
             HandleEffects(unit, NULL, NULL, effectNumber, SPELL_EFFECT_HANDLE_HIT_TARGET);
 
     return SPELL_MISS_NONE;


### PR DESCRIPTION
Every spell must return "Immune" only if the target is immune to all spell effects but every spell effect must be handled only if the target isn't immune to it. This commit will fix a large amount of problems of spell immunities (for example https://github.com/TrinityCore/TrinityCore/issues/4212).
