### PR TITLE
Implement melee damage delay

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2232,7 +2232,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
 
             SetSelection(0);
 
-            CombatStop();
+            CombatStop(false, true);
 
             ResetContestedPvP();
 
@@ -20997,7 +20997,7 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
     // Prepare to flight start now
 
     // stop combat at start taxi flight if any
-    CombatStop();
+    CombatStop(false, true);
 
     StopCastingCharm();
     StopCastingBindSight();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -264,6 +264,10 @@ Unit::Unit(bool isWorldObject) :
     _focusSpell = NULL;
     _lastLiquid = NULL;
     _isWalkingBeforeCharm = false;
+
+    _damageInfo.target = NULL;
+    _swingDelayTimer = 0;
+    _swingLanded = true;
 }
 
 ////////////////////////////////////////////////////////////
@@ -346,6 +350,16 @@ void Unit::Update(uint32 p_time)
             else
                 m_CombatTimer -= p_time;
         }
+    }
+
+    if (_damageInfo.target != NULL)
+    {
+        if (_swingLanded == true)
+            _damageInfo.target = NULL;
+        else if (_swingDelayTimer >= p_time)
+            _swingDelayTimer -= p_time;
+        else
+            ExecuteDelayedSwingHit();
     }
 
     // not implemented before 3.0.2
@@ -1893,6 +1907,35 @@ void Unit::CalcHealAbsorb(Unit* victim, const SpellInfo* healSpell, uint32 &heal
     healAmount = RemainingHeal;
 }
 
+bool Unit::HasDelayedSwing() const
+{
+    return _swingLanded == false;
+}
+
+void Unit::ExecuteDelayedSwingHit()
+{
+    ASSERT(_damageInfo.target);
+
+    _swingLanded = true;
+    _swingDelayTimer = 0;
+
+    sLog->outDebug(LOG_FILTER_UNITS, "Unit::ExecuteDelayedSwingHit() call for %s, victim = %s", GetName().c_str(), _damageInfo.target->GetName().c_str());
+
+    //TriggerAurasProcOnEvent(*_damageInfo);
+
+    DealMeleeDamage(&_damageInfo, true);
+
+    // Recursion warning here
+    ProcDamageAndSpell(_damageInfo.target, _damageInfo.procAttacker, _damageInfo.procVictim, _damageInfo.procEx, _damageInfo.damage, _damageInfo.attackType);
+}
+
+void Unit::SuspendDelayedSwing()
+{
+    sLog->outDebug(LOG_FILTER_UNITS, "Unit::SuspendDelayedSwing() call for %s, victim = %s", GetName().c_str(), _damageInfo.target ? _damageInfo.target->GetName().c_str() : "_removed_");
+
+    _swingLanded = true;
+}
+
 void Unit::AttackerStateUpdate (Unit* victim, WeaponAttackType attType, bool extra)
 {
     if (HasUnitState(UNIT_STATE_CANNOT_AUTOATTACK) || HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
@@ -1910,6 +1953,10 @@ void Unit::AttackerStateUpdate (Unit* victim, WeaponAttackType attType, bool ext
     if (attType != BASE_ATTACK && attType != OFF_ATTACK)
         return;                                             // ignore ranged case
 
+    // If attack is executed before previous swing finished, finish it forcefully
+    if (_damageInfo.target != NULL && _swingLanded == false)
+        ExecuteDelayedSwingHit();
+
     // melee attack spell casted at main hand attack only - no normal melee dmg dealt
     if (attType == BASE_ATTACK && m_currentSpells[CURRENT_MELEE_SPELL] && !extra)
         m_currentSpells[CURRENT_MELEE_SPELL]->cast();
@@ -1918,23 +1965,26 @@ void Unit::AttackerStateUpdate (Unit* victim, WeaponAttackType attType, bool ext
         // attack can be redirected to another target
         victim = GetMeleeHitRedirectTarget(victim);
 
-        CalcDamageInfo damageInfo;
-        CalculateMeleeDamage(victim, 0, &damageInfo, attType);
+        CalculateMeleeDamage(victim, 0, &_damageInfo, attType);
+        DealDamageMods(victim, _damageInfo.damage, &_damageInfo.absorb);
+
         // Send log damage message to client
-        DealDamageMods(victim, damageInfo.damage, &damageInfo.absorb);
-        SendAttackStateUpdate(&damageInfo);
+        SendAttackStateUpdate(&_damageInfo);
 
-        //TriggerAurasProcOnEvent(damageInfo);
-        ProcDamageAndSpell(damageInfo.target, damageInfo.procAttacker, damageInfo.procVictim, damageInfo.procEx, damageInfo.damage, damageInfo.attackType);
-
-        DealMeleeDamage(&damageInfo, true);
+        // If this attack is procced from another white damage (extra attack) execute it right now
+        // Else delay melee hit by average melee swing animation time (currently only players)
+        _swingLanded = false;
+        if (m_extraAttacks)
+            ExecuteDelayedSwingHit();
+        else
+            _swingDelayTimer = 500; // average value, need exact
 
         if (GetTypeId() == TYPEID_PLAYER)
             TC_LOG_DEBUG(LOG_FILTER_UNITS, "AttackerStateUpdate: (Player) %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
-                GetGUIDLow(), victim->GetGUIDLow(), victim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
+                GetGUIDLow(), victim->GetGUIDLow(), victim->GetTypeId(), _damageInfo.damage, _damageInfo.absorb, _damageInfo.blocked_amount, _damageInfo.resist);
         else
             TC_LOG_DEBUG(LOG_FILTER_UNITS, "AttackerStateUpdate: (NPC)    %u attacked %u (TypeId: %u) for %u dmg, absorbed %u, blocked %u, resisted %u.",
-                GetGUIDLow(), victim->GetGUIDLow(), victim->GetTypeId(), damageInfo.damage, damageInfo.absorb, damageInfo.blocked_amount, damageInfo.resist);
+                GetGUIDLow(), victim->GetGUIDLow(), victim->GetTypeId(), _damageInfo.damage, _damageInfo.absorb, _damageInfo.blocked_amount, _damageInfo.resist);
     }
 }
 
@@ -9071,24 +9121,26 @@ bool Unit::AttackStop()
     return true;
 }
 
