### PR TITLE
Core/Spell: DK T10 Melee 4P is SPELL_AURA_PROC_TRIGGER_SPELL proc

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7786,17 +7786,6 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                     }
                 }
             }
-            // Item - Death Knight T10 Melee 4P Bonus
-            if (dummySpell->Id == 70656)
-            {
-                Player* player = ToPlayer();
-                if (!player)
-                    return false;
-
-                for (uint32 i = 0; i < MAX_RUNES; ++i)
-                    if (player->GetRuneCooldown(i) == 0)
-                        return false;
-            }
             break;
         }
         case SPELLFAMILY_POTION:
@@ -8723,6 +8712,16 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
 
                     trigger_spell_id = 50475;
                     basepoints0 = CalculatePctN(int32(damage), triggerAmount);
+                }
+                // Item - Death Knight T10 Melee 4P Bonus
+                else if (auraSpellInfo->Id == 70656)
+                {
+                    if (GetTypeId() != TYPEID_PLAYER || getClass() != CLASS_DEATH_KNIGHT)
+                        return false;
+
+                    for (uint8 i = 0; i < MAX_RUNES; ++i)
+                        if (ToPlayer()->GetRuneCooldown(i) == 0)
+                            return false;
                 }
                 break;
             }


### PR DESCRIPTION
Effect 0: Id 6 (SPELL_EFFECT_APPLY_AURA)
BasePoints = -5
Targets (1, 0) (TARGET_UNIT_CASTER, NO_TARGET)
Aura Id 42 (SPELL_AURA_PROC_TRIGGER_SPELL), value = -5, misc = 0 (0), miscB = 0, periodic = 0
SpellClassMask = 00E012F7 00000000 00000000

   Trigger spell (70657) Vorteil (Rang 5). Chance = 100
   Description: Immer wenn alle Eure Runen von Abklingzeit betroffen sind, wird $d lang Euer verursachter Schaden durch Waffen, Zauber und Fertigkeiten um $s1% erhöht.
   ToolTip: Verursachter Schaden um $s1% erhöht.
