### PR TITLE
Core/Spells:Beacon of Light

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6671,7 +6671,7 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
 
                 if (triggered_spell_id && beaconTarget)
                 {
-                    victim->CastCustomSpell(beaconTarget, triggered_spell_id, &basepoints0, NULL, NULL, true, 0, triggeredByAura);
+                    victim->CastCustomSpell(beaconTarget, triggered_spell_id, &basepoints0, NULL, NULL, true);
                     return true;
                 }
 


### PR DESCRIPTION
When holy paladin put beacon on someone and heal someone else, it shows up that the player with the beacon is being healed by himself, instead of the person who casting the Beacon.
This problem can be solved by this.
