### PR TITLE
Core/Spells: Fix D.I.S.C.O ball. Closes #4214

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2979,6 +2979,9 @@ void SpellMgr::LoadDbcDataCorrections()
                 spellInfo->EffectImplicitTargetA[0] = TARGET_UNIT_CASTER;
                 spellInfo->EffectImplicitTargetB[0] = 0;
                 break;
+            case 50317: // Summon Disco Ball
+                spellInfo->EffectImplicitTargetA[1] = TARGET_UNIT_CASTER;
+                break;
             case 31344: // Howl of Azgalor
                 spellInfo->EffectRadiusIndex[0] = EFFECT_RADIUS_100_YARDS; // 100yards instead of 50000?!
                 break;


### PR DESCRIPTION
Nothing much to say on this ... still another fix similar to the Purify Hellboar Meat one. We really should find a general solution to avoid so much DBC hacks.
