### PR TITLE
Core/Scripts: Anub'Arak encounter changes and fixes.

### DIFF
--- a/sql/updates/world/2012_09_10_14_world_misc.sql
+++ b/sql/updates/world/2012_09_10_14_world_misc.sql
@@ -1,0 +1,11 @@
+-- ToCr orbs
+
+SET @NPC_ORB1  := 34606; -- Frost Sphere
+SET @NPC_ORB2  := 34649; -- Frost Sphere
+
+UPDATE `creature_template` SET `speed_walk`=1.2,`speed_run`=1.42,`InhabitType`=7 WHERE `entry` IN (@NPC_ORB1,@NPC_ORB2);
+
+DELETE FROM `creature_template_addon` WHERE `entry` IN (@NPC_ORB1,@NPC_ORB2);
+INSERT INTO `creature_template_addon` (`entry`,`mount`,`bytes1`,`bytes2`,`auras`) VALUES
+(@NPC_ORB1,0,0x3000000,0x1,''),
+(@NPC_ORB2,0,0x3000000,0x1,'');


### PR DESCRIPTION
Fixes burrow/unburrow phase for Nerubian Burrowers.
Fix casting Shadow Strike in hc mode for Nerubian Burrowers.
Usage of proper spells for Nerubian Burrowers.
Proper spawn locations for Frost Spheres.
Check if Sphere is in air or on ground level and then execute proper script.
Fix model view and move some flags to DB for Frost Spheres.
