### PR TITLE
Core/Spells: Check for Bane spells should be before check curse because Bane have dispel type Curse

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1950,13 +1950,13 @@ SpellSpecificType SpellInfo::GetSpellSpecific() const
         }
         case SPELLFAMILY_WARLOCK:
         {
-            // only warlock curses have this
-            if (Dispel == DISPEL_CURSE)
-                return SPELL_SPECIFIC_CURSE;
-
             // Warlock (Bane of Doom | Bane of Agony | Bane of Havoc)
             if (Id == 603 || Id ==  980 || Id == 80240)
                 return SPELL_SPECIFIC_BANE;
+
+            // only warlock curses have this
+            if (Dispel == DISPEL_CURSE)
+                return SPELL_SPECIFIC_CURSE;
 
             // Warlock (Demon Armor | Demon Skin | Fel Armor)
             if (SpellFamilyFlags[1] & 0x20000020 || SpellFamilyFlags[2] & 0x00000010)


### PR DESCRIPTION
e.g.
# ID - 603 Bane of Doom

Description: Banes the target with impending doom, causing $s1 Shadow damage every $T1 sec.  When Bane of Doom deals damage, it has a $s2% chance to summon a Demon guardian. 

Only one target can have Bane of Doom at a time, only one Bane per Warlock can be active on any one target. Lasts for $d.
ToolTip: Suffering $w1 Shadow damage every $t1 sec.
Category = 0, SpellIconID = 91, activeIconID = 0, SpellVisual = (5019,0)
Family SPELLFAMILY_WARLOCK, flag 0x00000000 00000002 00000000

SpellSchoolMask = 32 (SPELL_SCHOOL_MASK_SHADOW)
DamageClass = 1 (SPELL_DAMAGE_CLASS_MAGIC)
# PreventionType = 1 (SPELL_PREVENTION_TYPE_SILENCE)

Attributes: 0x00010000 (SPELL_ATTR0_NOT_SHAPESHIFT)
AttributesEx4: 0x00100000 (SPELL_ATTR4_NOT_CHECK_SELFCAST_POWER)
AttributesEx5: 0x00000020 (SPELL_ATTR5_SINGLE_TARGET_SPELL)
AttributesEx6: 0x00800000 (SPELL_ATTR6_UNK23)
# AttributesEx8: 0x00001000 (SPELL_ATTR8_AURA_SEND_AMOUNT)

Skill (Id 355) "Affliction"
    ReqSkillValue 1, Forward Spell = 0, MinMaxValue (0, 0), CharacterPoints (1, 0)Spell Level = 20, base 20, max 0, maxTarget 0

Category = 0
DispelType = 2 (DISPEL_CURSE)
Mechanic = 0 (MECHANIC_NONE)
SpellRange: (Id 5) "Long Range":
    MinRangeNegative = 0, MinRangePositive = 0
    MaxRangeNegative = 40, MaxRangePositive = 40
