### PR TITLE
Fix SPELL_DAMAGE_CLASS_NONE unable to crit

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10443,7 +10443,7 @@ bool Unit::isSpellCrit(Unit* victim, SpellInfo const* spellProto, SpellSchoolMas
                 default:
                     return false;
             }
-            break;
+        // Do not add a break here, case fallthrough is intentional! Adding a break will make above spells unable to crit.
         case SPELL_DAMAGE_CLASS_MAGIC:
         {
             if (schoolMask & SPELL_SCHOOL_MASK_NORMAL)


### PR DESCRIPTION
Corrected logic mistake where switch fallthrough was intended (or should have been).
Fixes the following.
// Earth Shield
// Lifebloom Final Bloom
// Divine Hymn
// Item - Bauble of True Blood 10m
// Item - Bauble of True Blood 25m
