### PR TITLE
Core/Spells: Destabilizing Azure Dragonshrine

### DIFF
--- a/sql/updates/world/2012_08_28_00_world_spell_script_name.sql
+++ b/sql/updates/world/2012_08_28_00_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Spell script name linking for Defending Wyrmrest Temple: Destabilize Azure Dragonshrine Effect
+DELETE FROM `spell_script_names` WHERE `spell_id`=49370 ;
+INSERT INTO `spell_script_names` VALUES
+(49370,'spell_q12372_destabilize_azure_dragonshrine_dummy');

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1276,6 +1276,46 @@ class spell_q12372_cast_from_gossip_trigger : public SpellScriptLoader
         }
 };
 
+// http://www.wowhead.com/quest=12372 Defending Wyrmrest Temple
+// 49370 - Wyrmrest Defender: Destabilize Azure Dragonshrine Effect
+enum eQuest12372Data
+{
+    NPC_WYRMREST_TEMPLE_CREDIT       = 27698,
+};
+
+class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoader
+{
+    public:
+        spell_q12372_destabilize_azure_dragonshrine_dummy() : SpellScriptLoader("spell_q12372_destabilize_azure_dragonshrine_dummy") { }
+
+        class spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript);
+             
+            void HandleDummy(SpellEffIndex /*effIndex*/)
+            {
+               if (GetHitCreature())
+               {
+               if (Unit* caster = GetOriginalCaster())
+                   if (Vehicle* vehicle = caster->GetVehicleKit())
+                       if (Unit* passenger = vehicle->GetPassenger(0))
+                           if (Player* player = passenger->ToPlayer())
+                               player->KilledMonsterCredit(NPC_WYRMREST_TEMPLE_CREDIT, 0);
+               }
+            } 
+	    
+            void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript();
+        }
+};
+
 void AddSC_quest_spell_scripts()
 {
     new spell_q55_sacred_cleansing();
@@ -1306,4 +1346,5 @@ void AddSC_quest_spell_scripts()
     new spell_q12066_bunny_kill_credit();
     new spell_q12735_song_of_cleansing();
     new spell_q12372_cast_from_gossip_trigger();
+    new spell_q12372_destabilize_azure_dragonshrine_dummy();
 }


### PR DESCRIPTION
- Add spell_script for effect 0 of spell Destabilizing Azure Dragonshrine Effect ID: 49370 - in order to give kill credit.
- Connected to: #1861 /with that achievement will be obtainable after timer is scripted and more spawns added (optional)/, more lesser things can be done and should, listed in the issue.
- // This is old script of @Tobmaps, all credits go to him and to @DDuarte who improved it to prevent crashes.
  https://gist.github.com/1011025/55ed62679cdeed13154faeb9de362434b6450f05
  Also thx to @Vincent-Michael for sniff. -> http://paste2.org/p/2163436
