### PR TITLE
Scripts/Scarlet Monastery: Final boss kill credit closes #7341

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
@@ -283,6 +283,12 @@ public:
             DoScriptText(SAY_WH_KILL, me);
         }
 
+        void DamageTaken(Unit* /*attacker*/, uint32& damage)
+        {
+            if (!_bCanResurrectCheck && damage >= me->GetHealth())
+                damage = me->GetHealth() - 1;
+        }
+
         void UpdateAI(const uint32 diff)
         {
             if (!UpdateVictim())


### PR DESCRIPTION
When Scarlet Commander Mograine dies and High Inquisitor Whitemane appears, if she is downed very quickly, then she will not perform the ressurection on Mograine and will not stun anyone, thus Mograine wont give the achievement nor loot. She should be invincible till she has ressurected Mograine.
Fix by Xanvial.
