### PR TITLE
Fixed spelling typo in gnomeregan.cpp script.

### DIFF
--- a/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.cpp
+++ b/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.cpp
@@ -29,7 +29,7 @@ Script Data End */
 #include "ScriptedEscortAI.h"
 #include "Player.h"
 
-#define GOSSIP_START_EVENT "I am ready to being"
+#define GOSSIP_START_EVENT "I am ready to begin."
 
 enum BlastmasterEmi
 {


### PR DESCRIPTION
Fixed a typo on line 32 where [GOSSIP_START_EVENT "I am ready to being"] should read [GOSSIP_START_EVENT "I am ready to begin."]
