### PR TITLE
Core/DB: Last fixes for creaturetext conversion

### DIFF
--- a/sql/updates/world/2012_12_09_00_world_creature_text.sql
+++ b/sql/updates/world/2012_12_09_00_world_creature_text.sql
@@ -1,0 +1,40 @@
+DELETE FROM `creature_text` WHERE `entry`=1756;
+INSERT INTO `creature_text`(`entry`,`groupid`,`id`,`type`,`sound`,`probability`,`comment`,`text`) VALUES
+(1756,0,0,12,0,100,"lord gregor lescovar SAY_GUARD_2","Yes, sir!"),
+(1756,1,0,12,0,100,"tyrion spybot SAY_GUARD_1","Of course. He awaits you in the library.");
+
+DELETE FROM `creature_text` WHERE `entry`=1754;
+INSERT INTO `creature_text`(`entry`,`groupid`,`id`,`type`,`sound`,`probability`,`comment`,`text`) VALUES
+(1754,0,0,12,0,100,"lord gregor lescovar SAY_LESCOVAR_2","It's time for my meditation, leave me."),
+(1754,1,0,12,0,100,"lord gregor lescovar SAY_LESCOVAR_3","There you are. What news from Westfall?"),
+(1754,2,0,12,0,100,"lord gregor lescovar SAY_LESCOVAR_4","Hmm, it could be that meddle Shaw. I will see what I can discover. Be off with you. I'll contact you again soon."),
+(1754,3,0,12,0,100,"tyrion spybot SAY_LESCOVAR_1","Ah, thank you kindly. I will leave you to the library while I tend to this small matter.");
+
+DELETE FROM `creature_text` WHERE `entry`=3849;
+INSERT INTO `creature_text`(`entry`,`groupid`,`id`,`type`,`sound`,`probability`,`comment`,`text`) VALUES
+(3849,0,0,14,0,100,"prisoner adamant SAY_FREE_AD","Free from this wretched cell at last! Let me show you to the courtyard...."),
+(3849,1,0,14,0,100,"prisoner adamant SAY_OPEN_DOOR_AD","You are indeed courageous for wanting to brave the horrors that lie beyond this door."),
+(3849,2,0,14,0,100,"prisoner adamant SAY_POST1_DOOR_AD","There we go!"),
+(3849,3,0,14,0,100,"prisoner adamant SAY_POST2_DOOR_AD","Good luck with Arugal. I must hurry back to Hadrec now."),
+(3849,4,0,12,0,100,"prisoner adamant SAY_BOSS_DIE_AD","About time someone killed the wretch.");
+
+DELETE FROM `creature_text` WHERE `entry`=17243;
+INSERT INTO `creature_text`(`entry`,`groupid`,`id`,`type`,`sound`,`probability`,`comment`,`text`) VALUES
+(17243,0,0,12,0,100,"engineer spark SAY_TEXT","Yes Master, all goes along as planned."),
+(17243,1,0,16,0,100,"engineer spark EMOTE_SHELL","%s puts the shell to his ear."),
+(17243,2,0,14,0,100,"engineer spark SAY_ATTACK","Now I cut you!"),
+(17243,3,0,12,0,100,"geezle SPARK_SAY_2","What's the big idea? You nearly blew my cover, idiot! I told you to put the compass and navigation maps somewhere safe - not out in the open for any fool to discover."),
+(17243,4,0,12,0,100,"geezle SPARK_SAY_3","The Master has gone to great lengths to secure information about the whereabouts of the Exodar. You could have blown the entire operation, including the cover of our spy on the inside."),
+(17243,5,0,12,0,100,"geezle SPARK_SAY_5","Relax? Do you know what Kael'thas does to those that fail him, Geezle? Eternal suffering and pain... Do NOT screw this up, fool."),
+(17243,6,0,12,0,100,"geezle SPARK_SAY_6","Our Bloodmyst scouts have located our contact. The fool, Velen, will soon leave himself open and defenseless -- long enough for us to strike! Now get out of my sight before I vaporize you..."),
+(17243,7,0,16,0,100,"geezle EMOTE_SPARK","picks up the naga flag.");
+
+DELETE FROM `creature_text` WHERE `entry`=38113;
+INSERT INTO `creature_text`(`entry`,`groupid`,`id`,`type`,`sound`,`probability`,`comment`,`text`) VALUES
+(38113,0,0,14,16734,100,"marwyn SAY_AGGRO","Death is all that you will find here!"),
+(38113,1,0,14,16735,100,"marwyn SAY_SLAY_1","I saw the same look in his eyes when he died. Terenas could hardly believe it. Hahahaha!"),
+(38113,1,1,14,16736,100,"marwyn SAY_SLAY_2","Choke on your suffering!"),
+(38113,2,0,14,16737,100,"marwyn SAY_DEATH","Yes... Run... Run to meet your destiny... Its bitter, cold embrace, awaits you."),
+(38113,3,0,14,16739,100,"marwyn SAY_CORRUPTED_FLESH_1","Your flesh has decayed before your very eyes!"),
+(38113,3,1,14,16740,100,"marwyn SAY_CORRUPTED_FLESH_2","Waste away into nothingness!"),
+(38113,4,0,14,16741,100,"marwyn SAY_MARWYN_INTRO_1","As you wish, my lord.");

