### PR TITLE
[Spell::CleanupEffectExecuteData] Fix possible memory leak.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6928,7 +6928,10 @@ void Spell::InitEffectExecuteData(uint8 effIndex)
 void Spell::CleanupEffectExecuteData()
 {
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        m_effectExecuteData[i] = NULL;
+        if(m_effectExecuteData[i]) {
+            delete m_effectExecuteData[i];
+            m_effectExecuteData[i] = NULL;
+        }
 }
 
 void Spell::CheckEffectExecuteData()


### PR DESCRIPTION
Me and @Nayd cannot find any reason why the memory is not being freed here. We can't find anywhere the pointer is being copied either, http://paste2.org/p/2191726. 
