### PR TITLE
[core/database]Repair fishing spell result fish escape

### DIFF
--- a/sql/updates/world/2014_05_10_fish_junk_loot_template.sql
+++ b/sql/updates/world/2014_05_10_fish_junk_loot_template.sql
@@ -1,0 +1,20 @@
+SET @FISH_JUNK_GROUP := 11799;
+SET @FISH_JUNK_LOOTMODE := 32768;
+
+DELETE FROM fishing_loot_template WHERE `item`=@FISH_JUNK_GROUP;
+INSERT INTO fishing_loot_template (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES
+(1, @FISH_JUNK_GROUP, 100, @FISH_JUNK_LOOTMODE, 1, -@FISH_JUNK_GROUP, 1);
+
+DELETE FROM reference_loot_template WHERE `entry`=@FISH_JUNK_GROUP;
+INSERT INTO reference_loot_template (`entry`, `item`, `ChanceOrQuestChance`, `lootmode`, `groupid`, `mincountOrRef`, `maxcount`) VALUES
+(@FISH_JUNK_GROUP, 45190, 15, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Driftwood]
+(@FISH_JUNK_GROUP, 45191, 2, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Water Snail]
+(@FISH_JUNK_GROUP, 45194, 15, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Tangled Fishing Line]
+(@FISH_JUNK_GROUP, 45195, 5, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Empty Rum Bottle]
+(@FISH_JUNK_GROUP, 45196, 15, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Tattered Cloth]
+(@FISH_JUNK_GROUP, 45197, 5, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Tree Branch]
+(@FISH_JUNK_GROUP, 45198, 15, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Weeds]
+(@FISH_JUNK_GROUP, 45199, 5, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Old Boot]
+(@FISH_JUNK_GROUP, 45200, 15, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Sickly Fish]
+(@FISH_JUNK_GROUP, 45201, 3, @FISH_JUNK_LOOTMODE, 1, 1, 1), -- [Rock]
+(@FISH_JUNK_GROUP, 45202, 5, @FISH_JUNK_LOOTMODE, 1, 1, 1); -- [Water Snail]

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -694,12 +694,39 @@ void GameObject::getFishLoot(Loot* fishloot, Player* loot_owner)
     fishloot->clear();
 
     uint32 zone, subzone;
+    uint32 defaultzone = 1;
     GetZoneAndAreaId(zone, subzone);
 
     // if subzone loot exist use it
-    if (!fishloot->FillLoot(subzone, LootTemplates_Fishing, loot_owner, true, true))
-        // else use zone loot (must exist in like case)
-        fishloot->FillLoot(zone, LootTemplates_Fishing, loot_owner, true);
+    fishloot->FillLoot(subzone, LootTemplates_Fishing, loot_owner, true, true);
+    if (fishloot->empty())  //use this becase if zone or subzone has set LOOT_MODE_JUNK_FISH,Even if no normal drop, fishloot->FillLoot return true. it wrong.
+    {
+        //subzone no result,use zone loot
+        fishloot->FillLoot(zone, LootTemplates_Fishing, loot_owner, true, true);
+        //use zone 1 as default, somewhere fishing got nothing,becase subzone and zone not set, like Off the coast of Storm Peaks. 
+        if (fishloot->empty())
+            fishloot->FillLoot(defaultzone, LootTemplates_Fishing, loot_owner, true, true);
+    }
+}
+
+void GameObject::getFishLootJunk(Loot* fishloot, Player* loot_owner)
+{
+    fishloot->clear();
+
+    uint32 zone, subzone;
+    uint32 defaultzone = 1;
+    GetZoneAndAreaId(zone, subzone);
+
+    // if subzone loot exist use it
+    fishloot->FillLoot(subzone, LootTemplates_Fishing, loot_owner, true, true, LOOT_MODE_JUNK_FISH);
+    if (fishloot->empty())  //use this becase if zone or subzone has normal mask drop, then fishloot->FillLoot return true.
+    {
+        //use zone loot
+        fishloot->FillLoot(zone, LootTemplates_Fishing, loot_owner, true, true, LOOT_MODE_JUNK_FISH);
+        if (fishloot->empty())
+            //use zone 1 as default
+            fishloot->FillLoot(defaultzone, LootTemplates_Fishing, loot_owner, true, true, LOOT_MODE_JUNK_FISH);
+    }
 }
 
 void GameObject::SaveToDB()
@@ -1413,10 +1440,8 @@ void GameObject::Use(Unit* user)
                         else
                             player->SendLoot(GetGUID(), LOOT_FISHING);
                     }
