### PR TITLE
Remove BOM from 2013_05_21_00_world_trinity_strings.sql

### DIFF
--- a/sql/updates/world/2013_05_21_00_world_trinity_strings.sql
+++ b/sql/updates/world/2013_05_21_00_world_trinity_strings.sql
@@ -1,4 +1,4 @@
-﻿DELETE FROM `trinity_string` WHERE entry IN (453, 548, 549, 550, 714, 716, 749, 752, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856); 
+DELETE FROM `trinity_string` WHERE entry IN (453, 548, 549, 550, 714, 716, 749, 752, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856); 
 INSERT INTO `trinity_string` (entry, content_default) VALUES
 (453,'│Player %s %s (guid: %u)'),
 (548,'│ GM Mode active, Phase: -1'),


### PR DESCRIPTION
Convert to UTF-8 without BOM (byte order mark). BOM prevents query from executing in CLI:

`You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ï»¿DELETE FROM `trinity_string` WHERE entry IN (45548, 549, 550, 714, 716, 74' at line 1
`
