### PR TITLE
Core/Socket: Fix race condition in WorldSocket

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -445,8 +445,14 @@ int WorldSocket::Update (void)
     if (closing_)
         return -1;
 
-    if (m_OutActive || (m_OutBuffer->length() == 0 && msg_queue()->is_empty()))
+    if (m_OutActive)
         return 0;
+
+    {
+        ACE_GUARD_RETURN (LockType, Guard, m_OutBufferLock, 0);
+        if (m_OutBuffer->length() == 0 && msg_queue()->is_empty())
+            return 0;
+    }
 
     int ret;
     do


### PR DESCRIPTION
ReactorRunnable::svc() checks the status of WorldSockets while WorldRunnable::run() updates them, causing a race condition.

Helgrind log:
Possible data race during write of size 8 at 0x49961810 by thread #9
Locks held: 1, at address 0x4367A620
   at 0x51781F7: ACE_Message_Block::copy(char const_, unsigned long) (Message_Block.inl:372)
   by 0x15D048F: WorldSocket::SendPacket(WorldPacket const&) (WorldSocket.cpp:180)
   by 0x141C45E: WorldSession::SendPacket(WorldPacket const_) (WorldSession.cpp:223)
   by 0x15C49C4: WorldSession::SendAuthResponse(unsigned char, bool, unsigned int) (AuthHandler.cpp:37)
   by 0x14DA71C: World::AddSession_(WorldSession_) (World.cpp:278)
   by 0x14E601E: World::UpdateSessions(unsigned int) (World.cpp:2617)
   by 0x14E3E67: World::Update(unsigned int) (World.cpp:1986)
   by 0x100EAFA: WorldRunnable::run() (WorldRunnable.cpp:60)
   by 0x163A626: ACE_Based::Thread::ThreadTask(void_) (Threading.cpp:186)
   by 0x518F555: ACE_OS_Thread_Adapter::invoke() (OS_Thread_Adapter.cpp:103)
   by 0x4C2B5AD: mythread_wrapper (hg_intercepts.c:219)
   by 0x61DAB4F: start_thread (pthread_create.c:304)

This conflicts with a previous read of size 8 by thread #14
Locks held: none
   at 0x1008414: ACE_Message_Block::length() const (Message_Block.inl:131)
   by 0x15D1207: WorldSocket::Update() (WorldSocket.cpp:448)
   by 0x1427CA3: ReactorRunnable::svc() (WorldSocketMgr.cpp:177)
   by 0x51CBB16: ACE_Task_Base::svc_run(void*) (Task.cpp:271)
   by 0x51CD3BC: ACE_Thread_Adapter::invoke_i() (Thread_Adapter.cpp:161)
   by 0x51CD4D4: ACE_Thread_Adapter::invoke() (Thread_Adapter.cpp:96)
   by 0x4C2B5AD: mythread_wrapper (hg_intercepts.c:219)
   by 0x61DAB4F: start_thread (pthread_create.c:304)

Address 0x49961810 is 16 bytes inside a block of size 80 alloc'd
   at 0x4C286BB: operator new(unsigned long, std::nothrow_t const&) (vg_replace_malloc.c:316)
   by 0x15D0818: WorldSocket::open(void_) (WorldSocket.cpp:237)
   by 0x1429560: ACE_Acceptor<WorldSocket, ACE_SOCK_Acceptor>::activate_svc_handler(WorldSocket_) (Acceptor.cpp:347)
   by 0x142916D: ACE_Acceptor<WorldSocket, ACE_SOCK_Acceptor>::handle_input(int) (Acceptor.cpp:429)
   by 0x515F48D: ACE_Dev_Poll_Reactor::dispatch_io_event(ACE_Dev_Poll_Reactor::Token_Guard&) (Dev_Poll_Reactor.inl:86)
   by 0x5161653: ACE_Dev_Poll_Reactor::handle_events(ACE_Time_Value_) (Dev_Poll_Reactor.cpp:1015)
   by 0x51ACCFC: ACE_Reactor::run_reactor_event_loop(ACE_Time_Value&, int (_)(ACE_Reactor_)) (Reactor.cpp:267)
   by 0x1427C57: ReactorRunnable::svc() (WorldSocketMgr.cpp:170)
   by 0x51CBB16: ACE_Task_Base::svc_run(void_) (Task.cpp:271)
   by 0x51CD3BC: ACE_Thread_Adapter::invoke_i() (Thread_Adapter.cpp:161)
   by 0x51CD4D4: ACE_Thread_Adapter::invoke() (Thread_Adapter.cpp:96)
   by 0x4C2B5AD: mythread_wrapper (hg_intercepts.c:219)
