### PR TITLE
Fix Eternal Water Elemental (Mage) - Glyph of Shadowflame (Warlock)

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -882,6 +882,11 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
                     SetBonusDamage(int32(m_owner->SpellBaseDamageBonus(SPELL_SCHOOL_MASK_FROST) * 0.33f));
                     break;
                 }
+				case 37994: // mage Eternal (Glyphed) Water Elemental
+				{
+					SetBonusDamage(int32(m_owner->SpellBaseDamageBonus(SPELL_SCHOOL_MASK_FROST) * 0.33f));                    
+					break;
+				}
                 case 1964: //force of nature
                 {
                     if (!pInfo)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2925,6 +2925,9 @@ void SpellMgr::LoadSpellCustomAttr()
             case 72293: // Mark of the Fallen Champion (Deathbringer Saurfang)
                 spellInfo->AttributesCu |= SPELL_ATTR0_CU_NEGATIVE_EFF0;
                 break;
+			case 63311:  //Fix Glyph of Shadowflame
+				spellInfo->AttributesCu |= SPELL_ATTR0_CU_CONE_LINE;
+				break;
             default:
                 break;
         }


### PR DESCRIPTION
This commits fix the Glyphed Eternal Water Elemental pet damage, that should scale like the normal version, and also fix the Glyph Of Shadowflame slowing effect that is affecting all enemies on a 100 yards range, instead of the frontal cone of 13 yards.
