### PR TITLE
Core/Spells: Periodic dispel effects broken

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4984,7 +4984,7 @@ SpellCastResult Spell::CheckCast(bool strict)
             break;
         }
 
-    if (!hasNonDispelEffect && !hasDispellableAura && m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL))
+    if (!hasNonDispelEffect && !hasDispellableAura && m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL) && m_spellInfo->HasPowerCost())
         return SPELL_FAILED_NOTHING_TO_DISPEL;
 
     for (int i = 0; i < MAX_SPELL_EFFECTS; i++)

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1665,6 +1665,11 @@ bool SpellInfo::HasAnyEffectMechanic() const
     return false;
 }
 
+bool SpellInfo::HasPowerCost() const
+{
+    return (PowerType < MAX_POWERS && (ManaCost != 0 || ManaCostPercentage != 0 || ManaCostPerlevel != 0));
+}
+
 uint32 SpellInfo::GetDispelMask() const
 {
     return GetDispelMask(DispelType(Dispel));

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -371,6 +371,7 @@ public:
     bool HasEffect(SpellEffects effect) const;
     bool HasAura(AuraType aura) const;
     bool HasAreaAuraEffect() const;
+    bool HasPowerCost() const;
 
     bool IsExplicitDiscovery() const;
     bool IsLootCrafting() const;


### PR DESCRIPTION
Issue: Periodic dispel effects (like Abolish poison and Abolish disease) were  removed after the first tick of their periodic effect. Those spells, when cast, were returning SPELL_FAILED_NOTHING_TO_DISPEL in Spell::CheckCast(bool), causing the aura to be removed.

Fix description: This commit adds a check that ensures that only spells with power cost will return SPELL_FAILED_NOTHING_TO_DISPEL. I made it this way because both Abolish Poison and Abolish Poison's periodically trigerred spells do not have a triggered flag, and do not have any power cost.

Been tested ingame, working, and no counterpart detected. Still looking for some better way though.
