### PR TITLE
Core/Spells: Anti-Magic shell should give immunity to all spells that belong to SPELL_SCHOOL_MASK_MAGIC regardless of dispel type

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11111,8 +11111,7 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index) cons
         // Check for immune to application of harmful magical effects
         AuraEffectList const& immuneAuraApply = GetAuraEffectsByType(SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL);
         for (AuraEffectList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
-            if (spellInfo->Dispel == DISPEL_MAGIC &&                                      // Magic debuff
-                ((*iter)->GetMiscValue() & spellInfo->GetSchoolMask()) &&  // Check school
+            if (((*iter)->GetMiscValue() & spellInfo->GetSchoolMask()) &&  // Check school
                 !spellInfo->IsPositiveEffect(index))                                  // Harmful
                 return true;
     }


### PR DESCRIPTION
https://github.com/TrinityCore/TrinityCore/issues/877
https://github.com/TrinityCore/TrinityCore/issues/2353
https://github.com/TrinityCore/TrinityCore/issues/2408 (part of it)
