### PR TITLE
More Dalaran Sewers Arena fixes

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundDS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundDS.cpp
@@ -139,6 +139,12 @@ void BattlegroundDS::StartingEventOpenDoors()
     // Turn off collision
     if (GameObject* gob = GetBgMap()->GetGameObject(BgObjects[BG_DS_OBJECT_WATER_1]))
         gob->SetGoState(GO_STATE_ACTIVE);
+
+    // Remove effects of Demonic Circle Summon
+    for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
+        if (Player* player = ObjectAccessor::FindPlayer(itr->first))
+            if (itr->HasAura(48018))
+                itr->RemoveAurasDueToSpell(48018);
 }
 
 void BattlegroundDS::AddPlayer(Player* player)
@@ -187,6 +193,10 @@ void BattlegroundDS::HandleAreaTrigger(Player* Source, uint32 Trigger)
     {
         case 5347:
         case 5348:
+            // Remove effects of Demonic Circle Summon
+            if (Source->HasAura(48018))
+                Source->RemoveAurasDueToSpell(48018);
+
             // Someone has get back into the pipes and the knockback has already been performed,
             // so we reset the knockback count for kicking the player again into the arena.
             if (getPipeKnockBackCount() >= BG_DS_PIPE_KNOCKBACK_TOTAL_COUNT)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundDS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundDS.cpp
@@ -65,6 +65,19 @@ void BattlegroundDS::PostUpdateImpl(uint32 diff)
             setPipeKnockBackTimer(getPipeKnockBackTimer() - diff);
     }
 
+    if (getWaterFallStatus() == BG_DS_WATERFALL_STATUS_ON) // Repeat knockback while the waterfall still active
+    {
+        if (getWaterFallKnockbackTimer() < diff)
+        {
+            if (Creature* waterSpout = GetBgMap()->GetCreature(BgCreatures[BG_DS_NPC_WATERFALL_KNOCKBACK]))
+                waterSpout->CastSpell(waterSpout, BG_DS_SPELL_WATER_SPOUT, true);
+
+            setWaterFallKnockbackTimer(BG_DS_WATERFALL_KNOCKBACK_TIMER);
+        }
+        else
+            setWaterFallKnockbackTimer(getWaterFallKnockbackTimer() - diff);
+    }
+
     if (getWaterFallTimer() < diff)
     {
         if (getWaterFallStatus() == BG_DS_WATERFALL_STATUS_OFF) // Add the water
@@ -83,6 +96,7 @@ void BattlegroundDS::PostUpdateImpl(uint32 diff)
 
             setWaterFallTimer(BG_DS_WATERFALL_DURATION);
             setWaterFallStatus(BG_DS_WATERFALL_STATUS_ON);
+            setWaterFallKnockbackTimer(BG_DS_WATERFALL_KNOCKBACK_TIMER);
         }
         else //if (getWaterFallStatus() == BG_DS_WATERFALL_STATUS_ON) // Remove collision and water
         {

--- a/src/server/game/Battlegrounds/Zones/BattlegroundDS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundDS.h
@@ -68,6 +68,8 @@ enum BattlegroundDSData
     BG_DS_WATERFALL_TIMER_MAX                    = 60000,
     BG_DS_WATERFALL_WARNING_DURATION             = 7000,
     BG_DS_WATERFALL_DURATION                     = 10000,
+    BG_DS_WATERFALL_KNOCKBACK_TIMER              = 500,
+
     BG_DS_PIPE_KNOCKBACK_FIRST_DELAY             = 5000,
     BG_DS_PIPE_KNOCKBACK_DELAY                   = 3000,
     BG_DS_PIPE_KNOCKBACK_TOTAL_COUNT             = 2,
@@ -106,6 +108,7 @@ class BattlegroundDS : public Battleground
     private:
         uint32 _waterfallTimer;
         uint8 _waterfallStatus;
+        uint32 _waterfallKnockbackTimer;
         uint32 _pipeKnockBackTimer;
         uint8 _pipeKnockBackCount;
 
@@ -115,6 +118,8 @@ class BattlegroundDS : public Battleground
         void setWaterFallStatus(uint8 status) { _waterfallStatus = status; };
         uint32 getWaterFallTimer() { return _waterfallTimer; };
         void setWaterFallTimer(uint32 timer) { _waterfallTimer = timer; };
+        uint32 getWaterFallKnockbackTimer() { return _waterfallTimer; };
+        void setWaterFallKnockbackTimer(uint32 timer) { _waterfallKnockbackTimer = timer; };
         uint8 getPipeKnockBackCount() { return _pipeKnockBackCount; };
         void setPipeKnockBackCount(uint8 count) { _pipeKnockBackCount = count; };
         uint32 getPipeKnockBackTimer() { return _pipeKnockBackTimer; };


### PR DESCRIPTION
On this pull request:
- Repeat the knockback effect of the central waterfall while it's active. This should prevent anyone from staying inside the waterfall (How did they get there? Charge or Demonic Circle sometimes help.).
- Remove Demonic Circle related auras on arena start and when players are jumping into the arena (_this behaviour was confirmed by a player on retail_)

In my opinion DS arena is almost ready for getting opened after this, what do you think about it, guys?
