### PR TITLE
Core/Spells: Fix Earthen Power

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7004,26 +7004,6 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
         {
             switch (dummySpell->Id)
             {
-                // Earthen Power (Rank 1, 2)
-                case 51523:
-                case 51524:
-                {
-                    // Totem itself must be a caster of this spell
-                    Unit* caster = NULL;
-                    for (ControlList::iterator itr = m_Controlled.begin(); itr != m_Controlled.end(); ++itr) {
-                        if ((*itr)->GetEntry() != 2630)
-                            continue;
-
-                        caster = *itr;
-                        break;
-                    }
-
-                    if (!caster)
-                        return false;
-
-                    caster->CastSpell(caster, 59566, true, castItem, triggeredByAura, originalCaster);
-                    return true;
-                }
                 // Tidal Force
                 case 55198:
                 {

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -26,16 +26,17 @@
 
 enum ShamanSpells
 {
-    SHAMAN_SPELL_GLYPH_OF_MANA_TIDE     = 55441,
-    SHAMAN_SPELL_MANA_TIDE_TOTEM        = 39609,
-    SHAMAN_SPELL_FIRE_NOVA_R1           = 1535,
-    SHAMAN_SPELL_FIRE_NOVA_TRIGGERED_R1 = 8349,
-    SHAMAN_SPELL_SATED                  = 57724,
-    SHAMAN_SPELL_EXHAUSTION             = 57723,
+    SHAMAN_SPELL_GLYPH_OF_MANA_TIDE        = 55441,
+    SHAMAN_SPELL_MANA_TIDE_TOTEM           = 39609,
+    SHAMAN_SPELL_FIRE_NOVA_R1              = 1535,
+    SHAMAN_SPELL_FIRE_NOVA_TRIGGERED_R1    = 8349,
+    SHAMAN_SPELL_SATED                     = 57724,
+    SHAMAN_SPELL_EXHAUSTION                = 57723,
 
-    //For Earthen Power
-    SHAMAN_TOTEM_SPELL_EARTHBIND_TOTEM  = 6474, //Spell casted by totem
-    SHAMAN_TOTEM_SPELL_EARTHEN_POWER    = 59566, //Spell witch remove snare effect
+    // For Earthen Power
+    SHAMAN_TOTEM_SPELL_EARTHBIND_TOTEM     = 6474,
+    SHAMAN_TOTEM_SPELL_EARTHEN_POWER       = 59566,
+    SHAMAN_TOTEM_SPELL_EARTHEN_POWER_BUFF  = 63532,
 };
 
 // 51474 - Astral shift
@@ -215,9 +216,22 @@ class spell_sha_earthbind_totem : public SpellScriptLoader
             {
                 Unit* target = GetTarget();
                 if (Unit* caster = aurEff->GetBase()->GetCaster())
-                    if (AuraEffect* aur = caster->GetDummyAuraEffect(SPELLFAMILY_SHAMAN, 2289, 0))
-                        if (roll_chance_i(aur->GetBaseAmount()))
-                            target->CastSpell(target, SHAMAN_TOTEM_SPELL_EARTHEN_POWER, true, NULL, aurEff);
+                {
+                    if (TempSummon* summon = caster->ToTempSummon())
+                    {
+                        if (Unit* owner = summon->GetOwner())
+                        {
+                            if (AuraEffect* aur = owner->GetDummyAuraEffect(SPELLFAMILY_SHAMAN, 2289, 0))
+                            {
+                                if (roll_chance_i(aur->GetBaseAmount()) && owner->HasAuraWithMechanic(1 << MECHANIC_SNARE))
+                                {
+                                    caster->CastSpell(caster, SHAMAN_TOTEM_SPELL_EARTHEN_POWER, true, NULL, aurEff);
+                                    caster->CastSpell(caster, SHAMAN_TOTEM_SPELL_EARTHEN_POWER_BUFF, true, NULL, aurEff);
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             void Register()

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -223,7 +223,7 @@ class spell_sha_earthbind_totem : public SpellScriptLoader
                         {
                             if (AuraEffect* aur = owner->GetDummyAuraEffect(SPELLFAMILY_SHAMAN, 2289, 0))
                             {
-                                if (roll_chance_i(aur->GetBaseAmount()) && owner->HasAuraWithMechanic(1 << MECHANIC_SNARE))
+                                if (roll_chance_i(aur->GetBaseAmount()) && target->HasAuraWithMechanic(1 << MECHANIC_SNARE))
                                 {
                                     caster->CastSpell(caster, SHAMAN_TOTEM_SPELL_EARTHEN_POWER, true, NULL, aurEff);
                                     caster->CastSpell(caster, SHAMAN_TOTEM_SPELL_EARTHEN_POWER_BUFF, true, NULL, aurEff);

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -36,7 +36,6 @@ enum ShamanSpells
     // For Earthen Power
     SHAMAN_TOTEM_SPELL_EARTHBIND_TOTEM     = 6474,
     SHAMAN_TOTEM_SPELL_EARTHEN_POWER       = 59566,
-    SHAMAN_TOTEM_SPELL_EARTHEN_POWER_BUFF  = 63532,
 };
 
 // 51474 - Astral shift
@@ -216,22 +215,11 @@ class spell_sha_earthbind_totem : public SpellScriptLoader
             {
                 Unit* target = GetTarget();
                 if (Unit* caster = aurEff->GetBase()->GetCaster())
-                {
                     if (TempSummon* summon = caster->ToTempSummon())
-                    {
                         if (Unit* owner = summon->GetOwner())
-                        {
                             if (AuraEffect* aur = owner->GetDummyAuraEffect(SPELLFAMILY_SHAMAN, 2289, 0))
-                            {
                                 if (roll_chance_i(aur->GetBaseAmount()) && target->HasAuraWithMechanic(1 << MECHANIC_SNARE))
-                                {
                                     caster->CastSpell(caster, SHAMAN_TOTEM_SPELL_EARTHEN_POWER, true, NULL, aurEff);
-                                    caster->CastSpell(caster, SHAMAN_TOTEM_SPELL_EARTHEN_POWER_BUFF, true, NULL, aurEff);
-                                }
-                            }
-                        }
-                    }
-                }
             }
 
             void Register()


### PR DESCRIPTION
``` sql
DELETE FROM spell_proc_event WHERE entry IN (51523,51524);
```

Had it tested without removing the HandleDummyAuraProc event and on a custom core, couldnt get it to compile on a clean one (CMake screwed up), so it would be very nice if someone could quickly doublecheck it.
- the part with HasAuraWithMechanic(1 << MECHANIC_SNARE) **MAY** be unneeded.

Thanks.
