### PR TITLE
Scripts: Lunar Festival related stuff

### DIFF
--- a/sql/updates/world/2012_01_28_01_world_misc.sql
+++ b/sql/updates/world/2012_01_28_01_world_misc.sql
@@ -1,0 +1,102 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (26374);
+INSERT INTO `spell_script_names`(`spell_id`,`ScriptName`) VALUES
+(26374,'spell_gen_elune_candle');
+
+-- Set Gigant Spotlight as not selectable
+UPDATE `creature_template` SET `unit_flags`=33554432 WHERE `entry`=15902;
+
+DELETE FROM `creature_template_addon` WHERE (`entry`IN(15902,15466));
+INSERT INTO `creature_template_addon`(`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES
+(15466,0,0,0,0,0,17327), -- Add spirit particles to Omen minions
+(15902,0,0,0,0,0,50236); -- Add Spotlight aura to Gigant Spotlight (ummoned by 26392 on Omen's death)
+
+UPDATE `creature_template` SET `ScriptName`='npc_giant_spotlight' WHERE `entry`=15902;
+UPDATE `creature_template` SET `RegenHealth`=0,`ScriptName`='npc_omen' WHERE `entry`=15467;
+UPDATE `creature_template` SET `ScriptName`='npc_firework',`AIName`='',`faction_A`=35,`faction_H`=35,`unit_flags`=33555200 WHERE `entry` IN (15879,15880,15881,15882,15883,15884,15885,15886,15887,15888,15889,15890,15872,15873,15874,15875,15876,15877,15911,15912,15913,15914,15915,15916,15918);
+-- Cleanup EventAI and SmartAI
+DELETE FROM `creature_ai_scripts` WHERE `creature_id` IN (15879,15880,15881,15882,15883,15884,15885,15886,15887,15888,15889,15890,15872,15873,15874,15875,15876,15877,15911,15912,15913,15914,15915,15916,15918);
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid` IN (15879,15880,15881,15882,15883,15884,15885,15886,15887,15888,15889,15890,15872,15873,15874,15875,15876,15877,15911,15912,15913,15914,15915,15916,15918);
+
+-- Update al targeting stuff for Fireworks and Rocket clusters
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry` IN (26294,26295,26333,26334,26336,26337,26338,26488,26490,26517,26521,26344,26347,26345,26348,26349,26351,26352,26354,26355,26356);
+INSERT INTO `conditions`(`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+-- Targeting Firework Launcher
+(13,0,26294,0,18,0,180771,0,0,'',"Small White Rocket target Firework Launcher"),
+(13,0,26294,0,18,0,180850,0,0,'',"Small White Rocket target Firework Launcher"),
+(13,0,26294,0,18,0,180868,0,0,'',"Small White Rocket target Firework Launcher"),
+(13,0,26295,0,18,0,180771,0,0,'',"Small Yellow Rocket target Firework Launcher"),
+(13,0,26295,0,18,0,180850,0,0,'',"Small Yellow Rocket target Firework Launcher"),
+(13,0,26295,0,18,0,180868,0,0,'',"Small Yellow Rocket target Firework Launcher"),
+(13,0,26333,0,18,0,180771,0,0,'',"Large Blue Rocket target Firework Launcher"),
+(13,0,26333,0,18,0,180850,0,0,'',"Large Blue Rocket target Firework Launcher"),
+(13,0,26333,0,18,0,180868,0,0,'',"Large Blue Rocket target Firework Launcher"),
+(13,0,26334,0,18,0,180771,0,0,'',"Large Green Rocket target Firework Launcher"),
+(13,0,26334,0,18,0,180850,0,0,'',"Large Green Rocket target Firework Launcher"),
+(13,0,26334,0,18,0,180868,0,0,'',"Large Green Rocket target Firework Launcher"),
+(13,0,26336,0,18,0,180771,0,0,'',"Large Red Rocket target Firework Launcher"),
+(13,0,26336,0,18,0,180850,0,0,'',"Large Red Rocket target Firework Launcher"),
+(13,0,26336,0,18,0,180868,0,0,'',"Large Red Rocket target Firework Launcher"),
+(13,0,26337,0,18,0,180771,0,0,'',"Large White Rocket target Firework Launcher"),
+(13,0,26337,0,18,0,180850,0,0,'',"Large White Rocket target Firework Launcher"),
+(13,0,26337,0,18,0,180868,0,0,'',"Large White Rocket target Firework Launcher"),
+(13,0,26338,0,18,0,180771,0,0,'',"Large Yellow Rocket target Firework Launcher"),
+(13,0,26338,0,18,0,180850,0,0,'',"Large Yellow Rocket target Firework Launcher"),
+(13,0,26338,0,18,0,180868,0,0,'',"Large Yellow Rocket target Firework Launcher"),
+-- Targeting Cluster Launcher
+(13,0,26488,0,18,0,180772,0,0,'',"Large Blue Rocket Cluster target Cluster Launcher"),
+(13,0,26488,0,18,0,180859,0,0,'',"Large Blue Rocket Cluster target Cluster Launcher"),
+(13,0,26488,0,18,0,180869,0,0,'',"Large Blue Rocket Cluster target Cluster Launcher"),
+(13,0,26488,0,18,0,180874,0,0,'',"Large Blue Rocket Cluster target Cluster Launcher"),
+(13,0,26490,0,18,0,180772,0,0,'',"Large Green Rocket Cluster target Cluster Launcher"),
+(13,0,26490,0,18,0,180859,0,0,'',"Large Green Rocket Cluster target Cluster Launcher"),
+(13,0,26490,0,18,0,180869,0,0,'',"Large Green Rocket Cluster target Cluster Launcher"),
+(13,0,26490,0,18,0,180874,0,0,'',"Large Green Rocket Cluster target Cluster Launcher"),
+(13,0,26517,0,18,0,180772,0,0,'',"Large Red Rocket Cluster target Cluster Launcher"),
+(13,0,26517,0,18,0,180859,0,0,'',"Large Red Rocket Cluster target Cluster Launcher"),
+(13,0,26517,0,18,0,180869,0,0,'',"Large Red Rocket Cluster target Cluster Launcher"),
+(13,0,26517,0,18,0,180874,0,0,'',"Large Red Rocket Cluster target Cluster Launcher"),
+(13,0,26521,0,18,0,180772,0,0,'',"Lucky Lunar rocket Cluster target Cluster Launcher"),
+(13,0,26521,0,18,0,180859,0,0,'',"Lucky Lunar rocket Cluster target Cluster Launcher"),
+(13,0,26521,0,18,0,180869,0,0,'',"Lucky Lunar rocket Cluster target Cluster Launcher"),
+(13,0,26521,0,18,0,180874,0,0,'',"Lucky Lunar rocket Cluster target Cluster Launcher"),
+-- Targeting Firework Launcher (Again)
+(13,0,26347,0,18,0,180771,0,0,'',"Rocket, RED target Firework Launcher"),
+(13,0,26347,0,18,0,180850,0,0,'',"Rocket, RED target Firework Launcher"),
+(13,0,26347,0,18,0,180868,0,0,'',"Rocket, RED target Firework Launcher"),
+(13,0,26344,0,18,0,180771,0,0,'',"Rocket, BLUE target Firework Launcher"),
+(13,0,26344,0,18,0,180850,0,0,'',"Rocket, BLUE target Firework Launcher"),
+(13,0,26344,0,18,0,180868,0,0,'',"Rocket, BLUE target Firework Launcher"),
+(13,0,26345,0,18,0,180771,0,0,'',"Rocket, GREEEN target Firework Launcher"),
+(13,0,26345,0,18,0,180850,0,0,'',"Rocket, GREEEN target Firework Launcher"),
+(13,0,26345,0,18,0,180868,0,0,'',"Rocket, GREEEN target Firework Launcher"),
+(13,0,26348,0,18,0,180771,0,0,'',"Rocket, WHITE target Firework Launcher"),
+(13,0,26348,0,18,0,180850,0,0,'',"Rocket, WHITE target Firework Launcher"),
+(13,0,26348,0,18,0,180868,0,0,'',"Rocket, WHITE target Firework Launcher"),
+(13,0,26349,0,18,0,180771,0,0,'',"Rocket, YELLOW target Firework Launcher"),
+(13,0,26349,0,18,0,180850,0,0,'',"Rocket, YELLOW target Firework Launcher"),
+(13,0,26349,0,18,0,180868,0,0,'',"Rocket, YELLOW target Firework Launcher"),
+(13,0,26351,0,18,0,180771,0,0,'',"Rocket, BLUE BIG target Firework Launcher"),
+(13,0,26351,0,18,0,180850,0,0,'',"Rocket, BLUE BIG target Firework Launcher"),
+(13,0,26351,0,18,0,180868,0,0,'',"Rocket, BLUE BIG target Firework Launcher"),
+(13,0,26352,0,18,0,180771,0,0,'',"Rocket, GREEN BIG target Firework Launcher"),
+(13,0,26352,0,18,0,180850,0,0,'',"Rocket, GREEN BIG target Firework Launcher"),
+(13,0,26352,0,18,0,180868,0,0,'',"Rocket, GREEN BIG target Firework Launcher"),
+(13,0,26354,0,18,0,180771,0,0,'',"Rocket, RED BIG target Firework Launcher"),
+(13,0,26354,0,18,0,180850,0,0,'',"Rocket, RED BIG target Firework Launcher"),
+(13,0,26354,0,18,0,180868,0,0,'',"Rocket, RED BIG target Firework Launcher"),
+(13,0,26355,0,18,0,180771,0,0,'',"Rocket, WHITE BIG target Firework Launcher"),
+(13,0,26355,0,18,0,180850,0,0,'',"Rocket, WHITE BIG target Firework Launcher"),
+(13,0,26355,0,18,0,180868,0,0,'',"Rocket, WHITE BIG target Firework Launcher"),
+(13,0,26356,0,18,0,180771,0,0,'',"Rocket, YELLOW BIG target Firework Launcher"),
+(13,0,26356,0,18,0,180850,0,0,'',"Rocket, YELLOW BIG target Firework Launcher"),
+(13,0,26356,0,18,0,180868,0,0,'',"Rocket, YELLOW BIG target Firework Launcher");
+
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=15466;
+DELETE FROM `smart_scripts` WHERE (`entryorguid`=15466 AND `source_type`=0);
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(15466,0,0,0,8,0,100,0,26636,0,8000,9000,11,25495,0,0,0,0,0,1,0,0,0,0,0,0,0,"Minion of Omen - Cast Firework Dazzled when hitted by Elune's Candle firework");
+
+-- Cast quest credit spell when getting Elune's Blessing buff
+DELETE FROM `spell_scripts` WHERE `id`=26393;
+INSERT INTO `spell_scripts`(`id`,`effIndex`,`delay`,`command`,`datalong`,`datalong2`,`dataint`,`x`,`y`,`z`,`o`) VALUES
+(26393,1,0,15,26394,2,0,0,0,0,0);

--- a/src/server/scripts/Kalimdor/moonglade.cpp
+++ b/src/server/scripts/Kalimdor/moonglade.cpp
@@ -573,8 +573,150 @@ public:
 };
 
 /*####
-#
+# npc_omen
 ####*/
