### PR TITLE
Scripts/Quests: Ogri'La and Skettis bombing related quests support

### DIFF
--- a/sql/updates/world/2012_09_13_00_fires_over_skettis.sql
+++ b/sql/updates/world/2012_09_13_00_fires_over_skettis.sql
@@ -1,0 +1,93 @@
+-- Add support for quest ID: 11008 - "Fires Over Skettis" based on Warpten fix and Nelegalno/shlomi1515 updates
+-- Also add support for achievement - http://www.wowhead.com/achievement=1275/bombs-away
+SET @TRIGGER :=  22991;
+SET @Script := 2299100;
+SET @EGG :=     185549;
+SET @SKYBLAST := 39844;
+SET @SUMMEGG :=  39843;
+-- Adds SAI support for Monstrous Kaliri Egg Trigger and the GO
+UPDATE `creature_template` SET `AIName`= 'SmartAI' WHERE `entry`=@TRIGGER;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@TRIGGER AND `source_type`=0;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@Script AND `source_type`=9;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES 
+(@TRIGGER,0,0,0,25,0,100,0,0,0,0,0,11,@SUMMEGG,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Monstrous Kaliri Egg Trigger - On spawn/reset - Summon Monstrous Kaliri Egg (object wild)'),
+(@TRIGGER,0,1,2,8,0,100,0,@SKYBLAST,0,0,0,33,@TRIGGER,0,0,0,0,0,16,0,0,0,0,0,0,0, 'Monstrous Kaliri Egg Trigger - On Skyguard Blasting Charge hit - Give kill credit to invoker party'),
+(@TRIGGER,0,2,3,61,0,100,0,0,0,0,0,45,0,1,0,0,0,0,20,@EGG,1,0,0,0,0,0, 'Monstrous Kaliri Egg Trigger - Linked with previous event - Despawn'),
+(@TRIGGER,0,3,0,61,0,100,0,0,0,0,0,80,@Script,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Monstrous Kaliri Egg Trigger - Linked with previous event - Start script 0'),
+-- Script 0
+(@Script,9,0,0,0,0,100,0,44000,44000,0,0,11,@SUMMEGG,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Monstrous Kaliri Egg Trigger /On actionlist/ - Action 0 - Cast Summon Monstrous Kaliri Egg');
+-- Add SAI for Cannonball Stack
+UPDATE `gameobject_template` SET `AIName`='SmartGameObjectAI' WHERE `entry`=@EGG;
+DELETE FROM `smart_scripts` WHERE `source_type`=1 AND `entryorguid`=@EGG;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@EGG,1,0,0,38,0,100,0,0,1,0,0,70,45,0,0,0,0,0,1,0,0,0,0,0,0,0,' Monstrous Kaliri Egg - On data set 0 1 - Respawn object /make it reappear after 45 secs/');
+-- Remove achievement from disabled
+DELETE FROM `disables` WHERE  `sourceType`=4 AND `entry`=3922;
+-- Insert GO spawns taken directly from already spawned triggers coordinates = no need to sniff them
+SET @guid := 164249; -- this is taken from clean trinity next free slot at 13.09.2012
+DELETE FROM `gameobject` WHERE `id`=@EGG;
+INSERT INTO `gameobject` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`) VALUES
+(@guid+0,@EGG,530,1,1,-3857.69,3426.25,363.733,-0.087267,180),
+(@guid+1,@EGG,530,1,1,-3845.16,3332.2,338.59,2.9147,180),
+(@guid+2,@EGG,530,1,1,-3965.16,3232.7,347.552,-0.122173,180),
+(@guid+3,@EGG,530,1,1,-3955.86,3222.16,347.503,0.244346,180),
+(@guid+4,@EGG,530,1,1,-3953.3,3227.94,347.564,-0.244346,180),
+(@guid+5,@EGG,530,1,1,-4044.66,3287.29,348.362,0.349066,180),
+(@guid+6,@EGG,530,1,1,-4041.39,3271,346.642,-2.09439,180),
+(@guid+7,@EGG,530,1,1,-4049.31,3285.9,348.335,1.43117,180),
+(@guid+8,@EGG,530,1,1,-4076.99,3415.22,334.008,-2.33874,180),
+(@guid+9,@EGG,530,1,1,-4076.79,3412.91,334.617,-1.0821,180),
+(@guid+10,@EGG,530,1,1,-4077.92,3412.57,334.768,-0.733038,180),
+(@guid+11,@EGG,530,1,1,-4107.93,3121.5,357.427,1.01229,180),
+(@guid+12,@EGG,530,1,1,-4108.31,3123.66,357.633,-0.680679,180),
+(@guid+13,@EGG,530,1,1,-4110.19,3122.64,358.083,-0.034907,180),
+(@guid+14,@EGG,530,1,1,-3996.89,3142.12,372.729,3.05433,180),
+(@guid+15,@EGG,530,1,1,-4109.06,3019.1,352.24,0.261799,180),
+(@guid+16,@EGG,530,1,1,-4018.35,3076.7,375.29,-0.733038,180),
+(@guid+17,@EGG,530,1,1,-4184.98,3044.71,352.394,1.81514,180),
+(@guid+18,@EGG,530,1,1,-4187.52,3040.39,352.071,-0.017453,180),
+(@guid+19,@EGG,530,1,1,-4189.67,3039.9,352.247,-0.785398,180),
+(@guid+20,@EGG,530,1,1,-4192.61,3045.1,352.096,3.14159,180),
+(@guid+21,@EGG,530,1,1,-4192.02,3046.91,352.297,2.46091,180),
+(@guid+22,@EGG,530,1,1,-4186.47,3047.19,352.316,2.60054,180),
+(@guid+23,@EGG,530,1,1,-3915.67,2983.4,396.957,-1.91986,180),
+(@guid+24,@EGG,530,1,1,-3883.21,3004.11,399.738,-1.64061,180),
+(@guid+25,@EGG,530,1,1,-3883.26,3001.55,399.431,-2.3911,180),
+(@guid+26,@EGG,530,1,1,-3884.29,3003.3,400.063,-1.88496,180),
+(@guid+27,@EGG,530,1,1,-3903.02,3095.85,383.783,-2.28638,180),
+(@guid+28,@EGG,530,1,1,-3898.45,3093.06,383.667,2.53073,180),
+(@guid+29,@EGG,530,1,1,-3900.75,3100.75,383.795,-0.436333,180),
+(@guid+30,@EGG,530,1,1,-4107.81,3023.42,352.142,1.06465,180),
+(@guid+31,@EGG,530,1,1,-4113.58,3022.4,352.157,-0.645772,180),
+(@guid+32,@EGG,530,1,1,-3893.09,3677.17,374.516,-1.23918,180),
+(@guid+33,@EGG,530,1,1,-3892.47,3674,374.478,-2.14675,180),
+(@guid+34,@EGG,530,1,1,-4198.53,3168.91,355.847,-0.383972,180),
+(@guid+35,@EGG,530,1,1,-4197.01,3170.04,356.117,-1.15192,180),
+(@guid+36,@EGG,530,1,1,-4196.54,3167.69,356.348,-0.541052,180),
+(@guid+37,@EGG,530,1,1,-4020.07,3077.84,374.391,1.53589,180),
+(@guid+38,@EGG,530,1,1,-4019.32,3079.74,375.109,-1.25664,180),
+(@guid+39,@EGG,530,1,1,-3917.21,2981.62,396.483,0.733038,180),
+(@guid+40,@EGG,530,1,1,-3918.45,2982.44,397.24,-1.72788,180),
+(@guid+41,@EGG,530,1,1,-3839.35,3344.85,337.834,2.75762,180),
+(@guid+42,@EGG,530,1,1,-3835.3,3344.77,338.155,-0.767945,180),
+(@guid+43,@EGG,530,1,1,-3846.43,3430.29,363.729,0.488692,180),
+(@guid+44,@EGG,530,1,1,-3864.13,3439.06,363.679,-0.05236,180),
+(@guid+45,@EGG,530,1,1,-3863.24,3440.42,363.655,0.349066,180),
+(@guid+46,@EGG,530,1,1,-3846.35,3439.34,363.628,-0.122173,180),
+(@guid+47,@EGG,530,1,1,-3847.32,3441.39,363.648,0.453786,180),
+(@guid+48,@EGG,530,1,1,-3686.21,3301,320.513,0.837758,180),
+(@guid+49,@EGG,530,1,1,-3687.77,3299.85,320.307,2.75762,180),
+(@guid+50,@EGG,530,1,1,-3692.64,3302.07,320.396,-0.226893,180),
+(@guid+51,@EGG,530,1,1,-3661.91,3379.15,320.377,0.890118,180),
+(@guid+52,@EGG,530,1,1,-3660.65,3381.9,320.182,1.18682,180),
+(@guid+53,@EGG,530,1,1,-3665.48,3380.11,320.365,-0.471239,180),
+(@guid+54,@EGG,530,1,1,-3685.07,3305.97,320.198,-2.87979,180),
+(@guid+55,@EGG,530,1,1,-3688.3,3308.93,320.337,1.65806,180),
+(@guid+56,@EGG,530,1,1,-3690.65,3306.77,320.43,-2.79253,180),
+(@guid+57,@EGG,530,1,1,-3879.37,3665.22,374.393,-2.30383,180),
+(@guid+58,@EGG,530,1,1,-3990.42,3139.13,372.878,-2.61799,180),
+(@guid+59,@EGG,530,1,1,-3991.59,3134.33,372.703,-0.017453,180),
+(@guid+60,@EGG,530,1,1,-3884.89,3684.98,374.492,-2.53073,180),
+(@guid+61,@EGG,530,1,1,-3800.8,3789.62,314,6.0912,180),
+(@guid+62,@EGG,530,1,1,-3799.02,3788.06,314.158,3.19395,180),
+(@guid+63,@EGG,530,1,1,-3798.91,3790.61,313.852,3.63029,180);

--- a/sql/updates/world/2012_09_13_00_world_ogrila.sql
+++ b/sql/updates/world/2012_09_13_00_world_ogrila.sql
@@ -22,7 +22,7 @@ DELETE FROM `creature_ai_scripts` WHERE `creature_id`=@Run_Dummy;
 DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=@Run_Dummy;
 DELETE FROM `smart_scripts` WHERE `source_type`=9 AND `entryorguid`=@Script;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
-(@Run_Dummy,0,0,1,8,0,100,0,@THROW_BOMB,0,1000,1000,33,23118,0,0,0,0,0,7,0,0,0,0,0,0,0, 'Run Target Dummy - On spell Throw Bomb hit - Give kill credit'),
+(@Run_Dummy,0,0,1,8,0,100,0,@THROW_BOMB,0,1000,1000,33,23118,0,0,0,0,0,16,0,0,0,0,0,0,0, 'Run Target Dummy - On spell Throw Bomb hit - Give kill credit to invoker party'),
 (@Run_Dummy,0,1,2,61,0,100,0,0,0,0,0,28,@RUN_MARK,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Remove auras from hunter mark'),
 (@Run_Dummy,0,2,3,61,0,100,0,0,0,0,0,45,0,1,0,0,0,0,20,@CANNONBALL_STACK,3,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Data set 0 1 on Cannonball Stack'),
 (@Run_Dummy,0,3,4,61,0,100,0,0,0,0,0,45,0,1,0,0,0,0,19,@Explosion_Bunny,3,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Data set 0 1 on Explosion Bunny'),

--- a/sql/updates/world/2012_09_13_00_world_ogrila.sql
+++ b/sql/updates/world/2012_09_13_00_world_ogrila.sql
@@ -1,0 +1,160 @@
+-- Quest support for http://www.wowhead.com/quest=11010 "Bombing Run", http://www.wowhead.com/quest=11102 "Bombing Run" /druid/ and http://www.wowhead.com/quest=11023 "Bomb Them Again!"
+-- Achievement support for http://www.wowhead.com/achievement=1282 and http://www.wowhead.com/achievement=1276,
+-- Based on Warpten Script
+SET @SKYGUARD_BOMB       := 32456;
+SET @Run_Dummy           := 23118;
+SET @Script            := 2311800;
+SET @Explosion_Bunny     := 23119;
+SET @Flak_Cannon         := 23076;
+SET @Flak_Cannon2        := 23082;
+SET @Fel_Cannon_Dummy    := 23077;
+SET @RUN_MARK            := 40196;
+SET @THROW_BOMB          := 40160;
+SET @EXPLOSION_VISUAL    := 40162;
+SET @See_Invisibility    := 40195;
+SET @Invisibility        := 40194;
+SET @CANNONBALL_STACK   := 185861;
+-- Add class requirements for druid version of "Bombing Run"
+UPDATE `quest_template` SET `RequiredClasses`=1024 WHERE `Id`=11102;
+-- Add SAI support for Bombing Run Target Dummy
+UPDATE `creature_template` SET `AIName`='SmartAI',`flags_extra`=`flags_extra`|128 WHERE `entry`=@Run_Dummy;
+DELETE FROM `creature_ai_scripts` WHERE `creature_id`=@Run_Dummy;
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=@Run_Dummy;
+DELETE FROM `smart_scripts` WHERE `source_type`=9 AND `entryorguid`=@Script;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@Run_Dummy,0,0,1,8,0,100,0,@THROW_BOMB,0,1000,1000,33,23118,0,0,0,0,0,7,0,0,0,0,0,0,0, 'Run Target Dummy - On spell Throw Bomb hit - Give kill credit'),
+(@Run_Dummy,0,1,2,61,0,100,0,0,0,0,0,28,@RUN_MARK,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Remove auras from hunter mark'),
+(@Run_Dummy,0,2,3,61,0,100,0,0,0,0,0,45,0,1,0,0,0,0,20,@CANNONBALL_STACK,3,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Data set 0 1 on Cannonball Stack'),
+(@Run_Dummy,0,3,4,61,0,100,0,0,0,0,0,45,0,1,0,0,0,0,19,@Explosion_Bunny,3,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Data set 0 1 on Explosion Bunny'),
+(@Run_Dummy,0,4,0,61,0,100,0,0,0,0,0,80,@Script,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Run Target Dummy - Linked with previous event - Start script 0'),
+-- Script 0
+(@Script,9,0,0,0,0,100,0,29000,29000,0,0,11,@RUN_MARK,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Run Target Dummy - Action 0 - Cast run mark on self');
+-- Add SAI for Cannonball Stack
+UPDATE `gameobject_template` SET `AIName`='SmartGameObjectAI' WHERE `entry`=@CANNONBALL_STACK;
+DELETE FROM `smart_scripts` WHERE `source_type`=1 AND `entryorguid`=@CANNONBALL_STACK;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@CANNONBALL_STACK,1,0,0,38,0,100,0,0,1,0,0,70,30,0,0,0,0,0,1,0,0,0,0,0,0,0,' Cannonball Stack - On data set 0 1 - Respawn object /make it reappear after 30 secs/');
+-- Add SAI support for Bombing Run Fel Cannon Dummy
+UPDATE `creature_template` SET `AIName`='SmartAI',`unit_flags`=4,`flags_extra`=`flags_extra`|128 WHERE `entry`=@Fel_Cannon_Dummy;
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=@Fel_Cannon_Dummy;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@Fel_Cannon_Dummy,0,0,0,8,0,100,0,40110,0,4350,5000,11,40119,0,0,0,0,0,19,@Flak_Cannon,5,0,0,0,0,0, 'Fel Cannon Dummy - On spell hit by Cannon trigger - Cast Aggro Burst on Flak Cannon');
+-- Add SAI support for Bombing Run Flak Cannon
+UPDATE `creature_template` SET `AIName`='SmartAI',`unit_flags`=`unit_flags`|4|256|131072,`flags_extra`=`flags_extra`|2 WHERE `entry`=@Flak_Cannon;
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=@Flak_Cannon;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@Flak_Cannon,0,0,0,25,0,100,0,0,0,0,0,11,40111,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Flak Cannon - On reset - Cast The Aggro Bunnies'),
+(@Flak_Cannon,0,1,2,8,0,100,0,41598,0,0,0,66,0,0,0,0,0,0,7,0,0,0,0,0,0,0, 'Flak Cannon - On hit by Bolt Pair - Set orientation to invoker'),
+(@Flak_Cannon,0,2,0,61,0,100,0,0,0,0,0,11,40109,0,0,0,0,0,7,0,0,0,0,0,0,0, 'Flak Cannon - Linked with previous event - Cast spell The Bolt');
+-- Add SAI support for Bombing Run Flak Cannon 2 /target bunny/
+UPDATE `creature_template` SET `AIName`='SmartAI',`flags_extra`=`flags_extra`|128,`InhabitType`=4 WHERE `entry`=@Flak_Cannon2;
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=@Flak_Cannon2;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@Flak_Cannon2,0,0,0,54,0,100,0,0,0,0,0,11,41598,0,0,0,0,0,7,0,0,0,0,0,0,0, 'Flak Cannon 2 - On just summoned - Cast The Bolt Pair on invoker'),
+(@Flak_Cannon2,0,1,2,8,0,100,0,40109,0,0,0,11,40075,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Flak Cannon 2 - On spell hit Cannon Bolt - Cast on self Fel Flak Fire'),
+(@Flak_Cannon2,0,2,0,61,0,100,0,0,0,0,0,41,5000,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Flak Cannon 2 - Linked with previous event - Despawn in 5 sec');
+-- Add SAI support for Explosion Bunny
+UPDATE `creature_template` SET `AIName`='SmartAI',`flags_extra`=`flags_extra`|128,`unit_flags`=0 WHERE `entry`=@Explosion_Bunny;
+DELETE FROM `smart_scripts` WHERE `source_type`=0 AND `entryorguid`=@Explosion_Bunny;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@Explosion_Bunny,0,0,0,38,0,100,0,0,1,0,0,11,@EXPLOSION_VISUAL,0,0,0,0,0,1,0,0,0,0,0,0,0, 'Explosion Bunny - On data set 0 1 - Cast Explosion Visual on self');
+-- Add conditions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry` IN (@THROW_BOMB,40110,40112,40075);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=17 AND `SourceEntry` IN (@THROW_BOMB,40200,41598,40111);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=22 AND `SourceEntry`=@Fel_Cannon_Dummy;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorTextId`,`Comment`) VALUES
+(17,0,@THROW_BOMB,0,29,0,@Run_Dummy,35,0,0,0,'Throw Bomb requires Run Target Dummy within 35y'),
+(13,1,@THROW_BOMB,0,31,0,3,@Run_Dummy,0,0,0,'Throw Bomb implicit effect 0 can hit only Run Target Dummy'),
+(13,1,@THROW_BOMB,0,1,0,@RUN_MARK,0,0,0,0,'Throw Bomb can hit only targets under the aura of 40196'),
+(17,0,40200,0,9,0,11010,0,0,1,0,'To cast remove see invisibility player must not be on quest 11010'),
+(17,0,40200,0,9,0,11102,0,0,1,0,'To cast remove see invisibility player must not be on quest 11102'),
+(17,0,40200,0,9,0,11023,0,0,1,0,'To cast remove see invisibility player must not be on quest 11023'),
+(13,1,40110,0,31,0,3,23077,0,0,0,'Cannon Trigger implicit targets can be only Fel Cannon Dummies'),
+(13,1,40110,0,35,0,1,65,2,0,0,'Cannon Trigger implicit hit can happen only on targets under 65 yards range'),
+(17,0,40111,0,29,0,@Fel_Cannon_Dummy,10,0,1,0,'The Aggro Bunnies caster should not be around Fel Cannon Dummies to cast'),
+(13,1,40112,0,31,0,4,0,0,0,0,'Bombing Run Dummy aggro check can hit players'),
+(13,3,40075,0,31,0,4,0,0,0,0,'Fel Flak Fire effect 2 can hit only players'),
+(22,1,@Fel_Cannon_Dummy,0,1,1,40119,0,0,1,0,'Fel Cannon Dummy event 0 will happen only if target is missing aura from aggro burst');
+-- Insert addon data
+DELETE FROM `creature_template_addon` WHERE `entry` IN (@Run_Dummy,@Explosion_Bunny,@Fel_Cannon_Dummy);
+INSERT INTO `creature_template_addon` (`entry`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES
+(@Run_Dummy,0,0,0,0,'40196 40194 40195'), -- Mark, See Invisibility, Invisibility
+(@Explosion_Bunny,0,0,0,0,'40194 40195'), -- See Invisibility, Invisibility
+(@Fel_Cannon_Dummy,0,0,0,0,'40113'); -- The Aggro Check Aura
+-- Remove achievement from disabled
+DELETE FROM `disables` WHERE `sourceType`=4 AND `entry`=3923;
+-- Add missing spell from dbc
+DELETE FROM `spell_dbc` WHERE `Id`=40200;
+INSERT INTO `spell_dbc` (`Id`,`Dispel`,`Mechanic`,`Attributes`,`AttributesEx`,`AttributesEx2`,`AttributesEx3`,`AttributesEx4`,`AttributesEx5`,`AttributesEx6`,`AttributesEx7`,`Stances`,`StancesNot`,`Targets`,`CastingTimeIndex`,`AuraInterruptFlags`,`ProcFlags`,`ProcChance`,`ProcCharges`,`MaxLevel`,`BaseLevel`,`SpellLevel`,`DurationIndex`,`RangeIndex`,`StackAmount`,`EquippedItemClass`,`EquippedItemSubClassMask`,`EquippedItemInventoryTypeMask`,`Effect1`,`Effect2`,`Effect3`,`EffectDieSides1`,`EffectDieSides2`,`EffectDieSides3`,`EffectRealPointsPerLevel1`,`EffectRealPointsPerLevel2`,`EffectRealPointsPerLevel3`,`EffectBasePoints1`,`EffectBasePoints2`,`EffectBasePoints3`,`EffectMechanic1`,`EffectMechanic2`,`EffectMechanic3`,`EffectImplicitTargetA1`,`EffectImplicitTargetA2`,`EffectImplicitTargetA3`,`EffectImplicitTargetB1`,`EffectImplicitTargetB2`,`EffectImplicitTargetB3`,`EffectRadiusIndex1`,`EffectRadiusIndex2`,`EffectRadiusIndex3`,`EffectApplyAuraName1`,`EffectApplyAuraName2`,`EffectApplyAuraName3`,`EffectAmplitude1`,`EffectAmplitude2`,`EffectAmplitude3`,`EffectMultipleValue1`,`EffectMultipleValue2`,`EffectMultipleValue3`,`EffectMiscValue1`,`EffectMiscValue2`,`EffectMiscValue3`,`EffectMiscValueB1`,`EffectMiscValueB2`,`EffectMiscValueB3`,`EffectTriggerSpell1`,`EffectTriggerSpell2`,`EffectTriggerSpell3`,`EffectSpellClassMaskA1`,`EffectSpellClassMaskA2`,`EffectSpellClassMaskA3`,`EffectSpellClassMaskB1`,`EffectSpellClassMaskB2`,`EffectSpellClassMaskB3`,`EffectSpellClassMaskC1`,`EffectSpellClassMaskC2`,`EffectSpellClassMaskC3`,`MaxTargetLevel`,`SpellFamilyName`,`SpellFamilyFlags1`,`SpellFamilyFlags2`,`SpellFamilyFlags3`,`MaxAffectedTargets`,`DmgClass`,`PreventionType`,`DmgMultiplier1`,`DmgMultiplier2`,`DmgMultiplier3`,`AreaGroupId`,`SchoolMask`,`Comment`) VALUES
+(40200,0,0,256,0,0,0,0,0,0,0,0,0,0,1,0,0,101,0,0,0,0,26,1,0,-1,0,0,164,0,0,0,0,0,0,0,0,0,0,0,0,0,0,18,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,40195,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,'Bombing Run: See Invisibility Aura Remover');
+-- Spell area - Check to cast remove aura /against see invisibility aura/, if having it and not on quest
+DELETE FROM `spell_area` WHERE `spell`=40200;
+INSERT INTO `spell_area` (`spell`,`area`,`quest_start`,`quest_start_active`,`quest_end`,`aura_spell`,`racemask`,`gender`,`autocast`) VALUES
+(40200,3522,0,0,0,@See_Invisibility,0,2,1);
+-- Insert cannonballs spawns /based on sniffs/
+SET @guid := 164235; -- Free slot on trinity clean core marked on 12.09.2012
+DELETE FROM `gameobject` WHERE `guid` IN (@guid+0,@guid+1,@guid+2,@guid+3,@guid+4,@guid+5,@guid+6,@guid+7,@guid+8,@guid+9,@guid+10,@guid+11,@guid+12,@guid+13);
+INSERT INTO `gameobject` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`rotation0`,`rotation1`,`rotation2`,`rotation3`,`spawntimesecs`,`animprogress`,`state`) VALUES
+(@guid+0,185861,530,1,1,2825.11,7024.05,369.982,5.69617,0,0,0.289313,-0.957235,300,0,1),
+(@guid+1,185861,530,1,1,2938.26,7094.72,369.413,2.78314,0,0,0.983982,0.178267,300,0,1),
+(@guid+2,185861,530,1,1,2924.84,7031.46,367.857,4.26205,0,0,0.847134,-0.53138,300,0,1),
+(@guid+3,185861,530,1,1,2938.02,7015.59,365.75,3.65778,0,0,0.966879,-0.255237,300,0,1),
+(@guid+4,185861,530,1,1,2998.57,7043.55,368.539,5.91266,0,0,0.184206,-0.982888,300,0,1),
+(@guid+5,185861,530,1,1,2982,7054.94,368.32,4.99766,0,0,0.599411,-0.800442,300,0,1),
+(@guid+6,185861,530,1,1,2978.73,6889.19,369.701,0.689745,0,0,0.338077,0.941119,300,0,1),
+(@guid+7,185861,530,1,1,2941.56,6827.17,367.3,4.08109,0,0,0.891683,-0.452661,300,0,1),
+(@guid+8,185861,530,1,1,2953.55,6859.3,369.954,6.14433,0,0,0.0693712,-0.997591,300,0,1),
+(@guid+9,185861,530,1,1,3023.13,6799.74,374.46,1.58666,0,0,0.712695,0.701474,300,0,1),
+(@guid+10,185861,530,1,1,3028.3,6824.84,373.591,5.0275,0,0,0.587401,-0.809296,300,0,1),
+(@guid+11,185861,530,1,1,3022.15,6859.05,369.546,3.44885,0,0,0.988222,-0.153025,300,0,1),
+(@guid+12,185861,530,1,1,3016.28,6876.11,370.188,3.47791,0,0,0.985895,-0.167365,300,0,1),
+(@guid+13,185861,530,1,1,2940.6,7106.65,370.123,0.88561,0,0,0.428475,0.903553,300,0,1);
+-- Insert spawns for Fel Flak Cannons, Run Target Dummies and Explosion Bunnies /based on sniffs/
+SET @guid := 209183; -- Free slot on trinity clean core marked on 12.09.2012
+DELETE FROM `creature` WHERE `guid` IN (@guid+0,@guid+1,@guid+2,@guid+3,@guid+4,@guid+5,@guid+6,@guid+7,@guid+8,@guid+9,@guid+10,@guid+11,@guid+12,@guid+13,@guid+14,@guid+15,@guid+16,@guid+17,@guid+18,@guid+19,@guid+20,@guid+21,@guid+22,@guid+23,@guid+24,@guid+25,@guid+26,@guid+27,@guid+28,@guid+29,@guid+30,@guid+31,@guid+32,@guid+33,@guid+34,@guid+35,@guid+36,@guid+37,@guid+38,@guid+39,@guid+40,@guid+41,@guid+42,@guid+43,@guid+44);
+INSERT INTO `creature` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`modelid`,`equipment_id`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`currentwaypoint`,`curhealth`,`curmana`,`MovementType`,`npcflag`,`unit_flags`,`dynamicflags`) VALUES
+(@guid+0,23118,530,1,1,0,0,2764.71,7024.45,370.203,0,300,0,0,42,0,0,0,33554432,0),
+(@guid+1,23119,530,1,1,0,0,2764.71,7024.45,370.203,0,300,0,0,6986,0,0,0,33554432,0),
+(@guid+2,23118,530,1,1,0,0,2786.61,7036.28,370.686,0,300,0,0,42,0,0,0,33554432,0),
+(@guid+3,23119,530,1,1,0,0,2786.61,7036.28,370.686,0,300,0,0,6986,0,0,0,33554432,0),
+(@guid+4,23118,530,1,1,0,0,2824.71,7044.79,369.877,0,300,0,0,42,0,0,0,33554432,0),
+(@guid+5,23119,530,1,1,0,0,2824.71,7044.79,369.877,0,300,0,0,6986,0,0,0,33554432,0),
+(@guid+6,23076,530,1,1,0,0,2775.81,7030.75,370.337,1.85606,300,0,0,22140,0,0,0,0,0),
+(@guid+7,23076,530,1,1,0,0,2933.28,7103.93,369.209,2.58129,300,0,0,21543,0,0,0,0,0),
+(@guid+8,23119,530,1,1,0,0,2940.82,7107.17,370.115,4.65944,300,0,0,6986,0,0,0,33554432,0),
+(@guid+9,23118,530,1,1,0,0,2940.82,7107.17,370.115,4.65944,300,0,0,42,0,0,0,33554432,0),
+(@guid+10,23118,530,1,1,0,0,2825.11,7024.05,369.982,5.69617,300,0,0,42,0,0,0,33554432,0),
+(@guid+11,23119,530,1,1,0,0,2825.11,7024.05,369.982,5.69617,300,0,0,6986,0,0,0,33554432,0),
+(@guid+12,23076,530,1,1,0,0,2834.14,7018.43,368.459,5.42992,300,0,0,21543,0,0,0,0,0),
+(@guid+13,23119,530,1,1,0,0,2938.84,7094.48,371.493,0.242375,300,0,0,6986,0,0,0,33554432,0),
+(@guid+14,23118,530,1,1,0,0,2938.84,7094.48,371.493,0.242375,300,0,0,42,0,0,0,33554432,0),
+(@guid+15,23076,530,1,1,0,0,2925.49,7021.72,367.007,3.59446,300,0,0,22140,0,0,0,0,0),
+(@guid+16,23119,530,1,1,0,0,2924.84,7031.46,367.857,4.26205,300,0,0,6986,0,0,0,33554432,0),
+(@guid+17,23118,530,1,1,0,0,2924.84,7031.46,367.857,4.26205,300,0,0,42,0,0,0,33554432,0),
+(@guid+18,23119,530,1,1,0,0,2938.02,7015.59,366.54,3.65778,300,0,0,6986,0,0,0,33554432,0),
+(@guid+19,23118,530,1,1,0,0,2938.02,7015.59,366.54,3.65778,300,0,0,42,0,0,0,33554432,0),
+(@guid+20,23076,530,1,1,0,0,2994.48,7039.91,369.42,5.26077,300,0,0,22140,0,0,0,0,0),
+(@guid+21,23119,530,1,1,0,0,2998.57,7043.55,368.539,5.91266,300,0,0,6986,0,0,0,33554432,0),
+(@guid+22,23118,530,1,1,0,0,2998.57,7043.55,368.539,5.91266,300,0,0,42,0,0,0,33554432,0),
+(@guid+23,23119,530,1,1,0,0,2982,7054.94,368.82,4.99766,300,0,0,6986,0,0,0,33554432,0),
+(@guid+24,23118,530,1,1,0,0,2982,7054.94,368.82,4.99766,300,0,0,42,0,0,0,33554432,0),
+(@guid+25,23076,530,1,1,0,0,2982.59,6886.5,370.082,0.831123,300,0,0,22140,0,0,0,0,0),
+(@guid+26,23118,530,1,1,0,0,2978.74,6889.12,371.288,0.897875,300,0,0,42,0,0,0,33554432,0),
+(@guid+27,23119,530,1,1,0,0,2978.74,6889.12,371.288,0.897875,300,0,0,6986,0,0,0,33554432,0),
+(@guid+28,23118,530,1,1,0,0,2941.56,6827.17,367.3,4.54054,300,0,0,42,0,0,0,33554432,0),
+(@guid+29,23119,530,1,1,0,0,2941.56,6827.17,367.3,4.54054,300,0,0,6986,0,0,0,33554432,0),
+(@guid+30,23076,530,1,1,0,0,2938.19,6818.01,366.959,3.31926,300,0,0,21543,0,0,0,0,0),
+(@guid+31,23076,530,1,1,0,0,2946.3,6875.71,370.04,3.2148,300,0,0,22140,0,0,0,0,0),
+(@guid+32,23118,530,1,1,0,0,2953.55,6859.3,369.954,6.14433,300,0,0,42,0,0,0,33554432,0),
+(@guid+33,23119,530,1,1,0,0,2953.55,6859.3,369.954,6.14433,300,0,0,6986,0,0,0,33554432,0),
+(@guid+34,23119,530,1,1,0,0,3023.13,6799.74,374.46,1.58666,300,0,0,6986,0,0,0,33554432,0),
+(@guid+35,23118,530,1,1,0,0,3023.13,6799.74,374.46,1.58666,300,0,0,42,0,0,0,33554432,0),
+(@guid+36,23076,530,1,1,0,0,3028.22,6807.09,374.075,5.94641,300,0,0,22140,0,0,0,0,0),
+(@guid+37,23118,530,1,1,0,0,3028.3,6824.84,373.591,5.0275,300,0,0,42,0,0,0,33554432,0),
+(@guid+38,23119,530,1,1,0,0,3028.3,6824.84,373.591,5.0275,300,0,0,6986,0,0,0,33554432,0),
+(@guid+39,23119,530,1,1,0,0,3022.15,6859.05,369.546,3.44885,300,0,0,6986,0,0,0,33554432,0),
+(@guid+40,23118,530,1,1,0,0,3022.15,6859.05,369.546,3.44885,300,0,0,42,0,0,0,33554432,0),
+(@guid+41,23076,530,1,1,0,0,3022.21,6864.61,369.93,0.100696,300,0,0,22140,0,0,0,0,0),
+(@guid+42,23118,530,1,1,0,0,3016.28,6876.11,370.188,3.47791,300,0,0,42,0,0,0,33554432,0),
+(@guid+43,23119,530,1,1,0,0,3016.28,6876.11,370.188,3.47791,300,0,0,6986,0,0,0,33554432,0),
+(@guid+44,23076,530,1,1,0,0,2816.74,7057.61,369.779,1.4555,300,0,0,21543,0,0,0,0,0);

--- a/sql/updates/world/2012_09_13_00_world_spell_script_name.sql
+++ b/sql/updates/world/2012_09_13_00_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Add spell script name for Knockdown Fel Cannon: Choose Loc
+DELETE FROM `spell_script_names` WHERE `spell_id`=40056;
+INSERT INTO `spell_script_names` VALUES
+(40056,'spell_q11010_q11102_q11023_choose_loc');

--- a/sql/updates/world/2012_09_13_01_world_spell_script_name.sql
+++ b/sql/updates/world/2012_09_13_01_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Add spell script name for Knockdown Fel Cannon: The Aggro Check
+DELETE FROM `spell_script_names` WHERE `spell_id`=40112;
+INSERT INTO `spell_script_names` VALUES
+(40112,'spell_q11010_q11102_q11023_aggro_check');

--- a/sql/updates/world/2012_09_13_02_world_spell_script_name.sql
+++ b/sql/updates/world/2012_09_13_02_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Add spell script name for Knockdown Fel Cannon: The Aggro Burst
+DELETE FROM `spell_script_names` WHERE `spell_id`=40119;
+INSERT INTO `spell_script_names` VALUES
+(40119,'spell_q11010_q11102_q11023_aggro_burst');

--- a/sql/updates/world/2012_09_13_03_world_spell_script_name.sql
+++ b/sql/updates/world/2012_09_13_03_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Add spell script name for Knockdown Fel Cannon: The Aggro Check Aura
+DELETE FROM `spell_script_names` WHERE `spell_id`=40113;
+INSERT INTO `spell_script_names` VALUES
+(40113,'spell_q11010_q11102_q11023_aggro_check_aura');

--- a/sql/updates/world/2012_09_13_04_world_spell_script_name.sql
+++ b/sql/updates/world/2012_09_13_04_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Add spell script name for Trhow Bomb
+DELETE FROM `spell_script_names` WHERE `spell_id`=40160;
+INSERT INTO `spell_script_names` VALUES
+(40160,'spell_q11010_q11102_q11023_throw_bomb');

--- a/sql/updates/world/2012_09_13_05_world_spell_script_name.sql
+++ b/sql/updates/world/2012_09_13_05_world_spell_script_name.sql
@@ -1,0 +1,4 @@
+-- Add spell script name for Skyguard Blasting Charge
+DELETE FROM `spell_script_names` WHERE `spell_id`=39844;
+INSERT INTO `spell_script_names` VALUES
+(39844,'spell_q11008_blasting_charge');

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1020,7 +1020,7 @@ bool SpellInfo::IsPassiveStackableWithRanks() const
 
 bool SpellInfo::IsMultiSlotAura() const
 {
-    return IsPassive() || Id == 44413;
+    return IsPassive() || Id == 40075 || Id == 44413; // No other way to make 40075 have more than 1 copy of aura
 }
 
 bool SpellInfo::IsDeathPersistent() const

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1489,6 +1489,38 @@ class spell_q11010_q11102_q11023_throw_bomb : public SpellScriptLoader
         }
 };
 
+// http://www.wowhead.com/quest=11008 "Fires Over Skettis"
+// 39844 - Skyguard Blasting Charge
+class spell_q11008_blasting_charge : public SpellScriptLoader
+{
+    public:
+        spell_q11008_blasting_charge() : SpellScriptLoader("spell_q11008_blasting_charge") { }
+
+        class spell_q11008_blasting_charge_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q11008_blasting_charge_SpellScript);
+
+            SpellCastResult CheckRequirement()
+            {
+                Unit* caster = GetCaster();
+                // This spell will be casted only if caster has one of these auras
+                if (!(caster->HasAuraType(SPELL_AURA_FLY) || caster->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED)))
+                    return SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW;
+                return SPELL_CAST_OK;
+            }
+
+            void Register()
+            {
+                OnCheckCast += SpellCheckCastFn(spell_q11008_blasting_charge_SpellScript::CheckRequirement);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q11008_blasting_charge_SpellScript();
+        }
+};
+
 void AddSC_quest_spell_scripts()
 {
     new spell_q55_sacred_cleansing();
@@ -1525,4 +1557,5 @@ void AddSC_quest_spell_scripts()
     new spell_q11010_q11102_q11023_aggro_burst();
     new spell_q11010_q11102_q11023_choose_loc();
     new spell_q11010_q11102_q11023_throw_bomb();
+    new spell_q11008_blasting_charge();
 }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -25,6 +25,7 @@
 #include "ScriptedCreature.h"
 #include "SpellScript.h"
 #include "Vehicle.h"
+#include "GridNotifiers.h"
 
 class spell_generic_quest_update_entry_SpellScript : public SpellScript
 {
@@ -1314,6 +1315,180 @@ class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoad
         }
 };
 
+// http://www.wowhead.com/quest=11010 "Bombing Run", http://www.wowhead.com/quest=11102 "Bombing Run" /druid/ and http://www.wowhead.com/quest=11023 "Bomb Them Again!"
+enum Quest11010_11102_11023Data
+{
+    // Spell
+    SPELL_FLAK_CANNON_TRIGGER       = 40110,
+    SPELL_CHOOSE_LOC        = 40056,
+    SPELL_AGGRO_CHECK       = 40112,
+    // NPCs	
+    NPC_FEL_CANNON2       = 23082
+};
+
+// 40113 Knockdown Fel Cannon: The Aggro Check Aura
+class spell_q11010_q11102_q11023_aggro_check_aura : public SpellScriptLoader
+{
+    public:
+        spell_q11010_q11102_q11023_aggro_check_aura() : SpellScriptLoader("spell_q11010_q11102_q11023_aggro_check_aura") { }
+
+        class spell_q11010_q11102_q11023_aggro_check_aura_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_q11010_q11102_q11023_aggro_check_aura_AuraScript);
+
+            void HandleTriggerSpell(AuraEffect const* /*aurEff*/)
+            {
+                if (Unit* target = GetTarget())
+                {
+                    // On trigger proccing
+                    target->CastSpell(target, SPELL_AGGRO_CHECK);
+                }
+            }
+
+            void Register()
+            {
+               OnEffectPeriodic += AuraEffectPeriodicFn(spell_q11010_q11102_q11023_aggro_check_aura_AuraScript::HandleTriggerSpell, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const
+        {
+            return new spell_q11010_q11102_q11023_aggro_check_aura_AuraScript();
+        }
+};
+
+// 40112 Knockdown Fel Cannon: The Aggro Check
+class spell_q11010_q11102_q11023_aggro_check : public SpellScriptLoader
+{
+    public:
+        spell_q11010_q11102_q11023_aggro_check() : SpellScriptLoader("spell_q11010_q11102_q11023_aggro_check") { }
+
+        class spell_q11010_q11102_q11023_aggro_check_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q11010_q11102_q11023_aggro_check_SpellScript);
+           		
+            void HandleDummy(SpellEffIndex /*effIndex*/)
+            {
+                if (Player* playerTarget = GetHitPlayer())
+                    // Check if found player target is on fly mount or using flying form  
+                    if (playerTarget->HasAuraType(SPELL_AURA_FLY) || playerTarget->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED))
+				    {
+                        playerTarget->CastSpell(playerTarget, SPELL_FLAK_CANNON_TRIGGER, TRIGGERED_IGNORE_CASTER_MOUNTED_OR_ON_VEHICLE);
+				    }
+            }
+		
+            void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_q11010_q11102_q11023_aggro_check_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
+     
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q11010_q11102_q11023_aggro_check_SpellScript();
+        }
+};
+
+// 40119 Knockdown Fel Cannon: The Aggro Burst
+class spell_q11010_q11102_q11023_aggro_burst : public SpellScriptLoader
+{
+    public:
+        spell_q11010_q11102_q11023_aggro_burst() : SpellScriptLoader("spell_q11010_q11102_q11023_aggro_burst") { }
+
+        class spell_q11010_q11102_q11023_aggro_burst_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_q11010_q11102_q11023_aggro_burst_AuraScript);
+
+            void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
+            {
+                if (Unit* target = GetTarget())
+                {
+                    // On each tick cast Choose Loc to trigger summon
+                    target->CastSpell(target, SPELL_CHOOSE_LOC);
+                }
+            }
+
+            void Register()
+            {
+                OnEffectPeriodic += AuraEffectPeriodicFn(spell_q11010_q11102_q11023_aggro_burst_AuraScript::HandleEffectPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
+            }
+        };
+
+        AuraScript* GetAuraScript() const
+        {
+            return new spell_q11010_q11102_q11023_aggro_burst_AuraScript();
+        }
+};
+
+// 40056 Knockdown Fel Cannon: Choose Loc
+class spell_q11010_q11102_q11023_choose_loc : public SpellScriptLoader
+{
+    public:
+        spell_q11010_q11102_q11023_choose_loc() : SpellScriptLoader("spell_q11010_q11102_q11023_choose_loc") { }
+
+        class spell_q11010_q11102_q11023_choose_loc_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q11010_q11102_q11023_choose_loc_SpellScript);
+           		
+            void HandleDummy(SpellEffIndex /*effIndex*/)
+            {
+                Unit* caster = GetCaster();
+                // Check for player that is in 65 y range			   
+                std::list<Player*> PlayerList;
+                Trinity::AnyPlayerInObjectRangeCheck checker(caster, 765.0f);
+                Trinity::PlayerListSearcher<Trinity::AnyPlayerInObjectRangeCheck> searcher(caster, PlayerList, checker);  
+                caster->VisitNearbyWorldObject(65.0f, searcher);    
+                    for (std::list<Player*>::const_iterator itr = PlayerList.begin(); itr != PlayerList.end(); ++itr)
+                    // Check if found player target is on fly mount or using flying form  
+                        if ((*itr)->HasAuraType(SPELL_AURA_FLY) || (*itr)->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED))
+                        {    
+                            // Summom Fel Cannon (bunny version) at found player
+                            caster->SummonCreature(NPC_FEL_CANNON2, (*itr)->GetPositionX(), (*itr)->GetPositionY(), (*itr)->GetPositionZ());
+                        }
+            }
+     
+            void Register()
+            {
+                OnEffectHit += SpellEffectFn(spell_q11010_q11102_q11023_choose_loc_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
+     
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q11010_q11102_q11023_choose_loc_SpellScript();
+        }
+};
+
+class spell_q11010_q11102_q11023_throw_bomb : public SpellScriptLoader
+{
+    public:
+        spell_q11010_q11102_q11023_throw_bomb() : SpellScriptLoader("spell_q11010_q11102_q11023_throw_bomb") { }
+
+        class spell_q11010_q11102_q11023_throw_bomb_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_q11010_q11102_q11023_throw_bomb_SpellScript);
+
+            SpellCastResult CheckRequirement()
+            {
+                Unit* caster = GetCaster();
+                // This spell will be casted only if caster has one of these auras
+                if (!(caster->HasAuraType(SPELL_AURA_FLY) || caster->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED)))
+                    return SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW;
+                return SPELL_CAST_OK;
+            }
+
+            void Register()
+            {
+                OnCheckCast += SpellCheckCastFn(spell_q11010_q11102_q11023_throw_bomb_SpellScript::CheckRequirement);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_q11010_q11102_q11023_throw_bomb_SpellScript();
+        }
+};
+
 void AddSC_quest_spell_scripts()
 {
     new spell_q55_sacred_cleansing();
@@ -1345,4 +1520,9 @@ void AddSC_quest_spell_scripts()
     new spell_q12735_song_of_cleansing();
     new spell_q12372_cast_from_gossip_trigger();
     new spell_q12372_destabilize_azure_dragonshrine_dummy();
+    new spell_q11010_q11102_q11023_aggro_check_aura();
+    new spell_q11010_q11102_q11023_aggro_check();
+    new spell_q11010_q11102_q11023_aggro_burst();
+    new spell_q11010_q11102_q11023_choose_loc();
+    new spell_q11010_q11102_q11023_throw_bomb();
 }


### PR DESCRIPTION
// Part I - Ogri'La //
- Bombing Run /all classes, druid/, Bomb Them Again quest support
- Sniffed spell support for Knockdown Fel Cannon: Choose Loc, Knockdown Fel Cannon: The Aggro Check, Knockdown Fel Cannon: The Aggro Burst, Knockdown Fel Cannon: The Aggro Check Aura, Trhow Bomb and Fel Flak Fire
- Sniffed spawns support, but only for quest related creatures and gos, no area patrols/spawns involved
- Achievement support for Blade's Edge Bomberman and Fa-la-la-la-Ogri'la
- Full DB support based on sniffs, all that can be done in SAI and not in *cpp is converted
- Credits: The SAI script is based on Warpen work, thanks to Subv for proposing fix for Fel Flak Fire /and helping/ and DDuarte for helping with conditions and thanks to Aokromes for sniffs

Closes: #4168
## 

// Part II - Skettis //
- Fires Over Skettis quest support
- Include SAI/Spawn and spell support, also achievement support for "Bombs Away"
- Credits: Based on Warpten script and Nelegalno/shlomi1515 updates and rest who helped

Closes:  #3402
