### PR TITLE
[4.3.4] Prevent seal of justice can be activated together with other seal

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2142,7 +2142,7 @@ SpellSpecificType SpellInfo::GetSpellSpecific() const
         case SPELLFAMILY_PALADIN:
         {
             // Collection of all the seal family flags. No other paladin spell has any of those.
-            if (SpellFamilyFlags[1] & 0x26000C00
+            if (SpellFamilyFlags[1] & 0xA6000C00
                 || SpellFamilyFlags[0] & 0x0A000000)
                 return SPELL_SPECIFIC_SEAL;
 


### PR DESCRIPTION
Currently, if you use seal of justice, you can activatee other seal without seal of Justice removed.

Seal of Justice http://www.wowhead.com/spell=20164

From spellwork

ID - 20164 Seal of Justice
Description: Fills the Paladin with the spirit of justice for $20164d, causing each single-target melee attack to limit the target's maximum run speed for $20170d and deal ${$MWS_(0.005_$AP+0.01_$SPH)_$<sop>/100} additional Holy damage.  Only one Seal can be active on the Paladin at any one time.

Unleashing this Seal's energy will deal ${1+0.25_$SPH+0.16_$AP} Holy damage to an enemy.
ToolTip: Melee attacks limit maximum run speed for $20170d and deal ${$MWS_(0.005_$AP+0.01_$SPH)_$<sop>/100} additional Holy damage.
Category = 0, SpellIconID = 307, activeIconID = 0, SpellVisual = (9504,0)
Family SPELLFAMILY_PALADIN, flag [0] 0x00000000 [1] 0x80000000 [2] 0x00000000
