### PR TITLE
[4.3.4] Fix extractor compile on Fedora

### DIFF
--- a/dep/g3dlite/include/G3D/GMutex.h
+++ b/dep/g3dlite/include/G3D/GMutex.h
@@ -12,6 +12,7 @@
 #include "G3D/AtomicInt32.h"
 #include "G3D/debugAssert.h"
 #include <string>
+#include <unistd.h>
 
 #ifndef G3D_WIN32
 #   include <pthread.h>


### PR DESCRIPTION
Originaly from Gamera 

http://www.trinitycore.org/f/topic/6656-error-while-compiling-tc-over-fedora-17/
