### PR TITLE
Fix various warnings.

### DIFF
--- a/dep/g3dlite/include/G3D/debugAssert.h
+++ b/dep/g3dlite/include/G3D/debugAssert.h
@@ -228,6 +228,6 @@ void _releaseInputGrab_();
     @internal*/
 void _restoreInputGrab_();
 
-} } // namespace
+}; }; // namespace
 
 #endif

--- a/dep/g3dlite/include/G3D/debugAssert.h
+++ b/dep/g3dlite/include/G3D/debugAssert.h
@@ -228,6 +228,6 @@ void _releaseInputGrab_();
     @internal*/
 void _restoreInputGrab_();
 
-}; }; // namespace
+} } // namespace
 
 #endif

--- a/src/server/authserver/Authentication/AuthCodes.cpp
+++ b/src/server/authserver/Authentication/AuthCodes.cpp
@@ -79,4 +79,4 @@ namespace AuthHelper
 
         return NULL;
     }
-};
+}

--- a/src/server/authserver/Authentication/AuthCodes.h
+++ b/src/server/authserver/Authentication/AuthCodes.h
@@ -92,6 +92,6 @@ namespace AuthHelper
     bool IsAcceptedClientBuild(int build);
     bool IsPostBCAcceptedClientBuild(int build);
     bool IsPreBCAcceptedClientBuild(int build);
-};
+}
 
 #endif

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22645,7 +22645,7 @@ bool Player::ModifyMoney(int32 amount, bool sendError /*= true*/)
         SetMoney (GetMoney() > uint32(-amount) ? GetMoney() + amount : 0);
     else
     {
-        if (GetMoney() < uint32(MAX_MONEY_AMOUNT - amount))
+        if (GetMoney() < MAX_MONEY_AMOUNT - static_cast<uint32>(amount))
             SetMoney(GetMoney() + amount);
         else
         {

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -29,6 +29,7 @@
 #include "SpellMgr.h"
 #include "Unit.h"
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -824,7 +825,8 @@ enum PlayerDelayedOperations
 
 // Player summoning auto-decline time (in secs)
 #define MAX_PLAYER_SUMMON_DELAY                   (2*MINUTE)
-#define MAX_MONEY_AMOUNT                       (0x7FFFFFFF-1)
+// Maximum money amount : 2^31 - 1
+auto constexpr MAX_MONEY_AMOUNT(static_cast<uint32>(std::numeric_limits<int32>::max()));
 
 struct InstancePlayerBind
 {

--- a/src/server/game/Guilds/Guild.cpp
+++ b/src/server/game/Guilds/Guild.cpp
@@ -754,7 +754,7 @@ int32 Guild::Member::GetBankWithdrawValue(uint8 tabId) const
 {
     // Guild master has unlimited amount.
     if (IsRank(GR_GUILDMASTER))
-        return tabId == GUILD_BANK_MAX_TABS ? GUILD_WITHDRAW_MONEY_UNLIMITED : GUILD_WITHDRAW_SLOT_UNLIMITED;
+        return static_cast<int32>(tabId == GUILD_BANK_MAX_TABS ? GUILD_WITHDRAW_MONEY_UNLIMITED : GUILD_WITHDRAW_SLOT_UNLIMITED);
 
     return m_bankWithdraw[tabId];
 }
@@ -1760,7 +1760,7 @@ void Guild::HandleMemberDepositMoney(WorldSession* session, uint32 amount)
 bool Guild::HandleMemberWithdrawMoney(WorldSession* session, uint32 amount, bool repair)
 {
     //clamp amount to MAX_MONEY_AMOUNT, Players can't hold more than that anyway
-    amount = std::min(amount, uint32(MAX_MONEY_AMOUNT));
+    amount = std::min(amount, MAX_MONEY_AMOUNT);
 
     if (m_bankMoney < amount)                               // Not enough money in bank
         return false;
@@ -2581,7 +2581,7 @@ inline int32 Guild::_GetMemberRemainingSlots(Member const* member, uint8 tabId) 
     {
         uint8 rankId = member->GetRankId();
         if (rankId == GR_GUILDMASTER)
-            return GUILD_WITHDRAW_SLOT_UNLIMITED;
+            return static_cast<int32>(GUILD_WITHDRAW_SLOT_UNLIMITED);
         if ((_GetRankBankTabRights(rankId, tabId) & GUILD_BANK_RIGHT_VIEW_TAB) != 0)
         {
             int32 remaining = _GetRankBankTabSlotsPerDay(rankId, tabId) - member->GetBankWithdrawValue(tabId);
@@ -2598,7 +2598,7 @@ inline int32 Guild::_GetMemberRemainingMoney(Member const* member) const
     {
         uint8 rankId = member->GetRankId();
         if (rankId == GR_GUILDMASTER)
-            return GUILD_WITHDRAW_MONEY_UNLIMITED;
+            return static_cast<int32>(GUILD_WITHDRAW_MONEY_UNLIMITED);
 
         if ((_GetRankRights(rankId) & (GR_RIGHT_WITHDRAW_REPAIR | GR_RIGHT_WITHDRAW_GOLD)) != 0)
         {

--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -299,14 +299,14 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& /*recvPacket*/)
         return;
     }
 
-    if (_player->GetMoney() >= uint32(MAX_MONEY_AMOUNT) - his_trade->GetMoney())
+    if (_player->GetMoney() >= MAX_MONEY_AMOUNT - his_trade->GetMoney())
     {
         _player->SendEquipError(EQUIP_ERR_TOO_MUCH_GOLD, NULL, NULL);
         my_trade->SetAccepted(false, true);
         return;
     }
 
-    if (trader->GetMoney() >= uint32(MAX_MONEY_AMOUNT) - my_trade->GetMoney())
+    if (trader->GetMoney() >= MAX_MONEY_AMOUNT - my_trade->GetMoney())
     {
         trader->SendEquipError(EQUIP_ERR_TOO_MUCH_GOLD, NULL, NULL);
         his_trade->SetAccepted(false, true);

--- a/src/server/game/Instances/InstanceScript.h
+++ b/src/server/game/Instances/InstanceScript.h
@@ -243,7 +243,7 @@ AI* GetInstanceAI(T* obj, char const* scriptName)
                 return new AI(obj);
 
     return NULL;
-};
+}
 
 template<class AI, class T>
 AI* GetInstanceAI(T* obj)
@@ -253,6 +253,6 @@ AI* GetInstanceAI(T* obj)
             return new AI(obj);
 
     return NULL;
-};
+}
 
 #endif // TRINITY_INSTANCE_DATA_H

--- a/src/server/scripts/Commands/cs_modify.cpp
+++ b/src/server/scripts/Commands/cs_modify.cpp
@@ -1020,7 +1020,7 @@ public:
             }
             else
             {
-                if (newmoney > MAX_MONEY_AMOUNT)
+                if (newmoney > static_cast<int32>(MAX_MONEY_AMOUNT))
                     newmoney = MAX_MONEY_AMOUNT;
 
                 handler->PSendSysMessage(LANG_YOU_TAKE_MONEY, abs(moneyToAdd), handler->GetNameLink(target).c_str());
@@ -1035,10 +1035,7 @@ public:
             if (handler->needReportToTarget(target))
                 ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_MONEY_GIVEN, handler->GetNameLink().c_str(), moneyToAdd);
 
-            if (moneyToAdd >= MAX_MONEY_AMOUNT)
-                moneyToAdd = MAX_MONEY_AMOUNT;
-
-            if (targetMoney >= uint32(MAX_MONEY_AMOUNT) - moneyToAdd)
+            if (targetMoney >= MAX_MONEY_AMOUNT - moneyToAdd)
                 moneyToAdd -= targetMoney;
 
             target->ModifyMoney(moneyToAdd);

--- a/src/server/scripts/EasternKingdoms/AlteracValley/boss_balinda.cpp
+++ b/src/server/scripts/EasternKingdoms/AlteracValley/boss_balinda.cpp
@@ -212,4 +212,4 @@ void AddSC_boss_balinda()
 {
     new boss_balinda;
     new npc_water_elemental;
-};
+}

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -183,7 +183,7 @@ class spell_egg_event : public SpellScriptLoader
 
         class spell_egg_eventSpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_egg_eventSpellScript);
+            PrepareSpellScript(spell_egg_eventSpellScript)
 
             void HandleOnHit()
             {

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -109,7 +109,7 @@ void SummonCroneIfReady(InstanceScript* instance, Creature* creature)
                 pCrone->AI()->AttackStart(creature->GetVictim());
         }
     }
-};
+}
 
 class boss_dorothee : public CreatureScript
 {

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_darkmaster_gandling.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_darkmaster_gandling.cpp
@@ -160,7 +160,7 @@ class spell_shadow_portal : public SpellScriptLoader
 
         class spell_shadow_portal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_shadow_portal_SpellScript);
+            PrepareSpellScript(spell_shadow_portal_SpellScript)
 
             void HandleCast(SpellEffIndex /*effIndex*/)
             {
@@ -274,7 +274,7 @@ class spell_shadow_portal_rooms : public SpellScriptLoader
 
         class spell_shadow_portal_rooms_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_shadow_portal_rooms_SpellScript);
+            PrepareSpellScript(spell_shadow_portal_rooms_SpellScript)
 
             void HandleSendEvent(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/EasternKingdoms/ShadowfangKeep/shadowfang_keep.cpp
+++ b/src/server/scripts/EasternKingdoms/ShadowfangKeep/shadowfang_keep.cpp
@@ -208,7 +208,7 @@ class spell_shadowfang_keep_haunting_spirits : public SpellScriptLoader
 
         class spell_shadowfang_keep_haunting_spirits_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_shadowfang_keep_haunting_spirits_AuraScript);
+            PrepareAuraScript(spell_shadowfang_keep_haunting_spirits_AuraScript)
 
             void CalcPeriodic(AuraEffect const* /*aurEff*/, bool& isPeriodic, int32& amplitude)
             {

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_hexlord.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_hexlord.cpp
@@ -959,7 +959,7 @@ class spell_hexlord_unstable_affliction : public SpellScriptLoader
 
         class spell_hexlord_unstable_affliction_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hexlord_unstable_affliction_AuraScript);
+            PrepareAuraScript(spell_hexlord_unstable_affliction_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -464,7 +464,7 @@ class spell_banging_the_gong : public SpellScriptLoader
 
         class spell_banging_the_gong_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_banging_the_gong_SpellScript);
+            PrepareSpellScript(spell_banging_the_gong_SpellScript)
 
             void Activate(SpellEffIndex index)
             {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -408,7 +408,7 @@ class spell_threatening_gaze : public SpellScriptLoader
 
         class spell_threatening_gaze_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_threatening_gaze_AuraScript);
+            PrepareAuraScript(spell_threatening_gaze_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/EasternKingdoms/zone_blasted_lands.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_blasted_lands.cpp
@@ -44,7 +44,7 @@ class spell_razelikh_teleport_group : public SpellScriptLoader
 
         class spell_razelikh_teleport_group_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_razelikh_teleport_group_SpellScript);
+            PrepareSpellScript(spell_razelikh_teleport_group_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Examples/example_spell.cpp
+++ b/src/server/scripts/Examples/example_spell.cpp
@@ -43,7 +43,7 @@ class spell_ex_5581 : public SpellScriptLoader
             // initialize script, this macro does compile time check for type of the function - prevents possible issues
             // if you have assigned wrong type of function to a hook you'll receive type conversion error during build
             // this line is required, otherwise you'll get XXXHandlerFunction - identifier not found errors
-            PrepareSpellScript(spell_ex_5581SpellScript);
+            PrepareSpellScript(spell_ex_5581SpellScript)
 
             std::string localVariable;
             char* localVariable2;
@@ -205,7 +205,7 @@ class spell_ex_66244 : public SpellScriptLoader
 
         class spell_ex_66244AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ex_66244AuraScript);
+            PrepareAuraScript(spell_ex_66244AuraScript)
             // function called on server startup
             // checks if script has data required for it to work
             bool Validate(SpellInfo const* /*spellInfo*/) override
@@ -364,7 +364,7 @@ class spell_ex_absorb_aura : public SpellScriptLoader
 
         class spell_ex_absorb_auraAuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ex_absorb_auraAuraScript);
+            PrepareAuraScript(spell_ex_absorb_auraAuraScript)
 
             void HandleOnEffectAbsorb(AuraEffect* /*aurEff*/, DamageInfo & dmgInfo, uint32 & absorbAmount)
             {
@@ -400,7 +400,7 @@ class spell_ex_463 : public SpellScriptLoader
 
         class spell_ex_463AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ex_463AuraScript);
+            PrepareAuraScript(spell_ex_463AuraScript)
 
             bool CheckAreaTarget(Unit* target)
             {
@@ -438,7 +438,7 @@ class spell_ex : public SpellScriptLoader
 
         class spell_ex_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ex_SpellScript);
+            PrepareSpellScript(spell_ex_SpellScript)
 
             //bool Validate(SpellInfo const* spellEntry){return true;} override
             //bool Load(){return true;}

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
@@ -181,7 +181,7 @@ class spell_mark_of_kazrogal : public SpellScriptLoader
 
         class spell_mark_of_kazrogal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mark_of_kazrogal_SpellScript);
+            PrepareSpellScript(spell_mark_of_kazrogal_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -196,7 +196,7 @@ class spell_mark_of_kazrogal : public SpellScriptLoader
 
         class spell_mark_of_kazrogal_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mark_of_kazrogal_AuraScript);
+            PrepareAuraScript(spell_mark_of_kazrogal_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Kalimdor/RazorfenKraul/razorfen_kraul.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenKraul/razorfen_kraul.cpp
@@ -257,7 +257,7 @@ class spell_snufflenose_command : public SpellScriptLoader
 
         class spell_snufflenose_commandSpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_snufflenose_commandSpellScript);
+            PrepareSpellScript(spell_snufflenose_commandSpellScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -247,7 +247,7 @@ class spell_egg_explosion : public SpellScriptLoader
 
         class spell_egg_explosion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_egg_explosion_SpellScript);
+            PrepareSpellScript(spell_egg_explosion_SpellScript)
 
             void HandleAfterCast()
             {

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -215,7 +215,7 @@ class spell_skeram_arcane_explosion : public SpellScriptLoader
 
         class spell_skeram_arcane_explosion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_skeram_arcane_explosion_SpellScript);
+            PrepareSpellScript(spell_skeram_arcane_explosion_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {

--- a/src/server/scripts/Kalimdor/boss_azuregos.cpp
+++ b/src/server/scripts/Kalimdor/boss_azuregos.cpp
@@ -178,7 +178,7 @@ class spell_mark_of_frost : public SpellScriptLoader
 
         class spell_mark_of_frost_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mark_of_frost_SpellScript);
+            PrepareSpellScript(spell_mark_of_frost_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Kalimdor/zone_dustwallow_marsh.cpp
+++ b/src/server/scripts/Kalimdor/zone_dustwallow_marsh.cpp
@@ -610,7 +610,7 @@ class spell_ooze_zap : public SpellScriptLoader
 
         class spell_ooze_zap_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ooze_zap_SpellScript);
+            PrepareSpellScript(spell_ooze_zap_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -657,7 +657,7 @@ class spell_ooze_zap_channel_end : public SpellScriptLoader
 
         class spell_ooze_zap_channel_end_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ooze_zap_channel_end_SpellScript);
+            PrepareSpellScript(spell_ooze_zap_channel_end_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -693,7 +693,7 @@ class spell_energize_aoe : public SpellScriptLoader
 
         class spell_energize_aoe_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_energize_aoe_SpellScript);
+            PrepareSpellScript(spell_energize_aoe_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Kalimdor/zone_feralas.cpp
+++ b/src/server/scripts/Kalimdor/zone_feralas.cpp
@@ -215,7 +215,7 @@ class spell_gordunni_trap : public SpellScriptLoader
 
         class spell_gordunni_trap_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gordunni_trap_SpellScript);
+            PrepareSpellScript(spell_gordunni_trap_SpellScript)
 
             void HandleDummy()
             {

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -1006,7 +1006,7 @@ void npc_qiraj_war_spawn::npc_qiraj_war_spawnAI::JustDied(Unit* /*slayer*/)
         if (npc_anachronos_quest_trigger::npc_anachronos_quest_triggerAI* triggerAI = CAST_AI(npc_anachronos_quest_trigger::npc_anachronos_quest_triggerAI, mob->AI()))
             triggerAI->LiveCounter();
 
-};
+}
 
 /*#####
 # go_crystalline_tear

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_elder_nadox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_elder_nadox.cpp
@@ -267,7 +267,7 @@ public:
 
     class spell_elder_nadox_guardian_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_elder_nadox_guardian_SpellScript);
+        PrepareSpellScript(spell_elder_nadox_guardian_SpellScript)
 
         void FilterTargets(std::list<WorldObject*>& targets)
         {

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
@@ -417,7 +417,7 @@ class spell_prince_taldaram_conjure_flame_sphere : public SpellScriptLoader
 
         class spell_prince_taldaram_conjure_flame_sphere_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_prince_taldaram_conjure_flame_sphere_SpellScript);
+            PrepareSpellScript(spell_prince_taldaram_conjure_flame_sphere_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -460,7 +460,7 @@ class spell_prince_taldaram_flame_sphere_summon : public SpellScriptLoader
 
         class spell_prince_taldaram_flame_sphere_summon_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_prince_taldaram_flame_sphere_summon_SpellScript);
+            PrepareSpellScript(spell_prince_taldaram_flame_sphere_summon_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_baltharus_the_warborn.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_baltharus_the_warborn.cpp
@@ -312,7 +312,7 @@ class spell_baltharus_enervating_brand_trigger : public SpellScriptLoader
 
         class spell_baltharus_enervating_brand_trigger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_baltharus_enervating_brand_trigger_SpellScript);
+            PrepareSpellScript(spell_baltharus_enervating_brand_trigger_SpellScript)
 
             void CheckDistance()
             {

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -1342,7 +1342,7 @@ class spell_halion_meteor_strike_marker : public SpellScriptLoader
 
         class spell_halion_meteor_strike_marker_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_halion_meteor_strike_marker_AuraScript);
+            PrepareAuraScript(spell_halion_meteor_strike_marker_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1373,7 +1373,7 @@ class spell_halion_combustion_consumption : public SpellScriptLoader
 
         class spell_halion_combustion_consumption_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_halion_combustion_consumption_AuraScript);
+            PrepareAuraScript(spell_halion_combustion_consumption_AuraScript)
 
         public:
             spell_halion_combustion_consumption_AuraScript(uint32 spellID) : AuraScript(), _markSpell(spellID) { }
@@ -1431,7 +1431,7 @@ class spell_halion_marks : public SpellScriptLoader
 
         class spell_halion_marks_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_halion_marks_AuraScript);
+            PrepareAuraScript(spell_halion_marks_AuraScript)
 
         public:
             spell_halion_marks_AuraScript(uint32 summonSpell, uint32 removeSpell) : AuraScript(),
@@ -1491,7 +1491,7 @@ class spell_halion_damage_aoe_summon : public SpellScriptLoader
 
         class spell_halion_damage_aoe_summon_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_halion_damage_aoe_summon_SpellScript);
+            PrepareSpellScript(spell_halion_damage_aoe_summon_SpellScript)
 
             void HandleSummon(SpellEffIndex effIndex)
             {
@@ -1528,7 +1528,7 @@ class spell_halion_twilight_realm_handlers : public SpellScriptLoader
 
         class spell_halion_twilight_realm_handlers_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_halion_twilight_realm_handlers_AuraScript);
+            PrepareAuraScript(spell_halion_twilight_realm_handlers_AuraScript)
 
         public:
             spell_halion_twilight_realm_handlers_AuraScript(uint32 beforeHitSpell, bool isApplyHandler) : AuraScript(),
@@ -1592,7 +1592,7 @@ class spell_halion_clear_debuffs : public SpellScriptLoader
 
         class spell_halion_clear_debuffs_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_halion_clear_debuffs_SpellScript);
+            PrepareSpellScript(spell_halion_clear_debuffs_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1643,7 +1643,7 @@ class spell_halion_twilight_cutter : public SpellScriptLoader
 
         class spell_halion_twilight_cutter_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_halion_twilight_cutter_SpellScript);
+            PrepareSpellScript(spell_halion_twilight_cutter_SpellScript)
 
             void RemoveNotBetween(std::list<WorldObject*>& unitList)
             {
@@ -1680,7 +1680,7 @@ class spell_halion_twilight_phasing : public SpellScriptLoader
 
         class spell_halion_twilight_phasing_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_halion_twilight_phasing_SpellScript);
+            PrepareSpellScript(spell_halion_twilight_phasing_SpellScript)
 
             void Phase()
             {
@@ -1709,7 +1709,7 @@ class spell_halion_summon_exit_portals : public SpellScriptLoader
 
         class spell_halion_summon_exit_portals_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_halion_summon_exit_portals_SpellScript);
+            PrepareSpellScript(spell_halion_summon_exit_portals_SpellScript)
 
             void SetDest0(SpellDestination& dest)
             {

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
@@ -221,7 +221,7 @@ class spell_saviana_conflagration_init : public SpellScriptLoader
 
         class spell_saviana_conflagration_init_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_saviana_conflagration_init_SpellScript);
+            PrepareSpellScript(spell_saviana_conflagration_init_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -258,7 +258,7 @@ class spell_saviana_conflagration_throwback : public SpellScriptLoader
 
         class spell_saviana_conflagration_throwback_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_saviana_conflagration_throwback_SpellScript);
+            PrepareSpellScript(spell_saviana_conflagration_throwback_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_argent_challenge.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_argent_challenge.cpp
@@ -128,7 +128,7 @@ class spell_eadric_radiance : public SpellScriptLoader
         spell_eadric_radiance() : SpellScriptLoader("spell_eadric_radiance") { }
         class spell_eadric_radiance_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_eadric_radiance_SpellScript);
+            PrepareSpellScript(spell_eadric_radiance_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -627,7 +627,7 @@ class spell_paletress_summon_memory : public SpellScriptLoader
 
         class spell_paletress_summon_memory_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_paletress_summon_memory_SpellScript);
+            PrepareSpellScript(spell_paletress_summon_memory_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -815,7 +815,7 @@ class spell_impale : public SpellScriptLoader
 
         class spell_impale_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_impale_SpellScript);
+            PrepareSpellScript(spell_impale_SpellScript)
 
             void HandleDamageCalc(SpellEffIndex /*effIndex*/)
             {
@@ -846,7 +846,7 @@ class spell_anubarak_leeching_swarm : public SpellScriptLoader
 
         class spell_anubarak_leeching_swarm_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_anubarak_leeching_swarm_AuraScript);
+            PrepareAuraScript(spell_anubarak_leeching_swarm_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
@@ -2232,7 +2232,7 @@ class spell_faction_champion_warl_unstable_affliction : public SpellScriptLoader
 
         class spell_faction_champion_warl_unstable_affliction_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_faction_champion_warl_unstable_affliction_AuraScript);
+            PrepareAuraScript(spell_faction_champion_warl_unstable_affliction_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2266,7 +2266,7 @@ class spell_faction_champion_death_grip : public SpellScriptLoader
 
         class spell_faction_champion_death_grip_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_faction_champion_death_grip_SpellScript);
+            PrepareSpellScript(spell_faction_champion_death_grip_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2304,7 +2304,7 @@ class spell_toc_bloodlust : public SpellScriptLoader
 
         class spell_toc_bloodlust_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_toc_bloodlust_SpellScript);
+            PrepareSpellScript(spell_toc_bloodlust_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2345,7 +2345,7 @@ class spell_toc_heroism : public SpellScriptLoader
 
         class spell_toc_heroism_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_toc_heroism_SpellScript);
+            PrepareSpellScript(spell_toc_heroism_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
@@ -495,7 +495,7 @@ class spell_mistress_kiss : public SpellScriptLoader
 
         class spell_mistress_kiss_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mistress_kiss_AuraScript);
+            PrepareAuraScript(spell_mistress_kiss_AuraScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -819,7 +819,7 @@ class spell_gormok_fire_bomb : public SpellScriptLoader
 
         class spell_gormok_fire_bomb_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gormok_fire_bomb_SpellScript);
+            PrepareSpellScript(spell_gormok_fire_bomb_SpellScript)
 
             void TriggerFireBomb(SpellEffIndex /*effIndex*/)
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_twin_valkyr.cpp
@@ -731,7 +731,7 @@ class spell_valkyr_essences : public SpellScriptLoader
 
         class spell_valkyr_essences_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_valkyr_essences_AuraScript);
+            PrepareAuraScript(spell_valkyr_essences_AuraScript)
 
             uint32 spellId;
 
@@ -826,7 +826,7 @@ class spell_power_of_the_twins : public SpellScriptLoader
 
         class spell_power_of_the_twins_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_power_of_the_twins_AuraScript);
+            PrepareAuraScript(spell_power_of_the_twins_AuraScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/DraktharonKeep/boss_novos.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_novos.cpp
@@ -354,7 +354,7 @@ class spell_novos_summon_minions : public SpellScriptLoader
 
         class spell_novos_summon_minions_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_novos_summon_minions_SpellScript);
+            PrepareSpellScript(spell_novos_summon_minions_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/DraktharonKeep/boss_tharon_ja.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_tharon_ja.cpp
@@ -212,7 +212,7 @@ class spell_tharon_ja_clear_gift_of_tharon_ja : public SpellScriptLoader
 
         class spell_tharon_ja_clear_gift_of_tharon_ja_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_tharon_ja_clear_gift_of_tharon_ja_SpellScript);
+            PrepareSpellScript(spell_tharon_ja_clear_gift_of_tharon_ja_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/DraktharonKeep/boss_trollgore.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_trollgore.cpp
@@ -219,7 +219,7 @@ class spell_trollgore_consume : public SpellScriptLoader
 
         class spell_trollgore_consume_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_trollgore_consume_SpellScript);
+            PrepareSpellScript(spell_trollgore_consume_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -254,7 +254,7 @@ class spell_trollgore_corpse_explode : public SpellScriptLoader
 
         class spell_trollgore_corpse_explode_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_trollgore_corpse_explode_AuraScript);
+            PrepareAuraScript(spell_trollgore_corpse_explode_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -297,7 +297,7 @@ class spell_trollgore_invader_taunt : public SpellScriptLoader
 
         class spell_trollgore_invader_taunt_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_trollgore_invader_taunt_SpellScript);
+            PrepareSpellScript(spell_trollgore_invader_taunt_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
@@ -239,7 +239,7 @@ class spell_bronjahm_magic_bane : public SpellScriptLoader
 
         class spell_bronjahm_magic_bane_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_bronjahm_magic_bane_SpellScript);
+            PrepareSpellScript(spell_bronjahm_magic_bane_SpellScript)
 
             void RecalculateDamage()
             {
@@ -273,7 +273,7 @@ class spell_bronjahm_consume_soul : public SpellScriptLoader
 
         class spell_bronjahm_consume_soul_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_bronjahm_consume_soul_SpellScript);
+            PrepareSpellScript(spell_bronjahm_consume_soul_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -300,7 +300,7 @@ class spell_bronjahm_soulstorm_channel : public SpellScriptLoader
 
         class spell_bronjahm_soulstorm_channel_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_bronjahm_soulstorm_channel_AuraScript);
+            PrepareAuraScript(spell_bronjahm_soulstorm_channel_AuraScript)
 
             void HandlePeriodicTick(AuraEffect const* /*aurEff*/)
             {
@@ -328,7 +328,7 @@ class spell_bronjahm_soulstorm_visual : public SpellScriptLoader
 
         class spell_bronjahm_soulstorm_visual_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_bronjahm_soulstorm_visual_AuraScript);
+            PrepareAuraScript(spell_bronjahm_soulstorm_visual_AuraScript)
 
             void HandlePeriodicTick(AuraEffect const* aurEff)
             {
@@ -374,7 +374,7 @@ class spell_bronjahm_soulstorm_targeting : public SpellScriptLoader
 
         class spell_bronjahm_soulstorm_targeting_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_bronjahm_soulstorm_targeting_SpellScript);
+            PrepareSpellScript(spell_bronjahm_soulstorm_targeting_SpellScript)
 
             void FilterTargetsInitial(std::list<WorldObject*>& targets)
             {

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
@@ -357,7 +357,7 @@ class spell_devourer_of_souls_mirrored_soul : public SpellScriptLoader
 
         class spell_devourer_of_souls_mirrored_soul_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_devourer_of_souls_mirrored_soul_SpellScript);
+            PrepareSpellScript(spell_devourer_of_souls_mirrored_soul_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -392,7 +392,7 @@ class spell_devourer_of_souls_mirrored_soul_proc : public SpellScriptLoader
 
         class spell_devourer_of_souls_mirrored_soul_proc_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_devourer_of_souls_mirrored_soul_proc_AuraScript);
+            PrepareAuraScript(spell_devourer_of_souls_mirrored_soul_proc_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -439,7 +439,7 @@ class spell_devourer_of_souls_mirrored_soul_target_selector : public SpellScript
 
         class spell_devourer_of_souls_mirrored_soul_target_selector_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_devourer_of_souls_mirrored_soul_target_selector_SpellScript);
+            PrepareSpellScript(spell_devourer_of_souls_mirrored_soul_target_selector_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/boss_marwyn.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/boss_marwyn.cpp
@@ -139,7 +139,7 @@ class spell_marwyn_shared_suffering : public SpellScriptLoader
 
         class spell_marwyn_shared_suffering_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_marwyn_shared_suffering_AuraScript);
+            PrepareAuraScript(spell_marwyn_shared_suffering_AuraScript)
 
             void HandleEffectRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
