### PR TITLE
prevent char bugging at wrong faction change

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1803,7 +1803,7 @@ void WorldSession::HandleCharFactionOrRaceChange(WorldPacket& recv_data)
         trans->Append(stmt);
     }
 
-    if (recv_data.GetOpcode() == CMSG_CHAR_FACTION_CHANGE)
+    if (recv_data.GetOpcode() == CMSG_CHAR_FACTION_CHANGE && oldRace != race)
     {
         // Delete all Flypaths
         PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_TAXI_PATH);


### PR DESCRIPTION
currently even if your char is flagged for faction change, you can just go to the char customizing screen and not pick any new race, but the current one. If you do so, your char gets bugged. You will be hated with everyone etc. Possibly some items/spells break too, havent tested everything.
