### PR TITLE
Define SPELL_ATTR4_UNK2

### DIFF
--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -421,7 +421,7 @@ enum SpellAttr4
 {
     SPELL_ATTR4_IGNORE_RESISTANCES               = 0x00000001, //  0 spells with this attribute will completely ignore the target's resistance (these spells can't be resisted)
     SPELL_ATTR4_PROC_ONLY_ON_CASTER              = 0x00000002, //  1 proc only on effects with TARGET_UNIT_CASTER?
-    SPELL_ATTR4_UNK2                             = 0x00000004, //  2
+    SPELL_ATTR4_CONTINUES_WHILE_LOGGED_OUT       = 0x00000004, //  2 auras with duration != infinite updates duration without player having to be in world/logged in. auras with infinite duration are removed on logout?
     SPELL_ATTR4_UNK3                             = 0x00000008, //  3
     SPELL_ATTR4_UNK4                             = 0x00000010, //  4 This will no longer cause guards to attack on use??
     SPELL_ATTR4_UNK5                             = 0x00000020, //  5


### PR DESCRIPTION
Spells from http://wowhead.com/spells?filter=cr=85:16;crs=1:3;crv=0:0
checked up against spellwork for spells with AttributeEx4 & 0x00000004
Named Attribute according to wowhead definition
