### PR TITLE
[Core/Auras]: Now priest is energized for each Power Word: Shield that is absorbed or dispelled

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1413,10 +1413,15 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                         // check cooldown
                         if (caster->GetTypeId() == TYPEID_PLAYER)
                         {
-                            if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()))
-                                break;
-                            // and add if needed
-                            caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
+                            //if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()))
+                            //    break;
+                            //// and add if needed
+                            //caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
+
+                            if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()) && caster->ToPlayer()->GetSpellCooldownDelay(aura->GetId()) <= 10)
+								break;
+                            if (!caster->ToPlayer()->HasSpellCooldown(aura->GetId()))
+								caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
                         }
                         // effect on caster
                         if (AuraEffect const* aurEff = aura->GetEffect(0))

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1413,15 +1413,10 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                         // check cooldown
                         if (caster->GetTypeId() == TYPEID_PLAYER)
                         {
-                            //if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()))
-                            //    break;
-                            //// and add if needed
-                            //caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
-
                             if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()) && caster->ToPlayer()->GetSpellCooldownDelay(aura->GetId()) <= 10)
-								break;
+                                break;
                             if (!caster->ToPlayer()->HasSpellCooldown(aura->GetId()))
-								caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
+                                caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
                         }
                         // effect on caster
                         if (AuraEffect const* aurEff = aura->GetEffect(0))

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1413,8 +1413,9 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                         // check cooldown
                         if (caster->GetTypeId() == TYPEID_PLAYER)
                         {
-                            if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()) && caster->ToPlayer()->GetSpellCooldownDelay(aura->GetId()) <= 10)
+                            if (caster->ToPlayer()->HasSpellCooldown(aura->GetId()) && ((float)caster->ToPlayer()->GetSpellCooldownDelay(aura->GetId())) <= 11.5f)
                                 break;
+                            // and add if needed
                             if (!caster->ToPlayer()->HasSpellCooldown(aura->GetId()))
                                 caster->ToPlayer()->AddSpellCooldown(aura->GetId(), 0, uint32(time(NULL) + 12));
                         }


### PR DESCRIPTION
Old code not allow the correct effects of talent Rapture when more Power Word: Shield are dispelled o destroyed at same time, that is showed in this video: http://www.youtube.com/watch?v=HnGKkc4p6XA . My fix add a micro delay to allow talent Rapture work correctly. The icd is granted.

(Sorry my English)