+
+enum Omen
+{
+    NPC_OMEN                    = 15467,
+
+    SPELL_OMEN_CLEAVE           = 15284,
+    SPELL_OMEN_STARFALL         = 26540,
+    SPELL_OMEN_SUMMON_SPOTLIGHT = 26392,
+    SPELL_ELUNE_CANDLE          = 26374,
+
+    GO_ELUNE_TRAP_1             = 180876,
+    GO_ELUNE_TRAP_2             = 180877,
+
+    EVENT_CAST_CLEAVE           = 1,
+    EVENT_CAST_STARFALL         = 2,
+    EVENT_DESPAWN               = 3,
+};
+
+class npc_omen : public CreatureScript
+{
+public:
+    npc_omen() : CreatureScript("npc_omen") { }
+
+    struct npc_omenAI : public ScriptedAI
+    {
+        npc_omenAI(Creature* creature) : ScriptedAI(creature)
+        {
+            me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
+            me->GetMotionMaster()->MovePoint(1, 7549.977f, -2855.137f, 456.9678f);
+        }
+
+        EventMap events;
+
+        void MovementInform(uint32 type, uint32 pointId)
+        {
+            if (type != POINT_MOTION_TYPE)
+                return;
+
+            if (pointId == 1)
+            {
+                me->SetHomePosition(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), me->GetOrientation());
+                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_OOC_NOT_ATTACKABLE);
+                if (Player* player = me->SelectNearestPlayer(40.0f))
+                    AttackStart(player);
+            }
+        }
+
+        void EnterCombat(Unit* /*attacker*/)
+        {
+            events.Reset();
+            events.ScheduleEvent(EVENT_CAST_CLEAVE, urand(3000, 5000));
+            events.ScheduleEvent(EVENT_CAST_STARFALL, urand(8000, 10000));
+        }
+
+        void JustDied(Unit* /*killer*/)
+        {
+            DoCast(SPELL_OMEN_SUMMON_SPOTLIGHT);
+        }
+
+        void SpellHit(Unit* /*caster*/, const SpellInfo* spell)
+        {
+            if (spell->Id == SPELL_ELUNE_CANDLE)
+            {
+                if (me->HasAura(SPELL_OMEN_STARFALL))
+                    me->RemoveAurasDueToSpell(SPELL_OMEN_STARFALL);
+
+                events.RescheduleEvent(EVENT_CAST_STARFALL, urand(14000, 16000));
+            }
+        }
+
+        void UpdateAI(const uint32 diff)
+        {
+            if (!UpdateVictim())
+                return;
+
+            events.Update(diff);
+
+            switch (events.ExecuteEvent())
+            {
+                case EVENT_CAST_CLEAVE:
+                    DoCastVictim(SPELL_OMEN_CLEAVE);
+                    events.ScheduleEvent(EVENT_CAST_CLEAVE, urand(8000, 10000));
+                    break;
+                case EVENT_CAST_STARFALL:
+                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                        DoCast(target, SPELL_OMEN_STARFALL);
+                    events.ScheduleEvent(EVENT_CAST_STARFALL, urand(14000, 16000));
+                    break;
+            }
+
+            DoMeleeAttackIfReady();
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const
+    {
+        return new npc_omenAI(creature);
+    }
+};
+
+class npc_giant_spotlight : public CreatureScript
+{
+public:
+    npc_giant_spotlight() : CreatureScript("npc_giant_spotlight") { }
+
+    struct npc_giant_spotlightAI : public ScriptedAI
+    {
+        npc_giant_spotlightAI(Creature* creature) : ScriptedAI(creature) {}
+
+        EventMap events;
+
+        void Reset()
+        {
+            events.Reset();
+            events.ScheduleEvent(EVENT_DESPAWN, 5*MINUTE*IN_MILLISECONDS);
+        }
+
+        void UpdateAI(const uint32 diff)
+        {
+            events.Update(diff);
+
+            if (events.ExecuteEvent() == EVENT_DESPAWN)
+            {
+                if (GameObject* trap = me->FindNearestGameObject(GO_ELUNE_TRAP_1, 5.0f))
+                    trap->RemoveFromWorld();
+
+                if (GameObject* trap = me->FindNearestGameObject(GO_ELUNE_TRAP_2, 5.0f))
+                    trap->RemoveFromWorld();
+
+                if (Creature* omen = me->FindNearestCreature(NPC_OMEN, 5.0f, false))
+                    omen->DespawnOrUnsummon();
+
+                me->DespawnOrUnsummon();
+            }
+        }
+    };
+
+    CreatureAI* GetAI(Creature* creature) const
+    {
+        return new npc_giant_spotlightAI(creature);
+    }
+};
 
 void AddSC_moonglade()
 {
@@ -583,4 +725,6 @@ void AddSC_moonglade()
     new npc_silva_filnaveth();
     new npc_clintar_dreamwalker();
     new npc_clintar_spirit();
+    new npc_omen();
+    new npc_giant_spotlight();
 }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -412,6 +412,75 @@ class spell_gen_leeching_swarm : public SpellScriptLoader
         }
 };
 
