### PR TITLE
[4.3.4] Core/VoidStorage: Fix SMSG_VOID_STORAGE_CONTENTS structure

### DIFF
--- a/src/server/game/Handlers/VoidStorageHandler.cpp
+++ b/src/server/game/Handlers/VoidStorageHandler.cpp
@@ -161,6 +161,7 @@ void WorldSession::HandleVoidStorageQuery(WorldPacket& recvData)
         itemData.WriteByteSeq(itemId[0]);
         itemData.WriteByteSeq(itemId[6]);
         itemData.WriteByteSeq(creatorGuid[0]);
+        itemData.WriteByteSeq(creatorGuid[1]);
 
         itemData << uint32(item->ItemRandomPropertyId);
 


### PR DESCRIPTION
- If you have items stored in void storage with owner guid, the void storage appear empty or partitial empty
