### PR TITLE
Scripts/Spells: Fix Unholy Blight not stacking.

### DIFF
--- a/sql/updates/world/2012_11_20_00_world_spell_script_names.sql
+++ b/sql/updates/world/2012_11_20_00_world_spell_script_names.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=50536;
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(50536, 'spell_dk_unholy_blight');

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -656,13 +656,6 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
                         AddPct(amount, m_spellInfo->Effects[EFFECT_2].CalcValue(caster));
                 }
             }
-            // Unholy Blight damage over time effect
-            else if (GetId() == 50536)
-            {
-                m_canBeRecalculated = false;
-                // we're getting total damage on aura apply, change it to be damage per tick
-                amount = int32((float)amount / GetTotalTicks());
-            }
             break;
         case SPELL_AURA_PERIODIC_ENERGIZE:
             switch (m_spellInfo->Id)


### PR DESCRIPTION
Note: As of patch 3.2.0: The damage supposed to accumulate similar to Ignite and Deep wounds.
Source: http://www.wowwiki.com/Unholy_Blight

Closes: #8265
