### PR TITLE
Fix mounting when transformed

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5333,6 +5333,15 @@ SpellCastResult Spell::CheckCast(bool strict)
 
                 if (m_caster->IsInDisallowedMountForm())
                     return SPELL_FAILED_NOT_SHAPESHIFT;
+                
+                Unit::AuraEffectList const& auras = m_caster->GetAuraEffectsByType(SPELL_AURA_TRANSFORM);
+                if (!auras.empty())
+                    for (Unit::AuraEffectList::const_iterator i = auras.begin(); i != auras.end(); i++)
+                        if (!((*i)->GetBase()->HasEffectType(SPELL_AURA_DUMMY)) && !((*i)->GetSpellInfo()->Attributes & SPELL_ATTR0_CANT_CANCEL))
+                        {
+                            m_customError = SPELL_CUSTOM_ERROR_CANT_MOUNT_WITH_SHAPESHIFT;
+                            return SPELL_FAILED_CUSTOM_ERROR;
+                        }
 
                 break;
             }


### PR DESCRIPTION
Updated the code to reflect that some transforms should still allow the player to mount. I believe it should only be transforms that also have SPELL_AURA_DUMMY...

Im sorry for being so bad with the whole editing and handling of PR's and commits still learning how to deal with github...