+enum EluneCandle
+{
+    NPC_OMEN = 15467,
+
+    SPELL_ELUNE_CANDLE_OMEN_HEAD   = 26622,
+    SPELL_ELUNE_CANDLE_OMEN_CHEST  = 26624,
+    SPELL_ELUNE_CANDLE_OMEN_HAND_R = 26625,
+    SPELL_ELUNE_CANDLE_OMEN_HAND_L = 26649,
+    SPELL_ELUNE_CANDLE_NORMAL      = 26636,
+};
+
+class spell_gen_elune_candle : public SpellScriptLoader
+{
+    public:
+        spell_gen_elune_candle() : SpellScriptLoader("spell_gen_elune_candle") {}
+
+        class spell_gen_elune_candle_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_gen_elune_candle_SpellScript);
+            bool Validate(SpellInfo const* /*spellEntry*/)
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_ELUNE_CANDLE_OMEN_HEAD))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_ELUNE_CANDLE_OMEN_CHEST))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_ELUNE_CANDLE_OMEN_HAND_R))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_ELUNE_CANDLE_OMEN_HAND_L))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_ELUNE_CANDLE_NORMAL))
+                    return false;
+                return true;
+            }
+
+            void HandleScript(SpellEffIndex /*effIndex*/)
+            {
+                if (Unit* target = GetHitUnit())
+                {
+                    uint32 spellId = 0;
+
+                    if (target->GetEntry() == NPC_OMEN)
+                    {
+                        switch (urand(0, 3))
+                        {
+                            case 0: spellId = SPELL_ELUNE_CANDLE_OMEN_HEAD; break;
+                            case 1: spellId = SPELL_ELUNE_CANDLE_OMEN_CHEST; break;
+                            case 2: spellId = SPELL_ELUNE_CANDLE_OMEN_HAND_R; break;
+                            case 3: spellId = SPELL_ELUNE_CANDLE_OMEN_HAND_L; break;
+                        }
+                    }
+                    else
+                        spellId = SPELL_ELUNE_CANDLE_NORMAL;
+
+                    GetCaster()->CastSpell(target, spellId, true, NULL);
+                }
+            }
+
+            void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_gen_elune_candle_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_gen_elune_candle_SpellScript();
+        }
+};
+
 // 24750 Trick
 enum eTrickSpells
 {
@@ -1592,4 +1661,5 @@ void AddSC_generic_spell_scripts()
     new spell_gen_luck_of_the_draw();
     new spell_gen_dalaran_disguise("spell_gen_sunreaver_disguise");
     new spell_gen_dalaran_disguise("spell_gen_silver_covenant_disguise");
+    new spell_gen_elune_candle();
 }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -40,6 +40,7 @@ npc_sayge               100%    Darkmoon event fortune teller, buff player based
 npc_snake_trap_serpents  80%    AI for snakes that summoned by Snake Trap
 npc_shadowfiend         100%   restore 5% of owner's mana when shadowfiend die from damage
 npc_locksmith            75%    list of keys needs to be confirmed
