### PR TITLE
DB/Spells: Rogue T9 2P - Should proc only from Rupture ticks.

### DIFF
--- a/sql/updates/world/2012_04_23_03_world_spell_proc_event.sql
+++ b/sql/updates/world/2012_04_23_03_world_spell_proc_event.sql
@@ -1,0 +1,4 @@
+ -- Rogue T9 2P - Should proc only from Rupture ticks.
+DELETE FROM `spell_proc_event` WHERE `entry` IN(67209);
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `procFlags`) VALUES 
+(67209, 0x01, 8, 0x100000, 0x50000);


### PR DESCRIPTION
Rogue T9 2P now proc from every dot, for example: Deadly Poison, Garrote, but it shouldn't.
