### PR TITLE
Force totems to spawn outside walls

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1435,6 +1435,10 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
         m_caster->GetFirstCollisionPosition(pos, dist, angle);
     else
         m_caster->GetNearPosition(pos, dist, angle);
+
+    if (!(&pos)->IsPositionValid())
+        m_caster->GetPosition(&pos);
+
     m_targets.SetDst(*m_caster);
     m_targets.ModDst(pos);
 }


### PR DESCRIPTION
Force totems to spawn outside walls
currently when totems spawn they dont calculate if there is anything in their way, for example: a wall
this forces the totem to spawn outside the wall
should close issues like #5525

Author: @Kandera
Tester: @Amit86
