### PR TITLE
update AuthResult to correct fail messages

### DIFF
--- a/src/server/authserver/Authentication/AuthCodes.h
+++ b/src/server/authserver/Authentication/AuthCodes.h
@@ -36,11 +36,11 @@ enum AuthResult
     WOW_FAIL_LOCKED_ENFORCED                     = 0x10,
     WOW_FAIL_TRIAL_ENDED                         = 0x11,
     WOW_FAIL_USE_BATTLENET                       = 0x12,
-    WOW_FAIL_TOO_FAST                            = 0x16,
-    WOW_FAIL_CHARGEBACK                          = 0x17,
+    WOW_FAIL_CHARGEBACK                          = 0x16,
+    WOW_FAIL_INTERNET_GAME_ROOM_WITHOUT_BNET     = 0x17,
     WOW_FAIL_GAME_ACCOUNT_LOCKED                 = 0x18,
-    WOW_FAIL_INTERNET_GAME_ROOM_WITHOUT_BNET     = 0x19,
-    WOW_FAIL_UNLOCKABLE_LOCK                     = 0x20,
+    WOW_FAIL_UNLOCKABLE_LOCK                     = 0x19,
+    WOW_FAIL_CONVERT_TO_BATTLE_NET               = 0x20,
     WOW_FAIL_DISCONNECTED                        = 0xFF
 };
 


### PR DESCRIPTION
i just messed with the AuthResult cause of something i work with and i check the fail messages i get. 
and this 4 was incorrect. so i update them to correct ones.
