### PR TITLE
Problems with argent tournament spells

### DIFF
--- a/sql/updates/world/2012_01_30_06_world_misc.sql
+++ b/sql/updates/world/2012_01_30_06_world_misc.sql
@@ -1,0 +1,5 @@
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id`=9798 AND `type`=6;
+
+DELETE FROM `spell_script_names` WHERE `spell_id`=63399;
+INSERT INTO `spell_script_names`(`spell_id`,`ScriptName`) VALUES
+(63399,'spell_gen_tournament_pennant');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -775,7 +775,10 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
 
             ASSERT(he->duel);
 
-            he->SetHealth(1);
+            if (duel_wasMounted) // In this case victim==mount
+                victim->SetHealth(1);
+            else
+                he->SetHealth(1);
 
             he->duel->opponent->CombatStopWithPets(true);
             he->CombatStopWithPets(true);

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1699,14 +1699,24 @@ public:
                         caster->CastSpell(target, spellId, false);
                     break;
                 case EFFECT_1: // On damaging spells, for removing the a defend layer
+                    uint32 defendSpellId = 0;
+
                     Unit::AuraApplicationMap const& auras = target->GetAppliedAuras();
                     for (Unit::AuraApplicationMap::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
                     {
                         Aura* aura = itr->second->GetBase();
                         SpellInfo const* auraInfo = aura->GetSpellInfo();
                         if (aura && auraInfo->SpellIconID == 2007 && aura->HasEffectType(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN))
+                        {
+                            defendSpellId = aura->GetId();
                             aura->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
+                            break;
+                        }
                     }
+                    // Remove dummys from rider (Necessary for updating visual shields)
+                    if (Unit* rider = target->GetCharmer())
+                        if (Aura* defend = rider->GetAura(defendSpellId))
+                            defend->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
                     break;
             }
         }
@@ -1806,6 +1816,10 @@ public:
                             return;
                     }
 
+                    // If target isn't a training dummy there's a chance of failing the charge
+                    if (!target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE) && urand(0,7) == 0)
+                        spellId = SPELL_CHARGE_MISS_EFFECT;
+
                     if (Unit* vehicle = caster->GetVehicleBase())
                         vehicle->CastSpell(target, spellId, false);
                     else
@@ -1813,14 +1827,24 @@ public:
                     break;
                 case EFFECT_1: // On damaging spells, for removing the a defend layer
                 case EFFECT_2:
+                    uint32 defendSpellId = 0;
+
                     Unit::AuraApplicationMap const& auras = target->GetAppliedAuras();
                     for (Unit::AuraApplicationMap::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
                     {
                         Aura* aura = itr->second->GetBase();
                         SpellInfo const* auraInfo = aura->GetSpellInfo();
                         if (aura && auraInfo->SpellIconID == 2007 && aura->HasEffectType(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN))
+                        {
+                            defendSpellId = aura->GetId();
                             aura->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
+                            break;
+                        }
                     }
+                    // Remove dummys from rider (Necessary for updating visual shields)
+                    if (Unit* rider = target->GetCharmer())
+                        if (Aura* defend = rider->GetAura(defendSpellId))
+                            defend->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
                     break;
             }
         }
@@ -1851,10 +1875,6 @@ public:
                 default:
                     return;
             }
-
-            // If target isn't a training dummy there's a chance of failing the charge
-            if (!target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_DISABLE_MOVE) && urand(0,7) == 0)
-                spellId = SPELL_CHARGE_MISS_EFFECT;
 
             if (Unit* rider = caster->GetCharmer())
                 rider->CastSpell(target, spellId, false);
@@ -1907,7 +1927,7 @@ class spell_gen_defend : public SpellScriptLoader
                 return true;
             }
 
-            void RefreshVisualShields(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            void RefreshVisualShields(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {
                 Unit* caster = GetCaster();
                 Unit* target = GetTarget();
@@ -1924,7 +1944,7 @@ class spell_gen_defend : public SpellScriptLoader
                 for (uint8 i = 0; i < GetSpellInfo()->StackAmount; ++i)
                     target->RemoveAurasDueToSpell(SPELL_VISUAL_SHIELD_1 + i);
 
-                target->CastSpell(target, SPELL_VISUAL_SHIELD_1 + GetAura()->GetStackAmount() - 1);
+                target->CastSpell(target, SPELL_VISUAL_SHIELD_1 + GetAura()->GetStackAmount() - 1, true, NULL, aurEff);
             }
 
             void RemoveVisualShields(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
@@ -1955,7 +1975,7 @@ class spell_gen_defend : public SpellScriptLoader
                 if (spell->Effects[EFFECT_0].ApplyAuraName == SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN)
                 {
                     AfterEffectApply += AuraEffectApplyFn(spell_gen_defendAuraScript::RefreshVisualShields, EFFECT_0, SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
-                    OnEffectRemove += AuraEffectRemoveFn(spell_gen_defendAuraScript::RemoveVisualShields, EFFECT_0, SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, AURA_EFFECT_HANDLE_REAL);
+                    OnEffectRemove += AuraEffectRemoveFn(spell_gen_defendAuraScript::RemoveVisualShields, EFFECT_0, SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, AURA_EFFECT_HANDLE_CHANGE_AMOUNT_MASK);
                 }
 
                 // Remove Defend spell from player when he dismounts
@@ -1966,7 +1986,7 @@ class spell_gen_defend : public SpellScriptLoader
                 if (spell->Effects[EFFECT_1].ApplyAuraName == SPELL_AURA_DUMMY)
                 {
                     AfterEffectApply += AuraEffectApplyFn(spell_gen_defendAuraScript::RefreshVisualShields, EFFECT_1, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
-                    OnEffectRemove += AuraEffectRemoveFn(spell_gen_defendAuraScript::RemoveVisualShields, EFFECT_1, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+                    OnEffectRemove += AuraEffectRemoveFn(spell_gen_defendAuraScript::RemoveVisualShields, EFFECT_1, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_CHANGE_AMOUNT_MASK);
                 }
             }
         };
@@ -2063,6 +2083,12 @@ class spell_gen_summon_tournament_mount : public SpellScriptLoader
             SpellCastResult CheckIfLanceEquiped()
             {
                 Unit* caster = GetCaster();
+
+                if (caster->HasAuraType(SPELL_AURA_MOD_SHAPESHIFT))
+                {
+                    SetCustomCastResultMessage(SPELL_CUSTOM_ERROR_CANT_MOUNT_WITH_SHAPESHIFT);
+                    return SPELL_FAILED_CUSTOM_ERROR;
+                }
 
                 if (!caster->HasAura(SPELL_LANCE_EQUIPPED))
                 {
@@ -2194,7 +2220,7 @@ class spell_gen_on_tournament_mount : public SpellScriptLoader
             bool Load()
             {
                 _pennantSpellId = 0;
-                return (GetCaster()->GetTypeId() == TYPEID_PLAYER);
+                return (GetCaster() && GetCaster()->GetTypeId() == TYPEID_PLAYER);
             }
 
             void HandleApplyEffect(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)

--- a/src/server/scripts/World/achievement_scripts.cpp
+++ b/src/server/scripts/World/achievement_scripts.cpp
@@ -285,6 +285,16 @@ class achievement_bg_sa_defense_of_ancients : public AchievementCriteriaScript
         }
 };
 
+enum ArgentTournamentAreas
+{
+    AREA_ARGENT_TOURNAMENT_FIELDS  = 4658,
+    AREA_RING_OF_ASPIRANTS         = 4670,
+    AREA_RING_OF_ARGENT_VALIANTS   = 4671,
+    AREA_RING_OF_ALLIANCE_VALIANTS = 4672,
+    AREA_RING_OF_HORDE_VALIANTS    = 4673,
+    AREA_RING_OF_CHAMPIONS         = 4669,
+};
+
 class achievement_tilted : public AchievementCriteriaScript
 {
     public:
@@ -292,7 +302,14 @@ class achievement_tilted : public AchievementCriteriaScript
 
         bool OnCheck(Player* player, Unit* /*target*/)
         {
-            return player && player->duel && player->duel->isMounted;
+            bool checkArea = player->GetAreaId() == AREA_ARGENT_TOURNAMENT_FIELDS ||
+                                player->GetAreaId() == AREA_RING_OF_ASPIRANTS ||
+                                player->GetAreaId() == AREA_RING_OF_ARGENT_VALIANTS ||
+                                player->GetAreaId() == AREA_RING_OF_ALLIANCE_VALIANTS ||
+                                player->GetAreaId() == AREA_RING_OF_HORDE_VALIANTS ||
+                                player->GetAreaId() == AREA_RING_OF_CHAMPIONS;
+
+            return player && checkArea && player->duel && player->duel->isMounted;
         }
 };
 


### PR DESCRIPTION
All this issues were introduced with my last commit, I'm sorry about it :(

Issues are:
- When a player loses a mounted duel his health gets down to one (1hp).
- When losing stacks of Defend the visual shields aren't being updated.
- Achievement "Tilted" was only doable if player wasn't inside a Tournament Ring.
- Random crashes at login when loged out mounted.
- Strange vehicle behaviour when charge failed.
- Don't allow players mount while shapeshifted.
- Sen'Jin champion pennant isn't being removed if player logs out while mounted.

Also some general code cleanup.
