### PR TITLE
Player: Add Water Walking when player is dead

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1771,6 +1771,9 @@ void Player::Update(uint32 p_time)
     if (m_deathState == JUST_DIED)
         KillPlayer();
 
+    if (m_deathState == DEAD)
+        SetWaterWalking(true, true);
+
     if (m_nextSave > 0)
     {
         if (p_time >= m_nextSave)


### PR DESCRIPTION
Don't get why this isn't in the core. Always been able to walk on water when player died.
