### PR TITLE
Core/Spells: Spells with SPELL_EFFECT_KNOCK_BACK(like Thunderstorm)

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5205,7 +5205,7 @@ void Spell::EffectKnockBack(SpellEffIndex effIndex)
             return;
 
     // Spells with SPELL_EFFECT_KNOCK_BACK(like Thunderstorm) can't knoback target if target has ROOT/STUN
-    if (unitTarget->HasUnitState(UNIT_STAT_ROOT | UNIT_STAT_STUNNED))
+    if (unitTarget->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED))
         return;
 
     // Typhoon

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5204,6 +5204,10 @@ void Spell::EffectKnockBack(SpellEffIndex effIndex)
         if (creatureTarget->isWorldBoss() || creatureTarget->IsDungeonBoss())
             return;
 
+    // Spells with SPELL_EFFECT_KNOCK_BACK(like Thunderstorm) can't knoback target if target has ROOT/STUN
+    if (unitTarget->HasUnitState(UNIT_STAT_ROOT | UNIT_STAT_STUNNED))
+        return;
+
     // Typhoon
     if (m_spellInfo->SpellFamilyName == SPELLFAMILY_DRUID && m_spellInfo->SpellFamilyFlags[1] & 0x01000000)
     {


### PR DESCRIPTION
Proof:
http://www.mmo-champion.com/threads/611960-Resisting-Thunderstorm/page2

Ok, just did some basic testing and this is what i can tell you so far

Stunned Targets (tested with warstomp and stoneclaw proc): Take damage, no knockback effect
Rooted Targets (tested with frost nova): Take damage, no knockback effect
Snared Targets (tested with earthbind totem): Take damage, take full distance knockback (not a decreased effect to do snare slowing)
Iceblocked Mage: Immune to both damage and knockback effect.
Feigned Death: Deals full damage and knockback effect
Polymorphed Target: Deals full damage and knockback effect, breaks the CC.
Freezing Trapped Target: Deals full damage and knockback effect, breaks the CC.
Feared Target (tested with Hunter's Fear Beast): Deals full damage and knockback effect, Has a chance to break the Fear just like any other direct damage spell.
Slept Target (tested with Hunter's Wyvern Sting): Deals full damage and knockback effect, breaks the CC.
