### PR TITLE
Core/Achievements: Fix PortalJockey

### DIFF
--- a/sql/updates/world/2013_01_28_00_world_achievement_criteria_data.sql
+++ b/sql/updates/world/2013_01_28_00_world_achievement_criteria_data.sql
@@ -1,0 +1,12 @@
+
+-- Was (12979, 12, 1, 0, '')
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` = 12979 AND `type` = 12;
+
+-- Was (12971, 12, 2, 0, '')
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` = 12971 AND `type` = 12;
+
+
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `ScriptName`)
+VALUES
+(12979, 12, 2, 0, ''),
+(12971, 12, 1, 0, '');

--- a/sql/updates/world/2013_01_28_00_world_achievement_criteria_data.sql
+++ b/sql/updates/world/2013_01_28_00_world_achievement_criteria_data.sql
@@ -1,12 +1,2 @@
-
--- Was (12979, 12, 1, 0, '')
-DELETE FROM `achievement_criteria_data` WHERE `criteria_id` = 12979 AND `type` = 12;
-
--- Was (12971, 12, 2, 0, '')
-DELETE FROM `achievement_criteria_data` WHERE `criteria_id` = 12971 AND `type` = 12;
-
-
-INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `ScriptName`)
-VALUES
-(12979, 12, 2, 0, ''),
-(12971, 12, 1, 0, '');
+UPDATE `achievement_criteria_data` SET `value1`=2 WHERE `criteria_id`=12979 AND `type`=12;
+UPDATE `achievement_criteria_data` SET `value1`=1 WHERE `criteria_id`=12971 AND `type`=12;


### PR DESCRIPTION
Current Status: Portal Jockey(10) is rewarded from 10nh and 25nh, Portal
Jockey(25) is rewarded from 10hc and 25hc.
Reason: Achievement-criteria 12971 is required for Portal Jockey(25), but
checks for map-difficulty 2=10hc.
On the other side achievment-criteria 12979 is required for Portal
Jockey(10), but checks for map-difficulty 1=25nh.
