### PR TITLE
Core/SpellScripts: implement Spell Proc Hooks and use it in old and new ...

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1274,7 +1274,10 @@ void AuraEffect::PeriodicTick(AuraApplication * aurApp, Unit* caster) const
 
 void AuraEffect::HandleProc(AuraApplication* aurApp, ProcEventInfo& eventInfo)
 {
-    // TODO: effect script handlers here
+    bool prevented = GetBase()->CallScriptEffectProcHandlers(const_cast<AuraEffect const*>(this), const_cast<AuraApplication const*>(aurApp), eventInfo);
+    if (prevented)
+        return;
+
     switch (GetAuraType())
     {
         case SPELL_AURA_PROC_TRIGGER_SPELL:
@@ -1295,6 +1298,8 @@ void AuraEffect::HandleProc(AuraApplication* aurApp, ProcEventInfo& eventInfo)
         default:
             break;
     }
+
+    GetBase()->CallScriptAfterEffectProcHandlers(const_cast<AuraEffect const*>(this), const_cast<AuraApplication const*>(aurApp), eventInfo);
 }
 
 void AuraEffect::CleanupTriggeredSpells(Unit* target)

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -194,7 +194,7 @@ class Aura
         void AddProcCooldown(uint32 msec);
         bool IsUsingCharges() const { return m_isUsingCharges; }
         void SetUsingCharges(bool val) { m_isUsingCharges = val; }
-        void PrepareProcToTrigger();
+        void PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo);
         bool IsProcTriggeredOnEvent(AuraApplication* aurApp, ProcEventInfo& eventInfo) const;
         float CalcProcChance(SpellProcEntry const& procEntry, ProcEventInfo& eventInfo) const;
         void TriggerProcOnEvent(AuraApplication* aurApp, ProcEventInfo& eventInfo);
@@ -218,6 +218,13 @@ class Aura
         void CallScriptEffectManaShieldHandlers(AuraEffect* aurEff, AuraApplication const* aurApp, DamageInfo & dmgInfo, uint32 & absorbAmount, bool & defaultPrevented);
         void CallScriptEffectAfterManaShieldHandlers(AuraEffect* aurEff, AuraApplication const* aurApp, DamageInfo & dmgInfo, uint32 & absorbAmount);
         void CallScriptEffectSplitHandlers(AuraEffect* aurEff, AuraApplication const* aurApp, DamageInfo & dmgInfo, uint32 & splitAmount);
+        // Spell Proc Hooks
+        bool CallScriptCheckProcHandlers(AuraApplication const* aurApp, ProcEventInfo& eventInfo);
+        bool CallScriptPrepareProcHandlers(AuraApplication const* aurApp, ProcEventInfo& eventInfo);
+        void CallScriptProcHandlers(AuraApplication const* aurApp, ProcEventInfo& eventInfo);
+        void CallScriptAfterProcHandlers(AuraApplication const* aurApp, ProcEventInfo& eventInfo);
+        bool CallScriptEffectProcHandlers(AuraEffect const* aurEff, AuraApplication const* aurApp, ProcEventInfo& eventInfo);
+        void CallScriptAfterEffectProcHandlers(AuraEffect const* aurEff, AuraApplication const* aurApp, ProcEventInfo& eventInfo);
 
         std::list<AuraScript*> m_loadedScripts;
     private:

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -428,14 +428,22 @@ enum AuraScriptHookType
     AURA_SCRIPT_HOOK_EFFECT_SPLIT,
     AURA_SCRIPT_HOOK_CHECK_AREA_TARGET,
     AURA_SCRIPT_HOOK_DISPEL,
-    AURA_SCRIPT_HOOK_AFTER_DISPEL
+    AURA_SCRIPT_HOOK_AFTER_DISPEL,
+    // Spell Proc Hooks
+    AURA_SCRIPT_HOOK_CHECK_PROC,
+    AURA_SCRIPT_HOOK_PREPARE_PROC,
+    AURA_SCRIPT_HOOK_PROC,
+    AURA_SCRIPT_HOOK_EFFECT_PROC,
+    AURA_SCRIPT_HOOK_EFFECT_AFTER_PROC,
+    AURA_SCRIPT_HOOK_AFTER_PROC,
     /*AURA_SCRIPT_HOOK_APPLY,
     AURA_SCRIPT_HOOK_REMOVE, */
 };
