### PR TITLE
Quest Fixes2

### DIFF
--- a/sql/updates/fixes2/Add The Botanica and The Mecanar exits.sql
+++ b/sql/updates/fixes2/Add The Botanica and The Mecanar exits.sql
@@ -1,0 +1,16 @@
+-- Add The Botanica and The Mecanar exits by Discover-
+-- Closes #3369
+
+-- The Botanica and The Mecanar exit areatriggers
+DELETE FROM `areatrigger_teleport` WHERE `id` IN (4612,4614);
+INSERT INTO `areatrigger_teleport` (`id`,`name`,`target_map`,`target_position_x`,`target_position_y`,`target_position_z`,`target_orientation`) VALUES
+(4612,'The Botanica',530,3407.110107,1488.479980,182.837753,2.501119),
+(4614,'The Mechanar',530,2869.885742,1552.755249,252.158997,0.733993);
+
+-- Spawn portals
+DELETE FROM `gameobject` WHERE `id` IN (184221,184222) AND `guid` BETWEEN 10000172 AND 10000178;
+INSERT INTO `gameobject` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`rotation0`,`rotation1`,`rotation2`,`rotation3`,`spawntimesecs`,`animprogress`,`state`) VALUES
+(10000176,184222,553,1,1,158.952,391.653,-35.5291,0.0494656,0,0,0.0247303,0.999694,300,0,1),
+(10000174,184222,554,1,1,71.1997,149.657,25.5811,3.17222,0,0,0.999883,-0.0153126,300,0,1),
+(10000178,184221,553,1,1,158.952,391.653,-35.5291,0.0494656,0,0,0.0247303,0.999694,300,0,1),
+(10000172,184221,554,1,1,71.1997,149.657,25.5811,3.17222,0,0,0.999883,-0.0153126,300,0,1);

--- a/sql/updates/fixes2/Drowned Guardian & Phylactery Guardian no XP.sql
+++ b/sql/updates/fixes2/Drowned Guardian & Phylactery Guardian no XP.sql
@@ -1,0 +1,3 @@
+-- Drowned Guardian & Phylactery Guardian summoned NPC should not give XP fix by tobmaps
+-- Closes #1860
+UPDATE `creature_template` SET `flags_extra` = 64 WHERE `entry` IN (26225, 26224);

--- a/sql/updates/fixes2/Emergency Supplies quest fix.sql
+++ b/sql/updates/fixes2/Emergency Supplies quest fix.sql
@@ -1,0 +1,13 @@
+-- Emergency Supplies quest fix by nelegalno
+-- Closes #4187
+SET @GUID := 25841;
+SET @MNID := 21248;
+SET @SPEL := 46362;
+
+DELETE FROM `smart_scripts` WHERE (`entryorguid`=@GUID AND `source_type`=0);
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(@GUID,0,0,0,11,0,100,0,0,0,0,0,81,1,0,0,0,0,0,1,0,0,0,0,0,0,0,'Fizzcrank Recon Pilot - On spawn - set gossip flag'),
+(@GUID,0,1,2,62,0,100,0,@MNID,0,0,0,85,@SPEL,0,0,0,0,0,7,0,0,0,0,0,0,0,'Fizzcrank Recon Pilot - On gossip option select - cast spell'),
+(@GUID,0,2,3,61,0,100,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,'Fizzcrank Recon Pilot - On gossip option select - close gossip'),
+(@GUID,0,3,0,61,0,100,0,0,0,0,0,23,1,0,0,0,0,0,1,0,0,0,0,0,0,0,'Fizzcrank Recon Pilot - On gossip option select - set phase 1'),
+(@GUID,0,4,0,1,1,100,0,3000,3000,0,0,41,0,0,0,0,0,0,1,0,0,0,0,0,0,0,'Fizzcrank Recon Pilot - OOC - wait 3 sec despawn (Phase 1)');

