### PR TITLE
Core/Spells: Fix proc for spells that should trigger on taken hots

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -814,7 +814,7 @@ bool SpellMgr::IsSpellProcEventCanTriggeredBy(SpellProcEventEntry const* spellPr
     {
         if (EventProcFlag & PROC_FLAG_TAKEN_SPELL_MAGIC_DMG_CLASS_POS)
         {
-            if (!(procExtra & PROC_EX_INTERNAL_DOT))
+            if (!(procExtra & PROC_EX_INTERNAL_HOT))
                 return false;
         }
         else if (procExtra & PROC_EX_INTERNAL_HOT)


### PR DESCRIPTION
Fixes spells that should proc on taken Hots eg. Spiritual Attunement http://wotlk.openwow.com/spell=31785
