### PR TITLE
[4.3.4] Spells: Dispel effects can always be casted

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5068,6 +5068,8 @@ SpellCastResult Spell::CheckCast(bool strict)
         }
     }
 
+    // Updated 4.3.4. Dispel effects can always be cast (even when there's nothing to dispel).
+    /*
     if (!hasNonDispelEffect && !hasDispellableAura && dispelMask && !IsTriggered())
     {
         if (Unit* target = m_targets.GetUnitTarget())
@@ -5078,6 +5080,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 return SPELL_FAILED_NOTHING_TO_DISPEL;
         }
     }
+    */
 
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {


### PR DESCRIPTION
Since 4.X dispel effects no longer check if there's something to dispel on the target.

Quote from GMs:

```
In Cataclysm we are raising the mana costs, making it possible to waste 
mana by casting a dispel when there is nothing to dispel.
```

Source: http://www.mmo-champion.com/threads/706936-Cataclysm-Dispel-Mechanics?p=7584466

I'm leaving it commented since we don't really know if this mechanic will eventually return.