@@ -246,7 +246,7 @@ class spell_garfrost_permafrost : public SpellScriptLoader
 
         class spell_garfrost_permafrost_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_garfrost_permafrost_SpellScript);
+            PrepareSpellScript(spell_garfrost_permafrost_SpellScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -504,7 +504,7 @@ class spell_krick_explosive_barrage : public SpellScriptLoader
 
         class spell_krick_explosive_barrage_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_krick_explosive_barrage_AuraScript);
+            PrepareAuraScript(spell_krick_explosive_barrage_AuraScript)
 
             void HandlePeriodicTick(AuraEffect const* /*aurEff*/)
             {
@@ -539,7 +539,7 @@ class spell_ick_explosive_barrage : public SpellScriptLoader
 
         class spell_ick_explosive_barrage_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ick_explosive_barrage_AuraScript);
+            PrepareAuraScript(spell_ick_explosive_barrage_AuraScript)
 
             void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -578,7 +578,7 @@ class spell_exploding_orb_hasty_grow : public SpellScriptLoader
 
         class spell_exploding_orb_hasty_grow_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_exploding_orb_hasty_grow_AuraScript);
+            PrepareAuraScript(spell_exploding_orb_hasty_grow_AuraScript)
 
             void OnStackChange(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -613,7 +613,7 @@ class spell_krick_pursuit : public SpellScriptLoader
 
         class spell_krick_pursuit_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_krick_pursuit_SpellScript);
+            PrepareSpellScript(spell_krick_pursuit_SpellScript)
 
             void HandleScriptEffect(SpellEffIndex /*effIndex*/)
             {
@@ -639,7 +639,7 @@ class spell_krick_pursuit : public SpellScriptLoader
 
         class spell_krick_pursuit_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_krick_pursuit_AuraScript);
+            PrepareAuraScript(spell_krick_pursuit_AuraScript)
 
             void HandleExtraEffect(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -672,7 +672,7 @@ class spell_krick_pursuit_confusion : public SpellScriptLoader
 
         class spell_krick_pursuit_confusion_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_krick_pursuit_confusion_AuraScript);
+            PrepareAuraScript(spell_krick_pursuit_confusion_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
@@ -413,7 +413,7 @@ class spell_tyrannus_overlord_brand : public SpellScriptLoader
 
         class spell_tyrannus_overlord_brand_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_tyrannus_overlord_brand_AuraScript);
+            PrepareAuraScript(spell_tyrannus_overlord_brand_AuraScript)
 
             bool Load() override
             {
@@ -465,7 +465,7 @@ class spell_tyrannus_mark_of_rimefang : public SpellScriptLoader
 
         class spell_tyrannus_mark_of_rimefang_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_tyrannus_mark_of_rimefang_AuraScript);
+            PrepareAuraScript(spell_tyrannus_mark_of_rimefang_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
@@ -212,7 +212,7 @@ class spell_trash_npc_glacial_strike : public SpellScriptLoader
 
         class spell_trash_npc_glacial_strike_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_trash_npc_glacial_strike_AuraScript);
+            PrepareAuraScript(spell_trash_npc_glacial_strike_AuraScript)
 
             void PeriodicTick(AuraEffect const* /*aurEff*/)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -1373,7 +1373,7 @@ class spell_taldaram_glittering_sparks : public SpellScriptLoader
 
         class spell_taldaram_glittering_sparks_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_taldaram_glittering_sparks_SpellScript);
+            PrepareSpellScript(spell_taldaram_glittering_sparks_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1400,7 +1400,7 @@ class spell_taldaram_summon_flame_ball : public SpellScriptLoader
 
         class spell_taldaram_summon_flame_ball_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_taldaram_summon_flame_ball_SpellScript);
+            PrepareSpellScript(spell_taldaram_summon_flame_ball_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1427,7 +1427,7 @@ class spell_taldaram_flame_ball_visual : public SpellScriptLoader
 
         class spell_flame_ball_visual_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_flame_ball_visual_AuraScript);
+            PrepareAuraScript(spell_flame_ball_visual_AuraScript)
 
             bool Load() override
             {
@@ -1471,7 +1471,7 @@ class spell_taldaram_ball_of_inferno_flame : public SpellScriptLoader
 
         class spell_taldaram_ball_of_inferno_flame_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_taldaram_ball_of_inferno_flame_SpellScript);
+            PrepareSpellScript(spell_taldaram_ball_of_inferno_flame_SpellScript)
 
             void ModAuraStack()
             {
@@ -1499,7 +1499,7 @@ class spell_valanar_kinetic_bomb : public SpellScriptLoader
 
         class spell_valanar_kinetic_bomb_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_valanar_kinetic_bomb_SpellScript);
+            PrepareSpellScript(spell_valanar_kinetic_bomb_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {
@@ -1515,7 +1515,7 @@ class spell_valanar_kinetic_bomb : public SpellScriptLoader
 
         class spell_valanar_kinetic_bomb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_valanar_kinetic_bomb_AuraScript);
+            PrepareAuraScript(spell_valanar_kinetic_bomb_AuraScript)
 
             void HandleDummyTick(AuraEffect const* /*aurEff*/)
             {
@@ -1556,7 +1556,7 @@ class spell_valanar_kinetic_bomb_knockback : public SpellScriptLoader
 
         class spell_valanar_kinetic_bomb_knockback_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_valanar_kinetic_bomb_knockback_SpellScript);
+            PrepareSpellScript(spell_valanar_kinetic_bomb_knockback_SpellScript)
 
             void KnockIntoAir()
             {
@@ -1583,7 +1583,7 @@ class spell_valanar_kinetic_bomb_absorb : public SpellScriptLoader
 
         class spell_valanar_kinetic_bomb_absorb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_valanar_kinetic_bomb_absorb_AuraScript);
+            PrepareAuraScript(spell_valanar_kinetic_bomb_absorb_AuraScript)
 
             void OnAbsorb(AuraEffect* aurEff, DamageInfo& dmgInfo, uint32& absorbAmount)
             {
@@ -1611,7 +1611,7 @@ class spell_blood_council_shadow_prison : public SpellScriptLoader
 
         class spell_blood_council_shadow_prison_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_blood_council_shadow_prison_AuraScript);
+            PrepareAuraScript(spell_blood_council_shadow_prison_AuraScript)
 
             void HandleDummyTick(AuraEffect const* aurEff)
             {
@@ -1638,7 +1638,7 @@ class spell_blood_council_shadow_prison_damage : public SpellScriptLoader
 
         class spell_blood_council_shadow_prison_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_blood_council_shadow_prison_SpellScript);
+            PrepareSpellScript(spell_blood_council_shadow_prison_SpellScript)
 
             void AddExtraDamage()
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -518,7 +518,7 @@ class spell_blood_queen_vampiric_bite : public SpellScriptLoader
 
         class spell_blood_queen_vampiric_bite_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_blood_queen_vampiric_bite_SpellScript);
+            PrepareSpellScript(spell_blood_queen_vampiric_bite_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -595,7 +595,7 @@ class spell_blood_queen_frenzied_bloodthirst : public SpellScriptLoader
 
         class spell_blood_queen_frenzied_bloodthirst_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_blood_queen_frenzied_bloodthirst_AuraScript);
+            PrepareAuraScript(spell_blood_queen_frenzied_bloodthirst_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -654,7 +654,7 @@ class spell_blood_queen_bloodbolt : public SpellScriptLoader
 
         class spell_blood_queen_bloodbolt_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_blood_queen_bloodbolt_SpellScript);
+            PrepareSpellScript(spell_blood_queen_bloodbolt_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -705,7 +705,7 @@ class spell_blood_queen_essence_of_the_blood_queen : public SpellScriptLoader
 
         class spell_blood_queen_essence_of_the_blood_queen_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_blood_queen_essence_of_the_blood_queen_AuraScript);
+            PrepareAuraScript(spell_blood_queen_essence_of_the_blood_queen_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -740,7 +740,7 @@ class spell_blood_queen_pact_of_the_darkfallen : public SpellScriptLoader
 
         class spell_blood_queen_pact_of_the_darkfallen_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_blood_queen_pact_of_the_darkfallen_SpellScript);
+            PrepareSpellScript(spell_blood_queen_pact_of_the_darkfallen_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -788,7 +788,7 @@ class spell_blood_queen_pact_of_the_darkfallen_dmg : public SpellScriptLoader
 
         class spell_blood_queen_pact_of_the_darkfallen_dmg_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_blood_queen_pact_of_the_darkfallen_dmg_AuraScript);
+            PrepareAuraScript(spell_blood_queen_pact_of_the_darkfallen_dmg_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -826,7 +826,7 @@ class spell_blood_queen_pact_of_the_darkfallen_dmg_target : public SpellScriptLo
 
         class spell_blood_queen_pact_of_the_darkfallen_dmg_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_blood_queen_pact_of_the_darkfallen_dmg_SpellScript);
+            PrepareSpellScript(spell_blood_queen_pact_of_the_darkfallen_dmg_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -1022,7 +1022,7 @@ class spell_deathbringer_blood_link : public SpellScriptLoader
 
         class spell_deathbringer_blood_link_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_blood_link_SpellScript);
+            PrepareSpellScript(spell_deathbringer_blood_link_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1058,7 +1058,7 @@ class spell_deathbringer_blood_link_aura : public SpellScriptLoader
 
         class spell_deathbringer_blood_link_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_deathbringer_blood_link_AuraScript);
+            PrepareAuraScript(spell_deathbringer_blood_link_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1094,7 +1094,7 @@ class spell_deathbringer_blood_power : public SpellScriptLoader
 
         class spell_deathbringer_blood_power_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_blood_power_SpellScript);
+            PrepareSpellScript(spell_deathbringer_blood_power_SpellScript)
 
             void ModAuraValue()
             {
@@ -1110,7 +1110,7 @@ class spell_deathbringer_blood_power : public SpellScriptLoader
 
         class spell_deathbringer_blood_power_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_deathbringer_blood_power_AuraScript);
+            PrepareAuraScript(spell_deathbringer_blood_power_AuraScript)
 
             void RecalculateHook(AuraEffect const* /*aurEffect*/, int32& amount, bool& canBeRecalculated)
             {
@@ -1143,7 +1143,7 @@ class spell_deathbringer_rune_of_blood : public SpellScriptLoader
 
         class spell_deathbringer_rune_of_blood_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_rune_of_blood_SpellScript);
+            PrepareSpellScript(spell_deathbringer_rune_of_blood_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1178,7 +1178,7 @@ class spell_deathbringer_blood_nova : public SpellScriptLoader
 
         class spell_deathbringer_blood_nova_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_blood_nova_SpellScript);
+            PrepareSpellScript(spell_deathbringer_blood_nova_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1213,7 +1213,7 @@ class spell_deathbringer_blood_nova_targeting : public SpellScriptLoader
 
         class spell_deathbringer_blood_nova_targeting_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_blood_nova_targeting_SpellScript);
+            PrepareSpellScript(spell_deathbringer_blood_nova_targeting_SpellScript)
 
             bool Load() override
             {
@@ -1292,7 +1292,7 @@ class spell_deathbringer_boiling_blood : public SpellScriptLoader
 
         class spell_deathbringer_boiling_blood_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_boiling_blood_SpellScript);
+            PrepareSpellScript(spell_deathbringer_boiling_blood_SpellScript)
 
             bool Load() override
             {
@@ -1329,7 +1329,7 @@ class spell_deathbringer_remove_marks : public SpellScriptLoader
 
         class spell_deathbringer_remove_marks_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_deathbringer_remove_marks_SpellScript);
+            PrepareSpellScript(spell_deathbringer_remove_marks_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_festergut.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_festergut.cpp
@@ -368,7 +368,7 @@ class spell_festergut_pungent_blight : public SpellScriptLoader
 
         class spell_festergut_pungent_blight_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_festergut_pungent_blight_SpellScript);
+            PrepareSpellScript(spell_festergut_pungent_blight_SpellScript)
 
             bool Load() override
             {
@@ -404,7 +404,7 @@ class spell_festergut_gastric_bloat : public SpellScriptLoader
 
         class spell_festergut_gastric_bloat_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_festergut_gastric_bloat_SpellScript);
+            PrepareSpellScript(spell_festergut_gastric_bloat_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -442,7 +442,7 @@ class spell_festergut_blighted_spores : public SpellScriptLoader
 
         class spell_festergut_blighted_spores_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_festergut_blighted_spores_AuraScript);
+            PrepareAuraScript(spell_festergut_blighted_spores_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -1824,7 +1824,7 @@ class spell_igb_rocket_pack : public SpellScriptLoader
 
         class spell_igb_rocket_pack_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_igb_rocket_pack_AuraScript);
+            PrepareAuraScript(spell_igb_rocket_pack_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1868,7 +1868,7 @@ class spell_igb_rocket_pack_useable : public SpellScriptLoader
 
         class spell_igb_rocket_pack_useable_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_igb_rocket_pack_useable_AuraScript);
+            PrepareAuraScript(spell_igb_rocket_pack_useable_AuraScript)
 
             bool Load()
             {
@@ -1917,7 +1917,7 @@ class spell_igb_on_gunship_deck : public SpellScriptLoader
 
         class spell_igb_on_gunship_deck_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_igb_on_gunship_deck_AuraScript);
+            PrepareAuraScript(spell_igb_on_gunship_deck_AuraScript)
 
             bool Load() override
             {
@@ -1962,7 +1962,7 @@ class spell_igb_periodic_trigger_with_power_cost : public SpellScriptLoader
 
         class spell_igb_periodic_trigger_with_power_cost_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_igb_periodic_trigger_with_power_cost_AuraScript);
+            PrepareAuraScript(spell_igb_periodic_trigger_with_power_cost_AuraScript)
 
             void HandlePeriodicTick(AuraEffect const* /*aurEff*/)
             {
@@ -1989,7 +1989,7 @@ class spell_igb_cannon_blast : public SpellScriptLoader
 
         class spell_igb_cannon_blast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_cannon_blast_SpellScript);
+            PrepareSpellScript(spell_igb_cannon_blast_SpellScript)
 
             bool Load()
             {
@@ -2026,7 +2026,7 @@ class spell_igb_incinerating_blast : public SpellScriptLoader
 
         class spell_igb_incinerating_blast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_incinerating_blast_SpellScript);
+            PrepareSpellScript(spell_igb_incinerating_blast_SpellScript)
 
             void StoreEnergy()
             {
@@ -2066,7 +2066,7 @@ class spell_igb_overheat : public SpellScriptLoader
 
         class spell_igb_overheat_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_igb_overheat_AuraScript);
+            PrepareAuraScript(spell_igb_overheat_AuraScript)
 
             bool Load() override
             {
@@ -2122,7 +2122,7 @@ class spell_igb_below_zero : public SpellScriptLoader
 
         class spell_igb_below_zero_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_below_zero_SpellScript);
+            PrepareSpellScript(spell_igb_below_zero_SpellScript)
 
             void RemovePassengers()
             {
@@ -2148,7 +2148,7 @@ class spell_igb_teleport_to_enemy_ship : public SpellScriptLoader
 
         class spell_igb_teleport_to_enemy_ship_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_teleport_to_enemy_ship_SpellScript);
+            PrepareSpellScript(spell_igb_teleport_to_enemy_ship_SpellScript)
 
             void RelocateTransportOffset(SpellEffIndex /*effIndex*/)
             {
@@ -2182,7 +2182,7 @@ class spell_igb_burning_pitch_selector : public SpellScriptLoader
 
         class spell_igb_burning_pitch_selector_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_burning_pitch_selector_SpellScript);
+            PrepareSpellScript(spell_igb_burning_pitch_selector_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -2231,7 +2231,7 @@ class spell_igb_burning_pitch : public SpellScriptLoader
 
         class spell_igb_burning_pitch_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_burning_pitch_SpellScript);
+            PrepareSpellScript(spell_igb_burning_pitch_SpellScript)
 
             void HandleDummy(SpellEffIndex effIndex)
             {
@@ -2259,7 +2259,7 @@ class spell_igb_rocket_artillery : public SpellScriptLoader
 
         class spell_igb_rocket_artillery_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_rocket_artillery_SpellScript);
+            PrepareSpellScript(spell_igb_rocket_artillery_SpellScript)
 
             void SelectRandomTarget(std::list<WorldObject*>& targets)
             {
@@ -2297,7 +2297,7 @@ class spell_igb_rocket_artillery_explosion : public SpellScriptLoader
 
         class spell_igb_rocket_artillery_explosion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_rocket_artillery_explosion_SpellScript);
+            PrepareSpellScript(spell_igb_rocket_artillery_explosion_SpellScript)
 
             void DamageGunship(SpellEffIndex /*effIndex*/)
             {
@@ -2324,7 +2324,7 @@ class spell_igb_gunship_fall_teleport : public SpellScriptLoader
 
         class spell_igb_gunship_fall_teleport_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_gunship_fall_teleport_SpellScript);
+            PrepareSpellScript(spell_igb_gunship_fall_teleport_SpellScript)
 
             bool Load()
             {
@@ -2365,7 +2365,7 @@ class spell_igb_check_for_players : public SpellScriptLoader
 
         class spell_igb_check_for_players_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_check_for_players_SpellScript);
+            PrepareSpellScript(spell_igb_check_for_players_SpellScript)
 
             bool Load() override
             {
@@ -2413,7 +2413,7 @@ class spell_igb_teleport_players_on_victory : public SpellScriptLoader
 
         class spell_igb_teleport_players_on_victory_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_igb_teleport_players_on_victory_SpellScript);
+            PrepareSpellScript(spell_igb_teleport_players_on_victory_SpellScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -956,7 +956,7 @@ class spell_deathwhisper_mana_barrier : public SpellScriptLoader
 
         class spell_deathwhisper_mana_barrier_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_deathwhisper_mana_barrier_AuraScript);
+            PrepareAuraScript(spell_deathwhisper_mana_barrier_AuraScript)
 
             void HandlePeriodicTick(AuraEffect const* /*aurEff*/)
             {
@@ -988,7 +988,7 @@ class spell_cultist_dark_martyrdom : public SpellScriptLoader
 
         class spell_cultist_dark_martyrdom_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_cultist_dark_martyrdom_SpellScript);
+            PrepareSpellScript(spell_cultist_dark_martyrdom_SpellScript)
 
             void HandleEffect(SpellEffIndex /*effIndex*/)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -499,7 +499,7 @@ class spell_marrowgar_coldflame : public SpellScriptLoader
 
         class spell_marrowgar_coldflame_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_marrowgar_coldflame_SpellScript);
+            PrepareSpellScript(spell_marrowgar_coldflame_SpellScript)
 
             void SelectTarget(std::list<WorldObject*>& targets)
             {
@@ -541,7 +541,7 @@ class spell_marrowgar_coldflame_bonestorm : public SpellScriptLoader
 
         class spell_marrowgar_coldflame_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_marrowgar_coldflame_SpellScript);
+            PrepareSpellScript(spell_marrowgar_coldflame_SpellScript)
 
             void HandleScriptEffect(SpellEffIndex effIndex)
             {
@@ -569,7 +569,7 @@ class spell_marrowgar_coldflame_damage : public SpellScriptLoader
 
         class spell_marrowgar_coldflame_damage_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_marrowgar_coldflame_damage_AuraScript);
+            PrepareAuraScript(spell_marrowgar_coldflame_damage_AuraScript)
 
             bool CanBeAppliedOn(Unit* target)
             {
@@ -605,7 +605,7 @@ class spell_marrowgar_bone_spike_graveyard : public SpellScriptLoader
 
         class spell_marrowgar_bone_spike_graveyard_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_marrowgar_bone_spike_graveyard_SpellScript);
+            PrepareSpellScript(spell_marrowgar_bone_spike_graveyard_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -670,7 +670,7 @@ class spell_marrowgar_bone_storm : public SpellScriptLoader
 
         class spell_marrowgar_bone_storm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_marrowgar_bone_storm_SpellScript);
+            PrepareSpellScript(spell_marrowgar_bone_storm_SpellScript)
 
             void RecalculateDamage()
             {
@@ -696,7 +696,7 @@ class spell_marrowgar_bone_slice : public SpellScriptLoader
 
         class spell_marrowgar_bone_slice_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_marrowgar_bone_slice_SpellScript);
+            PrepareSpellScript(spell_marrowgar_bone_slice_SpellScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -823,7 +823,7 @@ class spell_putricide_gaseous_bloat : public SpellScriptLoader
 
         class spell_putricide_gaseous_bloat_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_putricide_gaseous_bloat_AuraScript);
+            PrepareAuraScript(spell_putricide_gaseous_bloat_AuraScript)
 
             void HandleExtraEffect(AuraEffect const* /*aurEff*/)
             {
@@ -855,7 +855,7 @@ class spell_putricide_ooze_channel : public SpellScriptLoader
 
         class spell_putricide_ooze_channel_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_ooze_channel_SpellScript);
+            PrepareSpellScript(spell_putricide_ooze_channel_SpellScript)
 
             bool Validate(SpellInfo const* spell) override
             {
@@ -943,7 +943,7 @@ class spell_putricide_slime_puddle : public SpellScriptLoader
 
         class spell_putricide_slime_puddle_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_slime_puddle_SpellScript);
+            PrepareSpellScript(spell_putricide_slime_puddle_SpellScript)
 
             void ScaleRange(std::list<WorldObject*>& targets)
             {
@@ -971,7 +971,7 @@ class spell_putricide_slime_puddle_aura : public SpellScriptLoader
 
         class spell_putricide_slime_puddle_aura_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_slime_puddle_aura_SpellScript);
+            PrepareSpellScript(spell_putricide_slime_puddle_aura_SpellScript)
 
             void ReplaceAura()
             {
@@ -998,7 +998,7 @@ class spell_putricide_unstable_experiment : public SpellScriptLoader
 
         class spell_putricide_unstable_experiment_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_unstable_experiment_SpellScript);
+            PrepareSpellScript(spell_putricide_unstable_experiment_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1046,7 +1046,7 @@ class spell_putricide_ooze_eruption_searcher : public SpellScriptLoader
 
         class spell_putricide_ooze_eruption_searcher_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_ooze_eruption_searcher_SpellScript);
+            PrepareSpellScript(spell_putricide_ooze_eruption_searcher_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1077,7 +1077,7 @@ class spell_putricide_choking_gas_bomb : public SpellScriptLoader
 
         class spell_putricide_choking_gas_bomb_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_choking_gas_bomb_SpellScript);
+            PrepareSpellScript(spell_putricide_choking_gas_bomb_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1111,7 +1111,7 @@ class spell_putricide_unbound_plague : public SpellScriptLoader
 
         class spell_putricide_unbound_plague_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_unbound_plague_SpellScript);
+            PrepareSpellScript(spell_putricide_unbound_plague_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1190,7 +1190,7 @@ class spell_putricide_eat_ooze : public SpellScriptLoader
 
         class spell_putricide_eat_ooze_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_eat_ooze_SpellScript);
+            PrepareSpellScript(spell_putricide_eat_ooze_SpellScript)
 
             void SelectTarget(std::list<WorldObject*>& targets)
             {
@@ -1242,7 +1242,7 @@ class spell_putricide_mutated_plague : public SpellScriptLoader
 
         class spell_putricide_mutated_plague_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_putricide_mutated_plague_AuraScript);
+            PrepareAuraScript(spell_putricide_mutated_plague_AuraScript)
 
             void HandleTriggerSpell(AuraEffect const* aurEff)
             {
@@ -1292,7 +1292,7 @@ class spell_putricide_mutation_init : public SpellScriptLoader
 
         class spell_putricide_mutation_init_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_mutation_init_SpellScript);
+            PrepareSpellScript(spell_putricide_mutation_init_SpellScript)
 
             SpellCastResult CheckRequirementInternal(SpellCustomErrors& extendedError)
             {
@@ -1346,7 +1346,7 @@ class spell_putricide_mutation_init : public SpellScriptLoader
 
         class spell_putricide_mutation_init_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_putricide_mutation_init_AuraScript);
+            PrepareAuraScript(spell_putricide_mutation_init_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1381,7 +1381,7 @@ class spell_putricide_mutated_transformation_dismiss : public SpellScriptLoader
 
         class spell_putricide_mutated_transformation_dismiss_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_putricide_mutated_transformation_dismiss_AuraScript);
+            PrepareAuraScript(spell_putricide_mutated_transformation_dismiss_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1408,7 +1408,7 @@ class spell_putricide_mutated_transformation : public SpellScriptLoader
 
         class spell_putricide_mutated_transformation_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_mutated_transformation_SpellScript);
+            PrepareSpellScript(spell_putricide_mutated_transformation_SpellScript)
 
             void HandleSummon(SpellEffIndex effIndex)
             {
@@ -1469,7 +1469,7 @@ class spell_putricide_mutated_transformation_dmg : public SpellScriptLoader
 
         class spell_putricide_mutated_transformation_dmg_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_mutated_transformation_dmg_SpellScript);
+            PrepareSpellScript(spell_putricide_mutated_transformation_dmg_SpellScript)
 
             void FilterTargetsInitial(std::list<WorldObject*>& targets)
             {
@@ -1496,7 +1496,7 @@ class spell_putricide_regurgitated_ooze : public SpellScriptLoader
 
         class spell_putricide_regurgitated_ooze_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_regurgitated_ooze_SpellScript);
+            PrepareSpellScript(spell_putricide_regurgitated_ooze_SpellScript)
 
             // the only purpose of this hook is to fail the achievement
             void ExtraEffect(SpellEffIndex /*effIndex*/)
@@ -1525,7 +1525,7 @@ class spell_putricide_clear_aura_effect_value : public SpellScriptLoader
 
         class spell_putricide_clear_aura_effect_value_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_putricide_clear_aura_effect_value_SpellScript);
+            PrepareSpellScript(spell_putricide_clear_aura_effect_value_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1554,7 +1554,7 @@ class spell_stinky_precious_decimate : public SpellScriptLoader
 
         class spell_stinky_precious_decimate_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_stinky_precious_decimate_SpellScript);
+            PrepareSpellScript(spell_stinky_precious_decimate_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
@@ -455,7 +455,7 @@ class spell_rotface_ooze_flood : public SpellScriptLoader
 
         class spell_rotface_ooze_flood_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_ooze_flood_SpellScript);
+            PrepareSpellScript(spell_rotface_ooze_flood_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -505,7 +505,7 @@ class spell_rotface_mutated_infection : public SpellScriptLoader
 
         class spell_rotface_mutated_infection_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_mutated_infection_SpellScript);
+            PrepareSpellScript(spell_rotface_mutated_infection_SpellScript)
 
             bool Load() override
             {
@@ -565,7 +565,7 @@ class spell_rotface_little_ooze_combine : public SpellScriptLoader
 
         class spell_rotface_little_ooze_combine_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_little_ooze_combine_SpellScript);
+            PrepareSpellScript(spell_rotface_little_ooze_combine_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -597,7 +597,7 @@ class spell_rotface_large_ooze_combine : public SpellScriptLoader
 
         class spell_rotface_large_ooze_combine_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_large_ooze_combine_SpellScript);
+            PrepareSpellScript(spell_rotface_large_ooze_combine_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -639,7 +639,7 @@ class spell_rotface_large_ooze_buff_combine : public SpellScriptLoader
 
         class spell_rotface_large_ooze_buff_combine_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_large_ooze_buff_combine_SpellScript);
+            PrepareSpellScript(spell_rotface_large_ooze_buff_combine_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -694,7 +694,7 @@ class spell_rotface_unstable_ooze_explosion_init : public SpellScriptLoader
 
         class spell_rotface_unstable_ooze_explosion_init_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_unstable_ooze_explosion_init_SpellScript);
+            PrepareSpellScript(spell_rotface_unstable_ooze_explosion_init_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -734,7 +734,7 @@ class spell_rotface_unstable_ooze_explosion : public SpellScriptLoader
 
         class spell_rotface_unstable_ooze_explosion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_unstable_ooze_explosion_SpellScript);
+            PrepareSpellScript(spell_rotface_unstable_ooze_explosion_SpellScript)
 
             void CheckTarget(SpellEffIndex effIndex)
             {
@@ -771,7 +771,7 @@ class spell_rotface_unstable_ooze_explosion_suicide : public SpellScriptLoader
 
         class spell_rotface_unstable_ooze_explosion_suicide_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rotface_unstable_ooze_explosion_suicide_AuraScript);
+            PrepareAuraScript(spell_rotface_unstable_ooze_explosion_suicide_AuraScript)
 
             void DespawnSelf(AuraEffect const* /*aurEff*/)
             {
@@ -804,7 +804,7 @@ class spell_rotface_vile_gas_trigger : public SpellScriptLoader
 
         class spell_rotface_vile_gas_trigger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rotface_vile_gas_trigger_SpellScript);
+            PrepareSpellScript(spell_rotface_vile_gas_trigger_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -1023,7 +1023,7 @@ class spell_sindragosa_s_fury : public SpellScriptLoader
 
         class spell_sindragosa_s_fury_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sindragosa_s_fury_SpellScript);
+            PrepareSpellScript(spell_sindragosa_s_fury_SpellScript)
 
             bool Load() override
             {
@@ -1110,7 +1110,7 @@ class spell_sindragosa_unchained_magic : public SpellScriptLoader
 
         class spell_sindragosa_unchained_magic_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sindragosa_unchained_magic_SpellScript);
+            PrepareSpellScript(spell_sindragosa_unchained_magic_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -1139,7 +1139,7 @@ class spell_sindragosa_frost_breath : public SpellScriptLoader
 
         class spell_sindragosa_frost_breath_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sindragosa_frost_breath_SpellScript);
