### PR TITLE
Core/Thread: Fix race condition in FreezeDetectorRunnable

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -83,7 +83,7 @@
 
 ACE_Atomic_Op<ACE_Thread_Mutex, bool> World::m_stopEvent = false;
 uint8 World::m_ExitCode = SHUTDOWN_EXIT_CODE;
-volatile uint32 World::m_worldLoopCounter = 0;
+ACE_Atomic_Op<ACE_Thread_Mutex, uint32> World::m_worldLoopCounter = 0;
 
 float World::m_MaxVisibleDistanceOnContinents = DEFAULT_VISIBILITY_DISTANCE;
 float World::m_MaxVisibleDistanceInInstances  = DEFAULT_VISIBILITY_INSTANCE;

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -514,7 +514,7 @@ struct CharacterNameData
 class World
 {
     public:
-        static volatile uint32 m_worldLoopCounter;
+        static ACE_Atomic_Op<ACE_Thread_Mutex, uint32> m_worldLoopCounter;
 
         World();
         ~World();

--- a/src/server/worldserver/Master.cpp
+++ b/src/server/worldserver/Master.cpp
@@ -103,10 +103,11 @@ public:
             ACE_Based::Thread::Sleep(1000);
             uint32 curtime = getMSTime();
             // normal work
-            if (_loops != World::m_worldLoopCounter)
+            uint32 worldLoopCounter = World::m_worldLoopCounter.value();
+            if (_loops != worldLoopCounter)
             {
                 _lastChange = curtime;
-                _loops = World::m_worldLoopCounter;
+                _loops = worldLoopCounter;
             }
             // possible freeze
             else if (getMSTimeDiff(_lastChange, curtime) > _delaytime)


### PR DESCRIPTION
Fix race condition by replacing a static volatile uint32 with proper atomic thread-safe ACE_Atomic_Op<ACE_Thread_Mutex, uint32>, incremented in WorldRunnable::run() at each world loop and read in FreezeDetectorRunnable::run().

Helgrind log:
 Possible data race during read of size 4 at 0x2400D54 by thread #12
 Locks held: none
    at 0x100FEA6: FreezeDetectorRunnable::run() (Master.cpp:106)
    by 0x1637892: ACE_Based::Thread::ThreadTask(void*) (Threading.cpp:186)
    by 0x518F555: ACE_OS_Thread_Adapter::invoke() (OS_Thread_Adapter.cpp:103)
    by 0x4C2B5AD: mythread_wrapper (hg_intercepts.c:219)
    by 0x61DAB4F: start_thread (pthread_create.c:304)
    by 0x6C69A7C: clone (clone.S:112)

 This conflicts with a previous write of size 4 by thread #9
 Locks held: none
    at 0x100C23E: WorldRunnable::run() (WorldRunnable.cpp:55)
    by 0x1637892: ACE_Based::Thread::ThreadTask(void*) (Threading.cpp:186)
    by 0x518F555: ACE_OS_Thread_Adapter::invoke() (OS_Thread_Adapter.cpp:103)
    by 0x4C2B5AD: mythread_wrapper (hg_intercepts.c:219)
    by 0x61DAB4F: start_thread (pthread_create.c:304)
    by 0x6C69A7C: clone (clone.S:112)
