### PR TITLE
Make Onyxia fly and avoid movement during cast

### DIFF
--- a/sql/updates/world/2013_07_08_00_world_creature_template.sql
+++ b/sql/updates/world/2013_07_08_00_world_creature_template.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `InhabitType` = 5 WHERE `entry` = 10184;

--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -266,10 +266,11 @@ public:
                         break;
                     case 9:
                         me->GetMotionMaster()->MoveChase(me->GetVictim());
+						me->SetHover(false);  // stop show Onyxia flying on player's screen
                         BellowingRoarTimer = 1000;
                         break;
                     case 10:
-                        me->SetCanFly(true);
+                        me->SetHover(true);  // the only way to make Onyxia "flying" on the screen
                         me->GetMotionMaster()->MovePoint(11, Phase2Location.GetPositionX(), Phase2Location.GetPositionY(), Phase2Location.GetPositionZ()+25);
                         me->SetSpeed(MOVE_FLIGHT, 1.0f);
                         Talk(SAY_PHASE_2_TRANS);
@@ -283,9 +284,7 @@ public:
                             me->GetMotionMaster()->MovePoint(PointData->LocId, PointData->fX, PointData->fY, PointData->fZ);
                         me->GetMotionMaster()->Clear(false);
                         me->GetMotionMaster()->MoveIdle();
-
                         break;
-
                     default:
                         IsMoving = false;
                         break;
@@ -445,7 +444,7 @@ public:
 
                 if (MovementTimer <= Diff)
                 {
-                    if (!IsMoving)
+                    if (!IsMoving && !(me->HasUnitState(UNIT_STATE_CASTING)))  // move only if Onyxia isn't moving AND if she's not casting
                     {
                         SetNextRandomPoint();
                         PointData = GetMoveData();


### PR DESCRIPTION
Change the InhabitType of Onyxia from 3 (Ground and Water) to 5 (Ground and Flying) and make her flying on the player's screen by using SetHover(bool). And avoid movement during cast by the verification of the presence of the UNIT_STATE_CASTING flag.

known bug : Onyxia has a strange fly on the screen when she is flying up and when she stays in the air without moving.