--- a/src/server/scripts/EasternKingdoms/ShadowfangKeep/instance_shadowfang_keep.cpp
+++ b/src/server/scripts/EasternKingdoms/ShadowfangKeep/instance_shadowfang_keep.cpp
@@ -33,7 +33,7 @@ EndScriptData */
 
 enum eEnums
 {
-    SAY_BOSS_DIE_AD         = 0,
+    SAY_BOSS_DIE_AD         = 4,
     SAY_BOSS_DIE_AS         = 3,
     SAY_ARCHMAGE            = 0,
 

--- a/src/server/scripts/EasternKingdoms/stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/stormwind_city.cpp
@@ -470,8 +470,8 @@ enum eTyrionSpybot
     SAY_SPYBOT_3             = 3,
     SAY_SPYBOT_4             = 4,
     SAY_TYRION_1             = 0,
-    SAY_GUARD_1              = 0,
-    SAY_LESCOVAR_1           = 0,
+    SAY_GUARD_1              = 1,
+    SAY_LESCOVAR_1           = 3,
 
     NPC_PRIESTESS_TYRIONA    = 7779,
     NPC_LORD_GREGOR_LESCOVAR = 1754,

--- a/src/server/scripts/Kalimdor/azuremyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/azuremyst_isle.cpp
@@ -412,14 +412,14 @@ enum Geezle
     SPELL_TREE_DISGUISE = 30298,
 
     GEEZLE_SAY_1    = 0,
-    SPARK_SAY_2     = 0,
-    SPARK_SAY_3     = 1,
+    SPARK_SAY_2     = 3,
+    SPARK_SAY_3     = 4,
     GEEZLE_SAY_4    = 1,
-    SPARK_SAY_5     = 2,
-    SPARK_SAY_6     = 3,
+    SPARK_SAY_5     = 5,
+    SPARK_SAY_6     = 6,
     GEEZLE_SAY_7    = 2,
 
-    EMOTE_SPARK     = 4,
+    EMOTE_SPARK     = 7,
 
     MOB_SPARK       = 17243,
     GO_NAGA_FLAG    = 181694

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -70,7 +70,7 @@ enum Yells
     SAY_FALRIC_INTRO_1                  = 5,
     SAY_FALRIC_INTRO_2                  = 6,
 
-    SAY_MARWYN_INTRO_1                  = 0
+    SAY_MARWYN_INTRO_1                  = 4
 };
 
 enum Events


### PR DESCRIPTION
I first added some texts and deleted them by mistake in later delete queries in my previous PRs for creature text conversion as mentioned here: https://github.com/TrinityCore/TrinityCore/pull/8582#commitcomment-2272407 . This commit should restore the data and fix the assignments in the scripts.
