### PR TITLE
[Bug/Fix] Warriors and tournament mounts

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2041,11 +2041,8 @@ class spell_gen_summon_tournament_mount : public SpellScriptLoader
 
             SpellCastResult CheckIfLanceEquiped()
             {
-                if (GetCaster()->HasAuraType(SPELL_AURA_MOD_SHAPESHIFT))
-                {
-                    SetCustomCastResultMessage(SPELL_CUSTOM_ERROR_CANT_MOUNT_WITH_SHAPESHIFT);
-                    return SPELL_FAILED_CUSTOM_ERROR;
-                }
+                if (GetCaster()->IsInDisallowedMountForm())
+                    GetCaster()->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
 
                 if (!GetCaster()->HasAura(SPELL_LANCE_EQUIPPED))
                 {


### PR DESCRIPTION
Since warrior stances are considered as shapeshifts they are not able to mount up. 

Now we'll check for displayid instead of searching for shapeshift auras, so they'll be able to mount. This was also happening with priests on shadowform.
