### PR TITLE
World/Achievements: Piligrim's Peril

### DIFF
--- a/sql/updates/world/2012_11_20_00_world_achievement_criteria_data.sql
+++ b/sql/updates/world/2012_11_20_00_world_achievement_criteria_data.sql
@@ -1,0 +1,30 @@
+-- Achievement: Pilgrim's Peril
+-- Based on Vincent-Michael fix
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (11134,11135,11136,11137,11138,11139,11140,11141);
+INSERT INTO `achievement_criteria_data` (`criteria_id`,`type`,`value1`,`value2`,`ScriptName`) VALUES
+-- Horde
+(11134,6,14,0,''), -- Orgrimmar
+(11134,11,0,0,'achievement_piligrims_peril'),
+(11134,16,404,0,''), -- Orgrimmar
+(11135,6,3470,0,''), -- Silvermoon City
+(11135,11,0,0,'achievement_piligrims_peril'),
+(11135,16,404,0,''), -- Silvermoon City
+(11136,6,1638,0,''), -- Thunder Bluff
+(11136,11,0,0,'achievement_piligrims_peril'),
+(11136,16,404,0,''), -- Thunder Bluff
+(11137,6,1497,0,''), -- Undercity
+(11137,11,0,0,'achievement_piligrims_peril'),
+(11137,16,404,0,''), -- Undercity
+-- Alliance
+(11138,6,3557,0,''), -- Exodar
+(11138,11,0,0,'achievement_piligrims_peril'),
+(11138,16,404,0,''), -- Exodar
+(11139,6,1657,0,''), -- Darnassus
+(11139,11,0,0,'achievement_piligrims_peril'),
+(11139,16,404,0,''), -- Darnassus
+(11140,6,809,0,''), -- Ironforge
+(11140,11,0,0,'achievement_piligrims_peril'),
+(11140,16,404,0,''), -- Ironforge
+(11141,6,12,0,''), -- Stormwind
+(11141,11,0,0,'achievement_piligrims_peril'),
+(11141,16,404,0,''); -- Stormwind

--- a/src/server/scripts/World/achievement_scripts.cpp
+++ b/src/server/scripts/World/achievement_scripts.cpp
@@ -315,6 +315,22 @@ class achievement_not_even_a_scratch : public AchievementCriteriaScript
         }
 };
 
+class achievement_piligrims_peril : public AchievementCriteriaScript
+{
+	public:
+		achievement_piligrims_peril() : AchievementCriteriaScript("achievement_piligrims_peril") { }
+
+		bool OnCheck(Player* source, Unit* /*target*/)
+		{
+			if (source->HasItemOrGemWithIdEquipped(44785, 1) || source->HasItemOrGemWithIdEquipped(46824, 1) || source->HasItemOrGemWithIdEquipped(46800, 1))
+			{
+				return true;
+			}
+
+			return false;
+		}
+};
+
 void AddSC_achievement_scripts()
 {
     new achievement_resilient_victory();
@@ -333,4 +349,5 @@ void AddSC_achievement_scripts()
     new achievement_bg_sa_defense_of_ancients();
     new achievement_tilted();
     new achievement_not_even_a_scratch();
+    new achievement_piligrims_peril();
 }


### PR DESCRIPTION
- Based on VM fix, however had to add _cpp to replace the has aura from required item part, since the aura couldn't be detect by the has aura criteria most likely thanks to attribute behavior or needs additions for this case, so added *have one of the 3 items equipped check_. By default at this moment no matter where you sit  or what you wear you get the whole achievement since criteria data is placeholder against warnings.
## 

Wrong testing, the creator initial work works fine.