--- a/sql/updates/fixes2/Felsword Gas Mask.sql
+++ b/sql/updates/fixes2/Felsword Gas Mask.sql
@@ -1,0 +1,24 @@
+-- Thanks to @Aokromes for the sniff and @malcrom for all the help
+-- NPC gossip update from sniff
+UPDATE `creature_template` SET `gossip_menu_id`=8523 WHERE `entry`=22127;
+
+-- Gossip insert from sniff
+DELETE FROM `gossip_menu` WHERE `entry`=8523;
+INSERT INTO `gossip_menu` (`entry`,`text_id`) VALUES (8523,10657);
+
+-- Gossip option suggested by Malcrom "text made up"
+DELETE FROM `gossip_menu_option` WHERE `menu_id`=8523;
+INSERT INTO `gossip_menu_option` (`menu_id`,`id`,`option_icon`,`option_text`,`option_id`,`npc_option_npcflag`,`action_menu_id`,`action_poi_id`,`box_coded`,`box_money`,`box_text`) VALUES
+(8523,0,0,"Can I get another Felsworn Gas Mask?",1,1,0,0,0,0,'');
+
+-- Gossip option conditions
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId`=15 AND `SourceGroup`=8523);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(15,8523,0,1,9,10819,0,0,0,'','Show gossip only if Felsworn Gas Mask quest is rewarded'),
+(15,8523,0,1,26,31366,0,0,0,'','Show gossip only if player doesnt have Felsworn Gas Mask');
+
+-- SAI for Wildlord Antelarion
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=22127;
+DELETE FROM `smart_scripts` WHERE (`entryorguid`=22127 AND `source_type`=0);
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(22127,0,0,0,62,0,100,0,8523,0,0,0,11,39101,0,0,0,0,0,7,0,0,0,0,0,0,0,'Wildlord Antelarion - On Gossip option select - Cast Create Felsword Gas Mask');

--- a/sql/updates/fixes2/Finding the Keymaster quest fix.sql
+++ b/sql/updates/fixes2/Finding the Keymaster quest fix.sql
@@ -1,0 +1,8 @@
+-- [Q] Finding the Keymaster by nelegalno
+-- Closes #2604
+
+UPDATE `quest_template` SET `SpecialFlags` = 0, `RequiredSpellCast1` = 0 WHERE `ID` = 10256;
+DELETE FROM `event_scripts` WHERE id=12857;
+INSERT INTO `event_scripts` (`id`,`delay`,`command`,`datalong`,`datalong2`,`dataint`,`x`,`y`,`z`,`o`) VALUES
+(12857,0,10,19938,3000000,0,2248.43,2227.97,138.56,2.48121),
+(12857,1,8,19938,1,0,0,0,0,0);

--- a/sql/updates/fixes2/Glyph Chasing quest.sql
+++ b/sql/updates/fixes2/Glyph Chasing quest.sql
@@ -1,0 +1,32 @@
+-- Glyph Chasing quest workaround by unknown autor (updated by maxxx)
+-- Closes #1682
+
+DELETE FROM `gossip_menu` WHERE entry IN (6559,6560,6561);
+INSERT INTO `gossip_menu` (`entry`,`text_id`) VALUES
+(6559,7770),
+(6560,7770),
+(6561,7770);
+
+DELETE FROM `gossip_menu_option` WHERE menu_id IN (6559,6560,6561);
+INSERT INTO `gossip_menu_option` (`menu_id`,`id`,`option_icon`,`option_text`,`option_id`,`npc_option_npcflag`,`action_menu_id`,`action_poi_id`,`box_coded`,`box_money`,`box_text`) VALUES
+(6559,0,0,'<Use the transcription device to gather a rubbing.>',1,1,0,0,0,0,NULL),
+(6560,0,0,'<Use the transcription device to gather a rubbing.>',1,1,0,0,0,0,NULL),
+(6561,0,0,'<Use the transcription device to gather a rubbing.>',1,1,0,0,0,0,NULL);
+
+UPDATE `gameobject_template` SET `AIName`='SmartGameObjectAI' WHERE `entry`=180453;
+DELETE FROM smart_scripts WHERE (entryorguid=180453 AND source_type=1);
+INSERT INTO smart_scripts (entryorguid,source_type,id,link,event_type,event_phase_mask,event_chance,event_flags,event_param1,event_param2,event_param3,event_param4,action_type,action_param1,action_param2,action_param3,action_param4,action_param5,action_param6,target_type,target_param1,target_param2,target_param3,target_x,target_y,target_z,target_o,COMMENT) VALUES
+(180453,1,0,1,62,0,100,0,6561,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,'close gossip'),
+(180453,1,1,0,61,0,100,1,0,0,0,0,56,20456,1,0,0,0,0,7,0,0,0,0,0,0,0,'additem 20456');
+
+UPDATE `gameobject_template` SET `AIName`='SmartGameObjectAI' WHERE `entry`=180454;
+DELETE FROM smart_scripts WHERE (entryorguid=180454 AND source_type=1);
+INSERT INTO smart_scripts (entryorguid,source_type,id,link,event_type,event_phase_mask,event_chance,event_flags,event_param1,event_param2,event_param3,event_param4,action_type,action_param1,action_param2,action_param3,action_param4,action_param5,action_param6,target_type,target_param1,target_param2,target_param3,target_x,target_y,target_z,target_o,COMMENT) VALUES
+(180454,1,0,1,62,0,100,0,6560,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,'close gossip'),
+(180454,1,1,0,61,0,100,1,0,0,0,0,56,20455,1,0,0,0,0,7,0,0,0,0,0,0,0,'additem 20455');
+
+UPDATE `gameobject_template` SET `AIName`='SmartGameObjectAI' WHERE `entry`=180455;
+DELETE FROM smart_scripts WHERE (entryorguid=180455 AND source_type=1);
+INSERT INTO smart_scripts (entryorguid,source_type,id,link,event_type,event_phase_mask,event_chance,event_flags,event_param1,event_param2,event_param3,event_param4,action_type,action_param1,action_param2,action_param3,action_param4,action_param5,action_param6,target_type,target_param1,target_param2,target_param3,target_x,target_y,target_z,target_o,COMMENT) VALUES
+(180455,1,0,1,62,0,100,0,6559,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,'close gossip'),
+(180455,1,1,0,61,0,100,1,0,0,0,0,56,20454,1,0,0,0,0,7,0,0,0,0,0,0,0,'additem 20454');

--- a/sql/updates/fixes2/Peace at Last quest fix.sql
+++ b/sql/updates/fixes2/Peace at Last quest fix.sql
@@ -1,0 +1,33 @@
+-- Peace at Last quest fix by gecko32
+-- Closes #3144
+
+-- Add text for Lynn Hyal
+DELETE FROM `creature_text` WHERE `entry`=23768;
+INSERT INTO `creature_text` (`entry`,`groupid`,`id`,`text`,`type`,`language`,`probability`,`emote`,`duration`,`sound`,`comment`) VALUES 
+(23768,1,0,"James? James... No, you're not James, but I know who you are...",12,0,100,0,0,0,'Lynn Hyal'),
+(23768,2,0,"You're the one who tracked down the brutes who did this to us.",12,0,100,0,0,0,'Lynn Hyal'),
+(23768,3,0,"I tried so hard to tell Jim... to tell anyone... who was behind this, but I couldn't find a way...",12,0,100,0,0,0,'Lynn Hyal'),
+(23768,4,0,"Thank you for helping us and for helping Jim. If you see him, tell him little Jimmy and I love him and that we're waiting for him.",12,0,100,0,0,0,'Lynn Hyal'),
+(23768,5,0,"I don't know when we'll see Daddy again, Jimmy, but I know he loves you and he misses you very much.",12,0,100,0,0,0,'Lynn Hyal');
+
+-- Add text for Jimmy Hyal
+DELETE FROM `creature_text` WHERE `entry`=23769;
+INSERT INTO `creature_text` (`entry`,`groupid`,`id`,`text`,`type`,`language`,`probability`,`emote`,`duration`,`sound`,`comment`) VALUES 
+(23769,1,0,'Mommy, when will we see Daddy again?',12,0,100,0,0,0,'Jimmy Hyal');
+
+-- add smart ai dialog for Lynn Hyal and quest credit at end of dialog
+UPDATE `creature_template` SET AIName="SmartAI" WHERE `entry`=23768;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=23768;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(23768,0,0,0,1,0,100,1,0,0,0,0,84,1,0,0,0,0,0,1,0,0,0,0,0,0,0,'Lynn Hyal - on spawn - talk 1'),
+(23768,0,1,0,1,0,100,1,2000,2000,0,0,84,2,0,0,0,0,0,1,0,0,0,0,0,0,0,'Lynn Hyal - after 2 sec - talk 2'),
+(23768,0,2,0,1,0,100,1,5000,5000,0,0,84,3,0,0,0,0,0,1,0,0,0,0,0,0,0,'Lynn Hyal - after 5 sec - talk 3'),
+(23768,0,3,0,1,0,100,1,8000,8000,0,0,84,4,0,0,0,0,0,1,0,0,0,0,0,0,0,'Lynn Hyal - after 8 sec - talk 4'),
+(23768,0,4,0,1,0,100,1,12000,12000,0,0,84,5,0,0,0,0,0,1,0,0,0,0,0,0,0,'Lynn Hyal - after 12 sec - reply to jimmy'),
+(23768,0,5,0,1,0,100,1,12000,12000,0,0,33,23768,0,0,0,0,0,18,5,0,0,0,0,0,0,'Lynn Hyal - after 12 sec - kill credit quest complete');
+
+-- add smart ai dialog for Jimmy Hyal
+UPDATE `creature_template` SET AIName="SmartAI" WHERE `entry`=23769;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=23769;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(23769,0,0,0,1,0,100,1,10000,10000,0,0,84,1,0,0,0,0,0,1,0,0,0,0,0,0,0,'Jimmy Hyal - after 10 sec - talk 1');

--- a/sql/updates/fixes2/Report to Gryan Stoutmantle creature_questrelation.sql
+++ b/sql/updates/fixes2/Report to Gryan Stoutmantle creature_questrelation.sql
@@ -1,0 +1,11 @@
+-- Fix Report to Gryan Stoutmantle creature_questrelation values by nelegalno
+-- Closes #4461
+
+DELETE FROM `creature_questrelation` WHERE `quest` = 109;
+INSERT INTO `creature_questrelation` (`id`, `quest`) VALUES
+(233, 109), -- Farmer Saldean
+(237, 109), -- Farmer Furlbrow
+(240, 109), -- Marshal Dughan
+(261, 109), -- Guard Thomas
+(294, 109), -- Marshal Haggard
+(963, 109); -- Deputy Rainer

--- a/sql/updates/fixes2/The Cleansing event script.sql
+++ b/sql/updates/fixes2/The Cleansing event script.sql
@@ -1,9 +1,0 @@
--- The Cleansing fix by shlomi1515
--- Closes #3582
-
-DELETE FROM gameobject WHERE guid=150377;
-UPDATE gameobject_template SET data2=11322 WHERE entry=186649;
-
-DELETE FROM event_scripts WHERE id=11322;
-INSERT INTO event_scripts VALUES 
-(11322,1,8,27959,0,0,0,0,0,0);

--- a/sql/updates/fixes2/The Cleansing event script.sql
+++ b/sql/updates/fixes2/The Cleansing event script.sql
@@ -1,0 +1,9 @@
+-- The Cleansing fix by shlomi1515
+-- Closes #3582
+
+DELETE FROM gameobject WHERE guid=150377;
+UPDATE gameobject_template SET data2=11322 WHERE entry=186649;
+
+DELETE FROM event_scripts WHERE id=11322;
+INSERT INTO event_scripts VALUES 
+(11322,1,8,27959,0,0,0,0,0,0);

--- a/sql/updates/fixes2/The Thunderspike quest fix.sql
+++ b/sql/updates/fixes2/The Thunderspike quest fix.sql
@@ -1,0 +1,18 @@
+-- replacement for https://github.com/TrinityCore/TrinityCore/commit/dbcccbbb44cd331ab5ad31361b2fa4a6f12990bc
+
+-- The Thunderspike quest fix
+SET @ENTRY := 184729;
+
+-- revert to original TDB values
+UPDATE `gameobject_template` SET `ScriptName` = '', `data2`=13685, `data3`=3000 WHERE `entry` = @ENTRY;
+
+-- Add event_scripts 13685
+DELETE FROM `event_scripts` WHERE `id`=13685;
+INSERT INTO `event_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `dataint`, `x`, `y`, `z`, `o`) VALUES
+('13685','1','10','21319','900000','0','1326.51','6691.53','-20.3344','3.29793');
+
+-- SAI workaround untill event_scripts problem is fixed
+UPDATE `gameobject_template` SET `AIName`='SmartGameObjectAI' WHERE `entry`=@ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=1;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@ENTRY,1,0,0,64,0,100,1,0,0,0,0,12,21319,1,900000,0,0,0,8,0,0,0,1326.51,6691.53,-20.3344,3.29793,"The Thunderspike - On Gossip Hello - Summon Gor Grimgut");

