### PR TITLE
Core/GOs: When unlinking Fishing Bobber from player to prevent despawning, unlink from spell as well to prevent removing unwanted auras

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1404,6 +1404,7 @@ void GameObject::Use(Unit* user)
                         // prevent removing GO at spell cancel
                         RemoveFromOwner();
                         SetOwnerGUID(player->GetGUID());
+                        SetSpellId(0); // prevent removing unintended auras at Unit::RemoveGameObject
 
                         /// @todo find reasonable value for fishing hole search
                         GameObject* ok = LookupFishingHoleAround(20.0f + CONTACT_DISTANCE);


### PR DESCRIPTION
Solves that issue where if you try to fish while your last cast just failed, your new channeling is interrupted but your new boober doesn't fade. Which gets annoying later on.
