### PR TITLE
Core/Dungeon Finder: Properly save old state for LfgPlayerData

### DIFF
--- a/src/server/game/DungeonFinding/LFGPlayerData.cpp
+++ b/src/server/game/DungeonFinding/LFGPlayerData.cpp
@@ -35,7 +35,7 @@ void LfgPlayerData::SetState(LfgState state)
             m_SelectedDungeons.clear();
             // No break on purpose
         case LFG_STATE_DUNGEON:
-            m_OldState = state;
+            m_OldState = m_State;
             // No break on purpose
         default:
             m_State = state;


### PR DESCRIPTION
Once again, old state was not being save with the old but the new one.
