### PR TITLE
Core/Spells: Another set of fixes.

### DIFF
--- a/sql/updates/world/2012_12_02_00_world_spell_group_misc_434.sql
+++ b/sql/updates/world/2012_12_02_00_world_spell_group_misc_434.sql
@@ -1,0 +1,22 @@
+SET @GROUP = 1121;
+DELETE FROM `spell_group_stack_rules` WHERE `group_id`=@GROUP;
+INSERT INTO `spell_group_stack_rules` (`group_id`,`stack_rule`) VALUES
+(@GROUP, 1); -- SPEL_GROUP_STACK_RULE_EXCLUSIVE
+
+DELETE FROM `spell_group` WHERE `id`=@GROUP;
+INSERT INTO `spell_group` (`id`,`spell_id`) VALUES
+(@GROUP, 73413), -- Inner will
+(@GROUP, 588);   -- Inner fire
+
+-- Adding missing proc event for Fingers of Frost (Rank 3)
+DELETE FROM `spell_proc_event` WHERE `entry`=83074;
+INSERT INTO `spell_proc_event` (`entry`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`procFlags`,`procEx`,`ppmRate`,`CustomChance`,`Cooldown`) VALUES
+(83074, 0, 3, 1049120, 4096, 0, 65536, 0, 0, 20, 0);
+
+-- Updating spell_learn_spell's spell IDs range...
+ALTER TABLE `spell_learn_spell` MODIFY `entry` MEDIUMINT(8) NOT NULL;
+ALTER TABLE `spell_learn_spell` MODIFY `SpellID` MEDIUMINT(8) NOT NULL;
+-- ...So we can have sinister strike's combo point enabler.
+DELETE FROM `spell_learn_spell` WHERE `SpellID`=79327 AND `entry`=2098;
+INSERT INTO `spell_learn_spell` (`entry`,`SpellID`,`Active`) VALUES
+(2098, 79327, 0);


### PR DESCRIPTION
- Fixed Inner Fire and Inner Will stacking.
- Added a missing spell_proc_event entry to Fingers of Frost.
- Enable Sinister Strike's ability to grant combo points when Eviscerate is learnt.

No change is required core-side to load spell_learn_spell since the core reads it as an uint32.
