### PR TITLE
Core/Calendar: Minor change.

### DIFF
--- a/src/server/game/Calendar/CalendarMgr.cpp
+++ b/src/server/game/Calendar/CalendarMgr.cpp
@@ -44,8 +44,8 @@ CalendarMgr::~CalendarMgr()
 void CalendarMgr::LoadFromDB()
 {
     uint32 count = 0;
-    _maxEventId = 1;
-    _maxInviteId = 1;
+    _maxEventId = 0;
+    _maxInviteId = 0;
 
     //                                                       0   1        2      3            4     5        6          7      8
     if (QueryResult result = CharacterDatabase.Query("SELECT id, creator, title, description, type, dungeon, eventtime, flags, time2 FROM calendar_events"))


### PR DESCRIPTION
Requested by Horn (Who can't make a PR atm).

> <Horn> https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Calendar/CalendarMgr.cpp#L47
> <Horn> and line 48
> <Horn> both max ids are set to 1
> <Horn> but
> <Horn> when calendar_events and calendar_invites are empty
> <Horn> and we try to get first free event / invite id
> <Horn> https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Calendar/CalendarMgr.cpp#L303
> <Horn> ++_maxEvent/InviteId is returned
> <Horn> -> 2
> <Horn> so initialize these 2 variables to 0
> <Horn> so 1 is returned
