### PR TITLE
Fix wrong text id in pit of saron. :D

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
@@ -27,7 +27,7 @@ enum Yells
     SAY_PHASE2          = -1658005,
     SAY_PHASE3          = -1658006,
 
-    SAY_TYRANNUS_DEATH  = -1659007,
+    SAY_TYRANNUS_DEATH  = -1658007,
 };
 
 enum Spells


### PR DESCRIPTION
ERROR: TSCR: DoScriptText with source entry 36658 (TypeId=3, guid=15228916) could not find text entry -1659007.

Signed-off-by: frozenarmor venom.victorios@gmail.com
