### PR TITLE
Core/Timer: Better handle system clock changes

### DIFF
--- a/src/server/shared/Utilities/Timer.h
+++ b/src/server/shared/Utilities/Timer.h
@@ -66,7 +66,7 @@ struct IntervalTimer
         void Reset()
         {
             if (_current >= _interval)
-                _current -= _interval;
+                _current %= _interval;
         }
 
         void SetCurrent(time_t current)


### PR DESCRIPTION
Change IntervalTimer::Reset() behavior to handle system clock changes forward and backward.
This fixes IntervalTimer:.Passed() returning true till it catches up to the new time, triggering the event up to "std::numeric_limits<time_t>::max() / _interval" times.
Fixes https://github.com/TrinityCore/TrinityCore/issues/5816

The change itself is simpler than the explanation.
