### PR TITLE
[4.3.4] Spells/Mage: Ring of Frost

### DIFF
--- a/sql/updates/world/2013_01_26_01_world_misc_434.sql
+++ b/sql/updates/world/2013_01_26_01_world_misc_434.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (82676, 82691);
+INSERT INTO `spell_script_names`(`spell_id`, `ScriptName`) VALUES
+(82676, 'spell_mage_ring_of_frost'),
+(82691, 'spell_mage_ring_of_frost_freeze');
+
+-- Set flags UNIT_FLAG_DISABLE_MOVE| UNIT_FLAG_STUNNED|UNIT_FLAG_NOT_SELECTABLE on Ring of Frost
+UPDATE `creature_template` SET `unit_flags` = 0x4|0x40000|0x2000000 WHERE `entry` = 44199;

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -66,6 +66,10 @@ enum MageSpells
 
     SPELL_MAGE_IMPROVED_MANA_GEM_TRIGGERED       = 83098,
 
+    SPELL_MAGE_RING_OF_FROST_SUMMON              = 82676,
+    SPELL_MAGE_RING_OF_FROST_FREEZE              = 82691,
+    SPELL_MAGE_RING_OF_FROST_DUMMY               = 91264,
+
     SPELL_MAGE_FINGERS_OF_FROST                  = 44544
 };
 
@@ -886,6 +890,153 @@ class spell_mage_replenish_mana : public SpellScriptLoader
        }
 };
 
