### PR TITLE
correct removal of misdirection on player cancel aura (#4343)

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -574,7 +574,7 @@ class spell_hun_misdirection : public SpellScriptLoader
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 if (Unit* caster = GetCaster())
-                    if (!GetDuration())
+                    if (!GetDuration() || GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_CANCEL)
                         caster->SetReducedThreatPercent(0, 0);
             }
 


### PR DESCRIPTION
See the bugreport: #4343

Short description: If player cancelled misdirection by rightclick on buff, script would not disable thread reduction because in that case, GetDuration() still returns non-zero. Thus the required RemoveMode check.

I dont take all credit for this fix, Kandera came up with the solution in https://github.com/TrinityCore/TrinityCore/issues/4343#issuecomment-5550157 but missed the GetDuration part. That way, the correct buff removal by attack broke as well.
