### PR TITLE
DB/Spells: Fix Honor Among Thieves proc

### DIFF
--- a/sql/updates/world/2012_04_11_00_world_spell_proc_event.sql
+++ b/sql/updates/world/2012_04_11_00_world_spell_proc_event.sql
@@ -1,0 +1,4 @@
+-- Honor Among Thieves proc
+UPDATE `spell_proc_event` SET `CustomChance`=33 WHERE `entry`=51698; -- Rank 1
+UPDATE `spell_proc_event` SET `CustomChance`=66 WHERE `entry`=51700; -- Rank 2
+UPDATE `spell_proc_event` SET `CustomChance`=100 WHERE `entry`=51701; -- Rank 3


### PR DESCRIPTION
Info: http://www.wowwiki.com/Honor_Among_Thieves

Before this fix, all ranks of honor among thieves proc always.
