### PR TITLE
DB/Auth: Fix typo in sql/base/auth_database.sql

### DIFF
--- a/sql/base/auth_database.sql
+++ b/sql/base/auth_database.sql
@@ -213,7 +213,7 @@ CREATE TABLE `realmlist` (
 
 LOCK TABLES `realmlist` WRITE;
 /*!40000 ALTER TABLE `realmlist` DISABLE KEYS */;
-INSERT INTO `realmlist` VALUES (1,'Trinity','127.0.0.1',8085,1,0,1,0,0,12340);
+INSERT INTO `realmlist` VALUES (1,'Trinity','127.0.0.1','127.0.0.1','255.255.255.0',8085,1,0,1,0,0,12340);
 /*!40000 ALTER TABLE `realmlist` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
ERROR 1136 (21S01) at line 216: Column count doesn't match value count at row 1
