### PR TITLE
Core/Auras: Fix Pet & Totem aura stacking

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3306,19 +3306,19 @@ void Unit::_RemoveNoStackAurasDueToAura(Aura* aura)
         return;
 
     bool remove = false;
-    for (AuraMap::iterator i = m_ownedAuras.begin(); i != m_ownedAuras.end(); ++i)
+    for (AuraApplicationMap::iterator i = m_appliedAuras.begin(); i != m_appliedAuras.end(); ++i)
     {
         if (remove)
         {
             remove = false;
-            i = m_ownedAuras.begin();
+            i = m_appliedAuras.begin();
         }
 
-        if (aura->CanStackWith(i->second))
+        if (aura->CanStackWith(i->second->GetBase()))
             continue;
 
-        RemoveOwnedAura(i, AURA_REMOVE_BY_DEFAULT);
-        if (i == m_ownedAuras.end())
+        RemoveAura(i, AURA_REMOVE_BY_DEFAULT);
+        if (i == m_appliedAuras.end())
             break;
         remove = true;
     }


### PR DESCRIPTION
Fixes aura staking for Pet, Totem and other spell effects that do not use SPELL_EFFECT_APPLY_AURA.

_RemoveNoStackAurasDueToAura is iterating over owned auras. This causes auras which are owned by a player and applied to other group/raid members (such as Blood Pact or Trueshot Aura) to stack with other auras in the same spell_group. It should iterate over applied auras instead.

Signed-off-by: PKX pkx.icehell@gmail.com
