### PR TITLE
Dalaran Sewers Arena: Knockback from starting pipe

### DIFF
--- a/sql/updates/world/2012_02_25_01_world_misc.sql
+++ b/sql/updates/world/2012_02_25_01_world_misc.sql
@@ -1,0 +1,12 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (57405,61698);
+INSERT INTO `spell_script_names`(`spell_id`,`ScriptName`) VALUES
+(57405,'spell_gen_ds_flush'),
+(61698,'spell_gen_ds_flush_knockback');
+
+DELETE FROM `spell_dbc` WHERE `id`=61698;
+INSERT INTO `spell_dbc` (`Id`, `Dispel`, `Mechanic`, `Attributes`, `AttributesEx`, `AttributesEx2`, `AttributesEx3`, `AttributesEx4`, `AttributesEx5`, `AttributesEx6`, `AttributesEx7`, `Stances`, `StancesNot`, `Targets`, `CastingTimeIndex`, `AuraInterruptFlags`, `ProcFlags`, `ProcChance`, `ProcCharges`, `MaxLevel`, `BaseLevel`, `SpellLevel`, `DurationIndex`, `RangeIndex`, `StackAmount`, `EquippedItemClass`, `EquippedItemSubClassMask`, `EquippedItemInventoryTypeMask`, `Effect1`, `Effect2`, `Effect3`, `EffectDieSides1`, `EffectDieSides2`, `EffectDieSides3`, `EffectRealPointsPerLevel1`, `EffectRealPointsPerLevel2`, `EffectRealPointsPerLevel3`, `EffectBasePoints1`, `EffectBasePoints2`, `EffectBasePoints3`, `EffectMechanic1`, `EffectMechanic2`, `EffectMechanic3`, `EffectImplicitTargetA1`, `EffectImplicitTargetA2`, `EffectImplicitTargetA3`, `EffectImplicitTargetB1`, `EffectImplicitTargetB2`, `EffectImplicitTargetB3`, `EffectRadiusIndex1`, `EffectRadiusIndex2`, `EffectRadiusIndex3`, `EffectApplyAuraName1`, `EffectApplyAuraName2`, `EffectApplyAuraName3`, `EffectAmplitude1`, `EffectAmplitude2`, `EffectAmplitude3`, `EffectMultipleValue1`, `EffectMultipleValue2`, `EffectMultipleValue3`, `EffectMiscValue1`, `EffectMiscValue2`, `EffectMiscValue3`, `EffectMiscValueB1`, `EffectMiscValueB2`, `EffectMiscValueB3`, `EffectTriggerSpell1`, `EffectTriggerSpell2`, `EffectTriggerSpell3`, `EffectSpellClassMaskA1`, `EffectSpellClassMaskA2`, `EffectSpellClassMaskA3`, `EffectSpellClassMaskB1`, `EffectSpellClassMaskB2`, `EffectSpellClassMaskB3`, `EffectSpellClassMaskC1`, `EffectSpellClassMaskC2`, `EffectSpellClassMaskC3`, `MaxTargetLevel`, `SpellFamilyName`, `SpellFamilyFlags1`, `SpellFamilyFlags2`, `SpellFamilyFlags3`, `MaxAffectedTargets`, `DmgClass`, `PreventionType`, `DmgMultiplier1`, `DmgMultiplier2`, `DmgMultiplier3`, `AreaGroupId`, `SchoolMask`, `Comment`) VALUES
+(61698,0,0,536871296,269058048,67108868,268894272,2048,0,1024,0,0,0,0,1,0,0,0,0,0,0,0,0,1,0,-1,0,0,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,25,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,'Flush - Knockback effect');
+
+UPDATE `battleground_template` SET `HordeStartO`=3.14159 WHERE `id`=10;
+
+UPDATE `creature_template` SET `flags_extra` = 128 WHERE `entry` = 28567;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundDS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundDS.h
@@ -42,12 +42,34 @@ enum BattlegroundDSObjects
     BG_DS_OBJECT_TYPE_BUFF_2    = 184664
 };
 
+enum BattlegroundDSCreatureTypes
+{
+    BG_DS_NPC_WATERFALL_KNOCKBACK = 0,
+    BG_DS_NPC_PIPE_KNOCKBACK_1    = 1,
+    BG_DS_NPC_PIPE_KNOCKBACK_2    = 2,
+    BG_DS_NPC_MAX                 = 3
+};
+
+enum BattlegroundDSCreatures
+{
+    BG_DS_NPC_TYPE_WATER_SPOUT    = 28567,
+};
+
+enum BattlegroundDSSpells
+{
+    BG_DS_SPELL_FLUSH             = 57405, // Visual and target selector for the starting knockback from the pipe
+    BG_DS_SPELL_FLUSH_KNOCKBACK   = 61698, // Knockback effect for previous spell (triggered, not need to be casted)
+};
+
 enum BattlegroundDSData
 { // These values are NOT blizzlike... need the correct data!
     BG_DS_WATERFALL_TIMER_MIN                    = 30000,
     BG_DS_WATERFALL_TIMER_MAX                    = 60000,
     BG_DS_WATERFALL_WARNING_DURATION             = 7000,
     BG_DS_WATERFALL_DURATION                     = 10000,
+    BG_DS_PIPE_KNOCKBACK_FIRST_DELAY             = 5000,
+    BG_DS_PIPE_KNOCKBACK_DELAY                   = 3000,
+    BG_DS_PIPE_KNOCKBACK_TOTAL_COUNT             = 2,
 
     BG_DS_WATERFALL_STATUS_WARNING               = 1, // Water starting to fall, but no LoS Blocking nor movement blocking
     BG_DS_WATERFALL_STATUS_ON                    = 2, // LoS and Movement blocking active
@@ -83,12 +105,18 @@ class BattlegroundDS : public Battleground
     private:
         uint32 _waterfallTimer;
         uint8 _waterfallStatus;
+        uint32 _pipeKnockBackTimer;
+        uint8 _pipeKnockBackCount;
 
         virtual void PostUpdateImpl(uint32 diff);
     protected:
         uint32 getWaterFallStatus() { return _waterfallStatus; };
-        void setWaterFallStatus(uint32 status) { _waterfallStatus = status; };
-        void setWaterFallTimer(uint32 timer) { _waterfallTimer = timer; };
+        void setWaterFallStatus(uint8 status) { _waterfallStatus = status; };
         uint32 getWaterFallTimer() { return _waterfallTimer; };
+        void setWaterFallTimer(uint32 timer) { _waterfallTimer = timer; };
+        uint8 getPipeKnockBackCount() { return _pipeKnockBackCount; };
+        void setPipeKnockBackCount(uint8 count) { _pipeKnockBackCount = count; };
+        uint32 getPipeKnockBackTimer() { return _pipeKnockBackTimer; };
+        void setPipeKnockBackTimer(uint32 timer) { _pipeKnockBackTimer = timer; };
 };
 #endif


### PR DESCRIPTION
When a player stay for a while on the starting pipe after the battle has begun he/she should be knocked into the battle in order to avoid taking advantage of the higher position.

The current problem is the behaviour described above is not happening at all.

Thanks to Aokromes for the sniffs of the water spout positions.

Note: _This patch still having one exploitable bug. If a warlock summons a demonic circle inside the pipe he/she would be able to teleport back when the knockbacks have already been done. Not sure how is this handled on retail but we should maybe disable that spell cast on that positions._
