### PR TITLE
[CORE/SPELLS] Fix immuniry checks on apply aura.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3195,7 +3195,7 @@ void Unit::_ApplyAura(AuraApplication * aurApp, uint8 effMask)
     // apply effects of the aura
     for (uint8 i = 0 ; i < MAX_SPELL_EFFECTS; ++i)
     {
-        if (effMask & 1<<i && (!aurApp->GetRemoveMode()))
+        if (effMask & 1 << i && (!aurApp->GetRemoveMode()) && !IsImmunedToSpellEffect(aura->GetSpellInfo(), i))
             aurApp->_HandleEffect(i, true);
     }
 }


### PR DESCRIPTION
Some AOE auras need a immunity checks before the handle of their effects. This commit will fix a bug introdouced on 08bcbc89b04b5848596ec6073d3d7ef9e98b4dec
