### PR TITLE
Core/Players: Fix GetNPCIfCanInteractWith when dealing with creatures of neutral reputation/forced friendly reputation

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2741,11 +2741,8 @@ Creature* Player::GetNPCIfCanInteractWith(uint64 guid, uint32 npcflagmask)
         return NULL;
 
     // not unfriendly
-    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(creature->getFaction()))
-        if (factionTemplate->faction)
-            if (FactionEntry const* faction = sFactionStore.LookupEntry(factionTemplate->faction))
-                if (faction->reputationListID >= 0 && GetReputationMgr().GetRank(faction) <= REP_UNFRIENDLY)
-                    return NULL;
+    if (creature->GetReactionTo(this) <= REP_HOSTILE)
+        return NULL;
 
     // not too far
     if (!creature->IsWithinDistInMap(this, INTERACTION_DISTANCE))


### PR DESCRIPTION
Solves part of https://github.com/TrinityCore/TrinityCore/issues/4028, https://github.com/TrinityCore/TrinityCore/issues/12099 and https://github.com/TrinityCore/TrinityCore/issues/4210