+/*
 #define HOOK_AURA_EFFECT_START HOOK_AURA_EFFECT_APPLY
 #define HOOK_AURA_EFFECT_END HOOK_AURA_EFFECT_CALC_SPELLMOD + 1
 #define HOOK_AURA_EFFECT_COUNT HOOK_AURA_EFFECT_END - HOOK_AURA_EFFECT_START
-
+*/
 class AuraScript : public _SpellScript
 {
     // internal use classes & functions
@@ -453,6 +461,9 @@ class AuraScript : public _SpellScript
         typedef void(CLASSNAME::*AuraEffectCalcSpellModFnType)(AuraEffect const*, SpellModifier* &); \
         typedef void(CLASSNAME::*AuraEffectAbsorbFnType)(AuraEffect*, DamageInfo &, uint32 &); \
         typedef void(CLASSNAME::*AuraEffectSplitFnType)(AuraEffect*, DamageInfo &, uint32 &); \
+        typedef bool(CLASSNAME::*AuraCheckProcFnType)(ProcEventInfo&); \
+        typedef void(CLASSNAME::*AuraProcFnType)(ProcEventInfo&); \
+        typedef void(CLASSNAME::*AuraEffectProcFnType)(AuraEffect const*, ProcEventInfo&); \
 
         AURASCRIPT_FUNCTION_TYPE_DEFINES(AuraScript)
 
@@ -552,6 +563,30 @@ class AuraScript : public _SpellScript
             private:
                 AuraEffectSplitFnType pEffectHandlerScript;
         };
+        class CheckProcHandler
+        {
+            public:
+                CheckProcHandler(AuraCheckProcFnType handlerScript);
+                bool Call(AuraScript* auraScript, ProcEventInfo& eventInfo);
+            private:
+                AuraCheckProcFnType _HandlerScript;
+        };
+        class AuraProcHandler
+        {
+            public:
+                AuraProcHandler(AuraProcFnType handlerScript);
+                void Call(AuraScript* auraScript, ProcEventInfo& eventInfo);
+            private:
+                AuraProcFnType _HandlerScript;
+        };
+        class EffectProcHandler : public EffectBase
+        {
+            public:
+                EffectProcHandler(AuraEffectProcFnType effectHandlerScript, uint8 effIndex, uint16 effName);
+                void Call(AuraScript* auraScript, AuraEffect const* aurEff, ProcEventInfo& eventInfo);
+            private:
+                AuraEffectProcFnType _EffectHandlerScript;
+        };
 
         #define AURASCRIPT_FUNCTION_CAST_DEFINES(CLASSNAME) \
         class CheckAreaTargetFunction : public AuraScript::CheckAreaTargetHandler { public: CheckAreaTargetFunction(AuraCheckAreaTargetFnType _pHandlerScript) : AuraScript::CheckAreaTargetHandler((AuraScript::AuraCheckAreaTargetFnType)_pHandlerScript) {} }; \
@@ -565,6 +600,9 @@ class AuraScript : public _SpellScript
         class EffectAbsorbFunction : public AuraScript::EffectAbsorbHandler { public: EffectAbsorbFunction(AuraEffectAbsorbFnType _pEffectHandlerScript, uint8 _effIndex) : AuraScript::EffectAbsorbHandler((AuraScript::AuraEffectAbsorbFnType)_pEffectHandlerScript, _effIndex) {} }; \
         class EffectManaShieldFunction : public AuraScript::EffectManaShieldHandler { public: EffectManaShieldFunction(AuraEffectAbsorbFnType _pEffectHandlerScript, uint8 _effIndex) : AuraScript::EffectManaShieldHandler((AuraScript::AuraEffectAbsorbFnType)_pEffectHandlerScript, _effIndex) {} }; \
         class EffectSplitFunction : public AuraScript::EffectSplitHandler { public: EffectSplitFunction(AuraEffectSplitFnType _pEffectHandlerScript, uint8 _effIndex) : AuraScript::EffectSplitHandler((AuraScript::AuraEffectSplitFnType)_pEffectHandlerScript, _effIndex) {} }; \
