### PR TITLE
[4.3.4] Core/Spells: Paladin's Daybreak proc

### DIFF
--- a/sql/updates/world/2013_01_28_00_world_spell_proc_event_434.sql
+++ b/sql/updates/world/2013_01_28_00_world_spell_proc_event_434.sql
@@ -1,0 +1,5 @@
+-- Daybreak proc
+DELETE FROM `spell_proc_event` WHERE `entry` IN (88820,88821);
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES 
+(88820, 0, 10, 3221225472, 0, 1024, 0, 0, 0, 0, 0),
+(88821, 0, 10, 3221225472, 0, 1024, 0, 0, 0, 0, 0);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3630,6 +3630,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 5420: // Tree of Life (Passive)
                 spellInfo->Stances = 1 << (FORM_TREE - 1);
                 break;
+            case 88819: // Daybreak (proc)
+                spellInfo->ProcCharges = 1;
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
Daybreak
http://www.wowpedia.org/index.php?title=Daybreak&oldid=2748961

"Your Flash of Light, Holy Light and Divine Light have a 10/20% chance to make your next Holy Shock not trigger a cooldown if used within 12 sec."

Currently it can trigger from all spells, and when it trigger you can cast Holy Shock without cooldown multiple times until the buff timer run out.
