### PR TITLE
Core/Guild: Fix uninitialized value on guild creation

### DIFF
--- a/src/server/game/Guilds/Guild.h
+++ b/src/server/game/Guilds/Guild.h
@@ -292,6 +292,7 @@ private:
             m_zoneId(0),
             m_level(0),
             m_class(0),
+            m_flags(GUILDMEMBER_STATUS_NONE),
             m_logoutTime(::time(NULL)),
             m_accountId(0),
             m_rankId(rankId)


### PR DESCRIPTION
Fix GuildMember flags left uninitialized when creating a new guild. The same happens most likely in Guild::AddMember() when inviting a new Player, the PR fixes both.

Valgrind log:
 Conditional jump or move depends on uninitialised value(s)
  at 0xEE49CE: Guild::Member::WritePacket(WorldPacket&) const (Guild.cpp:714)
  by 0xEE721E: Guild::HandleRoster(WorldSession_) (Guild.cpp:1314)
  by 0xEE9EBA: Guild::SendLoginInfo(WorldSession_) (Guild.cpp:1920)
  by 0xEEB689: Guild::AddMember(unsigned long, unsigned char) (Guild.cpp:2230)
  by 0xEE6A09: Guild::Create(Player_, std::string const&) (Guild.cpp:1199)
  by 0x12A71F9: guild_commandscript::HandleGuildCreateCommand(ChatHandler_, char const_) (cs_guild.cpp:92)
  by 0xC47DBE: ChatHandler::ExecuteCommandInTable(ChatCommand_, char const_, std::string const&) (Chat.cpp:362)
  by 0xC47C23: ChatHandler::ExecuteCommandInTable(ChatCommand_, char const_, std::string const&) (Chat.cpp:343)
  by 0xC488C4: ChatHandler::ParseCommands(char const_) (Chat.cpp:489)
  by 0x1188EE3: WorldSession::HandleMessagechatOpcode(WorldPacket&) (ChatHandler.cpp:217)
  by 0xFCAE37: WorldSession::Update(unsigned int, PacketFilter&) (WorldSession.cpp:312)
  by 0x107EBC6: World::UpdateSessions(unsigned int) (World.cpp:2615)
