### PR TITLE
Core/Creature: Update template - reinitialize spell bar for vehicles

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -411,6 +411,16 @@ bool Creature::UpdateEntry(uint32 Entry, uint32 team, const CreatureData* data)
             SetPvP(false);
     }
 
+    // updates spell bars for vehicles and set player's faction - should be called here, to overwrite faction that is set from the new template
+    if (IsVehicle())
+    {   
+        if (Player* owner = Creature::GetCharmerOrOwnerPlayerOrPlayerItself()) // this check comes in case we don't have a player
+        { 
+            setFaction(owner->getFaction()); // vehicles should have same as owner faction
+            owner->VehicleSpellInitialize(); 
+        }
+    }
+
     // trigger creature is always not selectable and can not be attacked
     if (isTrigger())
         SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);


### PR DESCRIPTION
- update template didn't change spell bar for player, if on a vehicle that updates it's template, initialize spells was needed
- combined with faction changing, since when update is called player faction wasn't  considered and it should be changed to his (proven from sniffs)
- the idea of this automated check inside fix SAI problems mainly because there you have nothing to use to reinitialize the bar - closes #5424 and some other