+            PrepareSpellScript(spell_sindragosa_frost_breath_SpellScript)
 
             void HandleInfusion()
             {
@@ -1184,7 +1184,7 @@ class spell_sindragosa_instability : public SpellScriptLoader
 
         class spell_sindragosa_instability_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sindragosa_instability_AuraScript);
+            PrepareAuraScript(spell_sindragosa_instability_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1218,7 +1218,7 @@ class spell_sindragosa_frost_beacon : public SpellScriptLoader
 
         class spell_sindragosa_frost_beacon_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sindragosa_frost_beacon_AuraScript);
+            PrepareAuraScript(spell_sindragosa_frost_beacon_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1253,7 +1253,7 @@ class spell_sindragosa_ice_tomb : public SpellScriptLoader
 
         class spell_sindragosa_ice_tomb_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sindragosa_ice_tomb_SpellScript);
+            PrepareSpellScript(spell_sindragosa_ice_tomb_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1286,7 +1286,7 @@ class spell_sindragosa_ice_tomb : public SpellScriptLoader
 
         class spell_sindragosa_ice_tomb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sindragosa_ice_tomb_AuraScript);
+            PrepareAuraScript(spell_sindragosa_ice_tomb_AuraScript)
 
             void PeriodicTick(AuraEffect const* /*aurEff*/)
             {
@@ -1317,7 +1317,7 @@ class spell_sindragosa_icy_grip : public SpellScriptLoader
 
         class spell_sindragosa_icy_grip_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sindragosa_icy_grip_SpellScript);
+            PrepareSpellScript(spell_sindragosa_icy_grip_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1365,7 +1365,7 @@ class spell_sindragosa_mystic_buffet : public SpellScriptLoader
 
         class spell_sindragosa_mystic_buffet_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sindragosa_mystic_buffet_SpellScript);
+            PrepareSpellScript(spell_sindragosa_mystic_buffet_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -1391,7 +1391,7 @@ class spell_rimefang_icy_blast : public SpellScriptLoader
 
         class spell_rimefang_icy_blast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rimefang_icy_blast_SpellScript);
+            PrepareSpellScript(spell_rimefang_icy_blast_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1443,7 +1443,7 @@ class spell_frostwarden_handler_order_whelp : public SpellScriptLoader
 
         class spell_frostwarden_handler_order_whelp_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_frostwarden_handler_order_whelp_SpellScript);
+            PrepareSpellScript(spell_frostwarden_handler_order_whelp_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1498,7 +1498,7 @@ class spell_frostwarden_handler_focus_fire : public SpellScriptLoader
 
         class spell_frostwarden_handler_focus_fire_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_frostwarden_handler_focus_fire_SpellScript);
+            PrepareSpellScript(spell_frostwarden_handler_focus_fire_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1515,7 +1515,7 @@ class spell_frostwarden_handler_focus_fire : public SpellScriptLoader
 
         class spell_frostwarden_handler_focus_fire_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_frostwarden_handler_focus_fire_AuraScript);
+            PrepareAuraScript(spell_frostwarden_handler_focus_fire_AuraScript)
 
             void PeriodicTick(AuraEffect const* /*aurEff*/)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -2005,7 +2005,7 @@ class spell_the_lich_king_infest : public SpellScriptLoader
 
         class spell_the_lich_king_infest_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_infest_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_infest_AuraScript)
 
             void OnPeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -2045,7 +2045,7 @@ class spell_the_lich_king_necrotic_plague : public SpellScriptLoader
 
         class spell_the_lich_king_necrotic_plague_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_necrotic_plague_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_necrotic_plague_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2093,7 +2093,7 @@ class spell_the_lich_king_necrotic_plague_jump : public SpellScriptLoader
 
         class spell_the_lich_king_necrotic_plague_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_necrotic_plague_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_necrotic_plague_SpellScript)
 
             bool Load() override
             {
@@ -2133,7 +2133,7 @@ class spell_the_lich_king_necrotic_plague_jump : public SpellScriptLoader
 
         class spell_the_lich_king_necrotic_plague_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_necrotic_plague_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_necrotic_plague_AuraScript)
 
             bool Load() override
             {
@@ -2217,7 +2217,7 @@ class spell_the_lich_king_shadow_trap_visual : public SpellScriptLoader
 
         class spell_the_lich_king_shadow_trap_visual_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_shadow_trap_visual_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_shadow_trap_visual_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -2244,7 +2244,7 @@ class spell_the_lich_king_shadow_trap_periodic : public SpellScriptLoader
 
         class spell_the_lich_king_shadow_trap_periodic_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_shadow_trap_periodic_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_shadow_trap_periodic_SpellScript)
 
             void CheckTargetCount(std::list<WorldObject*>& targets)
             {
@@ -2273,7 +2273,7 @@ class spell_the_lich_king_quake : public SpellScriptLoader
 
         class spell_the_lich_king_quake_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_quake_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_quake_SpellScript)
 
             bool Load() override
             {
@@ -2312,7 +2312,7 @@ class spell_the_lich_king_ice_burst_target_search : public SpellScriptLoader
 
         class spell_the_lich_king_ice_burst_target_search_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_ice_burst_target_search_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_ice_burst_target_search_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2355,7 +2355,7 @@ class spell_the_lich_king_raging_spirit : public SpellScriptLoader
 
         class spell_the_lich_king_raging_spirit_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_raging_spirit_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_raging_spirit_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2404,7 +2404,7 @@ class spell_the_lich_king_defile : public SpellScriptLoader
 
         class spell_the_lich_king_defile_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_defile_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_defile_SpellScript)
 
             void CorrectRange(std::list<WorldObject*>& targets)
             {
@@ -2441,7 +2441,7 @@ class spell_the_lich_king_summon_into_air : public SpellScriptLoader
 
         class spell_the_lich_king_summon_into_air_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_summon_into_air_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_summon_into_air_SpellScript)
 
             void ModDestHeight(SpellEffIndex effIndex)
             {
@@ -2476,7 +2476,7 @@ class spell_the_lich_king_soul_reaper : public SpellScriptLoader
 
         class spell_the_lich_king_soul_reaper_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_soul_reaper_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_soul_reaper_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2510,7 +2510,7 @@ class spell_the_lich_king_valkyr_target_search : public SpellScriptLoader
 
         class spell_the_lich_king_valkyr_target_search_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_valkyr_target_search_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_valkyr_target_search_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2576,7 +2576,7 @@ class spell_the_lich_king_cast_back_to_caster : public SpellScriptLoader
 
         class spell_the_lich_king_cast_back_to_caster_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_cast_back_to_caster_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_cast_back_to_caster_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2602,7 +2602,7 @@ class spell_the_lich_king_life_siphon : public SpellScriptLoader
 
         class spell_the_lich_king_life_siphon_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_life_siphon_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_life_siphon_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2635,7 +2635,7 @@ class spell_the_lich_king_vile_spirits : public SpellScriptLoader
 
         class spell_the_lich_king_vile_spirits_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_vile_spirits_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_vile_spirits_AuraScript)
 
             bool Load() override
             {
@@ -2670,7 +2670,7 @@ class spell_the_lich_king_vile_spirits_visual : public SpellScriptLoader
 
         class spell_the_lich_king_vile_spirits_visual_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_vile_spirits_visual_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_vile_spirits_visual_SpellScript)
 
             void ModDestHeight(SpellEffIndex /*effIndex*/)
             {
@@ -2697,7 +2697,7 @@ class spell_the_lich_king_vile_spirit_move_target_search : public SpellScriptLoa
 
         class spell_the_lich_king_vile_spirit_move_target_search_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_vile_spirit_move_target_search_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_vile_spirit_move_target_search_SpellScript)
 
             bool Load() override
             {
@@ -2746,7 +2746,7 @@ class spell_the_lich_king_vile_spirit_damage_target_search : public SpellScriptL
 
         class spell_the_lich_king_vile_spirit_damage_target_search_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_vile_spirit_damage_target_search_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_vile_spirit_damage_target_search_SpellScript)
 
             bool Load() override
             {
@@ -2787,7 +2787,7 @@ class spell_the_lich_king_harvest_soul : public SpellScriptLoader
 
         class spell_the_lich_king_harvest_soul_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_harvest_soul_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_harvest_soul_AuraScript)
 
             bool Load() override
             {
@@ -2820,7 +2820,7 @@ class spell_the_lich_king_lights_favor : public SpellScriptLoader
 
         class spell_the_lich_king_lights_favor_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_lights_favor_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_lights_favor_AuraScript)
 
             void OnPeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -2857,7 +2857,7 @@ class spell_the_lich_king_soul_rip : public SpellScriptLoader
 
         class spell_the_lich_king_soul_rip_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_soul_rip_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_soul_rip_AuraScript)
 
             void OnPeriodic(AuraEffect const* aurEff)
             {
@@ -2886,7 +2886,7 @@ class spell_the_lich_king_restore_soul : public SpellScriptLoader
 
         class spell_the_lich_king_restore_soul_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_restore_soul_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_restore_soul_SpellScript)
 
             bool Load() override
             {
@@ -2939,7 +2939,7 @@ class spell_the_lich_king_dark_hunger : public SpellScriptLoader
 
         class spell_the_lich_king_dark_hunger_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_dark_hunger_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_dark_hunger_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2974,7 +2974,7 @@ class spell_the_lich_king_in_frostmourne_room : public SpellScriptLoader
 
         class spell_the_lich_king_in_frostmourne_room_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_the_lich_king_in_frostmourne_room_AuraScript);
+            PrepareAuraScript(spell_the_lich_king_in_frostmourne_room_AuraScript)
 
             bool Load() override
             {
@@ -3007,7 +3007,7 @@ class spell_the_lich_king_summon_spirit_bomb : public SpellScriptLoader
 
         class spell_the_lich_king_summon_spirit_bomb_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_summon_spirit_bomb_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_summon_spirit_bomb_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -3034,7 +3034,7 @@ class spell_the_lich_king_trigger_vile_spirit : public SpellScriptLoader
 
         class spell_the_lich_king_trigger_vile_spirit_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_trigger_vile_spirit_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_trigger_vile_spirit_SpellScript)
 
             void ActivateSpirit()
             {
@@ -3064,7 +3064,7 @@ class spell_the_lich_king_jump : public SpellScriptLoader
 
         class spell_the_lich_king_jump_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_jump_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_jump_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -3094,7 +3094,7 @@ class spell_the_lich_king_jump_remove_aura : public SpellScriptLoader
 
         class spell_the_lich_king_jump_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_jump_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_jump_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -3121,7 +3121,7 @@ class spell_the_lich_king_play_movie : public SpellScriptLoader
 
         class spell_the_lich_king_play_movie_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_the_lich_king_play_movie_SpellScript);
+            PrepareSpellScript(spell_the_lich_king_play_movie_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -1113,7 +1113,7 @@ class spell_dreamwalker_mana_void : public SpellScriptLoader
 
         class spell_dreamwalker_mana_void_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dreamwalker_mana_void_AuraScript);
+            PrepareAuraScript(spell_dreamwalker_mana_void_AuraScript)
 
             void PeriodicTick(AuraEffect const* aurEff)
             {
@@ -1143,7 +1143,7 @@ class spell_dreamwalker_decay_periodic_timer : public SpellScriptLoader
 
         class spell_dreamwalker_decay_periodic_timer_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dreamwalker_decay_periodic_timer_AuraScript);
+            PrepareAuraScript(spell_dreamwalker_decay_periodic_timer_AuraScript)
 
             bool Load() override
             {
@@ -1181,7 +1181,7 @@ class spell_dreamwalker_summoner : public SpellScriptLoader
 
         class spell_dreamwalker_summoner_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dreamwalker_summoner_SpellScript);
+            PrepareSpellScript(spell_dreamwalker_summoner_SpellScript)
 
             bool Load() override
             {
@@ -1230,7 +1230,7 @@ class spell_dreamwalker_summon_suppresser : public SpellScriptLoader
 
         class spell_dreamwalker_summon_suppresser_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dreamwalker_summon_suppresser_AuraScript);
+            PrepareAuraScript(spell_dreamwalker_summon_suppresser_AuraScript)
 
             void PeriodicTick(AuraEffect const* /*aurEff*/)
             {
@@ -1271,7 +1271,7 @@ class spell_dreamwalker_summon_suppresser_effect : public SpellScriptLoader
 
         class spell_dreamwalker_summon_suppresser_effect_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dreamwalker_summon_suppresser_effect_SpellScript);
+            PrepareSpellScript(spell_dreamwalker_summon_suppresser_effect_SpellScript)
 
             bool Load() override
             {
@@ -1308,7 +1308,7 @@ class spell_dreamwalker_summon_dream_portal : public SpellScriptLoader
 
         class spell_dreamwalker_summon_dream_portal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dreamwalker_summon_dream_portal_SpellScript);
+            PrepareSpellScript(spell_dreamwalker_summon_dream_portal_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1339,7 +1339,7 @@ class spell_dreamwalker_summon_nightmare_portal : public SpellScriptLoader
 
         class spell_dreamwalker_summon_nightmare_portal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dreamwalker_summon_nightmare_portal_SpellScript);
+            PrepareSpellScript(spell_dreamwalker_summon_nightmare_portal_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1370,7 +1370,7 @@ class spell_dreamwalker_nightmare_cloud : public SpellScriptLoader
 
         class spell_dreamwalker_nightmare_cloud_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dreamwalker_nightmare_cloud_AuraScript);
+            PrepareAuraScript(spell_dreamwalker_nightmare_cloud_AuraScript)
 
             bool Load() override
             {
@@ -1405,7 +1405,7 @@ class spell_dreamwalker_twisted_nightmares : public SpellScriptLoader
 
         class spell_dreamwalker_twisted_nightmares_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dreamwalker_twisted_nightmares_SpellScript);
+            PrepareSpellScript(spell_dreamwalker_twisted_nightmares_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -1733,7 +1733,7 @@ class spell_icc_stoneform : public SpellScriptLoader
 
         class spell_icc_stoneform_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_icc_stoneform_AuraScript);
+            PrepareAuraScript(spell_icc_stoneform_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1775,7 +1775,7 @@ class spell_icc_sprit_alarm : public SpellScriptLoader
 
         class spell_icc_sprit_alarm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_icc_sprit_alarm_SpellScript);
+            PrepareSpellScript(spell_icc_sprit_alarm_SpellScript)
 
             void HandleEvent(SpellEffIndex effIndex)
             {
@@ -1860,7 +1860,7 @@ class spell_frost_giant_death_plague : public SpellScriptLoader
 
         class spell_frost_giant_death_plague_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_frost_giant_death_plague_SpellScript);
+            PrepareSpellScript(spell_frost_giant_death_plague_SpellScript)
 
             bool Load() override
             {
@@ -1922,7 +1922,7 @@ class spell_icc_harvest_blight_specimen : public SpellScriptLoader
 
         class spell_icc_harvest_blight_specimen_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_icc_harvest_blight_specimen_SpellScript);
+            PrepareSpellScript(spell_icc_harvest_blight_specimen_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1966,7 +1966,7 @@ class spell_svalna_revive_champion : public SpellScriptLoader
 
         class spell_svalna_revive_champion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_svalna_revive_champion_SpellScript);
+            PrepareSpellScript(spell_svalna_revive_champion_SpellScript)
 
             void RemoveAliveTarget(std::list<WorldObject*>& targets)
             {
@@ -2007,7 +2007,7 @@ class spell_svalna_remove_spear : public SpellScriptLoader
 
         class spell_svalna_remove_spear_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_svalna_remove_spear_SpellScript);
+            PrepareSpellScript(spell_svalna_remove_spear_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -2040,7 +2040,7 @@ class spell_icc_soul_missile : public SpellScriptLoader
 
         class spell_icc_soul_missile_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_icc_soul_missile_SpellScript);
+            PrepareSpellScript(spell_icc_soul_missile_SpellScript)
 
             void RelocateDest(SpellDestination& dest)
             {

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
@@ -518,7 +518,7 @@ class spell_trigger_spell_from_caster : public SpellScriptLoader
 
         class spell_trigger_spell_from_caster_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_trigger_spell_from_caster_SpellScript);
+            PrepareSpellScript(spell_trigger_spell_from_caster_SpellScript)
 
         public:
             spell_trigger_spell_from_caster_SpellScript(uint32 triggerId) : SpellScript(), _triggerId(triggerId) { }

--- a/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
@@ -395,7 +395,7 @@ class spell_four_horsemen_mark : public SpellScriptLoader
 
         class spell_four_horsemen_mark_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_four_horsemen_mark_AuraScript);
+            PrepareAuraScript(spell_four_horsemen_mark_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -595,7 +595,7 @@ class spell_gothik_shadow_bolt_volley : public SpellScriptLoader
 
         class spell_gothik_shadow_bolt_volley_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gothik_shadow_bolt_volley_SpellScript);
+            PrepareSpellScript(spell_gothik_shadow_bolt_volley_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {

--- a/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
@@ -147,7 +147,7 @@ class spell_grobbulus_mutating_injection : public SpellScriptLoader
 
         class spell_grobbulus_mutating_injection_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_grobbulus_mutating_injection_AuraScript);
+            PrepareAuraScript(spell_grobbulus_mutating_injection_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -190,7 +190,7 @@ class spell_grobbulus_poison_cloud : public SpellScriptLoader
 
         class spell_grobbulus_poison_cloud_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_grobbulus_poison_cloud_AuraScript);
+            PrepareAuraScript(spell_grobbulus_poison_cloud_AuraScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {

--- a/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
@@ -188,7 +188,7 @@ class spell_heigan_eruption : public SpellScriptLoader
 
         class spell_heigan_eruption_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_heigan_eruption_SpellScript);
+            PrepareSpellScript(spell_heigan_eruption_SpellScript)
 
             void HandleScript(SpellEffIndex /*eff*/)
             {

--- a/src/server/scripts/Northrend/Naxxramas/boss_kelthuzad.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_kelthuzad.cpp
@@ -754,7 +754,7 @@ class spell_kelthuzad_detonate_mana : public SpellScriptLoader
 
         class spell_kelthuzad_detonate_mana_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_kelthuzad_detonate_mana_AuraScript);
+            PrepareAuraScript(spell_kelthuzad_detonate_mana_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/Naxxramas/boss_loatheb.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_loatheb.cpp
@@ -165,7 +165,7 @@ class spell_loatheb_necrotic_aura_warning : public SpellScriptLoader
 
         class spell_loatheb_necrotic_aura_warning_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_loatheb_necrotic_aura_warning_AuraScript);
+            PrepareAuraScript(spell_loatheb_necrotic_aura_warning_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -441,7 +441,7 @@ class spell_thaddius_pos_neg_charge : public SpellScriptLoader
 
         class spell_thaddius_pos_neg_charge_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_thaddius_pos_neg_charge_SpellScript);
+            PrepareSpellScript(spell_thaddius_pos_neg_charge_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -520,7 +520,7 @@ class spell_thaddius_polarity_shift : public SpellScriptLoader
 
         class spell_thaddius_polarity_shift_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_thaddius_polarity_shift_SpellScript);
+            PrepareSpellScript(spell_thaddius_polarity_shift_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -1647,7 +1647,7 @@ class spell_malygos_portal_beam : public SpellScriptLoader
 
         class spell_malygos_portal_beam_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_malygos_portal_beam_AuraScript);
+            PrepareAuraScript(spell_malygos_portal_beam_AuraScript)
 
             bool Load() override
             {
@@ -1694,7 +1694,7 @@ class spell_malygos_random_portal : public SpellScriptLoader
 
         class spell_malygos_random_portal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_malygos_random_portal_SpellScript);
+            PrepareSpellScript(spell_malygos_random_portal_SpellScript)
 
             bool Load() override
             {
@@ -1750,7 +1750,7 @@ class spell_malygos_arcane_storm : public SpellScriptLoader
 
         class spell_malygos_arcane_storm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_malygos_arcane_storm_SpellScript);
+            PrepareSpellScript(spell_malygos_arcane_storm_SpellScript)
 
             bool Load() override
             {
@@ -1847,7 +1847,7 @@ class spell_malygos_vortex_visual : public SpellScriptLoader
 
         class spell_malygos_vortex_visual_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_malygos_vortex_visual_AuraScript);
+            PrepareAuraScript(spell_malygos_vortex_visual_AuraScript)
 
             bool Load() override
             {
@@ -1926,7 +1926,7 @@ class spell_arcane_overload : public SpellScriptLoader
 
         class spell_arcane_overload_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_arcane_overload_SpellScript);
+            PrepareSpellScript(spell_arcane_overload_SpellScript)
 
             bool Load() override
             {
@@ -1959,7 +1959,7 @@ class spell_nexus_lord_align_disk_aggro : public SpellScriptLoader
 
         class spell_nexus_lord_align_disk_aggro_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_nexus_lord_align_disk_aggro_SpellScript);
+            PrepareSpellScript(spell_nexus_lord_align_disk_aggro_SpellScript)
 
             bool Load() override
             {
@@ -2010,7 +2010,7 @@ class spell_scion_of_eternity_arcane_barrage : public SpellScriptLoader
 
         class spell_scion_of_eternity_arcane_barrage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_scion_of_eternity_arcane_barrage_SpellScript);
+            PrepareSpellScript(spell_scion_of_eternity_arcane_barrage_SpellScript)
 
             bool Load() override
             {
@@ -2094,7 +2094,7 @@ class spell_malygos_destroy_platform_channel : public SpellScriptLoader
 
         class spell_malygos_destroy_platform_channel_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_malygos_destroy_platform_channel_AuraScript);
+            PrepareAuraScript(spell_malygos_destroy_platform_channel_AuraScript)
 
             bool Load() override
             {
@@ -2136,7 +2136,7 @@ class spell_alexstrasza_bunny_destroy_platform_boom_visual : public SpellScriptL
 
         class spell_alexstrasza_bunny_destroy_platform_boom_visual_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_alexstrasza_bunny_destroy_platform_boom_visual_SpellScript);
+            PrepareSpellScript(spell_alexstrasza_bunny_destroy_platform_boom_visual_SpellScript)
 
             bool Load() override
             {
@@ -2176,7 +2176,7 @@ class spell_alexstrasza_bunny_destroy_platform_event : public SpellScriptLoader
 
         class spell_alexstrasza_bunny_destroy_platform_event_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_alexstrasza_bunny_destroy_platform_event_SpellScript);
+            PrepareSpellScript(spell_alexstrasza_bunny_destroy_platform_event_SpellScript)
 
             bool Load() override
             {
@@ -2217,7 +2217,7 @@ class spell_wyrmrest_skytalon_summon_red_dragon_buddy : public SpellScriptLoader
 
         class spell_wyrmrest_skytalon_summon_red_dragon_buddy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_wyrmrest_skytalon_summon_red_dragon_buddy_SpellScript);
+            PrepareSpellScript(spell_wyrmrest_skytalon_summon_red_dragon_buddy_SpellScript)
 
             bool Load() override
             {
@@ -2250,7 +2250,7 @@ class spell_wyrmrest_skytalon_ride_red_dragon_buddy_trigger : public SpellScript
 
         class spell_wyrmrest_skytalon_ride_red_dragon_buddy_trigger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_wyrmrest_skytalon_ride_red_dragon_buddy_trigger_SpellScript);
+            PrepareSpellScript(spell_wyrmrest_skytalon_ride_red_dragon_buddy_trigger_SpellScript)
 
             bool Load() override
             {
@@ -2399,7 +2399,7 @@ class spell_alexstrasza_gift_beam : public SpellScriptLoader
 
         class spell_alexstrasza_gift_beam_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_alexstrasza_gift_beam_AuraScript);
+            PrepareAuraScript(spell_alexstrasza_gift_beam_AuraScript)
 
             bool Load() override
             {
@@ -2446,7 +2446,7 @@ class spell_alexstrasza_gift_beam_visual : public SpellScriptLoader
 
         class spell_alexstrasza_gift_beam_visual_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_alexstrasza_gift_beam_visual_AuraScript);
+            PrepareAuraScript(spell_alexstrasza_gift_beam_visual_AuraScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_keristrasza.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_keristrasza.cpp
@@ -234,7 +234,7 @@ class spell_intense_cold : public SpellScriptLoader
 
         class spell_intense_cold_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_intense_cold_AuraScript);
+            PrepareAuraScript(spell_intense_cold_AuraScript)
 
             void HandlePeriodicTick(AuraEffect const* aurEff)
             {

--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_ormorok.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_ormorok.cpp
@@ -263,7 +263,7 @@ class spell_crystal_spike : public SpellScriptLoader
 
         class spell_crystal_spike_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_crystal_spike_AuraScript);
+            PrepareAuraScript(spell_crystal_spike_AuraScript)
 
             void HandlePeriodic(AuraEffect const* /*aurEff*/)
             {

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_eregos.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_eregos.cpp
@@ -258,7 +258,7 @@ class spell_eregos_planar_shift : public SpellScriptLoader
 
         class spell_eregos_planar_shift_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_eregos_planar_shift_AuraScript);
+            PrepareAuraScript(spell_eregos_planar_shift_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_varos.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_varos.cpp
@@ -249,7 +249,7 @@ class spell_varos_centrifuge_shield : public SpellScriptLoader
 
         class spell_varos_centrifuge_shield_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_varos_centrifuge_shield_AuraScript);
+            PrepareAuraScript(spell_varos_centrifuge_shield_AuraScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -371,7 +371,7 @@ class spell_oculus_call_ruby_emerald_amber_drake : public SpellScriptLoader
 
         class spell_oculus_call_ruby_emerald_amber_drake_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_oculus_call_ruby_emerald_amber_drake_SpellScript);
+            PrepareSpellScript(spell_oculus_call_ruby_emerald_amber_drake_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {
@@ -402,7 +402,7 @@ class spell_oculus_ride_ruby_emerald_amber_drake_que : public SpellScriptLoader
 
         class spell_oculus_ride_ruby_emerald_amber_drake_que_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_oculus_ride_ruby_emerald_amber_drake_que_AuraScript);
+            PrepareAuraScript(spell_oculus_ride_ruby_emerald_amber_drake_que_AuraScript)
 
             void HandlePeriodic(AuraEffect const* aurEff)
             {
@@ -432,7 +432,7 @@ class spell_oculus_evasive_maneuvers : public SpellScriptLoader
 
         class spell_oculus_evasive_maneuvers_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_oculus_evasive_maneuvers_AuraScript);
+            PrepareAuraScript(spell_oculus_evasive_maneuvers_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -469,7 +469,7 @@ class spell_oculus_shock_lance : public SpellScriptLoader
 
         class spell_oculus_shock_lance_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_oculus_shock_lance_SpellScript);
+            PrepareSpellScript(spell_oculus_shock_lance_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -511,7 +511,7 @@ class spell_oculus_stop_time : public SpellScriptLoader
 
         class spell_oculus_stop_time_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_oculus_stop_time_AuraScript);
+            PrepareAuraScript(spell_oculus_stop_time_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -551,7 +551,7 @@ class spell_oculus_temporal_rift : public SpellScriptLoader
 
         class spell_oculus_temporal_rift_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_oculus_temporal_rift_AuraScript);
+            PrepareAuraScript(spell_oculus_temporal_rift_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -595,7 +595,7 @@ class spell_oculus_touch_the_nightmare : public SpellScriptLoader
 
         class spell_oculus_touch_the_nightmare_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_oculus_touch_the_nightmare_SpellScript);
+            PrepareSpellScript(spell_oculus_touch_the_nightmare_SpellScript)
 
             void HandleDamageCalc(SpellEffIndex /*effIndex*/)
             {
@@ -622,7 +622,7 @@ class spell_oculus_dream_funnel : public SpellScriptLoader
 
         class spell_oculus_dream_funnel_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_oculus_dream_funnel_AuraScript);
+            PrepareAuraScript(spell_oculus_dream_funnel_AuraScript)
 
             void HandleEffectCalcAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
             {

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
@@ -190,7 +190,7 @@ class spell_loken_pulsing_shockwave : public SpellScriptLoader
 
         class spell_loken_pulsing_shockwave_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_loken_pulsing_shockwave_SpellScript);
+            PrepareSpellScript(spell_loken_pulsing_shockwave_SpellScript)
 
             void CalculateDamage(SpellEffIndex /*effIndex*/)
             {

--- a/src/server/scripts/Northrend/Ulduar/HallsOfStone/boss_krystallus.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfStone/boss_krystallus.cpp
@@ -187,7 +187,7 @@ class spell_krystallus_shatter : public SpellScriptLoader
 
         class spell_krystallus_shatter_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_krystallus_shatter_SpellScript);
+            PrepareSpellScript(spell_krystallus_shatter_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -217,7 +217,7 @@ class spell_krystallus_shatter_effect : public SpellScriptLoader
 
         class spell_krystallus_shatter_effect_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_krystallus_shatter_effect_SpellScript);
+            PrepareSpellScript(spell_krystallus_shatter_effect_SpellScript)
 
             void CalculateDamage()
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -1039,7 +1039,7 @@ class spell_algalon_phase_punch : public SpellScriptLoader
 
         class spell_algalon_phase_punch_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_algalon_phase_punch_AuraScript);
+            PrepareAuraScript(spell_algalon_phase_punch_AuraScript)
 
             void HandlePeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -1093,7 +1093,7 @@ class spell_algalon_arcane_barrage : public SpellScriptLoader
 
         class spell_algalon_arcane_barrage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_algalon_arcane_barrage_SpellScript);
+            PrepareSpellScript(spell_algalon_arcane_barrage_SpellScript)
 
             void SelectTarget(std::list<WorldObject*>& targets)
             {
@@ -1128,7 +1128,7 @@ class spell_algalon_trigger_3_adds : public SpellScriptLoader
 
         class spell_algalon_trigger_3_adds_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_algalon_trigger_3_adds_SpellScript);
+            PrepareSpellScript(spell_algalon_trigger_3_adds_SpellScript)
 
             void SelectTarget(std::list<WorldObject*>& targets)
             {
@@ -1164,7 +1164,7 @@ class spell_algalon_collapse : public SpellScriptLoader
 
         class spell_algalon_collapse_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_algalon_collapse_AuraScript);
+            PrepareAuraScript(spell_algalon_collapse_AuraScript)
 
             void HandlePeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -1191,7 +1191,7 @@ class spell_algalon_big_bang : public SpellScriptLoader
 
         class spell_algalon_big_bang_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_algalon_big_bang_SpellScript);
