### PR TITLE
correct a typo in ToC sqls

### DIFF
--- a/sql/updates/world/2012_12_10_03_creature_template.sql
+++ b/sql/updates/world/2012_12_10_03_creature_template.sql
@@ -1,0 +1,2 @@
+UPDATE `creature_template` SET `mechanic_immune_mask` = 8388624 WHERE `entry` = 36066;
+UPDATE `creature_template` SET `mechanic_immune_mask` = 617299967 WHERE `entry` = 34496;

--- a/sql/updates/world/2012_12_10_03_creature_template.sql
+++ b/sql/updates/world/2012_12_10_03_creature_template.sql
@@ -1,2 +1,2 @@
-UPDATE `creature_template` SET `mechanic_immune_mask` = 8388624 WHERE `entry` = 36066;
-UPDATE `creature_template` SET `mechanic_immune_mask` = 617299967 WHERE `entry` = 34496;
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` & ~(1|2|4|8|32|64|128|256|512|1024|2048|4096|8192|65536|131072|524288|4194304|67108864|536870912) WHERE `entry` = 36066;
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` |1|2|4|8|32|64|128|256|512|1024|2048|4096|8192|65536|131072|524288|4194304|67108864|536870912 WHERE `entry` = 34496;


### PR DESCRIPTION
correcting a typo at immunities added at https://github.com/TrinityCore/TrinityCore/blob/1f9db80b69379f3abc4b2f8bb5dbc26ec971cc92/sql/updates/world/2012_11_18_02_world_toc.sql#L53  where I wrote entry 36066 instead of 34496.
34496 is Eydis 10m normal, 36066 is some dummy Eydis outside the instance, adding her back the old immunity
