### PR TITLE
Core/Movement:Add LOS check for fleeingmovement target point.

### DIFF
--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -25,6 +25,7 @@
 #include "MoveSplineInit.h"
 #include "MoveSpline.h"
 #include "Player.h"
+#include "VMapFactory.h"
 
 #define MIN_QUIET_DISTANCE 28.0f
 #define MAX_QUIET_DISTANCE 43.0f
@@ -42,6 +43,16 @@ void FleeingMovementGenerator<T>::_setTargetLocation(T* owner)
 
     float x, y, z;
     _getPoint(owner, x, y, z);
+    
+	//Add LOS check for target point
+	Position mypos;
+	owner->GetPosition(&mypos);
+	bool isInLOS = VMAP::VMapFactory::createOrGetVMapManager()->isInLineOfSight(owner->GetMapId(), mypos.m_positionX, mypos.m_positionY,
+		mypos.m_positionZ + 2.0f, x, y, z + 2.0f);
+	if(!isInLOS) {
+		i_nextCheckTime.Reset(200);
+		return;
+	}
 
     PathGenerator path(owner);
     path.SetPathLengthLimit(30.0f);


### PR DESCRIPTION
Prevents fleeing or feared units from going to upper floor ignoring walls/ceilings with mmaps on(and usually get stucked).

Current implementation just randomly selects a distance and angle against the frighting unit, when in narrow circumstance such as underground caves, such targeting point would be at another floor. 
