### PR TITLE
Battered Hilt Loot Fix

### DIFF
--- a/sql/updates/world/2012_08_31_00_world_creature_template.sql
+++ b/sql/updates/world/2012_08_31_00_world_creature_template.sql
@@ -1,0 +1,3 @@
+-- Update loot ids for(Ymirjar Deathbringer,Ymirjar Flamebearer,Ymirjar Skycaller,Ymirjar Wrathbringer,Stonespine Gargoyle) - Same as other ICC 5man hc trash
+UPDATE `creature_template` SET `lootid`=100001 WHERE `entry` IN (37641,37642,37643,37644,37622);
+DELETE FROM `creature_loot_template` WHERE `entry` IN (37641,37642,37643,37644,37622);

--- a/sql/updates/world/2012_08_31_00_world_creature_template.sql
+++ b/sql/updates/world/2012_08_31_00_world_creature_template.sql
@@ -1,3 +1,0 @@
--- Update loot ids for(Ymirjar Deathbringer,Ymirjar Flamebearer,Ymirjar Skycaller,Ymirjar Wrathbringer,Stonespine Gargoyle) - Same as other ICC 5man hc trash
-UPDATE `creature_template` SET `lootid`=100001 WHERE `entry` IN (37641,37642,37643,37644,37622);
-DELETE FROM `creature_loot_template` WHERE `entry` IN (37641,37642,37643,37644,37622);

--- a/sql/updates/world/2012_08_31_01_world_reference_loot_template.sql
+++ b/sql/updates/world/2012_08_31_01_world_reference_loot_template.sql
@@ -1,0 +1,5 @@
+-- New Battered Hilt Ref
+DELETE FROM `reference_loot_template` WHERE `entry`=35075;
+INSERT INTO `reference_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES 
+(35075, 50379, 0, 1, 1, 1, 1), -- Alliance
+(35075, 50380, 0, 1, 1, 1, 1); -- Horde

--- a/sql/updates/world/2012_08_31_02_world_conditions.sql
+++ b/sql/updates/world/2012_08_31_02_world_conditions.sql
@@ -1,0 +1,5 @@
+-- Conditions for Battered hilt drop
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=10 AND `SourceGroup`=35075;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+(10, 35075, 50379, 0, 0, 6, 0, 469, 0, 0, 0, 0, '', 'Battered Hilt Must Be Alliance'),
+(10, 35075, 50380, 0, 0, 6, 0, 67, 0, 0, 0, 0, '', 'Battered Hilt Must Be Horde');

--- a/sql/updates/world/2012_08_31_03_world_reference_loot_template.sql
+++ b/sql/updates/world/2012_08_31_03_world_reference_loot_template.sql
@@ -1,0 +1,4 @@
+-- Add new ref to ICC 5man hc Trash Ref (0.08 percent is average of values on wowhead 4.16/52)
+DELETE FROM `reference_loot_template` WHERE `entry`=35073 AND `item`=9 AND `mincountOrRef`=-35075;
+INSERT INTO `reference_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES 
+(35073, 9, 0.08, 1, 0, -35075, 1);


### PR DESCRIPTION
This is a fix for the Battered Hilt because it wasn't found in the loot database.
