### PR TITLE
Core-Vehicles: Change player mover when add/remove passenger (thanks Sub...

### DIFF
--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -359,6 +359,7 @@ bool Vehicle::AddPassenger(Unit* unit, int8 seatId)
     {
         if (!_me->SetCharmedBy(unit, CHARM_TYPE_VEHICLE))
             ASSERT(false);
+        unit->ToPlayer()->SetMover(this->GetBase());
     }
 
     if (_me->IsInWorld())
@@ -410,7 +411,10 @@ void Vehicle::RemovePassenger(Unit* unit)
     unit->ClearUnitState(UNIT_STAT_ONVEHICLE);
 
     if (_me->GetTypeId() == TYPEID_UNIT && unit->GetTypeId() == TYPEID_PLAYER && seat->first == 0 && seat->second.SeatInfo->m_flags & VEHICLE_SEAT_FLAG_CAN_CONTROL)
+    {
         _me->RemoveCharmedBy(unit);
+        unit->ToPlayer()->SetMover(unit->ToPlayer());
+    }
 
     if (_me->IsInWorld())
     {

--- a/src/server/game/Server/Protocol/Handlers/MovementHandler.cpp
+++ b/src/server/game/Server/Protocol/Handlers/MovementHandler.cpp
@@ -473,10 +473,7 @@ void WorldSession::HandleSetActiveMoverOpcode(WorldPacket &recv_data)
     if (GetPlayer()->IsInWorld())
     {
         if (_player->m_mover->GetGUID() != guid)
-        {
             sLog->outError("HandleSetActiveMoverOpcode: incorrect mover guid: mover is " UI64FMTD " (%s - Entry: %u) and should be " UI64FMTD, guid, GetLogNameForGuid(guid), GUID_ENPART(guid), _player->m_mover->GetGUID());
-            GetPlayer()->SetMover(GetPlayer());
-        }
     }
 }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3104,6 +3104,7 @@ void AuraEffect::HandleModPossess(AuraApplication const* aurApp, uint8 mode, boo
     {
         target->RemoveCharmedBy(caster);
         caster->ToPlayer()->SetMover(caster);
+        target->ToPlayer()->SetMover(target);
     }
 }
 


### PR DESCRIPTION
...v)

Core-Misc: Restore correct mover for victim of possesion spell.

Closes #4704, #4707
