### PR TITLE
Core/Spell: Prevent inner fire charge drop when caster has a shield

### DIFF
--- a/sql/updates/world/2013_01_18_00_world_spell_script_names.sql
+++ b/sql/updates/world/2013_01_18_00_world_spell_script_names.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=-588;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (-588, 'spell_pri_inner_fire');

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -455,6 +455,34 @@ class spell_pri_vampiric_touch : public SpellScriptLoader
         }
 };
 
+class spell_pri_inner_fire : public SpellScriptLoader
+{
+    public:
+        spell_pri_inner_fire() : SpellScriptLoader("spell_pri_inner_fire") { }
+ 
+        class spell_pri_inner_fire_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_pri_inner_fire_AuraScript);
+ 
+            void Prepare(ProcEventInfo& /*eventInfo*/)
+            {
+                if (Unit* owner = GetUnitOwner())
+                    if (owner->HasAuraType(SPELL_AURA_SCHOOL_ABSORB))
+                        PreventDefaultAction(); // will prevent charge drop
+            }
+ 
+            void Register()
+            {
+                DoPrepareProc += AuraProcFn(spell_pri_inner_fire_AuraScript::Prepare);
+            }
+    };
+ 
+    AuraScript* GetAuraScript() const
+    {
+        return new spell_pri_inner_fire_AuraScript();
+    }
+};
+
 void AddSC_priest_spell_scripts()
 {
     new spell_pri_guardian_spirit();
@@ -467,4 +495,5 @@ void AddSC_priest_spell_scripts()
     new spell_pri_renew();
     new spell_pri_shadow_word_death();
     new spell_pri_vampiric_touch();
+    new spell_pri_inner_fire();
 }


### PR DESCRIPTION
What steps will reproduce the problem?
1. Make a priest
2. Use Power Word: Shield and Inner Fire buff
3. Let be atacked by a mob or a player

What is the expected output? What do you see instead?
When you're hit by a mob/player and the Power Word:Shield is active the damage hit is absorbed by the spell. I see that Inner Fire stacks droping with every melee hit allthough I don't recieve any damage with melee swings.

rev: 7d28c10bd05276c8033814f8315d258b02f8ed25

Please provide any additional information below.
Inner Fire - " A burst of Holy Energy fills the caster, increasing armor by X. Each melee or ranged DAMAGE hit against the priest will remove one charge. Last 30 min or until 20 charges are used. "
