### PR TITLE
Clearify the guild limitation message on world server initation

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1779,7 +1779,7 @@ void World::SetInitialWorldSettings()
     sLog->outInfo(LOG_FILTER_SERVER_LOADING, "Calculate random battleground reset time...");
     InitRandomBGResetTime();
 
-    sLog->outInfo(LOG_FILTER_SERVER_LOADING, "Calculate Guild cap reset time...");
+    sLog->outInfo(LOG_FILTER_SERVER_LOADING, "Calculate guild limitation(s) reset time...");
     InitGuildResetTime();
 
     LoadCharacterNameData();


### PR DESCRIPTION
Clearify the guild limitation message on world server initation (3.3.5a withdrawal cap; 4.3.4 withdrawal and guild rep cap)
