### PR TITLE
Replace check in IsSingleTargetWith

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1174,10 +1174,8 @@ bool SpellInfo::IsSingleTarget() const
 
 bool SpellInfo::IsSingleTargetWith(SpellInfo const* spellInfo) const
 {
-    // TODO - need better check
-    // Equal icon and spellfamily
-    if (SpellFamilyName == spellInfo->SpellFamilyName &&
-        SpellIconID == spellInfo->SpellIconID)
+    // Same spell?
+    if (IsRankOf(spellInfo))
         return true;
 
     SpellSpecificType spec = GetSpellSpecific();


### PR DESCRIPTION
Old check was SpellFamily and SpellIcon, new is IsRankOf,
which seems to make more sense in that context.
close #8290

Fixes warrior vigilance.
Personal opinion:
If it causes a bug for something else, this was the wrong place to implement that anyway (it should either go into SpellGroups or SpellInfo::IsAuraExclusiveBySpecificWith).
