### PR TITLE
[4.3.4] Scripts/Paladin: Templar's Verdict

### DIFF
--- a/sql/updates/world/2013_01_22_01_world_spell_script_names_434.sql
+++ b/sql/updates/world/2013_01_22_01_world_spell_script_names_434.sql
@@ -1,0 +1,4 @@
+-- 85256 - Templar's Verdict
+DELETE FROM `spell_script_names` WHERE `spell_id`=85256;
+INSERT INTO `spell_script_names` VALUES
+(85256,'spell_pal_templar_s_verdict');


### PR DESCRIPTION
Templar's Verdict (http://old.wowhead.com/spell=85256)

An instant weapon attack that causes a percentage of weapon damage.  Consumes all charges of Holy Power to increase damage dealt:

1 Holy Power: 30% Weapon Damage
2 Holy Power: 90% Weapon Damage
3 Holy Power: 225% Weapon Damage

although i'm not quite sure this is the right way to do it...
