### PR TITLE
Core/Battlefield: Fix crashes due to invalid pointers use

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -460,10 +460,9 @@ WorldPacket Battlefield::BuildWarningAnnPacket(std::string const& msg)
 
 void Battlefield::SendWarningToAllInZone(uint32 entry)
 {
-    if (Unit* unit = sObjectAccessor->FindUnit(StalkerGuid))
-        if (Creature* stalker = unit->ToCreature())
-            // FIXME: replaced CHAT_TYPE_END with CHAT_MSG_BG_SYSTEM_NEUTRAL to fix compile, it's a guessed change :/
-            sCreatureTextMgr->SendChat(stalker, (uint8) entry, 0, CHAT_MSG_BG_SYSTEM_NEUTRAL, LANG_ADDON, TEXT_RANGE_ZONE);
+    if (Creature* stalker = GetCreature(StalkerGuid))
+        // FIXME: replaced CHAT_TYPE_END with CHAT_MSG_BG_SYSTEM_NEUTRAL to fix compile, it's a guessed change :/
+        sCreatureTextMgr->SendChat(stalker, (uint8) entry, 0, CHAT_MSG_BG_SYSTEM_NEUTRAL, LANG_ADDON, TEXT_RANGE_ZONE);
 }
 
 /*void Battlefield::SendWarningToAllInWar(int32 entry,...)
@@ -483,9 +482,8 @@ void Battlefield::SendWarningToAllInZone(uint32 entry)
 void Battlefield::SendWarningToPlayer(Player* player, uint32 entry)
 {
     if (player)
-        if (Unit* unit = sObjectAccessor->FindUnit(StalkerGuid))
-            if (Creature* stalker = unit->ToCreature())
-                sCreatureTextMgr->SendChat(stalker, (uint8)entry, player->GetGUID());
+        if (Creature* stalker = GetCreature(StalkerGuid))
+            sCreatureTextMgr->SendChat(stalker, (uint8)entry, player->GetGUID());
 }
 
 void Battlefield::SendUpdateWorldState(uint32 field, uint32 value)
@@ -738,7 +736,7 @@ void BfGraveyard::Resurrect()
 
         // Check  if the player is in world and on the good graveyard
         if (player->IsInWorld())
-            if (Unit* spirit = sObjectAccessor->FindUnit(m_SpiritGuide[m_ControlTeam]))
+            if (Creature* spirit = m_Bf->GetCreature(m_SpiritGuide[m_ControlTeam]))
                 spirit->CastSpell(spirit, SPELL_SPIRIT_HEAL, true);
 
         // Resurect player
@@ -786,6 +784,18 @@ void BfGraveyard::RelocateDeadPlayers()
                 player->TeleportTo(player->GetMapId(), closestGrave->x, closestGrave->y, closestGrave->z, player->GetOrientation());
         }
     }
+}
+
+bool BfGraveyard::HasNpc(uint64 guid)
+{
+    if (!m_SpiritGuide[0] || !m_SpiritGuide[1])
+        return false;
+
+    if (!m_Bf->GetCreature(m_SpiritGuide[0]) ||
+        !m_Bf->GetCreature(m_SpiritGuide[1]))
+        return false;
+
+    return (m_SpiritGuide[0] == guid || m_SpiritGuide[1] == guid);
 }
 
 // *******************************************************
@@ -861,11 +871,25 @@ GameObject* Battlefield::SpawnGameObject(uint32 entry, float x, float y, float z
     return go;
 }
 
+Creature* Battlefield::GetCreature(uint64 GUID)
+{
+    if (!m_Map)
+        return NULL;
+    return m_Map->GetCreature(GUID);
+}
+
+GameObject* Battlefield::GetGameObject(uint64 GUID)
+{
+    if (!m_Map)
+        return NULL;
+    return m_Map->GetGameObject(GUID);
+}
+
 // *******************************************************
 // ******************* CapturePoint **********************
 // *******************************************************
 
-BfCapturePoint::BfCapturePoint(Battlefield* battlefield) : m_Bf(battlefield), m_capturePoint(NULL)
+BfCapturePoint::BfCapturePoint(Battlefield* battlefield) : m_Bf(battlefield), m_capturePointGUID(0)
 {
     m_team = TEAM_NEUTRAL;
     m_value = 0;
@@ -880,19 +904,24 @@ BfCapturePoint::BfCapturePoint(Battlefield* battlefield) : m_Bf(battlefield), m_
 
 bool BfCapturePoint::HandlePlayerEnter(Player* player)
 {
-    if (m_capturePoint)
+    if (m_capturePointGUID)
     {
-        player->SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
-        player->SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldstate2, uint32(ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f)));
-        player->SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldstate3, m_neutralValuePct);
+        if (GameObject* capturePoint = m_Bf->GetGameObject(m_capturePointGUID))
+        {
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, uint32(ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f)));
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate3, m_neutralValuePct);
+        }
     }
+    
     return m_activePlayers[player->GetTeamId()].insert(player->GetGUID()).second;
 }
 
 GuidSet::iterator BfCapturePoint::HandlePlayerLeave(Player* player)
 {
-    if (m_capturePoint)
-        player->SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldState1, 0);
+    if (m_capturePointGUID)
+        if (GameObject* capturePoint = m_Bf->GetGameObject(m_capturePointGUID))
+            player->SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 0);
 
     GuidSet::iterator current = m_activePlayers[player->GetTeamId()].find(player->GetGUID());
 
@@ -905,15 +934,18 @@ GuidSet::iterator BfCapturePoint::HandlePlayerLeave(Player* player)
 
 void BfCapturePoint::SendChangePhase()
 {
-    if (!m_capturePoint)
+    if (!m_capturePointGUID)
         return;
-
-    // send this too, sometimes the slider disappears, dunno why :(
-    SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
-    // send these updates to only the ones in this objective
-    SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32) ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f));
-    // send this too, sometimes it resets :S
-    SendUpdateWorldState(m_capturePoint->GetGOInfo()->capturePoint.worldstate3, m_neutralValuePct);
+        
+    if (GameObject* capturePoint = m_Bf->GetGameObject(m_capturePointGUID))
+    {
+        // send this too, sometimes the slider disappears, dunno why :(
+        SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldState1, 1);
+        // send these updates to only the ones in this objective
+        SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate2, (uint32) ceil((m_value + m_maxValue) / (2 * m_maxValue) * 100.0f));
+        // send this too, sometimes it resets :S
+        SendUpdateWorldState(capturePoint->GetGOInfo()->capturePoint.worldstate3, m_neutralValuePct);
+    }
 }
 
 bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint)
@@ -922,7 +954,7 @@ bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint)
 
     sLog->outDebug(LOG_FILTER_BATTLEFIELD, "Creating capture point %u", capturePoint->GetEntry());
 
-    m_capturePoint = capturePoint;
+    m_capturePointGUID = MAKE_NEW_GUID(capturePoint->GetGUIDLow(), capturePoint->GetEntry(), HIGHGUID_GAMEOBJECT);
 
     // check info existence
     GameObjectTemplate const* goinfo = capturePoint->GetGOInfo();
@@ -952,13 +984,22 @@ bool BfCapturePoint::SetCapturePointData(GameObject* capturePoint)
     return true;
 }
 
+GameObject* BfCapturePoint::GetCapturePointGo() 
+{ 
+    return m_Bf->GetGameObject(m_capturePointGUID); 
+}
+
 bool BfCapturePoint::DelCapturePoint()
 {
-    if (m_capturePoint)
+    if (m_capturePointGUID)
     {
-        m_capturePoint->SetRespawnTime(0);                  // not save respawn time
-        m_capturePoint->Delete();
-        m_capturePoint = NULL;
+        if (GameObject* capturePoint = m_Bf->GetGameObject(m_capturePointGUID))
+        {
+            capturePoint->SetRespawnTime(0);                  // not save respawn time
+            capturePoint->Delete();
+            capturePoint = NULL;
+        }
+        m_capturePointGUID = 0;
     }
 
     return true;
@@ -966,37 +1007,40 @@ bool BfCapturePoint::DelCapturePoint()
 
 bool BfCapturePoint::Update(uint32 diff)
 {
-    if (!m_capturePoint)
+    if (!m_capturePointGUID)
         return false;
 
-    float radius = m_capturePoint->GetGOInfo()->capturePoint.radius;
-
-    for (uint8 team = 0; team < 2; ++team)
+    if (GameObject* capturePoint = m_Bf->GetGameObject(m_capturePointGUID))
     {
-        for (GuidSet::iterator itr = m_activePlayers[team].begin(); itr != m_activePlayers[team].end();)
+        float radius = capturePoint->GetGOInfo()->capturePoint.radius;
+
+        for (uint8 team = 0; team < 2; ++team)
         {
-            if (Player* player = sObjectAccessor->FindPlayer(*itr))
+            for (GuidSet::iterator itr = m_activePlayers[team].begin(); itr != m_activePlayers[team].end();)
             {
-                if (!m_capturePoint->IsWithinDistInMap(player, radius) || !player->IsOutdoorPvPActive())
-                    itr = HandlePlayerLeave(player);
+                if (Player* player = sObjectAccessor->FindPlayer(*itr))
+                {
+                    if (!capturePoint->IsWithinDistInMap(player, radius) || !player->IsOutdoorPvPActive())
+                        itr = HandlePlayerLeave(player);
+                    else
+                        ++itr;
+                }
                 else
                     ++itr;
             }
-            else
-                ++itr;
         }
+
+        std::list<Player*> players;
+        Trinity::AnyPlayerInObjectRangeCheck checker(capturePoint, radius);
+        Trinity::PlayerListSearcher<Trinity::AnyPlayerInObjectRangeCheck> searcher(capturePoint, players, checker);
+        capturePoint->VisitNearbyWorldObject(radius, searcher);
+    
+        for (std::list<Player*>::iterator itr = players.begin(); itr != players.end(); ++itr)
+            if ((*itr)->IsOutdoorPvPActive())
+                if (m_activePlayers[(*itr)->GetTeamId()].insert((*itr)->GetGUID()).second)
+                    HandlePlayerEnter(*itr);
     }
-
-    std::list<Player*> players;
-    Trinity::AnyPlayerInObjectRangeCheck checker(m_capturePoint, radius);
-    Trinity::PlayerListSearcher<Trinity::AnyPlayerInObjectRangeCheck> searcher(m_capturePoint, players, checker);
-    m_capturePoint->VisitNearbyWorldObject(radius, searcher);
-
-    for (std::list<Player*>::iterator itr = players.begin(); itr != players.end(); ++itr)
-        if ((*itr)->IsOutdoorPvPActive())
-            if (m_activePlayers[(*itr)->GetTeamId()].insert((*itr)->GetGUID()).second)
-                HandlePlayerEnter(*itr);
-
+    
     // get the difference of numbers
     float fact_diff = ((float) m_activePlayers[0].size() - (float) m_activePlayers[1].size()) * diff / BATTLEFIELD_OBJECTIVE_UPDATE_INTERVAL;
     if (G3D::fuzzyEq(fact_diff, 0.0f))

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -103,8 +103,9 @@ class BfCapturePoint
         virtual void SendChangePhase();
 
         bool SetCapturePointData(GameObject* capturePoint);
-        GameObject* GetCapturePointGo() { return m_capturePoint; }
-
+        GameObject* GetCapturePointGo();
+        uint32 GetCapturePointEntry(){ return m_capturePointEntry; }
+        
         TeamId GetTeamId() { return m_team; }
     protected:
         bool DelCapturePoint();
@@ -137,7 +138,7 @@ class BfCapturePoint
         uint32 m_capturePointEntry;
 
         // Gameobject related to that capture point
-        GameObject* m_capturePoint;
+        uint64 m_capturePointGUID;
 };
 
 class BfGraveyard
@@ -171,17 +172,7 @@ class BfGraveyard
         void RelocateDeadPlayers();
 
         // Check if this graveyard has a spirit guide
-        bool HasNpc(uint64 guid)
-        {
-            if (!m_SpiritGuide[0] || !m_SpiritGuide[1])
-                return false;
-
-            if (!sObjectAccessor->FindUnit(m_SpiritGuide[0]) ||
-                !sObjectAccessor->FindUnit(m_SpiritGuide[1]))
-                return false;
-
-            return (m_SpiritGuide[0] == guid || m_SpiritGuide[1] == guid);
-        }
+        bool HasNpc(uint64 guid);
 
         // Check if a player is in this graveyard's ressurect queue
         bool HasPlayer(uint64 guid) { return m_ResurrectQueue.find(guid) != m_ResurrectQueue.end(); }
@@ -299,6 +290,9 @@ class Battlefield : public ZoneScript
         Creature* SpawnCreature(uint32 entry, Position pos, TeamId team);
         GameObject* SpawnGameObject(uint32 entry, float x, float y, float z, float o);
 
+        Creature* GetCreature(uint64 GUID);
+        GameObject* GetGameObject(uint64 GUID);
+        
         // Script-methods
 
         /// Called on start
@@ -377,6 +371,7 @@ class Battlefield : public ZoneScript
         uint32 m_BattleId;                                      // BattleID (for packet)
         uint32 m_ZoneId;                                        // ZoneID of Wintergrasp = 4197
         uint32 m_MapId;                                         // MapId where is Battlefield
+        Map* m_Map;
         uint32 m_MaxPlayer;                                     // Maximum number of player that participated to Battlefield
         uint32 m_MinPlayer;                                     // Minimum number of player for Battlefield start
         uint32 m_MinLevel;                                      // Required level to participate at Battlefield
@@ -412,7 +407,7 @@ class Battlefield : public ZoneScript
         void BroadcastPacketToWar(WorldPacket& data) const;
 
         // CapturePoint system
-        void AddCapturePoint(BfCapturePoint* cp) { m_capturePoints[cp->GetCapturePointGo()->GetEntry()] = cp; }
+        void AddCapturePoint(BfCapturePoint* cp) { m_capturePoints[cp->GetCapturePointEntry()] = cp; }
 
         BfCapturePoint* GetCapturePoint(uint32 lowguid) const
         {

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -50,7 +50,8 @@ bool BattlefieldWG::SetupBattlefield()
     m_BattleId = BATTLEFIELD_BATTLEID_WG;
     m_ZoneId = BATTLEFIELD_WG_ZONEID;
     m_MapId = BATTLEFIELD_WG_MAPID;
-
+    m_Map = sMapMgr->FindMap(m_MapId, 0);
+    
     m_MaxPlayer = sWorld->getIntConfig(CONFIG_WINTERGRASP_PLR_MAX);
     m_IsEnabled = sWorld->getBoolConfig(CONFIG_WINTERGRASP_ENABLE);
     m_MinPlayer = sWorld->getIntConfig(CONFIG_WINTERGRASP_PLR_MIN);
@@ -137,9 +138,8 @@ bool BattlefieldWG::SetupBattlefield()
 
     // Hide NPCs from the Attacker's team in the keep
     for (GuidSet::const_iterator itr = KeepCreature[GetAttackerTeam()].begin(); itr != KeepCreature[GetAttackerTeam()].end(); ++itr)
-        if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-            if (Creature* creature = unit->ToCreature())
-                HideNpc(creature);
+        if (Creature* creature = GetCreature(*itr))
+            HideNpc(creature);
 
     // Spawn Horde NPCs outside the keep
     for (uint8 i = 0; i < WG_OUTSIDE_ALLIANCE_NPC; i++)
@@ -153,9 +153,8 @@ bool BattlefieldWG::SetupBattlefield()
 
     // Hide units outside the keep that are defenders
     for (GuidSet::const_iterator itr = OutsideCreature[GetDefenderTeam()].begin(); itr != OutsideCreature[GetDefenderTeam()].end(); ++itr)
-        if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-            if (Creature* creature = unit->ToCreature())
-                HideNpc(creature);
+        if (Creature* creature = GetCreature(*itr))
+            HideNpc(creature);
 
     // Spawn turrets and hide them per default
     for (uint8 i = 0; i < WG_MAX_TURRET; i++)
@@ -172,20 +171,24 @@ bool BattlefieldWG::SetupBattlefield()
     // Spawn all gameobjects
     for (uint8 i = 0; i < WG_MAX_OBJ; i++)
     {
-        GameObject* go = SpawnGameObject(WGGameObjectBuilding[i].entry, WGGameObjectBuilding[i].x, WGGameObjectBuilding[i].y, WGGameObjectBuilding[i].z, WGGameObjectBuilding[i].o);
-        BfWGGameObjectBuilding* b = new BfWGGameObjectBuilding(this);
-        b->Init(go, WGGameObjectBuilding[i].type, WGGameObjectBuilding[i].WorldState, WGGameObjectBuilding[i].nameId);
-        if (!IsEnabled() && go->GetEntry() == GO_WINTERGRASP_VAULT_GATE)
-            go->SetDestructibleState(GO_DESTRUCTIBLE_DESTROYED);
-        BuildingsInZone.insert(b);
+        if (GameObject* go = SpawnGameObject(WGGameObjectBuilding[i].entry, WGGameObjectBuilding[i].x, WGGameObjectBuilding[i].y, WGGameObjectBuilding[i].z, WGGameObjectBuilding[i].o))
+        {
+            BfWGGameObjectBuilding* b = new BfWGGameObjectBuilding(this);
+            b->Init(go, WGGameObjectBuilding[i].type, WGGameObjectBuilding[i].WorldState, WGGameObjectBuilding[i].nameId);
+            if (!IsEnabled() && go->GetEntry() == GO_WINTERGRASP_VAULT_GATE)
+                go->SetDestructibleState(GO_DESTRUCTIBLE_DESTROYED);
+            BuildingsInZone.insert(b);
+        }
     }
 
     // Spawning portal defender
     for (uint8 i = 0; i < WG_MAX_TELEPORTER; i++)
     {
-        GameObject* go = SpawnGameObject(WGPortalDefenderData[i].entry, WGPortalDefenderData[i].x, WGPortalDefenderData[i].y, WGPortalDefenderData[i].z, WGPortalDefenderData[i].o);
-        DefenderPortalList.insert(go);
-        go->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[GetDefenderTeam()]);
+        if (GameObject* go = SpawnGameObject(WGPortalDefenderData[i].entry, WGPortalDefenderData[i].x, WGPortalDefenderData[i].y, WGPortalDefenderData[i].z, WGPortalDefenderData[i].o))
+        {
+            DefenderPortalList.insert(go->GetGUID());
+            go->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[GetDefenderTeam()]);
+        }
     }
 
     UpdateCounterVehicle(true);
@@ -211,13 +214,13 @@ bool BattlefieldWG::Update(uint32 diff)
 void BattlefieldWG::OnBattleStart()
 {
     // Spawn titan relic
-    m_titansRelic = SpawnGameObject(GO_WINTERGRASP_TITAN_S_RELIC, 5440.0f, 2840.8f, 430.43f, 0);
-    if (m_titansRelic)
+    if (GameObject* relic = SpawnGameObject(GO_WINTERGRASP_TITAN_S_RELIC, 5440.0f, 2840.8f, 430.43f, 0))
     {
         // Update faction of relic, only attacker can click on
-        m_titansRelic->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[GetAttackerTeam()]);
+        relic->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[GetAttackerTeam()]);
         // Set in use (not allow to click on before last door is broken)
-        m_titansRelic->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
+        relic->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
+        m_titansRelicGUID = relic->GetGUID();
     }
     else
         sLog->outError(LOG_FILTER_BATTLEFIELD, "WG: Failed to spawn titan relic.");
@@ -226,13 +229,10 @@ void BattlefieldWG::OnBattleStart()
     // Update tower visibility and update faction
     for (GuidSet::const_iterator itr = CanonList.begin(); itr != CanonList.end(); ++itr)
     {
-        if (Unit* unit = sObjectAccessor->FindUnit(*itr))
+        if (Creature* creature = GetCreature(*itr))
         {
-            if (Creature* creature = unit->ToCreature())
-            {
-                ShowNpc(creature, true);
-                creature->setFaction(WintergraspFaction[GetDefenderTeam()]);
-            }
+            ShowNpc(creature, true);
+            creature->setFaction(WintergraspFaction[GetDefenderTeam()]);
         }
     }
 
@@ -302,21 +302,19 @@ void BattlefieldWG::UpdateCounterVehicle(bool init)
 void BattlefieldWG::OnBattleEnd(bool endByTimer)
 {
     // Remove relic
-    if (m_titansRelic)
-        m_titansRelic->RemoveFromWorld();
-    m_titansRelic = NULL;
+    if (m_titansRelicGUID)
+        if (GameObject* relic = GetGameObject(m_titansRelicGUID))
+            relic->RemoveFromWorld();
+    m_titansRelicGUID = 0;
 
     // Remove turret
     for (GuidSet::const_iterator itr = CanonList.begin(); itr != CanonList.end(); ++itr)
     {
-        if (Unit* unit = sObjectAccessor->FindUnit(*itr))
+        if (Creature* creature = GetCreature(*itr))
         {
-            if (Creature* creature = unit->ToCreature())
-            {
-                if (!endByTimer)
-                    creature->setFaction(WintergraspFaction[GetDefenderTeam()]);
-                HideNpc(creature);
-            }
+            if (!endByTimer)
+                creature->setFaction(WintergraspFaction[GetDefenderTeam()]);
+            HideNpc(creature);
         }
     }
 
@@ -324,25 +322,21 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
     {
         // Change all npc in keep
         for (GuidSet::const_iterator itr = KeepCreature[GetAttackerTeam()].begin(); itr != KeepCreature[GetAttackerTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    HideNpc(creature);
+            if (Creature* creature = GetCreature(*itr))
+                HideNpc(creature);
 
         for (GuidSet::const_iterator itr = KeepCreature[GetDefenderTeam()].begin(); itr != KeepCreature[GetDefenderTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    ShowNpc(creature, true);
+            if (Creature* creature = GetCreature(*itr))
+                ShowNpc(creature, true);
 
         // Change all npc out of keep
         for (GuidSet::const_iterator itr = OutsideCreature[GetDefenderTeam()].begin(); itr != OutsideCreature[GetDefenderTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    HideNpc(creature);
+            if (Creature* creature = GetCreature(*itr))
+                HideNpc(creature);
 
         for (GuidSet::const_iterator itr = OutsideCreature[GetAttackerTeam()].begin(); itr != OutsideCreature[GetAttackerTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    ShowNpc(creature, true);
+            if (Creature* creature = GetCreature(*itr))
+                ShowNpc(creature, true);
     }
 
     // Update all graveyard, control is to defender when no wartime
@@ -350,15 +344,18 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
         if (BfGraveyard* graveyard = GetGraveyardById(i))
             graveyard->GiveControlTo(GetDefenderTeam());
 
-    for (GameObjectSet::const_iterator itr = m_KeepGameObject[GetDefenderTeam()].begin(); itr != m_KeepGameObject[GetDefenderTeam()].end(); ++itr)
-        (*itr)->SetRespawnTime(RESPAWN_IMMEDIATELY);
+    for (GuidSet::const_iterator itr = m_KeepGameObject[GetDefenderTeam()].begin(); itr != m_KeepGameObject[GetDefenderTeam()].end(); ++itr)
+        if (GameObject* object = GetGameObject(*itr))
+            object->SetRespawnTime(RESPAWN_IMMEDIATELY);
 
-    for (GameObjectSet::const_iterator itr = m_KeepGameObject[GetAttackerTeam()].begin(); itr != m_KeepGameObject[GetAttackerTeam()].end(); ++itr)
-        (*itr)->SetRespawnTime(RESPAWN_ONE_DAY);
+    for (GuidSet::const_iterator itr = m_KeepGameObject[GetAttackerTeam()].begin(); itr != m_KeepGameObject[GetAttackerTeam()].end(); ++itr)
+        if (GameObject* object = GetGameObject(*itr))
+            object->SetRespawnTime(RESPAWN_ONE_DAY);
 
     // Update portal defender faction
-    for (GameObjectSet::const_iterator itr = DefenderPortalList.begin(); itr != DefenderPortalList.end(); ++itr)
-        (*itr)->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[GetDefenderTeam()]);
+    for (GuidSet::const_iterator itr = DefenderPortalList.begin(); itr != DefenderPortalList.end(); ++itr)
+        if (GameObject* portal = GetGameObject(*itr))
+            portal->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[GetDefenderTeam()]);
 
     // Saving data
     for (GameObjectBuilding::const_iterator itr = BuildingsInZone.begin(); itr != BuildingsInZone.end(); ++itr)
@@ -393,10 +390,9 @@ void BattlefieldWG::OnBattleEnd(bool endByTimer)
         m_PlayersInWar[team].clear();
 
         for (GuidSet::const_iterator itr = m_vehicles[team].begin(); itr != m_vehicles[team].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    if (creature->IsVehicle())
-                        creature->GetVehicleKit()->Dismiss();
+            if (Creature* creature = GetCreature(*itr))
+                if (creature->IsVehicle())
+                    creature->GetVehicleKit()->Dismiss();
 
         m_vehicles[team].clear();
     }
@@ -645,18 +641,15 @@ void BattlefieldWG::HandleKill(Player* killer, Unit* victim)
     for (GuidSet::const_iterator itr = KeepCreature[GetOtherTeam(killerTeam)].begin();
          itr != KeepCreature[GetOtherTeam(killerTeam)].end(); ++itr)
     {
-        if (Unit* unit = sObjectAccessor->FindUnit(*itr))
+        if (Creature* creature = GetCreature(*itr))
         {
-            if (Creature* creature = unit->ToCreature())
+            if (victim->GetEntry() == creature->GetEntry() && !again)
             {
-                if (victim->GetEntry() == creature->GetEntry() && !again)
-                {
-                    again = true;
-                    for (GuidSet::const_iterator iter = m_PlayersInWar[killerTeam].begin(); iter != m_PlayersInWar[killerTeam].end(); ++iter)
-                        if (Player* player = sObjectAccessor->FindPlayer(*iter))
-                            if (player->GetDistance2d(killer) < 40.0f)
-                                PromotePlayer(player);
-                }
+                again = true;
+                for (GuidSet::const_iterator iter = m_PlayersInWar[killerTeam].begin(); iter != m_PlayersInWar[killerTeam].end(); ++iter)
+                    if (Player* player = sObjectAccessor->FindPlayer(*iter))
+                        if (player->GetDistance2d(killer) < 40.0f)
+                            PromotePlayer(player);
             }
         }
     }
@@ -933,22 +926,25 @@ void BattlefieldWG::ProcessEvent(WorldObject *obj, uint32 eventId)
     {
         if (CanInteractWithRelic())
             EndBattle(false);
-        else
-            GetRelic()->SetRespawnTime(RESPAWN_IMMEDIATELY);
+        else if (GameObject* relic = GetRelic())
+            relic->SetRespawnTime(RESPAWN_IMMEDIATELY);
     }
 
     // if destroy or damage event, search the wall/tower and update worldstate/send warning message
     for (GameObjectBuilding::const_iterator itr = BuildingsInZone.begin(); itr != BuildingsInZone.end(); ++itr)
     {
-        if (go->GetEntry() == (*itr)->m_Build->GetEntry())
+        if (GameObject* build = GetGameObject((*itr)->m_BuildGUID))
         {
-            if ((*itr)->m_Build->GetGOInfo()->building.damagedEvent == eventId)
-                (*itr)->Damaged();
+            if (go->GetEntry() == build->GetEntry())
+            {
+                if (build->GetGOInfo()->building.damagedEvent == eventId)
+                    (*itr)->Damaged();
 
-            if ((*itr)->m_Build->GetGOInfo()->building.destroyedEvent == eventId)
-                (*itr)->Destroyed();
+                if (build->GetGOInfo()->building.destroyedEvent == eventId)
+                    (*itr)->Destroyed();
 
-            break;
+                break;
+            }
         }
     }
 }
@@ -1004,9 +1000,8 @@ void BattlefieldWG::UpdateTenacity()
                     player->RemoveAurasDueToSpell(SPELL_TENACITY);
 
         for (GuidSet::const_iterator itr = m_vehicles[team].begin(); itr != m_vehicles[team].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    creature->RemoveAurasDueToSpell(SPELL_TENACITY_VEHICLE);
+            if (Creature* creature = GetCreature(*itr))
+                creature->RemoveAurasDueToSpell(SPELL_TENACITY_VEHICLE);
     }
 
     // Apply new buff
@@ -1032,9 +1027,8 @@ void BattlefieldWG::UpdateTenacity()
                 player->SetAuraStack(SPELL_TENACITY, player, newStack);
 
         for (GuidSet::const_iterator itr = m_vehicles[team].begin(); itr != m_vehicles[team].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    creature->SetAuraStack(SPELL_TENACITY_VEHICLE, creature, newStack);
+            if (Creature* creature = GetCreature(*itr))
+                creature->SetAuraStack(SPELL_TENACITY_VEHICLE, creature, newStack);
 
         if (buff_honor != 0)
         {
@@ -1042,9 +1036,8 @@ void BattlefieldWG::UpdateTenacity()
                 if (Player* player = sObjectAccessor->FindPlayer(*itr))
                     player->CastSpell(player, buff_honor, true);
             for (GuidSet::const_iterator itr = m_vehicles[team].begin(); itr != m_vehicles[team].end(); ++itr)
-                if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                    if (Creature* creature = unit->ToCreature())
-                        creature->CastSpell(creature, buff_honor, true);
+                if (Creature* creature = GetCreature(*itr))
+                    creature->CastSpell(creature, buff_honor, true);
         }
     }
 }

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -384,10 +384,10 @@ class BattlefieldWG : public Battlefield
         bool SetupBattlefield();
 
         /// Return pointer to relic object
-        GameObject* GetRelic() { return m_titansRelic; }
+        GameObject* GetRelic() { return GetGameObject(m_titansRelicGUID); }
 
         /// Define relic object
-        void SetRelic(GameObject* relic) { m_titansRelic = relic; }
+        void SetRelic(uint64 relicGUID) { m_titansRelicGUID = relicGUID; }
 
         /// Check if players can interact with the relic (Only if the last door has been broken)
         bool CanInteractWithRelic() { return m_isRelicInteractible; }
@@ -421,8 +421,8 @@ class BattlefieldWG : public Battlefield
 
         Workshop WorkshopsList;
 
-        GameObjectSet DefenderPortalList;
-        GameObjectSet m_KeepGameObject[2];
+        GuidSet DefenderPortalList;
+        GuidSet m_KeepGameObject[2];
         GameObjectBuilding BuildingsInZone;
 
         GuidSet m_vehicles[2];
@@ -433,7 +433,7 @@ class BattlefieldWG : public Battlefield
         uint32 m_tenacityStack;
         uint32 m_saveTimer;
 
-        GameObject* m_titansRelic;
+        uint64 m_titansRelicGUID;
 };
 
 uint32 const VehNumWorldState[]        = { 3680, 3490 };
@@ -1066,7 +1066,7 @@ struct BfWGGameObjectBuilding
     {
         m_WG = WG;
         m_Team = 0;
-        m_Build = NULL;
+        m_BuildGUID = 0;
         m_Type = 0;
         m_WorldState = 0;
         m_State = 0;
@@ -1080,7 +1080,7 @@ struct BfWGGameObjectBuilding
     BattlefieldWG* m_WG;
 
     // Linked gameobject
-    GameObject* m_Build;
+    uint64 m_BuildGUID;
 
     // eWGGameObjectBuildingType
     uint32 m_Type;
@@ -1095,7 +1095,7 @@ struct BfWGGameObjectBuilding
     uint32 m_NameId;
 
     // GameObject associations
-    GameObjectSet m_GameObjectList[2];
+    GuidSet m_GameObjectList[2];
 
     // Creature associations
     GuidSet m_CreatureBottomList[2];
@@ -1121,20 +1121,23 @@ struct BfWGGameObjectBuilding
                 break;
         }
 
-        // Rebuild gameobject
-        if (m_Build->IsDestructibleBuilding())
+        if (GameObject* build = m_WG->GetGameObject(m_BuildGUID))
         {
-            m_Build->SetDestructibleState(GO_DESTRUCTIBLE_REBUILDING, NULL, true);
-            if (m_Build->GetEntry() == GO_WINTERGRASP_VAULT_GATE)
-                if (GameObject* go = m_Build->FindNearestGameObject(GO_WINTERGRASP_KEEP_COLLISION_WALL, 10.0f))
-                    go->EnableCollision(true);
+            // Rebuild gameobject
+            if (build->IsDestructibleBuilding())
+            {
+                build->SetDestructibleState(GO_DESTRUCTIBLE_REBUILDING, NULL, true);
+                if (build->GetEntry() == GO_WINTERGRASP_VAULT_GATE)
+                    if (GameObject* go = build->FindNearestGameObject(GO_WINTERGRASP_KEEP_COLLISION_WALL, 50.0f))
+                        go->EnableCollision(true);
 
-            // Update worldstate
-            m_State = BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_INTACT - (m_Team * 3);
-            m_WG->SendUpdateWorldState(m_WorldState, m_State);
+                // Update worldstate
+                m_State = BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_INTACT - (m_Team * 3);
+                m_WG->SendUpdateWorldState(m_WorldState, m_State);
+            }
+            UpdateCreatureAndGo();
+            build->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[m_Team]);
         }
-        UpdateCreatureAndGo();
-        m_Build->SetUInt32Value(GAMEOBJECT_FACTION, WintergraspFaction[m_Team]);
     }
 
     // Called when associated gameobject is damaged
@@ -1149,14 +1152,12 @@ struct BfWGGameObjectBuilding
             m_WG->SendWarningToAllInZone(m_NameId);
 
         for (GuidSet::const_iterator itr = m_CreatureTopList[m_WG->GetAttackerTeam()].begin(); itr != m_CreatureTopList[m_WG->GetAttackerTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    m_WG->HideNpc(creature);
+            if (Creature* creature = m_WG->GetCreature(*itr))
+                m_WG->HideNpc(creature);
 
         for (GuidSet::const_iterator itr = m_TurretTopList.begin(); itr != m_TurretTopList.end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    m_WG->HideNpc(creature);
+            if (Creature* creature = m_WG->GetCreature(*itr))
+                m_WG->HideNpc(creature);
 
         if (m_Type == BATTLEFIELD_WG_OBJECTTYPE_KEEP_TOWER)
             m_WG->UpdateDamagedTowerCount(m_WG->GetDefenderTeam());
@@ -1183,8 +1184,9 @@ struct BfWGGameObjectBuilding
                 m_WG->UpdatedDestroyedTowerCount(TeamId(m_Team));
                 break;
             case BATTLEFIELD_WG_OBJECTTYPE_DOOR_LAST:
-                if (GameObject* go = m_Build->FindNearestGameObject(GO_WINTERGRASP_KEEP_COLLISION_WALL, 10.0f))
-                    go->EnableCollision(false);
+                if (GameObject* build = m_WG->GetGameObject(m_BuildGUID))
+                    if (GameObject* go = build->FindNearestGameObject(GO_WINTERGRASP_KEEP_COLLISION_WALL, 10.0f))
+                        go->EnableCollision(false);
                 m_WG->SetRelicInteractible(true);
                 if (m_WG->GetRelic())
                     m_WG->GetRelic()->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
@@ -1198,8 +1200,11 @@ struct BfWGGameObjectBuilding
 
     void Init(GameObject* go, uint32 type, uint32 worldstate, uint32 nameid)
     {
+        if (!go)
+            return;
+        
         // GameObject associated to object
-        m_Build = go;
+        m_BuildGUID = go->GetGUID();
 
         // Type of building (WALL/TOWER/DOOR)
         m_Type = type;
@@ -1227,23 +1232,20 @@ struct BfWGGameObjectBuilding
         }
 
         m_State = sWorld->getWorldState(m_WorldState);
-        if (m_Build)
+        switch (m_State)
         {
-            switch (m_State)
-            {
-                case BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_INTACT:
-                case BATTLEFIELD_WG_OBJECTSTATE_HORDE_INTACT:
-                    m_Build->SetDestructibleState(GO_DESTRUCTIBLE_REBUILDING, NULL, true);
-                    break;
-                case BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_DESTROY:
-                case BATTLEFIELD_WG_OBJECTSTATE_HORDE_DESTROY:
-                    m_Build->SetDestructibleState(GO_DESTRUCTIBLE_DESTROYED);
-                    break;
-                case BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_DAMAGE:
-                case BATTLEFIELD_WG_OBJECTSTATE_HORDE_DAMAGE:
-                    m_Build->SetDestructibleState(GO_DESTRUCTIBLE_DAMAGED);
-                    break;
-            }
+            case BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_INTACT:
+            case BATTLEFIELD_WG_OBJECTSTATE_HORDE_INTACT:
+                go->SetDestructibleState(GO_DESTRUCTIBLE_REBUILDING, NULL, true);
+                break;
+            case BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_DESTROY:
+            case BATTLEFIELD_WG_OBJECTSTATE_HORDE_DESTROY:
+                go->SetDestructibleState(GO_DESTRUCTIBLE_DESTROYED);
+                break;
+            case BATTLEFIELD_WG_OBJECTSTATE_ALLIANCE_DAMAGE:
+            case BATTLEFIELD_WG_OBJECTSTATE_HORDE_DAMAGE:
+                go->SetDestructibleState(GO_DESTRUCTIBLE_DAMAGED);
+                break;
         }
 
         int32 towerid = -1;
@@ -1279,9 +1281,9 @@ struct BfWGGameObjectBuilding
             {
                 WintergraspObjectPositionData gobData = AttackTowers[towerid - 4].GameObject[i];
                 if (GameObject* go = m_WG->SpawnGameObject(gobData.entryHorde, gobData.x, gobData.y, gobData.z, gobData.o))
-                    m_GameObjectList[TEAM_HORDE].insert(go);
+                    m_GameObjectList[TEAM_HORDE].insert(go->GetGUID());
                 if (GameObject* go = m_WG->SpawnGameObject(gobData.entryAlliance, gobData.x, gobData.y, gobData.z, gobData.o))
-                    m_GameObjectList[TEAM_ALLIANCE].insert(go);
+                    m_GameObjectList[TEAM_ALLIANCE].insert(go->GetGUID());
             }
 
             // Spawn associate npc bottom
@@ -1365,64 +1367,59 @@ struct BfWGGameObjectBuilding
     void UpdateCreatureAndGo()
     {
         for (GuidSet::const_iterator itr = m_CreatureTopList[m_WG->GetDefenderTeam()].begin(); itr != m_CreatureTopList[m_WG->GetDefenderTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    m_WG->HideNpc(creature);
+            if (Creature* creature = m_WG->GetCreature(*itr))
+                m_WG->HideNpc(creature);
 
         for (GuidSet::const_iterator itr = m_CreatureTopList[m_WG->GetAttackerTeam()].begin(); itr != m_CreatureTopList[m_WG->GetAttackerTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    m_WG->ShowNpc(creature, true);
+            if (Creature* creature = m_WG->GetCreature(*itr))
+                m_WG->ShowNpc(creature, true);
 
         for (GuidSet::const_iterator itr = m_CreatureBottomList[m_WG->GetDefenderTeam()].begin(); itr != m_CreatureBottomList[m_WG->GetDefenderTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    m_WG->HideNpc(creature);
+            if (Creature* creature = m_WG->GetCreature(*itr))
+                m_WG->HideNpc(creature);
 
         for (GuidSet::const_iterator itr = m_CreatureBottomList[m_WG->GetAttackerTeam()].begin(); itr != m_CreatureBottomList[m_WG->GetAttackerTeam()].end(); ++itr)
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                if (Creature* creature = unit->ToCreature())
-                    m_WG->ShowNpc(creature, true);
+            if (Creature* creature = m_WG->GetCreature(*itr))
+                m_WG->ShowNpc(creature, true);
 
-        for (GameObjectSet::const_iterator itr = m_GameObjectList[m_WG->GetDefenderTeam()].begin(); itr != m_GameObjectList[m_WG->GetDefenderTeam()].end(); ++itr)
-            (*itr)->SetRespawnTime(RESPAWN_ONE_DAY);
+        for (GuidSet::const_iterator itr = m_GameObjectList[m_WG->GetDefenderTeam()].begin(); itr != m_GameObjectList[m_WG->GetDefenderTeam()].end(); ++itr)
+            if (GameObject* object = m_WG->GetGameObject(*itr))
+                object->SetRespawnTime(RESPAWN_ONE_DAY);
 
-        for (GameObjectSet::const_iterator itr = m_GameObjectList[m_WG->GetAttackerTeam()].begin(); itr != m_GameObjectList[m_WG->GetAttackerTeam()].end(); ++itr)
-            (*itr)->SetRespawnTime(RESPAWN_IMMEDIATELY);
+        for (GuidSet::const_iterator itr = m_GameObjectList[m_WG->GetAttackerTeam()].begin(); itr != m_GameObjectList[m_WG->GetAttackerTeam()].end(); ++itr)
+            if (GameObject* object = m_WG->GetGameObject(*itr))
+                object->SetRespawnTime(RESPAWN_IMMEDIATELY);
     }
 
     void UpdateTurretAttack(bool disable)
     {
         for (GuidSet::const_iterator itr = m_TowerCannonBottomList.begin(); itr != m_TowerCannonBottomList.end(); ++itr)
         {
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
+            if (Creature* creature = m_WG->GetCreature(*itr))
             {
-                if (Creature* creature = unit->ToCreature())
+                if (GameObject* build = m_WG->GetGameObject(m_BuildGUID))
                 {
-                    if (m_Build)
-                    {
-                        if (disable)
-                            m_WG->HideNpc(creature);
-                        else
-                            m_WG->ShowNpc(creature, true);
+                    if (disable)
+                        m_WG->HideNpc(creature);
+                    else
+                        m_WG->ShowNpc(creature, true);
 
-                        switch (m_Build->GetEntry())
+                    switch (build->GetEntry())
+                    {
+                        case GO_WINTERGRASP_FORTRESS_TOWER_1:
+                        case GO_WINTERGRASP_FORTRESS_TOWER_2:
+                        case GO_WINTERGRASP_FORTRESS_TOWER_3:
+                        case GO_WINTERGRASP_FORTRESS_TOWER_4:
                         {
-                            case GO_WINTERGRASP_FORTRESS_TOWER_1:
-                            case GO_WINTERGRASP_FORTRESS_TOWER_2:
-                            case GO_WINTERGRASP_FORTRESS_TOWER_3:
-                            case GO_WINTERGRASP_FORTRESS_TOWER_4:
-                            {
-                                creature->setFaction(WintergraspFaction[m_WG->GetDefenderTeam()]);
-                                break;
-                            }
-                            case GO_WINTERGRASP_SHADOWSIGHT_TOWER:
-                            case GO_WINTERGRASP_WINTER_S_EDGE_TOWER:
-                            case GO_WINTERGRASP_FLAMEWATCH_TOWER:
-                            {
-                                creature->setFaction(WintergraspFaction[m_WG->GetAttackerTeam()]);
-                                break;
-                            }
+                            creature->setFaction(WintergraspFaction[m_WG->GetDefenderTeam()]);
+                            break;
+                        }
+                        case GO_WINTERGRASP_SHADOWSIGHT_TOWER:
+                        case GO_WINTERGRASP_WINTER_S_EDGE_TOWER:
+                        case GO_WINTERGRASP_FLAMEWATCH_TOWER:
+                        {
+                            creature->setFaction(WintergraspFaction[m_WG->GetAttackerTeam()]);
+                            break;
                         }
                     }
                 }
@@ -1431,34 +1428,31 @@ struct BfWGGameObjectBuilding
 
         for (GuidSet::const_iterator itr = m_TurretTopList.begin(); itr != m_TurretTopList.end(); ++itr)
         {
-            if (Unit* unit = sObjectAccessor->FindUnit(*itr))
+            if (Creature* creature = m_WG->GetCreature(*itr))
             {
-                if (Creature* creature = unit->ToCreature())
+                if (GameObject* build = m_WG->GetGameObject(m_BuildGUID))
                 {
-                    if (m_Build)
-                    {
-                        if (disable)
-                            m_WG->HideNpc(creature);
-                        else
-                            m_WG->ShowNpc(creature, true);
+                    if (disable)
+                        m_WG->HideNpc(creature);
+                    else
+                        m_WG->ShowNpc(creature, true);
 
-                        switch (m_Build->GetEntry())
+                    switch (build->GetEntry())
+                    {
+                        case GO_WINTERGRASP_FORTRESS_TOWER_1:
+                        case GO_WINTERGRASP_FORTRESS_TOWER_2:
+                        case GO_WINTERGRASP_FORTRESS_TOWER_3:
+                        case GO_WINTERGRASP_FORTRESS_TOWER_4:
                         {
-                            case GO_WINTERGRASP_FORTRESS_TOWER_1:
-                            case GO_WINTERGRASP_FORTRESS_TOWER_2:
-                            case GO_WINTERGRASP_FORTRESS_TOWER_3:
-                            case GO_WINTERGRASP_FORTRESS_TOWER_4:
-                            {
-                                creature->setFaction(WintergraspFaction[m_WG->GetDefenderTeam()]);
-                                break;
-                            }
-                            case GO_WINTERGRASP_SHADOWSIGHT_TOWER:
-                            case GO_WINTERGRASP_WINTER_S_EDGE_TOWER:
-                            case GO_WINTERGRASP_FLAMEWATCH_TOWER:
-                            {
-                                creature->setFaction(WintergraspFaction[m_WG->GetAttackerTeam()]);
-                                break;
-                            }
+                            creature->setFaction(WintergraspFaction[m_WG->GetDefenderTeam()]);
+                            break;
+                        }
+                        case GO_WINTERGRASP_SHADOWSIGHT_TOWER:
+                        case GO_WINTERGRASP_WINTER_S_EDGE_TOWER:
+                        case GO_WINTERGRASP_FLAMEWATCH_TOWER:
+                        {
+                            creature->setFaction(WintergraspFaction[m_WG->GetAttackerTeam()]);
+                            break;
                         }
                     }
                 }
@@ -1545,19 +1539,19 @@ struct WGWorkshop
 struct WintergraspWorkshopData
 {
     BattlefieldWG* m_WG;                                    // Pointer to wintergrasp
-    GameObject* m_Build;
+    uint64 m_BuildGUID;
     uint32 m_Type;
     uint32 m_State;                                         // For worldstate
     uint32 m_WorldState;
     uint32 m_TeamControl;                                   // Team witch control the workshop
     GuidSet m_CreatureOnPoint[2];                           // Contain all Creature associate to this point
-    GameObjectSet m_GameObjectOnPoint[2];                   // Contain all Gameobject associate to this point
+    GuidSet m_GameObjectOnPoint[2];                     // Contain all Gameobject associate to this point
     uint32 m_NameId;                                        // Id of trinity_string witch contain name of this node, using for alert message
 
     WintergraspWorkshopData(BattlefieldWG* WG)
     {
         m_WG = WG;
-        m_Build = NULL;
+        m_BuildGUID = 0;
         m_Type = 0;
         m_State = 0;
         m_WorldState = 0;
@@ -1579,9 +1573,9 @@ struct WintergraspWorkshopData
     void AddGameObject(WintergraspObjectPositionData obj)
     {
         if (GameObject* gameobject = m_WG->SpawnGameObject(obj.entryHorde, obj.x, obj.y, obj.z, obj.o))
-            m_GameObjectOnPoint[TEAM_HORDE].insert(gameobject);
+            m_GameObjectOnPoint[TEAM_HORDE].insert(gameobject->GetGUID());
         if (GameObject* gameobject = m_WG->SpawnGameObject(obj.entryAlliance, obj.x, obj.y, obj.z, obj.o))
-            m_GameObjectOnPoint[TEAM_ALLIANCE].insert(gameobject);
+            m_GameObjectOnPoint[TEAM_ALLIANCE].insert(gameobject->GetGUID());
     }
 
     // Init method, setup variable
@@ -1608,23 +1602,23 @@ struct WintergraspWorkshopData
             {
                 // Show Alliance creature
                 for (GuidSet::const_iterator itr = m_CreatureOnPoint[TEAM_ALLIANCE].begin(); itr != m_CreatureOnPoint[TEAM_ALLIANCE].end(); ++itr)
-                    if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                        if (Creature* creature = unit->ToCreature())
-                            m_WG->ShowNpc(creature, creature->GetEntry() != 30499);
+                    if (Creature* creature = m_WG->GetCreature(*itr))
+                        m_WG->ShowNpc(creature, creature->GetEntry() != 30499);
 
                 // Hide Horde creature
                 for (GuidSet::const_iterator itr = m_CreatureOnPoint[TEAM_HORDE].begin(); itr != m_CreatureOnPoint[TEAM_HORDE].end(); ++itr)
-                    if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                        if (Creature* creature = unit->ToCreature())
-                            m_WG->HideNpc(creature);
+                    if (Creature* creature = m_WG->GetCreature(*itr))
+                        m_WG->HideNpc(creature);
 
                 // Show Alliance gameobject
-                for (GameObjectSet::const_iterator itr = m_GameObjectOnPoint[TEAM_ALLIANCE].begin(); itr != m_GameObjectOnPoint[TEAM_ALLIANCE].end(); ++itr)
-                    (*itr)->SetRespawnTime(RESPAWN_IMMEDIATELY);
+                for (GuidSet::const_iterator itr = m_GameObjectOnPoint[TEAM_ALLIANCE].begin(); itr != m_GameObjectOnPoint[TEAM_ALLIANCE].end(); ++itr)
+                    if (GameObject* object = m_WG->GetGameObject(*itr))
+                        object->SetRespawnTime(RESPAWN_IMMEDIATELY);
 
                 // Hide Horde gameobject
-                for (GameObjectSet::const_iterator itr = m_GameObjectOnPoint[TEAM_HORDE].begin(); itr != m_GameObjectOnPoint[TEAM_HORDE].end(); ++itr)
-                    (*itr)->SetRespawnTime(RESPAWN_ONE_DAY);
+                for (GuidSet::const_iterator itr = m_GameObjectOnPoint[TEAM_HORDE].begin(); itr != m_GameObjectOnPoint[TEAM_HORDE].end(); ++itr)
+                    if (GameObject* object = m_WG->GetGameObject(*itr))
+                        object->SetRespawnTime(RESPAWN_ONE_DAY);
 
 
                 // Updating worldstate
@@ -1647,23 +1641,23 @@ struct WintergraspWorkshopData
             {
                 // Show Horde creature
                 for (GuidSet::const_iterator itr = m_CreatureOnPoint[TEAM_HORDE].begin(); itr != m_CreatureOnPoint[TEAM_HORDE].end(); ++itr)
-                    if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                        if (Creature* creature = unit->ToCreature())
-                            m_WG->ShowNpc(creature, creature->GetEntry() != 30400);
+                    if (Creature* creature = m_WG->GetCreature(*itr))
+                        m_WG->ShowNpc(creature, creature->GetEntry() != 30400);
 
                 // Hide Alliance creature
                 for (GuidSet::const_iterator itr = m_CreatureOnPoint[TEAM_ALLIANCE].begin(); itr != m_CreatureOnPoint[TEAM_ALLIANCE].end(); ++itr)
-                    if (Unit* unit = sObjectAccessor->FindUnit(*itr))
-                        if (Creature* creature = unit->ToCreature())
-                            m_WG->HideNpc(creature);
+                    if (Creature* creature = m_WG->GetCreature(*itr))
+                        m_WG->HideNpc(creature);
 
                 // Hide Alliance gameobject
-                for (GameObjectSet::const_iterator itr = m_GameObjectOnPoint[TEAM_ALLIANCE].begin(); itr != m_GameObjectOnPoint[TEAM_ALLIANCE].end(); ++itr)
-                    (*itr)->SetRespawnTime(RESPAWN_ONE_DAY);
+                for (GuidSet::const_iterator itr = m_GameObjectOnPoint[TEAM_ALLIANCE].begin(); itr != m_GameObjectOnPoint[TEAM_ALLIANCE].end(); ++itr)
+                    if (GameObject* object = m_WG->GetGameObject(*itr))
+                        object->SetRespawnTime(RESPAWN_ONE_DAY);
 
                 // Show Horde gameobject
-                for (GameObjectSet::const_iterator itr = m_GameObjectOnPoint[TEAM_HORDE].begin(); itr != m_GameObjectOnPoint[TEAM_HORDE].end(); ++itr)
-                    (*itr)->SetRespawnTime(RESPAWN_IMMEDIATELY);
+                for (GuidSet::const_iterator itr = m_GameObjectOnPoint[TEAM_HORDE].begin(); itr != m_GameObjectOnPoint[TEAM_HORDE].end(); ++itr)
+                    if (GameObject* object = m_WG->GetGameObject(*itr))
+                        object->SetRespawnTime(RESPAWN_IMMEDIATELY);
 
                 // Update worlstate
                 m_State = BATTLEFIELD_WG_OBJECTSTATE_HORDE_INTACT;


### PR DESCRIPTION
Related to: https://github.com/TrinityCore/TrinityCore/issues/7805

Move all pointers (GameObject*) to GUIDs in both Battlefield system and Wintergrasp zone.
Should be deeply tested before merging as I can't verify it to be completely solving the problem.
