### PR TITLE
Fix evade mechanics to allow kiting in instances.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13051,7 +13051,7 @@ Unit* Creature::SelectVictim()
     // Mob may not be in range to attack or may have dropped target. In any case,
     //  don't evade if damage received within the last 10 seconds
     // Does not apply to world bosses to prevent kiting to cities
-    if (!isWorldBoss() && !GetInstanceId())
+    if (!isWorldBoss() || GetInstanceId())
         if (time(NULL) - GetLastDamagedTime() <= MAX_AGGRO_RESET_TIME)
             return target;
 


### PR DESCRIPTION
Closes #7833

You can't simply check GetInstanceId() because that excludes all mobs in an instance. If there is a particular case where a boss should evade (none that I know of) then that **boss's script** should handle it.

In general, all mobs should follow you if you've damaged them within 10 seconds unless you're outside fighting a world boss. Those should evade at a range so you can't pull them into cities.
