### PR TITLE
Shared/Build: Restore disabled warnings on Visual Studio

### DIFF
--- a/src/server/shared/CompilerDefs.h
+++ b/src/server/shared/CompilerDefs.h
@@ -55,11 +55,6 @@
 #  error "FATAL ERROR: Unknown compiler."
 #endif
 
-#if COMPILER == COMPILER_MICROSOFT
-#  pragma warning( disable : 4267 )                         // conversion from 'size_t' to 'int', possible loss of data
-#  pragma warning( disable : 4786 )                         // identifier was truncated to '255' characters in the debug information
-#endif
-
 #if defined(__cplusplus) && __cplusplus == 201103L
 #  define COMPILER_HAS_CPP11_SUPPORT 1
 #else


### PR DESCRIPTION
Restore 2 disabled warnings, 1 already disabled in CMake with the WITH_WARNINGS flag set to False and the other disabled by default as stated in VS documentation http://msdn.microsoft.com/en-us/library/aa984150.aspx
