### PR TITLE
Core/Logs: Fix race condition in Log

### DIFF
--- a/src/server/shared/Logging/AppenderFile.cpp
+++ b/src/server/shared/Logging/AppenderFile.cpp
@@ -40,7 +40,7 @@ AppenderFile::~AppenderFile()
 
 void AppenderFile::_write(LogMessage const& message)
 {
-    bool exceedMaxSize = maxFileSize > 0 && (fileSize + message.Size()) > maxFileSize;
+    bool exceedMaxSize = maxFileSize > 0 && (fileSize.value() + message.Size()) > maxFileSize;
 
     if (dynamicName)
     {
@@ -56,7 +56,7 @@ void AppenderFile::_write(LogMessage const& message)
 
     fprintf(logfile, "%s%s", message.prefix.c_str(), message.text.c_str());
     fflush(logfile);
-    fileSize += message.Size();
+    fileSize += uint64(message.Size());
 
     if (dynamicName)
         CloseFile();

--- a/src/server/shared/Logging/AppenderFile.h
+++ b/src/server/shared/Logging/AppenderFile.h
@@ -19,6 +19,7 @@
 #define APPENDERFILE_H
 
 #include "Appender.h"
+#include "ace/Atomic_Op.h"
 
 class AppenderFile: public Appender
 {
@@ -37,7 +38,7 @@ class AppenderFile: public Appender
         bool dynamicName;
         bool backup;
         uint64 maxFileSize;
-        uint64 fileSize;
+        ACE_Atomic_Op<ACE_Thread_Mutex, uint64> fileSize;
 };
 
 #endif


### PR DESCRIPTION
Fix race condition in Log by using atomic operators.

Helgrind log:
 Possible data race during read of size 8 at 0x7379D98 by thread #1
 Locks held: none
  at 0x15AE9C7: AppenderFile::_write(LogMessage const&) (AppenderFile.cpp:59)
  by 0x15ADFF8: Appender::write(LogMessage&) (Appender.cpp:106)
  by 0x159F14E: Logger::write(LogMessage&) (Logger.cpp:83)
  by 0x15A215B: Log::write(LogMessage_) (Log.cpp:290)
  by 0x15A200F: Log::vlog(LogFilterType, LogLevel, char const_, __va_list_tag_) (Log.cpp:272)
  by 0x15A2682: Log::outInfo(LogFilterType, char const_, ...) (Log.cpp:364)
  by 0xF7DA28: Master::Run() (Master.cpp:296)
  by 0xF835E8: main (Main.cpp:142)

 This conflicts with a previous write of size 8 by thread #10
 Locks held: none
  at 0x15AE9D7: AppenderFile::_write(LogMessage const&) (AppenderFile.cpp:59)
  by 0x15ADFF8: Appender::write(LogMessage&) (Appender.cpp:106)
  by 0x159F14E: Logger::write(LogMessage&) (Logger.cpp:83)
  by 0x15A215B: Log::write(LogMessage_) (Log.cpp:290)
  by 0x15A200F: Log::vlog(LogFilterType, LogLevel, char const_, __va_list_tag_) (Log.cpp:272)
  by 0x15A2682: Log::outInfo(LogFilterType, char const_, ...) (Log.cpp:364)
  by 0xF7EC1F: FreezeDetectorRunnable::run() (Master.cpp:98)
  by 0x15A5B3E: ACE_Based::Thread::ThreadTask(void*) (Threading.cpp:186)

 Address 0x7379D98 is 88 bytes inside a block of size 96 alloc'd
  at 0x4C2C857: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_helgrind-amd64-linux.so)
  by 0x15A0FE3: Log::CreateAppenderFromConfig(char const*) (Log.cpp:150)
  by 0x15A1AED: Log::ReadAppendersFromConfig() (Log.cpp:244)
  by 0x15A31B4: Log::LoadFromConfig() (Log.cpp:469)
  by 0x15A053B: Log::Log() (Log.cpp:35)
  by 0xF75CD1: ACE_Singleton<Log, ACE_Thread_Mutex>::ACE_Singleton() (Singleton.inl:13)
  by 0xF754A4: ACE_Singleton<Log, ACE_Thread_Mutex>::instance() (Singleton.cpp:91)
  by 0xF8351A: main (Main.cpp:135)
