### PR TITLE
Core/SAI: Also use loot recipient for SMART_ACTION_CALL_KILLEDMONSTER wh...

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -876,7 +876,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }
         case SMART_ACTION_CALL_KILLEDMONSTER:
         {
-            if (e.target.type == SMART_TARGET_NONE) // Loot recipient and his group members
+            if (e.target.type == SMART_TARGET_NONE || e.target.type == SMART_TARGET_SELF) // Loot recipient and his group members
             {
                 if (!me)
                     break;


### PR DESCRIPTION
...en target is SMART_TARGET_SELF (used in four cases in a clean TDB which will be fixed by this)
