### PR TITLE
Scripts/Oculus: Support for achievements Ruby, Emerald and Amber Void

### DIFF
--- a/sql/updates/world/2012_09_14_00_disables.sql
+++ b/sql/updates/world/2012_09_14_00_disables.sql
@@ -1,0 +1,4 @@
+-- Remove achievements from disables
+DELETE FROM `disables` WHERE  `sourceType`=4 AND `entry`=7323; -- Ruby Void
+DELETE FROM `disables` WHERE  `sourceType`=4 AND `entry`=7324; -- Emerald Void
+DELETE FROM `disables` WHERE  `sourceType`=4 AND `entry`=7325; -- Amber Void

--- a/sql/updates/world/2012_09_14_00_world_achievement_criteria_data.sql
+++ b/sql/updates/world/2012_09_14_00_world_achievement_criteria_data.sql
@@ -1,0 +1,6 @@
+-- Insert achievement instance criteria data scripts
+DELETE FROM `achievement_criteria_data` WHERE `type`=11 and `criteria_id` IN (7323,7324,7325);
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `ScriptName`) VALUES
+(7323,11,0,0,'achievement_ruby_void'),
+(7324,11,0,0,'achievement_emerald_void'),
+(7325,11,0,0,'achievement_amber_void');


### PR DESCRIPTION
- Add instance achievement criteria scripts and remove from disables. Based on retail data. Tested.
- vol2: Rewritten codestyle and add checks to private thanks to Vincent-Michael
  
  This involves everything needed by the achievement, however the dungeon still needs majour fixes/rewrite. The big check is to prevent some retail abuses. I'll try to look up on more stuff from Oculus.
