### PR TITLE
Core/Spells: Update nearby visible objects for new viewpoints

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1668,7 +1668,11 @@ bool WorldObject::canSeeOrDetect(WorldObject const* obj, bool ignoreStealth, boo
             }
         }
 
-        if (!corpseCheck && !IsWithinDist(obj, GetSightRange(obj), false))
+        WorldObject const* viewpoint = this;
+        if (Player const* player = this->ToPlayer())
+            viewpoint = player->GetViewpoint();
+
+        if (!corpseCheck && !viewpoint->IsWithinDist(obj, GetSightRange(obj), false))
             return false;
     }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22973,7 +22973,10 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
 WorldObject* Player::GetViewpoint() const
 {
     if (uint64 guid = GetUInt64Value(PLAYER_FARSIGHT))
-        return (WorldObject*)ObjectAccessor::GetObjectByTypeMask(*this, guid, TYPEMASK_SEER);
+    {
+        WorldObject* viewpoint = (WorldObject*) ObjectAccessor::GetObjectByTypeMask(*this, guid, TYPEMASK_SEER);
+        return viewpoint ? viewpoint : (WorldObject*) this;  // always expected not NULL
+    }
     return (WorldObject*) this;
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22974,7 +22974,7 @@ WorldObject* Player::GetViewpoint() const
 {
     if (uint64 guid = GetUInt64Value(PLAYER_FARSIGHT))
         return (WorldObject*)ObjectAccessor::GetObjectByTypeMask(*this, guid, TYPEMASK_SEER);
-    return NULL;
+    return (WorldObject*) this;
 }
 
 bool Player::CanUseBattlegroundObject()


### PR DESCRIPTION
This fix spells with Far Sight and Bind Sight effects.

When the viewpoint position is different than the current player position, nearby objects should be visible. 

Spyglass items aren't working yet, and sentry totem have some issues.

Spells now work correctly:
Eyes of the Beast (hunter): http://www.wowwiki.com/Eyes_of_the_Beast
Eagle Eye (hunter): http://www.wowhead.com/spell=6197
Eye of Kilrogg (warlock): http://www.wowhead.com/spell=126
Far Sight (shaman): http://www.wowhead.com/spell=6196
Steam Tonk Controller (engi item) http://www.wowhead.com/item=22728
And other non-class specific spells.
