### PR TITLE
[4.3.4] Core/DBC:

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -2676,13 +2676,6 @@ bool AchievementMgr<T>::AdditionalRequirementsSatisfied(AchievementCriteriaEntry
     for (uint8 i = 0; i < MAX_ADDITIONAL_CRITERIA_CONDITIONS; ++i)
     {
         uint32 reqType = criteria->additionalConditionType[i];
-
-        ///@TODO Extract additionalConditionValue[2] column from an older dbc and store it in database
-        ///      This column is not present in 4.3.4 Achievement_Criteria.dbc
-        ///      so for now, just return as failed condition to prevent invalid memory access
-        if (i == 2 && reqType)
-            return false;
-
         uint32 reqValue = criteria->additionalConditionValue[i];
 
         switch (AchievementCriteriaAdditionalCondition(reqType))

--- a/src/server/game/DataStores/DBCStructure.h
+++ b/src/server/game/DataStores/DBCStructure.h
@@ -530,8 +530,8 @@ struct AchievementCriteriaEntry
     uint32  showOrder;                                      // 15       m_ui_order  also used in achievement shift-links as index in state bitmask
     //uint32 unk1;                                          // 16 only one value, still unknown
     //uint32 unk2;                                          // 17 all zeros
-    uint32 additionalConditionType[MAX_ADDITIONAL_CRITERIA_CONDITIONS];      // 18-20
-    uint32 additionalConditionValue[MAX_ADDITIONAL_CRITERIA_CONDITIONS - 1]; // 21-22 WTF one column was cut off here in 4.3.4
+    uint32 additionalConditionType[MAX_ADDITIONAL_CRITERIA_CONDITIONS];  // 18-20
+    uint32 additionalConditionValue[MAX_ADDITIONAL_CRITERIA_CONDITIONS]; // 21-23
 };
 
 struct AreaTableEntry

--- a/src/server/game/DataStores/DBCfmt.h
+++ b/src/server/game/DataStores/DBCfmt.h
@@ -25,7 +25,7 @@
 char const Achievementfmt[] = "niixsxiixixxii";
 const std::string CustomAchievementfmt = "pppaaaapapaapp";
 const std::string CustomAchievementIndex = "ID";
-char const AchievementCriteriafmt[] = "niiiixiiiisiiiiixxiiiii";
+char const AchievementCriteriafmt[] = "niiiixiiiisiiiiixxiiiiii";
 char const AreaTableEntryfmt[] = "iiinixxxxxisiiiiiffixxxxxx";
 char const AreaGroupEntryfmt[] = "niiiiiii";
 char const AreaPOIEntryfmt[] = "niiiiiiiiiiiffixixxixx";

--- a/src/server/shared/DataStores/DBCFileLoader.cpp
+++ b/src/server/shared/DataStores/DBCFileLoader.cpp
@@ -77,6 +77,12 @@ bool DBCFileLoader::Load(const char* filename, const char* fmt)
 
     EndianConvert(recordSize);
 
+    if ((fieldCount * 4) != recordSize)
+    {
+        ASSERT(false && "Broken dbc file `fieldCount` * 4 is not equal `recordSize`");
+        return false;
+    }
+
     if (fread(&stringSize, 4, 1, f) != 1)                    // String size
     {
         fclose(f);


### PR DESCRIPTION
- Correct loading AchievementCriteria.dbc
- Added special check DBC file

I made today manual check header of this file in hex editor and I saw that we have 23 columns but each row using 96 bytes but 23 \* 4 is not equal to 96 it's 92 so I manualy changed this header to 24 and opened this file in dbc editor and I saw new column with correct data.
