### PR TITLE
Update Vehicle.cpp

### DIFF
--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -527,7 +527,8 @@ Vehicle* Vehicle::RemovePassenger(Unit* unit)
 
     // only for flyable vehicles
     if (unit->IsFlying())
-        _me->CastSpell(unit, VEHICLE_SPELL_PARACHUTE, true);
+        if (_me->IsFriendlyTo(unit))
+            _me->CastSpell(unit, VEHICLE_SPELL_PARACHUTE, true);
 
     if (_me->GetTypeId() == TYPEID_UNIT && _me->ToCreature()->IsAIEnabled)
         _me->ToCreature()->AI()->PassengerBoarded(unit, seat->first, false);


### PR DESCRIPTION
Just because it's a flying vehicle does not mean it should provide a parachute to players in every single case.
For example some bosses in Cataclysm use flying vehicles to handle players, for example Gravity Crush for the Ascendant Council encounter in Bastion of Twilight. The player should happlessly fall to the ground, not be provided with a parachute.

Therefor, if the vehicle is HOSTILE to the player, then the player shall NOT be provided with a parachute.
