### PR TITLE
Fix Bloodsurge talent being activate when Whirlwind causes damage.

### DIFF
--- a/sql/updates/world/2011_12_10_00_world_spell_proc_event.sql
+++ b/sql/updates/world/2011_12_10_00_world_spell_proc_event.sql
@@ -1,0 +1,2 @@
+-- Bloodsurge
+UPDATE `spell_proc_event` SET `procEx` = 0x0040000 WHERE `entry` = 46915;


### PR DESCRIPTION
Close #4160
