### PR TITLE
Core/Scripts: Fix Translocation Orb Activation in Magisters Terrace

### DIFF
--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -154,14 +154,18 @@ public:
             if (!instance)
                 return;
 
-            instance->HandleGameObject(instance->GetData64(DATA_KAEL_DOOR), true);
             // Open the encounter door
+            instance->HandleGameObject(instance->GetData64(DATA_KAEL_DOOR), true);
+
+            // Enable the Translocation Orb Exit
+            if (GameObject* escapeOrb = ObjectAccessor::GetGameObject(*me, instance->GetData64(DATA_ESCAPE_ORB)))
+                    escapeOrb->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
         }
 
         void DamageTaken(Unit* /*done_by*/, uint32 &damage)
         {
             if (damage > me->GetHealth())
-                RemoveGravityLapse();                           // Remove Gravity Lapse so that players fall to ground if they kill him when in air.
+                RemoveGravityLapse(); // Remove Gravity Lapse so that players fall to ground if they kill him when in air.
         }
 
         void EnterCombat(Unit* /*who*/)
@@ -169,8 +173,8 @@ public:
             if (!instance)
                 return;
 
+            //Close the encounter door, open it in JustDied/Reset
             instance->HandleGameObject(instance->GetData64(DATA_KAEL_DOOR), false);
-           //Close the encounter door, open it in JustDied/Reset
         }
 
         void MoveInLineOfSight(Unit* who)

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/instance_magisters_terrace.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/instance_magisters_terrace.cpp
@@ -35,6 +35,25 @@ EndScriptData */
 3  - Kael'thas Sunstrider
 */
 
