### PR TITLE
Core/Dungeon Finder: Old state should be saved, not the new one

### DIFF
--- a/src/server/game/DungeonFinding/LFGGroupData.cpp
+++ b/src/server/game/DungeonFinding/LFGGroupData.cpp
@@ -37,7 +37,7 @@ void LfgGroupData::SetState(LfgState state)
         case LFG_STATE_FINISHED_DUNGEON:
         case LFG_STATE_NONE:
         case LFG_STATE_DUNGEON:
-            m_OldState = state;
+            m_OldState = m_State;
             // No break on purpose
         default:
             m_State = state;


### PR DESCRIPTION
Fix a typo while saving the old state.
I'm still looking for more errors in case there are.
