### PR TITLE
[CORE] Fix pet and other types of minion pet attack on targets with Crowd Controls.

### DIFF
--- a/src/server/game/AI/CoreAI/CombatAI.cpp
+++ b/src/server/game/AI/CoreAI/CombatAI.cpp
@@ -158,6 +158,12 @@ void CasterAI::UpdateAI(const uint32 diff)
 
     events.Update(diff);
 
+    if (me->getVictim()->HasBreakableByDamageCrowdControlAura())
+    {
+        me->InterruptNonMeleeSpells(false);
+        return;
+    }
+
     if (me->HasUnitState(UNIT_STATE_CASTING))
         return;
 

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -50,7 +50,6 @@ class PetAI : public CreatureAI
 
         TimeTracker i_tracker;
         bool inCombat;
-        bool targetHasCC;
         std::set<uint64> m_AllySet;
         uint32 m_updateAlliesTimer;
 
@@ -58,7 +57,6 @@ class PetAI : public CreatureAI
         void HandleReturnMovement();
         void DoAttack(Unit* target, bool chase);
         bool CanAttack(Unit* target);
-        bool _CheckTargetCC(Unit* target);
 };
 #endif
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -516,6 +516,24 @@ bool Unit::HasAuraTypeWithFamilyFlags(AuraType auraType, uint32 familyName, uint
     return false;
 }
 
+bool Unit::HasBreakableByDamageAuraType(AuraType type) const
+{
+    AuraEffectList const& auras = GetAuraEffectsByType(type);
+    for (AuraEffectList::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
+        if ((*itr)->GetSpellInfo()->Attributes & SPELL_ATTR0_BREAKABLE_BY_DAMAGE || (*itr)->GetSpellInfo()->AuraInterruptFlags & AURA_INTERRUPT_FLAG_TAKE_DAMAGE)
+            return true;
+    return false;
+}
+
+bool Unit::HasBreakableByDamageCrowdControlAura() const
+{
+    return (   HasBreakableByDamageAuraType(SPELL_AURA_MOD_CONFUSE)
+            || HasBreakableByDamageAuraType(SPELL_AURA_MOD_FEAR)
+            || HasBreakableByDamageAuraType(SPELL_AURA_MOD_STUN)
+            || HasBreakableByDamageAuraType(SPELL_AURA_MOD_ROOT)
+            || HasBreakableByDamageAuraType(SPELL_AURA_TRANSFORM));
+}
+
 void Unit::DealDamageMods(Unit* victim, uint32 &damage, uint32* absorb)
 {
     if (!victim || !victim->isAlive() || victim->HasUnitState(UNIT_STATE_IN_FLIGHT) || (victim->GetTypeId() == TYPEID_UNIT && victim->ToCreature()->IsInEvadeMode()))

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1536,6 +1536,8 @@ class Unit : public WorldObject
 
         bool HasAuraTypeWithFamilyFlags(AuraType auraType, uint32 familyName, uint32 familyFlags) const;
         bool virtual HasSpell(uint32 /*spellID*/) const { return false; }
+        bool HasBreakableByDamageAuraType(AuraType type) const;
+        bool HasBreakableByDamageCrowdControlAura() const;
 
         bool HasStealthAura()      const { return HasAuraType(SPELL_AURA_MOD_STEALTH); }
         bool HasInvisibilityAura() const { return HasAuraType(SPELL_AURA_MOD_INVISIBILITY); }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -1738,6 +1738,12 @@ public:
             if (!UpdateVictim())
                 return;
 
+            if (me->getVictim()->HasBreakableByDamageCrowdControlAura())
+            {
+                me->InterruptNonMeleeSpells(false);
+                return;
+            }
+
             if (SpellTimer <= diff)
             {
                 if (IsViper) //Viper


### PR DESCRIPTION
The pets should not attack targets with Crowd Controls interruptible by any type of damage but they can not exit combat if their target is controlled. This will fix many types of minion: Mirror Image, Water Elemental, Gargoyle, Risen Ghoul, warlock's guardians and Hunter's pets.
