### PR TITLE
Core/Spells: Fixed incorrect mover errors for summoned creatures

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3135,6 +3135,12 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
             break;
         case SUMMON_CATEGORY_PUPPET:
             summon = m_caster->GetMap()->SummonCreature(entry, pos, properties, duration, m_originalCaster, m_spellInfo->Id);
+            if (properties->Id == 65 || properties->Id == 428) // Eye of Acherus, Raise Ally, Dream Vision, etc.
+                if (summon)
+                {
+                    summon->RemoveCharmedBy(m_caster); // need to remove the current charmer to cast new charm spell on it
+                    m_caster->CastSpell(summon, 530, true);
+                }
             break;
         case SUMMON_CATEGORY_VEHICLE:
             // Summoning spells (usually triggered by npc_spellclick) that spawn a vehicle and that cause the clicker

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3178,6 +3178,7 @@ void SpellMgr::LoadDbcDataCorrections()
             case 27915: // Anchor to Skulls
             case 27931: // Anchor to Skulls
             case 27937: // Anchor to Skulls
+            case 530: // Charm (Possess)
                 spellInfo->rangeIndex = 13;
                 break;
             // target allys instead of enemies, target A is src_caster, spells with effect like that have ally target


### PR DESCRIPTION
closes #4766

Spells with EffectMiscValueB = 65 or 428: http://pastebin.com/S6BSrCYw

Known issues: When Eye of Acherus is summoned, it move like a _pet_ to the player's position, then can be controlled without problems.