+            PrepareSpellScript(spell_algalon_big_bang_SpellScript)
 
             bool Load() override
             {
@@ -1232,7 +1232,7 @@ class spell_algalon_remove_phase : public SpellScriptLoader
 
         class spell_algalon_remove_phase_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_algalon_remove_phase_AuraScript);
+            PrepareAuraScript(spell_algalon_remove_phase_AuraScript)
 
             void HandlePeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -1260,7 +1260,7 @@ class spell_algalon_cosmic_smash : public SpellScriptLoader
 
         class spell_algalon_cosmic_smash_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_algalon_cosmic_smash_SpellScript);
+            PrepareSpellScript(spell_algalon_cosmic_smash_SpellScript)
 
             void ModDestHeight(SpellDestination& dest)
             {
@@ -1287,7 +1287,7 @@ class spell_algalon_cosmic_smash_damage : public SpellScriptLoader
 
         class spell_algalon_cosmic_smash_damage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_algalon_cosmic_smash_damage_SpellScript);
+            PrepareSpellScript(spell_algalon_cosmic_smash_damage_SpellScript)
 
             void RecalculateDamage()
             {
@@ -1318,7 +1318,7 @@ class spell_algalon_supermassive_fail : public SpellScriptLoader
 
         class spell_algalon_supermassive_fail_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_algalon_supermassive_fail_SpellScript);
+            PrepareSpellScript(spell_algalon_supermassive_fail_SpellScript)
 
             void RecalculateDamage()
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -633,7 +633,7 @@ class spell_shield_of_runes : public SpellScriptLoader
 
         class spell_shield_of_runes_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_shield_of_runes_AuraScript);
+            PrepareAuraScript(spell_shield_of_runes_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -661,7 +661,7 @@ class spell_assembly_meltdown : public SpellScriptLoader
 
         class spell_assembly_meltdown_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_assembly_meltdown_SpellScript);
+            PrepareSpellScript(spell_assembly_meltdown_SpellScript)
 
             void HandleInstaKill(SpellEffIndex /*effIndex*/)
             {
@@ -689,7 +689,7 @@ class spell_assembly_rune_of_summoning : public SpellScriptLoader
 
         class spell_assembly_rune_of_summoning_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_assembly_rune_of_summoning_AuraScript);
+            PrepareAuraScript(spell_assembly_rune_of_summoning_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -489,7 +489,7 @@ class spell_auriaya_strenght_of_the_pack : public SpellScriptLoader
 
         class spell_auriaya_strenght_of_the_pack_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_auriaya_strenght_of_the_pack_SpellScript);
+            PrepareSpellScript(spell_auriaya_strenght_of_the_pack_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -515,7 +515,7 @@ class spell_auriaya_sentinel_blast : public SpellScriptLoader
 
         class spell_auriaya_sentinel_blast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_auriaya_sentinel_blast_SpellScript);
+            PrepareSpellScript(spell_auriaya_sentinel_blast_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -1458,7 +1458,7 @@ class spell_load_into_catapult : public SpellScriptLoader
 
         class spell_load_into_catapult_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_load_into_catapult_AuraScript);
+            PrepareAuraScript(spell_load_into_catapult_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1503,7 +1503,7 @@ class spell_auto_repair : public SpellScriptLoader
 
         class spell_auto_repair_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_auto_repair_SpellScript);
+            PrepareSpellScript(spell_auto_repair_SpellScript)
 
             void CheckCooldownForTarget()
             {
@@ -1564,7 +1564,7 @@ class spell_systems_shutdown : public SpellScriptLoader
 
         class spell_systems_shutdown_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_systems_shutdown_AuraScript);
+            PrepareAuraScript(spell_systems_shutdown_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1650,7 +1650,7 @@ class spell_pursue : public SpellScriptLoader
 
         class spell_pursue_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pursue_SpellScript);
+            PrepareSpellScript(spell_pursue_SpellScript)
 
             bool Load() override
             {
@@ -1722,7 +1722,7 @@ class spell_vehicle_throw_passenger : public SpellScriptLoader
 
         class spell_vehicle_throw_passenger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_vehicle_throw_passenger_SpellScript);
+            PrepareSpellScript(spell_vehicle_throw_passenger_SpellScript)
             void HandleScript(SpellEffIndex effIndex)
             {
                 Spell* baseSpell = GetSpell();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -1533,7 +1533,7 @@ class spell_freya_attuned_to_nature_dose_reduction : public SpellScriptLoader
 
         class spell_freya_attuned_to_nature_dose_reduction_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_freya_attuned_to_nature_dose_reduction_SpellScript);
+            PrepareSpellScript(spell_freya_attuned_to_nature_dose_reduction_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1580,7 +1580,7 @@ class spell_freya_iron_roots : public SpellScriptLoader
 
         class spell_freya_iron_roots_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_freya_iron_roots_SpellScript);
+            PrepareSpellScript(spell_freya_iron_roots_SpellScript)
 
             void HandleSummon(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -450,7 +450,7 @@ class spell_general_vezax_mark_of_the_faceless : public SpellScriptLoader
 
         class spell_general_vezax_mark_of_the_faceless_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_general_vezax_mark_of_the_faceless_AuraScript);
+            PrepareAuraScript(spell_general_vezax_mark_of_the_faceless_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/)
             {
@@ -484,7 +484,7 @@ class spell_general_vezax_mark_of_the_faceless_leech : public SpellScriptLoader
 
         class spell_general_vezax_mark_of_the_faceless_leech_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_general_vezax_mark_of_the_faceless_leech_SpellScript);
+            PrepareSpellScript(spell_general_vezax_mark_of_the_faceless_leech_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -513,7 +513,7 @@ class spell_general_vezax_saronite_vapors : public SpellScriptLoader
 
         class spell_general_vezax_saronite_vapors_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_general_vezax_saronite_vapors_AuraScript);
+            PrepareAuraScript(spell_general_vezax_saronite_vapors_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -921,7 +921,7 @@ class spell_biting_cold : public SpellScriptLoader
 
         class spell_biting_cold_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_biting_cold_AuraScript);
+            PrepareAuraScript(spell_biting_cold_AuraScript)
 
             void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -977,7 +977,7 @@ public:
 
     class spell_biting_cold_dot_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_biting_cold_dot_AuraScript);
+        PrepareAuraScript(spell_biting_cold_dot_AuraScript)
 
         void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
         {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -430,7 +430,7 @@ class spell_ignis_slag_pot : public SpellScriptLoader
 
         class spell_ignis_slag_pot_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ignis_slag_pot_AuraScript);
+            PrepareAuraScript(spell_ignis_slag_pot_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -331,7 +331,7 @@ class spell_ulduar_rubble_summon : public SpellScriptLoader
 
         class spell_ulduar_rubble_summonSpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ulduar_rubble_summonSpellScript);
+            PrepareSpellScript(spell_ulduar_rubble_summonSpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -385,7 +385,7 @@ class spell_ulduar_stone_grip_cast_target : public SpellScriptLoader
 
         class spell_ulduar_stone_grip_cast_target_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ulduar_stone_grip_cast_target_SpellScript);
+            PrepareSpellScript(spell_ulduar_stone_grip_cast_target_SpellScript)
 
             bool Load() override
             {
@@ -445,7 +445,7 @@ class spell_ulduar_cancel_stone_grip : public SpellScriptLoader
 
         class spell_ulduar_cancel_stone_gripSpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ulduar_cancel_stone_gripSpellScript);
+            PrepareSpellScript(spell_ulduar_cancel_stone_gripSpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -485,7 +485,7 @@ class spell_ulduar_squeezed_lifeless : public SpellScriptLoader
 
         class spell_ulduar_squeezed_lifeless_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ulduar_squeezed_lifeless_SpellScript);
+            PrepareSpellScript(spell_ulduar_squeezed_lifeless_SpellScript)
 
             void HandleInstaKill(SpellEffIndex /*effIndex*/)
             {
@@ -523,7 +523,7 @@ class spell_ulduar_stone_grip_absorb : public SpellScriptLoader
 
         class spell_ulduar_stone_grip_absorb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ulduar_stone_grip_absorb_AuraScript);
+            PrepareAuraScript(spell_ulduar_stone_grip_absorb_AuraScript)
 
             //! This will be called when Right Arm (vehicle) has sustained a specific amount of damage depending on instance mode
             //! What we do here is remove all harmful aura's related and teleport to safe spot.
@@ -560,7 +560,7 @@ class spell_ulduar_stone_grip : public SpellScriptLoader
 
         class spell_ulduar_stone_grip_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ulduar_stone_grip_AuraScript);
+            PrepareAuraScript(spell_ulduar_stone_grip_AuraScript)
 
             void OnRemoveStun(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {
@@ -613,7 +613,7 @@ class spell_kologarn_stone_shout : public SpellScriptLoader
 
         class spell_kologarn_stone_shout_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_kologarn_stone_shout_SpellScript);
+            PrepareSpellScript(spell_kologarn_stone_shout_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -639,7 +639,7 @@ class spell_kologarn_summon_focused_eyebeam : public SpellScriptLoader
 
         class spell_kologarn_summon_focused_eyebeam_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_kologarn_summon_focused_eyebeam_SpellScript);
+            PrepareSpellScript(spell_kologarn_summon_focused_eyebeam_SpellScript)
 
             void HandleForceCast(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -1014,7 +1014,7 @@ class spell_razorscale_devouring_flame : public SpellScriptLoader
 
         class spell_razorscale_devouring_flame_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_razorscale_devouring_flame_SpellScript);
+            PrepareSpellScript(spell_razorscale_devouring_flame_SpellScript)
 
             void HandleSummon(SpellEffIndex effIndex)
             {
@@ -1047,7 +1047,7 @@ class spell_razorscale_flame_breath : public SpellScriptLoader
 
         class spell_razorscale_flame_breath_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_razorscale_flame_breath_SpellScript);
+            PrepareSpellScript(spell_razorscale_flame_breath_SpellScript)
 
             void CheckDamage()
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -767,7 +767,7 @@ class spell_xt002_searing_light_spawn_life_spark : public SpellScriptLoader
 
         class spell_xt002_searing_light_spawn_life_spark_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_xt002_searing_light_spawn_life_spark_AuraScript);
+            PrepareAuraScript(spell_xt002_searing_light_spawn_life_spark_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -803,7 +803,7 @@ class spell_xt002_gravity_bomb_aura : public SpellScriptLoader
 
         class spell_xt002_gravity_bomb_aura_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_xt002_gravity_bomb_aura_AuraScript);
+            PrepareAuraScript(spell_xt002_gravity_bomb_aura_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -855,7 +855,7 @@ class spell_xt002_gravity_bomb_damage : public SpellScriptLoader
 
         class spell_xt002_gravity_bomb_damage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_xt002_gravity_bomb_damage_SpellScript);
+            PrepareSpellScript(spell_xt002_gravity_bomb_damage_SpellScript)
 
             void HandleScript(SpellEffIndex /*eff*/)
             {
@@ -887,7 +887,7 @@ class spell_xt002_heart_overload_periodic : public SpellScriptLoader
 
         class spell_xt002_heart_overload_periodic_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_xt002_heart_overload_periodic_SpellScript);
+            PrepareSpellScript(spell_xt002_heart_overload_periodic_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -954,7 +954,7 @@ class spell_xt002_tympanic_tantrum : public SpellScriptLoader
 
         class spell_xt002_tympanic_tantrum_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_xt002_tympanic_tantrum_SpellScript);
+            PrepareSpellScript(spell_xt002_tympanic_tantrum_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -987,7 +987,7 @@ class spell_xt002_submerged : public SpellScriptLoader
 
         class spell_xt002_submerged_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_xt002_submerged_SpellScript);
+            PrepareSpellScript(spell_xt002_submerged_SpellScript)
 
             void HandleScript(SpellEffIndex /*eff*/)
             {
@@ -1018,7 +1018,7 @@ class spell_xt002_stand : public SpellScriptLoader
 
         class spell_xt002_stand_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_xt002_stand_SpellScript);
+            PrepareSpellScript(spell_xt002_stand_SpellScript)
 
             void HandleScript(SpellEffIndex /*eff*/)
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
@@ -1930,7 +1930,7 @@ class spell_yogg_saron_target_selectors : public SpellScriptLoader    // 63744, 
 
         class spell_yogg_saron_target_selectors_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_target_selectors_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_target_selectors_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1988,7 +1988,7 @@ class spell_yogg_saron_psychosis : public SpellScriptLoader      // 63795, 65301
 
         class spell_yogg_saron_psychosis_SpellScript : public SanityReduction
         {
-            PrepareSpellScript(spell_yogg_saron_psychosis_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_psychosis_SpellScript)
 
             bool Load() override
             {
@@ -2026,7 +2026,7 @@ class spell_yogg_saron_malady_of_the_mind : public SpellScriptLoader    // 63830
             public:
                 spell_yogg_saron_malady_of_the_mind_SpellScript() : SanityReduction(3) { }
 
-            PrepareSpellScript(spell_yogg_saron_malady_of_the_mind_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_malady_of_the_mind_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -2049,7 +2049,7 @@ class spell_yogg_saron_malady_of_the_mind : public SpellScriptLoader    // 63830
 
         class spell_yogg_saron_malady_of_the_mind_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_malady_of_the_mind_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_malady_of_the_mind_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2097,7 +2097,7 @@ class spell_yogg_saron_brain_link : public SpellScriptLoader    // 63802
 
         class spell_yogg_saron_brain_link_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_brain_link_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_brain_link_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -2121,7 +2121,7 @@ class spell_yogg_saron_brain_link : public SpellScriptLoader    // 63802
 
         class spell_yogg_saron_brain_link_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_brain_link_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_brain_link_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2198,7 +2198,7 @@ class spell_yogg_saron_brain_link_damage : public SpellScriptLoader      // 6380
             public:
                 spell_yogg_saron_brain_link_damage_SpellScript() : SanityReduction(2) { }
 
-            PrepareSpellScript(spell_yogg_saron_brain_link_damage_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_brain_link_damage_SpellScript)
 
             void Register() override
             {
@@ -2219,7 +2219,7 @@ class spell_yogg_saron_boil_ominously : public SpellScriptLoader    // 63030
 
         class spell_yogg_saron_boil_ominously_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_boil_ominously_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_boil_ominously_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2259,7 +2259,7 @@ class spell_yogg_saron_shadow_beacon : public SpellScriptLoader     // 64465
 
         class spell_yogg_saron_shadow_beacon_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_shadow_beacon_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_shadow_beacon_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -2293,7 +2293,7 @@ class spell_yogg_saron_empowering_shadows_range_check : public SpellScriptLoader
 
         class spell_yogg_saron_empowering_shadows_range_check_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_empowering_shadows_range_check_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_empowering_shadows_range_check_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2320,7 +2320,7 @@ class spell_yogg_saron_empowering_shadows_missile : public SpellScriptLoader    
 
         class spell_yogg_saron_empowering_shadows_missile_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_empowering_shadows_missile_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_empowering_shadows_missile_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2355,7 +2355,7 @@ class spell_yogg_saron_constrictor_tentacle : public SpellScriptLoader     // 64
 
         class spell_yogg_saron_constrictor_tentacle_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_constrictor_tentacle_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_constrictor_tentacle_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2388,7 +2388,7 @@ class spell_yogg_saron_lunge : public SpellScriptLoader    // 64131
 
         class spell_yogg_saron_lunge_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_lunge_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_lunge_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2425,7 +2425,7 @@ class spell_yogg_saron_squeeze : public SpellScriptLoader     // 64125
 
         class spell_yogg_saron_squeeze_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_squeeze_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_squeeze_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -2453,7 +2453,7 @@ class spell_yogg_saron_diminsh_power : public SpellScriptLoader     // 64148
 
         class spell_yogg_saron_diminsh_power_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_diminsh_power_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_diminsh_power_AuraScript)
 
             void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& /*eventInfo*/)
             {
@@ -2483,7 +2483,7 @@ class spell_yogg_saron_empowered : public SpellScriptLoader     // 64161
 
         class spell_yogg_saron_empowered_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_empowered_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_empowered_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2534,7 +2534,7 @@ class spell_yogg_saron_match_health : public SpellScriptLoader    // 64069
 
         class spell_yogg_saron_match_health_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_match_health_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_match_health_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2561,7 +2561,7 @@ class spell_yogg_saron_shattered_illusion : public SpellScriptLoader    // 65238
 
         class spell_yogg_saron_shattered_illusion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_shattered_illusion_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_shattered_illusion_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2588,7 +2588,7 @@ class spell_yogg_saron_death_ray_warning_visual : public SpellScriptLoader     /
 
         class spell_yogg_saron_death_ray_warning_visual_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_death_ray_warning_visual_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_death_ray_warning_visual_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2629,7 +2629,7 @@ class spell_yogg_saron_cancel_illusion_room_aura : public SpellScriptLoader    /
 
         class spell_yogg_saron_cancel_illusion_room_aura_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_cancel_illusion_room_aura_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_cancel_illusion_room_aura_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2666,7 +2666,7 @@ class spell_yogg_saron_nondescript : public SpellScriptLoader     // 64010, 6401
 
         class spell_yogg_saron_nondescript_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_nondescript_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_nondescript_AuraScript)
 
             void OnRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {
@@ -2692,7 +2692,7 @@ class spell_yogg_saron_revealed_tentacle : public SpellScriptLoader    // 64012
 
         class spell_yogg_saron_revealed_tentacle_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_revealed_tentacle_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_revealed_tentacle_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2732,7 +2732,7 @@ class spell_yogg_saron_grim_reprisal : public SpellScriptLoader     // 63305
 
         class spell_yogg_saron_grim_reprisal_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_grim_reprisal_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_grim_reprisal_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2766,7 +2766,7 @@ class spell_yogg_saron_induce_madness : public SpellScriptLoader    // 64059
 
         class spell_yogg_saron_induce_madness_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_induce_madness_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_induce_madness_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2816,7 +2816,7 @@ class spell_yogg_saron_sanity : public SpellScriptLoader     // 63050
 
         class spell_yogg_saron_sanity_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_sanity_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_sanity_SpellScript)
 
             // don't target players outside of room or handle it in SPELL_INSANE_PERIODIC?
 
@@ -2833,7 +2833,7 @@ class spell_yogg_saron_sanity : public SpellScriptLoader     // 63050
 
         class spell_yogg_saron_sanity_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_sanity_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_sanity_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2892,7 +2892,7 @@ class spell_yogg_saron_insane : public SpellScriptLoader     // 63120
 
         class spell_yogg_saron_insane_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_insane_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_insane_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2936,7 +2936,7 @@ class spell_yogg_saron_insane_periodic : public SpellScriptLoader    // 64555
 
         class spell_yogg_saron_insane_periodic_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_insane_periodic_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_insane_periodic_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2977,7 +2977,7 @@ class spell_yogg_saron_lunatic_gaze : public SpellScriptLoader      // 64164, 64
 
         class spell_yogg_saron_lunatic_gaze_SpellScript : public SanityReduction
         {
-            PrepareSpellScript(spell_yogg_saron_lunatic_gaze_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_lunatic_gaze_SpellScript)
 
             bool Load() override
             {
@@ -3011,7 +3011,7 @@ class spell_yogg_saron_keeper_aura : public SpellScriptLoader     // 62650, 6267
 
         class spell_yogg_saron_keeper_aura_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_keeper_aura_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_keeper_aura_AuraScript)
 
             bool CanApply(Unit* target)
             {
@@ -3039,7 +3039,7 @@ class spell_yogg_saron_hate_to_zero : public SpellScriptLoader    // 63984
 
         class spell_yogg_saron_hate_to_zero_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_hate_to_zero_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_hate_to_zero_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -3067,7 +3067,7 @@ class spell_yogg_saron_in_the_maws_of_the_old_god : public SpellScriptLoader    
 
         class spell_yogg_saron_in_the_maws_of_the_old_god_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_in_the_maws_of_the_old_god_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_in_the_maws_of_the_old_god_SpellScript)
 
             SpellCastResult CheckRequirement()
             {
@@ -3103,7 +3103,7 @@ class spell_yogg_saron_titanic_storm : public SpellScriptLoader    // 64172
 
         class spell_yogg_saron_titanic_storm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_yogg_saron_titanic_storm_SpellScript);
+            PrepareSpellScript(spell_yogg_saron_titanic_storm_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -3130,7 +3130,7 @@ class spell_yogg_saron_hodirs_protective_gaze : public SpellScriptLoader     // 
 
         class spell_yogg_saron_hodirs_protective_gaze_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_yogg_saron_hodirs_protective_gaze_AuraScript);
+            PrepareAuraScript(spell_yogg_saron_hodirs_protective_gaze_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
@@ -395,7 +395,7 @@ class spell_ingvar_summon_banshee : public SpellScriptLoader
 
         class spell_ingvar_summon_banshee_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_ingvar_summon_banshee_SpellScript);
+            PrepareSpellScript(spell_ingvar_summon_banshee_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {
@@ -422,7 +422,7 @@ class spell_ingvar_woe_strike : public SpellScriptLoader
 
         class spell_ingvar_woe_strike_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ingvar_woe_strike_AuraScript);
+            PrepareAuraScript(spell_ingvar_woe_strike_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -325,7 +325,7 @@ class spell_frost_tomb : public SpellScriptLoader
 
         class spell_frost_tomb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_frost_tomb_AuraScript);
+            PrepareAuraScript(spell_frost_tomb_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/utgarde_keep.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/utgarde_keep.cpp
@@ -126,7 +126,7 @@ class spell_ticking_time_bomb : public SpellScriptLoader
 
         class spell_ticking_time_bomb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_ticking_time_bomb_AuraScript);
+            PrepareAuraScript(spell_ticking_time_bomb_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -165,7 +165,7 @@ class spell_fixate : public SpellScriptLoader
 
         class spell_fixate_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_fixate_SpellScript);
+            PrepareSpellScript(spell_fixate_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -488,7 +488,7 @@ class spell_paralyze_pinnacle : public SpellScriptLoader
 
         class spell_paralyze_pinnacle_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_paralyze_pinnacle_SpellScript);
+            PrepareSpellScript(spell_paralyze_pinnacle_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
@@ -217,7 +217,7 @@ class spell_archavon_rock_shards : public SpellScriptLoader
 
         class spell_archavon_rock_shards_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_archavon_rock_shards_SpellScript);
+            PrepareSpellScript(spell_archavon_rock_shards_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_koralon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_koralon.cpp
@@ -189,7 +189,7 @@ class spell_koralon_meteor_fists : public SpellScriptLoader
 
         class spell_koralon_meteor_fists_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_koralon_meteor_fists_AuraScript);
+            PrepareAuraScript(spell_koralon_meteor_fists_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -223,7 +223,7 @@ class spell_koralon_meteor_fists_damage : public SpellScriptLoader
 
         class spell_koralon_meteor_fists_damage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_koralon_meteor_fists_damage_SpellScript);
+            PrepareSpellScript(spell_koralon_meteor_fists_damage_SpellScript)
 
             bool Load() override
             {
@@ -265,7 +265,7 @@ class spell_flame_warder_meteor_fists : public SpellScriptLoader
 
         class spell_flame_warder_meteor_fists_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_flame_warder_meteor_fists_AuraScript);
+            PrepareAuraScript(spell_flame_warder_meteor_fists_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2548,7 +2548,7 @@ public:
 
     class spell_windsoul_totem_aura_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_windsoul_totem_aura_AuraScript);
+        PrepareAuraScript(spell_windsoul_totem_aura_AuraScript)
 
         void OnRemove(AuraEffect const*, AuraEffectHandleModes)
         {

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -432,7 +432,7 @@ public:
 
     class spell_q12096_q12092_dummy_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_q12096_q12092_dummy_SpellScript);
+        PrepareSpellScript(spell_q12096_q12092_dummy_SpellScript)
 
         void HandleDummy(SpellEffIndex /*effIndex*/)
         {
@@ -479,7 +479,7 @@ public:
 
     class spell_q12096_q12092_bark_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_q12096_q12092_bark_SpellScript);
+        PrepareSpellScript(spell_q12096_q12092_bark_SpellScript)
 
         void HandleDummy(SpellEffIndex /*effIndex*/)
         {

--- a/src/server/scripts/Northrend/zone_grizzly_hills.cpp
+++ b/src/server/scripts/Northrend/zone_grizzly_hills.cpp
@@ -761,7 +761,7 @@ class spell_shredder_delivery : public SpellScriptLoader
 
         class spell_shredder_delivery_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_shredder_delivery_SpellScript);
+            PrepareSpellScript(spell_shredder_delivery_SpellScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/zone_howling_fjord.cpp
+++ b/src/server/scripts/Northrend/zone_howling_fjord.cpp
@@ -443,7 +443,7 @@ class spell_mindless_abomination_explosion_fx_master : public SpellScriptLoader
 
         class spell_mindless_abomination_explosion_fx_master_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mindless_abomination_explosion_fx_master_SpellScript);
+            PrepareSpellScript(spell_mindless_abomination_explosion_fx_master_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Northrend/zone_sholazar_basin.cpp
+++ b/src/server/scripts/Northrend/zone_sholazar_basin.cpp
@@ -762,7 +762,7 @@ public:
 
     class spell_q12620_the_lifewarden_wrath_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_q12620_the_lifewarden_wrath_SpellScript);
+        PrepareSpellScript(spell_q12620_the_lifewarden_wrath_SpellScript)
 
         void HandleSendEvent(SpellEffIndex effIndex)
         {
@@ -850,7 +850,7 @@ public:
 
     class spell_q12589_shoot_rjr_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_q12589_shoot_rjr_SpellScript);
+        PrepareSpellScript(spell_q12589_shoot_rjr_SpellScript)
 
         SpellCastResult CheckCast()
         {
@@ -1109,7 +1109,7 @@ public:
 
     class spell_shango_tracks_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_shango_tracks_SpellScript);
+        PrepareSpellScript(spell_shango_tracks_SpellScript)
 
         void HandleScript(SpellEffIndex /*effIndex*/)
         {

--- a/src/server/scripts/Northrend/zone_storm_peaks.cpp
+++ b/src/server/scripts/Northrend/zone_storm_peaks.cpp
@@ -732,7 +732,7 @@ class spell_jokkum_scriptcast : public SpellScriptLoader
 
         class spell_jokkum_scriptcast_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_jokkum_scriptcast_AuraScript);
+            PrepareAuraScript(spell_jokkum_scriptcast_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -765,7 +765,7 @@ class spell_veranus_summon : public SpellScriptLoader
 
         class spell_veranus_summon_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_veranus_summon_AuraScript);
+            PrepareAuraScript(spell_veranus_summon_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -804,7 +804,7 @@ class spell_close_rift : public SpellScriptLoader
 
         class spell_close_rift_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_close_rift_AuraScript);
+            PrepareAuraScript(spell_close_rift_AuraScript)
 
             bool Load() override
             {

--- a/src/server/scripts/Northrend/zone_wintergrasp.cpp
+++ b/src/server/scripts/Northrend/zone_wintergrasp.cpp
@@ -481,7 +481,7 @@ class spell_wintergrasp_force_building : public SpellScriptLoader
 
         class spell_wintergrasp_force_building_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_wintergrasp_force_building_SpellScript);
+            PrepareSpellScript(spell_wintergrasp_force_building_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -518,7 +518,7 @@ class spell_wintergrasp_grab_passenger : public SpellScriptLoader
 
         class spell_wintergrasp_grab_passenger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_wintergrasp_grab_passenger_SpellScript);
+            PrepareSpellScript(spell_wintergrasp_grab_passenger_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -574,7 +574,7 @@ public:
 
     class spell_wintergrasp_defender_teleport_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_wintergrasp_defender_teleport_SpellScript);
+        PrepareSpellScript(spell_wintergrasp_defender_teleport_SpellScript)
 
         SpellCastResult CheckCast()
         {
@@ -605,7 +605,7 @@ public:
 
     class spell_wintergrasp_defender_teleport_trigger_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_wintergrasp_defender_teleport_trigger_SpellScript);
+        PrepareSpellScript(spell_wintergrasp_defender_teleport_trigger_SpellScript)
 
         void HandleDummy(SpellEffIndex /*effindex*/)
         {

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -613,7 +613,7 @@ class spell_random_ingredient_aura : public SpellScriptLoader
 
         class spell_random_ingredient_aura_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_random_ingredient_aura_AuraScript);
+            PrepareAuraScript(spell_random_ingredient_aura_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -660,7 +660,7 @@ class spell_random_ingredient : public SpellScriptLoader
 
         class spell_random_ingredient_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_random_ingredient_SpellScript);
+            PrepareSpellScript(spell_random_ingredient_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -724,7 +724,7 @@ class spell_pot_check : public SpellScriptLoader
 
         class spell_pot_check_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pot_check_SpellScript);
+            PrepareSpellScript(spell_pot_check_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -817,7 +817,7 @@ class spell_fetch_ingredient_aura : public SpellScriptLoader
 
         class spell_fetch_ingredient_aura_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_fetch_ingredient_aura_AuraScript);
+            PrepareAuraScript(spell_fetch_ingredient_aura_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
@@ -181,7 +181,7 @@ class spell_murmur_sonic_boom : public SpellScriptLoader
 
         class spell_murmur_sonic_boom_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_murmur_sonic_boom_SpellScript);
+            PrepareSpellScript(spell_murmur_sonic_boom_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -215,7 +215,7 @@ class spell_murmur_sonic_boom_effect : public SpellScriptLoader
 
         class spell_murmur_sonic_boom_effect_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_murmur_sonic_boom_effect_SpellScript);
+            PrepareSpellScript(spell_murmur_sonic_boom_effect_SpellScript)
 
             void CalcDamage()
             {
@@ -258,7 +258,7 @@ class spell_murmur_thundering_storm : public SpellScriptLoader
 
         class spell_murmur_thundering_storm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_murmur_thundering_storm_SpellScript);
+            PrepareSpellScript(spell_murmur_thundering_storm_SpellScript)
 
             void FilterTarget(std::list<WorldObject*>& targets)
             {

--- a/src/server/scripts/Outland/BlackTemple/illidari_council.cpp
+++ b/src/server/scripts/Outland/BlackTemple/illidari_council.cpp
@@ -876,7 +876,7 @@ public:
 
     class spell_boss_lady_malande_shield_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_boss_lady_malande_shield_AuraScript);
+        PrepareAuraScript(spell_boss_lady_malande_shield_AuraScript)
 
         bool Validate(SpellInfo const* /*spellInfo*/) override
         {

--- a/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
@@ -263,7 +263,7 @@ class spell_gruul_shatter : public SpellScriptLoader
 
         class spell_gruul_shatter_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gruul_shatter_SpellScript);
+            PrepareSpellScript(spell_gruul_shatter_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -302,7 +302,7 @@ class spell_gruul_shatter_effect : public SpellScriptLoader
 
         class spell_gruul_shatter_effect_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gruul_shatter_effect_SpellScript);
+            PrepareSpellScript(spell_gruul_shatter_effect_SpellScript)
 
             void CalculateDamage()
             {

--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_broggok.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_broggok.cpp
@@ -195,7 +195,7 @@ class spell_broggok_poison_cloud : public SpellScriptLoader
 
         class spell_broggok_poison_cloud_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_broggok_poison_cloud_AuraScript);
+            PrepareAuraScript(spell_broggok_poison_cloud_AuraScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_astromancer.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_astromancer.cpp
@@ -513,7 +513,7 @@ class spell_astromancer_wrath_of_the_astromancer : public SpellScriptLoader
 
         class spell_astromancer_wrath_of_the_astromancer_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_astromancer_wrath_of_the_astromancer_AuraScript);
+            PrepareAuraScript(spell_astromancer_wrath_of_the_astromancer_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_mechano_lord_capacitus.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_mechano_lord_capacitus.cpp
@@ -163,7 +163,7 @@ class spell_capacitus_polarity_charge : public SpellScriptLoader
 
         class spell_capacitus_polarity_charge_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_capacitus_polarity_charge_SpellScript);
+            PrepareSpellScript(spell_capacitus_polarity_charge_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -231,7 +231,7 @@ class spell_capacitus_polarity_shift : public SpellScriptLoader
 
         class spell_capacitus_polarity_shift_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_capacitus_polarity_shift_SpellScript);
+            PrepareSpellScript(spell_capacitus_polarity_shift_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_commander_sarannis.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_commander_sarannis.cpp
@@ -156,7 +156,7 @@ class spell_commander_sarannis_summon_reinforcements : public SpellScriptLoader
 
         class spell_commander_sarannis_summon_reinforcements_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_commander_sarannis_summon_reinforcements_SpellScript);
+            PrepareSpellScript(spell_commander_sarannis_summon_reinforcements_SpellScript)
 
             void HandleCast(SpellEffIndex /*effIndex*/)
             {

--- a/src/server/scripts/Outland/boss_doomlord_kazzak.cpp
+++ b/src/server/scripts/Outland/boss_doomlord_kazzak.cpp
@@ -182,7 +182,7 @@ class spell_mark_of_kazzak : public SpellScriptLoader
 
         class spell_mark_of_kazzak_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mark_of_kazzak_AuraScript);
+            PrepareAuraScript(spell_mark_of_kazzak_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {

--- a/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
+++ b/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
@@ -1187,7 +1187,7 @@ class spell_oscillating_field : public SpellScriptLoader
 
         class spell_oscillating_field_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_oscillating_field_SpellScript);
+            PrepareSpellScript(spell_oscillating_field_SpellScript)
 
             void HandleEffect(SpellEffIndex /*effIndex*/)
             {

--- a/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
+++ b/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
@@ -1824,7 +1824,7 @@ class spell_unlocking_zuluheds_chains : public SpellScriptLoader
 
         class spell_unlocking_zuluheds_chains_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_unlocking_zuluheds_chains_SpellScript);
+            PrepareSpellScript(spell_unlocking_zuluheds_chains_SpellScript)
 
             void HandleAfterHit()
             {

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -79,7 +79,7 @@ class spell_dk_anti_magic_shell_raid : public SpellScriptLoader
 
         class spell_dk_anti_magic_shell_raid_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_anti_magic_shell_raid_AuraScript);
+            PrepareAuraScript(spell_dk_anti_magic_shell_raid_AuraScript)
 
             uint32 absorbPct;
 
@@ -121,7 +121,7 @@ class spell_dk_anti_magic_shell_self : public SpellScriptLoader
 
         class spell_dk_anti_magic_shell_self_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_anti_magic_shell_self_AuraScript);
+            PrepareAuraScript(spell_dk_anti_magic_shell_self_AuraScript)
 
             uint32 absorbPct, hpPct;
             bool Load() override
@@ -178,7 +178,7 @@ class spell_dk_anti_magic_zone : public SpellScriptLoader
 
         class spell_dk_anti_magic_zone_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_anti_magic_zone_AuraScript);
+            PrepareAuraScript(spell_dk_anti_magic_zone_AuraScript)
 
             uint32 absorbPct;
 
@@ -229,7 +229,7 @@ class spell_dk_blood_boil : public SpellScriptLoader
 
         class spell_dk_blood_boil_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_blood_boil_SpellScript);
+            PrepareSpellScript(spell_dk_blood_boil_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -275,7 +275,7 @@ class spell_dk_blood_gorged : public SpellScriptLoader
 
         class spell_dk_blood_gorged_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_blood_gorged_AuraScript);
+            PrepareAuraScript(spell_dk_blood_gorged_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -349,7 +349,7 @@ class spell_dk_corpse_explosion : public SpellScriptLoader
 
         class spell_dk_corpse_explosion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_corpse_explosion_SpellScript);
+            PrepareSpellScript(spell_dk_corpse_explosion_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -448,7 +448,7 @@ class spell_dk_death_coil : public SpellScriptLoader
 
         class spell_dk_death_coil_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_death_coil_SpellScript);
+            PrepareSpellScript(spell_dk_death_coil_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -515,7 +515,7 @@ class spell_dk_death_gate : public SpellScriptLoader
 
         class spell_dk_death_gate_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_death_gate_SpellScript);
+            PrepareSpellScript(spell_dk_death_gate_SpellScript)
 
             SpellCastResult CheckClass()
             {
@@ -556,7 +556,7 @@ class spell_dk_death_grip : public SpellScriptLoader
 
         class spell_dk_death_grip_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_death_grip_SpellScript);
+            PrepareSpellScript(spell_dk_death_grip_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -590,7 +590,7 @@ class spell_dk_death_pact : public SpellScriptLoader
 
         class spell_dk_death_pact_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_death_pact_SpellScript);
+            PrepareSpellScript(spell_dk_death_pact_SpellScript)
 
             SpellCastResult CheckCast()
             {
@@ -646,7 +646,7 @@ class spell_dk_death_strike : public SpellScriptLoader
 
         class spell_dk_death_strike_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_death_strike_SpellScript);
+            PrepareSpellScript(spell_dk_death_strike_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -690,7 +690,7 @@ class spell_dk_ghoul_explode : public SpellScriptLoader
 
         class spell_dk_ghoul_explode_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_ghoul_explode_SpellScript);
+            PrepareSpellScript(spell_dk_ghoul_explode_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -738,7 +738,7 @@ class spell_dk_icebound_fortitude : public SpellScriptLoader
 
         class spell_dk_icebound_fortitude_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_icebound_fortitude_AuraScript);
+            PrepareAuraScript(spell_dk_icebound_fortitude_AuraScript)
 
             bool Load() override
             {
@@ -787,7 +787,7 @@ class spell_dk_improved_blood_presence : public SpellScriptLoader
 
         class spell_dk_improved_blood_presence_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_improved_blood_presence_AuraScript);
+            PrepareAuraScript(spell_dk_improved_blood_presence_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -834,7 +834,7 @@ class spell_dk_improved_frost_presence : public SpellScriptLoader
 
         class spell_dk_improved_frost_presence_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_improved_frost_presence_AuraScript);
+            PrepareAuraScript(spell_dk_improved_frost_presence_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -881,7 +881,7 @@ class spell_dk_improved_unholy_presence : public SpellScriptLoader
 
         class spell_dk_improved_unholy_presence_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_improved_unholy_presence_AuraScript);
+            PrepareAuraScript(spell_dk_improved_unholy_presence_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -941,7 +941,7 @@ class spell_dk_presence : public SpellScriptLoader
 
         class spell_dk_presence_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_presence_AuraScript);
+            PrepareAuraScript(spell_dk_presence_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1057,7 +1057,7 @@ class spell_dk_raise_dead : public SpellScriptLoader
 
         class spell_dk_raise_dead_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_raise_dead_SpellScript);
+            PrepareSpellScript(spell_dk_raise_dead_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -1190,7 +1190,7 @@ class spell_dk_rune_tap_party : public SpellScriptLoader
 
         class spell_dk_rune_tap_party_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_rune_tap_party_SpellScript);
+            PrepareSpellScript(spell_dk_rune_tap_party_SpellScript)
 
             void CheckTargets(std::list<WorldObject*>& targets)
             {
@@ -1217,7 +1217,7 @@ class spell_dk_scent_of_blood : public SpellScriptLoader
 
         class spell_dk_scent_of_blood_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_scent_of_blood_AuraScript);
+            PrepareAuraScript(spell_dk_scent_of_blood_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1253,7 +1253,7 @@ class spell_dk_scourge_strike : public SpellScriptLoader
 
         class spell_dk_scourge_strike_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dk_scourge_strike_SpellScript);
+            PrepareSpellScript(spell_dk_scourge_strike_SpellScript)
             float multiplier;
 
             bool Load() override
@@ -1316,7 +1316,7 @@ class spell_dk_spell_deflection : public SpellScriptLoader
 
         class spell_dk_spell_deflection_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_spell_deflection_AuraScript);
+            PrepareAuraScript(spell_dk_spell_deflection_AuraScript)
 
             uint32 absorbPct;
 
@@ -1360,7 +1360,7 @@ class spell_dk_vampiric_blood : public SpellScriptLoader
 
         class spell_dk_vampiric_blood_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_vampiric_blood_AuraScript);
