### PR TITLE
Core/Spells: *Properly* solve the Disarm vs Bladestorm issue

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -567,7 +567,7 @@ m_caster((info->AttributesEx6 & SPELL_ATTR6_CAST_BY_CHARMER && caster->GetCharme
     m_spellState = SPELL_STATE_NULL;
     _triggeredCastFlags = triggerFlags;
     if (info->AttributesEx4 & SPELL_ATTR4_TRIGGERED)
-        _triggeredCastFlags = TRIGGERED_FULL_MASK;
+        _triggeredCastFlags = TriggerCastFlags(TRIGGERED_FULL_MASK & ~TRIGGERED_IGNORE_EQUIPPED_ITEM_REQUIREMENT);
 
     m_CastItem = NULL;
     m_castItemGUID = 0;


### PR DESCRIPTION
We might have to a dedicated set of triggered flags for SPELL_ATTR4_TRIGGERED, without TRIGGERED_IGNORE_EQUIPPED_ITEM_REQUIREMENT

This commit alone solves most of the issues, though
https://github.com/TrinityCore/TrinityCore/issues/9304
https://github.com/TrinityCore/TrinityCore/issues/11681
https://github.com/TrinityCore/TrinityCore/issues/11674
