### PR TITLE
Core/Misc. Some fixes here and there

### DIFF
--- a/src/server/collision/Maps/TileAssembler.cpp
+++ b/src/server/collision/Maps/TileAssembler.cpp
@@ -336,9 +336,15 @@ namespace VMAP
     void TileAssembler::exportGameobjectModels()
     {
         FILE* model_list = fopen((iSrcDir + "/" + "temp_gameobject_models").c_str(), "rb");
-        FILE* model_list_copy = fopen((iDestDir + "/" + GAMEOBJECT_MODELS).c_str(), "wb");
-        if (!model_list || !model_list_copy)
+        if (!model_list)
             return;
+
+        FILE* model_list_copy = fopen((iDestDir + "/" + GAMEOBJECT_MODELS).c_str(), "wb");
+        if (!model_list_copy)
+        {
+            fclose(model_list);
+            return;
+        }
 
         uint32 name_length, displayId;
         char buff[500];

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -1241,11 +1241,11 @@ LfgAnswer LFGMgr::GetCompatibles(std::string key)
 void LFGMgr::GetCompatibleDungeons(LfgDungeonSet& dungeons, const PlayerSet& players, LfgLockPartyMap& lockMap)
 {
     lockMap.clear();
-    for (PlayerSet::const_iterator it = players.begin(); it != players.end() && dungeons.size(); ++it)
+    for (PlayerSet::const_iterator it = players.begin(); it != players.end() && !dungeons.empty(); ++it)
     {
         uint64 guid = (*it)->GetGUID();
         LfgLockMap cachedLockMap = GetLockedDungeons(guid);
-        for (LfgLockMap::const_iterator it2 = cachedLockMap.begin(); it2 != cachedLockMap.end() && dungeons.size(); ++it2)
+        for (LfgLockMap::const_iterator it2 = cachedLockMap.begin(); it2 != cachedLockMap.end() && !dungeons.empty(); ++it2)
         {
             uint32 dungeonId = (it2->first & 0x00FFFFFF); // Compare dungeon ids
             LfgDungeonSet::iterator itDungeon = dungeons.find(dungeonId);

--- a/src/server/scripts/Commands/cs_disable.cpp
+++ b/src/server/scripts/Commands/cs_disable.cpp
@@ -78,7 +78,6 @@ public:
             return;
         }
 
-        std::string entryStr = cEntry;
         std::string disableComment = cComment;
         uint32 entry = (uint32)atoi(cEntry);
         uint8 flags = atoi(cFlags);

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -382,7 +382,6 @@ bool processArgv(int argc, char ** argv, const char *versionString)
 {
     bool result = true;
     hasInputPathParam = false;
-    bool preciseVectorData = false;
 
     for(int i=1; i< argc; ++i)
     {
@@ -482,7 +481,7 @@ int main(int argc, char ** argv)
     for (size_t i=0; i < archiveNames.size(); ++i)
     {
         MPQArchive *archive = new MPQArchive(archiveNames[i].c_str());
-        if(!gOpenArchives.size() || gOpenArchives.front() != archive)
+        if(gOpenArchives.empty() || gOpenArchives.front() != archive)
             delete archive;
     }
 


### PR DESCRIPTION
*xxx.size() -> !xxx.empty(); (in gcc execution time of xxx.size() is not constant)
Correctly close file handler at error in tileAssembler;
Fix typo in vmapexport;
