### PR TITLE
Core/Spells: Rouge Slice and Dice

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3023,6 +3023,8 @@ void SpellMgr::LoadDbcDataCorrections()
                 spellInfo->EffectTriggerSpell[0] = 36325; // They Must Burn Bomb Drop (DND)
                 break;
             case 49838: // Stop Time
+			case 5171:  // Slice and Dice
+            case 6774:
                 spellInfo->AttributesEx3 |= SPELL_ATTR3_NO_INITIAL_AGGRO;
                 break;
             case 61407: // Energize Cores


### PR DESCRIPTION
Slice and Dice should not make the caster enter in combat with the targets

Close https://github.com/TrinityCore/TrinityCore/issues/4139
