### PR TITLE
[3.3.5][Fix][GameObject]The trap is linked can despawn correct

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1069,11 +1069,13 @@ void GameObject::TriggeringLinkedGameObject(uint32 trapEntry, Unit* target)
     if (!trapInfo || trapInfo->type != GAMEOBJECT_TYPE_TRAP)
         return;
 
+	float range = 0.0f;
     SpellInfo const* trapSpell = sSpellMgr->GetSpellInfo(trapInfo->trap.spellId);
-    if (!trapSpell)                                          // checked at load already
-        return;
-
-    float range = float(target->GetSpellMaxRangeForTarget(GetOwner(), trapSpell));
+	if (!trapSpell) {                                         // checked at load already
+		range = 5.0f;
+	} else {
+		range = float(target->GetSpellMaxRangeForTarget(GetOwner(), trapSpell));
+	}
 
     // search nearest linked GO
     GameObject* trapGO = NULL;
@@ -1090,8 +1092,15 @@ void GameObject::TriggeringLinkedGameObject(uint32 trapEntry, Unit* target)
     }
 
     // found correct GO
-    if (trapGO)
-        trapGO->CastSpell(target, trapInfo->trap.spellId);
+	if (trapGO) {
+		if(trapInfo->trap.spellId)
+			trapGO->CastSpell(target, trapInfo->trap.spellId);
+		printf("asdfasfasfasf\n");
+		GameObjectTemplate const* goInfo = trapGO->GetGOInfo();
+		if (goInfo->trap.type == 1)         // Deactivate after trigger
+			trapGO->SetLootState(GO_JUST_DEACTIVATED);
+		trapGO->UpdateObjectVisibility();
+	}
 }
 
 GameObject* GameObject::LookupFishingHoleAround(float range)

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1095,7 +1095,6 @@ void GameObject::TriggeringLinkedGameObject(uint32 trapEntry, Unit* target)
 	if (trapGO) {
 		if(trapInfo->trap.spellId)
 			trapGO->CastSpell(target, trapInfo->trap.spellId);
-		printf("asdfasfasfasf\n");
 		GameObjectTemplate const* goInfo = trapGO->GetGOInfo();
 		if (goInfo->trap.type == 1)         // Deactivate after trigger
 			trapGO->SetLootState(GO_JUST_DEACTIVATED);

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -325,6 +325,119 @@ public:
     }
 };
 
+class npc_bethor_iceshard : public CreatureScript
+{
+public:
+    npc_bethor_iceshard() : CreatureScript("npc_bethor_iceshard")  {}
+
+    bool OnQuestReward(Player* player, Creature* creature, Quest const* quest, uint32 opt) { 
+        if (quest->GetQuestId() == QUEST_THE_PRODIGAL_LICH_RETURNS) {
+            CAST_AI(npc_bethor_iceshard::npc_bethor_iceshardAI, creature->AI())->startEvent = true;
+            CAST_AI(npc_bethor_iceshard::npc_bethor_iceshardAI, creature->AI())->_player = player;
+        }
+        return true; 
+    }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bethor_iceshardAI(creature);
+    }
+
+    struct npc_bethor_iceshardAI : public ScriptedAI
+    {
+        npc_bethor_iceshardAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void Reset() override
+        {
+            startEvent = false;
+            _player = NULL;
+            timer = 2000;
+            summon = NULL;
+            phase = 0;
+        }
+
+        bool startEvent;
+        Player * _player;
+        uint32 timer;
+        Creature * summon;
+        int phase;
+
+        void UpdateAI(uint32 diff) override {
+            if (startEvent) {
+                switch (phase) {
+                case 0:
+                    if (timer < diff) {
+                        me->CastSpell(me, 7762, false);
+                        phase++;
+                        timer = 2000;
+                        break;
+                    }
+                    else {
+                        timer -= diff;
+                    }
+                case 1:
+                    if (timer < diff) {
+                        Position position;
+                        position.m_positionX = 1767.448486f;
+                        position.m_positionY = 60.790691f;
+                        position.m_positionZ = -46.320290f;
+                        position.m_orientation = 1.768230f;
+
+                        summon = me->SummonCreature(5666, position, TEMPSUMMON_TIMED_DESPAWN, 20000);
+                        summon->SetWalk(true);
+                        position.m_positionX = 1766.795288f;
+                        position.m_positionY = 63.132595f;
+                        position.m_positionZ = -46.320072f;
+                        position.m_orientation = 1.803555f;
+                        summon->GetMotionMaster()->MovePoint(0, position, false);
+                        phase++;
+                        timer = 2000;
+                    }
+                    else {
+                        timer -= diff;
+                    }
+                    break;
+                case 2 :
+                    if (timer < diff) {
+                        me->MonsterSay("We meet again!", 0, summon);
+                        timer = 3000;
+                        phase++;
+                    }
+                    else {
+                        timer -= diff;
+                    }
+                    break;
+                case 3 :
+                    if (timer < diff) {
+                        summon->MonsterSay("Yes, my old friend!", 0, summon);
+
+                        timer = 13000;
+                        phase++;
+                    }
+                    else {
+                        timer -= diff;
+                    }
+                    break;
+                case 4:
+                    if (timer < diff) {
+                        summon->MonsterSay("Farewell letter!", 0, summon);
+                        timer = 1000;
+                        phase++;
+                    }
+                    else {
+                        timer -= diff;
+                    }
+                    break;
+                default:
+                    startEvent = false;
+                    break;
+                }
+
+            }
+        }
+    };
+};
+
 /*######
 ## AddSC
 ######*/
@@ -334,4 +447,5 @@ void AddSC_undercity()
     new npc_lady_sylvanas_windrunner();
     new npc_highborne_lamenter();
     new npc_parqual_fintallas();
+    new npc_bethor_iceshard();
 }


### PR DESCRIPTION
If a gameobject is a trap, it's data2(radius) is 0 (can not trigger by itself or directly by player), and data4 is 1(despawn after triggered/cast spell), just linked by anohter object,
after be triggered, it can not despawn correctly( The data in database is correct, if you change the data2 field to a positive number, it will be triggered directly, and after that, it will despawn).