+enum Creatures
+{
+    NPC_SELIN       = 24723,
+    NPC_DELRISSA    = 24560,
+    NPC_FELCRYSTALS = 24722
+};
+
+enum GameObjects
+{
+    GO_VEXALLUS_DOOR        = 187896,
+    GO_SELIN_DOOR           = 187979,
+    GO_SELIN_ENCOUNTER_DOOR = 188065,
+    GO_DELRISSA_DOOR        = 187770,
+    GO_KAEL_DOOR            = 188064,
+    GO_KAEL_STATUE_1        = 188165,
+    GO_KAEL_STATUE_2        = 188166,
+    GO_ESCAPE_ORB           = 188173
+};
+
 class instance_magisters_terrace : public InstanceMapScript
 {
 public:
@@ -49,7 +68,7 @@ public:
     {
         instance_magisters_terrace_InstanceMapScript(Map* map) : InstanceScript(map) {}
 
-        uint32 m_auiEncounter[MAX_ENCOUNTER];
+        uint32 Encounter[MAX_ENCOUNTER];
         uint32 DelrissaDeathCount;
 
         std::list<uint64> FelCrystals;
@@ -63,12 +82,13 @@ public:
         uint64 DelrissaDoorGUID;
         uint64 KaelDoorGUID;
         uint64 KaelStatue[2];
+        uint64 EscapeOrbGUID;
 
         bool InitializedItr;
 
         void Initialize()
         {
-            memset(&m_auiEncounter, 0, sizeof(m_auiEncounter));
+            memset(&Encounter, 0, sizeof(Encounter));
 
             FelCrystals.clear();
 
@@ -83,6 +103,7 @@ public:
             KaelDoorGUID = 0;
             KaelStatue[0] = 0;
             KaelStatue[1] = 0;
+            EscapeOrbGUID = 0;
 
             InitializedItr = false;
         }
@@ -90,7 +111,7 @@ public:
         bool IsEncounterInProgress() const
         {
             for (uint8 i = 0; i < MAX_ENCOUNTER; ++i)
-                if (m_auiEncounter[i] == IN_PROGRESS)
+                if (Encounter[i] == IN_PROGRESS)
                     return true;
             return false;
         }
@@ -99,12 +120,18 @@ public:
         {
             switch (identifier)
             {
-                case DATA_SELIN_EVENT:          return m_auiEncounter[0];
-                case DATA_VEXALLUS_EVENT:       return m_auiEncounter[1];
-                case DATA_DELRISSA_EVENT:       return m_auiEncounter[2];
-                case DATA_KAELTHAS_EVENT:       return m_auiEncounter[3];
-                case DATA_DELRISSA_DEATH_COUNT: return DelrissaDeathCount;
-                case DATA_FEL_CRYSTAL_SIZE:     return FelCrystals.size();
+                case DATA_SELIN_EVENT:
+                    return Encounter[0];
+                case DATA_VEXALLUS_EVENT:
+                    return Encounter[1];
+                case DATA_DELRISSA_EVENT:
+                    return Encounter[2];
+                case DATA_KAELTHAS_EVENT:
+                    return Encounter[3];
+                case DATA_DELRISSA_DEATH_COUNT:
+                    return DelrissaDeathCount;
+                case DATA_FEL_CRYSTAL_SIZE:
+                    return FelCrystals.size();
             }
             return 0;
         }
@@ -113,21 +140,24 @@ public:
         {
             switch (identifier)
             {
-                case DATA_SELIN_EVENT:       m_auiEncounter[0] = data;  break;
+                case DATA_SELIN_EVENT:
+                    Encounter[0] = data;
+                    break;
                 case DATA_VEXALLUS_EVENT:
                     if (data == DONE)
                         DoUseDoorOrButton(VexallusDoorGUID);
-                    m_auiEncounter[1] = data;
+                    Encounter[1] = data;
                     break;
                 case DATA_DELRISSA_EVENT:
                     if (data == DONE)
                         DoUseDoorOrButton(DelrissaDoorGUID);
                     if (data == IN_PROGRESS)
                         DelrissaDeathCount = 0;
-                    m_auiEncounter[2] = data;
+                    Encounter[2] = data;
                     break;
-                case DATA_KAELTHAS_EVENT:    m_auiEncounter[3] = data;  break;
-
+                case DATA_KAELTHAS_EVENT:
+                    Encounter[3] = data;
+                    break;
                 case DATA_DELRISSA_DEATH_COUNT:
                     if (data == SPECIAL)
                         ++DelrissaDeathCount;
@@ -141,9 +171,15 @@ public:
         {
             switch (creature->GetEntry())
             {
-                case 24723: SelinGUID = creature->GetGUID(); break;
-                case 24560: DelrissaGUID = creature->GetGUID(); break;
-                case 24722: FelCrystals.push_back(creature->GetGUID()); break;
+                case NPC_SELIN:
+                    SelinGUID = creature->GetGUID();
+                    break;
+                case NPC_DELRISSA:
+                    DelrissaGUID = creature->GetGUID();
+                    break;
+                case NPC_FELCRYSTALS:
+                    FelCrystals.push_back(creature->GetGUID());
+                    break;
             }
         }
 
@@ -151,15 +187,30 @@ public:
         {
             switch (go->GetEntry())
             {
-                case 187896:  VexallusDoorGUID = go->GetGUID();       break;
-                //SunwellRaid Gate 02
-                case 187979:  SelinDoorGUID = go->GetGUID();          break;
-                //Assembly Chamber Door
-                case 188065:  SelinEncounterDoorGUID = go->GetGUID(); break;
-                case 187770:  DelrissaDoorGUID = go->GetGUID();       break;
-                case 188064:  KaelDoorGUID = go->GetGUID();           break;
-                case 188165:  KaelStatue[0] = go->GetGUID();          break;
-                case 188166:  KaelStatue[1] = go->GetGUID();          break;
+                case GO_VEXALLUS_DOOR:
+                    VexallusDoorGUID = go->GetGUID();
+                    break;
+                case GO_SELIN_DOOR:
+                    SelinDoorGUID = go->GetGUID();
+                    break;
+                case GO_SELIN_ENCOUNTER_DOOR:
+                    SelinEncounterDoorGUID = go->GetGUID();
+                    break;
+                case GO_DELRISSA_DOOR:
+                    DelrissaDoorGUID = go->GetGUID();
+                    break;
+                case GO_KAEL_DOOR:
+                    KaelDoorGUID = go->GetGUID();
+                    break;
+                case GO_KAEL_STATUE_1:
+                    KaelStatue[0] = go->GetGUID();
+                    break;
+                case GO_KAEL_STATUE_2:
+                    KaelStatue[1] = go->GetGUID();
+                    break;
+                case GO_ESCAPE_ORB:
+                    EscapeOrbGUID = go->GetGUID();
+                    break;
             }
         }
 
@@ -167,15 +218,26 @@ public:
         {
             switch (identifier)
             {
-                case DATA_SELIN:                return SelinGUID;
-                case DATA_DELRISSA:             return DelrissaGUID;
-                case DATA_VEXALLUS_DOOR:        return VexallusDoorGUID;
-                case DATA_SELIN_DOOR:           return SelinDoorGUID;
-                case DATA_SELIN_ENCOUNTER_DOOR: return SelinEncounterDoorGUID;
-                case DATA_DELRISSA_DOOR:        return DelrissaDoorGUID;
-                case DATA_KAEL_DOOR:            return KaelDoorGUID;
-                case DATA_KAEL_STATUE_LEFT:     return KaelStatue[0];
-                case DATA_KAEL_STATUE_RIGHT:    return KaelStatue[1];
+                case DATA_SELIN:                
+                    return SelinGUID;
+                case DATA_DELRISSA:             
+                    return DelrissaGUID;
+                case DATA_VEXALLUS_DOOR:        
+                    return VexallusDoorGUID;
+                case DATA_SELIN_DOOR:           
+                    return SelinDoorGUID;
+                case DATA_SELIN_ENCOUNTER_DOOR: 
+                    return SelinEncounterDoorGUID;
+                case DATA_DELRISSA_DOOR:        
+                    return DelrissaDoorGUID;
+                case DATA_KAEL_DOOR:            
+                    return KaelDoorGUID;
+                case DATA_KAEL_STATUE_LEFT:     
+                    return KaelStatue[0];
+                case DATA_KAEL_STATUE_RIGHT:    
+                    return KaelStatue[1];
+                case DATA_ESCAPE_ORB:           
+                    return EscapeOrbGUID;
 
                 case DATA_FEL_CRYSTAL:
                 {

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/magisters_terrace.h
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/magisters_terrace.h
@@ -19,27 +19,31 @@
 #ifndef DEF_MAGISTERS_TERRACE_H
 #define DEF_MAGISTERS_TERRACE_H
 
-#define DATA_SELIN_EVENT             1
-#define DATA_VEXALLUS_EVENT          2
-#define DATA_DELRISSA_EVENT          3
-#define DATA_KAELTHAS_EVENT          4
-
-#define DATA_SELIN                   5
-#define DATA_FEL_CRYSTAL             6
-#define DATA_FEL_CRYSTAL_SIZE        7
-
-#define DATA_VEXALLUS_DOOR           8
-#define DATA_SELIN_DOOR              9
-#define DATA_DELRISSA                10
-#define DATA_DELRISSA_DOOR           11
-#define DATA_SELIN_ENCOUNTER_DOOR    12
-
-#define DATA_KAEL_DOOR              13
-#define DATA_KAEL_STATUE_LEFT       14
-#define DATA_KAEL_STATUE_RIGHT      15
-
-#define DATA_DELRISSA_DEATH_COUNT   16
-
 #define ERROR_INST_DATA      "TSCR Error: Instance Data not set properly for Magister's Terrace instance (map 585). Encounters will be buggy."
 #endif
 
+enum Data
+{
+    DATA_SELIN_EVENT            = 0,
+    DATA_VEXALLUS_EVENT         = 1,
+    DATA_DELRISSA_EVENT         = 2,
+    DATA_KAELTHAS_EVENT         = 3,
+
+    DATA_SELIN                  = 4,
+    DATA_FEL_CRYSTAL            = 5,
+    DATA_FEL_CRYSTAL_SIZE       = 6,
+
+    DATA_VEXALLUS_DOOR          = 7,
+    DATA_SELIN_DOOR             = 8,
+    DATA_DELRISSA               = 9,
+    DATA_DELRISSA_DOOR          = 10,
+    DATA_SELIN_ENCOUNTER_DOOR   = 11,
+
+    DATA_KAEL_DOOR              = 12,
+    DATA_KAEL_STATUE_LEFT       = 13,
+    DATA_KAEL_STATUE_RIGHT      = 14,
+
+    DATA_DELRISSA_DEATH_COUNT   = 15,
+
+    DATA_ESCAPE_ORB             = 16
+};


### PR DESCRIPTION
The exit in magisters terrace does not activate after Kael'thas has been killed.

This fix removes GO_FLAG_NON_SELECTABLE Flag when Kael'thas Encounter is finished.
