### PR TITLE
Core/World: WorldState must be loaded before Conditions

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1590,6 +1590,9 @@ void World::SetInitialWorldSettings()
     sLog->outString("Loading Creature Formations...");
     FormationMgr::LoadCreatureFormations();
 
+    sLog->outString("Loading World States...");              // must be loaded before battleground, outdoor PvP and conditions
+    LoadWorldStates();
+
     sLog->outString("Loading Conditions...");
     sConditionMgr->LoadConditions();
 
@@ -1716,9 +1719,6 @@ void World::SetInitialWorldSettings()
     sGameEventMgr->StartArenaSeason();
 
     sTicketMgr->Initialize();
-
-    sLog->outString("Loading World States...");              // must be loaded before battleground and outdoor PvP
-    LoadWorldStates();
 
     ///- Initialize Battlegrounds
     sLog->outString("Starting Battleground System");


### PR DESCRIPTION
Without this, does not accept any worldstate.
