### PR TITLE
Update sql/updates/world/2013_02_19_03_world_sai.sql

### DIFF
--- a/sql/updates/world/2013_02_19_03_world_sai.sql
+++ b/sql/updates/world/2013_02_19_03_world_sai.sql
@@ -1,3 +1,4 @@
+-- creature_ai_scripts table doesnt exist in TDB_full_434.04_2013_02_14
 -- Fix quest: Gather the Orbs http://www.wowhead.com/quest=10859
 -- ID indexes
 -- Almost all is based on Untaught script, just corrected some stuff with sniff


### PR DESCRIPTION
creature_ai_scripts table doesnt exist in TDB_full_434.04_2013_02_14, i was delete row "DELETE FROM `creature_ai_scripts` WHERE `creature_id`=@LightOrb;" in my home database and then script can run, otherwise send error that table dont exist
