### PR TITLE
Core/Misc: Implement CMSG_SET_TAXI_BENCHMARK_MODE to toggle PLAYER_FLAGS...

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1613,8 +1613,12 @@ void WorldSession::HandleRequestPetInfoOpcode(WorldPacket& /*recvData */)
 
 void WorldSession::HandleSetTaxiBenchmarkOpcode(WorldPacket& recvData)
 {
+    TC_LOG_DEBUG(LOG_FILTER_NETWORKIO, "WORLD: CMSG_SET_TAXI_BENCHMARK_MODE");
+
     uint8 mode;
     recvData >> mode;
+
+    mode ? _player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_TAXI_BENCHMARK) : _player->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_TAXI_BENCHMARK);
 
     TC_LOG_DEBUG(LOG_FILTER_NETWORKIO, "Client used \"/timetest %d\" command", mode);
 }

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -218,6 +218,8 @@ void FlightPathMovementGenerator::DoFinalize(Player* player)
         // when client side flight end early in comparison server side
         player->StopMoving();
     }
+
+    player->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_TAXI_BENCHMARK);
 }
 
 #define PLAYER_FLIGHT_SPEED 32.0f


### PR DESCRIPTION
..._TAXI_BENCHMARK based on arguments. To enable/disable this, call '/script SetTaxiBenchmarkMode(1)' (1 = on, 0 = off). Basically debugs the taxi flight and outputs min, max and avg FPS during flight. Automatically toggled off when flight ends.
