### PR TITLE
Core/SmartScripts

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2104,6 +2104,64 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
             break;
         }
+        case SMART_ACTION_ADD_PASSENGER:
+        {
+            if (!GetBaseObject())
+                break;
+
+            if (!IsCreature(GetBaseObject()->ToCreature()))
+                break;
+
+            Vehicle* veh = GetBaseObject()->ToCreature()->GetVehicleKit();
+            if (!veh)
+            {
+                TC_LOG_ERROR(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction: SMART_ACTION_ADD_PASSENGER: Creature entry %u is not a vehicle, exiting!", me->GetEntry());
+                return;
+            }
+
+            ObjectList* targets = GetTargets(e, unit);
+            if (targets && *targets->begin())
+            {
+                if (!IsUnit(*targets->begin()))
+                    break;
+
+                veh->AddPassenger((*targets->begin())->ToUnit(), e.action.vehicle.seatId);
+
+                delete targets;
+            }
+
+            break;
+        }
+        case SMART_ACTION_REMOVE_PASSENGER:
+        {
+            if (!GetBaseObject())
+                break;
+
+            if (!IsCreature(GetBaseObject()->ToCreature()))
+                break;
+
+            Vehicle* veh = GetBaseObject()->ToCreature()->GetVehicleKit();
+            if (!veh)
+                break;
+			
+            if (e.GetTargetType() == SMART_TARGET_NONE)
+                veh->RemoveAllPassengers();
+            else
+            {
+                ObjectList* targets = GetTargets(e, unit);
+                if (targets && *targets->begin())
+                {
+                    if (!IsUnit(*targets->begin()))
+                        break;
+
+                    veh->RemovePassenger((*targets->begin())->ToUnit());
+
+                    delete targets;
+                }
+            }
+
+            break;
+        }
         default:
             TC_LOG_ERROR(LOG_FILTER_SQL, "SmartScript::ProcessAction: Entry %d SourceType %u, Event %u, Unhandled Action type %u", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
             break;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -897,13 +897,19 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }
         case SMART_ACTION_CALL_KILLEDMONSTER:
         {
-            Player* player = NULL;
-            if (me)
-                player = me->GetLootRecipient();
+            if (e.target.type == SMART_TARGET_NONE) // Loot recipient and his group members
+            {
+                if (!me)
+                    break;
 
-            if (me && player)
-                player->RewardPlayerAndGroupAtEvent(e.action.killedMonster.creature, player);
-            else if (GetBaseObject())
+                if (Player* player = me->GetLootRecipient())
+                {
+                    player->RewardPlayerAndGroupAtEvent(e.action.killedMonster.creature, player);
+                    TC_LOG_DEBUG(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction: SMART_ACTION_CALL_KILLEDMONSTER: Player %u, Killcredit: %u",
+                        player->GetGUIDLow(), e.action.killedMonster.creature);
+                }
+            }
+            else // Specific target type
             {
                 ObjectList* targets = GetTargets(e, unit);
                 if (!targets)
@@ -911,29 +917,22 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                 for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
                 {
-                    // Special handling for vehicles
-                    if (IsUnit(*itr))
+                    if (IsPlayer(*itr))
+                    {
+                        (*itr)->ToPlayer()->KilledMonsterCredit(e.action.killedMonster.creature);
+                        TC_LOG_DEBUG(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction: SMART_ACTION_CALL_KILLEDMONSTER: Player %u, Killcredit: %u",
+                            (*itr)->GetGUIDLow(), e.action.killedMonster.creature);
+                    } 
+                    else if (IsUnit(*itr)) // Special handling for vehicles
                         if (Vehicle* vehicle = (*itr)->ToUnit()->GetVehicleKit())
                             for (SeatMap::iterator it = vehicle->Seats.begin(); it != vehicle->Seats.end(); ++it)
                                 if (Player* player = ObjectAccessor::FindPlayer(it->second.Passenger))
-                                    player->RewardPlayerAndGroupAtEvent(e.action.killedMonster.creature, player);
-
-                    if (!IsPlayer(*itr))
-                        continue;
-
-                    (*itr)->ToPlayer()->RewardPlayerAndGroupAtEvent(e.action.killedMonster.creature, (*itr)->ToPlayer());
-                    TC_LOG_DEBUG(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction: SMART_ACTION_CALL_KILLEDMONSTER: Player %u, Killcredit: %u",
-                        (*itr)->GetGUIDLow(), e.action.killedMonster.creature);
+                                    player->KilledMonsterCredit(e.action.killedMonster.creature);
                 }
 
                 delete targets;
             }
-            else if (trigger && IsPlayer(unit))
-            {
-                unit->ToPlayer()->RewardPlayerAndGroupAtEvent(e.action.killedMonster.creature, unit);
-                TC_LOG_DEBUG(LOG_FILTER_DATABASE_AI, "SmartScript::ProcessAction: SMART_ACTION_CALL_KILLEDMONSTER: (trigger == true) Player %u, Killcredit: %u",
-                    unit->GetGUIDLow(), e.action.killedMonster.creature);
-            }
+
             break;
         }
         case SMART_ACTION_SET_INST_DATA:

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1299,10 +1299,10 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
             for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
             {
-                if (!IsPlayer(*itr))
-                    continue;
-
-                (*itr)->ToPlayer()->TeleportTo(e.action.teleport.mapID, e.target.x, e.target.y, e.target.z, e.target.o);
+                if (IsPlayer(*itr))
+                    (*itr)->ToPlayer()->TeleportTo(e.action.teleport.mapID, e.target.x, e.target.y, e.target.z, e.target.o);
+                else if (IsCreature(*itr))
+                    (*itr)->ToCreature()->NearTeleportTo(e.target.x, e.target.y, e.target.z, e.target.o);
             }
 
             delete targets;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -795,7 +795,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                 return false;
             break;
         case SMART_ACTION_TELEPORT:
-            if (!sMapStore.LookupEntry(e.action.teleport.mapID))
+            if (e.action.teleport.mapID && !sMapStore.LookupEntry(e.action.teleport.mapID))
             {
                 TC_LOG_ERROR(LOG_FILTER_SQL, "SmartAIMgr: Entry %d SourceType %u Event %u Action %u uses non-existent Map entry %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.teleport.mapID);
                 return false;
@@ -837,6 +837,16 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                 return false;
             break;
         }
+        case SMART_ACTION_ADD_PASSENGER:
+        {
+            if (e.GetTargetType() == SMART_TARGET_SELF || e.GetTargetType() == SMART_TARGET_POSITION)
+            {
+                TC_LOG_ERROR(LOG_FILTER_SQL, "SmartAIMgr: Creature %d Event %u Action %u uses invalid Target Type %u, skipped.", e.entryOrGuid, e.event_id, e.GetActionType(), e.GetTargetType());
+                return false;
+            }
+            break;
+        }
+        case SMART_ACTION_REMOVE_PASSENGER:
         case SMART_ACTION_FOLLOW:
         case SMART_ACTION_SET_ORIENTATION:
         case SMART_ACTION_STORE_TARGET_LIST:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -490,8 +490,10 @@ enum SMART_ACTION
     SMART_ACTION_ADD_GO_FLAG                        = 105,    // Flags
     SMART_ACTION_REMOVE_GO_FLAG                     = 106,    // Flags
     SMART_ACTION_SUMMON_CREATURE_GROUP              = 107,    // Group, attackInvoker
+    SMART_ACTION_ADD_PASSENGER                      = 108,    // SeatId, target
+    SMART_ACTION_REMOVE_PASSENGER                   = 109,    // SeatId
 
-    SMART_ACTION_END                                = 108
+    SMART_ACTION_END                                = 110
 };
 
 struct SmartAction
@@ -940,6 +942,10 @@ struct SmartAction
             uint32 attackInvoker;
         } creatureGroup;
 