+npc_firework            100%    NPC's summoned by rockets and rocket clusters, for making them cast visual
 EndContentData */
 
 #include "ScriptPCH.h"
@@ -2764,6 +2765,285 @@ public:
     }
 };
 
+enum Fireworks
+{
+    NPC_OMEN                = 15467,
+    NPC_MINION_OF_OMEN      = 15466,
+    NPC_FIREWORK_BLUE       = 15879,
+    NPC_FIREWORK_GREEN      = 15880,
+    NPC_FIREWORK_PURPLE     = 15881,
+    NPC_FIREWORK_RED        = 15882,
+    NPC_FIREWORK_YELLOW     = 15883,
+    NPC_FIREWORK_WHITE      = 15884,
+    NPC_FIREWORK_BIG_BLUE   = 15885,
+    NPC_FIREWORK_BIG_GREEN  = 15886,
+    NPC_FIREWORK_BIG_PURPLE = 15887,
+    NPC_FIREWORK_BIG_RED    = 15888,
+    NPC_FIREWORK_BIG_YELLOW = 15889,
+    NPC_FIREWORK_BIG_WHITE  = 15890,
+
+    NPC_CLUSTER_BLUE        = 15872,
+    NPC_CLUSTER_RED         = 15873,
+    NPC_CLUSTER_GREEN       = 15874,
+    NPC_CLUSTER_PURPLE      = 15875,
+    NPC_CLUSTER_WHITE       = 15876,
+    NPC_CLUSTER_YELLOW      = 15877,
+    NPC_CLUSTER_BIG_BLUE    = 15911,
+    NPC_CLUSTER_BIG_GREEN   = 15912,
+    NPC_CLUSTER_BIG_PURPLE  = 15913,
+    NPC_CLUSTER_BIG_RED     = 15914,
+    NPC_CLUSTER_BIG_WHITE   = 15915,
+    NPC_CLUSTER_BIG_YELLOW  = 15916,
+    NPC_CLUSTER_ELUNE       = 15918,
+
+    GO_FIREWORK_LAUNCHER_1  = 180771,
+    GO_FIREWORK_LAUNCHER_2  = 180868,
+    GO_FIREWORK_LAUNCHER_3  = 180850,
+    GO_CLUSTER_LAUNCHER_1   = 180772,
+    GO_CLUSTER_LAUNCHER_2   = 180859,
+    GO_CLUSTER_LAUNCHER_3   = 180869,
+    GO_CLUSTER_LAUNCHER_4   = 180874,
+
+    SPELL_ROCKET_BLUE       = 26344,
+    SPELL_ROCKET_GREEN      = 26345,
+    SPELL_ROCKET_PURPLE     = 26346,
+    SPELL_ROCKET_RED        = 26347,
+    SPELL_ROCKET_WHITE      = 26348,
+    SPELL_ROCKET_YELLOW     = 26349,
+    SPELL_ROCKET_BIG_BLUE   = 26351,
+    SPELL_ROCKET_BIG_GREEN  = 26352,
+    SPELL_ROCKET_BIG_PURPLE = 26353,
+    SPELL_ROCKET_BIG_RED    = 26354,
+    SPELL_ROCKET_BIG_WHITE  = 26355,
+    SPELL_ROCKET_BIG_YELLOW = 26356,
+    SPELL_LUNAR_FORTUNE     = 26522,
+
+    ANIM_GO_LAUNCH_FIREWORK = 3,
+    ZONE_MOONGLADE          = 493,
+};
+
+Position omenSummonPos = {7558.993f, -2839.999f, 450.0214f, 4.46f};
+
+class npc_firework : public CreatureScript
+{
+public:
+    npc_firework() : CreatureScript("npc_firework") { }
+
+    struct npc_fireworkAI : public ScriptedAI
+    {
+        npc_fireworkAI(Creature* creature) : ScriptedAI(creature) {}
+
+        bool isCluster()
+        {
+            switch (me->GetEntry())
+            {
+                case NPC_FIREWORK_BLUE:
+                case NPC_FIREWORK_GREEN:
+                case NPC_FIREWORK_PURPLE:
+                case NPC_FIREWORK_RED:
+                case NPC_FIREWORK_YELLOW:
+                case NPC_FIREWORK_WHITE:
+                case NPC_FIREWORK_BIG_BLUE:
+                case NPC_FIREWORK_BIG_GREEN:
+                case NPC_FIREWORK_BIG_PURPLE:
+                case NPC_FIREWORK_BIG_RED:
+                case NPC_FIREWORK_BIG_YELLOW:
+                case NPC_FIREWORK_BIG_WHITE:
+                    return false;
+                case NPC_CLUSTER_BLUE:
+                case NPC_CLUSTER_GREEN:
+                case NPC_CLUSTER_PURPLE:
+                case NPC_CLUSTER_RED:
+                case NPC_CLUSTER_YELLOW:
+                case NPC_CLUSTER_WHITE:
+                case NPC_CLUSTER_BIG_BLUE:
+                case NPC_CLUSTER_BIG_GREEN:
+                case NPC_CLUSTER_BIG_PURPLE:
+                case NPC_CLUSTER_BIG_RED:
+                case NPC_CLUSTER_BIG_YELLOW:
+                case NPC_CLUSTER_BIG_WHITE:
+                case NPC_CLUSTER_ELUNE:
+                default:
+                    return true;
+            }
+        }
+
+        GameObject* FindNearestLauncher()
+        {
+            GameObject* launcher = NULL;
+
+            if (isCluster())
+            {
+                GameObject* launcher1 = GetClosestGameObjectWithEntry(me, GO_CLUSTER_LAUNCHER_1, 0.5f);
+                GameObject* launcher2 = GetClosestGameObjectWithEntry(me, GO_CLUSTER_LAUNCHER_2, 0.5f);
+                GameObject* launcher3 = GetClosestGameObjectWithEntry(me, GO_CLUSTER_LAUNCHER_3, 0.5f);
+                GameObject* launcher4 = GetClosestGameObjectWithEntry(me, GO_CLUSTER_LAUNCHER_4, 0.5f);
+
+                if (launcher1)
+                    launcher = launcher1;
+                else if (launcher2)
+                    launcher = launcher2;
+                else if (launcher3)
+                    launcher = launcher3;
+                else if (launcher4)
+                    launcher = launcher4;
+            }
+            else
+            {
+                GameObject* launcher1 = GetClosestGameObjectWithEntry(me, GO_FIREWORK_LAUNCHER_1, 0.5f);
+                GameObject* launcher2 = GetClosestGameObjectWithEntry(me, GO_FIREWORK_LAUNCHER_2, 0.5f);
+                GameObject* launcher3 = GetClosestGameObjectWithEntry(me, GO_FIREWORK_LAUNCHER_3, 0.5f);
+
+                if (launcher1)
+                    launcher = launcher1;
+                else if (launcher2)
+                    launcher = launcher2;
+                else if (launcher3)
+                    launcher = launcher3;
+            }
+
+            return launcher;
+        }
+
+        uint32 GetFireworkSpell(uint32 entry)
+        {
+            switch (entry)
+            {
+                case NPC_FIREWORK_BLUE:
+                    return SPELL_ROCKET_BLUE;
+                case NPC_FIREWORK_GREEN:
+                    return SPELL_ROCKET_GREEN;
+                case NPC_FIREWORK_PURPLE:
+                    return SPELL_ROCKET_PURPLE;
+                case NPC_FIREWORK_RED:
+                    return SPELL_ROCKET_RED;
+                case NPC_FIREWORK_YELLOW:
+                    return SPELL_ROCKET_YELLOW;
+                case NPC_FIREWORK_WHITE:
+                    return SPELL_ROCKET_WHITE;
+                case NPC_FIREWORK_BIG_BLUE:
+                    return SPELL_ROCKET_BIG_BLUE;
+                case NPC_FIREWORK_BIG_GREEN:
+                    return SPELL_ROCKET_BIG_GREEN;
+                case NPC_FIREWORK_BIG_PURPLE:
+                    return SPELL_ROCKET_BIG_PURPLE;
+                case NPC_FIREWORK_BIG_RED:
+                    return SPELL_ROCKET_BIG_RED;
+                case NPC_FIREWORK_BIG_YELLOW:
+                    return SPELL_ROCKET_BIG_YELLOW;
+                case NPC_FIREWORK_BIG_WHITE:
+                    return SPELL_ROCKET_BIG_WHITE;
+                default:
+                    return 0;
+            }
+        }
+
+        uint32 GetFireworkGameObjectId()
+        {
+            uint32 spellId = 0;
+
+            switch (me->GetEntry())
+            {
+                case NPC_CLUSTER_BLUE:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BLUE);
+                    break;
+                case NPC_CLUSTER_GREEN:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_GREEN);
+                    break;
+                case NPC_CLUSTER_PURPLE:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_PURPLE);
+                    break;
+                case NPC_CLUSTER_RED:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_RED);
+                    break;
+                case NPC_CLUSTER_YELLOW:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_YELLOW);
+                    break;
+                case NPC_CLUSTER_WHITE:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_WHITE);
+                    break;
+                case NPC_CLUSTER_BIG_BLUE:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BIG_BLUE);
+                    break;
+                case NPC_CLUSTER_BIG_GREEN:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BIG_GREEN);
+                    break;
+                case NPC_CLUSTER_BIG_PURPLE:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BIG_PURPLE);
+                    break;
+                case NPC_CLUSTER_BIG_RED:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BIG_RED);
+                    break;
+                case NPC_CLUSTER_BIG_YELLOW:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BIG_YELLOW);
+                    break;
+                case NPC_CLUSTER_BIG_WHITE:
+                    spellId = GetFireworkSpell(NPC_FIREWORK_BIG_WHITE);
+                    break;
+                case NPC_CLUSTER_ELUNE:
+                    spellId = GetFireworkSpell(urand(NPC_FIREWORK_BLUE, NPC_FIREWORK_WHITE));
+                    break;
+            }
+
+            const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+
+            if (spellInfo && spellInfo->Effects[0].Effect == SPELL_EFFECT_SUMMON_OBJECT_WILD)
+                return spellInfo->Effects[0].MiscValue;
+
+            return 0;
+        }
+
+        void Reset()
+        {
+            if (GameObject* launcher = FindNearestLauncher())
+            {
+                launcher->SendCustomAnim(ANIM_GO_LAUNCH_FIREWORK);
+                me->SetOrientation(launcher->GetOrientation() + M_PI/2);
+            }
+            else
+                return;
+
+            if (isCluster())
+            {
+                // Check if we are near Elune'ara lake south, if so try to summon Omen or a minion
+                if (me->GetZoneId() == ZONE_MOONGLADE)
+                {
+                    if (!me->FindNearestCreature(NPC_OMEN, 100.0f, false) && me->GetDistance2d(omenSummonPos.GetPositionX(), omenSummonPos.GetPositionY()) <= 100.0f)
+                    {
+                        switch (urand(0,9))
+                        {
+                            case 0:
+                            case 1:
+                            case 2:
+                            case 3:
+                                if (Creature* minion = me->SummonCreature(NPC_MINION_OF_OMEN, me->GetPositionX()+frand(-5.0f, 5.0f), me->GetPositionY()+frand(-5.0f, 5.0f), me->GetPositionZ(), 0.0f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 20000))
+                                    minion->AI()->AttackStart(me->SelectNearestPlayer(20.0f));
+                                break;
+                            case 9:
+                                me->SummonCreature(NPC_OMEN, omenSummonPos);
+                                break;
+                        }
+                    }
+                }
+                if (me->GetEntry() == NPC_CLUSTER_ELUNE)
+                    DoCast(SPELL_LUNAR_FORTUNE);
+
+                float displacement = 0.7f;
+                for (uint8 i = 0; i < 4; i++)
+                    me->SummonGameObject(GetFireworkGameObjectId(), me->GetPositionX() + (i%2 == 0 ? displacement : -displacement), me->GetPositionY() + (i > 1 ? displacement : -displacement), me->GetPositionZ() + 4.0f, me->GetOrientation(), 0.0f, 0.0f, 0.0f, 0.0f, 1);
+            }
+            else
+                //me->CastSpell(me, GetFireworkSpell(me->GetEntry()), true);
+                me->CastSpell(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), GetFireworkSpell(me->GetEntry()), true);
+        }
+    };
+
+    CreatureAI *GetAI(Creature* creature) const
+    {
+        return new npc_fireworkAI(creature);
+    }
+};
+
 void AddSC_npcs_special()
 {
     new npc_air_force_bots;
@@ -2796,5 +3076,6 @@ void AddSC_npcs_special()
     new npc_experience;
     new npc_fire_elemental;
     new npc_earth_elemental;
+    new npc_firework;
 }
 


### PR DESCRIPTION
Related to this patch:
- Items
  - Elune's Candle
    - Current effect: Nothing
    - What should happen: When used, the player should throw a candle towards his target and when candle hits tharget there should be some firework visual. Also if this item is used against Omen should also damage him (and delay his Starfall) and stun his minions.
  - Rockets (Small and large)
    - Current effect: Many of them have tareting issues and no effect due to this.
    - What should happen: When rocket launched it should automatically target the nearest Firework Launcher, make it do an animation, and then throw the fireworks.
  - Rocket Clusters (Normal and large)
    - Current effect: Nothing on most of them. Also targeting issues with large ones.
    - What should happen: When rocket cluster launched it should automatically target the nearest Cluster Launcher, make it do an animation, and then throw the fireworks (4). If used at the south of Elune'ara lake should summon _Omen_ and _Minions of Omen_.

Also added AI to Omen.
