### PR TITLE
Fix pets attacking on non-harmful spells

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3107,13 +3107,13 @@ void Spell::cast(bool skipCheck)
         // should be done before the spell is actually executed
         sScriptMgr->OnPlayerSpellCast(playerCaster, this, skipCheck);
 
-        // Let any pets know we've attacked something. As of 3.0.2 pets begin
-        //  attacking their owner's target immediately
-        if (Pet* playerPet = playerCaster->GetPet())
-        {
-            if (playerPet->isAlive() && playerPet->isControlled() && (m_targets.GetTargetMask() & TARGET_FLAG_UNIT))
-                playerPet->AI()->OwnerAttacked(m_targets.GetObjectTarget()->ToUnit());
-        }
+        // As of 3.0.2 pets begin attacking their owner's target immediately
+        // Let any pets know we've attacked something. Check DmgClass for harmful spells only
+        // This prevents spells such as Hunter's Mark from triggering pet attack
+        if (this->GetSpellInfo()->DmgClass != SPELL_DAMAGE_CLASS_NONE)
+            if (Pet* playerPet = playerCaster->GetPet())
+                if (playerPet->isAlive() && playerPet->isControlled() && (m_targets.GetTargetMask() & TARGET_FLAG_UNIT))
+                    playerPet->AI()->OwnerAttacked(m_targets.GetObjectTarget()->ToUnit());
     }
     SetExecutedCurrently(true);
 


### PR DESCRIPTION
Pets should no longer attack on spells such as Hunter's Mark

Addresses an issue brought up in #6070

Sorry the patch is late, been in bed sick the past few days :(
