### PR TITLE
Create 2013_11_28_00_world_creature_template_addon.sql

### DIFF
--- a/sql/updates/world/2013_11_28_00_world_creature_template_addon.sql
+++ b/sql/updates/world/2013_11_28_00_world_creature_template_addon.sql
@@ -1,0 +1,1 @@
+DELETE FROM `world`.`creature_template_addon` WHERE  `entry`=45979;


### PR DESCRIPTION
Removed aura 'Cosmetic - Purple Moonbeam' from creature 'General Purpose Bunny JMF'. That aura spell must be specifically applied to the trigger affliated with the specified event, not generally applied to every trigger spawned with same entry in the DB.