+            PrepareAuraScript(spell_dk_vampiric_blood_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -1387,7 +1387,7 @@ class spell_dk_will_of_the_necropolis : public SpellScriptLoader
 
         class spell_dk_will_of_the_necropolis_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_will_of_the_necropolis_AuraScript);
+            PrepareAuraScript(spell_dk_will_of_the_necropolis_AuraScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -54,7 +54,7 @@ class spell_dru_dash : public SpellScriptLoader
 
         class spell_dru_dash_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_dash_AuraScript);
+            PrepareAuraScript(spell_dru_dash_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -83,7 +83,7 @@ class spell_dru_enrage : public SpellScriptLoader
 
         class spell_dru_enrage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_enrage_SpellScript);
+            PrepareSpellScript(spell_dru_enrage_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -119,7 +119,7 @@ class spell_dru_glyph_of_starfire : public SpellScriptLoader
 
         class spell_dru_glyph_of_starfire_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_glyph_of_starfire_SpellScript);
+            PrepareSpellScript(spell_dru_glyph_of_starfire_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -172,7 +172,7 @@ class spell_dru_idol_lifebloom : public SpellScriptLoader
 
         class spell_dru_idol_lifebloom_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_idol_lifebloom_AuraScript);
+            PrepareAuraScript(spell_dru_idol_lifebloom_AuraScript)
 
             void HandleEffectCalcSpellMod(AuraEffect const* aurEff, SpellModifier*& spellMod)
             {
@@ -207,7 +207,7 @@ class spell_dru_innervate : public SpellScriptLoader
 
         class spell_dru_innervate_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_innervate_AuraScript);
+            PrepareAuraScript(spell_dru_innervate_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -234,7 +234,7 @@ class spell_dru_insect_swarm : public SpellScriptLoader
 
         class spell_dru_insect_swarm_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_insect_swarm_AuraScript);
+            PrepareAuraScript(spell_dru_insect_swarm_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32 & amount, bool & /*canBeRecalculated*/)
             {
@@ -263,7 +263,7 @@ class spell_dru_lifebloom : public SpellScriptLoader
 
         class spell_dru_lifebloom_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_lifebloom_AuraScript);
+            PrepareAuraScript(spell_dru_lifebloom_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -345,7 +345,7 @@ class spell_dru_living_seed : public SpellScriptLoader
 
         class spell_dru_living_seed_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_living_seed_AuraScript);
+            PrepareAuraScript(spell_dru_living_seed_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -381,7 +381,7 @@ class spell_dru_living_seed_proc : public SpellScriptLoader
 
         class spell_dru_living_seed_proc_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_living_seed_proc_AuraScript);
+            PrepareAuraScript(spell_dru_living_seed_proc_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -416,7 +416,7 @@ class spell_dru_moonkin_form_passive : public SpellScriptLoader
 
         class spell_dru_moonkin_form_passive_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_moonkin_form_passive_AuraScript);
+            PrepareAuraScript(spell_dru_moonkin_form_passive_AuraScript)
 
             uint32 absorbPct;
 
@@ -460,7 +460,7 @@ class spell_dru_owlkin_frenzy : public SpellScriptLoader
 
         class spell_dru_owlkin_frenzy_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_owlkin_frenzy_AuraScript);
+            PrepareAuraScript(spell_dru_owlkin_frenzy_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -487,7 +487,7 @@ class spell_dru_predatory_strikes : public SpellScriptLoader
 
         class spell_dru_predatory_strikes_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_predatory_strikes_AuraScript);
+            PrepareAuraScript(spell_dru_predatory_strikes_AuraScript)
 
             void UpdateAmount(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -516,7 +516,7 @@ class spell_dru_primal_tenacity : public SpellScriptLoader
 
         class spell_dru_primal_tenacity_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_primal_tenacity_AuraScript);
+            PrepareAuraScript(spell_dru_primal_tenacity_AuraScript)
 
             uint32 absorbPct;
 
@@ -560,7 +560,7 @@ class spell_dru_rip : public SpellScriptLoader
 
         class spell_dru_rip_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_rip_AuraScript);
+            PrepareAuraScript(spell_dru_rip_AuraScript)
 
             bool Load() override
             {
@@ -608,7 +608,7 @@ class spell_dru_savage_defense : public SpellScriptLoader
 
         class spell_dru_savage_defense_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_savage_defense_AuraScript);
+            PrepareAuraScript(spell_dru_savage_defense_AuraScript)
 
             uint32 absorbPct;
 
@@ -651,7 +651,7 @@ class spell_dru_savage_roar : public SpellScriptLoader
 
         class spell_dru_savage_roar_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_savage_roar_SpellScript);
+            PrepareSpellScript(spell_dru_savage_roar_SpellScript)
 
             SpellCastResult CheckCast()
             {
@@ -670,7 +670,7 @@ class spell_dru_savage_roar : public SpellScriptLoader
 
         class spell_dru_savage_roar_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_savage_roar_AuraScript);
+            PrepareAuraScript(spell_dru_savage_roar_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -716,7 +716,7 @@ class spell_dru_starfall_aoe : public SpellScriptLoader
 
         class spell_dru_starfall_aoe_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_starfall_aoe_SpellScript);
+            PrepareSpellScript(spell_dru_starfall_aoe_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -743,7 +743,7 @@ class spell_dru_starfall_dummy : public SpellScriptLoader
 
         class spell_dru_starfall_dummy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_starfall_dummy_SpellScript);
+            PrepareSpellScript(spell_dru_starfall_dummy_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -789,7 +789,7 @@ class spell_dru_survival_instincts : public SpellScriptLoader
 
         class spell_dru_survival_instincts_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_survival_instincts_SpellScript);
+            PrepareSpellScript(spell_dru_survival_instincts_SpellScript)
 
             SpellCastResult CheckCast()
             {
@@ -808,7 +808,7 @@ class spell_dru_survival_instincts : public SpellScriptLoader
 
         class spell_dru_survival_instincts_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_survival_instincts_AuraScript);
+            PrepareAuraScript(spell_dru_survival_instincts_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -855,7 +855,7 @@ class spell_dru_swift_flight_passive : public SpellScriptLoader
 
         class spell_dru_swift_flight_passive_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dru_swift_flight_passive_AuraScript);
+            PrepareAuraScript(spell_dru_swift_flight_passive_AuraScript)
 
             bool Load() override
             {
@@ -889,7 +889,7 @@ class spell_dru_tiger_s_fury : public SpellScriptLoader
 
         class spell_dru_tiger_s_fury_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_tiger_s_fury_SpellScript);
+            PrepareSpellScript(spell_dru_tiger_s_fury_SpellScript)
 
             void OnHit()
             {
@@ -917,7 +917,7 @@ class spell_dru_typhoon : public SpellScriptLoader
 
         class spell_dru_typhoon_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_typhoon_SpellScript);
+            PrepareSpellScript(spell_dru_typhoon_SpellScript)
 
             void HandleKnockBack(SpellEffIndex effIndex)
             {
@@ -946,7 +946,7 @@ class spell_dru_t10_restoration_4p_bonus : public SpellScriptLoader
 
         class spell_dru_t10_restoration_4p_bonus_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_t10_restoration_4p_bonus_SpellScript);
+            PrepareSpellScript(spell_dru_t10_restoration_4p_bonus_SpellScript)
 
             bool Load() override
             {
@@ -1018,7 +1018,7 @@ class spell_dru_wild_growth : public SpellScriptLoader
 
         class spell_dru_wild_growth_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dru_wild_growth_SpellScript);
+            PrepareSpellScript(spell_dru_wild_growth_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -45,7 +45,7 @@ class spell_gen_absorb0_hitlimit1 : public SpellScriptLoader
 
         class spell_gen_absorb0_hitlimit1_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_absorb0_hitlimit1_AuraScript);
+            PrepareAuraScript(spell_gen_absorb0_hitlimit1_AuraScript)
 
             uint32 limit;
 
@@ -90,7 +90,7 @@ class spell_gen_adaptive_warding : public SpellScriptLoader
 
         class spell_gen_adaptive_warding_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_adaptive_warding_AuraScript);
+            PrepareAuraScript(spell_gen_adaptive_warding_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -171,7 +171,7 @@ class spell_gen_allow_cast_from_item_only : public SpellScriptLoader
 
         class spell_gen_allow_cast_from_item_only_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_allow_cast_from_item_only_SpellScript);
+            PrepareSpellScript(spell_gen_allow_cast_from_item_only_SpellScript)
 
             SpellCastResult CheckRequirement()
             {
@@ -205,7 +205,7 @@ class spell_gen_animal_blood : public SpellScriptLoader
 
         class spell_gen_animal_blood_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_animal_blood_AuraScript);
+            PrepareAuraScript(spell_gen_animal_blood_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -249,7 +249,7 @@ class spell_gen_aura_of_anger : public SpellScriptLoader
 
         class spell_gen_aura_of_anger_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_aura_of_anger_AuraScript);
+            PrepareAuraScript(spell_gen_aura_of_anger_AuraScript)
 
             void HandleEffectPeriodicUpdate(AuraEffect* aurEff)
             {
@@ -287,7 +287,7 @@ class spell_gen_aura_service_uniform : public SpellScriptLoader
 
         class spell_gen_aura_service_uniform_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_aura_service_uniform_AuraScript);
+            PrepareAuraScript(spell_gen_aura_service_uniform_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -336,7 +336,7 @@ class spell_gen_av_drekthar_presence : public SpellScriptLoader
 
         class spell_gen_av_drekthar_presence_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_av_drekthar_presence_AuraScript);
+            PrepareAuraScript(spell_gen_av_drekthar_presence_AuraScript)
 
             bool CheckAreaTarget(Unit* target)
             {
@@ -384,7 +384,7 @@ class spell_gen_bandage : public SpellScriptLoader
 
         class spell_gen_bandage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_bandage_SpellScript);
+            PrepareSpellScript(spell_gen_bandage_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -436,7 +436,7 @@ class spell_gen_bonked : public SpellScriptLoader
 
         class spell_gen_bonked_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_bonked_SpellScript);
+            PrepareSpellScript(spell_gen_bonked_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -586,7 +586,7 @@ class spell_gen_burn_brutallus : public SpellScriptLoader
 
         class spell_gen_burn_brutallus_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_burn_brutallus_AuraScript);
+            PrepareAuraScript(spell_gen_burn_brutallus_AuraScript)
 
             void HandleEffectPeriodicUpdate(AuraEffect* aurEff)
             {
@@ -618,7 +618,7 @@ class spell_gen_cannibalize : public SpellScriptLoader
 
         class spell_gen_cannibalize_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_cannibalize_SpellScript);
+            PrepareSpellScript(spell_gen_cannibalize_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -706,7 +706,7 @@ class spell_gen_clone : public SpellScriptLoader
 
         class spell_gen_clone_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_clone_SpellScript);
+            PrepareSpellScript(spell_gen_clone_SpellScript)
 
             void HandleScriptEffect(SpellEffIndex effIndex)
             {
@@ -746,7 +746,7 @@ class spell_gen_clone_weapon : public SpellScriptLoader
 
         class spell_gen_clone_weapon_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_clone_weapon_SpellScript);
+            PrepareSpellScript(spell_gen_clone_weapon_SpellScript)
 
             void HandleScriptEffect(SpellEffIndex effIndex)
             {
@@ -773,7 +773,7 @@ class spell_gen_clone_weapon_aura : public SpellScriptLoader
 
         class spell_gen_clone_weapon_auraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_clone_weapon_auraScript);
+            PrepareAuraScript(spell_gen_clone_weapon_auraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -940,7 +940,7 @@ class spell_gen_create_lance : public SpellScriptLoader
 
         class spell_gen_create_lance_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_create_lance_SpellScript);
+            PrepareSpellScript(spell_gen_create_lance_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -982,7 +982,7 @@ class spell_gen_creature_permanent_feign_death : public SpellScriptLoader
 
         class spell_gen_creature_permanent_feign_death_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_creature_permanent_feign_death_AuraScript);
+            PrepareAuraScript(spell_gen_creature_permanent_feign_death_AuraScript)
 
             void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -1024,7 +1024,7 @@ class spell_gen_dalaran_disguise : public SpellScriptLoader
 
         class spell_gen_dalaran_disguise_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_dalaran_disguise_SpellScript);
+            PrepareSpellScript(spell_gen_dalaran_disguise_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -1096,7 +1096,7 @@ class spell_gen_damage_reduction_aura : public SpellScriptLoader
 
         class spell_gen_damage_reduction_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_damage_reduction_AuraScript);
+            PrepareAuraScript(spell_gen_damage_reduction_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1151,7 +1151,7 @@ class spell_gen_defend : public SpellScriptLoader
 
         class spell_gen_defend_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_defend_AuraScript);
+            PrepareAuraScript(spell_gen_defend_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1230,7 +1230,7 @@ class spell_gen_despawn_self : public SpellScriptLoader
 
         class spell_gen_despawn_self_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_despawn_self_SpellScript);
+            PrepareSpellScript(spell_gen_despawn_self_SpellScript)
 
             bool Load() override
             {
@@ -1268,7 +1268,7 @@ class spell_gen_divine_storm_cd_reset : public SpellScriptLoader
 
         class spell_gen_divine_storm_cd_reset_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_divine_storm_cd_reset_SpellScript);
+            PrepareSpellScript(spell_gen_divine_storm_cd_reset_SpellScript)
 
             bool Load() override
             {
@@ -1308,7 +1308,7 @@ class spell_gen_ds_flush_knockback : public SpellScriptLoader
 
         class spell_gen_ds_flush_knockback_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_ds_flush_knockback_SpellScript);
+            PrepareSpellScript(spell_gen_ds_flush_knockback_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1351,7 +1351,7 @@ class spell_gen_dummy_trigger : public SpellScriptLoader
 
         class spell_gen_dummy_trigger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_dummy_trigger_SpellScript);
+            PrepareSpellScript(spell_gen_dummy_trigger_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1390,7 +1390,7 @@ class spell_gen_dungeon_credit : public SpellScriptLoader
 
         class spell_gen_dungeon_credit_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_dungeon_credit_SpellScript);
+            PrepareSpellScript(spell_gen_dungeon_credit_SpellScript)
 
             bool Load() override
             {
@@ -1445,7 +1445,8 @@ class spell_gen_elune_candle : public SpellScriptLoader
 
         class spell_gen_elune_candle_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_elune_candle_SpellScript);
+            PrepareSpellScript(spell_gen_elune_candle_SpellScript)
+
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
                 if (!sSpellMgr->GetSpellInfo(SPELL_ELUNE_CANDLE_OMEN_HEAD) ||
@@ -1554,7 +1555,7 @@ class spell_gen_gift_of_naaru : public SpellScriptLoader
 
         class spell_gen_gift_of_naaru_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_gift_of_naaru_AuraScript);
+            PrepareAuraScript(spell_gen_gift_of_naaru_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -1646,7 +1647,7 @@ class spell_gen_gunship_portal : public SpellScriptLoader
 
         class spell_gen_gunship_portal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_gunship_portal_SpellScript);
+            PrepareSpellScript(spell_gen_gunship_portal_SpellScript)
 
             bool Load() override
             {
@@ -1685,7 +1686,7 @@ class spell_gen_launch : public SpellScriptLoader
 
         class spell_gen_launch_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_launch_SpellScript);
+            PrepareSpellScript(spell_gen_launch_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1733,7 +1734,7 @@ class spell_gen_lifeblood : public SpellScriptLoader
 
         class spell_gen_lifeblood_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_lifeblood_AuraScript);
+            PrepareAuraScript(spell_gen_lifeblood_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -1769,7 +1770,7 @@ class spell_gen_lifebloom : public SpellScriptLoader
 
         class spell_gen_lifebloom_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_lifebloom_AuraScript);
+            PrepareAuraScript(spell_gen_lifebloom_AuraScript)
 
         public:
             spell_gen_lifebloom_AuraScript(uint32 spellId) : AuraScript(), _spellId(spellId) { }
@@ -1823,7 +1824,7 @@ class spell_gen_magic_rooster : public SpellScriptLoader
 
         class spell_gen_magic_rooster_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_magic_rooster_SpellScript);
+            PrepareSpellScript(spell_gen_magic_rooster_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1922,7 +1923,7 @@ class spell_gen_mount : public SpellScriptLoader
 
         class spell_gen_mount_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_mount_SpellScript);
+            PrepareSpellScript(spell_gen_mount_SpellScript)
 
         public:
             spell_gen_mount_SpellScript(uint32 mount0, uint32 mount60, uint32 mount100, uint32 mount150, uint32 mount280, uint32 mount310) : SpellScript(),
@@ -2210,7 +2211,7 @@ class spell_gen_netherbloom : public SpellScriptLoader
 
         class spell_gen_netherbloom_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_netherbloom_SpellScript);
+            PrepareSpellScript(spell_gen_netherbloom_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2268,7 +2269,7 @@ class spell_gen_nightmare_vine : public SpellScriptLoader
 
         class spell_gen_nightmare_vine_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_nightmare_vine_SpellScript);
+            PrepareSpellScript(spell_gen_nightmare_vine_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2319,7 +2320,7 @@ class spell_gen_obsidian_armor : public SpellScriptLoader
 
         class spell_gen_obsidian_armor_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_obsidian_armor_AuraScript);
+            PrepareAuraScript(spell_gen_obsidian_armor_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2490,7 +2491,7 @@ class spell_gen_on_tournament_mount : public SpellScriptLoader
 
         class spell_gen_on_tournament_mount_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_on_tournament_mount_AuraScript);
+            PrepareAuraScript(spell_gen_on_tournament_mount_AuraScript)
 
             uint32 _pennantSpellId;
 
@@ -2648,7 +2649,7 @@ class spell_gen_oracle_wolvar_reputation : public SpellScriptLoader
 
         class spell_gen_oracle_wolvar_reputation_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_oracle_wolvar_reputation_SpellScript);
+            PrepareSpellScript(spell_gen_oracle_wolvar_reputation_SpellScript)
 
             bool Load() override
             {
@@ -2700,7 +2701,7 @@ class spell_gen_orc_disguise : public SpellScriptLoader
 
         class spell_gen_orc_disguise_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_orc_disguise_SpellScript);
+            PrepareSpellScript(spell_gen_orc_disguise_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2750,7 +2751,7 @@ class spell_gen_parachute : public SpellScriptLoader
 
         class spell_gen_parachute_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_parachute_AuraScript);
+            PrepareAuraScript(spell_gen_parachute_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2829,7 +2830,7 @@ class spell_gen_pet_summoned : public SpellScriptLoader
 
         class spell_gen_pet_summoned_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_pet_summoned_SpellScript);
