### PR TITLE
Scripts/Commands: Retrieve Creature template in HandlePetCreateCommand f...

### DIFF
--- a/src/server/scripts/Commands/cs_pet.cpp
+++ b/src/server/scripts/Commands/cs_pet.cpp
@@ -56,7 +56,7 @@ public:
             return false;
         }
 
-        CreatureTemplate const* creatrueTemplate = sObjectMgr->GetCreatureTemplate(creatureTarget->GetEntry());
+        CreatureTemplate const* creatrueTemplate = creatureTarget->GetCreatureTemplate();
         // Creatures with family 0 crashes the server
         if (!creatrueTemplate->family)
         {


### PR DESCRIPTION
...rom Creature itself

CreatureTemplate can be retrieved directly from the Creature itself instead of using ObjectMgr::GetCreatureTemplate(id) .

Should fix Coverity issue 1087070 .