+// 82676 - Ring of Frost
+/// Updated 4.3.4
+class spell_mage_ring_of_frost : public SpellScriptLoader
+{
+    public:
+        spell_mage_ring_of_frost() : SpellScriptLoader("spell_mage_ring_of_frost") { }
+
+        class spell_mage_ring_of_frost_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_mage_ring_of_frost_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/)
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_SUMMON))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_FREEZE))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_DUMMY))
+                    return false;
+                return true;
+            }
+
+            bool Load()
+            {
+                ringOfFrost = NULL;
+                return true;
+            }
+
+            void HandleEffectPeriodic(AuraEffect const* aurEff)
+            {
+                if (ringOfFrost)
+                    if (GetMaxDuration() - (int32)ringOfFrost->GetTimer() >= sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_DUMMY)->GetDuration())
+                        GetTarget()->CastSpell(ringOfFrost->GetPositionX(), ringOfFrost->GetPositionY(), ringOfFrost->GetPositionZ(), SPELL_MAGE_RING_OF_FROST_FREEZE, true);
+            }
+
+            void Apply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            {
+                std::list<Creature*> MinionList;
+                GetTarget()->GetAllMinionsByEntry(MinionList, GetSpellInfo()->Effects[EFFECT_0].MiscValue);
+
+                // Get the last summoned RoF, save it and despawn older ones
+                for (std::list<Creature*>::iterator itr = MinionList.begin(); itr != MinionList.end(); itr++)
+                {
+                    TempSummon* summon = (*itr)->ToTempSummon();
+
+                    if (ringOfFrost && summon)
+                    {
+                        if (summon->GetTimer() > ringOfFrost->GetTimer())
+                        {
+                            ringOfFrost->DespawnOrUnsummon();
+                            ringOfFrost = summon;
+                        }
+                        else
+                            summon->DespawnOrUnsummon();
+                    }
+                    else if (summon)
+                        ringOfFrost = summon;
+                }
+            }
+
+            TempSummon* ringOfFrost;
+
+            void Register()
+            {
+                 OnEffectPeriodic += AuraEffectPeriodicFn(spell_mage_ring_of_frost_AuraScript::HandleEffectPeriodic, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
+                 OnEffectApply += AuraEffectApplyFn(spell_mage_ring_of_frost_AuraScript::Apply, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
+            }
+        };
+
+        AuraScript* GetAuraScript() const
+        {
+            return new spell_mage_ring_of_frost_AuraScript();
+        }
+};
+
+// 82691 - Ring of Frost (freeze efect)
+/// Updated 4.3.4
+class spell_mage_ring_of_frost_freeze : public SpellScriptLoader
+{
+    public:
+        spell_mage_ring_of_frost_freeze() : SpellScriptLoader("spell_mage_ring_of_frost_freeze") { }
+
+        class spell_mage_ring_of_frost_freeze_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_mage_ring_of_frost_freeze_SpellScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/)
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_SUMMON))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_FREEZE))
+                    return false;
+                return true;
+            }
+
+            void FilterTargets(std::list<WorldObject*>& targets)
+            {
+                float outRadius = sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_SUMMON)->Effects[EFFECT_0].CalcRadius();
+                float inRadius  = 4.7f;
+
+                for (std::list<WorldObject*>::iterator itr = targets.begin(); itr != targets.end(); ++itr)
+                    if (Unit* unit = (*itr)->ToUnit())
+                        if (unit->HasAura(SPELL_MAGE_RING_OF_FROST_DUMMY) || unit->HasAura(SPELL_MAGE_RING_OF_FROST_FREEZE) || unit->GetExactDist(GetExplTargetDest()) > outRadius || unit->GetExactDist(GetExplTargetDest()) < inRadius)
+                            targets.erase(itr--);
+            }
+
+            void Register()
+            {
+                OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_mage_ring_of_frost_freeze_SpellScript::FilterTargets, EFFECT_0, TARGET_UNIT_DEST_AREA_ENEMY);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_mage_ring_of_frost_freeze_SpellScript();
+        }
+
+        class spell_mage_ring_of_frost_freeze_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_mage_ring_of_frost_freeze_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/)
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_MAGE_RING_OF_FROST_DUMMY))
+                    return false;
+                return true;
+            }
+
+            void OnRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+            {
+                if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_EXPIRE)
+                    if (GetCaster())
+                        GetCaster()->CastSpell(GetTarget(), SPELL_MAGE_RING_OF_FROST_DUMMY, true);
+            }
+
+            void Register()
+            {
+                AfterEffectRemove += AuraEffectRemoveFn(spell_mage_ring_of_frost_freeze_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_MOD_STUN, AURA_EFFECT_HANDLE_REAL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const
+        {
+            return new spell_mage_ring_of_frost_freeze_AuraScript();
+        }
+};
+
 // 31687 - Summon Water Elemental
 class spell_mage_summon_water_elemental : public SpellScriptLoader
 {
@@ -1008,6 +1159,8 @@ void AddSC_mage_spell_scripts()
     new spell_mage_master_of_elements();
     new spell_mage_polymorph_cast_visual();
     new spell_mage_replenish_mana();
+    new spell_mage_ring_of_frost();
+    new spell_mage_ring_of_frost_freeze();
     new spell_mage_summon_water_elemental();
     new spell_mage_water_elemental_freeze();
 }


### PR DESCRIPTION
Ring of Frost (http://old.wowhead.com/spell=82676)

A little bit of explanations about how this scripts work.

Fist of all we have spell `SPELL_MAGE_RING_OF_FROST_FREEZE` (http://old.wowhead.com/spell=82676) wich freezes enemies at a given position. On the script for this spell we're only filtering targets acording to the "ring" structure.

Secondly we have the spell itself, the `SPELL_MAGE_RING_OF_FROST_SUMMON` (http://old.wowhead.com/spell=82676). This one have two effects: summon the RoF npc and a periodic effect. We're using the periodic efect for making the mage cast the previous spell (`SPELL_MAGE_RING_OF_FROST_FREEZE`) at the summoned npc position on every tick.

Finally `SPELL_MAGE_RING_OF_FROST_DUMMY` is an aura wich lasts 3 seconds and is used as coalesce pseudo-marker for the ring and for preventing players wich got dispeled the freeze effect again frozen.

http://www.wowwiki.com/Ring_of_Frost

---

``` sql
DELETE FROM `spell_script_names` WHERE `spell_id` IN (82676, 82691);
INSERT INTO `spell_script_names`(`spell_id`, `ScriptName`) VALUES
(82676, 'spell_mage_ring_of_frost'),
(82691, 'spell_mage_ring_of_frost_freeze');

-- Set flags UNIT_FLAG_DISABLE_MOVE| UNIT_FLAG_STUNNED|UNIT_FLAG_NOT_SELECTABLE on Ring of Frost
UPDATE `creature_template` SET `unit_flags` = 0x4|0x40000|0x2000000 WHERE `entry` = 44199;
```
