### PR TITLE
prevent XP boost hack for players in Azshara

### DIFF
--- a/sql/updates/world/086_creature_template.sql
+++ b/sql/updates/world/086_creature_template.sql
@@ -1,0 +1,2 @@
+-- UPDATE flags extra (adds +64) to prevent XP boost for players in Azshara, they can simply run throught invisible stalkers and get up XP and levels
+UPDATE `creature_template` SET `flags_extra`=192 WHERE `entry`=12999;


### PR DESCRIPTION
prevent XP boost for players in Azshara, they can simply run throught invisible stalkers and get up XP and levels
