### PR TITLE
Revert CMakeLists.txt mistake for mmaps_generator

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -11,9 +11,8 @@
 add_subdirectory(map_extractor)
 add_subdirectory(vmap4_assembler)
 add_subdirectory(vmap4_extractor)
+add_subdirectory(mmaps_generator)
 
-#if (WITH_MESHEXTRACTOR)
-#  add_subdirectory(mesh_extractor)
-#else()
-#  add_subdirectory(mmaps_generator)
-#endif()
+if (WITH_MESHEXTRACTOR)
+  add_subdirectory(mesh_extractor)
+endif()


### PR DESCRIPTION
this revert https://github.com/TrinityCore/TrinityCore/commit/401527c351a7dee7768b70ca5e73bde52f9b2977
because when I select "tools" in cmake, mmaps_generator isn't in project and cant compile
delete "#" too for both meshextractor and mmaps_generator - revert https://github.com/TrinityCore/TrinityCore/commit/ad8c046916262918b88917cbe4194a943ce75d16#diff-31
