### PR TITLE
Dependencies/G3D: Fix typo in isNaN(float x).

### DIFF
--- a/dep/g3dlite/source/g3dmath.cpp
+++ b/dep/g3dlite/source/g3dmath.cpp
@@ -41,7 +41,7 @@ double inf() {
 }
 
 bool isNaN(float x) {
-    static const float n = nan();
+    static const float n = fnan();
     return memcmp(&x, &n, sizeof(float)) == 0;
 }
 


### PR DESCRIPTION
*In original G3D svn it was fixed long time ago.