+        struct
+        {
+            uint32 seatId;
+        } vehicle;
         //! Note for any new future actions
         //! All parameters must have type uint32
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -759,6 +759,9 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
     // delay creature move for grid/cell to grid/cell moves
     if (old_cell.DiffCell(new_cell) || old_cell.DiffGrid(new_cell))
     {
+        if (old_cell.DiffGrid(new_cell))
+            EnsureGridLoadedForActiveObject(new_cell, creature);
+
         #ifdef TRINITY_DEBUG
             TC_LOG_DEBUG(LOG_FILTER_MAPS, "Creature (GUID: %u Entry: %u) added to moving list from grid[%u, %u]cell[%u, %u] to grid[%u, %u]cell[%u, %u].", creature->GetGUIDLow(), creature->GetEntry(), old_cell.GridX(), old_cell.GridY(), old_cell.CellX(), old_cell.CellY(), new_cell.GridX(), new_cell.GridY(), new_cell.CellX(), new_cell.CellY());
         #endif
@@ -820,6 +823,8 @@ void Map::MoveAllCreaturesInMoveList()
         {
             // update pos
             c->Relocate(c->_newPosition);
+            if (c->IsVehicle())
+                c->GetVehicleKit()->RelocatePassengers();
             //CreatureRelocationNotify(c, new_cell, new_cell.cellCoord());
             c->UpdateObjectVisibility(false);
         }


### PR DESCRIPTION
- `SMART_ACTION_CALL_KILLEDMONSTER` rewritten to properly give kill credit when target type is set.
- Allow `SMART_ACTION_TELEPORT` to teleport creatures also.

Other:
- Load grid before teleporting a creature to it.
- Relocate passengers when teleporting a vehicle to prevent vehicle despawn.

Adding core changes as I'm trying to script `As Hyjal Burns` quest without C++.
