### PR TITLE
Fix default MaxArenaPoints config value, should be 5000

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -1095,9 +1095,9 @@ StartHonorPoints = 0
 #
 #    MaxArenaPoints
 #        Description: Maximum arena points a character can have.
-#        Default:     10000
+#        Default:     5000
 
-MaxArenaPoints = 10000
+MaxArenaPoints = 5000
 
 #
 #    StartArenaPoints


### PR DESCRIPTION
Seriously guys, the fact that it is on wowwiki (was actually) does not mean it's true. I could not find some proof other than my memory however, so if somebody proves me wrong...
