### PR TITLE
Core: Blood Furnace - Broggok event

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/instance_blood_furnace.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/instance_blood_furnace.cpp
@@ -133,7 +133,7 @@ class instance_blood_furnace : public InstanceMapScript
                 }
             }
 
-            void OnCreatureDeath(Creature* unit)
+            void OnUnitDeath(Unit* unit)
             {
                 if (unit && unit->GetTypeId() == TYPEID_UNIT && unit->GetEntry() == 17398)
                     PrisonerDied(unit->GetGUID());

--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/instance_blood_furnace.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/instance_blood_furnace.cpp
@@ -316,6 +316,7 @@ class instance_blood_furnace : public InstanceMapScript
                 if (!prisoner->isAlive())
                     prisoner->Respawn(true);
                 prisoner->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_NON_ATTACKABLE);
+                prisoner->GetMotionMaster()->MoveTargetedHome();
             }
 
             void StorePrisoner(Creature* creature)


### PR DESCRIPTION
Move prisoners back in cages after respawn. They didn't reset correctly
for players which were still in the instance after wipe
