### PR TITLE
Core/VMaps: drop "vmap.ignoreSpellIds" in config

### DIFF
--- a/src/server/collision/Management/VMapFactory.cpp
+++ b/src/server/collision/Management/VMapFactory.cpp
@@ -16,99 +16,12 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <sys/types.h>
 #include "VMapFactory.h"
 #include "VMapManager2.h"
-#include "G3D/Table.h"
-
-using namespace G3D;
 
 namespace VMAP
 {
-    void chompAndTrim(std::string& str)
-    {
-        while (str.length() >0)
-        {
-            char lc = str[str.length()-1];
-            if (lc == '\r' || lc == '\n' || lc == ' ' || lc == '"' || lc == '\'')
-            {
-                str = str.substr(0, str.length()-1);
-            }
-            else
-            {
-                break;
-            }
-        }
-        while (str.length() >0)
-        {
-            char lc = str[0];
-            if (lc == ' ' || lc == '"' || lc == '\'')
-            {
-                str = str.substr(1, str.length()-1);
-            }
-            else
-            {
-                break;
-            }
-        }
-    }
-
-    IVMapManager* gVMapManager = 0;
-    Table<unsigned int, bool>* iIgnoreSpellIds=0;
-
-    //===============================================
-    // result false, if no more id are found
-
-    bool getNextId(const std::string& pString, unsigned int& pStartPos, unsigned int& pId)
-    {
-        bool result = false;
-        unsigned int i;
-        for (i=pStartPos;i<pString.size(); ++i)
-        {
-            if (pString[i] == ',')
-            {
-                break;
-            }
-        }
-        if (i>pStartPos)
-        {
-            std::string idString = pString.substr(pStartPos, i-pStartPos);
-            pStartPos = i+1;
-            chompAndTrim(idString);
-            pId = atoi(idString.c_str());
-            result = true;
-        }
-        return(result);
-    }
-
-    //===============================================
-    /**
-    parameter: String of map ids. Delimiter = ","
-    */
-
-    void VMapFactory::preventSpellsFromBeingTestedForLoS(const char* pSpellIdString)
-    {
-        if (!iIgnoreSpellIds)
-            iIgnoreSpellIds = new Table<unsigned int, bool>();
-        if (pSpellIdString != NULL)
-        {
-            unsigned int pos =0;
-            unsigned int id;
-            std::string confString(pSpellIdString);
-            chompAndTrim(confString);
-            while (getNextId(confString, pos, id))
-            {
-                iIgnoreSpellIds->set(id, true);
-            }
-        }
-    }
-
-    //===============================================
-
-    bool VMapFactory::checkSpellForLoS(unsigned int pSpellId)
-    {
-        return(!iIgnoreSpellIds->containsKey(pSpellId));
-    }
+    IVMapManager* gVMapManager = NULL;
 
     //===============================================
     // just return the instance
@@ -123,9 +36,6 @@ namespace VMAP
     // delete all internal data structures
     void VMapFactory::clear()
     {
-        delete iIgnoreSpellIds;
-        iIgnoreSpellIds = NULL;
-
         delete gVMapManager;
         gVMapManager = NULL;
     }

--- a/src/server/collision/Management/VMapFactory.h
+++ b/src/server/collision/Management/VMapFactory.h
@@ -34,9 +34,6 @@ namespace VMAP
         public:
             static IVMapManager* createOrGetVMapManager();
             static void clear();
-
-            static void preventSpellsFromBeingTestedForLoS(const char* pSpellIdString);
-            static bool checkSpellForLoS(unsigned int pSpellId);
     };
 
 }

--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -310,6 +310,8 @@ bool IsDisabledFor(DisableType type, uint32 entry, Unit const* unit, uint8 flags
             }
             else if (spellFlags & SPELL_DISABLE_DEPRECATED_SPELL)    // call not from spellcast
                 return true;
+            else if (flags & SPELL_DISABLE_LOS)
+                return spellFlags & SPELL_DISABLE_LOS;
 
             break;
         }

--- a/src/server/game/Conditions/DisableMgr.h
+++ b/src/server/game/Conditions/DisableMgr.h
@@ -42,8 +42,10 @@ enum SpellDisableTypes
     SPELL_DISABLE_DEPRECATED_SPELL  = 0x8,
     SPELL_DISABLE_MAP               = 0x10,
     SPELL_DISABLE_AREA              = 0x20,
