### PR TITLE
worldserver crashed after .level 100

### DIFF
--- a/sql/updates/world/2012_12_09_00_world_trinity_string.sql
+++ b/sql/updates/world/2012_12_09_00_world_trinity_string.sql
@@ -1,0 +1,3 @@
+DELETE FROM `trinity_string` WHERE `entry` IN (5035);
+INSERT INTO `trinity_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES
+  (5035, 'Player levels must be in range 1-%d!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/sql/updates/world/2012_12_09_00_world_trinity_string.sql
+++ b/sql/updates/world/2012_12_09_00_world_trinity_string.sql
@@ -1,3 +1,3 @@
 DELETE FROM `trinity_string` WHERE `entry` IN (5035);
 INSERT INTO `trinity_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES
-  (5035, 'Player levels must be in range 0-%d!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  (5035, 'Player levels must be in range 1-%d!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/sql/updates/world/2012_12_09_00_world_trinity_string.sql
+++ b/sql/updates/world/2012_12_09_00_world_trinity_string.sql
@@ -1,0 +1,3 @@
+DELETE FROM `trinity_string` WHERE `entry` IN (5035);
+INSERT INTO `trinity_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES
+  (5035, 'Player levels must be in range 0-%d!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -974,7 +974,8 @@ enum TrinityStrings
     LANG_COMMAND_NO_BATTLEGROUND_FOUND  = 5032,
     LANG_COMMAND_NO_ACHIEVEMENT_CRITERIA_FOUND = 5033,
     LANG_COMMAND_NO_OUTDOOR_PVP_FORUND  = 5034,
-    // Room for more Trinity strings      5035-9999
+    LANG_COMMAND_LEVEL_RANGE_ERROR      = 5035,
+    // Room for more Trinity strings      5036-9999
 
     // Level requirement notifications
     LANG_SAY_REQ                        = 6604,

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -360,10 +360,16 @@ public:
         int32 newlevel = levelStr ? atoi(levelStr) : oldlevel;
 
         if (newlevel < 1)
+        {
+            handler->PSendSysMessage(LANG_COMMAND_LEVEL_RANGE_ERROR, MAX_LEVEL);
             return false;                                       // invalid level
+        }
 
-        if (newlevel > STRONG_MAX_LEVEL)                         // hardcoded maximum level
-            newlevel = STRONG_MAX_LEVEL;
+        if (newlevel > MAX_LEVEL)                               // hardcoded client/dbc maximum level
+        {
+            handler->PSendSysMessage(LANG_COMMAND_LEVEL_RANGE_ERROR, MAX_LEVEL);
+            newlevel = MAX_LEVEL;
+        }
 
         HandleCharacterLevel(target, targetGuid, oldlevel, newlevel, handler);
         if (!handler->GetSession() || handler->GetSession()->GetPlayer() != target)      // including player == NULL
@@ -733,13 +739,23 @@ public:
         int32 oldlevel = target ? target->getLevel() : Player::GetLevelFromDB(targetGuid);
         int32 addlevel = levelStr ? atoi(levelStr) : 1;
         int32 newlevel = oldlevel + addlevel;
+        bool warnRange = false;
 
         if (newlevel < 1)
+        {
             newlevel = 1;
+            warnRange = true;
+        }
 
-        if (newlevel > STRONG_MAX_LEVEL)                         // hardcoded maximum level
-            newlevel = STRONG_MAX_LEVEL;
+        if (newlevel > MAX_LEVEL)                               // hardcoded client/dbc maximum level
+        {
+            newlevel = MAX_LEVEL;
+            warnRange = true;
+        }
 
+        if (warnRange)
+            handler->PSendSysMessage(LANG_COMMAND_LEVEL_RANGE_ERROR, MAX_LEVEL);
+        
         HandleCharacterLevel(target, targetGuid, oldlevel, newlevel, handler);
 
         if (!handler->GetSession() || handler->GetSession()->GetPlayer() != target)      // including chr == NULL


### PR DESCRIPTION
Small change to idiot (me) proof the .level command, and keep worldserver alive.

Since there seem to be several different range limitations at play (mysql, dbc, client), and opening the character panel at level 101 crashes my 4.3.4 client, it seemed best to put this into the command validation code instead of a spot fix at the crash point.  I'm guessing out of the box we're well protected from "organically" leveling beyond MAX_LEVEL.
