### PR TITLE
Scripts/Spells: Fix Unholy Blight not stacking

### DIFF
--- a/sql/updates/world/2012_11_20_00_world_spell_script_names.sql
+++ b/sql/updates/world/2012_11_20_00_world_spell_script_names.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=50536;
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(50536, 'spell_dk_unholy_blight');

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -656,13 +656,6 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
                         AddPct(amount, m_spellInfo->Effects[EFFECT_2].CalcValue(caster));
                 }
             }
-            // Unholy Blight damage over time effect
-            else if (GetId() == 50536)
-            {
-                m_canBeRecalculated = false;
-                // we're getting total damage on aura apply, change it to be damage per tick
-                amount = int32((float)amount / GetTotalTicks());
-            }
             break;
         case SPELL_AURA_PERIODIC_ENERGIZE:
             switch (m_spellInfo->Id)

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -43,6 +43,7 @@ enum DeathKnightSpells
     DK_SPELL_IMPROVED_UNHOLY_PRESENCE_TRIGGERED = 63622,
     SPELL_DK_ITEM_T8_MELEE_4P_BONUS             = 64736,
     DK_SPELL_BLACK_ICE_R1                       = 49140,
+    DK_SPELL_UNHOLY_BLIGHT                      = 50536
 };
 
 // 50462 - Anti-Magic Shell (on raid member)
@@ -848,6 +849,52 @@ class spell_dk_death_grip : public SpellScriptLoader
         }
 };
 
+/* Spell: Unholy Blight
+   ID: 50536
+   Note: As of Patch 3.2.0 (2009-08-04) the spell's damage accumulates in the same way as Ignite and Deep Wounds. */
+class spell_dk_unholy_blight : public SpellScriptLoader
+{
+public:
+    spell_dk_unholy_blight() : SpellScriptLoader("spell_dk_unholy_blight") { }
+
+    class spell_dk_unholy_blight_AuraScript : public AuraScript
+    {
+        PrepareAuraScript(spell_dk_unholy_blight_AuraScript);
+
+        //Keep track of how much damage the spell has done in the previous cast per tick. Used to accumulate the total damage.
+        int32 prev_damage_per_tick;
+
+        bool Validate(SpellInfo const* /*entry*/)
+        {
+            if (!sSpellMgr->GetSpellInfo(DK_SPELL_UNHOLY_BLIGHT))
+                return false;
+            return true;
+        }
+
+        bool Load()
+        {
+            prev_damage_per_tick = 0;
+            return true;
+        }
+
+        void CalculateAmount(AuraEffect const* aurEff, int32 & amount, bool & /*canBeRecalculated*/)
+        {
+            prev_damage_per_tick += amount / aurEff->GetTotalTicks();
+            amount = prev_damage_per_tick;
+        }
+
+        void Register()
+        {
+            DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_dk_unholy_blight_AuraScript::CalculateAmount, EFFECT_0, SPELL_AURA_PERIODIC_DAMAGE);
+        }
+    };
+
+    AuraScript* GetAuraScript() const
+    {
+        return new spell_dk_unholy_blight_AuraScript();
+    }
+};
+
 void AddSC_deathknight_spell_scripts()
 {
     new spell_dk_anti_magic_shell_raid();
@@ -866,4 +913,5 @@ void AddSC_deathknight_spell_scripts()
     new spell_dk_death_strike();
     new spell_dk_death_coil();
     new spell_dk_death_grip();
+    new spell_dk_unholy_blight();
 }


### PR DESCRIPTION
Note: As of patch 3.2.0: The damage supposed to accumulate similar to Ignite and Deep wounds.
Source: http://www.wowwiki.com/Unholy_Blight

Closes: #8265