+    SPELL_DISABLE_LOS               = 0x40,
     MAX_SPELL_DISABLE_TYPE = (  SPELL_DISABLE_PLAYER | SPELL_DISABLE_CREATURE | SPELL_DISABLE_PET |
-                                SPELL_DISABLE_DEPRECATED_SPELL | SPELL_DISABLE_MAP | SPELL_DISABLE_AREA)
+                                SPELL_DISABLE_DEPRECATED_SPELL | SPELL_DISABLE_MAP | SPELL_DISABLE_AREA |
+                                SPELL_DISABLE_LOS)
 };
 
 enum VmapDisableTypes

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4909,7 +4909,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 return SPELL_FAILED_NOT_INFRONT;
 
             if (m_caster->GetEntry() != WORLD_TRIGGER) // Ignore LOS for gameobjects casts (wrongly casted by a trigger)
-                if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !m_caster->IsWithinLOSInMap(target))
+                if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, m_spellInfo->Id, NULL, SPELL_DISABLE_LOS) && !m_caster->IsWithinLOSInMap(target))
                     return SPELL_FAILED_LINE_OF_SIGHT;
         }
     }
@@ -4920,7 +4920,7 @@ SpellCastResult Spell::CheckCast(bool strict)
         float x, y, z;
         m_targets.GetDstPos()->GetPosition(x, y, z);
 
-        if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !m_caster->IsWithinLOS(x, y, z))
+        if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, m_spellInfo->Id, NULL, SPELL_DISABLE_LOS) && !m_caster->IsWithinLOS(x, y, z))
             return SPELL_FAILED_LINE_OF_SIGHT;
     }
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4909,7 +4909,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 return SPELL_FAILED_NOT_INFRONT;
 
             if (m_caster->GetEntry() != WORLD_TRIGGER) // Ignore LOS for gameobjects casts (wrongly casted by a trigger)
-                if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && VMAP::VMapFactory::checkSpellForLoS(m_spellInfo->Id) && !m_caster->IsWithinLOSInMap(target))
+                if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !m_caster->IsWithinLOSInMap(target))
                     return SPELL_FAILED_LINE_OF_SIGHT;
         }
     }
@@ -4920,7 +4920,7 @@ SpellCastResult Spell::CheckCast(bool strict)
         float x, y, z;
         m_targets.GetDstPos()->GetPosition(x, y, z);
 
-        if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && VMAP::VMapFactory::checkSpellForLoS(m_spellInfo->Id) && !m_caster->IsWithinLOS(x, y, z))
+        if (!(m_spellInfo->AttributesEx2 & SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !m_caster->IsWithinLOS(x, y, z))
             return SPELL_FAILED_LINE_OF_SIGHT;
     }
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1134,15 +1134,13 @@ void World::LoadConfigSettings(bool reload)
     bool enableLOS = ConfigMgr::GetBoolDefault("vmap.enableLOS", true);
     bool enableHeight = ConfigMgr::GetBoolDefault("vmap.enableHeight", true);
     bool enablePetLOS = ConfigMgr::GetBoolDefault("vmap.petLOS", true);
-    std::string ignoreSpellIds = ConfigMgr::GetStringDefault("vmap.ignoreSpellIds", "");
 
     if (!enableHeight)
         sLog->outError(LOG_FILTER_SERVER_LOADING, "VMap height checking disabled! Creatures movements and other various things WILL be broken! Expect no support.");
 
     VMAP::VMapFactory::createOrGetVMapManager()->setEnableLineOfSightCalc(enableLOS);
     VMAP::VMapFactory::createOrGetVMapManager()->setEnableHeightCalc(enableHeight);
-    VMAP::VMapFactory::preventSpellsFromBeingTestedForLoS(ignoreSpellIds.c_str());
-    sLog->outInfo(LOG_FILTER_SERVER_LOADING, "VMap support included. LineOfSight:%i, getHeight:%i, indoorCheck:%i PetLOS:%i", enableLOS, enableHeight, enableIndoor, enablePetLOS);
+    sLog->outInfo(LOG_FILTER_SERVER_LOADING, "VMap support included. LineOfSight: %i, getHeight: %i, indoorCheck: %i PetLOS: %i", enableLOS, enableHeight, enableIndoor, enablePetLOS);
     sLog->outInfo(LOG_FILTER_SERVER_LOADING, "VMap data directory is: %svmaps", m_dataPath.c_str());
 
     m_int_configs[CONFIG_MAX_WHO] = ConfigMgr::GetIntDefault("MaxWhoListReturns", 49);

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -280,15 +280,6 @@ vmap.enableLOS    = 1
 vmap.enableHeight = 1
 
 #
-#    vmap.ignoreSpellIds
-#        Description: These spells are ignored for LoS calculation.
-#                     List of ids with delimiter ','.
-#        Example:     "7720,1337"
-#        Default:     "7720"
-
-vmap.ignoreSpellIds = "7720"
-
-#
 #    vmap.petLOS
 #        Description: Check line of sight for pets, to avoid them attacking through walls.
 #        Default:     1 - (Enabled, each pet attack will be checked for line of sight)


### PR DESCRIPTION
this is not longer necessary since we use SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS
