### PR TITLE
Speedup loading in LoadCreatureFormations

### DIFF
--- a/src/server/game/Entities/Creature/CreatureGroups.cpp
+++ b/src/server/game/Entities/Creature/CreatureGroups.cpp
@@ -88,21 +88,6 @@ void LoadCreatureFormations()
         return;
     }
 
-    std::set<uint32> guidSet;
-
-    QueryResult guidResult = WorldDatabase.PQuery("SELECT guid FROM creature");
-    if (guidResult)
-    {
-        do
-        {
-            Field* fields = guidResult->Fetch();
-            uint32 guid = fields[0].GetUInt32();
-
-            guidSet.insert(guid);
-
-        } while (guidResult->NextRow());
-    }
-
     uint32 count = 0;
     Field* fields;
     FormationInfo* group_member;
@@ -114,8 +99,8 @@ void LoadCreatureFormations()
         //Load group member data
         group_member                        = new FormationInfo;
         group_member->leaderGUID            = fields[0].GetUInt32();
-        uint32 memberGUID = fields[1].GetUInt32();
-        group_member->groupAI                = fields[4].GetUInt8();
+        uint32 memberGUID                   = fields[1].GetUInt32();
+        group_member->groupAI               = fields[4].GetUInt8();
         //If creature is group leader we may skip loading of dist/angle
         if (group_member->leaderGUID != memberGUID)
         {
@@ -130,14 +115,14 @@ void LoadCreatureFormations()
 
         // check data correctness
         {
-            if (guidSet.find(group_member->leaderGUID) == guidSet.end())
+            if (!sObjectMgr->GetCreatureData(group_member->leaderGUID))
             {
                 sLog->outErrorDb("creature_formations table leader guid %u incorrect (not exist)", group_member->leaderGUID);
                 delete group_member;
                 continue;
             }
 
-            if (guidSet.find(memberGUID) == guidSet.end())
+            if (!sObjectMgr->GetCreatureData(memberGUID))
             {
                 sLog->outErrorDb("creature_formations table member guid %u incorrect (not exist)", memberGUID);
                 delete group_member;


### PR DESCRIPTION
the creature data is already loaded by the time LoadCreatureFormations is called, so that set was useless, and due to the high amount of guids it was storing, it caused a big delay when gone out of scope
