### PR TITLE
Fix race condition in Thread

### DIFF
--- a/src/server/shared/Threading/Threading.cpp
+++ b/src/server/shared/Threading/Threading.cpp
@@ -130,10 +130,13 @@ bool Thread::start()
     if (m_task == 0 || m_iThreadId != 0)
         return false;
 
+    //incRef before spawing the thread, otherwise Thread::ThreadTask() might call decRef and delete m_task
+    m_task->incReference();
+
     bool res = (ACE_Thread::spawn(&Thread::ThreadTask, (void*)m_task, THREADFLAG, &m_iThreadId, &m_hThreadHandle) == 0);
 
-    if (res)
-        m_task->incReference();
+    if (!res)
+        m_task->decReference();
 
     return res;
 }


### PR DESCRIPTION
Increment the reference count of m_task in Thread::start() before spawning the actual Thread that will execute the task, otherwise the thread might finish, decRef the task and delete it.
Valgrind log of the issue:
 Invalid read of size 8
   at 0x1314CAD: ACE_Atomic_Op_GCC<long>::operator++() (Atomic_Op_GCC_T.inl:34)
   by 0x15933FB: ACE_Based::Runnable::incReference() (Threading.h:36)
   by 0x1592D2D: ACE_Based::Thread::start() (Threading.cpp:136)
   by 0x1592C37: ACE_Based::Thread::Thread(ACE_Based::Runnable_) (Threading.cpp:111)
   by 0xF6C463: Master::Run() (Master.cpp:195)
   by 0xF725D0: main (Main.cpp:142)
 Address 0x26137278 is 8 bytes inside a block of size 24 free'd
   at 0x4C2B59C: operator delete(void_) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0xF67FDB: RARunnable::~RARunnable() (RARunnable.cpp:55)
   by 0x1593441: ACE_Based::Runnable::decReference() (Threading.h:40)
   by 0x1592E92: ACE_Based::Thread::ThreadTask(void*) (Threading.cpp:186)
   by 0x515EA35: ACE_OS_Thread_Adapter::invoke() (in /usr/lib/libACE-6.0.3.so)
   by 0x5F19F8D: start_thread (pthread_create.c:311)
   by 0x6A46E1C: clone (clone.S:113)
