### PR TITLE
Some TicketMgr fixes

### DIFF
--- a/src/server/game/Tickets/TicketMgr.cpp
+++ b/src/server/game/Tickets/TicketMgr.cpp
@@ -144,11 +144,24 @@ void GmTicket::SendResponse(WorldSession* session) const
     data << uint32(1);          // responseID
     data << uint32(_id);        // ticketID
     data << _message.c_str();
-    data << _response.c_str();
-    // 3 null strings (unused)
-    data << uint8(0);
-    data << uint8(0);
-    data << uint8(0);
+
+    size_t len = _response.size();
+    char const* s = _response.c_str();
+
+    for (int i = 0; i < 4; i++)
+    {
+        if (len)
+        {
+            size_t writeLen = std::min<size_t>(len, 3999);
+            data.append(s, writeLen);
+
+            len -= writeLen;
+            s += writeLen;
+        }
+
+        data << uint8(0);
+    }
+
     session->SendPacket(&data);
 }
 

--- a/src/server/game/Tickets/TicketMgr.cpp
+++ b/src/server/game/Tickets/TicketMgr.cpp
@@ -384,17 +384,7 @@ void TicketMgr::SendTicket(WorldSession* session, GmTicket* ticket) const
 
         // we've got the easy stuff done by now.
         // Now we need to go through the client logic for displaying various levels of ticket load
-        if (ticket)
-            ticket->WritePacket(data);
-        else
-        {
-            // we can't actually get any numbers here...
-            data << float(0);
-            data << float(0);
-            data << float(1);
-            data << uint8(0);
-            data << uint8(0);
-        }
+        ticket->WritePacket(data);
     }
     session->SendPacket(&data);
 }


### PR DESCRIPTION
Also, it may become useful to store response in the database. I wonder why it isn't implemented already.

Reference for the second fix:

```
void TicketMgr::SendTicket(WorldSession* session, GmTicket* ticket) const
{
    uint32 status = GMTICKET_STATUS_DEFAULT;
    std::string message;
    if (ticket)
    {
        message = ticket->GetMessage();
        status = GMTICKET_STATUS_HASTEXT;
    }

    WorldPacket data(SMSG_GMTICKET_GETTICKET, (4 + 4 + (ticket ? message.length() + 1 + 4 + 4 + 4 + 1 + 1 : 0)));
    data << uint32(status);                         // standard 0x0A, 0x06 if text present
    data << uint32(ticket ? ticket->GetId() : 0);   // ticketID

    if (ticket)
    {
        data << message.c_str();                    // ticket text
        data << uint8(0x7);                         // ticket category; why is this hardcoded? does it make a diff re: client?

        // we've got the easy stuff done by now.
        // Now we need to go through the client logic for displaying various levels of ticket load
        ticket->WritePacket(data);
    }
    session->SendPacket(&data);
}
```