-                    /// @todo else: junk
-                    else
-                        m_respawnTime = time(NULL);
-
+                    else // else: junk
+                        player->SendLoot(GetGUID(), LOOT_FISHING_JUNK);
                     break;
                 }
                 case GO_JUST_DEACTIVATED:                   // nothing to do, will be deleted at next update

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -713,6 +713,7 @@ class GameObject : public WorldObject, public GridObject<GameObject>, public Map
         void Refresh();
         void Delete();
         void getFishLoot(Loot* loot, Player* loot_owner);
+        void getFishLootJunk(Loot* loot, Player* loot_owner);
         GameobjectTypes GetGoType() const { return GameobjectTypes(GetByteValue(GAMEOBJECT_BYTES_1, 1)); }
         void SetGoType(GameobjectTypes type) { SetByteValue(GAMEOBJECT_BYTES_1, 1, type); }
         GOState GetGoState() const { return GOState(GetByteValue(GAMEOBJECT_BYTES_1, 0)); }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8756,7 +8756,7 @@ void Player::SendLoot(uint64 guid, LootType loot_type)
 
         // not check distance for GO in case owned GO (fishing bobber case, for example)
         // And permit out of range GO with no owner in case fishing hole
-        if (!go || (loot_type != LOOT_FISHINGHOLE && (loot_type != LOOT_FISHING || go->GetOwnerGUID() != GetGUID()) && !go->IsWithinDistInMap(this, INTERACTION_DISTANCE)) || (loot_type == LOOT_CORPSE && go->GetRespawnTime() && go->isSpawnedByDefault()))
+        if (!go || (loot_type != LOOT_FISHINGHOLE && ((loot_type != LOOT_FISHING && loot_type != LOOT_FISHING_JUNK) || go->GetOwnerGUID() != GetGUID()) && !go->IsWithinDistInMap(this, INTERACTION_DISTANCE)) || (loot_type == LOOT_CORPSE && go->GetRespawnTime() && go->isSpawnedByDefault()))
         {
             SendLootRelease(guid);
             return;
@@ -8794,6 +8794,8 @@ void Player::SendLoot(uint64 guid, LootType loot_type)
 
             if (loot_type == LOOT_FISHING)
                 go->getFishLoot(loot, this);
+            else if (loot_type == LOOT_FISHING_JUNK)
+                go->getFishLootJunk(loot, this);
 
             if (go->GetGOInfo()->type == GAMEOBJECT_TYPE_CHEST && go->GetGOInfo()->chest.groupLootRules)
             {
@@ -9036,6 +9038,7 @@ void Player::SendLoot(uint64 guid, LootType loot_type)
     {
         case LOOT_INSIGNIA:    loot_type = LOOT_SKINNING; break;
         case LOOT_FISHINGHOLE: loot_type = LOOT_FISHING; break;
+        case LOOT_FISHING_JUNK: loot_type = LOOT_FISHING; break;
         default: break;
     }
 

--- a/src/server/game/Loot/LootMgr.h
+++ b/src/server/game/Loot/LootMgr.h
@@ -86,7 +86,8 @@ enum LootType
     LOOT_MILLING                = 8,
 
     LOOT_FISHINGHOLE            = 20,                       // unsupported by client, sending LOOT_FISHING instead
-    LOOT_INSIGNIA               = 21                        // unsupported by client, sending LOOT_CORPSE instead
+    LOOT_INSIGNIA               = 21,                       // unsupported by client, sending LOOT_CORPSE instead
+    LOOT_FISHING_JUNK           = 22                        // unsupported by client, sending LOOT_FISHING instead
 };
 
 // type of Loot Item in Loot View

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -41,7 +41,8 @@ enum LootModes
     LOOT_MODE_HARD_MODE_1              = 0x2,
     LOOT_MODE_HARD_MODE_2              = 0x4,
     LOOT_MODE_HARD_MODE_3              = 0x8,
-    LOOT_MODE_HARD_MODE_4              = 0x10
+    LOOT_MODE_HARD_MODE_4              = 0x10,
+    LOOT_MODE_JUNK_FISH                = 0x8000
 };
 
 enum Expansions


### PR DESCRIPTION
http://www.wowwiki.com/Fishing_items

As of 3.1, there is no longer a minimum skill requirement to fish in any zone, and all casts will catch something and award a chance for a skill-up. However, if your skill level is too low for a zone, you will catch mostly junk items. The skill level required to guarantee "no junk" catches is equivalent to the old "no get away" level.

https://github.com/TrinityCore/TrinityCore/issues/12026
