### PR TITLE
Fix uninitialized UpdateMask field

### DIFF
--- a/src/server/game/Entities/Object/Updates/UpdateMask.h
+++ b/src/server/game/Entities/Object/Updates/UpdateMask.h
@@ -36,7 +36,7 @@ class UpdateMask
 
         UpdateMask() : _fieldCount(0), _blockCount(0), _bits(NULL) { }
 
-        UpdateMask(UpdateMask const& right)
+        UpdateMask(UpdateMask const& right) : _bits(NULL)
         {
             SetCount(right.GetCount());
             memcpy(_bits, right._bits, sizeof(uint8) * _blockCount * 32);


### PR DESCRIPTION
Initialized UpdateMask::_bits to NULL in all constructors.
UpdateMask(UpdateMask const& right) constructor sets the field count with SetCount() method before any field initialization. This means that SetCount() will call delete[] on the uninitialized _bits pointer field, leading to undefined behavior.