+        class CheckProcHandlerFunction : public AuraScript::CheckProcHandler { public: CheckProcHandlerFunction(AuraCheckProcFnType handlerScript) : AuraScript::CheckProcHandler((AuraScript::AuraCheckProcFnType)handlerScript) {} }; \
+        class AuraProcHandlerFunction : public AuraScript::AuraProcHandler { public: AuraProcHandlerFunction(AuraProcFnType handlerScript) : AuraScript::AuraProcHandler((AuraScript::AuraProcFnType)handlerScript) {} }; \
+        class EffectProcHandlerFunction : public AuraScript::EffectProcHandler { public: EffectProcHandlerFunction(AuraEffectProcFnType effectHandlerScript, uint8 effIndex, uint16 effName) : AuraScript::EffectProcHandler((AuraScript::AuraEffectProcFnType)effectHandlerScript, effIndex, effName) {} }; \
 
         #define PrepareAuraScript(CLASSNAME) AURASCRIPT_FUNCTION_TYPE_DEFINES(CLASSNAME) AURASCRIPT_FUNCTION_CAST_DEFINES(CLASSNAME)
 
@@ -694,6 +732,36 @@ class AuraScript : public _SpellScript
         // where function is: void function (AuraEffect* aurEff, DamageInfo& dmgInfo, uint32& splitAmount);
         HookList<EffectSplitHandler> OnEffectSplit;
         #define AuraEffectSplitFn(F, I) EffectSplitFunction(&F, I)
+
+        // executed when aura checks if it can proc
+        // example: DoCheckProc += AuraCheckProcFn(class::function);
+        // where function is: bool function (ProcEventInfo& eventInfo);
+        HookList<CheckProcHandler> DoCheckProc;
+        #define AuraCheckProcFn(F) CheckProcHandlerFunction(&F)
+
+        // executed before aura procs (possibility to prevent charge drop/cooldown)
+        // example: DoPrepareProc += AuraProcFn(class::function);
+        // where function is: void function (ProcEventInfo& eventInfo);
+        HookList<AuraProcHandler> DoPrepareProc;
+        // executed when aura procs
+        // example: OnProc += AuraProcFn(class::function);
+        // where function is: void function (ProcEventInfo& eventInfo);
+        HookList<AuraProcHandler> OnProc;
+        // executed after aura proced
+        // example: AfterProc += AuraProcFn(class::function);
+        // where function is: void function (ProcEventInfo& eventInfo);
+        HookList<AuraProcHandler> AfterProc;
+        #define AuraProcFn(F) AuraProcHandlerFunction(&F)
+
+        // executed when aura effect procs
+        // example: OnEffectProc += AuraEffectProcFn(class::function, EffectIndexSpecifier, EffectAuraNameSpecifier);
+        // where function is: void function (AuraEffect const* aurEff, ProcEventInfo& procInfo);
+        HookList<EffectProcHandler> OnEffectProc;
+        // executed after aura effect proced
+        // example: AfterEffectProc += AuraEffectProcFn(class::function, EffectIndexSpecifier, EffectAuraNameSpecifier);
+        // where function is: void function (AuraEffect const* aurEff, ProcEventInfo& procInfo);
+        HookList<EffectProcHandler> AfterEffectProc;
+        #define AuraEffectProcFn(F, I, N) EffectProcHandlerFunction(&F, I, N)
 
         // AuraScript interface - hook/effect execution manipulators
 


### PR DESCRIPTION
...proc system

Hooks:
- DoCheckProc: executed when aura checks if it can proc
- DoPrepareProc: executed before aura procs (possibility to prevent charge drop/cooldown)
- OnProc: executed when aura procs
- OnEffectProc: executed when aura effect procs
- AfterEffectProc: executed after aura effect proced
- AfterProc: executed after aura proced and charges removed

using PreventDefaultAction() in DoPrepareProc will prevent charge drop and cooldown

default execution of a proc can prevented in OnEffectProc with PreventDefaultAction()

Now we should be able to convert almost all procs from Unit::ProcDamageAndSpellFor to SpellScripts

Notes to old proc system:
- if a proc should have a cooldown we must check it in spellscript and add it when we handle the proc
- behavior with charge drops is possible undefined (use PreventDefaultAction() in OnEffectProc to notify that the script is executed)
