### PR TITLE
Quest Complete, OnLevelChanged

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -522,6 +522,9 @@ void WorldSession::HandleQuestgiverCompleteQuest(WorldPacket& recvData)
             else                                            // no items required
                 _player->PlayerTalkClass->SendQuestGiverOfferReward(quest, guid, true);
         }
+
+        if (Creature* creature = object->ToCreature())
+            sScriptMgr->OnQuestComplete(_player, creature, quest);
     }
 }
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -688,8 +688,8 @@ class PlayerScript : public UnitScript
         // Called when a player is killed by a creature
         virtual void OnPlayerKilledByCreature(Creature* /*killer*/, Player* /*killed*/) { }
 
-        // Called when a player's level changes (right before the level is applied)
-        virtual void OnLevelChanged(Player* /*player*/, uint8 /*newLevel*/) { }
+        // Called when a player's level changes (after the level is applied)
+        virtual void OnLevelChanged(Player* /*player*/, uint8 /*oldLevel*/) { }
 
         // Called when a player's free talent points change (right before the change is applied)
         virtual void OnFreeTalentPointsChanged(Player* /*player*/, uint32 /*points*/) { }


### PR DESCRIPTION
Changes the comments on OnLevelChanged hook from newlevel to oldlevel (was really confusing..) and saying the hook was called before leveling to after.
Since the hook is called after, you should be able to get the new level with GetLevel if needed, so its not needed in the hook.

Fixes the Quest Complete hook. A script already seems to use it, but it is never called.
Not exactly sure about this, but this is how the other hooks are coded it seems.

~Removed FindCreature from commit
