### PR TITLE
Fix player mounting while transformed

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5334,7 +5334,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                 if (m_caster->IsInDisallowedMountForm())
                     return SPELL_FAILED_NOT_SHAPESHIFT;
 
-                if (m_caster->HasAura(SPELL_AURA_TRANSFORM))
+                if (m_caster->HasAuraType(SPELL_AURA_TRANSFORM))
                     return SPELL_FAILED_NOT_ON_SHAPESHIFT;
 
                 break;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5334,6 +5334,9 @@ SpellCastResult Spell::CheckCast(bool strict)
                 if (m_caster->IsInDisallowedMountForm())
                     return SPELL_FAILED_NOT_SHAPESHIFT;
 
+                if (m_caster->HasAura(SPELL_AURA_TRANSFORM))
+                    return SPELL_FAILED_NOT_ON_SHAPESHIFT;
+
                 break;
             }
             case SPELL_AURA_RANGED_ATTACK_POWER_ATTACKER_BONUS:


### PR DESCRIPTION
As seen a couple of times in https://www.youtube.com/watch?v=VufhWXi4K14 players should not be able to mount while a transform aura is active. Not sure if SPELL_FAILED_NOT_ON_SHAPESHIFT is the most appropriate error message though.
