### PR TITLE
Achievement: Volunteer's Work

### DIFF
--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
@@ -402,7 +402,8 @@ public:
                     if (!CAST_AI(boss_jedoga_shadowseeker::boss_jedoga_shadowseekerAI, boss->AI())->bOpFerok)
                         CAST_AI(boss_jedoga_shadowseeker::boss_jedoga_shadowseekerAI, boss->AI())->bOpFerokFail = true;
 
-                    boss->AI()->DoAction(ACTION_INITIAND_KILLED);
+                    if (Killer->GetTypeId() == TYPEID_PLAYER)
+                        boss->AI()->DoAction(ACTION_INITIAND_KILLED);
                 }
 
                 instance->SetData64(DATA_ADD_JEDOGA_OPFER, 0);


### PR DESCRIPTION
Properly fix achievement Volunteer's Work and close Issue #3276. Now achievement shall be awarded if boss sacrifice npc and none if player's party kills it. All credit goes to Vincent-Michael and his fix. In connection with https://github.com/TrinityCore/TrinityCore/pull/5191. /Clean pull I hope this time/.
