### PR TITLE
Warrior - Unrelenting Assault

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -443,7 +443,7 @@ public:
 
             Unit* target = GetHitUnit();
             if (target->HasUnitState(UNIT_STATE_CASTING))
-                GetCaster()->CastSpell(target, spellId, true);
+                target->CastSpell(target, spellId, true);
         }
 
         void Register()


### PR DESCRIPTION
Fixes a simple mistake that makes Unrelenting Assault proc on the Warrior who casted the overpower instead of the target.
