### PR TITLE
Revert CMakeLists.txt mistake for mmaps_generator

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -11,9 +11,8 @@
 add_subdirectory(map_extractor)
 add_subdirectory(vmap4_assembler)
 add_subdirectory(vmap4_extractor)
+add_subdirectory(mmaps_generator)
 
 #if (WITH_MESHEXTRACTOR)
 #  add_subdirectory(mesh_extractor)
-#else()
-#  add_subdirectory(mmaps_generator)
 #endif()


### PR DESCRIPTION
this revert 401527c
because when I select "tools" in cmake, mmaps_generator isn't in project and cant compile
