### PR TITLE
Core/Spells: Hand of Freedom can now be used under all types of stun (Sa...

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5682,7 +5682,9 @@ SpellCastResult Spell::CheckCasterAuras() const
                         switch (part->GetAuraType())
                         {
                             case SPELL_AURA_MOD_STUN:
-                                if (!usableInStun || !(auraInfo->GetAllEffectsMechanicMask() & (1<<MECHANIC_STUN)))
+                                //! Hand of Freedom should always be usable, under any type of stun regarding the
+                                //! mechanics of the stun (like Sap, Gouge, Cyclone, etc.).
+                                if (m_spellInfo->Id != 1044 && (!usableInStun || !(auraInfo->GetAllEffectsMechanicMask() & (1<<MECHANIC_STUN))))
                                     return SPELL_FAILED_STUNNED;
                                 break;
                             case SPELL_AURA_MOD_CONFUSE:


### PR DESCRIPTION
...p, Gouge, Cyclone, etc.) as well as while being feared or confused (Polymorph, Blind, etc.).

Fixes #7206
