### PR TITLE
Small levelup fix

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6280,6 +6280,9 @@ void Player::UpdateSkillsForLevel()
         if (GetSkillRangeType(pSkill, false) != SKILL_RANGE_LEVEL)
             continue;
 
+        if (IsWeaponSkill(pSkill->id))
+            continue;
+
         uint16 field = itr->second.pos / 2;
         uint8 offset = itr->second.pos & 1; // itr->second.pos % 2
 
@@ -6306,6 +6309,9 @@ void Player::UpdateSkillsToMaxSkillsForLevel()
 
         uint32 pskill = itr->first;
         if (IsProfessionOrRidingSkill(pskill))
+            continue;
+
+        if (IsWeaponSkill(pskill))
             continue;
 
         uint16 field = itr->second.pos / 2;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6280,8 +6280,8 @@ void Player::UpdateSkillsForLevel()
         if (GetSkillRangeType(pSkill, false) != SKILL_RANGE_LEVEL)
             continue;
 
-		if (IsWeaponSkill(pSkill->id))
-+			continue;
+        if (IsWeaponSkill(pSkill->id))
+            continue;
 
         uint16 field = itr->second.pos / 2;
         uint8 offset = itr->second.pos & 1; // itr->second.pos % 2
@@ -6311,8 +6311,8 @@ void Player::UpdateSkillsToMaxSkillsForLevel()
         if (IsProfessionOrRidingSkill(pskill))
             continue;
 
-		if (IsWeaponSkill(pSkill->id))
-+			continue;
+        if (IsWeaponSkill(pskill))
+            continue;
 
         uint16 field = itr->second.pos / 2;
         uint8 offset = itr->second.pos & 1; // itr->second.pos % 2

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6280,6 +6280,9 @@ void Player::UpdateSkillsForLevel()
         if (GetSkillRangeType(pSkill, false) != SKILL_RANGE_LEVEL)
             continue;
 
+		if (IsWeaponSkill(pSkill->id))
++			continue;
+
         uint16 field = itr->second.pos / 2;
         uint8 offset = itr->second.pos & 1; // itr->second.pos % 2
 
@@ -6307,6 +6310,9 @@ void Player::UpdateSkillsToMaxSkillsForLevel()
         uint32 pskill = itr->first;
         if (IsProfessionOrRidingSkill(pskill))
             continue;
+
+		if (IsWeaponSkill(pSkill->id))
++			continue;
 
         uint16 field = itr->second.pos / 2;
         uint8 offset = itr->second.pos & 1; // itr->second.pos % 2

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -48,7 +48,7 @@ bool IsPrimaryProfessionSkill(uint32 skill)
 
 bool IsWeaponSkill(uint32 skill)
 {
-	SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
+    SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
     if (!pSkill)
         return false;
     if (pSkill->categoryId != SKILL_CATEGORY_WEAPON)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -46,6 +46,17 @@ bool IsPrimaryProfessionSkill(uint32 skill)
     return true;
 }
 
+bool IsWeaponSkill(uint32 skill)
+{
+	SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
+    if (!pSkill)
+        return false;
+    if (pSkill->categoryId != SKILL_CATEGORY_WEAPON)
+        return false;
+
+    return true;
+}
+
 bool IsPartOfSkillLine(uint32 skillId, uint32 spellId)
 {
     SkillLineAbilityMapBounds skillBounds = sSpellMgr->GetSkillLineAbilityMapBounds(spellId);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -46,6 +46,17 @@ bool IsPrimaryProfessionSkill(uint32 skill)
     return true;
 }
 
+bool IsWeaponSkill(uint32 skill)
+{
+    SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
+    if (!pSkill)
+        return false;
+    if (pSkill->categoryId != SKILL_CATEGORY_WEAPON)
+        return false;
+
+    return true;
+}
+
 bool IsPartOfSkillLine(uint32 skillId, uint32 spellId)
 {
     SkillLineAbilityMapBounds skillBounds = sSpellMgr->GetSkillLineAbilityMapBounds(spellId);

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -578,6 +578,8 @@ typedef std::map<int32, std::vector<int32> > SpellLinkedMap;
 
 bool IsPrimaryProfessionSkill(uint32 skill);
 
+bool IsWeaponSkill(uint32 skill);
+
 inline bool IsProfessionSkill(uint32 skill)
 {
     return  IsPrimaryProfessionSkill(skill) || skill == SKILL_FISHING || skill == SKILL_COOKING || skill == SKILL_FIRST_AID;


### PR DESCRIPTION
Prevents blue text spam on levelup ("Your skill in Axes increased to 30")
Weapon skill levels were removed in 4.0.1
http://www.wowwiki.com/Weapon_skill#Patch_changes

Tested working, Blizzlike. This change does not affect chance to hit.
