### PR TITLE
Core/Scripts: Improve Wyrmrest Defender gossip 

### DIFF
--- a/src/server/scripts/Northrend/dragonblight.cpp
+++ b/src/server/scripts/Northrend/dragonblight.cpp
@@ -179,6 +179,13 @@ enum Spells
     SPELL_CHARACTER_SCRIPT       = 49213
 };
 
+enum eDefender
+{
+    QUEST_DEFENDING_WYRMREST_TEMPLE       = 12372,
+    GOSSIP_TEXTID_DEF1       = 12899,
+    GOSSIP_TEXTID_DEF2       = 12900
+};
+
 #define GOSSIP_ITEM_1      "We need to get into the fight. Are you ready?"
 
 class npc_wyrmrest_defender : public CreatureScript
@@ -187,22 +194,26 @@ class npc_wyrmrest_defender : public CreatureScript
         npc_wyrmrest_defender() : CreatureScript("npc_wyrmrest_defender") { }
 
         bool OnGossipHello(Player* player, Creature* creature)
+        {      
+        if (player->GetQuestStatus(QUEST_DEFENDING_WYRMREST_TEMPLE) == QUEST_STATUS_INCOMPLETE)
         {
             player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_ITEM_1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF+1);
-            player->SEND_GOSSIP_MENU(player->GetGossipTextId(creature), creature->GetGUID());
+            player->SEND_GOSSIP_MENU(GOSSIP_TEXTID_DEF1, creature->GetGUID());
+        }
+        else player->SEND_GOSSIP_MENU(player->GetGossipTextId(creature), creature->GetGUID());
 
             return true;
         }
 
-        bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action)
+        bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action)
         {
-            player->PlayerTalkClass->ClearMenus();
-            if (action == GOSSIP_ACTION_INFO_DEF+1)
-            {
-                player->CLOSE_GOSSIP_MENU();
-                // Makes player cast trigger spell for 49207 on self
-                player->CastSpell(player, SPELL_CHARACTER_SCRIPT, true);
-            }
+        player->PlayerTalkClass->ClearMenus();
+        if (action == GOSSIP_ACTION_INFO_DEF+1)
+        {
+            player->SEND_GOSSIP_MENU(GOSSIP_TEXTID_DEF2, creature->GetGUID());
+            // Makes player cast trigger spell for 49207 on self
+            player->CastSpell(player, SPELL_CHARACTER_SCRIPT, true);
+        }
 
             return true;
         }


### PR DESCRIPTION
- Added conditions to only show default gossip, if not on quest 12372
- Else show other gossip text
- Add second gossip text on gossip select
- Remove close gossip - after a lot of videos turns out character close it by moving or clicking "goodbye"

Connected with: #1861

/finaly solved random spacing problems, also this is the final version of this npc, before it gets mounted/
