### PR TITLE
Core/Players: Prevent summon spell effects if there's already a summon not accepted

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2299,6 +2299,8 @@ class Player : public Unit, public GridObject<Player>
         std::string GetMapAreaAndZoneString();
         std::string GetCoordsMapAreaAndZoneString();
 
+        time_t GetSummonExpireTimer() const { return m_summon_expire; }
+
     protected:
         // Gamemaster whisper whitelist
         WhisperListContainer WhisperList;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4258,6 +4258,9 @@ void Spell::EffectSummonPlayer(SpellEffIndex /*effIndex*/)
     if (unitTarget->HasAura(23445))
         return;
 
+    if (unitTarget->ToPlayer()->GetSummonExpireTimer() > time(NULL))
+        return;
+
     float x, y, z;
     m_caster->GetPosition(x, y, z);
 


### PR DESCRIPTION
https://github.com/TrinityCore/TrinityCore/issues/12063, and possible a few other issues
