### PR TITLE
Core/Commands: Add two commands to read and tweak instance stored data

### DIFF
--- a/sql/updates/world/2012_05_24_02_world_command.sql
+++ b/sql/updates/world/2012_05_24_02_world_command.sql
@@ -1,0 +1,8 @@
+DELETE FROM command WHERE name IN("instance getdata", "instance setdata");
+INSERT INTO command (name, security, help) VALUES
+("instance getdata", 3, "Syntax: .instance getdata #dataIndex
+
+Attempts to call an InstanceScript's GetData and prints you the value. Will work on the selected player's map, or on your map as a fallback."),
+("instance setdata", 3, "Syntax: .instance setdata #dataIndex #newValue
+
+Calls InstanceScript::GetData and sets data identified by #dataIndex to #newValue. Will work on the selected player's map, or on your map as a fallback.");

--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -161,6 +161,8 @@ ChatCommand* ChatHandler::getCommandTable()
         { "listbinds",      SEC_ADMINISTRATOR,  false, OldHandler<&ChatHandler::HandleInstanceListBindsCommand>,   "", NULL },
         { "unbind",         SEC_ADMINISTRATOR,  false, OldHandler<&ChatHandler::HandleInstanceUnbindCommand>,      "", NULL },
         { "stats",          SEC_ADMINISTRATOR,  true,  OldHandler<&ChatHandler::HandleInstanceStatsCommand>,       "", NULL },
+        { "setdata",        SEC_ADMINISTRATOR,  false, OldHandler<&ChatHandler::HandleInstanceSetDataCommand>,     "", NULL },
+        { "getdata",        SEC_ADMINISTRATOR,  false, OldHandler<&ChatHandler::HandleInstanceGetDataCommand>,     "", NULL },
         { "savedata",       SEC_ADMINISTRATOR,  false, OldHandler<&ChatHandler::HandleInstanceSaveDataCommand>,    "", NULL },
         { NULL,             0,                  false, NULL,                                           "", NULL }
     };

--- a/src/server/game/Chat/Chat.h
+++ b/src/server/game/Chat/Chat.h
@@ -183,6 +183,8 @@ class ChatHandler
         bool HandleInstanceListBindsCommand(const char* args);
         bool HandleInstanceUnbindCommand(const char* args);
         bool HandleInstanceStatsCommand(const char* args);
+        bool HandleInstanceSetDataCommand(const char * args);
+        bool HandleInstanceGetDataCommand(const char * args);
         bool HandleInstanceSaveDataCommand(const char * args);
 
         bool HandleListAurasCommand(const char * args);

--- a/src/server/game/Chat/Commands/Level3.cpp
+++ b/src/server/game/Chat/Commands/Level3.cpp
@@ -4096,6 +4096,68 @@ std::string GetTimeString(uint64 time)
     return ss.str();
 }
 
+bool ChatHandler::HandleInstanceGetDataCommand(const char* args)
+{
+    Map* map = getSelectedPlayer()->GetMap();
+    if (!map->IsDungeon())
+    {
+        PSendSysMessage("Map is not a dungeon.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    InstanceScript* instanceScript = ((InstanceMap*)map)->GetInstanceScript();
+    if (!instanceScript)
+    {
+        PSendSysMessage("Map has no instance script.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    uint32 dataIndex = uint32(atof(strtok((char*)args, " ")));
+    uint32 dataValue = instanceScript->GetData(dataIndex);
+
+    PSendSysMessage("Data %u (MapId: %u, InstanceID: %u) value: %u.", dataIndex, map->GetId(), map->GetInstanceId(), dataValue);
+    return true;
+}
+
+bool ChatHandler::HandleInstanceSetDataCommand(const char * args)
+{
+    Map* map = getSelectedPlayer()->GetMap();
+    if (!map->IsDungeon())
+    {
+        PSendSysMessage("Map is not a dungeon.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    InstanceScript* instanceScript = ((InstanceMap*)map)->GetInstanceScript();
+    if (!instanceScript)
+    {
+        PSendSysMessage("Map has no instance script.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    uint32 dataIndex = uint32(atof(strtok((char*)args, " ")));
+    char* newVal = strtok(NULL, " ");
+    if (!newVal)
+    {
+        PSendSysMessage("You must provide a new value for that data index.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    uint32 newValue = uint32(atol(newVal));
+
+    uint32 oldValue = instanceScript->GetData(dataIndex);
+    instanceScript->SetData(dataIndex, newValue);
+
+    PSendSysMessage("Data %u (MapId: %u, InstanceID: %u).", dataIndex, map->GetId(), map->GetInstanceId());
+    PSendSysMessage("Old value: %u. New Value: %u", oldValue, newValue);
+    return true;
+}
+
 bool ChatHandler::HandleInstanceListBindsCommand(const char* /*args*/)
 {
     Player* player = getSelectedPlayer();


### PR DESCRIPTION
- `.instance getdata #dataIndex`
  Tries to read data from the instance script at index `#dataIndex`.
- `.instance setdata #dataIndex #value`
  Attempts to change the value at `#dataIndex` to `#value`.

These commands do not check any injection. It's purely for developping purpose, unexpected behavior may happen if you don't use it wisely. This is the main reason why I didn't document these in the `commands` table.
