### PR TITLE
Core/Spells: stop channeling bar when interrupted also for creature

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4126,9 +4126,6 @@ void Spell::SendChannelUpdate(uint32 time)
         m_caster->SetUInt32Value(UNIT_CHANNEL_SPELL, 0);
     }
 
-    if (m_caster->GetTypeId() != TYPEID_PLAYER)
-        return;
-
     WorldPacket data(MSG_CHANNEL_UPDATE, 8+4);
     data.append(m_caster->GetPackGUID());
     data << uint32(time);


### PR DESCRIPTION
If you try to interrupt a npc channeling spell like http://www.wowhead.com/spell=64389, the cast is interrupted but the casting bar still is visible
