### PR TITLE
Fix percentage HOTs proccing everything

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6099,7 +6099,7 @@ void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const
     uint32 procVictim   = PROC_FLAG_TAKEN_PERIODIC;
     uint32 procEx = (crit ? PROC_EX_CRITICAL_HIT : PROC_EX_NORMAL_HIT) | PROC_EX_INTERNAL_HOT;
     // ignore item heals
-    if (!haveCastItem)
+    if (!haveCastItem && GetAuraType() != SPELL_AURA_OBS_MOD_HEALTH)
         caster->ProcDamageAndSpell(target, procAttacker, procVictim, procEx, damage, BASE_ATTACK, GetSpellInfo());
 }
 

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -813,7 +813,7 @@ bool SpellMgr::IsSpellProcEventCanTriggeredBy(SpellProcEventEntry const* spellPr
         return true;
 
     /// Any aura that has only PROC_FLAG_DONE_PERIODIC or PROC_FLAG_TAKEN_PERIODIC should always proc, if procSpell is correct or not is checked in Unit::HandleAuraProc
-    if (EventProcFlag == PROC_FLAG_DONE_PERIODIC || EventProcFlag == PROC_FLAG_TAKEN_PERIODIC)
+    if ((EventProcFlag == PROC_FLAG_DONE_PERIODIC && procFlags == PROC_FLAG_DONE_PERIODIC) || (EventProcFlag == PROC_FLAG_TAKEN_PERIODIC && procFlags == PROC_FLAG_TAKEN_PERIODIC))
         return true;
 
     if (procFlags & PROC_FLAG_DONE_PERIODIC && EventProcFlag & PROC_FLAG_DONE_PERIODIC)


### PR DESCRIPTION
Fixes unforeseen sideeffect of 057169c21c141f690891c908b8f09e63d917289d
Percentage HOTs are not supposed to proc anything at all.
Closes: https://github.com/TrinityCore/TrinityCore/issues/11914
