### PR TITLE
Core/Commands: Fix NULL dereference crash in .account password

### DIFF
--- a/src/server/scripts/Commands/cs_account.cpp
+++ b/src/server/scripts/Commands/cs_account.cpp
@@ -453,9 +453,9 @@ public:
         char* oldPassword = strtok((char*)args, " ");    // This extracts [$oldpassword]
         char* newPassword = strtok(NULL, " ");           // This extracts [$newpassword]
         char* passwordConfirmation = strtok(NULL, " ");  // This extracts [$newpasswordconfirmation]
-        char* emailConfirmation = NULL;                  // This defines the emailConfirmation variable, which is optional depending on sec type.
+        const char* emailConfirmation;                   // This defines the emailConfirmation variable, which is optional depending on sec type.
         if (!(emailConfirmation = strtok(NULL, " ")))    // This extracts [$emailconfirmation]. If it doesn't exist, however...
-            emailConfirmation = '\0';                    // ... it's simply "" for emailConfirmation.
+            emailConfirmation = "";                      // ... it's simply "" for emailConfirmation.
 
         //Is any of those variables missing for any reason ? We return false.
         if (!oldPassword || !newPassword || !passwordConfirmation)


### PR DESCRIPTION
Fix NULL dereference crash in .account password added in bd8d0cfbce9a38e0f2fc8b6903434c3553faf143
Fixes #10791
