### PR TITLE
Core/Movement: Fix uninitialized MovementInfo fields

### DIFF
--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -450,7 +450,7 @@ struct MovementInfo
     float splineElevation;
 
     MovementInfo() :
-        guid(0), flags(0), flags2(0), time(0), pitch(0.0f)
+        guid(0), flags(0), flags2(0), time(0), pitch(0.0f), fallTime(0), splineElevation(0.0f)
     {
         pos.Relocate(0.0f, 0.0f, 0.0f, 0.0f);
         transport.Reset();


### PR DESCRIPTION
Fix uninitialized fallTime and splineElevation fields of MovementInfo.

Valgrind log:
 Conditional jump or move depends on uninitialised value(s)
   at 0x5FBEB50: deflate (in /lib/x86_64-linux-gnu/libz.so.1.2.7)
   by 0x1269883: UpdateData::Compress(void_, unsigned int_, void_, int) (UpdateData.cpp:85)
   by 0x1269BB6: UpdateData::BuildPacket(WorldPacket_) (UpdateData.cpp:133)
   by 0x130E9B3: Trinity::VisibleNotifier::SendToSelf() (GridNotifiers.cpp:68)
   by 0x117A89D: Player::UpdateVisibilityForPlayer() (Player.cpp:22344)
   by 0x117B334: Player::SendInitialPacketsAfterAddToMap() (Player.cpp:22567)
   by 0x15A48BC: WorldSession::HandlePlayerLogin(LoginQueryHolder_) (CharacterHandler.cpp:937)
   by 0x141D04B: WorldSession::ProcessQueryCallbacks() (WorldSession.cpp:1106)
   by 0x141994D: WorldSession::Update(unsigned int, PacketFilter&) (WorldSession.cpp:391)
   by 0x14E289C: World::UpdateSessions(unsigned int) (World.cpp:2629)
   by 0x14E0613: World::Update(unsigned int) (World.cpp:1986)
   by 0x100B37F: WorldRunnable::run() (WorldRunnable.cpp:60)
 Uninitialised value was created by a heap allocation
   at 0x4C286E7: operator new(unsigned long) (vg_replace_malloc.c:287)
   by 0x159E64F: void LoadHelper<Creature>(std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&, CoordPair<512u>&, GridRefManager<Creature>&, unsigned int&, Map_) (ObjectGridLoader.cpp:94)
   by 0x159DECF: ObjectGridLoader::Visit(GridRefManager<Creature>&) (ObjectGridLoader.cpp:150)
   by 0x159F092: void VisitorHelper<ObjectGridLoader, Creature>(ObjectGridLoader&, ContainerMapList<Creature>&) (TypeContainerVisitor.h:64)
   by 0x159EFF5: void VisitorHelper<ObjectGridLoader, Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > >(ObjectGridLoader&, ContainerMapList<TypeList<Creature, TypeList<DynamicObject, TypeList<Corpse, TypeNull> > > >&) (TypeContainerVisitor.h:70)