--- a/sql/updates/fixes2/Tiger Matriarch Credit update AIName.sql
+++ b/sql/updates/fixes2/Tiger Matriarch Credit update AIName.sql
@@ -1,0 +1,2 @@
+-- Tiger Matriarch Credit have no SAI script
+UPDATE `creature_template` SET `AIName`='' WHERE `entry`=40301;

--- a/src/server/scripts/Outland/blades_edge_mountains.cpp
+++ b/src/server/scripts/Outland/blades_edge_mountains.cpp
@@ -30,7 +30,6 @@ npc_daranelle
 npc_overseer_nuaar
 npc_saikkal_the_elder
 go_legion_obelisk
-go_thunderspike
 EndContentData */
 
 #include "ScriptPCH.h"
@@ -538,29 +537,8 @@ public:
 };
 
 /*######
-## go_thunderspike
+## AddSC
 ######*/
-
-enum TheThunderspike
-{
-    NPC_GOR_GRIMGUT     = 21319,
-    QUEST_THUNDERSPIKE  = 10526,
-};
-
-class go_thunderspike : public GameObjectScript
-{
-    public:
-        go_thunderspike() : GameObjectScript("go_thunderspike") { }
-
-        bool OnGossipHello(Player* player, GameObject* go)
-        {
-            if (player->GetQuestStatus(QUEST_THUNDERSPIKE) == QUEST_STATUS_INCOMPLETE && !go->FindNearestCreature(NPC_GOR_GRIMGUT, 25.0f, true))
-                if (Creature* gorGrimgut = go->SummonCreature(NPC_GOR_GRIMGUT, -2413.4f, 6914.48f, 25.01f, 3.67f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 300000))
-                    gorGrimgut->AI()->AttackStart(player);
-
-            return true;
-        }
-};
 
 void AddSC_blades_edge_mountains()
 {
@@ -572,5 +550,4 @@ void AddSC_blades_edge_mountains()
     new go_legion_obelisk();
     new npc_bloodmaul_brutebane();
     new npc_ogre_brute();
-    new go_thunderspike();
 }


### PR DESCRIPTION
Remove SmartAI from Tiger Matriarch Credit NPC because it have no SAI script
Fix Report to Gryan Stoutmantle creature_questrelation values. Closes #4461
Wildlord Antelarion NPC gossip fix. Closes #4444
Drowned Guardian & Phylactery Guardian summoned NPC should not give XP fix by tobmaps. Closes #1860
Add The Botanica and The Mecanar exits (not from sniff) by Discover-. Closes #3369
Emergency Supplies quest fix by nelegalno. Closes #4187
Finding the Keymaster event_scripts fix by nelegalno. Closes #2604
Glyph Chasing quest workaround by unknown autor (updated by maxxx). Closes #1682
Peace at Last quest fix by gecko32. Closes #3144
The Thunderspike quest fix. replacement for the not working dbcccbbb44cd331ab5ad31361b2fa4a6f12990bc
