### PR TITLE
Core/LFG: Minimum item level in Wotlk heroic dungeons

### DIFF
--- a/sql/updates/world/2014_01_21_world_access_requirement.sql
+++ b/sql/updates/world/2014_01_21_world_access_requirement.sql
@@ -1,0 +1,9 @@
+-- Add new collum in the access_requirement table.
+ALTER TABLE `access_requirement`  ADD COLUMN `item_level` SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0' AFTER `level_max`;
+
+-- All WotLK Heroics require at least an average item level of 180.
+UPDATE `access_requirement` SET `item_level`=180 WHERE `mapId` IN (574, 575, 576, 578, 595, 599, 600, 601, 602, 604, 608, 619) AND `difficulty`=1;
+-- Trial of the Champion, Pit of Saron, and the Forge of Souls require an average item level of 200.
+UPDATE `access_requirement` SET `item_level`=200 WHERE `mapId` IN (632, 650, 658);
+-- Halls of Reflection requires an average item level of 219.
+UPDATE `access_requirement` SET `item_level`=219 WHERE `mapId`=668;

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -405,7 +405,9 @@ void LFGMgr::InitializeLockedDungeons(Player* player, uint8 level /* = 0 */)
             lockData = LFG_LOCKSTATUS_NOT_IN_SEASON;
         else if (AccessRequirement const* ar = sObjectMgr->GetAccessRequirement(dungeon->map, Difficulty(dungeon->difficulty)))
         {
-            if (ar->achievement && !player->HasAchieved(ar->achievement))
+            if (player->GetAverageItemLevel() < ar->item_level)
+                lockData = LFG_LOCKSTATUS_TOO_LOW_GEAR_SCORE;
+            else if (ar->achievement && !player->HasAchieved(ar->achievement))
                 lockData = LFG_LOCKSTATUS_MISSING_ACHIEVEMENT;
             else if (player->GetTeam() == ALLIANCE && ar->quest_A && !player->GetQuestRewardStatus(ar->quest_A))
                 lockData = LFG_LOCKSTATUS_QUEST_NOT_COMPLETED;
@@ -422,7 +424,6 @@ void LFGMgr::InitializeLockedDungeons(Player* player, uint8 level /* = 0 */)
         }
 
         /* @todo VoA closed if WG is not under team control (LFG_LOCKSTATUS_RAID_LOCKED)
-            lockData = LFG_LOCKSTATUS_TOO_LOW_GEAR_SCORE;
             lockData = LFG_LOCKSTATUS_TOO_HIGH_GEAR_SCORE;
             lockData = LFG_LOCKSTATUS_ATTUNEMENT_TOO_LOW_LEVEL;
             lockData = LFG_LOCKSTATUS_ATTUNEMENT_TOO_HIGH_LEVEL;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -840,6 +840,7 @@ struct AccessRequirement
 {
     uint8  levelMin;
     uint8  levelMax;
+    uint16 item_level;
     uint32 item;
     uint32 item2;
     uint32 quest_A;

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -6012,8 +6012,9 @@ void ObjectMgr::LoadAccessRequirements()
         _accessRequirementStore.clear();                                  // need for reload case
     }
 
-    //                                               0      1           2          3          4     5      6             7             8                      9
-    QueryResult result = WorldDatabase.Query("SELECT mapid, difficulty, level_min, level_max, item, item2, quest_done_A, quest_done_H, completed_achievement, quest_failed_text FROM access_requirement");
+    //                                               0      1           2          3          4           5      6             7             8                      9     10
+    QueryResult result = WorldDatabase.Query("SELECT mapid, difficulty, level_min, level_max, item_level, item, item2, quest_done_A, quest_done_H, completed_achievement, quest_failed_text FROM access_requirement");
+
     if (!result)
     {
         TC_LOG_INFO("server.loading", ">> Loaded 0 access requirement definitions. DB table `access_requirement` is empty.");
@@ -6036,12 +6037,13 @@ void ObjectMgr::LoadAccessRequirements()
 
         ar->levelMin = fields[2].GetUInt8();
         ar->levelMax = fields[3].GetUInt8();
-        ar->item = fields[4].GetUInt32();
-        ar->item2 = fields[5].GetUInt32();
-        ar->quest_A = fields[6].GetUInt32();
-        ar->quest_H = fields[7].GetUInt32();
-        ar->achievement = fields[8].GetUInt32();
-        ar->questFailedText = fields[9].GetString();
+        ar->item_level = fields[4].GetUInt16();
+        ar->item = fields[5].GetUInt32();
+        ar->item2 = fields[6].GetUInt32();
+        ar->quest_A = fields[7].GetUInt32();
+        ar->quest_H = fields[8].GetUInt32();
+        ar->achievement = fields[9].GetUInt32();
+        ar->questFailedText = fields[10].GetString();
 
         if (ar->item)
         {


### PR DESCRIPTION
WotLK Heroics, beside Trial of the Champion, Pit of Saron, Halls of Reflection and The Forge of Souls unlock with an average item level of 160.
Also Trial of the Champion (normal) and The Forge of Souls (normal) unlock with an item level of 160.

http://www.wowwiki.com/Dungeon_Finder?oldid=2404648#Wrath_of_the_Lich_King_dungeons 
