### PR TITLE
Core/Scripts: Defending Wyrmrest Temple

### DIFF
--- a/sql/updates/world/2012_08_26_00_creature_template.sql
+++ b/sql/updates/world/2012_08_26_00_creature_template.sql
@@ -1,0 +1,2 @@
+-- NPC script linking for Wyrmrest Defender ID: 27629
+UPDATE `creature_template` SET `ScriptName`='npc_wyrmrest_defender' WHERE `entry`=27629;

--- a/sql/updates/world/2012_08_26_00_world_spell_script_name.sql
+++ b/sql/updates/world/2012_08_26_00_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Spell script name linking for Defending Wyrmrest Temple: Character Script Cast From Gossip ID: 49123
+DELETE FROM `spell_script_names` WHERE `spell_id`=49213;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(49213,'spell_q12372_cast_from_gossip_trigger');

--- a/src/server/scripts/Northrend/dragonblight.cpp
+++ b/src/server/scripts/Northrend/dragonblight.cpp
@@ -170,9 +170,48 @@ public:
     }
 };
 
+/*######
+## wyrmrest_defender
+######*/
+
+enum Spells
+{
+    SPELL_CHARACTER_SCRIPT       = 49213
+};
+
+#define GOSSIP_ITEM_1      "We need to get into the fight. Are you ready?"
+
+class npc_wyrmrest_defender : public CreatureScript
+{
+    public:
+        npc_wyrmrest_defender() : CreatureScript("npc_wyrmrest_defender") { }
+                        
+        bool OnGossipHello(Player* player, Creature* creature)
+        {
+            player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_ITEM_1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF+1);
+            player->SEND_GOSSIP_MENU(player->GetGossipTextId(creature), creature->GetGUID());
+                         
+            return true;
+        }
+                        
+        bool OnGossipSelect(Player* player, Creature* creature, uint32 /*uiSender*/, uint32 uiAction)
+        {
+            player->PlayerTalkClass->ClearMenus();
+            if (uiAction == GOSSIP_ACTION_INFO_DEF+1)
+            {
+                player->CLOSE_GOSSIP_MENU();
+                //Makes player cast trigger spell for 49207 on self
+                player->CastSpell(creature, SPELL_CHARACTER_SCRIPT, true);
+            }
+                
+            return true;
+        }
+};
+
 void AddSC_dragonblight()
 {
     new npc_alexstrasza_wr_gate;
     new spell_q12096_q12092_dummy;
     new spell_q12096_q12092_bark;
+    new npc_wyrmrest_defender;
 }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1245,6 +1245,37 @@ class spell_q12735_song_of_cleansing : public SpellScriptLoader
         }
 };
 
+enum DefendingWyrmrestTemple
+{
+    SPELL_SUMMON_WYRMREST_DEFENDER       = 49207
+};
+
+class spell_q12372_cast_from_gossip_trigger : public SpellScriptLoader
+{
+    public:
+        spell_q12372_cast_from_gossip_trigger() : SpellScriptLoader("spell_q12372_cast_from_gossip_trigger") { }
+
+        class spell_q12372_cast_from_gossip_trigger_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q12372_cast_from_gossip_trigger_SpellScript);
+
+            void HandleScript(SpellEffIndex /*effIndex*/)
+            {
+                Player* caster = GetCaster()->ToPlayer();
+                caster->CastSpell(caster, SPELL_SUMMON_WYRMREST_DEFENDER, true);
+            }
+            void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_q12372_cast_from_gossip_trigger_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q12372_cast_from_gossip_trigger_SpellScript();
+        }
+};
+
 void AddSC_quest_spell_scripts()
 {
     new spell_q55_sacred_cleansing();
@@ -1274,4 +1305,5 @@ void AddSC_quest_spell_scripts()
     new spell_q12277_wintergarde_mine_explosion();
     new spell_q12066_bunny_kill_credit();
     new spell_q12735_song_of_cleansing();
+    new spell_q12372_cast_from_gossip_trigger();
 }


### PR DESCRIPTION
- Add gossip script\* support for creature Wyrmrest Defender (27629)
- Add spell script for Defending Wyrmrest Temple: Character Script Cast From Gossip (4913)
  SQL files linking scripts are included in #1861.
## 

The gossip script is the only option, SAI cause a lot of bugs for the drake -> screwing vehicle mechanisms: like no dismounting, current destination /kill mount and you get force moved to the position you mounted, when fight you get los and out of range bugs, npc move, fight and many more, if it is hard to believe you can always test it. Decided to write it again in case someone ask for SAI.
## 

Codestyle fixing screwed somehting...
