### PR TITLE
Detect invisibility for mage-guards - Dalaran

### DIFF
--- a/src/server/scripts/Northrend/dalaran.cpp
+++ b/src/server/scripts/Northrend/dalaran.cpp
@@ -31,9 +31,10 @@ Script Data End */
 
 enum Spells
 {
-    SPELL_TRESPASSER_A = 54028,
-    SPELL_TRESPASSER_H = 54029,
-
+    SPELL_TRESPASSER_A                     = 54028,
+    SPELL_TRESPASSER_H                     = 54029,
+    SPELL_DETECTION                        = 70465,
+    
     SPELL_SUNREAVER_DISGUISE_FEMALE        = 70973,
     SPELL_SUNREAVER_DISGUISE_MALE          = 70974,
     SPELL_SILVER_COVENANT_DISGUISE_FEMALE  = 70971,
@@ -60,7 +61,10 @@ public:
             creature->ApplySpellImmune(0, IMMUNITY_DAMAGE, SPELL_SCHOOL_MASK_MAGIC, true);
         }
 
-        void Reset(){}
+        void Reset()
+        {
+            me->CastSpell(me, SPELL_DETECTION, true);
+        }
 
         void EnterCombat(Unit* /*who*/){}
 


### PR DESCRIPTION
- Fixes mage-guardians to detect invisibility (stealth) for trespasser spell.

Signed-off-by: Bootz bootz@projectskyfire.org
