### PR TITLE
Core/Spell: Convert pct damage spells in SpellScript

### DIFF
--- a/sql/updates/world/2012_04_07_00_world_spell_script_names.sql
+++ b/sql/updates/world/2012_04_07_00_world_spell_script_names.sql
@@ -1,0 +1,14 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (20625,29142,35139,42393,49882,55269,56578,38441,66316,67100,67101,67102);
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(20625,'spell_gen_default_count_pct_from_max_hp'), -- Ritual of Doom Sacrifice
+(29142,'spell_gen_default_count_pct_from_max_hp'), -- Eyesore Blaster
+(35139,'spell_gen_default_count_pct_from_max_hp'), -- Throw Boom's Doom
+(42393,'spell_gen_default_count_pct_from_max_hp'), -- Brewfest - Attack Keg
+(49882,'spell_gen_default_count_pct_from_max_hp'), -- Leviroth Self-Impale
+(55269,'spell_gen_default_count_pct_from_max_hp'), -- Deathly Stare
+(56578,'spell_gen_default_count_pct_from_max_hp'), -- Rapid-Fire Harpoon
+(38441,'spell_gen_50pct_count_pct_from_max_hp'), -- Cataclysmic Bolt
+(66316,'spell_gen_50pct_count_pct_from_max_hp'), -- Spinning Pain Spike 10m
+(67100,'spell_gen_50pct_count_pct_from_max_hp'), -- Spinning Pain Spike 25m
+(67101,'spell_gen_50pct_count_pct_from_max_hp'), -- Spinning Pain Spike 10m heroic
+(67102,'spell_gen_50pct_count_pct_from_max_hp'); -- Spinning Pain Spike 25m heroic

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -390,23 +390,6 @@ void Spell::EffectSchoolDMG(SpellEffIndex effIndex)
                         if (!unitTarget->HasAura(27825))
                             return;
                         break;
-                    // Cataclysmic Bolt
-                    case 38441:
-                    {
-                        damage = unitTarget->CountPctFromMaxHealth(50);
-                        break;
-                    }
-                    case 20625: // Ritual of Doom Sacrifice
-                    case 29142: // Eyesore Blaster
-                    case 35139: // Throw Boom's Doom
-                    case 42393: // Brewfest - Attack Keg
-                    case 55269: // Deathly Stare
-                    case 56578: // Rapid-Fire Harpoon
-                    case 62775: // Tympanic Tantrum
-                    {
-                        damage = unitTarget->CountPctFromMaxHealth(damage);
-                        break;
-                    }
                     // Gargoyle Strike
                     case 51963:
                     {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
@@ -515,36 +515,6 @@ public:
 
 };
 
-class spell_spinning_pain_spike : public SpellScriptLoader
-{
-    public:
-        spell_spinning_pain_spike() : SpellScriptLoader("spell_spinning_pain_spike") {}
-
-        class spell_spinning_pain_spike_SpellScript : public SpellScript
-        {
-            PrepareSpellScript(spell_spinning_pain_spike_SpellScript);
-
-            void HandleScript(SpellEffIndex /*eff*/)
-            {
-                Unit* target = GetHitUnit();
-                if (!target)
-                    return;
-
-                if (target->isAlive())
-                    SetHitDamage(target->CountPctFromMaxHealth(50));
-            }
-            void Register()
-            {
-                OnEffectHitTarget += SpellEffectFn(spell_spinning_pain_spike_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
-            }
-        };
-
-        SpellScript* GetSpellScript() const
-        {
-            return new spell_spinning_pain_spike_SpellScript();
-        }
-};
-
 void AddSC_boss_jaraxxus()
 {
     new boss_jaraxxus();
@@ -553,5 +523,4 @@ void AddSC_boss_jaraxxus()
     new mob_fel_infernal();
     new mob_nether_portal();
     new mob_mistress_of_pain();
-    new spell_spinning_pain_spike();
 }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -947,13 +947,19 @@ class spell_xt002_tympanic_tantrum : public SpellScriptLoader
 
             void FilterTargets(std::list<Unit*>& unitList)
             {
-                unitList.remove_if (PlayerOrPetCheck());
+                unitList.remove_if(PlayerOrPetCheck());
+            }
+
+            void RecalculateDamage()
+            {
+                SetHitDamage(GetHitUnit()->CountPctFromMaxHealth(GetHitDamage()));
             }
 
             void Register()
             {
                 OnUnitTargetSelect += SpellUnitTargetFn(spell_xt002_tympanic_tantrum_SpellScript::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
                 OnUnitTargetSelect += SpellUnitTargetFn(spell_xt002_tympanic_tantrum_SpellScript::FilterTargets, EFFECT_1, TARGET_UNIT_SRC_AREA_ENEMY);
+                OnHit += SpellHitFn(spell_xt002_tympanic_tantrum_SpellScript::RecalculateDamage);
             }
         };
 

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2618,6 +2618,47 @@ class spell_gen_wg_water : public SpellScriptLoader
         }
 };
 
+class spell_gen_count_pct_from_max_hp : public SpellScriptLoader
+{
+    public:
+        spell_gen_count_pct_from_max_hp(const char* name, int32 damagePct = 0) : SpellScriptLoader(name), _damagePct(damagePct) { }
+
+        class spell_gen_count_pct_from_max_hp_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_gen_count_pct_from_max_hp_SpellScript)
+
+        public:
+            spell_gen_count_pct_from_max_hp_SpellScript(int32 damagePct) : SpellScript(), _damagePct(damagePct) { }
+
+            void RecalculateDamage()
+            {
+                if (!_damagePct)
+                    _damagePct = GetHitDamage();
+
+                if (_damagePct == 100)
+                    SetHitDamage(GetHitUnit()->GetMaxHealth());
+                else
+                    SetHitDamage(GetHitUnit()->CountPctFromMaxHealth(_damagePct));
+            }
+
+            void Register()
+            {
+                OnHit += SpellHitFn(spell_gen_count_pct_from_max_hp_SpellScript::RecalculateDamage);
+            }
+
+        private:
+            int32 _damagePct;
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_gen_count_pct_from_max_hp_SpellScript(_damagePct);
+        }
+
+    private:
+        int32 _damagePct;
+};
+
 void AddSC_generic_spell_scripts()
 {
     new spell_gen_absorb0_hitlimit1();
@@ -2669,4 +2710,6 @@ void AddSC_generic_spell_scripts()
     new spell_gen_chaos_blast();
     new spell_gen_ds_flush_knockback();
     new spell_gen_wg_water();
+    new spell_gen_count_pct_from_max_hp("spell_gen_default_count_pct_from_max_hp");
+    new spell_gen_count_pct_from_max_hp("spell_gen_50pct_count_pct_from_max_hp", 50);
 }


### PR DESCRIPTION
- Convert pct damage spells in SpellScript
- Fix Leviroth Self-Impale damage

(finally) 
