### PR TITLE
Core/Command Line: Fix memory leak

### DIFF
--- a/src/server/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/worldserver/CommandLine/CliRunnable.cpp
@@ -175,6 +175,8 @@ void CliRunnable::run()
             {
 #if PLATFORM == PLATFORM_WINDOWS
                 printf("TC>");
+#else
+                free(command_str);
 #endif
                 continue;
             }
@@ -184,6 +186,8 @@ void CliRunnable::run()
             {
 #if PLATFORM == PLATFORM_WINDOWS
                 printf("TC>");
+#else
+                free(command_str);
 #endif
                 continue;
             }
@@ -192,6 +196,7 @@ void CliRunnable::run()
             sWorld->QueueCliCommand(new CliCommandHolder(NULL, command.c_str(), &utf8print, &commandFinished));
 #if PLATFORM != PLATFORM_WINDOWS
             add_history(command.c_str());
+            free(command_str);
 #endif
         }
         else if (feof(stdin))


### PR DESCRIPTION
Fix memory leak in command line handler on platforms other than Windows. The result of readline() is supposed to be freed with free() as described at http://cnswww.cns.cwru.edu/php/chet/readline/readline.html#SEC24 .

Valgrind log:
 11 bytes in 2 blocks are definitely lost in loss record 6 of 61
  at 0x4C28BED: malloc (vg_replace_malloc.c:263)
  by 0x4E5F6E8: xmalloc (in /lib/x86_64-linux-gnu/libreadline.so.6.2)
  by 0x4E4571A: readline_internal_teardown (in /lib/x86_64-linux-gnu/libreadline.so.6.2)
  by 0x4E46541: readline (in /lib/x86_64-linux-gnu/libreadline.so.6.2)
  by 0x1005284: CliRunnable::run() (CliRunnable.cpp:161)
  by 0x163A3DA: ACE_Based::Thread::ThreadTask(void*) (Threading.cpp:186)
  by 0x518C555: ACE_OS_Thread_Adapter::invoke() (OS_Thread_Adapter.cpp:103)
  by 0x61D7B4F: start_thread (pthread_create.c:304)
  by 0x6C66A7C: clone (clone.S:112)
