### PR TITLE
[4.3.4] Spells/Mage: Mages should be able to see everything while on Invisibility

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2026,13 +2026,6 @@ bool WorldObject::CanDetectInvisibilityOf(WorldObject const* obj) const
     if (mask != obj->m_invisibility.GetFlags())
         return false;
 
-    // It isn't possible in invisibility to detect something that can't detect the invisible object
-    // (it's at least true for spell: 66)
-    // It seems like that only Units are affected by this check (couldn't see arena doors with preparation invisibility)
-    if (obj->ToUnit())
-        if ((m_invisibility.GetFlags() & obj->m_invisibilityDetect.GetFlags()) != m_invisibility.GetFlags())
-            return false;
-
     for (uint32 i = 0; i < TOTAL_INVISIBILITY_TYPES; ++i)
     {
         if (!(mask & (1 << i)))


### PR DESCRIPTION
Since 4.X the hablility Invisibility (http://old.wowhead.com/spell=66) only makes the mage inivible, making him able to see other people (not other mages in invisibility) and only detectable by units with a detection aura.
