### PR TITLE
Core/Commands: Improve .damage command, now can damage destructible gameobjects => ".damage go <guid> <damage>"

### DIFF
--- a/sql/updates/world/2013_05_13_00_world_misc.sql
+++ b/sql/updates/world/2013_05_13_00_world_misc.sql
@@ -1,0 +1,5 @@
+SET @ENTRY := 176;
+DELETE FROM `trinity_string` WHERE `entry` IN(@ENTRY, @ENTRY+1);
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES 
+(@ENTRY,   'Invalid gameobject type, must be a destructible building.'),
+(@ENTRY+1, 'Gameobject %s (GUID: %u) damaged %u (actual health: %u).');

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -209,7 +209,9 @@ enum TrinityStrings
     LANG_YOU_CHANGE_RUNIC_POWER         = 173,
     LANG_YOURS_RUNIC_POWER_CHANGED      = 174,
     LANG_LIQUID_STATUS                  = 175,
-    // Room for more level 1              176-199 not used
+    LANG_INVALID_GAMEOBJECT_TYPE        = 176,
+    LANG_GAMEOBJECT_DAMAGED             = 177,
+    // Room for more level 1              178-199 not used
 
     // level 2 chat
     LANG_NO_SELECTION                   = 200,

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -2042,6 +2042,70 @@ public:
         if (!*args)
             return false;
 
+        char* str = strtok((char*)args, " ");
+
+        if (strcmp(str, "go") == 0)
+        {
+            char* guidStr = strtok(NULL, " ");
+            if (!guidStr)
+            {
+                handler->SendSysMessage(LANG_BAD_VALUE);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+
+            int32 guid = atoi(guidStr);
+            if (!guid)
+            {
+                handler->SendSysMessage(LANG_BAD_VALUE);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+
+            char* damageStr = strtok(NULL, " ");
+            if (!damageStr)
+            {
+                handler->SendSysMessage(LANG_BAD_VALUE);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+
+            int32 damage = atoi(damageStr);
+            if (!damage)
+            {
+                handler->SendSysMessage(LANG_BAD_VALUE);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+
+            if (Player* player = handler->GetSession()->GetPlayer())
+            {
+                GameObject* go = NULL;
+
+                if (GameObjectData const* goData = sObjectMgr->GetGOData(guid))
+                    go = handler->GetObjectGlobalyWithGuidOrNearWithDbGuid(guid, goData->id);
+
+                if (!go)
+                {
+                    handler->PSendSysMessage(LANG_COMMAND_OBJNOTFOUND, guid);
+                    handler->SetSentErrorMessage(true);
+                    return false;
+                }
+
+                if (!go->IsDestructibleBuilding())
+                {
+                    handler->SendSysMessage(LANG_INVALID_GAMEOBJECT_TYPE);
+                    handler->SetSentErrorMessage(true);
+                    return false;
+                }
+
+                go->ModifyHealth(-damage, player);
+                handler->PSendSysMessage(LANG_GAMEOBJECT_DAMAGED, go->GetName().c_str(), guid, -damage, go->GetGOValue()->Building.Health);
+            }
+
+            return true;
+        }
+
         Unit* target = handler->getSelectedUnit();
         if (!target || !handler->GetSession()->GetPlayer()->GetSelection())
         {


### PR DESCRIPTION
A command to do damage to buildings to allow test buildings destruction.

Request by @Aokromes 
Thanks to @Shauren
