### PR TITLE
Icc Lich King heroic version and Kinetic Bombs fix

### DIFF
--- a/sql/updates/world/2013_01_24_world_creature_template_immune_mask_valkyr_shadowguard.sql
+++ b/sql/updates/world/2013_01_24_world_creature_template_immune_mask_valkyr_shadowguard.sql
@@ -1,0 +1,1 @@
+UPDATE `world`.`creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` | 4 WHERE `entry` IN(36609, 39120, 39121, 39122);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -887,8 +887,18 @@ class boss_prince_valanar_icc : public CreatureScript
                         float x, y, z;
                         summon->GetPosition(x, y, z);
                         float ground_Z = summon->GetMap()->GetHeight(summon->GetPhaseMask(), x, y, z, true, 500.0f);
+                        if (IsHeroic())
+                        {
+                        summon->SetSpeed(MOVE_FLIGHT, 0.5f, true); // by Sqru
+                        summon->GetMotionMaster()->MovePoint(POINT_KINETIC_BOMB_IMPACT, x, y, ground_Z);
+                        summon->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);   
+                        }
+                        else
+                        {
+                        summon->SetSpeed(MOVE_FLIGHT, 0.2f, true); // by Sqru
                         summon->GetMotionMaster()->MovePoint(POINT_KINETIC_BOMB_IMPACT, x, y, ground_Z);
                         summon->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                        }
                         break;
                     }
                     case NPC_SHOCK_VORTEX:
@@ -1243,9 +1253,15 @@ class npc_kinetic_bomb : public CreatureScript
                 else if (action == ACTION_KINETIC_BOMB_JUMP)
                 {
                     if (!me->HasAura(SPELL_KINETIC_BOMB_KNOCKBACK))
-                        me->GetMotionMaster()->MoveCharge(_x, _y, me->GetPositionZ() + 100.0f, me->GetSpeed(MOVE_RUN), 0);
-                    _events.RescheduleEvent(EVENT_CONTINUE_FALLING, 3000);
+                    {
+                        if (IsHeroic())
+                            me->SetSpeed(MOVE_FLIGHT,0.5f);
+                        else
+                            me->SetSpeed(MOVE_FLIGHT,0.2f);
+                    }
+                    me->GetMotionMaster()->MoveCharge(_x, _y, me->GetPositionZ() + 5.0f, me->GetSpeed(MOVE_FLIGHT), 0);
                 }
+                _events.RescheduleEvent(EVENT_CONTINUE_FALLING, 0);
             }
 
             void UpdateAI(uint32 const diff)
@@ -1261,7 +1277,16 @@ class npc_kinetic_bomb : public CreatureScript
                             me->DespawnOrUnsummon(5000);
                             break;
                         case EVENT_CONTINUE_FALLING:
-                            me->GetMotionMaster()->MoveCharge(_x, _y, _groundZ, me->GetSpeed(MOVE_WALK), POINT_KINETIC_BOMB_IMPACT);
+                            if (IsHeroic())
+                            {
+                                me->SetSpeed(MOVE_FLIGHT, 0.5f, true);
+                                me->GetMotionMaster()->MovePoint(POINT_KINETIC_BOMB_IMPACT, _x, _y, _groundZ);
+                            }
+                            else
+                            {
+                                me->SetSpeed(MOVE_FLIGHT, 0.2f, true);
+                                me->GetMotionMaster()->MovePoint(POINT_KINETIC_BOMB_IMPACT, _x, _y, _groundZ);
+                            }
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -303,6 +303,7 @@ class instance_icecrown_citadel : public InstanceMapScript
                         // Remove corpse as soon as it dies (and respawn 10 seconds later)
                         creature->SetCorpseDelay(0);
                         creature->SetReactState(REACT_PASSIVE);
+                        creature->SetSpeed(MOVE_FLIGHT, 0.5f, true);
                         break;
                     default:
                         break;


### PR DESCRIPTION
Sorry for that earlier commit I admit i fucked sth up... it should be all ok now. This should make the Val'kyrs immune to deathgrip effects, it decreases their fly height (still in melee range), also I slowed down Wicked Spirits and Spirit Bombs in Frostmourne room. The Spirit Bombs now have also a 3 sec explosion delay as it should be. I also modified the Kinetic Bombs on BPC encounter.

PS: The part which makes Val'kyr to not drop players after stuns/charge effects is not mine i just implemented it and saw it works. Originaly it comes from here: https://github.com/TrinityCore/TrinityCore/issues/7266
