### PR TITLE
Core/CreatureTextMgr: Fix crash in GetLocalizedChatString()

### DIFF
--- a/src/server/game/Texts/CreatureTextMgr.cpp
+++ b/src/server/game/Texts/CreatureTextMgr.cpp
@@ -453,8 +453,7 @@ std::string CreatureTextMgr::GetLocalizedChatString(uint32 entry, uint8 textGrou
     if (locItr == mLocaleTextMap.end())
         return baseText;
 
-    if (locItr->second.Text[locale].length())
-        return locItr->second.Text[locale];
+    ObjectMgr::GetLocaleString(locItr->second.Text, locale, baseText);
 
     return baseText;
 }


### PR DESCRIPTION
locItr->second.Text[locale] can be out of size of locItr->second.Text

how can you reproduce it:
1. creaturetext has only loc 1 or 2
2. connect with client with loc 3, 4, ...
3. server crashs on creature talk

i hope you can unterstand my english :D
