### PR TITLE
Death and Decay on invis targets (#6345)

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3582,9 +3582,9 @@ void SpellMgr::LoadDbcDataCorrections()
                 spellInfo->manaCost = 0;
                 spellInfo->manaPerSecond = 0;
                 break;
-			case 52212: // Death Knight: Death and Decay triggered spell
-				spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
-				break;
+            case 52212: // Death Knight: Death and Decay triggered spell
+                spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
+                break;
             default:
                 break;
         }

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3582,6 +3582,9 @@ void SpellMgr::LoadDbcDataCorrections()
                 spellInfo->manaCost = 0;
                 spellInfo->manaPerSecond = 0;
                 break;
+			case 52212: // Death Knight: Death and Decay triggered spell
+				spellInfo->AttributesEx6 |= SPELL_ATTR6_CAN_TARGET_INVISIBLE;
+				break;
             default:
                 break;
         }


### PR DESCRIPTION
Resolves #6345

Allow the Death and Decay trigger spell to be casted on invisable targets, thus removing their stealth. 
