### PR TITLE
Core/Spell: Fix Warrior Retaliation

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5676,6 +5676,9 @@ bool Unit::HandleDummyAuraProc(Unit* victim, uint32 damage, AuraEffect* triggere
                 if (!HasInArc(M_PI, victim))
                     return false;
 
+                if (HasUnitState(UNIT_STATE_STUNNED))
+                     return false;
+
                 triggered_spell_id = 22858;
                 break;
             }


### PR DESCRIPTION
Patch 1.7.0 (13-Sep-2005):
In addition, retaliatory strikes will not be possible while stunned.
