### PR TITLE
[4.3.4] Should decrease fuzzy movement.

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -381,17 +381,16 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvPacket)
     /*----------------------*/
     /* process position-change */
     // this is almost never true (not sure why it is sometimes, but it is), normally use mover->IsVehicle()
+    WorldPacket data(SMSG_PLAYER_MOVE, recvPacket.size());
     if (mover->GetVehicle())
     {
         mover->SetOrientation(movementInfo.pos.GetOrientation());
+        _player->WriteMovementInfo(data);
+        mover->SendMessageToSet(&data, _player);
         return;
     }
 
     mover->UpdatePosition(movementInfo.pos);
-
-    WorldPacket data(SMSG_PLAYER_MOVE, recvPacket.size());
-    _player->WriteMovementInfo(data);
-    mover->SendMessageToSet(&data, _player);
 
     if (plrMover)                                            // nothing is charmed, or player charmed
     {
@@ -418,6 +417,8 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvPacket)
             }
         }
     }
+    _player->WriteMovementInfo(data);
+    mover->SendMessageToSet(&data, _player);
 }
 
 void WorldSession::HandleForceSpeedChangeAck(WorldPacket &recvData)


### PR DESCRIPTION
Reason: The Core overrides the positions, so the positioning get async to the other clients.
PS: To decrease the movement delay, you should set mapupdate-interval 25-50ms

Signed-off-by: Zazi gir_zippo@hellokitty.com
