### PR TITLE
Core/Creature: Fix corpse despawn time

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2285,7 +2285,7 @@ void Creature::AllLootRemovedFromCorpse()
     if (loot.loot_type == LOOT_SKINNING)
         m_corpseRemoveTime = time(NULL);
     else
-        m_corpseRemoveTime = now + m_corpseDelay * decayRate;
+        m_corpseRemoveTime = now + uint32(m_corpseDelay * decayRate);
 
     m_respawnTime = m_corpseRemoveTime + m_respawnDelay;
 }


### PR DESCRIPTION
I was getting a lot of issues with corpses that had no loot de-spawning instantly after death. m_corpseRemoveTime was often being set to a time less than the current time. This change fixed that.
