### PR TITLE
Core/Cmake: Allow settings to detach custom scripts

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -8,12 +8,13 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-option(SERVERS          "Build worldserver and authserver"                            1)
-option(SCRIPTS          "Build core with scripts included"                            1)
-option(TOOLS            "Build map/vmap/mmap extraction/assembler tools"              0)
-option(USE_SCRIPTPCH    "Use precompiled headers when compiling scripts"              1)
-option(USE_COREPCH      "Use precompiled headers when compiling servers"              1)
-option(WITH_WARNINGS    "Show all warnings during compile"                            0)
-option(WITH_COREDEBUG   "Include additional debug-code in core"                       0)
-option(WITH_MESHEXTRACTOR "Build meshextractor (alpha)"                               0)
-option(WITHOUT_GIT      "Disable the GIT testing routines"                            0)
+option(SERVERS          "Build worldserver and authserver"                              1)
+option(SCRIPTS          "Build core with scripts included"                              1)
+option(TOOLS            "Build map/vmap/mmap extraction/assembler tools"                0)
+option(USE_SCRIPTPCH    "Use precompiled headers when compiling scripts"                1)
+option(USE_COREPCH      "Use precompiled headers when compiling servers"                1)
+option(DETACH_CSCRIPTS  "Detach custom scripts to compile individually to core scripts" 0)
+option(WITH_WARNINGS    "Show all warnings during compile"                              0)
+option(WITH_COREDEBUG   "Include additional debug-code in core"                         0)
+option(WITH_MESHEXTRACTOR "Build meshextractor (alpha)"                                 0)
+option(WITHOUT_GIT      "Disable the GIT testing routines"                              0)

--- a/cmake/showoptions.cmake
+++ b/cmake/showoptions.cmake
@@ -49,6 +49,12 @@ else()
   message("* Build scripts w/PCH    : No")
 endif()
 
+if( DETACH_CSCRIPTS )
+  message("* Detach custom scripts  : Yes")
+else()
+  message("* Detach custom scripts  : No (default)")
+endif()
+
 if( WITH_WARNINGS )
   message("* Show all warnings      : Yes")
 else()

--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -22,6 +22,10 @@ include(Commands/CMakeLists.txt)
 
 include(Examples/CMakeLists.txt)
 
+if (DETACH_CSCRIPTS)
+  include(Custom/CMakeLists.txt)
+endif()
+
 set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
   ../game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -29,8 +33,10 @@ set(scripts_STAT_SRCS
   ../game/AI/ScriptedAI/ScriptedFollowerAI.cpp
 )
 
-if(SCRIPTS)
-  include(Custom/CMakeLists.txt)
+if (SCRIPTS)
+  if(NOT DETACH_CSCRIPTS)
+    include(Custom/CMakeLists.txt)
+  endif()
   include(World/CMakeLists.txt)
   include(OutdoorPvP/CMakeLists.txt)
   include(EasternKingdoms/CMakeLists.txt)


### PR DESCRIPTION
Allow to remove coupled custom scripts to regular scripts on build.
Meaning, if you change custom scripts and have this enabled, only custom scripts are rebuilt and core scripts are untouched. Disabled by default.
Original Code by @LilleCarl.
