### PR TITLE
[Spell::CleanupEffectExecuteData] Remove this confusing and potentially worthless function, use memset instead.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -583,7 +583,7 @@ m_caster((info->AttributesEx6 & SPELL_ATTR6_CAST_BY_CHARMER && caster->GetCharme
         && !m_spellInfo->IsPassive() && !m_spellInfo->IsPositive();
 
     CleanupTargetList();
-    CleanupEffectExecuteData();
+    memset(m_effectExecuteData, NULL, MAX_SPELL_EFFECTS * sizeof(ByteBuffer*));
 
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
         m_destTargets[i] = SpellDestination(*m_caster);
@@ -6923,12 +6923,6 @@ void Spell::InitEffectExecuteData(uint8 effIndex)
         uint32 count = (*m_effectExecuteData[effIndex]).read<uint32>(0);
         (*m_effectExecuteData[effIndex]).put<uint32>(0, ++count);
     }
-}
-
-void Spell::CleanupEffectExecuteData()
-{
-    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        m_effectExecuteData[i] = NULL;
 }
 
 void Spell::CheckEffectExecuteData()

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -616,7 +616,6 @@ class Spell
 
         // spell execution log
         void InitEffectExecuteData(uint8 effIndex);
-        void CleanupEffectExecuteData();
         void CheckEffectExecuteData();
 
         // Scripting system


### PR DESCRIPTION
Hopefully this should prevent some confusion in the future. 
