### PR TITLE
correcting SotA teleports + cleanup

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -648,7 +648,7 @@ void BattlegroundSA::DestroyGate(Player* player, GameObject* go)
             }
 
             if (i < 5)
-                DelObject(i+9);
+                DelObject(i + 14);
             UpdatePlayerScore(player, SCORE_DESTROYED_WALL, 1);
             if (rewardHonor)
                 UpdatePlayerScore(player, SCORE_BONUS_HONOR, GetBonusHonorFromKill(1));

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -92,7 +92,7 @@ bool BattlegroundSA::ResetObjs()
             return false;
     }
 
-    for (uint8 i = BG_SA_BOAT_ONE; i < BG_SA_SIGIL_1; i++)
+    for (uint8 i = BG_SA_BOAT_ONE; i <= BG_SA_BOAT_TWO; i++)
     {
         uint32 boatid = 0;
         switch (i)
@@ -113,7 +113,7 @@ bool BattlegroundSA::ResetObjs()
             return false;
     }
 
-    for (uint8 i = BG_SA_SIGIL_1; i < BG_SA_CENTRAL_FLAG; i++)
+    for (uint8 i = BG_SA_SIGIL_1; i <= BG_SA_SIGIL_5; i++)
     {
         if (!AddObject(i, BG_SA_ObjEntries[i],
             BG_SA_ObjSpawnlocs[i][0], BG_SA_ObjSpawnlocs[i][1],
@@ -141,7 +141,7 @@ bool BattlegroundSA::ResetObjs()
     OverrideGunFaction();
     DemolisherStartState(true);
 
-    for (uint8 i = 0; i <= BG_SA_TITAN_RELIC; i++)
+    for (uint8 i = 0; i <= BG_SA_PORTAL_DEFFENDER_RED; i++)
     {
         SpawnBGObject(i, RESPAWN_IMMEDIATELY);
         GetBGObject(i)->SetUInt32Value(GAMEOBJECT_FACTION, defF);
@@ -182,22 +182,13 @@ bool BattlegroundSA::ResetObjs()
     }
 
     //GY capture points
-    for (uint8 i = BG_SA_CENTRAL_FLAG; i < BG_SA_PORTAL_DEFFENDER_BLUE; i++)
+    for (uint8 i = BG_SA_CENTRAL_FLAG; i <= BG_SA_LEFT_FLAG; i++)
     {
         AddObject(i, (BG_SA_ObjEntries[i] - (Attackers == TEAM_ALLIANCE ? 1 : 0)),
             BG_SA_ObjSpawnlocs[i][0], BG_SA_ObjSpawnlocs[i][1],
             BG_SA_ObjSpawnlocs[i][2], BG_SA_ObjSpawnlocs[i][3],
             0, 0, 0, 0, RESPAWN_ONE_DAY);
         GetBGObject(i)->SetUInt32Value(GAMEOBJECT_FACTION, atF);
-    }
-
-    for (uint8 i = BG_SA_PORTAL_DEFFENDER_BLUE; i < BG_SA_BOMB; i++)
-    {
-        AddObject(i, BG_SA_ObjEntries[i],
-            BG_SA_ObjSpawnlocs[i][0], BG_SA_ObjSpawnlocs[i][1],
-            BG_SA_ObjSpawnlocs[i][2], BG_SA_ObjSpawnlocs[i][3],
-            0, 0, 0, 0, RESPAWN_ONE_DAY);
-        GetBGObject(i)->SetUInt32Value(GAMEOBJECT_FACTION, defF);
     }
 
     for (uint8 i = BG_SA_BOMB; i < BG_SA_MAXOBJ; i++)
@@ -973,4 +964,3 @@ void BattlegroundSA::SendTransportsRemove(Player* player)
         player->GetSession()->SendPacket(&packet);
     }
 }
-

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -86,7 +86,7 @@ bool BattlegroundSA::ResetObjs()
     for (uint8 i = 0; i < 6; i++)
         GateStatus[i] = BG_SA_GATE_OK;
 
-    for (uint8 i = 0; i < BG_SA_BOAT_ONE; i++)
+    for (uint8 i = 0; i <= BG_SA_PORTAL_DEFFENDER_RED; i++)
     {
         if (!AddObject(i, BG_SA_ObjEntries[i], BG_SA_ObjSpawnlocs[i][0], BG_SA_ObjSpawnlocs[i][1], BG_SA_ObjSpawnlocs[i][2], BG_SA_ObjSpawnlocs[i][3], 0, 0, 0, 0, RESPAWN_ONE_DAY))
             return false;
@@ -113,7 +113,7 @@ bool BattlegroundSA::ResetObjs()
             return false;
     }
 
-    for (uint8 i = BG_SA_SIGIL_1; i <= BG_SA_SIGIL_5; i++)
+    for (uint8 i = BG_SA_SIGIL_1; i <= BG_SA_LEFT_FLAGPOLE; i++)
     {
         if (!AddObject(i, BG_SA_ObjEntries[i],
             BG_SA_ObjSpawnlocs[i][0], BG_SA_ObjSpawnlocs[i][1],

--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.h
@@ -228,6 +228,11 @@ enum BG_SA_Objects
     BG_SA_PURPLE_GATE,
     BG_SA_ANCIENT_GATE,
     BG_SA_TITAN_RELIC,
+    BG_SA_PORTAL_DEFFENDER_BLUE,
+    BG_SA_PORTAL_DEFFENDER_GREEN,
+    BG_SA_PORTAL_DEFFENDER_YELLOW,
+    BG_SA_PORTAL_DEFFENDER_PURPLE,
+    BG_SA_PORTAL_DEFFENDER_RED,
     BG_SA_BOAT_ONE,
     BG_SA_BOAT_TWO,
     BG_SA_SIGIL_1,
@@ -241,11 +246,6 @@ enum BG_SA_Objects
     BG_SA_CENTRAL_FLAG,
     BG_SA_RIGHT_FLAG,
     BG_SA_LEFT_FLAG,
-    BG_SA_PORTAL_DEFFENDER_BLUE,
-    BG_SA_PORTAL_DEFFENDER_GREEN,
-    BG_SA_PORTAL_DEFFENDER_YELLOW,
-    BG_SA_PORTAL_DEFFENDER_PURPLE,
-    BG_SA_PORTAL_DEFFENDER_RED,
     BG_SA_BOMB,
     BG_SA_MAXOBJ = BG_SA_BOMB+68
 };
@@ -259,6 +259,12 @@ float const BG_SA_ObjSpawnlocs[BG_SA_MAXOBJ][4] =
     { 1214.681f, 81.21f, 53.413f, 5.745f },
     { 878.555f, -108.2f, 117.845f, 0.0f },
     { 836.5f, -108.8f, 120.219f, 0.0f },
+    // Portal
+    {1468.380005f, -225.798996f, 30.896200f, 0.0f}, //blue
+    {1394.270020f, 72.551399f, 31.054300f, 0.0f}, //green
+    {1065.260010f, -89.79501f, 81.073402f, 0.0f}, //yellow
+    {1216.069946f, 47.904301f, 54.278198f, 0.0f}, //purple
+    {1255.569946f, -233.548996f, 56.43699f, 0.0f}, //red
     // Ships
     { 2679.696777f, -826.891235f, 3.712860f, 5.78367f}, //rot2 1 rot3 0.0002f
     { 2574.003662f, 981.261475f, 2.603424f, 0.807696f},
@@ -276,12 +282,6 @@ float const BG_SA_ObjSpawnlocs[BG_SA_MAXOBJ][4] =
     { 1215.108032f, -65.715767f, 70.084267f, -3.124123f},
     { 1338.859253f, -153.327316f, 30.895077f, -2.530723f},
     { 1309.192017f, 9.416233f, 30.893402f, 1.518436f},
-    // Portal
-    {1468.380005f, -225.798996f, 30.896200f, 0.0f}, //blue
-    {1394.270020f, 72.551399f, 31.054300f, 0.0f}, //green
-    {1065.260010f, -89.79501f, 81.073402f, 0.0f}, //yellow
-    {1216.069946f, 47.904301f, 54.278198f, 0.0f}, //purple
-    {1255.569946f, -233.548996f, 56.43699f, 0.0f}, //red
     // Bombs
     {1333.45f, 211.354f, 31.0538f, 5.03666f},
     {1334.29f, 209.582f, 31.0532f, 1.28088f},
@@ -375,6 +375,11 @@ uint32 const BG_SA_ObjEntries[BG_SA_MAXOBJ + BG_SA_FLAG_AMOUNT] =
     190723,
     192549,
     192834,
+    192819,
+    192819,
+    192819,
+    192819,
+    192819,
     0, // Boat
     0, // Boat
     192687,
@@ -388,11 +393,6 @@ uint32 const BG_SA_ObjEntries[BG_SA_MAXOBJ + BG_SA_FLAG_AMOUNT] =
     191310,
     191306,
     191308,
-    192819,
-    192819,
-    192819,
-    192819,
-    192819,
     190753
 };
 

--- a/src/server/scripts/Northrend/wintergrasp.cpp
+++ b/src/server/scripts/Northrend/wintergrasp.cpp
@@ -559,7 +559,8 @@ public:
         {
             if (Battlefield* wg = sBattlefieldMgr->GetBattlefieldByBattleId(BATTLEFIELD_BATTLEID_WG))
                 if (Player* target = GetExplTargetUnit()->ToPlayer())
-                    if (target->GetTeamId() != wg->GetDefenderTeam() || target->HasAura(SPELL_WINTERGRASP_TELEPORT_TRIGGER))
+                    // check if we are in Wintergrasp at all, SotA uses same teleport spells
+                    if ((target->GetZoneId() == 4197) && target->GetTeamId() != wg->GetDefenderTeam() || target->HasAura(SPELL_WINTERGRASP_TELEPORT_TRIGGER))
                         return SPELL_FAILED_BAD_TARGETS;
             return SPELL_CAST_OK;
         }


### PR DESCRIPTION
currently in SotA horde cannot use the teleport, as wintergrasp and sota teleporters use the same spell for porting. 
Also some minor cleanup to give the code more sense imo
