### PR TITLE
[434] Core/Entities Map Phasing. Finish Work.

### DIFF
--- a/sql/updates/world/2012_08_31_00_world_phase_area.sql
+++ b/sql/updates/world/2012_08_31_00_world_phase_area.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS `phase_area`;
+CREATE TABLE `phase_area` (
+  `phase` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `area` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest_start` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest_start_active` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `quest_end` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`phase`,`area`,`quest_start`,`quest_start_active`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/sql/updates/world/2012_08_31_01_world_phase_template.sql
+++ b/sql/updates/world/2012_08_31_01_world_phase_template.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS `phase_template`;
 CREATE TABLE `phase_template` (
   `id` mediumint(8) unsigned NOT NULL COMMENT 'id from Phase.dbc',
   `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
-  `map` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `map` smallint(5) NOT NULL DEFAULT '0',
   `terrainSwap` smallint(5) unsigned NOT NULL DEFAULT '0',
   `unkFirstCounter` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)

--- a/sql/updates/world/2012_08_31_01_world_phase_template.sql
+++ b/sql/updates/world/2012_08_31_01_world_phase_template.sql
@@ -1,8 +1,8 @@
 DROP TABLE IF EXISTS `phase_template`;
 CREATE TABLE `phase_template` (
   `id` mediumint(8) unsigned NOT NULL COMMENT 'id from Phase.dbc',
-  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '-1',
-  `map` smallint(5) NOT NULL DEFAULT '0',
+  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
+  `map` smallint(5) NOT NULL DEFAULT '-1',
   `terrainSwap` smallint(5) unsigned NOT NULL DEFAULT '0',
   `unkFirstCounter` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)

--- a/sql/updates/world/2012_08_31_01_world_phase_template.sql
+++ b/sql/updates/world/2012_08_31_01_world_phase_template.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS `phase_template`;
 CREATE TABLE `phase_template` (
   `id` mediumint(8) unsigned NOT NULL COMMENT 'id from Phase.dbc',
-  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
+  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '-1',
   `map` smallint(5) NOT NULL DEFAULT '0',
   `terrainSwap` smallint(5) unsigned NOT NULL DEFAULT '0',
   `unkFirstCounter` smallint(5) unsigned NOT NULL DEFAULT '0',

--- a/sql/updates/world/2012_08_31_01_world_phase_template.sql
+++ b/sql/updates/world/2012_08_31_01_world_phase_template.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS `phase_template`;
+CREATE TABLE `phase_template` (
+  `id` mediumint(8) unsigned NOT NULL COMMENT 'id from Phase.dbc',
+  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
+  `map` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `terrainSwap` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `unkFirstCounter` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.cpp
@@ -75,7 +75,7 @@ void BattlegroundIC::SendTransportInit(Player* player)
     if (!gunshipAlliance || !gunshipHorde)
         return;
 
-    UpdateData transData(player->GetMapId());
+    UpdateData transData(player->GetRootPhaseMapId());
 
     gunshipAlliance->BuildCreateUpdateBlockForPlayer(&transData, player);
     gunshipHorde->BuildCreateUpdateBlockForPlayer(&transData, player);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -273,7 +273,7 @@ void BattlegroundSA::StartShips()
         {
             if (Player* p = ObjectAccessor::FindPlayer(itr->first))
             {
-                UpdateData data(p->GetMapId());
+                UpdateData data(p->GetRootPhaseMapId());
                 WorldPacket pkt;
                 GetBGObject(i)->BuildValuesUpdateBlockForPlayer(&data, p);
                 data.BuildPacket(&pkt);

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -159,7 +159,7 @@ extern DBCStorage <MountCapabilityEntry>         sMountCapabilityStore;
 extern DBCStorage <MountTypeEntry>               sMountTypeStore;
 extern DBCStorage <NameGenEntry>                 sNameGenStore;
 extern DBCStorage <NumTalentsAtLevelEntry>       sNumTalentsAtLevelStore;
-extern DBCStorage <PhaseEntry>                   sPhaseStore;
+extern DBCStorage <PhaseEntry>                   sPhaseStores;
 //extern DBCStorage <MapDifficultyEntry>           sMapDifficultyStore; -- use GetMapDifficultyData insteed
 extern MapDifficultyMap                          sMapDifficultyMap;
 extern DBCStorage <MovieEntry>                   sMovieStore;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -311,7 +311,7 @@ void GameObject::Update(uint32 diff)
                             SetGoState(GO_STATE_ACTIVE);
                             SetUInt32Value(GAMEOBJECT_FLAGS, GO_FLAG_NODESPAWN);
 
-                            UpdateData udata(caster->GetMapId());
+                            UpdateData udata(caster->GetRootPhaseMapId());
                             WorldPacket packet;
                             BuildValuesUpdateBlockForPlayer(&udata, caster->ToPlayer());
                             udata.BuildPacket(&packet);

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -84,6 +84,7 @@ Object::Object() : m_PackGUID(sizeof(uint64)+1)
     m_objectUpdated     = false;
 
     m_PackGUID.appendPackGUID(0);
+    m_rootPhaseMap      = -1;
 }
 
 WorldObject::~WorldObject()
@@ -253,7 +254,7 @@ void Object::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) c
 void Object::SendUpdateToPlayer(Player* player)
 {
     // send create update to player
-    UpdateData upd(player->GetMapId());
+    UpdateData upd(player->GetRootPhaseMapId());
     WorldPacket packet;
 
     BuildCreateUpdateBlockForPlayer(&upd, player);
@@ -903,7 +904,7 @@ void Object::BuildFieldsUpdate(Player* player, UpdateDataMapType& data_map) cons
 
     if (iter == data_map.end())
     {
-        std::pair<UpdateDataMapType::iterator, bool> p = data_map.insert(UpdateDataMapType::value_type(player, UpdateData(player->GetMapId())));
+        std::pair<UpdateDataMapType::iterator, bool> p = data_map.insert(UpdateDataMapType::value_type(player, UpdateData(player->GetRootPhaseMapId())));
         ASSERT(p.second);
         iter = p.first;
     }

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2343,6 +2343,7 @@ void WorldObject::SetMap(Map* map)
     }
     m_currMap = map;
     m_mapId = map->GetId();
+    m_rootPhaseMap = map->GetRootPhaseMapId();
     m_InstanceId = map->GetInstanceId();
     if (IsWorldObject())
         m_currMap->AddWorldObject(this);
@@ -2355,6 +2356,7 @@ void WorldObject::ResetMap()
     if (IsWorldObject())
         m_currMap->RemoveWorldObject(this);
     m_currMap = NULL;
+    m_rootPhaseMap = -1;
     //maybe not for corpse
     //m_mapId = 0;
     //m_InstanceId = 0;

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -379,6 +379,8 @@ class Object
         DynamicObject* ToDynObject() { if (GetTypeId() == TYPEID_DYNAMICOBJECT) return reinterpret_cast<DynamicObject*>(this); else return NULL; }
         DynamicObject const* ToDynObject() const { if (GetTypeId() == TYPEID_DYNAMICOBJECT) return reinterpret_cast<DynamicObject const*>(this); else return NULL; }
 
+        uint32 GetRootPhaseMapId() const { ASSERT(m_rootPhaseMap >= 0); return m_rootPhaseMap; }
+        void SetRootPhaseMap(int32 map) { m_rootPhaseMap = map; }
     protected:
         Object();
 
@@ -416,6 +418,7 @@ class Object
 
         bool m_objectUpdated;
 
+        int32 m_rootPhaseMap;
     private:
         bool m_inWorld;
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22190,6 +22190,9 @@ void Player::SendInitialPacketsBeforeAddToMap()
     data << (uint32) m_homebindAreaId;
     GetSession()->SendPacket(&data);
 
+    ResetTimeSync();
+    SendTimeSync();
+
     // SMSG_SET_PROFICIENCY
     // SMSG_SET_PCT_SPELL_MODIFIER
     // SMSG_SET_FLAT_SPELL_MODIFIER
@@ -22205,10 +22208,25 @@ void Player::SendInitialPacketsBeforeAddToMap()
 
     SendInitialActionButtons();
     m_reputationMgr.SendInitialReputations();
+
+    // SMSG_CORPSE_RECLAIM_DELAY
+    // SMSG_INIT_WORLD_STATES
+    // SMSG_SET_PHASE_SHIFT
+
+    SendCurrencies();
+    SendEquipmentSetList();
     m_achievementMgr.SendAllAchievementData(this);
 
-    SendEquipmentSetList();
+    // SMSG_LOGIN_VERIFY_WORLD
+    data.Initialize(SMSG_LOGIN_VERIFY_WORLD, 20);
+    data << GetMapId();
+    data << GetPositionX();
+    data << GetPositionY();
+    data << GetPositionZ();
+    data << GetOrientation();
+    GetSession()->SendPacket(&data);
 
+    // SMSG_LOGIN_VERIFY_WORLD
     data.Initialize(SMSG_LOGIN_SETTIMESPEED, 4 + 4 + 4);
     data << uint32(secsToTimeBitFields(sWorld->GetGameTime()));
     data << float(0.01666667f);                             // game speed
@@ -22217,12 +22235,14 @@ void Player::SendInitialPacketsBeforeAddToMap()
 
     GetReputationMgr().SendForceReactions();                // SMSG_SET_FORCED_REACTIONS
 
+    // MSG_LIST_STABLED_PETS
+    // SMSG_WEEKLY_SPELL_USAGE
+    // SMSG_WORLD_SERVER_INFO
     // SMSG_TALENTS_INFO x 2 for pet (unspent points and talents in separate packets...)
     // SMSG_PET_GUIDS
     // SMSG_UPDATE_WORLD_STATE
     // SMSG_POWER_UPDATE
 
-    SendCurrencies();
     SetMover(this);
 }
 
@@ -22234,9 +22254,6 @@ void Player::SendInitialPacketsAfterAddToMap()
     uint32 newzone, newarea;
     GetZoneAndAreaId(newzone, newarea);
     UpdateZone(newzone, newarea);                            // also call SendInitWorldStates();
-
-    ResetTimeSync();
-    SendTimeSync();
 
     CastSpell(this, 836, true);                             // LOGINEFFECT
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26119,11 +26119,13 @@ void Player::UpdatePhasing()
     //check auras
     Unit::AuraEffectList const& phases = GetAuraEffectsByType(SPELL_AURA_PHASE);
     if (!phases.empty())
+    {
         for (Unit::AuraEffectList::const_iterator itr = phases.begin(); itr != phases.end(); ++itr)
         {
             newPhase |= (*itr)->GetMiscValue();
             phaseSet.insert((*itr)->GetMiscValueB());
         }
+    }
 
     //get phase mask, if our mask is the same no need to send data.
     uint32 phaseCount = 0;
@@ -26132,15 +26134,17 @@ void Player::UpdatePhasing()
     uint32 mapID = 0;
     for(ApplyPhaseSet::iterator itr = phaseSet.begin(); itr != phaseSet.end(); ++itr)
     {
+        ++phaseCount;
+
         PhaseTemplate const* phaseTemplate = sObjectMgr->GetPhaseTemplate(*itr);
         if (!phaseTemplate)
         {
-            // not handled template. need support in db.
-            phaseSet.erase(itr++);
+            // not handled template. 
+            // in moste cases phasing perfome by spells and in this cases we just send phaseID with root map data
+            // so no need add for them template.
             continue;
         }
         newPhase |= phaseTemplate->PhaseMask;
-        ++phaseCount;
 
         if (phaseTemplate->terrainSwap)
             ++terrainCount;
@@ -26242,12 +26246,7 @@ void Player::SendPhaseShifting(ApplyPhaseSet &phaseSet, uint32 map, uint32 phase
     {
         data << uint32(phaseCount*2); // number of phase array *2
         for (ApplyPhaseSet::iterator itr = phaseSet.begin(); itr != phaseSet.end(); ++itr)
-        {
-            PhaseTemplate const* phaseTemplate = sObjectMgr->GetPhaseTemplate(*itr);
-            if (!phaseTemplate)
-                continue;
             data << uint16(*itr);
-        }
     }else
         data << uint32(0);
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22218,6 +22218,11 @@ void Player::SendInitialPacketsAfterAddToMap()
     GetZoneAndAreaId(newzone, newarea);
     UpdateZone(newzone, newarea);                            // also call SendInitWorldStates();
 
+    //init phasing
+    Unit::AuraEffectList const& auraList = GetAuraEffectsByType(SPELL_AURA_PHASE);
+    if (auraList.empty())
+        GetSession()->SendSetPhaseShift(0, GetMapId(), 0);
+
     SendCurrencies();
     SendEquipmentSetList();
     m_achievementMgr.SendAllAchievementData(this);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22227,7 +22227,7 @@ void Player::SendInitialPacketsAfterAddToMap()
     //init phasing
     Unit::AuraEffectList const& auraList = GetAuraEffectsByType(SPELL_AURA_PHASE);
     if (auraList.empty())
-        GetSession()->SendSetPhaseShift(0, GetMapId(), 0);
+        GetSession()->SendSetPhaseShift(GetMapId(), 0);
 
     SendCurrencies();
     SendEquipmentSetList();

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2942,6 +2942,7 @@ class Player : public Unit, public GridObject<Player>
         uint32 _pendingBindTimer;
 
         // Phasing
+        void SendPhaseShifting(ApplyPhaseSet &data, uint32 map, uint32 phaseCount, uint32 terrainCount, uint32 unkCounter);
         bool m_update_phasing;
 };
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -500,6 +500,7 @@ enum AtLoginFlags
 
 typedef std::map<uint32, QuestStatusData> QuestStatusMap;
 typedef std::set<uint32> RewardedQuestSet;
+typedef std::set<uint32> ApplyPhaseSet;
 
 //               quest,  keep
 typedef std::map<uint32, bool> QuestStatusSaveMap;
@@ -1858,6 +1859,9 @@ class Player : public Unit, public GridObject<Player>
             m_contestedPvPTimer = 0;
         }
 
+        void UpdatePhasing();
+        void SetUpdatePhasing(bool state = true) { m_update_phasing = state; }
+
         /** todo: -maybe move UpdateDuelFlag+DuelComplete to independent DuelHandler.. **/
         DuelInfo* duel;
         void UpdateDuelFlag(time_t currTime);
@@ -2936,6 +2940,9 @@ class Player : public Unit, public GridObject<Player>
         InstanceTimeMap _instanceResetTimes;
         uint32 _pendingBindId;
         uint32 _pendingBindTimer;
+
+        // Phasing
+        bool m_update_phasing;
 };
 
 void AddItemsSetItem(Player*player, Item* item);

--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -580,7 +580,7 @@ void Transport::UpdateForMap(Map const* targetMap)
         {
             if (this != itr->getSource()->GetTransport())
             {
-                UpdateData transData(GetMapId());
+                UpdateData transData(targetMap->GetRootPhaseMapId());
                 BuildCreateUpdateBlockForPlayer(&transData, itr->getSource());
                 WorldPacket packet;
                 transData.BuildPacket(&packet);
@@ -590,7 +590,7 @@ void Transport::UpdateForMap(Map const* targetMap)
     }
     else
     {
-        UpdateData transData(targetMap->GetId());
+        UpdateData transData(targetMap->GetRootPhaseMapId());
         BuildOutOfRangeUpdateBlock(&transData);
         WorldPacket out_packet;
         transData.BuildPacket(&out_packet);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8687,7 +8687,7 @@ void Unit::SetOwnerGUID(uint64 owner)
 
     SetFieldNotifyFlag(UF_FLAG_OWNER);
 
-    UpdateData udata(GetMapId());
+    UpdateData udata(GetRootPhaseMapId());
     WorldPacket packet;
     BuildValuesUpdateBlockForPlayer(&udata, player);
     udata.BuildPacket(&packet);

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8650,7 +8650,7 @@ void ObjectMgr::LoadPhaseTemplate()
 
         PhaseTemplate data;
         data.PhaseMask = fields[1].GetUInt32();
-        data.map = fields[2].GetUInt32();
+        data.map = fields[2].GetInt32();
         data.terrainSwap = fields[3].GetUInt32();
         data.unkFirstCounter = fields[4].GetUInt32();
         mPhaseTemplateMap.insert(std::pair<uint32, PhaseTemplate>(phaseID, data));

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8615,6 +8615,61 @@ void ObjectMgr::LoadHotfixData()
     sLog->outInfo(LOG_FILTER_SERVER_LOADING, ">> Loaded %u hotfix info entries in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
 }
 
+// in 4.3.0 client get phaseId instead phaseMask. Data with suported phaseId storied on phase.dbc
+// template help us for link phase id with out phaseMask system and prepare and send correct data in SMSG_SET_PHASE_SHIFT
+//
+// This system work with phase_aura so map column there is only for simple check
+void ObjectMgr::LoadPhaseTemplate()
+{
+    //cleanup
+    mPhaseTemplateMap.clear();
+
+    uint32 oldMSTime = getMSTime();
+
+    QueryResult result = WorldDatabase.Query("SELECT `id`, `phaseMask`, `map`, `terrainSwap`, `unkFirstCounter` FROM `phase_template`");
+
+    if (!result)
+    {
+        sLog->outInfo(LOG_FILTER_SERVER_LOADING, ">> Loaded 0 phase_template entries. DB table `phase_template` is empty.");
+        return;
+    }
+
+    uint32 count = 0;
+
+    do
+    {
+        Field* fields = result->Fetch();
+
+        uint32 phaseID = fields[0].GetUInt32();
+
+        if(!sPhaseStores.LookupEntry(phaseID))
+        {
+            sLog->outError(LOG_FILTER_SQL, "PhaseID %u listed in `phase_template` does not exist", phaseID);
+            continue;
+        }
+
+        PhaseTemplate data;
+        data.PhaseMask = fields[1].GetUInt32();
+        data.map = fields[2].GetUInt32();
+        data.terrainSwap = fields[3].GetUInt32();
+        data.unkFirstCounter = fields[4].GetUInt32();
+        mPhaseTemplateMap.insert(std::pair<uint32, PhaseTemplate>(phaseID, data));
+        ++count;
+    }
+    while (result->NextRow());
+
+    sLog->outInfo(LOG_FILTER_SERVER_LOADING, ">> Loaded %u phase templates entries in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
+}
+
+PhaseTemplate const* ObjectMgr::GetPhaseTemplate(uint32 entry)
+{
+    PhaseTemplateMap::const_iterator itr = mPhaseTemplateMap.find(entry);
+    if (itr != mPhaseTemplateMap.end())
+        return &(itr->second);
+
+    return NULL;
+}
+
 GameObjectTemplate const* ObjectMgr::GetGameObjectTemplate(uint32 entry)
 {
     GameObjectTemplateContainer::const_iterator itr = _gameObjectTemplateStore.find(entry);

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -589,7 +589,7 @@ typedef std::vector<HotfixInfo> HotfixData;
 struct PhaseTemplate
 {
     uint32 PhaseMask;
-    uint32 map;
+    int32 map;  // -1 state used for not perfoming map
     uint32 terrainSwap;
     uint32 unkFirstCounter;
 };

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -586,6 +586,16 @@ struct HotfixInfo
 
 typedef std::vector<HotfixInfo> HotfixData;
 
+struct PhaseTemplate
+{
+    uint32 PhaseMask;
+    uint32 map;
+    uint32 terrainSwap;
+    uint32 unkFirstCounter;
+};
+
+typedef UNORDERED_MAP<uint32 /*entry*/, PhaseTemplate> PhaseTemplateMap;
+
 class PlayerDumpReader;
 
 class ObjectMgr
@@ -1147,6 +1157,8 @@ class ObjectMgr
             return ret ? ret : time(NULL);
         }
 
+        void LoadPhaseTemplate();
+        PhaseTemplate const* GetPhaseTemplate(uint32 entry);
     private:
         // first free id for selected id type
         uint32 _auctionId;
@@ -1285,6 +1297,8 @@ class ObjectMgr
             GO_TO_CREATURE,         // GO is dependant on creature
         };
         HotfixData _hotfixData;
+
+        PhaseTemplateMap mPhaseTemplateMap;
 };
 
 #define sObjectMgr ACE_Singleton<ObjectMgr, ACE_Null_Mutex>::instance()

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -215,7 +215,7 @@ void DelayedUnitRelocation::Visit(PlayerMapType &m)
         Cell cell2(pair2);
         //cell.SetNoCreate(); need load cells around viewPoint or player, that's why its commented
 
-        PlayerRelocationNotifier relocate(*player);
+        PlayerRelocationNotifier relocate(*player, i_map.GetRootPhaseMapId());
         TypeContainerVisitor<PlayerRelocationNotifier, WorldTypeMapContainer > c2world_relocation(relocate);
         TypeContainerVisitor<PlayerRelocationNotifier, GridTypeMapContainer >  c2grid_relocation(relocate);
 

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -44,7 +44,7 @@ namespace Trinity
         std::set<Unit*> i_visibleNow;
         Player::ClientGUIDs vis_guids;
 
-        VisibleNotifier(Player &player) : i_player(player), i_data(player.GetMapId()), vis_guids(player.m_clientGUIDs) {}
+        VisibleNotifier(Player &player, uint32 mapID) : i_player(player), i_data(mapID), vis_guids(player.m_clientGUIDs) {}
         template<class T> void Visit(GridRefManager<T> &m);
         void SendToSelf(void);
     };
@@ -62,7 +62,7 @@ namespace Trinity
 
     struct PlayerRelocationNotifier : public VisibleNotifier
     {
-        PlayerRelocationNotifier(Player &player) : VisibleNotifier(player) {}
+        PlayerRelocationNotifier(Player &player, uint32 mapID) : VisibleNotifier(player, mapID) {}
 
         template<class T> void Visit(GridRefManager<T> &m) { VisibleNotifier::Visit(m); }
         void Visit(CreatureMapType &);

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -473,7 +473,7 @@ bool Group::AddMember(Player* player)
             // Broadcast new player group member fields to rest of the group
             player->SetFieldNotifyFlag(UF_FLAG_PARTY_MEMBER);
 
-            UpdateData groupData(player->GetMapId());
+            UpdateData groupData(player->GetRootPhaseMapId());
             WorldPacket groupDataPacket;
 
             // Broadcast group members' fields to player
@@ -493,7 +493,7 @@ bool Group::AddMember(Player* player)
 
                     if (member->HaveAtClient(player))
                     {
-                        UpdateData newData(player->GetMapId());
+                        UpdateData newData(player->GetRootPhaseMapId());
                         WorldPacket newDataPacket;
                         player->BuildValuesUpdateBlockForPlayer(&newData, member);
                         if (newData.HasData())

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -838,7 +838,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
     pCurrChar->SendDungeonDifficulty(false);
 
     WorldPacket data(SMSG_LOGIN_VERIFY_WORLD, 20);
-    data << pCurrChar->GetMapId();
+    data << pCurrChar->GetRootPhaseMapId();
     data << pCurrChar->GetPositionX();
     data << pCurrChar->GetPositionY();
     data << pCurrChar->GetPositionZ();

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -837,20 +837,28 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
     pCurrChar->GetMotionMaster()->Initialize();
     pCurrChar->SendDungeonDifficulty(false);
 
+    WorldPacket data(SMSG_LOGIN_VERIFY_WORLD, 20);
+    data << pCurrChar->GetMapId();
+    data << pCurrChar->GetPositionX();
+    data << pCurrChar->GetPositionY();
+    data << pCurrChar->GetPositionZ();
+    data << pCurrChar->GetOrientation();
+    SendPacket(&data);
+
     // load player specific part before send times
     LoadAccountData(holder->GetPreparedResult(PLAYER_LOGIN_QUERY_LOADACCOUNTDATA), PER_CHARACTER_CACHE_MASK);
     SendAccountDataTimes(PER_CHARACTER_CACHE_MASK);
 
     bool featureBit4 = true;
-    WorldPacket data(SMSG_FEATURE_SYSTEM_STATUS, 7);         // checked in 4.2.2
+    data.Initialize(SMSG_FEATURE_SYSTEM_STATUS, 7);         // checked in 4.2.2
     data << uint8(2);                                       // unknown value
     data << uint32(1);
     data << uint32(1);
-    data << uint32(2);
-    data << uint32(0);
+    data << uint32(41);
+    data << uint32(1623);
     data.WriteBit(1);
     data.WriteBit(1);
-    data.WriteBit(0);
+    data.WriteBit(0);   //Enable friend on BattleNet system
     data.WriteBit(featureBit4);
     data.WriteBit(0);
     data.WriteBit(0);
@@ -858,7 +866,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
     if (featureBit4)
     {
         data << uint32(1);
-        data << uint32(0);
+        data << uint32(0);  //Total played time on account
         data << uint32(10);
         data << uint32(60);
     }

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -837,20 +837,12 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
     pCurrChar->GetMotionMaster()->Initialize();
     pCurrChar->SendDungeonDifficulty(false);
 
-    WorldPacket data(SMSG_LOGIN_VERIFY_WORLD, 20);
-    data << pCurrChar->GetMapId();
-    data << pCurrChar->GetPositionX();
-    data << pCurrChar->GetPositionY();
-    data << pCurrChar->GetPositionZ();
-    data << pCurrChar->GetOrientation();
-    SendPacket(&data);
-
     // load player specific part before send times
     LoadAccountData(holder->GetPreparedResult(PLAYER_LOGIN_QUERY_LOADACCOUNTDATA), PER_CHARACTER_CACHE_MASK);
     SendAccountDataTimes(PER_CHARACTER_CACHE_MASK);
 
     bool featureBit4 = true;
-    data.Initialize(SMSG_FEATURE_SYSTEM_STATUS, 7);         // checked in 4.2.2
+    WorldPacket data(SMSG_FEATURE_SYSTEM_STATUS, 7);         // checked in 4.2.2
     data << uint8(2);                                       // unknown value
     data << uint32(1);
     data << uint32(1);

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1724,8 +1724,7 @@ void WorldSession::HandleReadyForAccountDataTimes(WorldPacket& /*recvData*/)
 //PhaseID from phase.dbc
 void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, uint16 terrain)
 {
-    //client understand only guids with hi huid data. For plr HiGuid == 0x780
-    ObjectGuid guid = _player->GetGUID()|0x780000000000000;
+    ObjectGuid guid = _player->GetGUID();
     WorldPacket data(SMSG_SET_PHASE_SHIFT, 16+4+4+(terrain ? 6 : 4)+(mapID ? 6 : 4)+(terrain ? 6 : 4));
     data.WriteBit(guid[2]);
     data.WriteBit(guid[3]);
@@ -1733,8 +1732,8 @@ void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, u
     data.WriteBit(guid[6]);
     data.WriteBit(guid[4]);
     data.WriteBit(guid[5]);
-    data.WriteBit(guid[7]);
     data.WriteBit(guid[0]);
+    data.WriteBit(guid[7]);
 
     data.FlushBits();
 

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1722,7 +1722,7 @@ void WorldSession::HandleReadyForAccountDataTimes(WorldPacket& /*recvData*/)
 }
 
 //PhaseID from phase.dbc
-void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, uint16 terrain)
+void WorldSession::SendSetPhaseShift(uint16 mapID, uint16 phaseID, uint16 terrain /*=0*/)
 {
     ObjectGuid guid = _player->GetGUID();
     WorldPacket data(SMSG_SET_PHASE_SHIFT, 16+4+4+(terrain ? 6 : 4)+(mapID ? 6 : 4)+(terrain ? 6 : 4));
@@ -1746,12 +1746,12 @@ void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, u
     //    data << uint16(0);
 
     data.WriteByteSeq(guid[1]);
-    data << uint32(unk);  //unk
+    data << uint32(0);  //unk. At first logining in Gilneas == 8
     data.WriteByteSeq(guid[2]);
     data.WriteByteSeq(guid[6]);
 
     // terrain swap
-    if(terrain)
+    if (terrain)
     {
         data << uint32(2);   //number of tarrain sap array *2
         data << uint16(terrain);
@@ -1759,7 +1759,7 @@ void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, u
         data << uint32(0);
 
     // Phase mask
-    if(phaseID)
+    if (phaseID)
     {
         data << uint32(2); // number of phase array *2
         data << int16(phaseID);
@@ -1770,7 +1770,7 @@ void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, u
     data.WriteByteSeq(guid[0]);
 
     // map counter
-    if(mapID)
+    if (mapID)
     {
         data << uint32(2); // number of map array *2
         data << uint16(mapID);

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1721,10 +1721,64 @@ void WorldSession::HandleReadyForAccountDataTimes(WorldPacket& /*recvData*/)
     SendAccountDataTimes(GLOBAL_CACHE_MASK);
 }
 
-void WorldSession::SendSetPhaseShift(uint32 PhaseShift)
+//PhaseID from phase.dbc
+void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, uint16 terrain)
 {
-    WorldPacket data(SMSG_SET_PHASE_SHIFT, 4);
-    data << uint32(PhaseShift);
+    ObjectGuid guid = _player->GetGUID();
+    WorldPacket data(SMSG_SET_PHASE_SHIFT, 16+4+4+(terrain ? 6 : 4)+(mapID ? 6 : 4)+(terrain ? 6 : 4));
+    data.WriteBit(guid[2]);
+    data.WriteBit(guid[3]);
+    data.WriteBit(guid[1]);
+    data.WriteBit(guid[6]);
+    data.WriteBit(guid[4]);
+    data.WriteBit(guid[5]);
+    data.WriteBit(guid[7]);
+    data.WriteBit(guid[0]);
+
+    data.FlushBits();
+
+    data.WriteByteSeq(guid[7]);
+    data.WriteByteSeq(guid[4]);
+
+    // unk counter
+    data << uint32(0);  //number of unk counter *2
+    //for(uint32 i = 0; i < count; ++i)
+    //    data << uint16(0);
+
+    data.WriteByteSeq(guid[1]);
+    data << uint32(unk);  //unk
+    data.WriteByteSeq(guid[2]);
+    data.WriteByteSeq(guid[6]);
+
+    // terrain swap
+    if(terrain)
+    {
+        data << uint32(2);   //number of tarrain sap array *2
+        data << uint16(terrain);
+    }else
+        data << uint32(0);
+
+    // Phase mask
+    if(phaseID)
+    {
+        data << uint32(2); // number of phase array *2
+        data << int16(phaseID);
+    }else
+        data << uint32(0);
+
+    data.WriteByteSeq(guid[3]);
+    data.WriteByteSeq(guid[0]);
+
+    // map counter
+    if(mapID)
+    {
+        data << uint32(2); // number of map array *2
+        data << uint16(mapID);
+    }else
+        data << uint32(0);
+
+    data.WriteByteSeq(guid[5]);
+
     SendPacket(&data);
 }
 

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1724,7 +1724,8 @@ void WorldSession::HandleReadyForAccountDataTimes(WorldPacket& /*recvData*/)
 //PhaseID from phase.dbc
 void WorldSession::SendSetPhaseShift(uint16 phaseID, uint16 mapID, uint32 unk, uint16 terrain)
 {
-    ObjectGuid guid = _player->GetGUID();
+    //client understand only guids with hi huid data. For plr HiGuid == 0x780
+    ObjectGuid guid = _player->GetGUID()|0x780000000000000;
     WorldPacket data(SMSG_SET_PHASE_SHIFT, 16+4+4+(terrain ? 6 : 4)+(mapID ? 6 : 4)+(terrain ? 6 : 4));
     data.WriteBit(guid[2]);
     data.WriteBit(guid[3]);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -400,11 +400,7 @@ bool Map::AddPlayerToMap(Player* player)
     player->SetMap(this);
     player->AddToWorld();
 
-    SendInitSelf(player);
-    SendInitTransports(player);
-
     player->m_clientGUIDs.clear();
-    player->UpdateObjectVisibility(false);
 
     sScriptMgr->OnPlayerEnterMap(this, player);
     return true;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -398,6 +398,7 @@ bool Map::AddPlayerToMap(Player* player)
     // Check if we are adding to correct map
     ASSERT (player->GetMap() == this);
     player->SetMap(this);
+    player->SetRootPhaseMap(GetRootPhaseMapId());
     player->AddToWorld();
 
     player->m_clientGUIDs.clear();
@@ -449,6 +450,7 @@ bool Map::AddToMap(T *obj)
 
     //Must already be set before AddToMap. Usually during obj->Create.
     //obj->SetMap(this);
+    obj->SetRootPhaseMap(GetRootPhaseMapId());
     obj->AddToWorld();
 
     InitializeObject(obj);
@@ -663,6 +665,8 @@ void Map::RemovePlayerFromMap(Player* player, bool remove)
     else
         ASSERT(remove); //maybe deleted in logoutplayer when player is not in a map
 
+    player->SetRootPhaseMap(-1);
+
     if (remove)
     {
         DeleteFromWorld(player);
@@ -681,7 +685,9 @@ void Map::RemoveFromMap(T *obj, bool remove)
     obj->UpdateObjectVisibility(true);
     obj->RemoveFromGrid();
 
+    obj->SetRootPhaseMap(-1);
     obj->ResetMap();
+
 
     if (remove)
     {
@@ -1969,7 +1975,7 @@ void Map::UpdateObjectVisibility(WorldObject* obj, Cell cell, CellCoord cellpair
 
 void Map::UpdateObjectsVisibilityFor(Player* player, Cell cell, CellCoord cellpair)
 {
-    Trinity::VisibleNotifier notifier(*player);
+    Trinity::VisibleNotifier notifier(*player, GetRootPhaseMapId());
 
     cell.SetNoCreate();
     TypeContainerVisitor<Trinity::VisibleNotifier, WorldTypeMapContainer > world_notifier(notifier);
@@ -1985,7 +1991,7 @@ void Map::SendInitSelf(Player* player)
 {
     sLog->outInfo(LOG_FILTER_MAPS, "Creating player data for himself %u", player->GetGUIDLow());
 
-    UpdateData data(player->GetMapId());
+    UpdateData data(GetRootPhaseMapId());
 
     // attach to player data current transport data
     if (Transport* transport = player->GetTransport())
@@ -2022,7 +2028,7 @@ void Map::SendInitTransports(Player* player)
     if (tmap.find(player->GetMapId()) == tmap.end())
         return;
 
-    UpdateData transData(player->GetMapId());
+    UpdateData transData(GetRootPhaseMapId());
 
     MapManager::TransportSet& tset = tmap[player->GetMapId()];
 
@@ -2049,7 +2055,7 @@ void Map::SendRemoveTransports(Player* player)
     if (tmap.find(player->GetMapId()) == tmap.end())
         return;
 
-    UpdateData transData(player->GetMapId());
+    UpdateData transData(GetRootPhaseMapId());
 
     MapManager::TransportSet& tset = tmap[player->GetMapId()];
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -398,7 +398,6 @@ bool Map::AddPlayerToMap(Player* player)
     // Check if we are adding to correct map
     ASSERT (player->GetMap() == this);
     player->SetMap(this);
-    player->SetRootPhaseMap(GetRootPhaseMapId());
     player->AddToWorld();
 
     player->m_clientGUIDs.clear();
@@ -450,7 +449,6 @@ bool Map::AddToMap(T *obj)
 
     //Must already be set before AddToMap. Usually during obj->Create.
     //obj->SetMap(this);
-    obj->SetRootPhaseMap(GetRootPhaseMapId());
     obj->AddToWorld();
 
     InitializeObject(obj);
@@ -665,8 +663,6 @@ void Map::RemovePlayerFromMap(Player* player, bool remove)
     else
         ASSERT(remove); //maybe deleted in logoutplayer when player is not in a map
 
-    player->SetRootPhaseMap(-1);
-
     if (remove)
     {
         DeleteFromWorld(player);
@@ -684,10 +680,7 @@ void Map::RemoveFromMap(T *obj, bool remove)
 
     obj->UpdateObjectVisibility(true);
     obj->RemoveFromGrid();
-
-    obj->SetRootPhaseMap(-1);
     obj->ResetMap();
-
 
     if (remove)
     {

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -296,6 +296,7 @@ class Map : public GridRefManager<NGridType>
 
         time_t GetGridExpiry(void) const { return i_gridExpiry; }
         uint32 GetId(void) const { return i_mapEntry->MapID; }
+        uint32 GetRootPhaseMapId(void) const { return i_mapEntry->rootPhaseMap > 0 ? i_mapEntry->rootPhaseMap : i_mapEntry->MapID; }
 
         static bool ExistMap(uint32 mapid, int gx, int gy);
         static bool ExistVMap(uint32 mapid, int gx, int gy);

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -476,6 +476,9 @@ class Map : public GridRefManager<NGridType>
 
         static void DeleteRespawnTimesInDB(uint16 mapId, uint32 instanceId);
 
+        void SendInitSelf(Player* player);
+
+        void SendInitTransports(Player* player);
     private:
         void LoadMapAndVMap(int gx, int gy);
         void LoadVMap(int gx, int gy);
@@ -484,9 +487,6 @@ class Map : public GridRefManager<NGridType>
 
         void SetTimer(uint32 t) { i_gridExpiry = t < MIN_GRID_DELAY ? MIN_GRID_DELAY : t; }
 
-        void SendInitSelf(Player* player);
-
-        void SendInitTransports(Player* player);
         void SendRemoveTransports(Player* player);
 
         bool CreatureCellRelocation(Creature* creature, Cell new_cell);

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -1158,7 +1158,7 @@ void InitOpcodes()
     DEFINE_OPCODE_HANDLER(SMSG_SET_FLAT_SPELL_MODIFIER,                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     DEFINE_OPCODE_HANDLER(SMSG_SET_FORCED_REACTIONS,                    STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     DEFINE_OPCODE_HANDLER(SMSG_SET_PCT_SPELL_MODIFIER,                  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    DEFINE_OPCODE_HANDLER(SMSG_SET_PHASE_SHIFT,                         STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    DEFINE_OPCODE_HANDLER(SMSG_SET_PHASE_SHIFT,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     DEFINE_OPCODE_HANDLER(SMSG_SET_PLAYER_DECLINED_NAMES_RESULT,        STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     DEFINE_OPCODE_HANDLER(SMSG_SET_PLAY_HOVER_ANIM,                     STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     DEFINE_OPCODE_HANDLER(SMSG_SET_PROFICIENCY,                         STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -253,7 +253,7 @@ class WorldSession
         void SendPetNameInvalid(uint32 error, const std::string& name, DeclinedName *declinedName);
         void SendPartyResult(PartyOperation operation, const std::string& member, PartyResult res, uint32 val = 0);
         void SendAreaTriggerMessage(const char* Text, ...) ATTR_PRINTF(2, 3);
-        void SendSetPhaseShift(uint32 phaseShift);
+        void SendSetPhaseShift(uint16 phaseID, uint16 mapId, uint32 unk, uint16 terrain = 0);
         void SendQueryTimeResponse();
 
         void SendAuthResponse(uint8 code, bool queued, uint32 queuePos = 0);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -253,7 +253,7 @@ class WorldSession
         void SendPetNameInvalid(uint32 error, const std::string& name, DeclinedName *declinedName);
         void SendPartyResult(PartyOperation operation, const std::string& member, PartyResult res, uint32 val = 0);
         void SendAreaTriggerMessage(const char* Text, ...) ATTR_PRINTF(2, 3);
-        void SendSetPhaseShift(uint16 phaseID, uint16 mapId, uint32 unk, uint16 terrain = 0);
+        void SendSetPhaseShift(uint16 mapId, uint16 phaseID, uint16 terrain = 0);
         void SendQueryTimeResponse();
 
         void SendAuthResponse(uint8 code, bool queued, uint32 queuePos = 0);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1803,7 +1803,7 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
             newPhase = 0xFFFFFFFF;
 
         player->SetPhaseMask(newPhase, false);
-        player->GetSession()->SendSetPhaseShift(newPhase);
+        player->GetSession()->SendSetPhaseShift(GetMiscValueB(), player->GetMapId(), 0);
     }
     else
     {

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1789,7 +1789,7 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
     if (Player* player = target->ToPlayer())
     {
         // now everything handled in Player::UpdatePhasing()
-        player->SetUpdatePhasing();
+        player->SetUpdatePhasing(true);
     }
     else
     {

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1788,7 +1788,7 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
 
     if (Player* player = target->ToPlayer())
     {
-        // now everything handled 
+        // now everything handled in Player::UpdatePhasing()
         player->SetUpdatePhasing();
     }
     else

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1786,29 +1786,20 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
 
     Unit* target = aurApp->GetTarget();
 
-    // no-phase is also phase state so same code for apply and remove
-    uint32 newPhase = 0;
-    Unit::AuraEffectList const& phases = target->GetAuraEffectsByType(SPELL_AURA_PHASE);
-    if (!phases.empty())
-        for (Unit::AuraEffectList::const_iterator itr = phases.begin(); itr != phases.end(); ++itr)
-            newPhase |= (*itr)->GetMiscValue();
-
     if (Player* player = target->ToPlayer())
     {
-        if (!newPhase)
-            newPhase = PHASEMASK_NORMAL;
-
-        // GM-mode have mask 0xFFFFFFFF
-        if (player->isGameMaster())
-            newPhase = 0xFFFFFFFF;
-
-        player->SetPhaseMask(newPhase, false);
-
-        // MiscValueB == PhaseID from phase.dbc
-        player->GetSession()->SendSetPhaseShift(player->GetMapId(), GetMiscValueB());
+        // now everything handled 
+        player->SetUpdatePhasing();
     }
     else
     {
+        // no-phase is also phase state so same code for apply and remove
+        uint32 newPhase = 0;
+        Unit::AuraEffectList const& phases = target->GetAuraEffectsByType(SPELL_AURA_PHASE);
+        if (!phases.empty())
+            for (Unit::AuraEffectList::const_iterator itr = phases.begin(); itr != phases.end(); ++itr)
+                newPhase |= (*itr)->GetMiscValue();
+
         if (!newPhase)
         {
             newPhase = PHASEMASK_NORMAL;
@@ -1818,6 +1809,10 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
         }
 
         target->SetPhaseMask(newPhase, false);
+
+        // need triggering visibility update base at phase update of not GM invisible (other GMs anyway see in any phases)
+        if (target->IsVisible())
+            target->UpdateObjectVisibility();
     }
 
     // call functions which may have additional effects after chainging state of unit
@@ -1828,9 +1823,6 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
         target->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_IMMUNE_OR_LOST_SELECTION);
     }
 
-    // need triggering visibility update base at phase update of not GM invisible (other GMs anyway see in any phases)
-    if (target->IsVisible())
-        target->UpdateObjectVisibility();
 }
 
 /**********************/

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1803,7 +1803,9 @@ void AuraEffect::HandlePhase(AuraApplication const* aurApp, uint8 mode, bool app
             newPhase = 0xFFFFFFFF;
 
         player->SetPhaseMask(newPhase, false);
-        player->GetSession()->SendSetPhaseShift(GetMiscValueB(), player->GetMapId(), 0);
+
+        // MiscValueB == PhaseID from phase.dbc
+        player->GetSession()->SendSetPhaseShift(player->GetMapId(), GetMiscValueB());
     }
     else
     {

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -485,9 +485,16 @@ class PetAura
 };
 typedef std::map<uint32, PetAura> SpellPetAuraMap;
 
+// ToDo: now it already use for PhaseArea too.
 struct SpellArea
 {
+    SpellArea() : spellId(0), phaseid(0), areaId(0), questStart(0), questEnd(0),
+        auraSpell(0), raceMask(0), gender(GENDER_NONE), questStartCanActive(false), autocast(false) 
+    {
+    }
+
     uint32 spellId;
+    uint32 phaseid;
     uint32 areaId;                                          // zone/subzone/or 0 is not limited to zone
     uint32 questStart;                                      // quest start (quest must be active or rewarded for spell apply)
     uint32 questEnd;                                        // quest end (quest must not be rewarded for spell apply)
@@ -685,6 +692,10 @@ class SpellMgr
         SpellAreaForAuraMapBounds GetSpellAreaForAuraMapBounds(uint32 spell_id) const;
         SpellAreaForAreaMapBounds GetSpellAreaForAreaMapBounds(uint32 area_id) const;
 
+        // Phase area
+        SpellAreaMapBounds GetPhaseAreaMapBounds(uint32 phase_id) const;
+        SpellAreaForAreaMapBounds GetPhaseAreaForAreaMapBounds(uint32 area_id) const;
+
         // SpellInfo object management
         SpellInfo const* GetSpellInfo(uint32 spellId) const { return spellId < GetSpellInfoStoreSize() ?  mSpellInfoMap[spellId] : NULL; }
         uint32 GetSpellInfoStoreSize() const { return mSpellInfoMap.size(); }
@@ -712,6 +723,7 @@ class SpellMgr
         void LoadPetLevelupSpellMap();
         void LoadPetDefaultSpells();
         void LoadSpellAreas();
+        void LoadPhaseAreas();
         void LoadSpellInfoStore();
         void UnloadSpellInfoStore();
         void UnloadSpellInfoImplicitTargetConditionLists();
@@ -743,6 +755,8 @@ class SpellMgr
         SpellAreaForQuestMap       mSpellAreaForQuestEndMap;
         SpellAreaForAuraMap        mSpellAreaForAuraMap;
         SpellAreaForAreaMap        mSpellAreaForAreaMap;
+        SpellAreaMap               mPhaseAreaMap;                 // yes. We use SpellAreaMap as it's need same data.
+        SpellAreaForAreaMap        mPhaseAreaForAreaMap;
         SkillLineAbilityMap        mSkillLineAbilityMap;
         PetLevelupSpellMap         mPetLevelupSpellMap;
         PetDefaultSpellsMap        mPetDefaultSpellsMap;           // only spells not listed in related mPetLevelupSpellMap entry

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1465,6 +1465,9 @@ void World::SetInitialWorldSettings()
     sLog->outInfo(LOG_FILTER_SERVER_LOADING, "Loading SpellArea Data...");                // must be after quest load
     sSpellMgr->LoadSpellAreas();
 
+    sLog->outInfo(LOG_FILTER_SERVER_LOADING, "Loading PhaseArea Data...");                // must be after quest load
+    sSpellMgr->LoadPhaseAreas();
+
     sLog->outInfo(LOG_FILTER_SERVER_LOADING, "Loading AreaTrigger definitions...");
     sObjectMgr->LoadAreaTriggerTeleports();
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1764,6 +1764,9 @@ void World::SetInitialWorldSettings()
     sLog->outInfo(LOG_FILTER_GENERAL, "Loading hotfix info...");
     sObjectMgr->LoadHotfixData();
 
+    sLog->outInfo(LOG_FILTER_GENERAL, "Loading Phase Template info...");
+    sObjectMgr->LoadPhaseTemplate();
+
     uint32 startupDuration = GetMSTimeDiffToNow(startupBegin);
 
     sLog->outInfo(LOG_FILTER_WORLDSERVER, "World initialized in %u minutes %u seconds", (startupDuration / 60000), ((startupDuration % 60000) / 1000));

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -948,8 +948,19 @@ public:
         if (!*args)
             return false;
 
+        char* m = strtok((char*)args, " ");
+        char* p = strtok(NULL, " ");
+        char* t = strtok(NULL, " ");
+
+        if (!m || !p || !t)
+            return false;
+
+        uint16 phaseID = (uint32)atoi(p);
+        uint16 mapID = (uint32)atoi(m);
+        uint16 terrainSwap = (uint32)atoi(t);
+
         uint32 PhaseShift = atoi(args);
-        handler->GetSession()->SendSetPhaseShift(PhaseShift);
+        handler->GetSession()->SendSetPhaseShift(phaseID, mapID, terrainSwap);
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -945,6 +945,8 @@ public:
 
     static bool HandleDebugSendSetPhaseShiftCommand(ChatHandler* handler, char const* args)
     {
+        // Args: real map ID, PhaseID from phase.dbc, terrainSwap - unk.
+        // terrainSwap in moste cases == 0
         if (!*args)
             return false;
 
@@ -955,12 +957,11 @@ public:
         if (!m || !p || !t)
             return false;
 
-        uint16 phaseID = (uint32)atoi(p);
         uint16 mapID = (uint32)atoi(m);
+        uint16 phaseID = (uint32)atoi(p);
         uint16 terrainSwap = (uint32)atoi(t);
 
-        uint32 PhaseShift = atoi(args);
-        handler->GetSession()->SendSetPhaseShift(phaseID, mapID, terrainSwap);
+        handler->GetSession()->SendSetPhaseShift(mapID, phaseID, terrainSwap);
         return true;
     }
 


### PR DESCRIPTION
In cataclysm was performed new phase technology with epic terrain changing. 
How it work.
At beginning client ported to basic map (654 for expl) and for client everything is performing only on this map.
But for server plr will be on map wich correspond our phase position. For gilneas first phase map is 638. 
For server plr wolking on 638 map, kill mobs witch are on 638 map and etc. But create/update data should be send for root map (654).
For changing phase we just set plr on next phase map, no need to send teleportation, just correct phase change declaration by SMSG_SET_PHASE_SHIFT
ToDo: create switcher between phase maps.
Additionally: fix SPELL_AURA_PHASE with proper sending SMSG_SET_PHASE_SHIFT
