### PR TITLE
Core/Gossip: Change max menu items to 32

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -25,7 +25,7 @@
 
 class WorldSession;
 
-#define GOSSIP_MAX_MENU_ITEMS 64                            // client supported items unknown, but provided number must be enough
+#define GOSSIP_MAX_MENU_ITEMS               32
 #define DEFAULT_GOSSIP_MESSAGE              0xffffff
 
 enum Gossip_Option


### PR DESCRIPTION
Tested and a gossip menu can show max 32 items on a menu.
When sending 40 options: (image below used to show that you could only see 32 of the options.)
![image](http://puu.sh/7rqb6.jpg)
