### PR TITLE
[4.3.4] Spells/Mage: Mirror Image summoning

### DIFF
--- a/sql/updates/world/2013_04_05_00_world_version_434.sql
+++ b/sql/updates/world/2013_04_05_00_world_version_434.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 55342;
+INSERT INTO `spell_script_names`(`spell_id`, `ScriptName`) VALUES (55342, 'spell_mage_mirror_image');
+
+UPDATE `creature_template` SET `spell1` = 88084, `ScriptName` = 'npc_mirror_image' WHERE `entry` = 47243;
+UPDATE `creature_template` SET `spell1` = 88082, `ScriptName` = 'npc_mirror_image' WHERE `entry` = 47244;

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -981,8 +981,12 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
                     break;
                 }
                 case 31216: // Mirror Image
+                case 47243: // Mirror Image
+                case 47244: // Mirror Image
                 {
                     SetBonusDamage(int32(GetOwner()->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_FROST) * 0.33f));
+                    SetBonusDamage(int32(GetOwner()->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_FIRE) * 0.33f));
+                    SetBonusDamage(int32(GetOwner()->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_ARCANE) * 0.33f));
                     SetDisplayId(GetOwner()->GetDisplayId());
                     if (!pInfo)
                     {


### PR DESCRIPTION
Fixes the summonig of Mirror Images npcs and implements the Glyph of Mirror Image.

Mirror Image: http://old.wowhead.com/spell=55342
Glyph of Mirror Image: http://old.wowhead.com/spell=63093

Anyways the AI seems to still bugged by some reason (at least on my case).
