### PR TITLE
Core/Spells: Fixed double heal reduction on Earth Shield (issue #4032).

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -310,6 +310,12 @@ class spell_sha_earth_shield : public SpellScriptLoader
                     amount = caster->SpellHealingBonusDone(GetUnitOwner(), GetSpellInfo(), amount, HEAL);
                     amount = GetUnitOwner()->SpellHealingBonusTaken(caster, GetSpellInfo(), amount, HEAL);
 
+                    // If target is affected by healing reduction, modifier is guaranteed to be negative 
+                    // value (e.g. -50). To revert the effect, multiply amount with reciprocal of relative value:
+                    // (100 / ((-1) * modifier)) * 100 = (-1) * 100 * 100 / modifier = -10000 / modifier
+                    if (int32 modifier = GetUnitOwner()->GetMaxNegativeAuraModifier(SPELL_AURA_MOD_HEALING_PCT))
+                        ApplyPct(amount, -10000.0f / float(modifier));
+
                     // Glyph of Earth Shield
                     //! WORKAROUND
                     //! this glyph is a proc


### PR DESCRIPTION
The SpellScript for Earth Shield applies healing reducing auras once when the spell is casted on the target and every time when the buff procs. The suggested code revokes the application of healing reduced auras at cast time which yields the desired behavior of 50% healing reduction when instead of 75% when Earth Shield was cast while any such aura was active on the target.

Edit: Tested in duels with an arms warrior applying Mortal Strike to a Resto Shaman.
