### PR TITLE
Unsummon current mage's Water Elemental before summoning a new one

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "Player.h"
+#include "Pet.h"
 #include "ScriptMgr.h"
 #include "SpellScript.h"
 #include "SpellAuraEffects.h"
@@ -198,6 +199,13 @@ class spell_mage_summon_water_elemental : public SpellScriptLoader
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
                 Unit* caster = GetCaster();
+
+                if (Player* player = caster->ToPlayer())
+                    if (Guardian* elemental = player->GetGuardianPet())
+                        // Check if the pet we are going to unsummon is the mage's water elemental
+                        if (elemental->GetEntry() == sSpellMgr->GetSpellInfo(SPELL_MAGE_SUMMON_WATER_ELEMENTAL_TEMPORARY)->Effects[EFFECT_0].MiscValue || elemental->GetEntry() == sSpellMgr->GetSpellInfo(SPELL_MAGE_SUMMON_WATER_ELEMENTAL_PERMANENT)->Effects[EFFECT_0].MiscValue)
+                            elemental->UnSummon();
+
                 // Glyph of Eternal Water
                 if (caster->HasAura(SPELL_MAGE_GLYPH_OF_ETERNAL_WATER))
                     caster->CastSpell(caster, SPELL_MAGE_SUMMON_WATER_ELEMENTAL_PERMANENT, true);


### PR DESCRIPTION
Ok, now, the great question. Is this the correct behaviour?

AFAIK since version4.X, Frost Specialization for mages suffered deep changes (specially the Elemental wich is permanent since that). On older versions i'm almost sure that if you cast "Summon water elemental" while your elemental was already out, the older would get despawned and a new one is summoned (yes, reseting his Freeze cooldown).

Anyway, I ask for some info from the memories of people.

If we finally manage to agree that this is not the correct behaviour, this could be useful for the 4.3.4 branch (where i'm 100% sure this is correct).
