### PR TITLE
DB/Spells: Fix spell Surge of Adrenaline.

### DIFF
--- a/sql/updates/world/2012_04_09_00_world_spell_linked_spell.sql
+++ b/sql/updates/world/2012_04_09_00_world_spell_linked_spell.sql
@@ -1,0 +1,5 @@
+-- Fix Surge of Adrenaline
+DELETE FROM `spell_linked_spell` WHERE `spell_effect`=68667;
+INSERT INTO `spell_linked_spell` (`spell_trigger`,`spell_effect`,`type`,`comment`) VALUES
+(-66683,68667,0, 'Icehowl - Surge of Adrenaline'),
+(-67660,68667,0, 'Icehowl - Surge of Adrenaline');


### PR DESCRIPTION
Info: http://www.wowwiki.com/Icehowl

The whole raid gains a 50% movement buff(Surge of Adrenaline)(In
normal mode only), and everyone near the spot of Icehowl's target
should move away.

Wrong spell 67661 (10H) in spell_linked_spell.
