### PR TITLE
Core/SAI: Clear UNIT_STATE_EVADE immediately if we're about to follow a target on EnterEvadeMode

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -439,6 +439,9 @@ void SmartAI::EnterEvadeMode()
     {
         if (Unit* target = me->GetUnit(*me, mFollowGuid))
             me->GetMotionMaster()->MoveFollow(target, mFollowDist, mFollowAngle);
+
+        // evade is not cleared in MoveFollow, so we can't keep it
+        me->ClearUnitState(UNIT_STATE_EVADE);
     }
     else
         me->GetMotionMaster()->MoveTargetedHome();


### PR DESCRIPTION
MoveFollow does not clear evade

This solves an evade bug or two
