### PR TITLE
Core/Spells: Removed incorrect diminishing group check for Improved Hams...

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -104,9 +104,6 @@ DiminishingGroup GetDiminishingReturnsGroupForSpell(SpellInfo const* spellproto,
             // Hamstring - limit duration to 10s in PvP
             if (spellproto->SpellFamilyFlags[0] & 0x2)
                 return DIMINISHING_LIMITONLY;
-            // Improved Hamstring
-            else if (spellproto->AttributesEx3 & 0x80000 && spellproto->SpellIconID == 23)
-                return DIMINISHING_ROOT;
             // Charge Stun (own diminishing)
             else if (spellproto->SpellFamilyFlags[0] & 0x01000000)
                 return DIMINISHING_CHARGE;


### PR DESCRIPTION
This fixes problem described in #3407

This code 
`(spellproto->AttributesEx3 & 0x80000 && spellproto->SpellIconID == 23)`

Match with the talent aura, not the triggered spell wich is http://www.wowhead.com/spell=23694
The procFlags of these auras makes warrior stack DR time for spells with DR group DIMINISHING_ROOT at the point of being immune to these roots.

The triggered spell 23694 has MechanicsType MECHANIC_ROOT and is correctly diminished by it's mechanic, no explicit check is needed at all. 