+            PrepareSpellScript(spell_gen_pet_summoned_SpellScript)
 
             bool Load() override
             {
@@ -2842,30 +2843,28 @@ class spell_gen_pet_summoned : public SpellScriptLoader
                 if (player->GetLastPetNumber())
                 {
                     PetType newPetType = (player->getClass() == CLASS_HUNTER) ? HUNTER_PET : SUMMON_PET;
-                    if (Pet* newPet = new Pet(player, newPetType))
+                    auto newPet = new Pet(player, newPetType);
+                    if (newPet->LoadPetFromDB(player, 0, player->GetLastPetNumber(), true))
                     {
-                        if (newPet->LoadPetFromDB(player, 0, player->GetLastPetNumber(), true))
+                        // revive the pet if it is dead
+                        if (newPet->getDeathState() == DEAD)
+                            newPet->setDeathState(ALIVE);
+
+                        newPet->SetFullHealth();
+                        newPet->SetPower(newPet->getPowerType(), newPet->GetMaxPower(newPet->getPowerType()));
+
+                        switch (newPet->GetEntry())
                         {
-                            // revive the pet if it is dead
-                            if (newPet->getDeathState() == DEAD)
-                                newPet->setDeathState(ALIVE);
-
-                            newPet->SetFullHealth();
-                            newPet->SetPower(newPet->getPowerType(), newPet->GetMaxPower(newPet->getPowerType()));
-
-                            switch (newPet->GetEntry())
-                            {
-                                case NPC_DOOMGUARD:
-                                case NPC_INFERNAL:
-                                    newPet->SetEntry(NPC_IMP);
-                                    break;
-                                default:
-                                    break;
-                            }
+                            case NPC_DOOMGUARD:
+                            case NPC_INFERNAL:
+                                newPet->SetEntry(NPC_IMP);
+                                break;
+                            default:
+                                break;
                         }
-                        else
-                            delete newPet;
                     }
+                    else
+                        delete newPet;
                 }
             }
 
@@ -2888,7 +2887,7 @@ class spell_gen_profession_research : public SpellScriptLoader
 
         class spell_gen_profession_research_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_profession_research_SpellScript);
+            PrepareSpellScript(spell_gen_profession_research_SpellScript)
 
             bool Load() override
             {
@@ -2938,7 +2937,7 @@ class spell_gen_remove_flight_auras : public SpellScriptLoader
 
         class spell_gen_remove_flight_auras_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_remove_flight_auras_SpellScript);
+            PrepareSpellScript(spell_gen_remove_flight_auras_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2986,7 +2985,7 @@ class spell_gen_replenishment : public SpellScriptLoader
 
         class spell_gen_replenishment_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_replenishment_SpellScript);
+            PrepareSpellScript(spell_gen_replenishment_SpellScript)
 
             void RemoveInvalidTargets(std::list<WorldObject*>& targets)
             {
@@ -3025,7 +3024,7 @@ class spell_gen_replenishment : public SpellScriptLoader
 
         class spell_gen_replenishment_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_replenishment_AuraScript);
+            PrepareAuraScript(spell_gen_replenishment_AuraScript)
 
             bool Load() override
             {
@@ -3071,7 +3070,7 @@ class spell_gen_seaforium_blast : public SpellScriptLoader
 
         class spell_gen_seaforium_blast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_seaforium_blast_SpellScript);
+            PrepareSpellScript(spell_gen_seaforium_blast_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -3149,7 +3148,7 @@ class spell_gen_spirit_healer_res : public SpellScriptLoader
 
         class spell_gen_spirit_healer_res_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_spirit_healer_res_SpellScript);
+            PrepareSpellScript(spell_gen_spirit_healer_res_SpellScript)
 
             bool Load() override
             {
@@ -3192,7 +3191,7 @@ class spell_gen_summon_elemental : public SpellScriptLoader
 
         class spell_gen_summon_elemental_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_summon_elemental_AuraScript);
+            PrepareAuraScript(spell_gen_summon_elemental_AuraScript)
 
         public:
             spell_gen_summon_elemental_AuraScript(uint32 spellId) : AuraScript(), _spellId(spellId) { }
@@ -3250,7 +3249,7 @@ class spell_gen_summon_tournament_mount : public SpellScriptLoader
 
         class spell_gen_summon_tournament_mount_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_summon_tournament_mount_SpellScript);
+            PrepareSpellScript(spell_gen_summon_tournament_mount_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -3293,7 +3292,7 @@ class spell_gen_throw_shield : public SpellScriptLoader
 
         class spell_gen_throw_shield_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_throw_shield_SpellScript);
+            PrepareSpellScript(spell_gen_throw_shield_SpellScript)
 
             void HandleScriptEffect(SpellEffIndex effIndex)
             {
@@ -3326,7 +3325,7 @@ class spell_gen_tournament_duel : public SpellScriptLoader
 
         class spell_gen_tournament_duel_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_tournament_duel_SpellScript);
+            PrepareSpellScript(spell_gen_tournament_duel_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -3372,7 +3371,7 @@ class spell_gen_tournament_pennant : public SpellScriptLoader
 
         class spell_gen_tournament_pennant_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_tournament_pennant_AuraScript);
+            PrepareAuraScript(spell_gen_tournament_pennant_AuraScript)
 
             bool Load() override
             {
@@ -3413,7 +3412,7 @@ class spell_pvp_trinket_wotf_shared_cd : public SpellScriptLoader
 
         class spell_pvp_trinket_wotf_shared_cd_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pvp_trinket_wotf_shared_cd_SpellScript);
+            PrepareSpellScript(spell_pvp_trinket_wotf_shared_cd_SpellScript)
 
             bool Load() override
             {
@@ -3459,7 +3458,7 @@ class spell_gen_turkey_marker : public SpellScriptLoader
 
         class spell_gen_turkey_marker_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_turkey_marker_AuraScript);
+            PrepareAuraScript(spell_gen_turkey_marker_AuraScript)
 
             void OnApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {
@@ -3513,7 +3512,7 @@ class spell_gen_upper_deck_create_foam_sword : public SpellScriptLoader
 
         class spell_gen_upper_deck_create_foam_sword_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_upper_deck_create_foam_sword_SpellScript);
+            PrepareSpellScript(spell_gen_upper_deck_create_foam_sword_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -3555,7 +3554,7 @@ class spell_gen_vehicle_scaling : public SpellScriptLoader
 
         class spell_gen_vehicle_scaling_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_vehicle_scaling_AuraScript);
+            PrepareAuraScript(spell_gen_vehicle_scaling_AuraScript)
 
             bool Load() override
             {
@@ -3644,7 +3643,7 @@ class spell_gen_wg_water : public SpellScriptLoader
 
         class spell_gen_wg_water_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_wg_water_SpellScript);
+            PrepareSpellScript(spell_gen_wg_water_SpellScript)
 
             SpellCastResult CheckCast()
             {
@@ -3677,7 +3676,7 @@ class spell_gen_whisper_gulch_yogg_saron_whisper : public SpellScriptLoader
 
         class spell_gen_whisper_gulch_yogg_saron_whisper_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_whisper_gulch_yogg_saron_whisper_AuraScript);
+            PrepareAuraScript(spell_gen_whisper_gulch_yogg_saron_whisper_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -3711,7 +3710,7 @@ class spell_gen_eject_all_passengers : public SpellScriptLoader
 
         class spell_gen_eject_all_passengers_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_gen_eject_all_passengers_SpellScript);
+            PrepareSpellScript(spell_gen_eject_all_passengers_SpellScript)
 
             void RemoveVehicleAuras()
             {

--- a/src/server/scripts/Spells/spell_holiday.cpp
+++ b/src/server/scripts/Spells/spell_holiday.cpp
@@ -48,7 +48,7 @@ class spell_love_is_in_the_air_romantic_picnic : public SpellScriptLoader
 
         class spell_love_is_in_the_air_romantic_picnic_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_love_is_in_the_air_romantic_picnic_AuraScript);
+            PrepareAuraScript(spell_love_is_in_the_air_romantic_picnic_AuraScript)
 
             void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -134,7 +134,7 @@ class spell_hallow_end_trick : public SpellScriptLoader
 
         class spell_hallow_end_trick_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hallow_end_trick_SpellScript);
+            PrepareSpellScript(spell_hallow_end_trick_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -207,7 +207,7 @@ class spell_hallow_end_trick_or_treat : public SpellScriptLoader
 
         class spell_hallow_end_trick_or_treat_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hallow_end_trick_or_treat_SpellScript);
+            PrepareSpellScript(spell_hallow_end_trick_or_treat_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -245,7 +245,7 @@ class spell_hallow_end_tricky_treat : public SpellScriptLoader
 
         class spell_hallow_end_tricky_treat_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hallow_end_tricky_treat_SpellScript);
+            PrepareSpellScript(spell_hallow_end_tricky_treat_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -347,7 +347,7 @@ class spell_winter_veil_mistletoe : public SpellScriptLoader
 
         class spell_winter_veil_mistletoe_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_winter_veil_mistletoe_SpellScript);
+            PrepareSpellScript(spell_winter_veil_mistletoe_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -395,7 +395,7 @@ class spell_winter_veil_px_238_winter_wondervolt : public SpellScriptLoader
 
         class spell_winter_veil_px_238_winter_wondervolt_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_winter_veil_px_238_winter_wondervolt_SpellScript);
+            PrepareSpellScript(spell_winter_veil_px_238_winter_wondervolt_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -65,7 +65,7 @@ class spell_hun_aspect_of_the_beast : public SpellScriptLoader
 
         class spell_hun_aspect_of_the_beast_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_aspect_of_the_beast_AuraScript);
+            PrepareAuraScript(spell_hun_aspect_of_the_beast_AuraScript)
 
             bool Load() override
             {
@@ -114,7 +114,7 @@ class spell_hun_ascpect_of_the_viper : public SpellScriptLoader
 
         class spell_hun_ascpect_of_the_viper_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_ascpect_of_the_viper_AuraScript);
+            PrepareAuraScript(spell_hun_ascpect_of_the_viper_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -175,7 +175,7 @@ class spell_hun_chimera_shot : public SpellScriptLoader
 
         class spell_hun_chimera_shot_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_chimera_shot_SpellScript);
+            PrepareSpellScript(spell_hun_chimera_shot_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -268,7 +268,7 @@ class spell_hun_disengage : public SpellScriptLoader
 
         class spell_hun_disengage_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_disengage_SpellScript);
+            PrepareSpellScript(spell_hun_disengage_SpellScript)
 
             SpellCastResult CheckCast()
             {
@@ -299,7 +299,7 @@ class spell_hun_improved_mend_pet : public SpellScriptLoader
 
         class spell_hun_improved_mend_pet_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_improved_mend_pet_AuraScript);
+            PrepareAuraScript(spell_hun_improved_mend_pet_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -339,7 +339,7 @@ class spell_hun_invigoration : public SpellScriptLoader
 
         class spell_hun_invigoration_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_invigoration_SpellScript);
+            PrepareSpellScript(spell_hun_invigoration_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -376,7 +376,7 @@ class spell_hun_last_stand_pet : public SpellScriptLoader
 
         class spell_hun_last_stand_pet_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_last_stand_pet_SpellScript);
+            PrepareSpellScript(spell_hun_last_stand_pet_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -412,7 +412,7 @@ class spell_hun_masters_call : public SpellScriptLoader
 
         class spell_hun_masters_call_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_masters_call_SpellScript);
+            PrepareSpellScript(spell_hun_masters_call_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -464,7 +464,7 @@ class spell_hun_misdirection : public SpellScriptLoader
 
         class spell_hun_misdirection_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_misdirection_AuraScript);
+            PrepareAuraScript(spell_hun_misdirection_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -512,7 +512,7 @@ class spell_hun_misdirection_proc : public SpellScriptLoader
 
         class spell_hun_misdirection_proc_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_misdirection_proc_AuraScript);
+            PrepareAuraScript(spell_hun_misdirection_proc_AuraScript)
 
             void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -539,7 +539,7 @@ class spell_hun_pet_carrion_feeder : public SpellScriptLoader
 
         class spell_hun_pet_carrion_feeder_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_pet_carrion_feeder_SpellScript);
+            PrepareSpellScript(spell_hun_pet_carrion_feeder_SpellScript)
 
             bool Load() override
             {
@@ -596,7 +596,7 @@ class spell_hun_pet_heart_of_the_phoenix : public SpellScriptLoader
 
         class spell_hun_pet_heart_of_the_phoenix_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_pet_heart_of_the_phoenix_SpellScript);
+            PrepareSpellScript(spell_hun_pet_heart_of_the_phoenix_SpellScript)
 
             bool Load() override
             {
@@ -643,7 +643,7 @@ class spell_hun_readiness : public SpellScriptLoader
 
         class spell_hun_readiness_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_readiness_SpellScript);
+            PrepareSpellScript(spell_hun_readiness_SpellScript)
 
             bool Load() override
             {
@@ -692,7 +692,7 @@ class spell_hun_scatter_shot : public SpellScriptLoader
 
         class spell_hun_scatter_shot_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_scatter_shot_SpellScript);
+            PrepareSpellScript(spell_hun_scatter_shot_SpellScript)
 
             bool Load() override
             {
@@ -728,7 +728,7 @@ class spell_hun_sniper_training : public SpellScriptLoader
 
         class spell_hun_sniper_training_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_sniper_training_AuraScript);
+            PrepareAuraScript(spell_hun_sniper_training_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -782,7 +782,7 @@ class spell_hun_tame_beast : public SpellScriptLoader
 
         class spell_hun_tame_beast_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_tame_beast_SpellScript);
+            PrepareSpellScript(spell_hun_tame_beast_SpellScript)
 
             SpellCastResult CheckCast()
             {
@@ -835,7 +835,7 @@ class spell_hun_target_only_pet_and_owner : public SpellScriptLoader
 
         class spell_hun_target_only_pet_and_owner_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_hun_target_only_pet_and_owner_SpellScript);
+            PrepareSpellScript(spell_hun_target_only_pet_and_owner_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -866,7 +866,7 @@ class spell_hun_viper_attack_speed : public SpellScriptLoader
 
         class spell_hun_viper_attack_speed_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_hun_viper_attack_speed_AuraScript);
+            PrepareAuraScript(spell_hun_viper_attack_speed_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -40,7 +40,7 @@ class spell_item_trigger_spell : public SpellScriptLoader
 
         class spell_item_trigger_spell_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_trigger_spell_SpellScript);
+            PrepareSpellScript(spell_item_trigger_spell_SpellScript)
         private:
             uint32 _triggeredSpellId;
 
@@ -86,7 +86,7 @@ class spell_item_aegis_of_preservation : public SpellScriptLoader
 
         class spell_item_aegis_of_preservation_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_aegis_of_preservation_AuraScript);
+            PrepareAuraScript(spell_item_aegis_of_preservation_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -121,7 +121,7 @@ class spell_item_arcane_shroud : public SpellScriptLoader
 
         class spell_item_arcane_shroud_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_arcane_shroud_AuraScript);
+            PrepareAuraScript(spell_item_arcane_shroud_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -155,7 +155,7 @@ class spell_item_blessing_of_ancient_kings : public SpellScriptLoader
 
         class spell_item_blessing_of_ancient_kings_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_blessing_of_ancient_kings_AuraScript);
+            PrepareAuraScript(spell_item_blessing_of_ancient_kings_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -215,7 +215,7 @@ class spell_item_defibrillate : public SpellScriptLoader
 
         class spell_item_defibrillate_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_defibrillate_SpellScript);
+            PrepareSpellScript(spell_item_defibrillate_SpellScript)
 
         public:
             spell_item_defibrillate_SpellScript(uint8 chance, uint32 failSpell) : SpellScript(), _chance(chance), _failSpell(failSpell) { }
@@ -270,7 +270,7 @@ class spell_item_desperate_defense : public SpellScriptLoader
 
         class spell_item_desperate_defense_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_desperate_defense_AuraScript);
+            PrepareAuraScript(spell_item_desperate_defense_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -315,7 +315,7 @@ class spell_item_deviate_fish : public SpellScriptLoader
 
         class spell_item_deviate_fish_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_deviate_fish_SpellScript);
+            PrepareSpellScript(spell_item_deviate_fish_SpellScript)
 
             bool Load() override
             {
@@ -357,7 +357,7 @@ class spell_item_echoes_of_light : public SpellScriptLoader
 
         class spell_item_echoes_of_light_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_echoes_of_light_SpellScript);
+            PrepareSpellScript(spell_item_echoes_of_light_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -399,7 +399,7 @@ class spell_item_flask_of_the_north : public SpellScriptLoader
 
         class spell_item_flask_of_the_north_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_flask_of_the_north_SpellScript);
+            PrepareSpellScript(spell_item_flask_of_the_north_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -468,7 +468,7 @@ class spell_item_gnomish_death_ray : public SpellScriptLoader
 
         class spell_item_gnomish_death_ray_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_gnomish_death_ray_SpellScript);
+            PrepareSpellScript(spell_item_gnomish_death_ray_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -519,7 +519,7 @@ class spell_item_make_a_wish : public SpellScriptLoader
 
         class spell_item_make_a_wish_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_make_a_wish_SpellScript);
+            PrepareSpellScript(spell_item_make_a_wish_SpellScript)
 
             bool Load() override
             {
@@ -568,7 +568,7 @@ class spell_item_mingos_fortune_generator : public SpellScriptLoader
 
         class spell_item_mingos_fortune_generator_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_mingos_fortune_generator_SpellScript);
+            PrepareSpellScript(spell_item_mingos_fortune_generator_SpellScript)
 
             void HandleDummy(SpellEffIndex effIndex)
             {
@@ -628,7 +628,7 @@ class spell_item_necrotic_touch : public SpellScriptLoader
 
         class spell_item_necrotic_touch_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_necrotic_touch_AuraScript);
+            PrepareAuraScript(spell_item_necrotic_touch_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -678,7 +678,7 @@ class spell_item_net_o_matic : public SpellScriptLoader
 
         class spell_item_net_o_matic_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_net_o_matic_SpellScript);
+            PrepareSpellScript(spell_item_net_o_matic_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -730,7 +730,7 @@ class spell_item_noggenfogger_elixir : public SpellScriptLoader
 
         class spell_item_noggenfogger_elixir_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_noggenfogger_elixir_SpellScript);
+            PrepareSpellScript(spell_item_noggenfogger_elixir_SpellScript)
 
             bool Load() override
             {
@@ -777,7 +777,7 @@ class spell_item_piccolo_of_the_flaming_fire : public SpellScriptLoader
 
         class spell_item_piccolo_of_the_flaming_fire_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_piccolo_of_the_flaming_fire_SpellScript);
+            PrepareSpellScript(spell_item_piccolo_of_the_flaming_fire_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -815,7 +815,7 @@ class spell_item_savory_deviate_delight : public SpellScriptLoader
 
         class spell_item_savory_deviate_delight_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_savory_deviate_delight_SpellScript);
+            PrepareSpellScript(spell_item_savory_deviate_delight_SpellScript)
 
             bool Load() override
             {
@@ -876,7 +876,7 @@ class spell_item_scroll_of_recall : public SpellScriptLoader
 
         class spell_item_scroll_of_recall_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_scroll_of_recall_SpellScript);
+            PrepareSpellScript(spell_item_scroll_of_recall_SpellScript)
 
             bool Load() override
             {
@@ -943,7 +943,7 @@ class spell_item_unsated_craving : public SpellScriptLoader
 
         class spell_item_unsated_craving_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_unsated_craving_AuraScript);
+            PrepareAuraScript(spell_item_unsated_craving_AuraScript)
 
             bool CheckProc(ProcEventInfo& procInfo)
             {
@@ -977,7 +977,7 @@ class spell_item_shadows_fate : public SpellScriptLoader
 
         class spell_item_shadows_fate_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_shadows_fate_AuraScript);
+            PrepareAuraScript(spell_item_shadows_fate_AuraScript)
 
             void HandleProc(ProcEventInfo& procInfo)
             {
@@ -1018,7 +1018,7 @@ class spell_item_shadowmourne : public SpellScriptLoader
 
         class spell_item_shadowmourne_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_shadowmourne_AuraScript);
+            PrepareAuraScript(spell_item_shadowmourne_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1075,7 +1075,7 @@ class spell_item_shadowmourne_soul_fragment : public SpellScriptLoader
 
         class spell_item_shadowmourne_soul_fragment_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_shadowmourne_soul_fragment_AuraScript);
+            PrepareAuraScript(spell_item_shadowmourne_soul_fragment_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1144,7 +1144,7 @@ class spell_item_six_demon_bag : public SpellScriptLoader
 
         class spell_item_six_demon_bag_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_six_demon_bag_SpellScript);
+            PrepareSpellScript(spell_item_six_demon_bag_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1204,7 +1204,7 @@ class spell_item_the_eye_of_diminution : public SpellScriptLoader
 
         class spell_item_the_eye_of_diminution_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_item_the_eye_of_diminution_AuraScript);
+            PrepareAuraScript(spell_item_the_eye_of_diminution_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -1241,7 +1241,7 @@ class spell_item_underbelly_elixir : public SpellScriptLoader
 
         class spell_item_underbelly_elixir_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_underbelly_elixir_SpellScript);
+            PrepareSpellScript(spell_item_underbelly_elixir_SpellScript)
 
             bool Load() override
             {
@@ -1292,7 +1292,7 @@ class spell_item_red_rider_air_rifle : public SpellScriptLoader
 
         class spell_item_red_rider_air_rifle_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_red_rider_air_rifle_SpellScript);
+            PrepareSpellScript(spell_item_red_rider_air_rifle_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1357,7 +1357,7 @@ class spell_item_create_heart_candy : public SpellScriptLoader
 
         class spell_item_create_heart_candy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_create_heart_candy_SpellScript);
+            PrepareSpellScript(spell_item_create_heart_candy_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -1388,7 +1388,7 @@ class spell_item_book_of_glyph_mastery : public SpellScriptLoader
 
         class spell_item_book_of_glyph_mastery_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_book_of_glyph_mastery_SpellScript);
+            PrepareSpellScript(spell_item_book_of_glyph_mastery_SpellScript)
 
             bool Load() override
             {
@@ -1442,7 +1442,7 @@ class spell_item_gift_of_the_harvester : public SpellScriptLoader
 
         class spell_item_gift_of_the_harvester_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_gift_of_the_harvester_SpellScript);
+            PrepareSpellScript(spell_item_gift_of_the_harvester_SpellScript)
 
             SpellCastResult CheckRequirement()
             {
@@ -1483,7 +1483,7 @@ class spell_item_map_of_the_geyser_fields : public SpellScriptLoader
 
         class spell_item_map_of_the_geyser_fields_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_map_of_the_geyser_fields_SpellScript);
+            PrepareSpellScript(spell_item_map_of_the_geyser_fields_SpellScript)
 
             SpellCastResult CheckSinkholes()
             {
@@ -1523,7 +1523,7 @@ class spell_item_vanquished_clutches : public SpellScriptLoader
 
         class spell_item_vanquished_clutches_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_vanquished_clutches_SpellScript);
+            PrepareSpellScript(spell_item_vanquished_clutches_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1574,7 +1574,7 @@ class spell_item_ashbringer : public SpellScriptLoader
 
         class spell_item_ashbringer_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_ashbringer_SpellScript);
+            PrepareSpellScript(spell_item_ashbringer_SpellScript)
 
             bool Load() override
             {
@@ -1623,7 +1623,7 @@ class spell_magic_eater_food : public SpellScriptLoader
 
         class spell_magic_eater_food_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_magic_eater_food_AuraScript);
+            PrepareAuraScript(spell_magic_eater_food_AuraScript)
 
             void HandleTriggerSpell(AuraEffect const* /*aurEff*/)
             {
@@ -1671,7 +1671,7 @@ class spell_item_shimmering_vessel : public SpellScriptLoader
 
         class spell_item_shimmering_vessel_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_shimmering_vessel_SpellScript);
+            PrepareSpellScript(spell_item_shimmering_vessel_SpellScript)
 
             void HandleDummy(SpellEffIndex /* effIndex */)
             {
@@ -1704,7 +1704,7 @@ class spell_item_purify_helboar_meat : public SpellScriptLoader
 
         class spell_item_purify_helboar_meat_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_purify_helboar_meat_SpellScript);
+            PrepareSpellScript(spell_item_purify_helboar_meat_SpellScript)
 
             bool Load() override
             {
@@ -1748,7 +1748,7 @@ class spell_item_crystal_prison_dummy_dnd : public SpellScriptLoader
 
         class spell_item_crystal_prison_dummy_dnd_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_crystal_prison_dummy_dnd_SpellScript);
+            PrepareSpellScript(spell_item_crystal_prison_dummy_dnd_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1795,7 +1795,7 @@ class spell_item_reindeer_transformation : public SpellScriptLoader
 
         class spell_item_reindeer_transformation_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_reindeer_transformation_SpellScript);
+            PrepareSpellScript(spell_item_reindeer_transformation_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1860,7 +1860,7 @@ class spell_item_nigh_invulnerability : public SpellScriptLoader
 
         class spell_item_nigh_invulnerability_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_nigh_invulnerability_SpellScript);
+            PrepareSpellScript(spell_item_nigh_invulnerability_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1906,7 +1906,7 @@ class spell_item_poultryizer : public SpellScriptLoader
 
         class spell_item_poultryizer_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_poultryizer_SpellScript);
+            PrepareSpellScript(spell_item_poultryizer_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1946,7 +1946,7 @@ class spell_item_socrethars_stone : public SpellScriptLoader
 
         class spell_item_socrethars_stone_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_socrethars_stone_SpellScript);
+            PrepareSpellScript(spell_item_socrethars_stone_SpellScript)
 
             bool Load() override
             {
@@ -2001,7 +2001,7 @@ class spell_item_demon_broiled_surprise : public SpellScriptLoader
 
         class spell_item_demon_broiled_surprise_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_demon_broiled_surprise_SpellScript);
+            PrepareSpellScript(spell_item_demon_broiled_surprise_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2058,7 +2058,7 @@ class spell_item_complete_raptor_capture : public SpellScriptLoader
 
         class spell_item_complete_raptor_capture_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_complete_raptor_capture_SpellScript);
+            PrepareSpellScript(spell_item_complete_raptor_capture_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2104,7 +2104,7 @@ class spell_item_impale_leviroth : public SpellScriptLoader
 
         class spell_item_impale_leviroth_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_impale_leviroth_SpellScript);
+            PrepareSpellScript(spell_item_impale_leviroth_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2149,7 +2149,7 @@ class spell_item_brewfest_mount_transformation : public SpellScriptLoader
 
         class spell_item_brewfest_mount_transformation_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_brewfest_mount_transformation_SpellScript);
+            PrepareSpellScript(spell_item_brewfest_mount_transformation_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2212,7 +2212,7 @@ class spell_item_nitro_boots : public SpellScriptLoader
 
         class spell_item_nitro_boots_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_nitro_boots_SpellScript);
+            PrepareSpellScript(spell_item_nitro_boots_SpellScript)
 
             bool Load() override
             {
@@ -2259,7 +2259,7 @@ class spell_item_teach_language : public SpellScriptLoader
 
         class spell_item_teach_language_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_teach_language_SpellScript);
+            PrepareSpellScript(spell_item_teach_language_SpellScript)
 
             bool Load() override
             {
@@ -2305,7 +2305,7 @@ class spell_item_rocket_boots : public SpellScriptLoader
 
         class spell_item_rocket_boots_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_rocket_boots_SpellScript);
+            PrepareSpellScript(spell_item_rocket_boots_SpellScript)
 
             bool Load() override
             {
@@ -2362,7 +2362,7 @@ class spell_item_pygmy_oil : public SpellScriptLoader
 
         class spell_item_pygmy_oil_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_pygmy_oil_SpellScript);
+            PrepareSpellScript(spell_item_pygmy_oil_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2408,7 +2408,7 @@ class spell_item_unusual_compass : public SpellScriptLoader
 
         class spell_item_unusual_compass_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_unusual_compass_SpellScript);
+            PrepareSpellScript(spell_item_unusual_compass_SpellScript)
 
             void HandleDummy(SpellEffIndex /* effIndex */)
             {
@@ -2443,7 +2443,7 @@ class spell_item_chicken_cover : public SpellScriptLoader
 
         class spell_item_chicken_cover_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_chicken_cover_SpellScript);
+            PrepareSpellScript(spell_item_chicken_cover_SpellScript)
 
             bool Load() override
             {
@@ -2496,7 +2496,7 @@ class spell_item_refocus : public SpellScriptLoader
 
         class spell_item_refocus_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_refocus_SpellScript);
+            PrepareSpellScript(spell_item_refocus_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -2534,7 +2534,7 @@ class spell_item_muisek_vessel : public SpellScriptLoader
 
         class spell_item_muisek_vessel_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_item_muisek_vessel_SpellScript);
+            PrepareSpellScript(spell_item_muisek_vessel_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -2566,7 +2566,7 @@ public:
 
     class spell_item_greatmothers_soulcatcher_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_item_greatmothers_soulcatcher_SpellScript);
+        PrepareSpellScript(spell_item_greatmothers_soulcatcher_SpellScript)
 
         void HandleDummy(SpellEffIndex /*effIndex*/)
         {

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -82,7 +82,7 @@ class spell_mage_blast_wave : public SpellScriptLoader
 
         class spell_mage_blast_wave_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mage_blast_wave_SpellScript);
+            PrepareSpellScript(spell_mage_blast_wave_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -117,7 +117,7 @@ class spell_mage_burnout : public SpellScriptLoader
 
         class spell_mage_burnout_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mage_burnout_AuraScript);
