### PR TITLE
Core/Spells: Destabilizing Azure Dragonshrine 

### DIFF
--- a/sql/updates/world/2012_08_28_00_world_spell_script_name.sql
+++ b/sql/updates/world/2012_08_28_00_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Spell script name linking for Defending Wyrmrest Temple: Destabilize Azure Dragonshrine Effect
+DELETE FROM `spell_script_names` WHERE `spell_id`=49370 ;
+INSERT INTO `spell_script_names` VALUES
+(49370,'spell_q12372_destabilize_azure_dragonshrine_dummy');

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1286,33 +1286,33 @@ enum eQuest12372Data
 class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoader
 {
     public:
-         spell_q12372_destabilize_azure_dragonshrine_dummy() : SpellScriptLoader("spell_q12372_destabilize_azure_dragonshrine_dummy") { }
+        spell_q12372_destabilize_azure_dragonshrine_dummy() : SpellScriptLoader("spell_q12372_destabilize_azure_dragonshrine_dummy") { }
 
-         class spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript : public SpellScript
-         {
-             PrepareSpellScript(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript);
+        class spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript);
              
-             void HandleDummy(SpellEffIndex /*effIndex*/)
-             {
-                if (GetHitCreature())
-    			{
-                if (Unit* caster = GetOriginalCaster())
-                    if (Vehicle* vkit = caster->GetVehicleKit())
-                        if (Unit* passenger = vkit->GetPassenger(0))
-                            if (Player* player = passenger->ToPlayer())
-                                player->KilledMonsterCredit(NPC_WYRMREST_TEMPLE_CREDIT, 0);
-				}
-			 } 
-			 void Register()
-             {
-                 OnEffectHitTarget += SpellEffectFn(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
-             }
-          };
+            void HandleDummy(SpellEffIndex /*effIndex*/)
+            {
+               if (GetHitCreature())
+               {
+               if (Unit* caster = GetOriginalCaster())
+                   if (Vehicle* vkit = caster->GetVehicleKit())
+                       if (Unit* passenger = vkit->GetPassenger(0))
+                           if (Player* player = passenger->ToPlayer())
+                               player->KilledMonsterCredit(NPC_WYRMREST_TEMPLE_CREDIT, 0);
+               }
+            } 
+			void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
 
-          SpellScript* GetSpellScript() const
-          {
-              return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
-          }
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
+        }
 };
 
 void AddSC_quest_spell_scripts()

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1295,21 +1295,24 @@ class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoad
              void HandleDummy(SpellEffIndex /*effIndex*/)
              {
                 if (GetHitCreature())
-                {
-                     GetOriginalCaster()->GetVehicleKit()->GetPassenger(0)->ToPlayer()->KilledMonsterCredit(NPC_WYRMREST_TEMPLE_CREDIT, 0);
-                }
-             }
-
-             void Register()
+    			{
+                if (Unit* caster = GetOriginalCaster())
+                    if (Vehicle* vkit = caster->GetVehicleKit())
+                        if (Unit* passenger = vkit->GetPassenger(0))
+                            if (Player* player = passenger->ToPlayer())
+                                player->KilledMonsterCredit(NPC_WYRMREST_TEMPLE_CREDIT, 0);
+				}
+			 } 
+			 void Register()
              {
                  OnEffectHitTarget += SpellEffectFn(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
              }
-         };
+          };
 
-         SpellScript* GetSpellScript() const
-         {
-         return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
-         }
+          SpellScript* GetSpellScript() const
+          {
+              return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
+          }
 };
 
 void AddSC_quest_spell_scripts()

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1276,6 +1276,42 @@ class spell_q12372_cast_from_gossip_trigger : public SpellScriptLoader
         }
 };
 
+// http://www.wowhead.com/quest=12372 Defending Wyrmrest Temple
+// 49370 Wyrmrest Defender: Destabilize Azure Dragonshrine Effect
+enum eQuest12372Data
+{
+   NPC_WYRMREST_TEMPLE_CREDIT = 27698,
+};
+
+class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoader
+{
+    public:
+         spell_q12372_destabilize_azure_dragonshrine_dummy() : SpellScriptLoader("spell_q12372_destabilize_azure_dragonshrine_dummy") { }
+
+         class spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript : public SpellScript
+         {
+             PrepareSpellScript(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript);
+             
+             void HandleDummy(SpellEffIndex /*effIndex*/)
+             {
+                if (GetHitCreature())
+                {
+                     GetOriginalCaster()->GetVehicleKit()->GetPassenger(0)->ToPlayer()->KilledMonsterCredit(NPC_WYRMREST_TEMPLE_CREDIT, 0);
+                }
+             }
+
+             void Register()
+             {
+                 OnEffectHitTarget += SpellEffectFn(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+             }
+     };
+
+     SpellScript* GetSpellScript() const
+     {
+         return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
+     }
+};
+
 void AddSC_quest_spell_scripts()
 {
     new spell_q55_sacred_cleansing();
@@ -1306,4 +1342,5 @@ void AddSC_quest_spell_scripts()
     new spell_q12066_bunny_kill_credit();
     new spell_q12735_song_of_cleansing();
     new spell_q12372_cast_from_gossip_trigger();
+    new spell_q12372_destabilize_azure_dragonshrine_dummy();
 }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1304,12 +1304,12 @@ class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoad
              {
                  OnEffectHitTarget += SpellEffectFn(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
              }
-     };
+         };
 
-     SpellScript* GetSpellScript() const
-     {
+         SpellScript* GetSpellScript() const
+         {
          return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
-     }
+         }
 };
 
 void AddSC_quest_spell_scripts()


### PR DESCRIPTION
- Add spell_script for spell Destabilizing Azure Dragonshrine Effect ID: 49370 - in order to give kill credit.

// This is old script of Tobmaps, all credits go to him.
Just changed code style a bit /saddly my normal notepad killed spacing at 2-3 lines/ and added new form of the register of effect in order to work with current core:
https://gist.github.com/1011025/55ed62679cdeed13154faeb9de362434b6450f05
// Connected with: #1861, no other way to fix this in non hacky way. Tried cleaner and different methods.
