### PR TITLE
Scripts/Spells: Fix Weapon Copy related auras.

### DIFF
--- a/sql/updates/world/2012_08_30_00_world_spell_script_names.sql
+++ b/sql/updates/world/2012_08_30_00_world_spell_script_names.sql
@@ -1,0 +1,8 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (41054, 63418, 69893, 45205, 69896, 57594);
+INSERT INTO `spell_script_names` VALUES
+(41054, "spell_gen_clone_weapon_aura"),
+(63418, "spell_gen_clone_weapon_aura"),
+(69893, "spell_gen_clone_weapon_aura"),
+(45205, "spell_gen_clone_weapon_aura"),
+(69896, "spell_gen_clone_weapon_aura"),
+(57594, "spell_gen_clone_weapon_aura");


### PR DESCRIPTION
Solution for problems with auras not being showed on players (usually mages).

In summary what happens is the next:
- Player casts mirror image.
- Player gets 6/8 invisible auras from his copies (Copy OffHand Weapon and Copy Main Hand weapon for each copy spawned)
- When player casts several times mirror image he will eventually make his new auras not to be shown on the client side due to a overflow, even when he gets the effects. Also any cast on the player that requieres an aura wich is active on the player but not visible due to this bug will fail.

There's more info on #3731
