### PR TITLE
Core/Chat: Fix AddonMessaging and logging

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -107,20 +107,12 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
             case CHAT_MSG_GUILD:
             case CHAT_MSG_BATTLEGROUND:
             case CHAT_MSG_WHISPER:
-                if (sWorld->getBoolConfig(CONFIG_CHATLOG_ADDON))
-                {
-                    std::string msg = "";
-                    recvData >> msg;
-
-                    if (msg.empty())
-                        return;
-
-                    sScriptMgr->OnPlayerChat(sender, uint32(CHAT_MSG_ADDON), lang, msg);
-                }
-
-                // Disabled addon channel?
+                // check if addon messages are disabled
                 if (!sWorld->getBoolConfig(CONFIG_ADDON_CHANNEL))
+                {
+                    recvData.rfinish();
                     return;
+                }
                 break;
             default:
                 TC_LOG_ERROR("network", "Player %s (GUID: %u) sent a chatmessage with an invalid language/message type combination",


### PR DESCRIPTION
Addon messages are handled a bit off.
Before anything is done, the code gets the message from the packet.
then the message is checked that it isn't empty and then passed through player chat hook for scriptmgr.

Now, the message handling is not stopped there though.
It will continue through the normal chat handling.
This obviously doesnt do anything, since the message was already taken from the packet and as such the rest of the code sees msg as empty.

The logging of an addon message for whispers is also broken.
As for whisper the target name comes first and then the message.
The handling as it is now treats whisper like any other message type, so it will take the msg right away.
So msg will actually be the target name, causing whisper not to work properly for scripts nor logging.

The logging of addon messages is coded in the `OnPlayerChat` hooks (all of them) but as it is, only the normal chat hook is used.
As the hooks check for the config option `CONFIG_CHATLOG_ADDON` and the chathandler also checks for it, there is double checking.

With this code change the addon messages will go through, unless `CONFIG_ADDON_CHANNEL` is disabled. Before they did not go through if logging for the messages was disabled :(
Also the logging will be set correctly that logging for guild messages will take care of guild addon messages.
This will also fix the whisper addon messages. As I said before, the message was lost and showed as receiver name only.
The addon messages will also be sent to the player clients as well.
This means that if you send an addon message to a player, he will receive it to the client as well.
Not just in the c++ code. (the message was never sent before)

Addon messages will have restrictions still like ignore list and GM accept whispers.

Links:
https://github.com/TrinityCore/TrinityCore/blob/master/src/server/scripts/World/chat_log.cpp
https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Handlers/ChatHandler.cpp#L100

Tested to fix carbonite guild addon messaging on https://github.com/TrinityCore/TrinityCore/commit/e4c57d839d83a7e735d4b651827e2dca1ddc68cd
