### PR TITLE
 Scripts/Oculus: Fixes here and there, implement phasing

### DIFF
--- a/sql/updates/world/2012_10_02_00_world_oculus.sql
+++ b/sql/updates/world/2012_10_02_00_world_oculus.sql
@@ -1,0 +1,80 @@
+-- Addon data based on sniff fixed by Vincent-Michael
+DELETE FROM `creature_template_addon` WHERE `entry` IN (27692,27755,27756);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES 
+(27692,0,0,0x3000000,0x1,0,'50296 50325'), -- Emerald Drake
+(27755,0,0,0x3000000,0x1,0,'50296 50325'), -- Amber Drake
+(27756,0,0,0x3000000,0x1,0,'50296 50248 50325'); -- Ruby Drake // Evasive aura should be here from the start
+-- Change InhabitType to prevent drakes falling on summon
+UPDATE `creature_template` SET `InhabitType`=4 WHERE `entry` IN (27692,27755,27756);
+-- Change script name for gossip npcs and drakes and set npc_flag to 0, since only after Ist boss is dead, they should acquire gossip flag
+UPDATE `creature_template` SET `npcflag`=2,`ScriptName`='npc_verdisa_beglaristrasz_eternos' WHERE `entry` IN (27657,27658,27659);
+UPDATE `creature_template` SET `spell2`=50240,`spell3`=50253,`spell4`=0  WHERE `entry`=27756; -- Remove Evasive Aura and set Evasive Manouvres since it is an aura always applied, also set Martyr as 3rd
+UPDATE `creature_template` SET `spell6`=53389,`ScriptName`='npc_ruby_emerald_amber_drake' WHERE `entry` IN (27692,27755,27756); -- Add GPS spell for all drakes and script names for drakes
+-- Add spell_script name for Call Ruby/Emerald/Amber Drake spells
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (49462,49345,49461);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(49462,'spell_call_ruby_emerald_amber_drake'), -- Ruby
+(49345,'spell_call_ruby_emerald_amber_drake'), -- Emerald
+(49461,'spell_call_ruby_emerald_amber_drake'); -- Amber
+-- Remove wrong use of npc_spellclick_spell, the drake should auto do all on summon
+DELETE FROM `npc_spellclick_spells` WHERE `npc_entry` IN (27692,27755,27756);
+-- Add conditions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry` IN (49464,49346,49460,66667,49838);
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=17 AND `SourceEntry` IN (49840,49592,50328,50341,50232);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(13,1|4,49464,0,0,33,0,1,5,0,0,0,'','Ruby Drake Saddle control vehicle aura can hit only created unit'),
+(13,1|4,49346,0,0,33,0,1,5,0,0,0,'','Emerald Drake Saddle control vehicle aura can hit only created unit'),
+(13,1|4,49460,0,0,33,0,1,5,0,0,0,'','Amber Drake Saddle control vehicle aura can hit only created unit'),
+(13,1|2|4,66667,0,0,33,1,0,0,0,0,0,'','Gear scaling for Oculus drakes can only be casted on self'),
+(17,0,49840,0,1,31,1,3,28236,0,0,0,'','Shock Lance target can be Azure Ring Captain'),
+(17,0,49840,0,2,31,1,3,27638,0,0,0,'','Shock Lance target can be Azure Ring Guardian'),
+(17,0,49840,0,3,31,1,3,28276,0,0,0,'','Shock Lance target can be Greater Lay Whelp'),
+(17,0,49840,0,4,31,1,3,27656,0,0,0,'','Shock Lance target can be Eregos'),
+(13,1,49838,0,1,31,0,3,28236,0,0,0,'','Stop Time can hit Azure Ring Captain'),
+(13,1,49838,0,2,31,0,3,27638,0,0,0,'','Stop Time can hit Azure Ring Guardian'),
+(13,1,49838,0,3,31,0,3,28276,0,0,0,'','Stop Time can hit Greater Lay Whelp'),
+(13,1,49838,0,4,31,0,3,27656,0,0,0,'','Stop Time can hit Eregos'),
+(17,0,49592,0,1,31,1,3,28236,0,0,0,'','Temporal Rift target can be Azure Ring Captain'),
+(17,0,49592,0,2,31,1,3,27638,0,0,0,'','Temporal Rift target can be Azure Ring Guardian'),
+(17,0,49592,0,3,31,1,3,28276,0,0,0,'','Temporal Rift target can be Greater Lay Whelp'),
+(17,0,49592,0,4,31,1,3,27656,0,0,0,'','Temporal Rift target can be Eregos'),
+(17,0,50328,0,1,31,1,3,28236,0,0,0,'','Leeching Poison target can be Azure Ring Captain'),
+(17,0,50328,0,2,31,1,3,27638,0,0,0,'','Leeching Poison target can be Azure Ring Guardian'),
+(17,0,50328,0,3,31,1,3,28276,0,0,0,'','Leeching Poison target can be Greater Lay Whelp'),
+(17,0,50328,0,4,31,1,3,27656,0,0,0,'','Leeching Poison target can be Eregos'),
+(17,0,50341,0,1,31,1,3,28236,0,0,0,'','Touch the Nightmare target can be Azure Ring Captain'),
+(17,0,50341,0,2,31,1,3,27638,0,0,0,'','Touch the Nightmare target can be Azure Ring Guardian'),
+(17,0,50341,0,3,31,1,3,28276,0,0,0,'','Touch the Nightmare target can be Greater Lay Whelp'),
+(17,0,50341,0,4,31,1,3,27656,0,0,0,'','Touch the Nightmare target can be Eregos'),
+(17,0,50232,0,1,31,1,3,28236,0,0,0,'','Searing Wrath target can be Azure Ring Captain'),
+(17,0,50232,0,2,31,1,3,27638,0,0,0,'','Searing Wrath target can be Azure Ring Guardian'),
+(17,0,50232,0,3,31,1,3,28276,0,0,0,'','Searing Wrath target can be Greater Lay Whelp'),
+(17,0,50232,0,4,31,1,3,27656,0,0,0,'','Searing Wrath target can be Eregos');
+-- Add text for Belgaristrasz
+SET @Belgaristrasz := 27658;
+DELETE FROM `creature_text` WHERE `entry`=@Belgaristrasz;
+INSERT INTO `creature_text` (`entry`,`groupid`,`id`,`text`,`type`,`language`,`probability`,`emote`,`duration`,`sound`,`comment`) VALUES
+(@Belgaristrasz,0,0,'Thank you for freeing us, mortals. Beware, the blue flight is alerted to your presence. Even now, Malygos sends Varos Cloudstrider and his ring guardians to defend the Oculus. You will need our help to stand a chance.',12,0,100,1,3500,0,'Belgaristrasz - On freed');
+-- Add text for Ruby, Amber and Emerald drakes
+SET @Ruby :=    27756;
+SET @Emerald := 27692;
+SET @Amber :=   27755;
+DELETE FROM `creature_text` WHERE `entry` IN (@Ruby,@Emerald,@Amber);
+INSERT INTO `creature_text` (`entry`,`groupid`,`id`,`text`,`type`,`language`,`probability`,`emote`,`duration`,`sound`,`comment`) VALUES
+(@Ruby,0,0,'Ruby Drake flies away.',16,0,100,1,0,2858,'Ruby - On take off'),
+(@Ruby,1,0,'Welcome Friend. Keep your head down and hold on tight!',15,0,100,1,0,0,'Ruby - On welcome'),
+(@Ruby,2,0,'Use Searing Wrath to damage enemies and Evasive Maneuvers if I start taking damage. Remember I need to build up Evasive Charges by taking damage to perform Evasive Maneuvers!',15,0,100,1,0,0,'Ruby - On explaining abilities'),
+(@Ruby,3,0,'Now that I am at my full power I can perform Martyr. You can use it to protect other drakes, but I will take lots of damage, so make sure you''re using Evasive Maneuvers too!',15,0,100,1,0,0,'Ruby - On ultimate ability unlocked'),
+(@Ruby,4,0,'I''m badly injured! I can''t take much more of this!',15,0,100,1,0,0,'Ruby - On below 40%'),
+(@Emerald,0,0,'Emerald Drake flies away.',16,0,100,1,0,2858,'Emerald - On take off'),
+(@Emerald,1,0,'Welcome Friend. Keep your head down and hold on tight!',15,0,100,1,0,0,'Emerald - On welcome'),
+(@Emerald,2,0,'Use Leeching Poison to damage enemies and keep me healed. Touch the Nightmare is very powerful, but it hurts me, so only use it when I have a lot of health!',15,0,100,1,0,0,'Emerald - On explaining abilities'),
+(@Emerald,3,0,'Now that I am at my full power I can perform Dream Funnel. You can use it to heal other drakes, but it drains my health, so make sure you''re using Leeching Poison too!',15,0,100,1,0,0,'Emerald - On ultimate ability unlocked'),
+(@Emerald,4,0,'I''m badly injured! I can''t take much more of this!',15,0,100,1,0,0,'Emerald - On below 40%'),
+(@Amber,0,0,'Amber Drake flies away.',16,0,100,1,0,2858,'Amber - On take off'),
+(@Amber,1,0,'Welcome Friend. Keep your head down and hold on tight!',15,0,100,1,0,0,'Amber - On welcome'),
+(@Amber,2,0,'Use Shock Lance to damage enemies. If we get in trouble, Stop Time to freeze all enemies in place, then hit them with Shock Lance for massive damage!',15,0,100,1,0,0,'Amber - On explaining abilities'),
+(@Amber,3,0,'Now that I am at my full power I can perform Temporal Rift. You can use it to make enemies take extra damage and to get Shock Charges. Save up Shock Charges and then Shock Lance for huge damage!',15,0,100,1,0,0,'Amber - On ultimate ability unlocked'),
+(@Amber,4,0,'I''m badly injured! I can''t take much more of this!',15,0,100,1,0,0,'Amber - On below 40%');
+-- Fix Oculus phasing db side, all listed get changed only on specific isntance data
+UPDATE `creature` SET `phaseMask`=2 WHERE `id` IN (27447,27655,28276,27656);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3599,6 +3599,13 @@ void SpellMgr::LoadDbcDataCorrections()
                 spellInfo->manaCost = 0;
                 spellInfo->manaPerSecond = 0;
                 break;
+            // OCULUS SPELLS
+            // The spells below are here, because their effect 1 is giving warning, because the triggered spell is not found in dbc and is missing from encounter sniff.
+            case 49462: // Call Ruby Drake
+            case 49461: // Call Amber Drake
+            case 49345: // Call Emerald Drake
+                spellInfo->Effect[1] = 0;
+                break;
             default:
                 break;
         }

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_eregos.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_eregos.cpp
@@ -68,51 +68,6 @@ enum Actions
     ACTION_SET_NORMAL_EVENTS = 1
 };
 
-/*Ruby Drake,
-(npc 27756) (item 37860)
-(summoned by spell Ruby Essence = 37860 ---> Call Amber Drake == 49462 ---> Summon 27756)
-*/
-enum RubyDrake
-{
-    NPC_RUBY_DRAKE_VEHICLE                        = 27756,
-    SPELL_RIDE_RUBY_DRAKE_QUE                     = 49463,          //Apply Aura: Periodic Trigger, Interval: 3 seconds ---> 49464
-    SPELL_RUBY_DRAKE_SADDLE                       = 49464,          //Allows you to ride on the back of an Amber Drake. ---> Dummy
-    SPELL_RUBY_SEARING_WRATH                      = 50232,          //(60 yds) - Instant - Breathes a stream of fire at an enemy dragon, dealing 6800 to 9200 Fire damage and then jumping to additional dragons within 30 yards. Each jump increases the damage by 50%. Affects up to 5 total targets
-    SPELL_RUBY_EVASIVE_AURA                       = 50248,          //Instant - Allows the Ruby Drake to generate Evasive Charges when hit by hostile attacks and spells.
-    SPELL_RUBY_EVASIVE_MANEUVERS                  = 50240,          //Instant - 5 sec. cooldown - Allows your drake to dodge all incoming attacks and spells. Requires Evasive Charges to use. Each attack or spell dodged while this ability is active burns one Evasive Charge. Lasts 30 sec. or until all charges are exhausted.
-    //you do not have acces to until you kill Mage-Lord Urom
-    SPELL_RUBY_MARTYR                             = 50253          //Instant - 10 sec. cooldown - Redirect all harmful spells cast at friendly drakes to yourself for 10 sec.
-};
-/*Amber Drake,
-(npc 27755)  (item 37859)
-(summoned by spell Amber Essence = 37859 ---> Call Amber Drake == 49461 ---> Summon 27755)
-*/
-enum AmberDrake
-{
-    NPC_AMBER_DRAKE_VEHICLE                       = 27755,
-    SPELL_RIDE_AMBER_DRAKE_QUE                    = 49459,          //Apply Aura: Periodic Trigger, Interval: 3 seconds ---> 49460
-    SPELL_AMBER_DRAKE_SADDLE                      = 49460,          //Allows you to ride on the back of an Amber Drake. ---> Dummy
-    SPELL_AMBER_SHOCK_LANCE                       = 49840,         //(60 yds) - Instant - Deals 4822 to 5602 Arcane damage and detonates all Shock Charges on an enemy dragon. Damage is increased by 6525 for each detonated.
-//  SPELL_AMBER_STOP_TIME                                    //Instant - 1 min cooldown - Halts the passage of time, freezing all enemy dragons in place for 10 sec. This attack applies 5 Shock Charges to each affected target.
-    //you do not have access to until you kill the  Mage-Lord Urom.
-    SPELL_AMBER_TEMPORAL_RIFT                     = 49592         //(60 yds) - Channeled - Channels a temporal rift on an enemy dragon for 10 sec. While trapped in the rift, all damage done to the target is increased by 100%. In addition, for every 15, 000 damage done to a target affected by Temporal Rift, 1 Shock Charge is generated.
-};
-
-/*Emerald Drake,
-(npc 27692)  (item 37815),
- (summoned by spell Emerald Essence = 37815 ---> Call Emerald Drake == 49345 ---> Summon 27692)
-*/
-enum EmeraldDrake
-{
-    NPC_EMERALD_DRAKE_VEHICLE                     = 27692,
-    SPELL_RIDE_EMERALD_DRAKE_QUE                  = 49427,         //Apply Aura: Periodic Trigger, Interval: 3 seconds ---> 49346
-    SPELL_EMERALD_DRAKE_SADDLE                    = 49346,         //Allows you to ride on the back of an Amber Drake. ---> Dummy
-    SPELL_EMERALD_LEECHING_POISON                 = 50328,         //(60 yds) - Instant - Poisons the enemy dragon, leeching 1300 to the caster every 2 sec. for 12 sec. Stacks up to 3 times.
-    SPELL_EMERALD_TOUCH_THE_NIGHTMARE             = 50341,         //(60 yds) - Instant - Consumes 30% of the caster's max health to inflict 25, 000 nature damage to an enemy dragon and reduce the damage it deals by 25% for 30 sec.
-    // you do not have access to until you kill the Mage-Lord Urom
-    SPELL_EMERALD_DREAM_FUNNEL                    = 50344         //(60 yds) - Channeled - Transfers 5% of the caster's max health to a friendly drake every second for 10 seconds as long as the caster channels.
-};
-
 enum EregosData
 {
     DATA_RUBY_VOID          = 0,      // http://www.wowhead.com/achievement=2044

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -38,7 +38,8 @@ enum Spells
     SPELL_SUMMON_MENAGERIE_3                      = 50496,
     SPELL_TELEPORT                                = 51112, //Teleports to the center of Oculus
     SPELL_TIME_BOMB                               = 51121, //Deals arcane damage to a random player, and after 6 seconds, deals zone damage to nearby equal to the health missing of the target afflicted by the debuff.
-    SPELL_TIME_BOMB_2                             = 59376
+    SPELL_TIME_BOMB_2                             = 59376,
+    SPELL_EVOCATE                                 = 51602 // He always cast it on reset or after teleportation
 };
 
 enum Yells
@@ -103,10 +104,9 @@ public:
 
         void Reset()
         {
-            if (instance->GetBossState(DATA_VAROS_EVENT) != DONE)
-                DoCast(SPELL_ARCANE_SHIELD);
-
-            _Reset();
+            me->CastSpell(me, SPELL_EVOCATE);
+			
+			_Reset();
 
             if (instance->GetData(DATA_UROM_PLATAFORM) == 0)
             {
@@ -307,14 +307,17 @@ public:
                 case SPELL_SUMMON_MENAGERIE:
                     me->SetHomePosition(968.66f, 1042.53f, 527.32f, 0.077f);
                     LeaveCombat();
+                    me->CastSpell(me, SPELL_EVOCATE);
                     break;
                 case SPELL_SUMMON_MENAGERIE_2:
                     me->SetHomePosition(1164.02f, 1170.85f, 527.321f, 3.66f);
                     LeaveCombat();
+                    me->CastSpell(me, SPELL_EVOCATE);
                     break;
                 case SPELL_SUMMON_MENAGERIE_3:
                     me->SetHomePosition(1118.31f, 1080.377f, 508.361f, 4.25f);
                     LeaveCombat();
+                    me->CastSpell(me, SPELL_EVOCATE);
                     break;
                 case SPELL_TELEPORT:
                     //! Unconfirmed, previous below

--- a/src/server/scripts/Northrend/Nexus/Oculus/instance_oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/instance_oculus.cpp
@@ -56,9 +56,13 @@ public:
 
             eregosCacheGUID = 0;
 
-            azureDragonsList.clear();
+            gwhelpList.clear();
             gameObjectList.clear();
-        }
+
+            belgaristraszGUID = 0;
+            eternosGUID = 0;
+            verdisaGUID = 0;
+}
 
         void OnUnitDeath(Unit* unit)
         {
@@ -112,16 +116,48 @@ public:
                     break;
                 case NPC_VAROS:
                     varosGUID = creature->GetGUID();
+                    if (GetBossState(DATA_DRAKOS_EVENT) == DONE)
+                       creature->SetPhaseMask(1, true);
                     break;
                 case NPC_UROM:
                     uromGUID = creature->GetGUID();
+                    if (GetBossState(DATA_VAROS_EVENT) == DONE)
+                        creature->SetPhaseMask(1, true);
                     break;
                 case NPC_EREGOS:
                     eregosGUID = creature->GetGUID();
+                    if (GetBossState(DATA_UROM_EVENT) == DONE)
+                        creature->SetPhaseMask(1, true);
                     break;
                 case NPC_CENTRIFUGE_CONSTRUCT:
                     if (creature->isAlive())
                         DoUpdateWorldState(WORLD_STATE_CENTRIFUGE_CONSTRUCT_AMOUNT, ++centrifugueConstructCounter);
+                    break;
+                case NPC_BELGARISTRASZ:
+                    belgaristraszGUID = creature->GetGUID();
+                    if (GetBossState(DATA_DRAKOS_EVENT) == DONE)
+                        creature->SetWalk(true),
+                        creature->GetMotionMaster()->MovePoint(0, 941.453f, 1044.1f, 359.967f),
+                        creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
+                    break;
+                case NPC_ETERNOS:
+                    eternosGUID = creature->GetGUID();
+                    if (GetBossState(DATA_DRAKOS_EVENT) == DONE)
+                        creature->SetWalk(true),
+                        creature->GetMotionMaster()->MovePoint(0, 943.202f, 1059.35f, 359.967f),
+                        creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
+                    break;
+                case NPC_VERDISA:
+                    verdisaGUID = creature->GetGUID();
+                    if (GetBossState(DATA_DRAKOS_EVENT) == DONE)
+                        creature->SetWalk(true),
+                        creature->GetMotionMaster()->MovePoint(0, 949.188f, 1032.91f, 359.967f),
+                        creature->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
+                    break;
+                case NPC_GREATER_WHELP:
+                    if (GetBossState(DATA_UROM_EVENT) == DONE)
+                        creature->SetPhaseMask(1, true);
+                        gwhelpList.push_back(creature->GetGUID());
                     break;
             }
         }
@@ -159,11 +195,22 @@ public:
                         DoUpdateWorldState(WORLD_STATE_CENTRIFUGE_CONSTRUCT_SHOW, 1);
                         DoUpdateWorldState(WORLD_STATE_CENTRIFUGE_CONSTRUCT_AMOUNT, centrifugueConstructCounter);
                         OpenCageDoors();
+                        FreeDragons();
+                        if (Creature* varos = instance->GetCreature(varosGUID))
+                            varos->SetPhaseMask(1, true);
                     }
                     break;
                 case DATA_VAROS_EVENT:
                     if (state == DONE)
                         DoUpdateWorldState(WORLD_STATE_CENTRIFUGE_CONSTRUCT_SHOW, 0);
+                        if (Creature* urom = instance->GetCreature(uromGUID))
+                            urom->SetPhaseMask(1, true);
+                    break;
+                case DATA_UROM_EVENT:
+                    if (state == DONE)
+                        if (Creature* eregos = instance->GetCreature(eregosGUID))
+                            eregos->SetPhaseMask(1, true);
+                            GreaterWhelps();
                     break;
                 case DATA_EREGOS_EVENT:
                     if (state == DONE)
@@ -221,6 +268,31 @@ public:
             }
         }
 
+        void FreeDragons()
+        {
+            if (Creature* belgaristrasz = instance->GetCreature(belgaristraszGUID))
+                belgaristrasz->SetWalk(true),
+                belgaristrasz->GetMotionMaster()->MovePoint(0, 941.453f, 1044.1f, 359.967f);
+            if (Creature* eternos = instance->GetCreature(eternosGUID))
+                eternos->SetWalk(true),
+                eternos->GetMotionMaster()->MovePoint(0, 943.202f, 1059.35f, 359.967f);
+            if (Creature* verdisa = instance->GetCreature(verdisaGUID))
+                verdisa->SetWalk(true),
+                verdisa->GetMotionMaster()->MovePoint(0, 949.188f, 1032.91f, 359.967f); 
+        }
+
+        void GreaterWhelps()
+        {
+            if (gwhelpList.empty())
+                return;
+
+            for (std::list<uint64>::const_iterator itr = gwhelpList.begin(); itr != gwhelpList.end(); ++itr)
+            {
+                if (Creature* gwhelp = instance->GetCreature(*itr))
+                    gwhelp->SetPhaseMask(1, true);
+            }
+        }
+
         std::string GetSaveData()
         {
             OUT_SAVE_INST_DATA;
@@ -269,6 +341,10 @@ public:
             uint64 uromGUID;
             uint64 eregosGUID;
 
+            uint64 belgaristraszGUID;
+            uint64 eternosGUID;
+            uint64 verdisaGUID;
+
             uint8 platformUrom;
             uint8 centrifugueConstructCounter;
 
@@ -277,9 +353,8 @@ public:
             std::string str_data;
 
             std::list<uint64> gameObjectList;
-            std::list<uint64> azureDragonsList;
+            std::list<uint64> gwhelpList;
     };
-
 };
 
 void AddSC_instance_oculus()

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -20,6 +20,7 @@
 #include "ScriptedGossip.h"
 #include "SpellScript.h"
 #include "SpellAuraEffects.h"
+#include "Vehicle.h"
 #include "oculus.h"
 
 #define GOSSIP_ITEM_DRAKES         "So where do we go from here?"
@@ -32,7 +33,7 @@
 
 #define HAS_ESSENCE(a) ((a)->HasItemCount(ITEM_EMERALD_ESSENCE, 1) || (a)->HasItemCount(ITEM_AMBER_ESSENCE, 1) || (a)->HasItemCount(ITEM_RUBY_ESSENCE, 1))
 
-enum Drakes
+enum GossipNPCs
 {
     GOSSIP_TEXTID_DRAKES                          = 13267,
     GOSSIP_TEXTID_BELGARISTRASZ1                  = 12916,
@@ -49,25 +50,67 @@ enum Drakes
     ITEM_AMBER_ESSENCE                            = 37859,
     ITEM_RUBY_ESSENCE                             = 37860,
 
-    NPC_VERDISA                                   = 27657,
-    NPC_BELGARISTRASZ                             = 27658,
-    NPC_ETERNOS                                   = 27659,
+    SPELL_SHOCK_CHARGE                            = 49836
+};
 
-    SPELL_SHOCK_CHARGE                            = 49836,
+enum Drakes
+{
+/*Ruby Drake,
+(npc 27756) (item 37860)
+(summoned by spell Ruby Essence = 37860 ---> Call Amber Drake == 49462 ---> Summon 27756)
+*/
+    SPELL_RIDE_RUBY_DRAKE_QUE                     = 49463,          //Apply Aura: Periodic Trigger, Interval: 3 seconds ---> 49464
+    SPELL_RUBY_DRAKE_SADDLE                       = 49464,          //Allows you to ride on the back of an Amber Drake. ---> Dummy
+    SPELL_RUBY_SEARING_WRATH                      = 50232,          //(60 yds) - Instant - Breathes a stream of fire at an enemy dragon, dealing 6800 to 9200 Fire damage and then jumping to additional dragons within 30 yards. Each jump increases the damage by 50%. Affects up to 5 total targets
+    SPELL_RUBY_EVASIVE_AURA                       = 50248,          //Instant - Allows the Ruby Drake to generate Evasive Charges when hit by hostile attacks and spells.
+    SPELL_RUBY_EVASIVE_MANEUVERS                  = 50240,          //Instant - 5 sec. cooldown - Allows your drake to dodge all incoming attacks and spells. Requires Evasive Charges to use. Each attack or spell dodged while this ability is active burns one Evasive Charge. Lasts 30 sec. or until all charges are exhausted.
+    //you do not have acces to until you kill Mage-Lord Urom
+    SPELL_RUBY_MARTYR                             = 50253,          //Instant - 10 sec. cooldown - Redirect all harmful spells cast at friendly drakes to yourself for 10 sec.
+
+/*Amber Drake,
+(npc 27755)  (item 37859)
+(summoned by spell Amber Essence = 37859 ---> Call Amber Drake == 49461 ---> Summon 27755)
+*/
+
+    SPELL_RIDE_AMBER_DRAKE_QUE                    = 49459,          //Apply Aura: Periodic Trigger, Interval: 3 seconds ---> 49460
+    SPELL_AMBER_DRAKE_SADDLE                      = 49460,          //Allows you to ride on the back of an Amber Drake. ---> Dummy
+    SPELL_AMBER_SHOCK_LANCE                       = 49840,          //(60 yds) - Instant - Deals 4822 to 5602 Arcane damage and detonates all Shock Charges on an enemy dragon. Damage is increased by 6525 for each detonated.
+    // SPELL_AMBER_STOP_TIME                                        //Instant - 1 min cooldown - Halts the passage of time, freezing all enemy dragons in place for 10 sec. This attack applies 5 Shock Charges to each affected target.
+    //you do not have access to until you kill the  Mage-Lord Urom.
+    SPELL_AMBER_TEMPORAL_RIFT                     = 49592,          //(60 yds) - Channeled - Channels a temporal rift on an enemy dragon for 10 sec. While trapped in the rift, all damage done to the target is increased by 100%. In addition, for every 15, 000 damage done to a target affected by Temporal Rift, 1 Shock Charge is generated.
+
+/*Emerald Drake,
+(npc 27692)  (item 37815),
+ (summoned by spell Emerald Essence = 37815 ---> Call Emerald Drake == 49345 ---> Summon 27692)
+*/
+    SPELL_RIDE_EMERALD_DRAKE_QUE                  = 49427,         //Apply Aura: Periodic Trigger, Interval: 3 seconds ---> 49346
+    SPELL_EMERALD_DRAKE_SADDLE                    = 49346,         //Allows you to ride on the back of an Amber Drake. ---> Dummy
+    SPELL_EMERALD_LEECHING_POISON                 = 50328,         //(60 yds) - Instant - Poisons the enemy dragon, leeching 1300 to the caster every 2 sec. for 12 sec. Stacks up to 3 times.
+    SPELL_EMERALD_TOUCH_THE_NIGHTMARE             = 50341,         //(60 yds) - Instant - Consumes 30% of the caster's max health to inflict 25, 000 nature damage to an enemy dragon and reduce the damage it deals by 25% for 30 sec.
+    // you do not have access to until you kill the Mage-Lord Urom
+    SPELL_EMERALD_DREAM_FUNNEL                    = 50344,         //(60 yds) - Channeled - Transfers 5% of the caster's max health to a friendly drake every second for 10 seconds as long as the caster channels.
 };
 
 enum Says
 {
-    SAY_VAROS          = 0,
-    SAY_UROM           = 1
+    SAY_VAROS                         = 0,
+    SAY_UROM                          = 1,
+    SAY_BELGARISTRASZ                 = 0,
+    SAY_DRAKES_TAKEOFF                = 0,
+    WHISPER_DRAKES_WELCOME            = 1,
+    WHISPER_DRAKES_ABILITIES          = 2,
+    WHISPER_DRAKES_SPECIAL            = 3,
+    WHISPER_DRAKES_LOWHEALTH          = 4
 };
 
-class npc_oculus_drake : public CreatureScript
+class npc_verdisa_beglaristrasz_eternos : public CreatureScript
 {
 public:
-    npc_oculus_drake() : CreatureScript("npc_oculus_drake") { }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action)
+    npc_verdisa_beglaristrasz_eternos() : CreatureScript("npc_verdisa_beglaristrasz_eternos") { }
+    
+	    InstanceScript* instance;
+    
+	bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action)
     {
         player->PlayerTalkClass->ClearMenus();
         switch (creature->GetEntry())
@@ -184,6 +227,28 @@ public:
         return true;
     }
 
+    struct npc_verdisa_beglaristrasz_eternosAI : public ScriptedAI
+    {
+        npc_verdisa_beglaristrasz_eternosAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void MovementInform(uint32 type, uint32 id)
+        {
+            // When Belgaristraz finish his moving say grateful text
+            if (me->GetEntry() == NPC_BELGARISTRASZ)
+                if (id == 0)
+                {
+                    Talk(SAY_BELGARISTRASZ);
+                }
+            // The gossip flag should activate when Drakos die and not from DB
+            if (id == 0)
+                me->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
+        }
+    };
+        
+    CreatureAI* GetAI(Creature* creature) const
+    {
+        return new npc_verdisa_beglaristrasz_eternosAI(creature);
+    }
 };
 
 class npc_image_belgaristrasz : public CreatureScript
@@ -193,7 +258,7 @@ public:
 
     struct npc_image_belgaristraszAI : public ScriptedAI
     {
-        npc_image_belgaristraszAI(Creature* creature) : ScriptedAI(creature) {}
+        npc_image_belgaristraszAI(Creature* creature) : ScriptedAI(creature) { }
 
         void IsSummonedBy(Unit* summoner)
         {
@@ -213,6 +278,176 @@ public:
     CreatureAI* GetAI(Creature* creature) const
     {
         return new npc_image_belgaristraszAI(creature);
+    }
+};
+
+class npc_ruby_emerald_amber_drake : public CreatureScript
+{
+public:
+    npc_ruby_emerald_amber_drake() : CreatureScript("npc_ruby_emerald_amber_drake") { }
+
+    struct npc_ruby_emerald_amber_drakeAI : public VehicleAI
+    {
+        npc_ruby_emerald_amber_drakeAI(Creature* creature) : VehicleAI(creature)
+        {
+            instance = creature->GetInstanceScript();
+        }
+     
+            InstanceScript* instance;
+
+            uint64 summonerGUID;
+            uint32 WelcomeTimer;
+            uint32 WelcomeSequelTimer;
+            uint32 SpecialTimer;
+            uint32 WarningTimer;
+            uint32 TakeOffTimer;
+
+            bool WelcomeOff;
+            bool WelcomeSequelOff;
+            bool SpecialOff;
+            bool HealthWarningOff;
+            bool DisableTakeOff;
+
+        void Reset()
+        {
+            summonerGUID = 0;
+            WelcomeTimer = 4500;
+            WelcomeSequelTimer = 4500;
+            SpecialTimer = 10000;
+            WarningTimer = 25000;
+            TakeOffTimer = 3500;
+
+            WelcomeOff = false;
+            WelcomeSequelOff = false;
+            SpecialOff = false;
+            HealthWarningOff = false;
+            DisableTakeOff = false;
+        }
+            
+        void IsSummonedBy(Unit* summoner)
+        {   
+            if (instance->GetBossState(DATA_EREGOS_EVENT) == IN_PROGRESS)
+                if (Creature* eregos = me->FindNearestCreature(NPC_EREGOS, 450.0f, true))
+                {
+                    eregos->DespawnOrUnsummon(); // On retail this kills abusive call of drake during engaged Eregos
+                }
+            summonerGUID = summoner->GetGUID();
+            me->SetFacingToObject(summoner);
+            // TO DO: Drake Ques should be casted from vehicle to player, however the way core handle triggered spells from auras break it no matter the conditions. So this change the caster and give the same result until someone fix triggered spells from auras that involve implicit targets or make exception for this case.
+            if (me->GetEntry() == NPC_RUBY_DRAKE_VEHICLE)
+                summoner->CastSpell(summoner, SPELL_RIDE_RUBY_DRAKE_QUE);
+            if (me->GetEntry() == NPC_EMERALD_DRAKE_VEHICLE)
+                summoner->CastSpell(summoner, SPELL_RIDE_EMERALD_DRAKE_QUE);
+            if (me->GetEntry() == NPC_AMBER_DRAKE_VEHICLE)
+                summoner->CastSpell(summoner, SPELL_RIDE_AMBER_DRAKE_QUE);
+            Position pos;
+            summoner->GetPosition(&pos);
+            me->GetMotionMaster()->MovePoint(0, pos);
+        }
+
+        void MovementInform(uint32 type, uint32 id)
+        {
+            if (type == POINT_MOTION_TYPE && id == 0)
+            {
+                me->SetDisableGravity(false); // Needed this for proper animation after spawn, the summon in air fall to ground bug leave no other option for now, if this isn't used the drake will only walk on move.
+            }
+        }
+
+        void UpdateAI(const uint32 diff)
+        {
+            if (!(instance->GetBossState(DATA_VAROS_EVENT) == DONE))
+            {   
+                if (me->HasAuraType(SPELL_AURA_CONTROL_VEHICLE))
+                {
+                    if (!(WelcomeOff))
+                    {
+                        if (WelcomeTimer <= diff)
+                        {
+                            Talk(WHISPER_DRAKES_WELCOME, me->GetCreatorGUID());
+                            WelcomeOff = true;
+                            WelcomeSequelOff = true;
+                        }
+                        else WelcomeTimer -= diff;
+                    }
+                }
+            }
+            if (me->HasAuraType(SPELL_AURA_CONTROL_VEHICLE))
+            {
+                if (WelcomeSequelOff)
+                {
+                    if (WelcomeSequelTimer <= diff)
+                    {
+                        Talk(WHISPER_DRAKES_ABILITIES, me->GetCreatorGUID());
+                        WelcomeSequelOff = false;
+                    }   
+                    else WelcomeSequelTimer -= diff;
+                }
+            }
+            if (me->HasAuraType(SPELL_AURA_CONTROL_VEHICLE))
+            {
+                if (instance->GetBossState(DATA_UROM_EVENT) == DONE)
+                {
+                    if (!(SpecialOff))
+                    {
+                        if (SpecialTimer <= diff)
+                        { 
+                            Talk(WHISPER_DRAKES_SPECIAL, me->GetCreatorGUID());
+                            SpecialOff = true;
+                        }   
+                        else SpecialTimer -= diff;
+                    }
+                }
+            }
+            if (me->HasAuraType(SPELL_AURA_CONTROL_VEHICLE))
+            {
+                if (!(HealthWarningOff))
+                {  
+                    if (me->GetHealthPct() <= 40.0f)
+                    {
+                        Talk(WHISPER_DRAKES_LOWHEALTH, me->GetCreatorGUID());
+                        HealthWarningOff = true;
+                    }
+                }
+            } 
+            if (me->HasAuraType(SPELL_AURA_CONTROL_VEHICLE))
+            {    
+                if (HealthWarningOff)
+                { 
+                    if (WarningTimer <= diff)
+                    {
+                        HealthWarningOff = false;
+                        WarningTimer = 25000;
+                    }
+                    else WarningTimer -= diff;
+                } 
+            }
+            if (!(me->HasAuraType(SPELL_AURA_CONTROL_VEHICLE)))
+            {
+                if (!(DisableTakeOff))
+                {
+                    if (TakeOffTimer <= diff)
+                    {
+                        me->DespawnOrUnsummon(2050);
+                        me->SetOrientation(2.5f);
+                        me->SetSpeed(MOVE_FLIGHT, 1.0f, true);
+                        Talk(SAY_DRAKES_TAKEOFF);
+                        Position pos;
+                        me->GetPosition(&pos); 
+                        pos.m_positionX += 10.0f;
+                        pos.m_positionY += 10.0f;
+                        pos.m_positionZ += 12.0f;
+                        me->GetMotionMaster()->MovePoint(1, pos);
+                        DisableTakeOff = true;
+                    }
+                    else TakeOffTimer -= diff;
+                 }
+            }
+        };
+    };
+
+    CreatureAI* GetAI(Creature* creature) const
+    {
+        return new npc_ruby_emerald_amber_drakeAI(creature);
     }
 };
 
@@ -247,9 +482,50 @@ public:
     }
 };
 
+class spell_call_ruby_emerald_amber_drake : public SpellScriptLoader
+{
+public:
+    spell_call_ruby_emerald_amber_drake() : SpellScriptLoader("spell_call_ruby_emerald_amber_drake") { }
+
+    class spell_call_ruby_emerald_amber_drake_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_call_ruby_emerald_amber_drake_SpellScript);
+
+        void ChangeSummonPos(SpellEffIndex /*effIndex*/)
+        {
+            // Adjust effect summon position
+            WorldLocation summonPos = *GetExplTargetDest();
+            Position offset = {0.0f, 0.0f, 12.0f, 0.0f};
+            summonPos.RelocateOffset(offset);
+            SetExplTargetDest(summonPos);
+            GetHitDest()->RelocateOffset(offset);
+        }
+
+        void ModDestHeight(SpellEffIndex /*effIndex*/)
+        {
+            // Used to cast visual effect at proper position
+            Position offset = {0.0f, 0.0f, 12.0f, 0.0f};
+            const_cast<WorldLocation*>(GetExplTargetDest())->RelocateOffset(offset);
+        }
+
+        void Register()
+        {
+            OnEffectHit += SpellEffectFn(spell_call_ruby_emerald_amber_drake_SpellScript::ChangeSummonPos, EFFECT_0, SPELL_EFFECT_SUMMON);
+            OnEffectLaunch += SpellEffectFn(spell_call_ruby_emerald_amber_drake_SpellScript::ModDestHeight, EFFECT_0, SPELL_EFFECT_SUMMON);
+        }
+    };
+
+    SpellScript* GetSpellScript() const
+    {
+        return new spell_call_ruby_emerald_amber_drake_SpellScript();
+    }
+};
+
 void AddSC_oculus()
 {
-    new npc_oculus_drake();
+    new npc_verdisa_beglaristrasz_eternos();
     new npc_image_belgaristrasz();
+    new npc_ruby_emerald_amber_drake();
     new spell_gen_stop_time();
+    new spell_call_ruby_emerald_amber_drake();
 }

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.h
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.h
@@ -35,15 +35,22 @@ enum Data64
     DATA_EREGOS
 };
 
-enum Bosses
+enum Bosses_NPCs
 {
     NPC_DRAKOS                  = 27654,
     NPC_VAROS                   = 27447,
     NPC_UROM                    = 27655,
     NPC_EREGOS                  = 27656,
 
-    NPC_AZURE_RING_GUARDIAN     = 28236,
-    NPC_CENTRIFUGE_CONSTRUCT    = 27641,
+    NPC_AZURE_RING_GUARDIAN         = 28236,
+    NPC_CENTRIFUGE_CONSTRUCT        = 27641,
+    NPC_RUBY_DRAKE_VEHICLE          = 27756,
+    NPC_EMERALD_DRAKE_VEHICLE       = 27692,
+    NPC_AMBER_DRAKE_VEHICLE         = 27755,
+    NPC_VERDISA                     = 27657,
+    NPC_BELGARISTRASZ               = 27658,
+    NPC_ETERNOS                     = 27659,
+    NPC_GREATER_WHELP               = 28276
 };
 
 enum GameObjects


### PR DESCRIPTION
- Implement phasing (sniffed)
- Add drakes proper support (events, texts, conditions for spells), remove npc_spellclick_spells
- Add proper support for Gossip npcs
- Removed the arcane shield Urom use first time we are about to meet him, because he only get it after he spawns a wave, added Evocation casts from sniff/retail, I may break the tp bug these days and arcane shield handling
- Some db updates based on Aokromes sniffs
  I intended to do it all, but there are core issues I have no knowledge to fix and I don't want to jump to other things before fixing them. :) So, I will submit boss updates, if I ever fix them. There are still stuff do do for drakes spells left from before.
- Majour thanks to Shauren for helping me with summoning spells and w/e I ask him and all who answered my questions.
