### PR TITLE
Restore original patch for mob evade reset mechanics to include DOT damage

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -167,6 +167,8 @@ void CreatureAI::EnterEvadeMode()
 
     if (me->IsVehicle()) // use the same sequence of addtoworld, aireset may remove all summons!
         me->GetVehicleKit()->Reset(true);
+
+    me->SetLastDamagedTime(0);
 }
 
 /*void CreatureAI::AttackedBy(Unit* attacker)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -743,8 +743,6 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
         if (damagetype == DIRECT_DAMAGE || damagetype == SPELL_DIRECT_DAMAGE)
         {
             victim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE, spellProto ? spellProto->Id : 0);
-            if (victim->GetTypeId() == TYPEID_UNIT && !victim->IsPet())
-                victim->SetLastDamagedTime(time(NULL));
         }
 
         if (victim->GetTypeId() != TYPEID_PLAYER)
@@ -11989,6 +11987,10 @@ int32 Unit::ModifyHealth(int32 dVal)
 
     if (dVal == 0)
         return 0;
+
+    // Part of Evade mechanics. Only track health lost, not gained (ALL damage types)
+    if (dVal < 0 && GetTypeId() != TYPEID_PLAYER && !IsPet())
+        SetLastDamagedTime(time(NULL));
 
     int32 curHealth = (int32)GetHealth();
 


### PR DESCRIPTION
All damage should be counted toward evade reset. See comments and links in issue.

Closes #11153
