### PR TITLE
PetAI - Another overhaul / bug fix of the PetAI

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -58,6 +58,7 @@ class PetAI : public CreatureAI
         void HandleReturnMovement();
         void DoAttack(Unit* target, bool chase);
         bool CanAttack(Unit* target);
+        void ClearCharmInfoFlags();
 };
 #endif
 

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -117,7 +117,8 @@ class CreatureAI : public UnitAI
         virtual void SpellHitTarget(Unit* /*target*/, SpellInfo const* /*spell*/) {}
 
         // Called when the creature is target of hostile action: swing, hostile spell landed, fear/etc)
-        //virtual void AttackedBy(Unit* attacker);
+        // virtual void AttackedBy(Unit* attacker) {}
+
         virtual bool IsEscorted() { return false; }
 
         // Called when creature is spawned or respawned (for reseting variables)

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -622,11 +622,13 @@ class Creature : public Unit, public GridObject<Creature>, public MapCreature
 
         bool canStartAttack(Unit const* u, bool force) const;
         float GetAttackDistance(Unit const* player) const;
+        float GetPetAggroRange(Unit const* target) const;
 
         void SendAIReaction(AiReaction reactionType);
 
         Unit* SelectNearestTarget(float dist = 0) const;
         Unit* SelectNearestTargetInAttackDistance(float dist = 0) const;
+        Unit* AggressivePetSelectTarget(bool useLOS = false);
         Player* SelectNearestPlayer(float distance = 0) const;
 
         void DoFleeToGetAssistance();

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -74,6 +74,7 @@ void Pet::AddToWorld()
     if (GetCharmInfo() && GetCharmInfo()->HasCommandState(COMMAND_FOLLOW))
     {
         GetCharmInfo()->SetIsCommandAttack(false);
+        GetCharmInfo()->SetIsCommandFollow(false);
         GetCharmInfo()->SetIsAtStay(false);
         GetCharmInfo()->SetIsFollowing(false);
         GetCharmInfo()->SetIsReturning(false);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -17580,6 +17580,16 @@ bool CharmInfo::IsCommandAttack()
     return m_isCommandAttack;
 }
 
+void CharmInfo::SetIsCommandFollow(bool val)
+{
+    m_isCommandFollow = val;
+}
+
+bool CharmInfo::IsCommandFollow()
+{
+    return m_isCommandFollow;
+}
+
 void CharmInfo::SaveStayPosition()
 {
     //! At this point a new spline destination is enabled because of Unit::StopMoving()

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -253,6 +253,7 @@ enum UnitRename
 #define MAX_SPELL_CONTROL_BAR   10
 
 #define MAX_AGGRO_RESET_TIME 10 // in seconds
+#define MAX_AGGRO_RADIUS 45.0f  // Per wowwiki, aggro radius is capped at 45 yards for creatures with level difference > 25
 
 enum Swing
 {
@@ -1126,6 +1127,8 @@ struct CharmInfo
 
         void SetIsCommandAttack(bool val);
         bool IsCommandAttack();
+        void SetIsCommandFollow(bool val);
+        bool IsCommandFollow();
         void SetIsAtStay(bool val);
         bool IsAtStay();
         void SetIsFollowing(bool val);
@@ -1148,6 +1151,7 @@ struct CharmInfo
         ReactStates     m_oldReactState;
 
         bool m_isCommandAttack;
+        bool m_isCommandFollow;
         bool m_isAtStay;
         bool m_isFollowing;
         bool m_isReturning;

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1052,6 +1052,35 @@ namespace Trinity
             NearestHostileUnitCheck(NearestHostileUnitCheck const&);
     };
 
+    class AggressivePetHostileUnitCheck
+    {
+        public:
+            explicit AggressivePetHostileUnitCheck(Creature const* creature, bool useLOS = false) : me(creature)
+            {
+            }
+            bool operator()(Unit* u)
+            {
+                if (!u->IsHostileTo(me))
+                    return false;
+
+                if (!me->IsValidAttackTarget(u))
+                    return false;
+
+                if (m_useLOS && !u->IsWithinLOSInMap(me))
+                    return false;
+
+                if (!u->IsWithinDistInMap(me, me->GetPetAggroRange(u)))
+                    return false;
+
+                return true;
+            }
+
+    private:
+            Creature const* me;
+            bool m_useLOS;
+            AggressivePetHostileUnitCheck(AggressivePetHostileUnitCheck const&);
+    };
+
     class NearestHostileUnitInAttackDistanceCheck
     {
         public:

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -162,6 +162,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, uint64 guid1, uint32 spellid
 
                     charmInfo->SetIsCommandAttack(false);
                     charmInfo->SetIsAtStay(true);
+                    charmInfo->SetIsCommandFollow(false);
                     charmInfo->SetIsFollowing(false);
                     charmInfo->SetIsReturning(false);
                     charmInfo->SaveStayPosition();
@@ -176,6 +177,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, uint64 guid1, uint32 spellid
                     charmInfo->SetIsAtStay(false);
                     charmInfo->SetIsReturning(true);
                     charmInfo->SetIsFollowing(false);
+                    charmInfo->SetIsCommandFollow(true);
                     break;
                 case COMMAND_ATTACK:                        //spellid=1792  //ATTACK
                 {
@@ -215,6 +217,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, uint64 guid1, uint32 spellid
                             charmInfo->SetIsCommandAttack(true);
                             charmInfo->SetIsAtStay(false);
                             charmInfo->SetIsFollowing(false);
+                            charmInfo->SetIsCommandFollow(false);
                             charmInfo->SetIsReturning(false);
 
                             pet->ToCreature()->AI()->AttackStart(TargetUnit);
@@ -236,6 +239,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, uint64 guid1, uint32 spellid
                             charmInfo->SetIsCommandAttack(true);
                             charmInfo->SetIsAtStay(false);
                             charmInfo->SetIsFollowing(false);
+                            charmInfo->SetIsCommandFollow(false);
                             charmInfo->SetIsReturning(false);
 
                             pet->Attack(TargetUnit, true);

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -64,9 +64,11 @@ void TargetedMovementGeneratorMedium<T,D>::_setTargetLocation(T &owner)
 
         // Pets need special handling.
         // We need to subtract GetObjectSize() because it gets added back further down the chain
-        //  and that makes pets too far away. Subtracting it allows pets to properly
-        //  be (GetCombatReach() + i_offset) away.
-        if (owner.isPet())
+        //   and that makes pets too far away. Subtracting it allows pets to properly
+        //   be (GetCombatReach() + i_offset) away.
+        // Only applies when target is pet's owner otherwise pets and mobs end up
+        //   doing a "dance" while fighting
+        if (owner.isPet() && i_target->GetTypeId() == TYPEID_PLAYER)
         {
             dist = i_target->GetCombatReach();
             size = i_target->GetCombatReach() - i_target->GetObjectSize();


### PR DESCRIPTION
- Aggressive pets now use aggro radius check based on level diff
  - Aggro radius limited to max 45 yards (per wowwiki)
  - Pets no longer "dance" when fighting a creature
  - Pets returning will defend themselves (not passive) if owner didn't click "follow"
  - Pets at stay will properly pick up their owner's attackers that pass by
  - Minor code style cleanups

Closes #8398
