### PR TITLE
Core/Scripts: Fix training dummies

### DIFF
--- a/sql/updates/world/2014_06_15_02_world_creature_template.sql
+++ b/sql/updates/world/2014_06_15_02_world_creature_template.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_template` SET `unit_flags` = 0 WHERE `ScriptName` = 'npc_training_dummy'; 

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -1533,6 +1533,7 @@ public:
         {
             SetCombatMovement(false);
             entry = creature->GetEntry();
+            me->SetReactState(REACT_PASSIVE);
         }
 
         uint32 entry;


### PR DESCRIPTION
Fixes the issue where dummies wont enter combat because they cant aquire a target due to UNIT_FLAG_PACIFIED
