### PR TITLE
Core/Achievements: Enable timer for timed quest achievements...

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -1107,7 +1107,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
                     if (!data->Meets(GetPlayer(), unit))
                         continue;
 
-                SetCriteriaProgress(achievementCriteria, 1);
+                SetCriteriaProgress(achievementCriteria, 1, PROGRESS_ACCUMULATE);
                 break;
             }
             case ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET:


### PR DESCRIPTION
...(ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST=27).
This will allow achievement credit for quests that start a timer on quest accept and if player turns in the quest before the max time is reached.
