### PR TITLE
Core/PacketIO: Fix crash and exploit caused when client sends tampered m...

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21731,6 +21731,8 @@ void Player::SendInitialPacketsBeforeAddToMap()
     // SMSG_PET_GUIDS
     // SMSG_UPDATE_WORLD_STATE
     // SMSG_POWER_UPDATE
+
+    SetMover(this);
 }
 
 void Player::SendInitialPacketsAfterAddToMap()

--- a/src/server/game/Server/Protocol/Handlers/MovementHandler.cpp
+++ b/src/server/game/Server/Protocol/Handlers/MovementHandler.cpp
@@ -472,18 +472,7 @@ void WorldSession::HandleSetActiveMoverOpcode(WorldPacket &recv_data)
 
     if (GetPlayer()->IsInWorld())
     {
-        if (Unit* mover = ObjectAccessor::GetUnit(*GetPlayer(), guid))
-        {
-            GetPlayer()->SetMover(mover);
-            if (mover != GetPlayer() && mover->canFly())
-            {
-                WorldPacket data(SMSG_MOVE_SET_CAN_FLY, 12);
-                data.append(mover->GetPackGUID());
-                data << uint32(0);
-                SendPacket(&data);
-            }
-        }
-        else
+        if (_player->m_mover->GetGUID() != guid)
         {
             sLog->outError("HandleSetActiveMoverOpcode: incorrect mover guid: mover is " UI64FMTD " (%s - Entry: %u) and should be " UI64FMTD, guid, GetLogNameForGuid(guid), GUID_ENPART(guid), _player->m_mover->GetGUID());
             GetPlayer()->SetMover(GetPlayer());

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3096,9 +3096,15 @@ void AuraEffect::HandleModPossess(AuraApplication const* aurApp, uint8 mode, boo
     }
 
     if (apply)
-        target->SetCharmedBy(caster, CHARM_TYPE_POSSESS, aurApp);
+    {
+        if (target->SetCharmedBy(caster, CHARM_TYPE_POSSESS, aurApp))
+            caster->ToPlayer()->SetMover(target);
+    }
     else
+    {
         target->RemoveCharmedBy(caster);
+        caster->ToPlayer()->SetMover(caster);
+    }
 }
 
 // only one spell has this aura
@@ -3126,11 +3132,13 @@ void AuraEffect::HandleModPossessPet(AuraApplication const* aurApp, uint8 mode, 
         if (caster->ToPlayer()->GetPet() != pet)
             return;
 
-        pet->SetCharmedBy(caster, CHARM_TYPE_POSSESS, aurApp);
+        if (pet->SetCharmedBy(caster, CHARM_TYPE_POSSESS, aurApp))
+            caster->ToPlayer()->SetMover(pet);
     }
     else
     {
         pet->RemoveCharmedBy(caster);
+        caster->ToPlayer()->SetMover(caster);
 
         if (!pet->IsWithinDistInMap(caster, pet->GetMap()->GetVisibilityRange()))
             pet->Remove(PET_SAVE_NOT_IN_SLOT, true);
@@ -4807,7 +4815,7 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                     if (Aura* newAura = target->AddAura(71564, target))
                         newAura->SetStackAmount(newAura->GetSpellInfo()->StackAmount);
                         break;
-                case 59628: // Tricks of the Trade  
+                case 59628: // Tricks of the Trade
                     if (caster && caster->GetMisdirectionTarget())
                         target->SetReducedThreatPercent(100, caster->GetMisdirectionTarget()->GetGUID());
                     break;
@@ -4970,7 +4978,7 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                                 target->SetReducedThreatPercent(0,0);
                             else
                                 target->SetReducedThreatPercent(0,caster->GetMisdirectionTarget()->GetGUID());
-                            break;       
+                            break;
                     }
                 default:
                     break;


### PR DESCRIPTION
...over guids

How the crash is caused:
The attacker needs 2 chars and a packet editor with some logic (can't use WPE). Player A knows the guid of Player B

1) Player B login
2) Player A login sending CMSG_SET_ACTIVE_MOVER with the guid of Player B, then Player A have as mover the Player B
3) Player B logout. Now Player A have as mover invalid pointer to non-existant Player B
4) Player A sends MSG_MOVE_XXX packet
5) Result: 100% server crash

If also Player A manipulates the guid of MSG_MOVE he can gain control over other's player movements.

The fix:

It's insecure and unnecesary to set the mover based on the guid recived from client, instead of that, it can be set in the functions that require set new player mover, eg: when player login and when spells with Possess aura effect are casted.
This implementation is based on the current Mangos code, so thanks to them.

PS: I changed code in low level functions so please test this and report unexpected behavior like being unable to move.
