### PR TITLE
Tools/VMAP: Fix not null terminated string

### DIFF
--- a/src/server/collision/Maps/TileAssembler.cpp
+++ b/src/server/collision/Maps/TileAssembler.cpp
@@ -508,7 +508,8 @@ namespace VMAP
             return false;
         }
 
-        char ident[8];
+        char ident[9];
+        ident[8] = '\0';
         int readOperation = 0;
 
         READ_OR_RETURN(&ident, 8);


### PR DESCRIPTION
Fix not null terminated string in vmap assembler tool, fix coverity issue id 1010351 .
