### PR TITLE
Core/Battlegrounds: Fix visual honor gain in PvPLogData

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -430,7 +430,7 @@ void BattlegroundMgr::BuildPvpLogDataPacket(WorldPacket* data, Battleground* bg)
 
         if (!isArena) // Unk 3 prolly is (bg)
         {
-            buff << uint32(itr2->second->BonusHonor);
+            buff << uint32(itr2->second->BonusHonor / 100);
             buff << uint32(itr2->second->Deaths);
             buff << uint32(itr2->second->HonorableKills);
         }


### PR DESCRIPTION
At the end of BG honor gain is wrong