-void Unit::CombatStop(bool includingCast)
+void Unit::CombatStop(bool includingCast, bool includingAttacks)
 {
     if (includingCast && IsNonMeleeSpellCasted(false))
         InterruptNonMeleeSpells(false);
 
     AttackStop();
-    RemoveAllAttackers();
+    RemoveAllAttackers(includingAttacks);
+    if (_swingLanded == false)
+        SuspendDelayedSwing();
     if (GetTypeId() == TYPEID_PLAYER)
         ToPlayer()->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
     ClearInCombat();
 }
 
-void Unit::CombatStopWithPets(bool includingCast)
+void Unit::CombatStopWithPets(bool includingCast, bool includingAttacks)
 {
-    CombatStop(includingCast);
+    CombatStop(includingCast, includingAttacks);
 
     for (ControlList::const_iterator itr = m_Controlled.begin(); itr != m_Controlled.end(); ++itr)
-        (*itr)->CombatStop(includingCast);
+        (*itr)->CombatStop(includingCast, includingAttacks);
 }
 
 bool Unit::isAttackingPlayer() const
@@ -9109,11 +9161,15 @@ bool Unit::isAttackingPlayer() const
     return false;
 }
 
-void Unit::RemoveAllAttackers()
+void Unit::RemoveAllAttackers(bool stopAttacks)
 {
     while (!m_attackers.empty())
     {
         AttackerSet::iterator iter = m_attackers.begin();
+        //attacker may still have delayed swing on us
+        //Placeholder, need proper handling for this case
+        if (stopAttacks)
+            (*iter)->SuspendDelayedSwing();
         if (!(*iter)->AttackStop())
         {
             TC_LOG_ERROR(LOG_FILTER_UNITS, "WORLD: Unit has an attacker that isn't attacking it!");
@@ -13518,7 +13574,7 @@ void Unit::CleanupBeforeRemoveFromMap(bool finalCleanup)
         m_cleanupDone = true;
 
     m_Events.KillAllEvents(false);                      // non-delatable (currently casted spells) will not deleted now but it will deleted at call in Map::RemoveAllObjectsInRemoveList
-    CombatStop();
+    CombatStop(false, true);
     ClearComboPointHolders();
     DeleteThreatList();
     getHostileRefManager().setOnlineOfflineState(false);
@@ -15328,8 +15384,8 @@ void Unit::Kill(Unit* victim, bool durabilityLoss)
         // last damage from non duel opponent or opponent controlled creature
         if (plrVictim->duel)
         {
-            plrVictim->duel->opponent->CombatStopWithPets(true);
-            plrVictim->CombatStopWithPets(true);
+            plrVictim->duel->opponent->CombatStopWithPets(true, true);
+            plrVictim->CombatStopWithPets(true, true);
             plrVictim->DuelComplete(DUEL_INTERRUPTED);
         }
     }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1305,13 +1305,13 @@ class Unit : public WorldObject
         bool Attack(Unit* victim, bool meleeAttack);
         void CastStop(uint32 except_spellid = 0);
         bool AttackStop();
-        void RemoveAllAttackers();
+        void RemoveAllAttackers(bool stopAttacks = false);
         AttackerSet const& getAttackers() const { return m_attackers; }
         bool isAttackingPlayer() const;
         Unit* GetVictim() const { return m_attacking; }
 
-        void CombatStop(bool includingCast = false);
-        void CombatStopWithPets(bool includingCast = false);
+        void CombatStop(bool includingCast = false, bool includingAttacks = false);
+        void CombatStopWithPets(bool includingCast = false, bool includingAttacks = false);
         void StopAttackFaction(uint32 faction_id);
         Unit* SelectNearbyTarget(Unit* exclude = NULL, float dist = NOMINAL_MELEE_RANGE) const;
         void SendMeleeAttackStop(Unit* victim = NULL);
@@ -2137,6 +2137,10 @@ class Unit : public WorldObject
         time_t GetLastDamagedTime() const { return _lastDamagedTime; }
         void SetLastDamagedTime(time_t val) { _lastDamagedTime = val; }
 
+        bool HasDelayedSwing() const;
+        void SuspendDelayedSwing();
+        void ExecuteDelayedSwingHit();
+
     protected:
         explicit Unit (bool isWorldObject);
 
@@ -2238,6 +2242,7 @@ class Unit : public WorldObject
         uint32 m_state;                                     // Even derived shouldn't modify
         uint32 m_CombatTimer;
         uint32 m_lastManaUse;                               // msecs
+        uint32 _swingDelayTimer;
         TimeTrackerSmall m_movesplineTimer;
 
         Diminishing m_Diminishing;
@@ -2250,6 +2255,9 @@ class Unit : public WorldObject
 
         RedirectThreatInfo _redirectThreadInfo;
 
+        CalcDamageInfo _damageInfo;
+
+        bool _swingLanded;
         bool m_cleanupDone; // lock made to not add stuff after cleanup before delete
         bool m_duringRemoveFromWorld; // lock made to not add stuff after begining removing from world
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3269,6 +3269,10 @@ void Spell::cast(bool skipCheck)
         return;
     }
 
+    // if we are applying crowd control aura execute caster's delayed attack immediately to prevent instant CC break
+    if (m_caster->HasDelayedSwing() && m_targets.GetUnitTarget() && (m_spellInfo->AuraInterruptFlags & AURA_INTERRUPT_FLAG_TAKE_DAMAGE))
+        m_caster->ExecuteDelayedSwingHit();
+
     PrepareTriggersExecutedOnHit();
 
     CallScriptOnCastHandlers();


### PR DESCRIPTION
As title says, this adds 'flytime' for white melee attacks. CC spells casts are taken in account. Extra attacks are handled properly (also in combat log - attack with overkill will be always last). Despawning units will not cause crashes. This also makes on-hit effects proc at actual melee hit.
Hm... closes #5794
