### PR TITLE
Fixed achievement Shocking! on 10-man and 25-man

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -333,38 +333,6 @@ void Spell::EffectSchoolDMG(SpellEffIndex effIndex)
 
                 switch (m_spellInfo->Id)                     // better way to check unknown
                 {
-                    // Positive/Negative Charge
-                    case 28062:
-                    case 28085:
-                    case 39090:
-                    case 39093:
-                        if (!m_triggeredByAuraSpell)
-                            break;
-                        if (unitTarget == m_caster)
-                        {
-                            uint8 count = 0;
-                            for (std::list<TargetInfo>::iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
-                                if (ihit->targetGUID != m_caster->GetGUID())
-                                    if (Player* target = ObjectAccessor::GetPlayer(*m_caster, ihit->targetGUID))
-                                        if (target->HasAura(m_triggeredByAuraSpell->Id))
-                                            ++count;
-                            if (count)
-                            {
-                                uint32 spellId = 0;
-                                switch (m_spellInfo->Id)
-                                {
-                                    case 28062: spellId = 29659; break;
-                                    case 28085: spellId = 29660; break;
-                                    case 39090: spellId = 39089; break;
-                                    case 39093: spellId = 39092; break;
-                                }
-                                m_caster->SetAuraStack(spellId, m_caster, count);
-                            }
-                        }
-
-                        if (unitTarget->HasAura(m_triggeredByAuraSpell->Id))
-                            damage = 0;
-                        break;
                     // Consumption
                     case 28865:
                         damage = (((InstanceMap*)m_caster->GetMap())->GetDifficulty() == REGULAR_DIFFICULTY ? 2750 : 4250);

--- a/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
@@ -148,6 +148,8 @@ public:
         time_t maxHorsemenDiedTime;
 
         uint32 playerDied;
+        
+        uint32 PolaritySwitch;
 
         void Initialize()
         {
@@ -166,8 +168,10 @@ public:
             kelthuzadGUID             = 0;
             kelthuzadTriggerGUID      = 0;
 
-            playerDied        = 0;
-            gothikDoorState   = GO_STATE_ACTIVE;
+            playerDied                = 0;
+            gothikDoorState           = GO_STATE_ACTIVE;
+            
+            PolaritySwitch            = 0;
 
             memset(portalsGUID, 0, sizeof(portalsGUID));
         }
@@ -311,6 +315,9 @@ public:
                 case DATA_ABOMINATION_KILLED:
                     AbominationCount = value;
                     break;
+                case DATA_POLARITY_SWITCHED:
+                    PolaritySwitch = value;
+                    break;
             }
         }
 
@@ -440,6 +447,13 @@ public:
                     if (AreAllEncoutersDone() && !playerDied)
                         return true;
                     return false;
+                // Criteria for achievement 2178: Shocking! (10-man)
+                case 7604:
+                // Criteria for achievement 2179: Shocking! (25-man)
+                case 7605:
+                    if (!PolaritySwitch)
+                        return true;
+                    return false;
             }
             return false;
         }
@@ -447,14 +461,14 @@ public:
         std::string GetSaveData()
         {
             std::ostringstream saveStream;
-            saveStream << GetBossSaveData() << gothikDoorState << ' ' << playerDied;
+            saveStream << GetBossSaveData() << gothikDoorState << ' ' << playerDied << ' ' << PolaritySwitch;
             return saveStream.str();
         }
 
         void Load(const char * data)
         {
             std::istringstream loadStream(LoadBossState(data));
-            uint32 temp, buff, buff2;
+            uint32 temp, buff, buff2, buff3;
 
             for (uint32 i = 0; i < MAX_BOSS_NUMBER; ++i)
                 loadStream >> temp;
@@ -463,6 +477,8 @@ public:
             gothikDoorState = GOState(buff);
             loadStream >> buff2;
             playerDied = buff2;
+            loadStream >> buff3;
+            PolaritySwitch = buff3;
         }
     };
 

--- a/src/server/scripts/Northrend/Naxxramas/naxxramas.h
+++ b/src/server/scripts/Northrend/Naxxramas/naxxramas.h
@@ -49,6 +49,8 @@ enum Data
     DATA_HORSEMEN2,
     DATA_HORSEMEN3,
     DATA_ABOMINATION_KILLED,
+    
+    DATA_POLARITY_SWITCHED,
 };
 
 enum Data64


### PR DESCRIPTION
closes #4751
I did not use a sql file because of the missmatching dates, i dont know when this pull request will be merged

``` sql

DELETE FROM `spell_script_names` WHERE `spell_id` IN (28062, 28085, 39090, 39093);
INSERT INTO `spell_script_names`(`spell_id`, `scriptname`) VALUES
(28062, "spell_thaddius_pos_neg_charge"),
(28085, "spell_thaddius_pos_neg_charge"),
(39090, "spell_thaddius_pos_neg_charge"),
(39093, "spell_thaddius_pos_neg_charge");

DELETE FROM `disables` WHERE `sourcetype` = 4 AND `entry` IN (7604, 7605); -- Enable the criteria

DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (7604, 7605) AND `type` = 18;
INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `scriptname`) VALUES
(7604, 18, 0, 0, ""),
(7605, 18, 0, 0, "");
```

Signed-off-by: Subv2112 s.v.h21@hotmail.com
