### PR TITLE
Fix crash on Mograine revive.

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
@@ -83,6 +83,7 @@ public:
         bool _bHasDied;
         bool _bHeal;
         bool _bFakeDeath;
+        bool _bRevived;
 
         void Reset() override
         {
@@ -100,6 +101,7 @@ public:
             _bHasDied = false;
             _bHeal = false;
             _bFakeDeath = false;
+            _BRevived = false;
         }
 
         void JustReachedHome() override
@@ -162,8 +164,7 @@ public:
             {
                 Talk(SAY_MO_RESURRECTED);
                 _bFakeDeath = false;
-
-                instance->SetData(TYPE_MOGRAINE_AND_WHITE_EVENT, SPECIAL);
+                _bRevived = true;
             }
         }
 
@@ -172,7 +173,7 @@ public:
             if (!UpdateVictim())
                 return;
 
-            if (_bHasDied && !_bHeal && instance->GetData(TYPE_MOGRAINE_AND_WHITE_EVENT) == SPECIAL)
+            if (_bHasDied && !_bHeal && _bRevived)
             {
                 //On resurrection, stop fake death and heal whitemane and resume fight
                 if (Unit* Whitemane = ObjectAccessor::GetUnit(*me, instance->GetData64(DATA_WHITEMANE)))

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
@@ -101,7 +101,7 @@ public:
             _bHasDied = false;
             _bHeal = false;
             _bFakeDeath = false;
-            _BRevived = false;
+            _bRevived = false;
         }
 
         void JustReachedHome() override


### PR DESCRIPTION
Fix Crash caused on Mograine ressurection, may be considered a hack due to the use of an addition variable, I also propose fusing the four bools into one single byte variable, as per good game design principles to cut back on ram usage.
