### PR TITLE
Support 1.12.3 (build 6141)

### DIFF
--- a/src/server/authserver/Authentication/AuthCodes.cpp
+++ b/src/server/authserver/Authentication/AuthCodes.cpp
@@ -37,6 +37,7 @@ namespace AuthHelper
 
     static RealmBuildInfo const PreBcAcceptedClientBuilds[] =
     {
+        {6141,  1, 12, 3, ' '},
         {6005,  1, 12, 2, ' '},
         {5875,  1, 12, 1, ' '},
         {0,     0, 0, 0, ' '}                                   // terminator


### PR DESCRIPTION
At 2006/11/14 , Blizzard and The9 released 1.12.3 (build 6141) client in China, I already pulled the 1.12.3 (build 6141) support to http://github.com/cmangos/mangos-classic, please view details here: https://github.com/cmangos/mangos-classic/pull/24

I also uploaded the 1.12.3 (build 6141) version of wow.exe to skydrive: http://sdrv.ms/Wp9IgF , hope it will be useful

Thank you : )
