### PR TITLE
Fix Evade Mechanics:

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -153,13 +153,20 @@ void CreatureAI::EnterEvadeMode()
             me->GetMotionMaster()->MoveFollow(owner, PET_FOLLOW_DIST, me->GetFollowAngle(), MOTION_SLOT_ACTIVE);
         }
         else
+        {
+            // Required to prevent attacking creatures that are evading and cause them to reenter combat
+            // Does not apply to MoveFollow
+            me->AddUnitState(UNIT_STATE_EVADE);
             me->GetMotionMaster()->MoveTargetedHome();
+        }
     }
 
     Reset();
 
     if (me->IsVehicle()) // use the same sequence of addtoworld, aireset may remove all summons!
         me->GetVehicleKit()->Reset(true);
+
+    me->SetLastDamagedTime(0);
 }
 
 /*void CreatureAI::AttackedBy(Unit* attacker)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -173,6 +173,7 @@ Unit::Unit(bool isWorldObject): WorldObject(isWorldObject)
     , m_vehicleKit(NULL)
     , m_unitTypeMask(UNIT_MASK_NONE)
     , m_HostileRefManager(this)
+    , _lastDamagedTime(0)
 {
 #ifdef _MSC_VER
 #pragma warning(default:4355)
@@ -12429,6 +12430,10 @@ int32 Unit::ModifyHealth(int32 dVal)
     if (dVal == 0)
         return 0;
 
+    // Part of Evade mechanics. Only track health lost, not gained.
+    if (dVal < 0 && GetTypeId() != TYPEID_PLAYER && !isPet())
+        SetLastDamagedTime(getMSTime());
+
     int32 curHealth = (int32)GetHealth();
 
     int32 val = dVal + curHealth;
@@ -13053,6 +13058,25 @@ Unit* Creature::SelectVictim()
     {
         SetInFront(target);
         return target;
+    }
+
+    // Case where mob is being kited.
+    // Mob may not be in range to attack or may have dropped target. In any case,
+    //  don't evade if damage received within the last 10 seconds
+    // Does not apply to world bosses to prevent kiting to cities
+    if (!isWorldBoss())
+    {
+        if (uint32 oldTime = GetLastDamagedTime())
+        {
+            if ((getMSTimeDiff(oldTime, getMSTime()) / 1000) <= 10)
+            {
+                // In some cases target does not exist but need to return it if it does
+                if (target)
+                    return target;
+                else
+                    return NULL;
+            }
+        }
     }
 
     // last case when creature must not go to evade mode:

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2239,6 +2239,10 @@ class Unit : public WorldObject
         // Movement info
         Movement::MoveSpline * movespline;
 
+        // Part of Evade mechanics
+        uint32 GetLastDamagedTime() const { return _lastDamagedTime; }
+        void SetLastDamagedTime(uint32 val) { _lastDamagedTime = val; }
+
     protected:
         explicit Unit (bool isWorldObject);
 
@@ -2361,6 +2365,8 @@ class Unit : public WorldObject
         Spell const* _focusSpell;
         bool _targetLocked; // locks the target during spell cast for proper facing
         bool _isWalkingBeforeCharm; // Are we walking before we were charmed?
+
+        uint32 _lastDamagedTime; // Part of Evade mechanics
 };
 
 namespace Trinity


### PR DESCRIPTION
- Can now kite mobs beyond ThreatRadius (CONF) if continuing to damage them. World bosses still use ThreatRadius
  to prevent pulling them to cities
- A mob that is beyond the ThreatRadius, it will return home (evade) after 10 seconds of no damage _if_ there are no valid
  targets within attack distance of it, otherwise it will still attack
- Mobs now properly report "Evade" if attacked while returning home.
