### PR TITLE
Core/Spells: Root auras should break stealth when applied.

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2656,6 +2656,7 @@ void SpellMgr::LoadSpellCustomAttr()
                 case SPELL_AURA_AOE_CHARM:
                 case SPELL_AURA_MOD_FEAR:
                 case SPELL_AURA_MOD_STUN:
+                case SPELL_AURA_MOD_ROOT:
                     spellInfo->AttributesCu |= SPELL_ATTR0_CU_AURA_CC;
                     break;
                 case SPELL_AURA_PERIODIC_HEAL:


### PR DESCRIPTION
Like others CCs, roots also break stealth on players when applied. 
For example Earthgrab and Entrapment are supposed to break stealth when the debuff is applied (i tested on retail).

This behavior was fixed in a1eaec791ea6757b99b0ceea07edf5cc09380a69 but broken after 8e9d2cdf01929f513e37eccbfdea952aa04e78f6
