### PR TITLE
Core/Aura: Fix SPELL_AURA_BIND_SIGHT invalid read

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2114,6 +2114,10 @@ void Map::AddObjectToRemoveList(WorldObject* obj)
 void Map::AddObjectToSwitchList(WorldObject* obj, bool on)
 {
     ASSERT(obj->GetMapId() == GetId() && obj->GetInstanceId() == GetInstanceId());
+    // i_objectsToSwitch is iterated only in Map::RemoveAllObjectsInRemoveList() and it uses
+    // the contained objects only if GetTypeId() == TYPEID_UNIT , so we can return in all other cases
+    if (obj->GetTypeId() != TYPEID_UNIT)
+        return;
 
     std::map<WorldObject*, bool>::iterator itr = i_objectsToSwitch.find(obj);
     if (itr == i_objectsToSwitch.end())


### PR DESCRIPTION
Mind Vision has Aura Effect SPELL_AURA_BIND_SIGHT which adds the target to a special Map container i_objectsToSwitch, used to switch grid containers for target Creatures of this Aura Effect.

When the target is a Creature, when the Creature is removed from world it's added to i_objectsToSwitch and then to i_objectsToRemove, iterated in this order in Map::RemoveAllObjectsInRemoveList() so the reference in i_objectsToSwitch is valid.
When the target is a Player, when the Player logs out it's added to i_objectsToSwitch but then Map::RemovePlayerFromMap() deletes the Player, leaving an invalid reference in i_objectsToSwitch.

Since the whole point of i_objectsToSwitch is to store Creatures and since the stored references are used only if the condition "GetTypeId() == TYPEID_UNIT" is verified, it's safe to add only objects of TYPEID_UNIT type to the container.

Valgrind log:
 Invalid read of size 4
   at 0xC52332: Object::GetTypeId() const (Object.h:140)
   by 0xF540D3: Map::RemoveAllObjectsInRemoveList() (Map.cpp:2136)
   by 0xF53CD2: Map::DelayedUpdate(unsigned int) (Map.cpp:2087)
   by 0xF639B1: MapManager::Update(unsigned int) (MapManager.cpp:292)
   by 0x107CB40: World::Update(unsigned int) (World.cpp:2025)
   by 0xBEB263: WorldRunnable::run() (WorldRunnable.cpp:60)
   by 0x1213792: ACE_Based::Thread::ThreadTask(void_) (Threading.cpp:186)
   by 0x515EA35: ACE_OS_Thread_Adapter::invoke() (in /usr/lib/libACE-6.0.3.so)
   by 0x5F19F8D: start_thread (pthread_create.c:311)
   by 0x6A46E1C: clone (clone.S:113)
 Address 0x401eacac is 12 bytes inside a block of size 11,736 free'd
   at 0x4C2B59C: operator delete(void_) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0xD80239: Player::~Player() (Player.cpp:915)
   by 0xF4D5A2: void Map::DeleteFromWorld<Player>(Player_) (Map.cpp:319)
   by 0xF4EBBB: Map::RemovePlayerFromMap(Player_, bool) (Map.cpp:687)
   by 0xFCC18D: WorldSession::LogoutPlayer(bool) (WorldSession.cpp:531)
   by 0xF1EDD5: WorldSession::HandleLogoutRequestOpcode(WorldPacket&) (MiscHandler.cpp:403)
   by 0xFCAE37: WorldSession::Update(unsigned int, PacketFilter&) (WorldSession.cpp:312)
   by 0x107EBC6: World::UpdateSessions(unsigned int) (World.cpp:2615)
   by 0x107C94B: World::Update(unsigned int) (World.cpp:1978)
   by 0xBEB263: WorldRunnable::run() (WorldRunnable.cpp:60)
   by 0x1213792: ACE_Based::Thread::ThreadTask(void*) (Threading.cpp:186)
   by 0x515EA35: ACE_OS_Thread_Adapter::invoke() (in /usr/lib/libACE-6.0.3.so)
