### PR TITLE
"An Audience With The Arcanist" and "A Meeting With The Magister"

### DIFF
--- a/sql/updates/world/2012_01_17_00_world_misc.sql
+++ b/sql/updates/world/2012_01_17_00_world_misc.sql
@@ -1,0 +1,27 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (69672,69673);
+INSERT INTO `spell_script_names`(`spell_id`,`ScriptName`) VALUES
+(69672,'spell_gen_sunreaver_disguise'),
+(69673,'spell_gen_silver_covenant_disguise');
+
+-- Update spells used on script. Now they are always casting the female spell,
+-- since the spell script is fixed we should cast now the correct spell.
+UPDATE `smart_scripts` SET `action_param1`=69672 WHERE `entryorguid`=36669 AND `action_type`=11 AND `action_param1`=70973;
+UPDATE `smart_scripts` SET `action_param1`=69673 WHERE `entryorguid`=36670 AND `action_type`=11 AND `action_param1`=70971;
+-- Set correct gossip menus ids for renewing the disguise
+UPDATE `smart_scripts` SET `event_param1`=10858 WHERE `entryorguid`=36669 AND `event_param1`=10857;
+UPDATE `smart_scripts` SET `event_param1`=10857 WHERE `entryorguid`=36670 AND `event_param1`=10858;
+
+-- Gossip options were crossed. They should offer to cast the oposing faction disguise,instead of his own faction disguise.
+UPDATE `gossip_menu_option` SET `option_text`="Would you renew my Covenant disguise?" WHERE `menu_id`=10857 AND `id`=1;
+UPDATE `gossip_menu_option` SET `option_text`="Would you renew my Sunreaver disguise?" WHERE `menu_id`=10858 AND `id`=1;
+
+-- Correct quest ids on conditios for showing the renew disguise option.
+-- Also add a check for male disguise aura.
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup` IN (10857,10858) AND `SourceEntry`=1;
+INSERT INTO `conditions`(`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(15,10858,1,0,11,70973,0,0,0,'',NULL),
+(15,10858,1,0,11,70974,0,0,0,'',NULL),
+(15,10858,1,0,9,20439,0,0,0,'',NULL),
+(15,10857,1,0,11,70971,0,0,0,'',NULL),
+(15,10857,1,0,11,70972,0,0,0,'',NULL),
+(15,10857,1,0,9,24451,0,0,0,'',NULL);

--- a/src/server/scripts/Northrend/dalaran.cpp
+++ b/src/server/scripts/Northrend/dalaran.cpp
@@ -32,7 +32,12 @@ Script Data End */
 enum Spells
 {
     SPELL_TRESPASSER_A = 54028,
-    SPELL_TRESPASSER_H = 54029
+    SPELL_TRESPASSER_H = 54029,
+
+    SPELL_SUNREAVER_DISGUISE_FEMALE        = 70973,
+    SPELL_SUNREAVER_DISGUISE_MALE          = 70974,
+    SPELL_SILVER_COVENANT_DISGUISE_FEMALE  = 70971,
+    SPELL_SILVER_COVENANT_DISGUISE_MALE    = 70972,
 };
 
 enum NPCs // All outdoor guards are within 35.0f of these NPCs
@@ -71,8 +76,10 @@ public:
 
             Player* player = who->GetCharmerOrOwnerPlayerOrPlayerItself();
             
-            // If player has Disguise aura for quest A Meeting With The Magister or An Audience With The Arcanist, do not teleport it away but let it pass
-            if (!player || player->isGameMaster() || player->IsBeingTeleported() || player->HasAura(70973) || player->HasAura(70971))
+            if (!player || player->isGameMaster() || player->IsBeingTeleported() ||
+                // If player has Disguise aura for quest A Meeting With The Magister or An Audience With The Arcanist, do not teleport it away but let it pass
+                player->HasAura(SPELL_SUNREAVER_DISGUISE_FEMALE) || player->HasAura(SPELL_SUNREAVER_DISGUISE_MALE) ||
+                player->HasAura(SPELL_SILVER_COVENANT_DISGUISE_FEMALE) || player->HasAura(SPELL_SILVER_COVENANT_DISGUISE_MALE))
                 return;
 
             switch (me->GetEntry())

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1471,6 +1471,82 @@ class spell_gen_luck_of_the_draw : public SpellScriptLoader
         }
 };
 
