### PR TITLE
[4.3.4] Scripts/Paladin: Grand Crusader

### DIFF
--- a/sql/updates/world/2013_01_27_01_world_misc_434.sql
+++ b/sql/updates/world/2013_01_27_01_world_misc_434.sql
@@ -1,0 +1,10 @@
+-- Grand Crusader
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pal_grand_crusader';
+INSERT INTO `spell_script_names` VALUES
+(85416,'spell_pal_grand_crusader');
+
+-- Grand Crusader can only be activated by Crusader Strike or Hammer of the Righteous
+DELETE FROM `spell_proc_event` WHERE `entry` IN (75806, 85043);
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES 
+(75806, 0, 10, 0, 294912, 0, 16, 0, 0, 0, 0),
+(85043, 0, 10, 0, 294912, 0, 16, 0, 0, 0, 0);

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -45,6 +45,8 @@ enum PaladinSpells
     SPELL_PALADIN_DIVINE_STORM_DUMMY             = 54171,
     SPELL_PALADIN_DIVINE_STORM_HEAL              = 54172,
 
+    SPELL_PALADIN_AVENGER_S_SHIELD               = 31935,
+
     SPELL_PALADIN_FORBEARANCE                    = 25771,
     SPELL_PALADIN_AVENGING_WRATH_MARKER          = 61987,
     SPELL_PALADIN_IMMUNE_SHIELD_MARKER           = 61988,
@@ -409,6 +411,42 @@ class spell_pal_exorcism_and_holy_wrath_damage : public SpellScriptLoader
         AuraScript* GetAuraScript() const
         {
             return new spell_pal_exorcism_and_holy_wrath_damage_AuraScript();
+        }
+};
+
+// 75806, 85043, 85416 - Grand Crusader
+/// Updated 4.3.4
+class spell_pal_grand_crusader : public SpellScriptLoader
+{
+    public:
+        spell_pal_grand_crusader() : SpellScriptLoader("spell_pal_grand_crusader") { }
+
+        class spell_pal_grand_crusader_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_pal_grand_crusader_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/)
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_PALADIN_AVENGER_S_SHIELD))
+                    return false;
+                return true;
+            }
+
+            void HandleApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            {
+                if (Unit* caster = GetCaster())
+                    caster->ToPlayer()->RemoveSpellCooldown(SPELL_PALADIN_AVENGER_S_SHIELD, true);
+            }
+
+            void Register()
+            {
+                OnEffectApply += AuraEffectApplyFn(spell_pal_grand_crusader_AuraScript::HandleApply, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
+            }
+        };
+
+        AuraScript* GetAuraScript() const
+        {
+            return new spell_pal_grand_crusader_AuraScript();
         }
 };
 
@@ -796,6 +834,7 @@ void AddSC_paladin_spell_scripts()
     new spell_pal_blessing_of_sanctuary();
     new spell_pal_divine_sacrifice();
     new spell_pal_exorcism_and_holy_wrath_damage();
+    new spell_pal_grand_crusader();
     new spell_pal_guarded_by_the_light();
     new spell_pal_hand_of_sacrifice();
     new spell_pal_holy_shock();


### PR DESCRIPTION
Grand Crusader (http://www.wowpedia.org/Grand_Crusader_(paladin_talent))

Grand Crusader is a passive specialization ability for Protection paladins, available at level 50. This passive has a 20% chance of refreshing the cooldown on your  [Avenger's Shield] when your [Crusader Strike] or [Hammer of the Righteous] deal damage to your primary target, as well as causing it to generate 1 charge of Holy Power if used within 6 seconds.

Currently, it doesn't reset Avenger's Shield when activated, and it can be activated using all melee spells.
