### PR TITLE
Core/Spells: Healing spells with SPELL_ATTR6_NO_DONE_PCT_DAMAGE_MODS get...

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10823,6 +10823,9 @@ uint32 Unit::SpellHealingBonusDone(Unit* victim, SpellInfo const* spellProto, ui
 
 uint32 Unit::SpellHealingBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 healamount, DamageEffectType damagetype, uint32 stack) const
 {
+    if (spellProto->AttributesEx6 & SPELL_ATTR6_NO_DONE_PCT_DAMAGE_MODS)
+        return healamount;
+
     float TakenTotalMod = 1.0f;
 
     // Healing taken percent


### PR DESCRIPTION
... no healing taken mods (confirmed for Leeching Swarm)

http://www.worldoflogs.com/reports/jz78urnmw3a3a01p/details/213/?s=6803&e=7037 a raid with a rogue using Wound Poison, and there are as well many suspicions on various forums