+enum DalaranDisguiseSpells
+{
+    SPELL_SUNREAVER_DISGUISE_TRIGGER       = 69672,
+    SPELL_SUNREAVER_DISGUISE_FEMALE        = 70973,
+    SPELL_SUNREAVER_DISGUISE_MALE          = 70974,
+
+    SPELL_SILVER_COVENANT_DISGUISE_TRIGGER = 69673,
+    SPELL_SILVER_COVENANT_DISGUISE_FEMALE  = 70971,
+    SPELL_SILVER_COVENANT_DISGUISE_MALE    = 70972,
+};
+
+class spell_gen_dalaran_disguise : public SpellScriptLoader
+{
+    public:
+        spell_gen_dalaran_disguise(const char* name) : SpellScriptLoader(name) {}
+
+        class spell_gen_dalaran_disguise_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_gen_dalaran_disguise_SpellScript);
+            bool Validate(SpellInfo const* spellEntry)
+            {
+                switch (spellEntry->Id)
+                {
+                    case SPELL_SUNREAVER_DISGUISE_TRIGGER:
+                        if (!sSpellMgr->GetSpellInfo(SPELL_SUNREAVER_DISGUISE_FEMALE))
+                            return false;
+                        if (!sSpellMgr->GetSpellInfo(SPELL_SUNREAVER_DISGUISE_MALE))
+                            return false;
+                        break;
+                    case SPELL_SILVER_COVENANT_DISGUISE_TRIGGER:
+                        if (!sSpellMgr->GetSpellInfo(SPELL_SILVER_COVENANT_DISGUISE_FEMALE))
+                            return false;
+                        if (!sSpellMgr->GetSpellInfo(SPELL_SILVER_COVENANT_DISGUISE_MALE))
+                            return false;
+                        break;
+                }
+                return true;
+            }
+
+            void HandleScript(SpellEffIndex /*effIndex*/)
+            {
+
+                if (Player* player = GetHitPlayer())
+                {
+                    uint8 gender = player->getGender();
+
+                    uint32 spellId = GetSpellInfo()->Id;
+
+                    switch (spellId)
+                    {
+                        case SPELL_SUNREAVER_DISGUISE_TRIGGER:
+                            spellId = gender ? SPELL_SUNREAVER_DISGUISE_FEMALE : SPELL_SUNREAVER_DISGUISE_MALE;
+                            break;
+                        case SPELL_SILVER_COVENANT_DISGUISE_TRIGGER:
+                            spellId = gender ? SPELL_SILVER_COVENANT_DISGUISE_FEMALE : SPELL_SILVER_COVENANT_DISGUISE_MALE;
+                            break;
+                        default:
+                            break;
+                    }
+
+                    GetCaster()->CastSpell(player, spellId, true);
+                }
+            }
+
+            void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_gen_dalaran_disguise_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_gen_dalaran_disguise_SpellScript();
+        }
+};
+
 void AddSC_generic_spell_scripts()
 {
     new spell_gen_absorb0_hitlimit1();
@@ -1504,4 +1580,6 @@ void AddSC_generic_spell_scripts()
     new spell_gen_oracle_wolvar_reputation();
     new spell_gen_damage_reduction_aura();
     new spell_gen_luck_of_the_draw();
+    new spell_gen_dalaran_disguise("spell_gen_sunreaver_disguise");
+    new spell_gen_dalaran_disguise("spell_gen_silver_covenant_disguise");
 }


### PR DESCRIPTION
Currently this two quest have the problems listed below
- Disguise spells casted on players are always the female one, regardless the gender of the character.
- Guards of faction zones in Dalaran only check if player has the female disguise aura.
- When talking with the own faction herald, he should offer the option of recasting the disguise if aura expired on player, they don't. In fact, this option is shown by the oposing herald but when clicked does nothing.

These problems are solved on this commit.

The quests are completable as they are right now, but this commit makes them work in a propper way.
