### PR TITLE
Wretched mobs damage fix

### DIFF
--- a/sql/old/3.3.5a/2012_07_16_00_world_creature_template.sql
+++ b/sql/old/3.3.5a/2012_07_16_00_world_creature_template.sql
@@ -1,0 +1,3 @@
+-- Fix the damage for Wretched mobs in Magisters' Terrace
+
+UPDATE `creature_template` SET `dmg_multiplier`=0.6 WHERE `entry` IN (24688, 24689, 24690);


### PR DESCRIPTION
Damage for the wretched mobs in mgt were very high, damage is more like on live with this fix.
