### PR TITLE
Core/WorldSession: After sudden disconnects, session should persist for a minute

### DIFF
--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -1021,6 +1021,8 @@ class WorldSession
         bool isRecruiter;
         ACE_Based::LockedQueue<WorldPacket*, ACE_Thread_Mutex> _recvQueue;
         rbac::RBACData* _RBACData;
+        uint32 expireTime;
+        bool forceExit;
 
         WorldSession(WorldSession const& right) = delete;
         WorldSession& operator=(WorldSession const& right) = delete;


### PR DESCRIPTION
With this change, if a player alt-f4, he'll only fade from world after a minute

Behavior seen in https://www.youtube.com/watch?feature=player_detailpage&v=RSeVCw3hVgQ#t=168
I'm not completely sure about the expire time, the 1 minute was said by Shauren

If a player tries to log back in, the session will be forced out by KickPlayer()
