### PR TITLE
Core/Spells: Sentry Totem Aura remove fix and some minor fix in totem.cpp

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -21,6 +21,7 @@
 #include "CreatureAI.h"
 #include "ObjectMgr.h"
 #include "TemporarySummon.h"
+#include "Totem.h"
 
 TempSummon::TempSummon(SummonPropertiesEntry const* properties, Unit* owner, bool isWorldObject) :
 Creature(isWorldObject), m_Properties(properties), m_type(TEMPSUMMON_MANUAL_DESPAWN),
@@ -195,7 +196,12 @@ void TempSummon::InitStats(uint32 duration)
             {
                 Creature* oldSummon = GetMap()->GetCreature(owner->m_SummonSlot[slot]);
                 if (oldSummon && oldSummon->isSummon())
-                    oldSummon->ToTempSummon()->UnSummon();
+                {
+                    if (oldSummon->isTotem())
+                        oldSummon->ToTotem()->UnSummon();
+                    else
+                        oldSummon->ToTempSummon()->UnSummon();
+                }
             }
             owner->m_SummonSlot[slot] = GetGUID();
         }

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -21,7 +21,6 @@
 #include "CreatureAI.h"
 #include "ObjectMgr.h"
 #include "TemporarySummon.h"
-#include "Totem.h"
 
 TempSummon::TempSummon(SummonPropertiesEntry const* properties, Unit* owner, bool isWorldObject) :
 Creature(isWorldObject), m_Properties(properties), m_type(TEMPSUMMON_MANUAL_DESPAWN),
@@ -196,12 +195,7 @@ void TempSummon::InitStats(uint32 duration)
             {
                 Creature* oldSummon = GetMap()->GetCreature(owner->m_SummonSlot[slot]);
                 if (oldSummon && oldSummon->isSummon())
-                {
-                    if (oldSummon->isTotem())
-                        oldSummon->ToTotem()->UnSummon();
-                    else
-                        oldSummon->ToTempSummon()->UnSummon();
-                }
+                    oldSummon->ToTempSummon()->UnSummon();
             }
             owner->m_SummonSlot[slot] = GetGUID();
         }

--- a/src/server/game/Entities/Creature/TemporarySummon.h
+++ b/src/server/game/Entities/Creature/TemporarySummon.h
@@ -29,7 +29,7 @@ class TempSummon : public Creature
         void Update(uint32 time);
         virtual void InitStats(uint32 lifetime);
         virtual void InitSummon();
-        void UnSummon(uint32 msTime = 0);
+        virtual void UnSummon(uint32 msTime = 0);
         void RemoveFromWorld();
         void SetTempSummonType(TempSummonType type);
         void SaveToDB(uint32 /*mapid*/, uint8 /*spawnMask*/, uint32 /*phaseMask*/) {}

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -86,7 +86,7 @@ void Totem::InitStats(uint32 duration)
 
 void Totem::InitSummon()
 {
-    if (m_type == TOTEM_PASSIVE)
+    if (m_type == TOTEM_PASSIVE && GetSpell())
     {
         CastSpell(this, GetSpell(), true);
     }
@@ -99,7 +99,7 @@ void Totem::InitSummon()
 void Totem::UnSummon()
 {
     CombatStop();
-    RemoveAurasDueToSpell(GetSpell());
+    RemoveAurasDueToSpell(GetSpell(), GetGUID());
 
     // clear owner's totem slot
     for (int i = SUMMON_SLOT_TOTEM; i < MAX_TOTEM_SLOT; ++i)
@@ -111,7 +111,11 @@ void Totem::UnSummon()
         }
     }
 
-    m_owner->RemoveAurasDueToSpell(GetSpell());
+    m_owner->RemoveAurasDueToSpell(GetSpell(), GetGUID());
+
+    // Remove Sentry Totem Aura
+    if (GetEntry() == SENTRY_TOTEM_ENTRY)
+        m_owner->RemoveAurasDueToSpell(SENTRY_TOTEM_SPELLID);
 
     //remove aura all party members too
     if (Player* owner = m_owner->ToPlayer())
@@ -127,7 +131,7 @@ void Totem::UnSummon()
             {
                 Player* target = itr->getSource();
                 if (target && group->SameSubGroup(owner, target))
-                    target->RemoveAurasDueToSpell(GetSpell());
+                    target->RemoveAurasDueToSpell(GetSpell(), GetGUID());
             }
         }
     }

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -96,7 +96,7 @@ void Totem::InitSummon()
         CastSpell(this, GetSpell(1), true);
 }
 
-void Totem::UnSummon()
+void Totem::UnSummon(uint32 msTime)
 {
     CombatStop();
     RemoveAurasDueToSpell(GetSpell(), GetGUID());

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -40,7 +40,7 @@ class Totem : public Minion
         void Update(uint32 time);
         void InitStats(uint32 duration);
         void InitSummon();
-        void UnSummon();
+        void UnSummon(uint32 msTime = 0);
         uint32 GetSpell(uint8 slot = 0) const { return m_spells[slot]; }
         uint32 GetTotemDuration() const { return m_duration; }
         void SetTotemDuration(uint32 duration) { m_duration = duration; }

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -27,8 +27,10 @@ enum TotemType
     TOTEM_ACTIVE     = 1,
     TOTEM_STATUE     = 2 // copied straight from MaNGOS, may need more implementation to work
 };
+// Some Totems cast spells that are not in creature DB
+#define SENTRY_TOTEM_SPELLID  6495
 
-#define SENTRY_TOTEM_ENTRY  3968
+#define SENTRY_TOTEM_ENTRY    3968
 
 class Totem : public Minion
 {

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -514,8 +514,8 @@ void WorldSession::HandleTotemDestroyed(WorldPacket& recvPacket)
         return;
 
     Creature* totem = GetPlayer()->GetMap()->GetCreature(_player->m_SummonSlot[slotId]);
-    // Don't unsummon sentry totem
-    if (totem && totem->isTotem() && totem->GetEntry() != SENTRY_TOTEM_ENTRY)
+
+    if (totem && totem->isTotem())
         totem->ToTotem()->UnSummon();
 }
 


### PR DESCRIPTION
Fix Sentry Totem aura removing when Sentry totem is destroyed.
Add casterguid to RemoveAurasDueToSpell this will protect auras that are not casted by removing totem.
Sentry Totem can be destroyed by totem timers.
When new totem replace old totem use Totem::Unsummon
