### PR TITLE
[4.3.4] Revert CMakeLists.txt mistake for mmaps

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -11,9 +11,7 @@
 add_subdirectory(map_extractor)
 add_subdirectory(vmap4_assembler)
 add_subdirectory(vmap4_extractor)
-
-#if (WITH_MESHEXTRACTOR)
-#  add_subdirectory(mesh_extractor)
-#else()
-#  add_subdirectory(mmaps_generator)
-#endif()
+add_subdirectory(mmaps_generator)
+if (WITH_MESHEXTRACTOR)
+  add_subdirectory(mesh_extractor)
+endif()


### PR DESCRIPTION
this revert https://github.com/TrinityCore/TrinityCore/commit/401527c
because when I select "tools" in cmake, mmaps_generator isn't in project and can't compile

i didnt select meshextractor, only tools in cmake
meshextractor have problem during compile with library
