### PR TITLE
Fix Evade Bug

### DIFF
--- a/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.cpp
@@ -25,7 +25,6 @@
 
 void HomeMovementGenerator<Creature>::Initialize(Creature & owner)
 {
-    owner.AddUnitState(UNIT_STATE_EVADE);
     _setTargetLocation(owner);
 }
 


### PR DESCRIPTION
Based on Testing this will fix the evade bugged npc's.  Caused by evade being called while in the evade portion of the AI.  Checked against manos where there spline patch as from and this line was not present.