+            PrepareAuraScript(spell_mage_burnout_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -162,7 +162,7 @@ class spell_mage_cold_snap : public SpellScriptLoader
 
         class spell_mage_cold_snap_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mage_cold_snap_SpellScript);
+            PrepareSpellScript(spell_mage_cold_snap_SpellScript)
 
             bool Load() override
             {
@@ -210,7 +210,7 @@ class spell_mage_fire_frost_ward : public SpellScriptLoader
 
         class spell_mage_fire_frost_ward_AuraScript : public spell_mage_incanters_absorbtion_base_AuraScript
         {
-            PrepareAuraScript(spell_mage_fire_frost_ward_AuraScript);
+            PrepareAuraScript(spell_mage_fire_frost_ward_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -276,7 +276,7 @@ class spell_mage_focus_magic : public SpellScriptLoader
 
         class spell_mage_focus_magic_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mage_focus_magic_AuraScript);
+            PrepareAuraScript(spell_mage_focus_magic_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -327,7 +327,7 @@ class spell_mage_ice_barrier : public SpellScriptLoader
 
         class spell_mage_ice_barrier_AuraScript : public spell_mage_incanters_absorbtion_base_AuraScript
         {
-            PrepareAuraScript(spell_mage_ice_barrier_AuraScript);
+            PrepareAuraScript(spell_mage_ice_barrier_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& canBeRecalculated)
             {
@@ -370,7 +370,7 @@ class spell_mage_ignite : public SpellScriptLoader
 
         class spell_mage_ignite_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mage_ignite_AuraScript);
+            PrepareAuraScript(spell_mage_ignite_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -417,7 +417,7 @@ class spell_mage_living_bomb : public SpellScriptLoader
 
         class spell_mage_living_bomb_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mage_living_bomb_AuraScript);
+            PrepareAuraScript(spell_mage_living_bomb_AuraScript)
 
             bool Validate(SpellInfo const* spell) override
             {
@@ -456,7 +456,7 @@ class spell_mage_mana_shield : public SpellScriptLoader
 
         class spell_mage_mana_shield_AuraScript : public spell_mage_incanters_absorbtion_base_AuraScript
         {
-            PrepareAuraScript(spell_mage_mana_shield_AuraScript);
+            PrepareAuraScript(spell_mage_mana_shield_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
             {
@@ -494,7 +494,7 @@ class spell_mage_master_of_elements : public SpellScriptLoader
 
         class spell_mage_master_of_elements_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_mage_master_of_elements_AuraScript);
+            PrepareAuraScript(spell_mage_master_of_elements_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -546,7 +546,7 @@ class spell_mage_polymorph_cast_visual : public SpellScriptLoader
 
         class spell_mage_polymorph_cast_visual_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mage_polymorph_cast_visual_SpellScript);
+            PrepareSpellScript(spell_mage_polymorph_cast_visual_SpellScript)
 
             static const uint32 PolymorhForms[6];
 
@@ -596,7 +596,7 @@ class spell_mage_summon_water_elemental : public SpellScriptLoader
 
         class spell_mage_summon_water_elemental_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mage_summon_water_elemental_SpellScript);
+            PrepareSpellScript(spell_mage_summon_water_elemental_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -97,7 +97,7 @@ class spell_pal_ardent_defender : public SpellScriptLoader
 
         class spell_pal_ardent_defender_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_ardent_defender_AuraScript);
+            PrepareAuraScript(spell_pal_ardent_defender_AuraScript)
 
             uint32 absorbPct, healPct;
 
@@ -173,7 +173,7 @@ class spell_pal_aura_mastery : public SpellScriptLoader
 
         class spell_pal_aura_mastery_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_aura_mastery_AuraScript);
+            PrepareAuraScript(spell_pal_aura_mastery_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -213,7 +213,7 @@ class spell_pal_aura_mastery_immune : public SpellScriptLoader
 
         class spell_pal_aura_mastery_immune_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_aura_mastery_immune_AuraScript);
+            PrepareAuraScript(spell_pal_aura_mastery_immune_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -247,7 +247,7 @@ class spell_pal_avenging_wrath : public SpellScriptLoader
 
         class spell_pal_avenging_wrath_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_avenging_wrath_AuraScript);
+            PrepareAuraScript(spell_pal_avenging_wrath_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -293,7 +293,7 @@ class spell_pal_blessing_of_faith : public SpellScriptLoader
 
         class spell_pal_blessing_of_faith_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_blessing_of_faith_SpellScript);
+            PrepareSpellScript(spell_pal_blessing_of_faith_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -350,7 +350,7 @@ class spell_pal_blessing_of_sanctuary : public SpellScriptLoader
 
         class spell_pal_blessing_of_sanctuary_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_blessing_of_sanctuary_AuraScript);
+            PrepareAuraScript(spell_pal_blessing_of_sanctuary_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -408,7 +408,7 @@ class spell_pal_divine_sacrifice : public SpellScriptLoader
 
         class spell_pal_divine_sacrifice_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_divine_sacrifice_AuraScript);
+            PrepareAuraScript(spell_pal_divine_sacrifice_AuraScript)
 
             uint32 groupSize, minHpPct;
             int32 remainingAmount;
@@ -463,7 +463,7 @@ class spell_pal_divine_storm : public SpellScriptLoader
 
         class spell_pal_divine_storm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_divine_storm_SpellScript);
+            PrepareSpellScript(spell_pal_divine_storm_SpellScript)
 
             uint32 healPct;
 
@@ -506,7 +506,7 @@ class spell_pal_divine_storm_dummy : public SpellScriptLoader
 
         class spell_pal_divine_storm_dummy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_divine_storm_dummy_SpellScript);
+            PrepareSpellScript(spell_pal_divine_storm_dummy_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -552,7 +552,7 @@ class spell_pal_exorcism_and_holy_wrath_damage : public SpellScriptLoader
 
         class spell_pal_exorcism_and_holy_wrath_damage_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_exorcism_and_holy_wrath_damage_AuraScript);
+            PrepareAuraScript(spell_pal_exorcism_and_holy_wrath_damage_AuraScript)
 
             void HandleEffectCalcSpellMod(AuraEffect const* aurEff, SpellModifier*& spellMod)
             {
@@ -588,7 +588,7 @@ class spell_pal_eye_for_an_eye : public SpellScriptLoader
 
         class spell_pal_eye_for_an_eye_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_eye_for_an_eye_AuraScript);
+            PrepareAuraScript(spell_pal_eye_for_an_eye_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -625,7 +625,7 @@ class spell_pal_glyph_of_holy_light : public SpellScriptLoader
 
         class spell_pal_glyph_of_holy_light_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_glyph_of_holy_light_SpellScript);
+            PrepareSpellScript(spell_pal_glyph_of_holy_light_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -658,7 +658,7 @@ class spell_pal_guarded_by_the_light : public SpellScriptLoader
 
         class spell_pal_guarded_by_the_light_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_guarded_by_the_light_SpellScript);
+            PrepareSpellScript(spell_pal_guarded_by_the_light_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -694,7 +694,7 @@ class spell_pal_hand_of_sacrifice : public SpellScriptLoader
 
         class spell_pal_hand_of_sacrifice_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_hand_of_sacrifice_AuraScript);
+            PrepareAuraScript(spell_pal_hand_of_sacrifice_AuraScript)
 
             int32 remainingAmount;
 
@@ -738,7 +738,7 @@ class spell_pal_hand_of_salvation : public SpellScriptLoader
 
         class spell_pal_hand_of_salvation_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_hand_of_salvation_AuraScript);
+            PrepareAuraScript(spell_pal_hand_of_salvation_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -771,7 +771,7 @@ class spell_pal_holy_shock : public SpellScriptLoader
 
         class spell_pal_holy_shock_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_holy_shock_SpellScript);
+            PrepareSpellScript(spell_pal_holy_shock_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -849,7 +849,7 @@ class spell_pal_improved_aura : public SpellScriptLoader
 
         class spell_pal_improved_aura_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_improved_aura_AuraScript);
+            PrepareAuraScript(spell_pal_improved_aura_AuraScript)
 
         public:
             spell_pal_improved_aura_AuraScript(uint32 spellId) : AuraScript(), _spellId(spellId) { }
@@ -910,7 +910,7 @@ class spell_pal_improved_aura_effect : public SpellScriptLoader
 
         class spell_pal_improved_aura_effect_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_improved_aura_effect_AuraScript);
+            PrepareAuraScript(spell_pal_improved_aura_effect_AuraScript)
 
             bool CheckAreaTarget(Unit* target)
             {
@@ -950,7 +950,7 @@ class spell_pal_item_healing_discount : public SpellScriptLoader
 
         class spell_pal_item_healing_discount_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_item_healing_discount_AuraScript);
+            PrepareAuraScript(spell_pal_item_healing_discount_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -987,7 +987,7 @@ class spell_pal_judgement : public SpellScriptLoader
 
         class spell_pal_judgement_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_judgement_SpellScript);
+            PrepareSpellScript(spell_pal_judgement_SpellScript)
 
         public:
             spell_pal_judgement_SpellScript(uint32 spellId) : SpellScript(), _spellId(spellId) { }
@@ -1046,7 +1046,7 @@ class spell_pal_judgement_of_command : public SpellScriptLoader
 
         class spell_pal_judgement_of_command_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_judgement_of_command_SpellScript);
+            PrepareSpellScript(spell_pal_judgement_of_command_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1075,7 +1075,7 @@ class spell_pal_lay_on_hands : public SpellScriptLoader
 
         class spell_pal_lay_on_hands_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_lay_on_hands_SpellScript);
+            PrepareSpellScript(spell_pal_lay_on_hands_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1131,7 +1131,7 @@ class spell_pal_righteous_defense : public SpellScriptLoader
 
         class spell_pal_righteous_defense_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pal_righteous_defense_SpellScript);
+            PrepareSpellScript(spell_pal_righteous_defense_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1195,7 +1195,7 @@ class spell_pal_sacred_shield : public SpellScriptLoader
 
         class spell_pal_sacred_shield_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_sacred_shield_AuraScript);
+            PrepareAuraScript(spell_pal_sacred_shield_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -1239,7 +1239,7 @@ class spell_pal_seal_of_righteousness : public SpellScriptLoader
 
         class spell_pal_seal_of_righteousness_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pal_seal_of_righteousness_AuraScript);
+            PrepareAuraScript(spell_pal_seal_of_righteousness_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_pet.cpp
+++ b/src/server/scripts/Spells/spell_pet.cpp
@@ -93,7 +93,7 @@ class spell_gen_pet_calculate : public SpellScriptLoader
 
         class spell_gen_pet_calculate_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_gen_pet_calculate_AuraScript);
+            PrepareAuraScript(spell_gen_pet_calculate_AuraScript)
 
             bool Load() override
             {
@@ -227,7 +227,7 @@ public:
 
     class spell_warl_pet_scaling_01_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_scaling_01_AuraScript);
+        PrepareAuraScript(spell_warl_pet_scaling_01_AuraScript)
 
         bool Load() override
         {
@@ -364,7 +364,7 @@ public:
 
     class spell_warl_pet_scaling_02_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_scaling_02_AuraScript);
+        PrepareAuraScript(spell_warl_pet_scaling_02_AuraScript)
 
         bool Load() override
         {
@@ -477,7 +477,7 @@ public:
 
     class spell_warl_pet_scaling_03_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_scaling_03_AuraScript);
+        PrepareAuraScript(spell_warl_pet_scaling_03_AuraScript)
 
         bool Load() override
         {
@@ -544,7 +544,7 @@ public:
 
     class spell_warl_pet_scaling_04_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_scaling_04_AuraScript);
+        PrepareAuraScript(spell_warl_pet_scaling_04_AuraScript)
 
         bool Load() override
         {
@@ -584,7 +584,7 @@ public:
 
     class spell_warl_pet_scaling_05_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_scaling_05_AuraScript);
+        PrepareAuraScript(spell_warl_pet_scaling_05_AuraScript)
 
         bool Load() override
         {
@@ -659,7 +659,7 @@ public:
 
     class spell_warl_pet_passive_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_passive_AuraScript);
+        PrepareAuraScript(spell_warl_pet_passive_AuraScript)
 
         bool Load() override
         {
@@ -732,7 +732,7 @@ public:
 
     class spell_warl_pet_passive_damage_done_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_passive_damage_done_AuraScript);
+        PrepareAuraScript(spell_warl_pet_passive_damage_done_AuraScript)
 
         bool Load() override
         {
@@ -783,7 +783,7 @@ public:
 
     class spell_warl_pet_passive_voidwalker_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_warl_pet_passive_voidwalker_AuraScript);
+        PrepareAuraScript(spell_warl_pet_passive_voidwalker_AuraScript)
 
         bool Load() override
         {
@@ -821,7 +821,7 @@ public:
 
     class spell_sha_pet_scaling_04_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_sha_pet_scaling_04_AuraScript);
+        PrepareAuraScript(spell_sha_pet_scaling_04_AuraScript)
 
         bool Load() override
         {
@@ -880,7 +880,7 @@ public:
 
     class spell_hun_pet_scaling_01_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_pet_scaling_01_AuraScript);
+        PrepareAuraScript(spell_hun_pet_scaling_01_AuraScript)
 
         void CalculateStaminaAmount(AuraEffect const* /* aurEff */, int32& amount, bool& /*canBeRecalculated*/)
         {
@@ -1006,7 +1006,7 @@ public:
 
     class spell_hun_pet_scaling_02_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_pet_scaling_02_AuraScript);
+        PrepareAuraScript(spell_hun_pet_scaling_02_AuraScript)
 
         bool Load() override
         {
@@ -1093,7 +1093,7 @@ public:
 
     class spell_hun_pet_scaling_03_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_pet_scaling_03_AuraScript);
+        PrepareAuraScript(spell_hun_pet_scaling_03_AuraScript)
 
         bool Load() override
         {
@@ -1180,7 +1180,7 @@ public:
 
     class spell_hun_pet_scaling_04_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_pet_scaling_04_AuraScript);
+        PrepareAuraScript(spell_hun_pet_scaling_04_AuraScript)
 
         bool Load() override
         {
@@ -1261,7 +1261,7 @@ public:
 
     class spell_hun_pet_passive_crit_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_pet_passive_crit_AuraScript);
+        PrepareAuraScript(spell_hun_pet_passive_crit_AuraScript)
 
         bool Load() override
         {
@@ -1332,7 +1332,7 @@ public:
 
     class spell_hun_pet_passive_damage_done_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_pet_passive_damage_done_AuraScript);
+        PrepareAuraScript(spell_hun_pet_passive_damage_done_AuraScript)
 
         bool Load() override
         {
@@ -1390,7 +1390,7 @@ public:
 
     class spell_hun_animal_handler_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_hun_animal_handler_AuraScript);
+        PrepareAuraScript(spell_hun_animal_handler_AuraScript)
 
         bool Load() override
         {
@@ -1432,7 +1432,7 @@ public:
 
     class spell_dk_avoidance_passive_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_dk_avoidance_passive_AuraScript);
+        PrepareAuraScript(spell_dk_avoidance_passive_AuraScript)
 
         bool Load() override
         {
@@ -1476,7 +1476,7 @@ public:
 
     class spell_dk_pet_scaling_01_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_dk_pet_scaling_01_AuraScript);
+        PrepareAuraScript(spell_dk_pet_scaling_01_AuraScript)
 
         bool Load() override
         {
@@ -1579,7 +1579,7 @@ public:
 
     class spell_dk_pet_scaling_02_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_dk_pet_scaling_02_AuraScript);
+        PrepareAuraScript(spell_dk_pet_scaling_02_AuraScript)
 
         bool Load() override
         {
@@ -1622,7 +1622,7 @@ public:
 
     class spell_dk_pet_scaling_03_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_dk_pet_scaling_03_AuraScript);
+        PrepareAuraScript(spell_dk_pet_scaling_03_AuraScript)
 
         bool Load() override
         {
@@ -1685,7 +1685,7 @@ public:
 
     class spell_dk_rune_weapon_scaling_02_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_dk_rune_weapon_scaling_02_AuraScript);
+        PrepareAuraScript(spell_dk_rune_weapon_scaling_02_AuraScript)
 
         bool Load() override
         {

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -96,7 +96,7 @@ class spell_pri_circle_of_healing : public SpellScriptLoader
 
         class spell_pri_circle_of_healing_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_circle_of_healing_SpellScript);
+            PrepareSpellScript(spell_pri_circle_of_healing_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -138,7 +138,7 @@ class spell_pri_divine_aegis : public SpellScriptLoader
 
         class spell_pri_divine_aegis_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_divine_aegis_AuraScript);
+            PrepareAuraScript(spell_pri_divine_aegis_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -188,7 +188,7 @@ class spell_pri_divine_hymn : public SpellScriptLoader
 
         class spell_pri_divine_hymn_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_divine_hymn_SpellScript);
+            PrepareSpellScript(spell_pri_divine_hymn_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -223,7 +223,7 @@ class spell_pri_glyph_of_prayer_of_healing : public SpellScriptLoader
 
         class spell_pri_glyph_of_prayer_of_healing_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_glyph_of_prayer_of_healing_AuraScript);
+            PrepareAuraScript(spell_pri_glyph_of_prayer_of_healing_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -261,7 +261,7 @@ class spell_pri_guardian_spirit : public SpellScriptLoader
 
         class spell_pri_guardian_spirit_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_guardian_spirit_AuraScript);
+            PrepareAuraScript(spell_pri_guardian_spirit_AuraScript)
 
             uint32 healPct;
 
@@ -318,7 +318,7 @@ class spell_pri_hymn_of_hope : public SpellScriptLoader
 
         class spell_pri_hymn_of_hope_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_hymn_of_hope_SpellScript);
+            PrepareSpellScript(spell_pri_hymn_of_hope_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -354,7 +354,7 @@ class spell_pri_item_greater_heal_refund : public SpellScriptLoader
 
         class spell_pri_item_greater_heal_refund_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_item_greater_heal_refund_AuraScript);
+            PrepareAuraScript(spell_pri_item_greater_heal_refund_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -389,7 +389,7 @@ class spell_pri_lightwell_renew : public SpellScriptLoader
 
         class spell_pri_lightwell_renew_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_lightwell_renew_AuraScript);
+            PrepareAuraScript(spell_pri_lightwell_renew_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
             {
@@ -421,7 +421,7 @@ class spell_pri_mana_burn : public SpellScriptLoader
 
         class spell_pri_mana_burn_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_mana_burn_SpellScript);
+            PrepareSpellScript(spell_pri_mana_burn_SpellScript)
 
             void HandleAfterHit()
             {
@@ -449,7 +449,7 @@ class spell_pri_mana_leech : public SpellScriptLoader
 
         class spell_pri_mana_leech_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_mana_leech_AuraScript);
+            PrepareAuraScript(spell_pri_mana_leech_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -500,7 +500,7 @@ class spell_pri_mind_sear : public SpellScriptLoader
 
         class spell_pri_mind_sear_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_mind_sear_SpellScript);
+            PrepareSpellScript(spell_pri_mind_sear_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -527,7 +527,7 @@ class spell_pri_pain_and_suffering_proc : public SpellScriptLoader
 
         class spell_pri_pain_and_suffering_proc_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_pain_and_suffering_proc_SpellScript);
+            PrepareSpellScript(spell_pri_pain_and_suffering_proc_SpellScript)
 
             void HandleEffectScriptEffect(SpellEffIndex /*effIndex*/)
             {
@@ -557,7 +557,7 @@ class spell_pri_penance : public SpellScriptLoader
 
         class spell_pri_penance_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_penance_SpellScript);
+            PrepareSpellScript(spell_pri_penance_SpellScript)
 
             bool Load() override
             {
@@ -630,7 +630,7 @@ class spell_pri_power_word_shield : public SpellScriptLoader
 
         class spell_pri_power_word_shield_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_power_word_shield_AuraScript);
+            PrepareAuraScript(spell_pri_power_word_shield_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -705,7 +705,7 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
 
         class spell_pri_prayer_of_mending_heal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript);
+            PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript)
 
             void HandleHeal(SpellEffIndex /*effIndex*/)
             {
@@ -740,7 +740,7 @@ class spell_pri_renew : public SpellScriptLoader
 
         class spell_pri_renew_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_renew_AuraScript);
+            PrepareAuraScript(spell_pri_renew_AuraScript)
 
             bool Load() override
             {
@@ -783,7 +783,7 @@ class spell_pri_shadow_word_death : public SpellScriptLoader
 
         class spell_pri_shadow_word_death_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_pri_shadow_word_death_SpellScript);
+            PrepareSpellScript(spell_pri_shadow_word_death_SpellScript)
 
             void HandleDamage()
             {
@@ -816,7 +816,7 @@ class spell_pri_vampiric_touch : public SpellScriptLoader
 
         class spell_pri_vampiric_touch_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_pri_vampiric_touch_AuraScript);
+            PrepareAuraScript(spell_pri_vampiric_touch_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -33,7 +33,7 @@
 
 class spell_generic_quest_update_entry_SpellScript : public SpellScript
 {
-    PrepareSpellScript(spell_generic_quest_update_entry_SpellScript);
+    PrepareSpellScript(spell_generic_quest_update_entry_SpellScript)
     private:
         uint16 _spellEffect;
         uint8 _effIndex;
@@ -99,7 +99,7 @@ class spell_q2203_thaumaturgy_channel : public SpellScriptLoader
 
         class spell_q2203_thaumaturgy_channel_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q2203_thaumaturgy_channel_AuraScript);
+            PrepareAuraScript(spell_q2203_thaumaturgy_channel_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -142,7 +142,7 @@ class spell_q5206_test_fetid_skull : public SpellScriptLoader
 
         class spell_q5206_test_fetid_skull_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q5206_test_fetid_skull_SpellScript);
+            PrepareSpellScript(spell_q5206_test_fetid_skull_SpellScript)
 
             bool Load() override
             {
@@ -194,7 +194,7 @@ class spell_q6124_6129_apply_salve : public SpellScriptLoader
 
         class spell_q6124_6129_apply_salve_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q6124_6129_apply_salve_SpellScript);
+            PrepareSpellScript(spell_q6124_6129_apply_salve_SpellScript)
 
             bool Load() override
             {
@@ -274,7 +274,7 @@ class spell_q11396_11399_force_shield_arcane_purple_x3 : public SpellScriptLoade
 
         class spell_q11396_11399_force_shield_arcane_purple_x3_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q11396_11399_force_shield_arcane_purple_x3_AuraScript);
+            PrepareAuraScript(spell_q11396_11399_force_shield_arcane_purple_x3_AuraScript)
 
             void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -310,7 +310,7 @@ class spell_q11396_11399_scourging_crystal_controller : public SpellScriptLoader
 
         class spell_q11396_11399_scourging_crystal_controller_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11396_11399_scourging_crystal_controller_SpellScript);
+            PrepareSpellScript(spell_q11396_11399_scourging_crystal_controller_SpellScript)
 
             bool Validate(SpellInfo const* /*spellEntry*/) override
             {
@@ -348,7 +348,7 @@ class spell_q11396_11399_scourging_crystal_controller_dummy : public SpellScript
 
         class spell_q11396_11399_scourging_crystal_controller_dummy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11396_11399_scourging_crystal_controller_dummy_SpellScript);
+            PrepareSpellScript(spell_q11396_11399_scourging_crystal_controller_dummy_SpellScript)
 
             bool Validate(SpellInfo const* /*spellEntry*/) override
             {
@@ -411,7 +411,7 @@ class spell_q11587_arcane_prisoner_rescue : public SpellScriptLoader
 
         class spell_q11587_arcane_prisoner_rescue_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11587_arcane_prisoner_rescue_SpellScript);
+            PrepareSpellScript(spell_q11587_arcane_prisoner_rescue_SpellScript)
 
             bool Validate(SpellInfo const* /*spellEntry*/) override
             {
@@ -469,7 +469,7 @@ class spell_q11730_ultrasonic_screwdriver : public SpellScriptLoader
 
         class spell_q11730_ultrasonic_screwdriver_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11730_ultrasonic_screwdriver_SpellScript);
+            PrepareSpellScript(spell_q11730_ultrasonic_screwdriver_SpellScript)
 
             bool Load() override
             {
@@ -539,7 +539,7 @@ class spell_q12459_seeds_of_natures_wrath : public SpellScriptLoader
 
         class spell_q12459_seeds_of_natures_wrath_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12459_seeds_of_natures_wrath_SpellScript);
+            PrepareSpellScript(spell_q12459_seeds_of_natures_wrath_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -586,7 +586,7 @@ class spell_q12634_despawn_fruit_tosser : public SpellScriptLoader
 
         class spell_q12634_despawn_fruit_tosser_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12634_despawn_fruit_tosser_SpellScript);
+            PrepareSpellScript(spell_q12634_despawn_fruit_tosser_SpellScript)
 
             bool Validate(SpellInfo const* /*spellEntry*/) override
             {
@@ -630,7 +630,7 @@ class spell_q12683_take_sputum_sample : public SpellScriptLoader
 
         class spell_q12683_take_sputum_sample_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12683_take_sputum_sample_SpellScript);
+            PrepareSpellScript(spell_q12683_take_sputum_sample_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -675,7 +675,7 @@ class spell_q12851_going_bearback : public SpellScriptLoader
 
         class spell_q12851_going_bearback_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q12851_going_bearback_AuraScript);
+            PrepareAuraScript(spell_q12851_going_bearback_AuraScript)
 
             void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -733,7 +733,7 @@ class spell_q12937_relief_for_the_fallen : public SpellScriptLoader
 
         class spell_q12937_relief_for_the_fallen_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12937_relief_for_the_fallen_SpellScript);
+            PrepareSpellScript(spell_q12937_relief_for_the_fallen_SpellScript)
 
             bool Load() override
             {
@@ -784,7 +784,7 @@ class spell_q10041_q10040_who_are_they : public SpellScriptLoader
 
         class spell_q10041_q10040_who_are_they_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q10041_q10040_who_are_they_SpellScript);
+            PrepareSpellScript(spell_q10041_q10040_who_are_they_SpellScript)
 
             bool Validate(SpellInfo const* /*spellEntry*/) override
             {
@@ -828,7 +828,7 @@ class spell_symbol_of_life_dummy : public SpellScriptLoader
 
         class spell_symbol_of_life_dummy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_symbol_of_life_dummy_SpellScript);
+            PrepareSpellScript(spell_symbol_of_life_dummy_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -871,7 +871,7 @@ class spell_q12659_ahunaes_knife : public SpellScriptLoader
 
         class spell_q12659_ahunaes_knife_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12659_ahunaes_knife_SpellScript);
+            PrepareSpellScript(spell_q12659_ahunaes_knife_SpellScript)
 
             bool Load() override
             {
@@ -915,7 +915,7 @@ class spell_q9874_liquid_fire : public SpellScriptLoader
 
         class spell_q9874_liquid_fire_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q9874_liquid_fire_SpellScript);
+            PrepareSpellScript(spell_q9874_liquid_fire_SpellScript)
 
             bool Load() override
             {
@@ -960,7 +960,7 @@ class spell_q12805_lifeblood_dummy : public SpellScriptLoader
 
         class spell_q12805_lifeblood_dummy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12805_lifeblood_dummy_SpellScript);
+            PrepareSpellScript(spell_q12805_lifeblood_dummy_SpellScript)
 
             bool Load() override
             {
@@ -1008,7 +1008,7 @@ class spell_q13280_13283_plant_battle_standard: public SpellScriptLoader
 
         class spell_q13280_13283_plant_battle_standard_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q13280_13283_plant_battle_standard_SpellScript);
+            PrepareSpellScript(spell_q13280_13283_plant_battle_standard_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1045,7 +1045,7 @@ class spell_q14112_14145_chum_the_water: public SpellScriptLoader
 
         class spell_q14112_14145_chum_the_water_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q14112_14145_chum_the_water_SpellScript);
+            PrepareSpellScript(spell_q14112_14145_chum_the_water_SpellScript)
 
             bool Validate(SpellInfo const* /*spellEntry*/) override
             {
@@ -1087,7 +1087,7 @@ class spell_q9452_cast_net: public SpellScriptLoader
 
         class spell_q9452_cast_net_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q9452_cast_net_SpellScript);
