### PR TITLE
Core/Spells: Fix Glyph of Earth Shield.

### DIFF
--- a/sql/updates/world/2012_05_30_00_world_spell_script_names.sql
+++ b/sql/updates/world/2012_05_30_00_world_spell_script_names.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=-974;
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(-974 ,'spell_sha_earth_shield');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7409,10 +7409,6 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                 originalCaster = triggeredByAura->GetCasterGUID();
                 target = this;
                 basepoints0 = triggerAmount;
-
-                // Glyph of Earth Shield
-                if (AuraEffect* aur = GetAuraEffect(63279, 0))
-                    AddPctN(basepoints0, aur->GetAmount());
                 triggered_spell_id = 379;
                 break;
             }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -587,16 +587,6 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
                 DoneActualBenefit += caster->SpellBaseDamageBonusDone(m_spellInfo->GetSchoolMask()) * 0.8053f;
             }
             break;
-        case SPELL_AURA_DUMMY:
-            if (!caster)
-                break;
-            // Earth Shield
-            if (GetSpellInfo()->SpellFamilyName == SPELLFAMILY_SHAMAN && m_spellInfo->SpellFamilyFlags[1] & 0x400)
-            {
-                amount = caster->SpellHealingBonusDone(GetBase()->GetUnitOwner(), GetSpellInfo(), amount, SPELL_DIRECT_DAMAGE);
-                amount = GetBase()->GetUnitOwner()->SpellHealingBonusTaken(caster, GetSpellInfo(), amount, SPELL_DIRECT_DAMAGE);
-            }
-            break;
         case SPELL_AURA_PERIODIC_DAMAGE:
             if (!caster)
                 break;


### PR DESCRIPTION
It now increase amount healed by Earth Shield on all players, no only the shaman.

This fixes problem where the glyph only increase heal done by ES to players who have the glyph aura.
