### PR TITLE
Deathbringer's Will and Deathbringer's Will HC.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5469,7 +5469,7 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                         case CLASS_DRUID:
                             RandomSpells.push_back(71484);
                             RandomSpells.push_back(71485);
-                            RandomSpells.push_back(71486);
+                            RandomSpells.push_back(71492);
                             break;
                         case CLASS_HUNTER:
                             RandomSpells.push_back(71486);
@@ -5515,7 +5515,7 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                         case CLASS_DRUID:
                             RandomSpells.push_back(71561);
                             RandomSpells.push_back(71556);
-                            RandomSpells.push_back(71558);
+                            RandomSpells.push_back(71560);
                             break;
                         case CLASS_HUNTER:
                             RandomSpells.push_back(71558);


### PR DESCRIPTION
Deathbringer's Will and it's Heroic counterpart are currently giving incorrect procs for a Druid.

According to http://www.wowhead.com/item=50362#comments and http://www.wowhead.com/item=50363#comments

Druids are supposed to receive either a Strength, Agility or Haste proc from Deathbringer's Will, they are currently receiving Strength, Agility and Attack Power.

This pull request allows Haste to proc for a Druid instead of Attack Power.
