### PR TITLE
Core/Movement:Fix waypointed creature aggro

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -191,6 +191,10 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
     }
     else
     {
+        // Set home position at place on waypoint movement.
+        if (!creature->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) || !creature->GetTransGUID())
+            creature->SetHomePosition(creature->GetPositionX(), creature->GetPositionY(), creature->GetPositionZ(), creature->GetOrientation());
+
         if (creature->IsStopped())
             Stop(STOP_TIME_FOR_PLAYER);
         else if (creature->movespline->Finalized())


### PR DESCRIPTION
In original code, when creature is moving on waypoint(patroling), its homeposition will not be updated unless reaches non-repeating waypoint's destination. This means homeposition is always bound to its spawn position, so creatures with long waypoint path don't aggro even when approaches very near(instance creature is ok because not use this value).

This fix sets creature homepositon to its current position when on waypointed movement.(I think homepositon in code means "OOC return position".) Tested on some creatures(Duskwood emerald dragon, etc.) They can aggro correctly when move in range.
