### PR TITLE
[4.3.4] Scripts/Paladin: Shield of the Righteous

### DIFF
--- a/sql/updates/world/2013_01_27_00_world_spell_script_names_434.sql
+++ b/sql/updates/world/2013_01_27_00_world_spell_script_names_434.sql
@@ -1,0 +1,7 @@
+-- 53600 - Shield of the Righteous
+-- Delete old (wotlk) scaling
+DELETE FROM `spell_bonus_data` WHERE `entry`=53600;
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pal_shield_of_the_righteous';
+INSERT INTO `spell_script_names` VALUES
+(53600,'spell_pal_shield_of_the_righteous');

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -721,6 +721,55 @@ class spell_pal_sacred_shield : public SpellScriptLoader
         }
 };
 
+// 53600 - Shield of the Righteous
+/// Updated 4.3.4
+class spell_pal_shield_of_the_righteous : public SpellScriptLoader
+{
+    public:
+        spell_pal_shield_of_the_righteous() : SpellScriptLoader("spell_pal_shield_of_the_righteous") { }
+
+        class spell_pal_shield_of_the_righteous_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_pal_shield_of_the_righteous_SpellScript);
+
+            bool Load()
+            {
+                if (GetCaster()->GetTypeId() != TYPEID_PLAYER)
+                    return false;
+
+                if (GetCaster()->ToPlayer()->getClass() != CLASS_PALADIN)
+                    return false;
+
+                return true;
+            }
+
+            void ChangeDamage(SpellEffIndex /*effIndex*/)
+            {
+                int32 damage = GetHitDamage();
+
+                // Because 1 Holy Power (HP) is consumed when casting spell,
+                // GetPower(POWER_HOLY_POWER) will return 0 when player has 1 HP,
+                // return 1 at 2 HP, and 2 at 3 HP
+                int32 hp = GetCaster()->GetPower(POWER_HOLY_POWER);
+
+                // Holy Power Scaling: 3 times damage at 2 HP, 6 times at 3 HP
+                damage *= 0.5*hp*hp + 1.5*hp + 1;
+
+                SetHitDamage(damage);
+            }
+
+            void Register()
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_pal_shield_of_the_righteous_SpellScript::ChangeDamage, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+            }
+        };
+
+        SpellScript* GetSpellScript() const
+        {
+            return new spell_pal_shield_of_the_righteous_SpellScript();
+        }
+};
+
 // 85256 - Templar's Verdict
 /// Updated 4.3.4
 class spell_pal_templar_s_verdict : public SpellScriptLoader
@@ -803,5 +852,6 @@ void AddSC_paladin_spell_scripts()
     new spell_pal_lay_on_hands();
     new spell_pal_righteous_defense();
     new spell_pal_sacred_shield();
+    new spell_pal_shield_of_the_righteous();
     new spell_pal_templar_s_verdict();
 }


### PR DESCRIPTION
Shield of the Righteous 
Slam the target with your shield, causing Holy damage. Consumes all charges of Holy Power to determine damage dealt:

1 Holy Power: (X - 1) damage
2 Holy Power: (X \* 3 - 3) damage
3 Holy Power: (X \* 6 - 6) damage

http://www.wowpedia.org/index.php?title=Shield_of_the_Righteous&direction=prev&oldid=3036127
Last update in wowpedia before MoP

I delete entry in spell_bonus_data because it contains wotlk scaling (0% AP and SP)
Can't find how much it scaling now, so i hope dbc data is already correct
