### PR TITLE
Core/Achievements: Fix ACHIEVEMENT_CRITERIA_TYPE_GET_KILLING_BLOWS

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -15248,8 +15248,8 @@ void Unit::Kill(Unit* victim, bool durabilityLoss)
 
     // update get killing blow achievements, must be done before setDeathState to be able to require auras on target
     // and before Spirit of Redemption as it also removes auras
-    if (player)
-        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_GET_KILLING_BLOWS, 1, 0, victim);
+    if (Player* killerPlayer = GetCharmerOrOwnerPlayerOrPlayerItself())
+        killerPlayer->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_GET_KILLING_BLOWS, 1, 0, victim);
 
     // if talent known but not triggered (check priest class for speedup check)
     bool spiritOfRedemption = false;


### PR DESCRIPTION
Confirmed in http://www.wowhead.com/achievement=3856#comments
http://www.wowhead.com/achievement=2910
http://www.wowhead.com/achievement=2149

And others with type ACHIEVEMENT_CRITERIA_TYPE_GET_KILLING_BLOW
Previous code would often give the achievement credit to the loot recipient, rather than the actual killer
