### PR TITLE
Core/Spell: Fix unit tracking to not being limited to the caster of SPELL_AURA_MOD_STALKED.

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -626,11 +626,9 @@ void Object::_BuildValuesUpdate(uint8 updatetype, ByteBuffer * data, UpdateMask*
                         if (!target->isAllowedToLoot(creature))
                             dynamicFlags &= ~UNIT_DYNFLAG_LOOTABLE;
                     }
-                    if(Unit const* unit = ToUnit())
-                    {
-                        if(!unit->HasAuraTypeWithCaster(SPELL_AURA_MOD_STALKED, target->GetGUID()))
+                    if (Unit const* unit = ToUnit())
+                        if (!unit->HasAuraTypeWithCaster(SPELL_AURA_MOD_STALKED, target->GetGUID()))
                             dynamicFlags &= ~UNIT_DYNFLAG_TRACK_UNIT;
-                    }
                     *data << dynamicFlags;
                 }
                 // FG: pretend that OTHER players in own group are friendly ("blue")

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -626,7 +626,11 @@ void Object::_BuildValuesUpdate(uint8 updatetype, ByteBuffer * data, UpdateMask*
                         if (!target->isAllowedToLoot(creature))
                             dynamicFlags &= ~UNIT_DYNFLAG_LOOTABLE;
                     }
-
+                    if(Unit const* unit = ToUnit())
+                    {
+                        if(!unit->HasAuraTypeWithCaster(SPELL_AURA_MOD_STALKED, target->GetGUID()))
+                            dynamicFlags &= ~UNIT_DYNFLAG_TRACK_UNIT;
+                    }
                     *data << dynamicFlags;
                 }
                 // FG: pretend that OTHER players in own group are friendly ("blue")

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -626,9 +626,10 @@ void Object::_BuildValuesUpdate(uint8 updatetype, ByteBuffer * data, UpdateMask*
                         if (!target->isAllowedToLoot(creature))
                             dynamicFlags &= ~UNIT_DYNFLAG_LOOTABLE;
                     }
-                    if (Unit const* unit = ToUnit())
-                        if (!unit->HasAuraTypeWithCaster(SPELL_AURA_MOD_STALKED, target->GetGUID()))
-                            dynamicFlags &= ~UNIT_DYNFLAG_TRACK_UNIT;
+                    if(dynamicFlags & UNIT_DYNFLAG_TRACK_UNIT)
+                        if (Unit const* unit = ToUnit())
+                            if (!unit->HasAuraTypeWithCaster(SPELL_AURA_MOD_STALKED, target->GetGUID()))
+                                dynamicFlags &= ~UNIT_DYNFLAG_TRACK_UNIT;
                     *data << dynamicFlags;
                 }
                 // FG: pretend that OTHER players in own group are friendly ("blue")


### PR DESCRIPTION
Fix unit tracking to not being limited to the caster of SPELL_AURA_MOD_STALKED, fixes https://github.com/TrinityCore/TrinityCore/issues/6208