+            PrepareSpellScript(spell_q9452_cast_net_SpellScript)
 
             bool Load() override
             {
@@ -1130,7 +1130,7 @@ public:
 
     class spell_q12987_read_pronouncement_AuraScript : public AuraScript
     {
-        PrepareAuraScript(spell_q12987_read_pronouncement_AuraScript);
+        PrepareAuraScript(spell_q12987_read_pronouncement_AuraScript)
 
         void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
@@ -1171,7 +1171,7 @@ class spell_q12277_wintergarde_mine_explosion : public SpellScriptLoader
 
         class spell_q12277_wintergarde_mine_explosion_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12277_wintergarde_mine_explosion_SpellScript);
+            PrepareSpellScript(spell_q12277_wintergarde_mine_explosion_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1224,7 +1224,7 @@ public:
 
     class spell_q12066_bunny_kill_credit_SpellScript : public SpellScript
     {
-        PrepareSpellScript(spell_q12066_bunny_kill_credit_SpellScript);
+        PrepareSpellScript(spell_q12066_bunny_kill_credit_SpellScript)
 
         void HandleDummy(SpellEffIndex /*effIndex*/)
         {
@@ -1262,7 +1262,7 @@ class spell_q12735_song_of_cleansing : public SpellScriptLoader
 
         class spell_q12735_song_of_cleansing_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12735_song_of_cleansing_SpellScript);
+            PrepareSpellScript(spell_q12735_song_of_cleansing_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1307,7 +1307,7 @@ class spell_q12372_cast_from_gossip_trigger : public SpellScriptLoader
 
         class spell_q12372_cast_from_gossip_trigger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12372_cast_from_gossip_trigger_SpellScript);
+            PrepareSpellScript(spell_q12372_cast_from_gossip_trigger_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1343,7 +1343,7 @@ class spell_q12372_destabilize_azure_dragonshrine_dummy : public SpellScriptLoad
 
         class spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript);
+            PrepareSpellScript(spell_q12372_destabilize_azure_dragonshrine_dummy_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1375,7 +1375,7 @@ class spell_q12372_azure_on_death_force_whisper : public SpellScriptLoader
 
         class spell_q12372_azure_on_death_force_whisper_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12372_azure_on_death_force_whisper_SpellScript);
+            PrepareSpellScript(spell_q12372_azure_on_death_force_whisper_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -1414,7 +1414,7 @@ class spell_q11010_q11102_q11023_aggro_check_aura : public SpellScriptLoader
 
         class spell_q11010_q11102_q11023_aggro_check_aura_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q11010_q11102_q11023_aggro_check_aura_AuraScript);
+            PrepareAuraScript(spell_q11010_q11102_q11023_aggro_check_aura_AuraScript)
 
             void HandleTriggerSpell(AuraEffect const* /*aurEff*/)
             {
@@ -1443,7 +1443,7 @@ class spell_q11010_q11102_q11023_aggro_check : public SpellScriptLoader
 
         class spell_q11010_q11102_q11023_aggro_check_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11010_q11102_q11023_aggro_check_SpellScript);
+            PrepareSpellScript(spell_q11010_q11102_q11023_aggro_check_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1473,7 +1473,7 @@ class spell_q11010_q11102_q11023_aggro_burst : public SpellScriptLoader
 
         class spell_q11010_q11102_q11023_aggro_burst_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q11010_q11102_q11023_aggro_burst_AuraScript);
+            PrepareAuraScript(spell_q11010_q11102_q11023_aggro_burst_AuraScript)
 
             void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
             {
@@ -1502,7 +1502,7 @@ class spell_q11010_q11102_q11023_choose_loc : public SpellScriptLoader
 
         class spell_q11010_q11102_q11023_choose_loc_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11010_q11102_q11023_choose_loc_SpellScript);
+            PrepareSpellScript(spell_q11010_q11102_q11023_choose_loc_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1540,7 +1540,7 @@ class spell_q11010_q11102_q11023_q11008_check_fly_mount : public SpellScriptLoad
 
         class spell_q11010_q11102_q11023_q11008_check_fly_mount_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q11010_q11102_q11023_q11008_check_fly_mount_SpellScript);
+            PrepareSpellScript(spell_q11010_q11102_q11023_q11008_check_fly_mount_SpellScript)
 
             SpellCastResult CheckRequirement()
             {
@@ -1575,7 +1575,7 @@ class spell_q12527_zuldrak_rat : public SpellScriptLoader
 
         class spell_q12527_zuldrak_rat_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12527_zuldrak_rat_SpellScript);
+            PrepareSpellScript(spell_q12527_zuldrak_rat_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1614,7 +1614,7 @@ class spell_q12661_q12669_q12676_q12677_q12713_summon_stefan : public SpellScrip
 
         class spell_q12661_q12669_q12676_q12677_q12713_summon_stefan_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12661_q12669_q12676_q12677_q12713_summon_stefan_SpellScript);
+            PrepareSpellScript(spell_q12661_q12669_q12676_q12677_q12713_summon_stefan_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {
@@ -1647,7 +1647,7 @@ class spell_q12730_quenching_mist : public SpellScriptLoader
 
         class spell_q12730_quenching_mist_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q12730_quenching_mist_AuraScript);
+            PrepareAuraScript(spell_q12730_quenching_mist_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1690,7 +1690,7 @@ class spell_q13291_q13292_q13239_q13261_frostbrood_skytalon_grab_decoy : public 
 
         class spell_q13291_q13292_q13239_q13261_frostbrood_skytalon_grab_decoy_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q13291_q13292_q13239_q13261_frostbrood_skytalon_grab_decoy_SpellScript);
+            PrepareSpellScript(spell_q13291_q13292_q13239_q13261_frostbrood_skytalon_grab_decoy_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -1729,7 +1729,7 @@ class spell_q13291_q13292_q13239_q13261_armored_decoy_summon_skytalon : public S
 
         class spell_q13291_q13292_q13239_q13261_armored_decoy_summon_skytalon_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q13291_q13292_q13239_q13261_armored_decoy_summon_skytalon_SpellScript);
+            PrepareSpellScript(spell_q13291_q13292_q13239_q13261_armored_decoy_summon_skytalon_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {
@@ -1758,7 +1758,7 @@ class spell_q12847_summon_soul_moveto_bunny : public SpellScriptLoader
 
         class spell_q12847_summon_soul_moveto_bunny_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12847_summon_soul_moveto_bunny_SpellScript);
+            PrepareSpellScript(spell_q12847_summon_soul_moveto_bunny_SpellScript)
 
             void SetDest(SpellDestination& dest)
             {
@@ -1793,7 +1793,7 @@ class spell_q13011_bear_flank_master : public SpellScriptLoader
 
         class spell_q13011_bear_flank_master_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q13011_bear_flank_master_SpellScript);
+            PrepareSpellScript(spell_q13011_bear_flank_master_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1843,7 +1843,7 @@ class spell_q13086_cannons_target : public SpellScriptLoader
 
         class spell_q13086_cannons_target_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q13086_cannons_target_SpellScript);
+            PrepareSpellScript(spell_q13086_cannons_target_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -1894,7 +1894,7 @@ class spell_q12690_burst_at_the_seams : public SpellScriptLoader
 
         class spell_q12690_burst_at_the_seams_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12690_burst_at_the_seams_SpellScript);
+            PrepareSpellScript(spell_q12690_burst_at_the_seams_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -1970,7 +1970,7 @@ class spell_q12308_escape_from_silverbrook : public SpellScriptLoader
 
         class spell_q12308_escape_from_silverbrook_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12308_escape_from_silverbrook_SpellScript);
+            PrepareSpellScript(spell_q12308_escape_from_silverbrook_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2004,7 +2004,7 @@ class spell_q12308_escape_from_silverbrook_summon_worgen : public SpellScriptLoa
 
         class spell_q12308_escape_from_silverbrook_summon_worgen_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12308_escape_from_silverbrook_summon_worgen_SpellScript);
+            PrepareSpellScript(spell_q12308_escape_from_silverbrook_summon_worgen_SpellScript)
 
             void ModDest(SpellDestination& dest)
             {
@@ -2049,7 +2049,7 @@ class spell_q12641_death_comes_from_on_high : public SpellScriptLoader
 
         class spell_q12641_death_comes_from_on_high_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12641_death_comes_from_on_high_SpellScript);
+            PrepareSpellScript(spell_q12641_death_comes_from_on_high_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2106,7 +2106,7 @@ class spell_q12619_emblazon_runeblade : public SpellScriptLoader
 
         class spell_q12619_emblazon_runeblade_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_q12619_emblazon_runeblade_AuraScript);
+            PrepareAuraScript(spell_q12619_emblazon_runeblade_AuraScript)
 
             void HandleEffectPeriodic(AuraEffect const* aurEff)
             {
@@ -2135,7 +2135,7 @@ class spell_q12619_emblazon_runeblade_effect : public SpellScriptLoader
 
         class spell_q12619_emblazon_runeblade_effect_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12619_emblazon_runeblade_effect_SpellScript);
+            PrepareSpellScript(spell_q12619_emblazon_runeblade_effect_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2167,7 +2167,7 @@ class spell_q12919_gymers_grab : public SpellScriptLoader
 
         class spell_q12919_gymers_grab_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q12919_gymers_grab_SpellScript);
+            PrepareSpellScript(spell_q12919_gymers_grab_SpellScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -2209,7 +2209,7 @@ class spell_q12919_gymers_throw : public SpellScriptLoader
 
         class spell_q12919_gymers_throw_SpellScript : public SpellScript
         {
-           PrepareSpellScript(spell_q12919_gymers_throw_SpellScript);
+           PrepareSpellScript(spell_q12919_gymers_throw_SpellScript)
 
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
@@ -2246,7 +2246,7 @@ class spell_q13400_illidan_kill_master : public SpellScriptLoader
 
         class spell_q13400_illidan_kill_master_SpellScript : public SpellScript
         {
-           PrepareSpellScript(spell_q13400_illidan_kill_master_SpellScript);
+           PrepareSpellScript(spell_q13400_illidan_kill_master_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -2288,7 +2288,7 @@ class spell_q14100_q14111_make_player_destroy_totems : public SpellScriptLoader
 
         class spell_q14100_q14111_make_player_destroy_totems_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_q14100_q14111_make_player_destroy_totems_SpellScript);
+            PrepareSpellScript(spell_q14100_q14111_make_player_destroy_totems_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -50,7 +50,7 @@ class spell_rog_blade_flurry : public SpellScriptLoader
 
         class spell_rog_blade_flurry_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_blade_flurry_AuraScript);
+            PrepareAuraScript(spell_rog_blade_flurry_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -105,7 +105,7 @@ class spell_rog_cheat_death : public SpellScriptLoader
 
         class spell_rog_cheat_death_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_cheat_death_AuraScript);
+            PrepareAuraScript(spell_rog_cheat_death_AuraScript)
 
             uint32 absorbChance;
 
@@ -168,7 +168,7 @@ class spell_rog_deadly_poison : public SpellScriptLoader
 
         class spell_rog_deadly_poison_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rog_deadly_poison_SpellScript);
+            PrepareSpellScript(spell_rog_deadly_poison_SpellScript)
 
             bool Load() override
             {
@@ -263,7 +263,7 @@ class spell_rog_killing_spree : public SpellScriptLoader
 
         class spell_rog_killing_spree_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rog_killing_spree_SpellScript);
+            PrepareSpellScript(spell_rog_killing_spree_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -294,7 +294,7 @@ class spell_rog_killing_spree : public SpellScriptLoader
 
         class spell_rog_killing_spree_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_killing_spree_AuraScript);
+            PrepareAuraScript(spell_rog_killing_spree_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -362,7 +362,7 @@ class spell_rog_nerves_of_steel : public SpellScriptLoader
 
         class spell_rog_nerves_of_steel_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_nerves_of_steel_AuraScript);
+            PrepareAuraScript(spell_rog_nerves_of_steel_AuraScript)
 
             uint32 absorbPct;
 
@@ -406,7 +406,7 @@ class spell_rog_preparation : public SpellScriptLoader
 
         class spell_rog_preparation_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rog_preparation_SpellScript);
+            PrepareSpellScript(spell_rog_preparation_SpellScript)
 
             bool Load() override
             {
@@ -473,7 +473,7 @@ class spell_rog_prey_on_the_weak : public SpellScriptLoader
 
         class spell_rog_prey_on_the_weak_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_prey_on_the_weak_AuraScript);
+            PrepareAuraScript(spell_rog_prey_on_the_weak_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -518,7 +518,7 @@ class spell_rog_rupture : public SpellScriptLoader
 
         class spell_rog_rupture_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_rupture_AuraScript);
+            PrepareAuraScript(spell_rog_rupture_AuraScript)
 
             bool Load() override
             {
@@ -570,7 +570,7 @@ class spell_rog_shiv : public SpellScriptLoader
 
         class spell_rog_shiv_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_rog_shiv_SpellScript);
+            PrepareSpellScript(spell_rog_shiv_SpellScript)
 
             bool Load() override
             {
@@ -611,7 +611,7 @@ class spell_rog_tricks_of_the_trade : public SpellScriptLoader
 
         class spell_rog_tricks_of_the_trade_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_tricks_of_the_trade_AuraScript);
+            PrepareAuraScript(spell_rog_tricks_of_the_trade_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -675,7 +675,7 @@ class spell_rog_tricks_of_the_trade_proc : public SpellScriptLoader
 
         class spell_rog_tricks_of_the_trade_proc_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_rog_tricks_of_the_trade_proc_AuraScript);
+            PrepareAuraScript(spell_rog_tricks_of_the_trade_proc_AuraScript)
 
             void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -70,7 +70,7 @@ class spell_sha_ancestral_awakening_proc : public SpellScriptLoader
 
         class spell_sha_ancestral_awakening_proc_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_ancestral_awakening_proc_SpellScript);
+            PrepareSpellScript(spell_sha_ancestral_awakening_proc_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -119,7 +119,7 @@ class spell_sha_astral_shift : public SpellScriptLoader
 
         class spell_sha_astral_shift_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_astral_shift_AuraScript);
+            PrepareAuraScript(spell_sha_astral_shift_AuraScript)
 
             uint32 absorbPct;
 
@@ -163,7 +163,7 @@ class spell_sha_bloodlust : public SpellScriptLoader
 
         class spell_sha_bloodlust_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_bloodlust_SpellScript);
+            PrepareSpellScript(spell_sha_bloodlust_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -206,7 +206,7 @@ class spell_sha_chain_heal : public SpellScriptLoader
 
         class spell_sha_chain_heal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_chain_heal_SpellScript);
+            PrepareSpellScript(spell_sha_chain_heal_SpellScript)
 
             bool Load() override
             {
@@ -256,7 +256,7 @@ class spell_sha_cleansing_totem_pulse : public SpellScriptLoader
 
         class spell_sha_cleansing_totem_pulse_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_cleansing_totem_pulse_SpellScript);
+            PrepareSpellScript(spell_sha_cleansing_totem_pulse_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -292,7 +292,7 @@ class spell_sha_earth_shield : public SpellScriptLoader
 
         class spell_sha_earth_shield_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_earth_shield_AuraScript);
+            PrepareAuraScript(spell_sha_earth_shield_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -360,7 +360,7 @@ class spell_sha_earthbind_totem : public SpellScriptLoader
 
         class spell_sha_earthbind_totem_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_earthbind_totem_AuraScript);
+            PrepareAuraScript(spell_sha_earthbind_totem_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -432,7 +432,7 @@ class spell_sha_earthen_power : public SpellScriptLoader
 
         class spell_sha_earthen_power_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_earthen_power_SpellScript);
+            PrepareSpellScript(spell_sha_earthen_power_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -459,7 +459,7 @@ class spell_sha_fire_nova : public SpellScriptLoader
 
         class spell_sha_fire_nova_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_fire_nova_SpellScript);
+            PrepareSpellScript(spell_sha_fire_nova_SpellScript)
 
             bool Validate(SpellInfo const* spellInfo) override
             {
@@ -517,7 +517,7 @@ class spell_sha_flame_shock : public SpellScriptLoader
 
         class spell_sha_flame_shock_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_flame_shock_AuraScript);
+            PrepareAuraScript(spell_sha_flame_shock_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -563,7 +563,7 @@ class spell_sha_healing_stream_totem : public SpellScriptLoader
 
         class spell_sha_healing_stream_totem_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_healing_stream_totem_SpellScript);
+            PrepareSpellScript(spell_sha_healing_stream_totem_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -618,7 +618,7 @@ class spell_sha_heroism : public SpellScriptLoader
 
         class spell_sha_heroism_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_heroism_SpellScript);
+            PrepareSpellScript(spell_sha_heroism_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -661,7 +661,7 @@ class spell_sha_item_lightning_shield : public SpellScriptLoader
 
         class spell_sha_item_lightning_shield_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_item_lightning_shield_AuraScript);
+            PrepareAuraScript(spell_sha_item_lightning_shield_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -696,7 +696,7 @@ class spell_sha_item_lightning_shield_trigger : public SpellScriptLoader
 
         class spell_sha_item_lightning_shield_trigger_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_item_lightning_shield_trigger_AuraScript);
+            PrepareAuraScript(spell_sha_item_lightning_shield_trigger_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -731,7 +731,7 @@ class spell_sha_item_mana_surge : public SpellScriptLoader
 
         class spell_sha_item_mana_surge_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_item_mana_surge_AuraScript);
+            PrepareAuraScript(spell_sha_item_mana_surge_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -819,7 +819,7 @@ class spell_sha_mana_spring_totem : public SpellScriptLoader
 
         class spell_sha_mana_spring_totem_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_mana_spring_totem_SpellScript);
+            PrepareSpellScript(spell_sha_mana_spring_totem_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -858,7 +858,7 @@ class spell_sha_mana_tide_totem : public SpellScriptLoader
 
         class spell_sha_mana_tide_totem_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_mana_tide_totem_SpellScript);
+            PrepareSpellScript(spell_sha_mana_tide_totem_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -906,7 +906,7 @@ class spell_sha_sentry_totem : public SpellScriptLoader
 
         class spell_sha_sentry_totem_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_sha_sentry_totem_AuraScript);
+            PrepareAuraScript(spell_sha_sentry_totem_AuraScript)
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
@@ -951,7 +951,7 @@ class spell_sha_thunderstorm : public SpellScriptLoader
 
         class spell_sha_thunderstorm_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_sha_thunderstorm_SpellScript);
+            PrepareSpellScript(spell_sha_thunderstorm_SpellScript)
 
             void HandleKnockBack(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -69,7 +69,7 @@ class spell_warl_banish : public SpellScriptLoader
 
         class spell_warl_banish_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_banish_SpellScript);
+            PrepareSpellScript(spell_warl_banish_SpellScript)
 
             bool Load() override
             {
@@ -121,7 +121,7 @@ class spell_warl_create_healthstone : public SpellScriptLoader
 
         class spell_warl_create_healthstone_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_create_healthstone_SpellScript);
+            PrepareSpellScript(spell_warl_create_healthstone_SpellScript)
 
             static uint32 const iTypes[8][3];
 
@@ -204,7 +204,7 @@ class spell_warl_curse_of_doom : public SpellScriptLoader
 
         class spell_warl_curse_of_doom_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_curse_of_doom_AuraScript);
+            PrepareAuraScript(spell_warl_curse_of_doom_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -251,7 +251,7 @@ class spell_warl_demonic_circle_summon : public SpellScriptLoader
 
         class spell_warl_demonic_circle_summon_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_demonic_circle_summon_AuraScript);
+            PrepareAuraScript(spell_warl_demonic_circle_summon_AuraScript)
 
             void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes mode)
             {
@@ -303,7 +303,7 @@ class spell_warl_demonic_circle_teleport : public SpellScriptLoader
 
         class spell_warl_demonic_circle_teleport_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_demonic_circle_teleport_AuraScript);
+            PrepareAuraScript(spell_warl_demonic_circle_teleport_AuraScript)
 
             void HandleTeleport(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -337,7 +337,7 @@ class spell_warl_demonic_empowerment : public SpellScriptLoader
 
         class spell_warl_demonic_empowerment_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_demonic_empowerment_SpellScript);
+            PrepareSpellScript(spell_warl_demonic_empowerment_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -401,7 +401,7 @@ class spell_warl_everlasting_affliction : public SpellScriptLoader
 
         class spell_warl_everlasting_affliction_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_everlasting_affliction_SpellScript);
+            PrepareSpellScript(spell_warl_everlasting_affliction_SpellScript)
 
             void HandleScriptEffect(SpellEffIndex /*effIndex*/)
             {
@@ -431,7 +431,7 @@ class spell_warl_fel_synergy : public SpellScriptLoader
 
         class spell_warl_fel_synergy_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_fel_synergy_AuraScript);
+            PrepareAuraScript(spell_warl_fel_synergy_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -474,7 +474,7 @@ class spell_warl_glyph_of_shadowflame : public SpellScriptLoader
 
         class spell_warl_glyph_of_shadowflame_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_glyph_of_shadowflame_AuraScript);
+            PrepareAuraScript(spell_warl_glyph_of_shadowflame_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -509,7 +509,7 @@ class spell_warl_haunt : public SpellScriptLoader
 
         class spell_warl_haunt_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_haunt_SpellScript);
+            PrepareSpellScript(spell_warl_haunt_SpellScript)
 
             void HandleOnHit()
             {
@@ -526,7 +526,7 @@ class spell_warl_haunt : public SpellScriptLoader
 
         class spell_warl_haunt_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_haunt_AuraScript);
+            PrepareAuraScript(spell_warl_haunt_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -569,7 +569,7 @@ class spell_warl_health_funnel : public SpellScriptLoader
 
         class spell_warl_health_funnel_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_health_funnel_AuraScript);
+            PrepareAuraScript(spell_warl_health_funnel_AuraScript)
 
             void ApplyEffect(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
@@ -612,7 +612,7 @@ class spell_warl_life_tap : public SpellScriptLoader
 
         class spell_warl_life_tap_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_life_tap_SpellScript);
+            PrepareSpellScript(spell_warl_life_tap_SpellScript)
 
             bool Load() override
             {
@@ -684,7 +684,7 @@ class spell_warl_ritual_of_doom_effect : public SpellScriptLoader
 
         class spell_warl_ritual_of_doom_effect_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_ritual_of_doom_effect_SpellScript);
+            PrepareSpellScript(spell_warl_ritual_of_doom_effect_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -712,7 +712,7 @@ class spell_warl_seed_of_corruption : public SpellScriptLoader
 
         class spell_warl_seed_of_corruption_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_seed_of_corruption_SpellScript);
+            PrepareSpellScript(spell_warl_seed_of_corruption_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -740,7 +740,7 @@ class spell_warl_shadow_ward : public SpellScriptLoader
 
         class spell_warl_shadow_ward_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_shadow_ward_AuraScript);
+            PrepareAuraScript(spell_warl_shadow_ward_AuraScript)
 
             void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& canBeRecalculated)
             {
@@ -777,7 +777,7 @@ class spell_warl_siphon_life : public SpellScriptLoader
 
         class spell_warl_siphon_life_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_siphon_life_AuraScript);
+            PrepareAuraScript(spell_warl_siphon_life_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -826,7 +826,7 @@ class spell_warl_soulshatter : public SpellScriptLoader
 
         class spell_warl_soulshatter_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warl_soulshatter_SpellScript);
+            PrepareSpellScript(spell_warl_soulshatter_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -865,7 +865,7 @@ class spell_warl_unstable_affliction : public SpellScriptLoader
 
         class spell_warl_unstable_affliction_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warl_unstable_affliction_AuraScript);
+            PrepareAuraScript(spell_warl_unstable_affliction_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -78,7 +78,7 @@ class spell_warr_bloodthirst : public SpellScriptLoader
 
         class spell_warr_bloodthirst_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_bloodthirst_SpellScript);
+            PrepareSpellScript(spell_warr_bloodthirst_SpellScript)
 
             void HandleDamage(SpellEffIndex /*effIndex*/)
             {
@@ -120,7 +120,7 @@ class spell_warr_bloodthirst_heal : public SpellScriptLoader
 
         class spell_warr_bloodthirst_heal_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_bloodthirst_heal_SpellScript);
+            PrepareSpellScript(spell_warr_bloodthirst_heal_SpellScript)
 
             void HandleHeal(SpellEffIndex /*effIndex*/)
             {
@@ -148,7 +148,7 @@ class spell_warr_charge : public SpellScriptLoader
 
         class spell_warr_charge_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_charge_SpellScript);
+            PrepareSpellScript(spell_warr_charge_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -188,7 +188,7 @@ class spell_warr_concussion_blow : public SpellScriptLoader
 
         class spell_warr_concussion_blow_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_concussion_blow_SpellScript);
+            PrepareSpellScript(spell_warr_concussion_blow_SpellScript)
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -215,7 +215,7 @@ class spell_warr_damage_shield : public SpellScriptLoader
 
         class spell_warr_damage_shield_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warr_damage_shield_AuraScript);
+            PrepareAuraScript(spell_warr_damage_shield_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -253,7 +253,7 @@ class spell_warr_deep_wounds : public SpellScriptLoader
 
         class spell_warr_deep_wounds_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_deep_wounds_SpellScript);
+            PrepareSpellScript(spell_warr_deep_wounds_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -308,7 +308,7 @@ class spell_warr_execute : public SpellScriptLoader
 
         class spell_warr_execute_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_execute_SpellScript);
+            PrepareSpellScript(spell_warr_execute_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -364,7 +364,7 @@ class spell_warr_glyph_of_sunder_armor : public SpellScriptLoader
 
         class spell_warr_glyph_of_sunder_armor_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warr_glyph_of_sunder_armor_AuraScript);
+            PrepareAuraScript(spell_warr_glyph_of_sunder_armor_AuraScript)
 
             void HandleEffectCalcSpellMod(AuraEffect const* aurEff, SpellModifier*& spellMod)
             {
@@ -400,7 +400,7 @@ class spell_warr_improved_spell_reflection : public SpellScriptLoader
 
         class spell_warr_improved_spell_reflection_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_improved_spell_reflection_SpellScript);
+            PrepareSpellScript(spell_warr_improved_spell_reflection_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -428,7 +428,7 @@ class spell_warr_intimidating_shout : public SpellScriptLoader
 
         class spell_warr_intimidating_shout_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_intimidating_shout_SpellScript);
+            PrepareSpellScript(spell_warr_intimidating_shout_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& unitList)
             {
@@ -456,7 +456,7 @@ class spell_warr_last_stand : public SpellScriptLoader
 
         class spell_warr_last_stand_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_last_stand_SpellScript);
+            PrepareSpellScript(spell_warr_last_stand_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -492,7 +492,7 @@ class spell_warr_overpower : public SpellScriptLoader
 
         class spell_warr_overpower_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_overpower_SpellScript);
+            PrepareSpellScript(spell_warr_overpower_SpellScript)
 
             void HandleEffect(SpellEffIndex /*effIndex*/)
             {
@@ -530,7 +530,7 @@ class spell_warr_rend : public SpellScriptLoader
 
         class spell_warr_rend_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warr_rend_AuraScript);
+            PrepareAuraScript(spell_warr_rend_AuraScript)
 
             void CalculateAmount(AuraEffect const* aurEff, int32& amount, bool& canBeRecalculated)
             {
@@ -576,7 +576,7 @@ class spell_warr_retaliation : public SpellScriptLoader
 
         class spell_warr_retaliation_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warr_retaliation_AuraScript);
+            PrepareAuraScript(spell_warr_retaliation_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -618,7 +618,7 @@ class spell_warr_shattering_throw : public SpellScriptLoader
 
         class spell_warr_shattering_throw_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_shattering_throw_SpellScript);
+            PrepareSpellScript(spell_warr_shattering_throw_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {
@@ -649,7 +649,7 @@ class spell_warr_slam : public SpellScriptLoader
 
         class spell_warr_slam_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_slam_SpellScript);
+            PrepareSpellScript(spell_warr_slam_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -684,7 +684,7 @@ class spell_warr_sweeping_strikes : public SpellScriptLoader
 
         class spell_warr_sweeping_strikes_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warr_sweeping_strikes_AuraScript);
+            PrepareAuraScript(spell_warr_sweeping_strikes_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -748,7 +748,7 @@ class spell_warr_vigilance : public SpellScriptLoader
 
         class spell_warr_vigilance_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_warr_vigilance_AuraScript);
+            PrepareAuraScript(spell_warr_vigilance_AuraScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -842,7 +842,7 @@ class spell_warr_vigilance_trigger : public SpellScriptLoader
 
         class spell_warr_vigilance_trigger_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_warr_vigilance_trigger_SpellScript);
+            PrepareSpellScript(spell_warr_vigilance_trigger_SpellScript)
 
             void HandleScript(SpellEffIndex effIndex)
             {

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -687,7 +687,7 @@ class spell_dream_fog_sleep : public SpellScriptLoader
 
         class spell_dream_fog_sleep_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_dream_fog_sleep_SpellScript);
+            PrepareSpellScript(spell_dream_fog_sleep_SpellScript)
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
@@ -731,7 +731,7 @@ class spell_mark_of_nature : public SpellScriptLoader
 
         class spell_mark_of_nature_SpellScript : public SpellScript
         {
-            PrepareSpellScript(spell_mark_of_nature_SpellScript);
+            PrepareSpellScript(spell_mark_of_nature_SpellScript)
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
@@ -781,4 +781,4 @@ void AddSC_emerald_dragons()
     // dragon spellscripts
     new spell_dream_fog_sleep();
     new spell_mark_of_nature();
-};
+}

--- a/src/tools/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/mmaps_generator/TerrainBuilder.cpp
@@ -906,7 +906,7 @@ namespace MMAP
             float p0[3], p1[3];
             uint32 mid, tx, ty;
             float size;
-            if (sscanf(buf, "%d %d,%d (%f %f %f) (%f %f %f) %f", &mid, &tx, &ty,
+            if (sscanf(buf, "%u %u,%u (%f %f %f) (%f %f %f) %f", &mid, &tx, &ty,
                 &p0[0], &p0[1], &p0[2], &p1[0], &p1[1], &p1[2], &size) != 10)
                 continue;
 


### PR DESCRIPTION
The core, the scripts and the tools now compile without warnings with -Wall -Wextra -pedantic.

-Fix warnings from -Woverflow on implicit constant conversion.
-Fix a lot of warnings from -pedantic. Most of them are from the scripts and come from an useless semicolon in uses of PrepareAuraScript and PrepareSpellScript macros, which is also present in the examples. I corrected the example script in the scripts directory, but the one from http://collab.kpsn.org/display/tc/How+to%3A+Spell+system also needs to be corrected.
-Fix warnings from -Wformat.

Two minor changes in addition :

-Replace MAX_MONEY_AMOUNT, a defined value equal to 2^31 - 2 by std::numeric_limits<int>::max(). According to http://www.wowwiki.com/Money, the maximum money amount on WotLK is 2^31 - 1.
-Remove useless null-check on pointer returned by new. New doesn't returns nullptr on failure, it throws std::bad_alloc.
