### PR TITLE
Core/Maps: Fix Spline triggered assert

### DIFF
--- a/src/server/collision/Maps/MapTree.cpp
+++ b/src/server/collision/Maps/MapTree.cpp
@@ -156,6 +156,11 @@ namespace VMAP
     bool StaticMapTree::isInLineOfSight(const Vector3& pos1, const Vector3& pos2) const
     {
         float maxDist = (pos2 - pos1).magnitude();
+        // return false if distance is over max float, in case of cheater teleporting to the end of the universe
+        if( maxDist == std::numeric_limits<float>::max() ||
+            maxDist == std::numeric_limits<float>::infinity())
+            return false;
+
         // valid map coords should *never ever* produce float overflow, but this would produce NaNs too
         ASSERT(maxDist < std::numeric_limits<float>::max());
         // prevent NaN values which can cause BIH intersection to enter infinite loop

--- a/src/server/game/Movement/Spline/Spline.h
+++ b/src/server/game/Movement/Spline/Spline.h
@@ -21,6 +21,7 @@
 
 #include "MovementTypedefs.h"
 #include <G3D/Vector3.h>
+#include <limits>
 
 namespace Movement {
 
@@ -184,6 +185,9 @@ public:
         while (i < index_hi)
         {
             new_length = cacher(*this, i);
+            //length overflowed, assign to max positive value
+            if( new_length < 0)
+                new_length = std::numeric_limits<length_type>::max();
             lengths[++i] = new_length;
 
             ASSERT(prev_length <= new_length);


### PR DESCRIPTION
Fix an assert triggered by float to int32 cast overflowing to -1, now it replaces -\ with max int32 value.
Fix another assert triggered by Vector3 magnitude float overflow to max/infinity in StaticMapTree::isInLineOfSight(), in this case return false.

Both asserts can be reproduced by casting Mind Control to a NPC, tele to z: 1.0e+38 using client hack tools, move to allow the server to register the new position and stop Mind Control.

Fixes https://github.com/TrinityCore/TrinityCore/issues/8970 and https://github.com/TrinityCore/TrinityCore/issues/10578 , might fix https://github.com/TrinityCore/TrinityCore/issues/10355 as well.
