### PR TITLE
Core/Misc: Silenced 500 OS X Warnings and removed deprecated finite() me...

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -15,4 +15,5 @@ if(WITH_COREDEBUG)
 endif()
 
 # -Wno-narrowing needed to suppress a warning in g3d
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-narrowing")
+# -Wno-deprecated-register is needed to suppress 185 gsoap warnings on Unix systems.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-narrowing -Wno-deprecated-register")

--- a/src/server/game/Grids/GridDefines.h
+++ b/src/server/game/Grids/GridDefines.h
@@ -213,7 +213,7 @@ namespace Trinity
 
     inline bool IsValidMapCoord(float c)
     {
-        return finite(c) && (std::fabs(c) <= MAP_HALFSIZE - 0.5f);
+        return std::isfinite(c) && (std::fabs(c) <= MAP_HALFSIZE - 0.5f);
     }
 
     inline bool IsValidMapCoord(float x, float y)
@@ -223,12 +223,12 @@ namespace Trinity
 
     inline bool IsValidMapCoord(float x, float y, float z)
     {
-        return IsValidMapCoord(x, y) && finite(z);
+        return IsValidMapCoord(x, y) && std::isfinite(z);
     }
 
     inline bool IsValidMapCoord(float x, float y, float z, float o)
     {
-        return IsValidMapCoord(x, y, z) && finite(o);
+        return IsValidMapCoord(x, y, z) && std::isfinite(o);
     }
 }
 #endif

--- a/src/server/shared/Common.h
+++ b/src/server/shared/Common.h
@@ -111,7 +111,7 @@
 
 #endif
 
-inline float finiteAlways(float f) { return finite(f) ? f : 0.0f; }
+inline float finiteAlways(float f) { return std::isfinite(f) ? f : 0.0f; }
 
 #define STRINGIZE(a) #a
 

--- a/src/server/shared/Threading/ProcessPriority.h
+++ b/src/server/shared/Threading/ProcessPriority.h
@@ -28,6 +28,11 @@
 
 void SetProcessPriority(const std::string logChannel)
 {
+// Suppresses Mac OS X Warning since logChannel isn't used.
+#if PLATFORM_APPLE
+    (void)logChannel;
+#endif
+    
 #if defined(_WIN32) || defined(__linux__)
 
     ///- Handle affinity for multiple processors and process priority

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 
 add_dependencies(worldserver revision.h)
 
-if( UNIX AND NOT NOJEM )
+if( UNIX AND NOT NOJEM AND NOT APPLE )
   set(worldserver_LINK_FLAGS "-pthread -lncurses ${worldserver_LINK_FLAGS}")
 endif()
 

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -535,6 +535,9 @@ void ClearOnlineAccounts()
 
 variables_map GetConsoleArguments(int argc, char** argv, std::string& configFile, std::string& configService)
 {
+    // Silences warning about configService not be used if the OS is not Windows
+    (void)configService;
+    
     options_description all("Allowed options");
     all.add_options()
         ("help,h", "print usage message")


### PR DESCRIPTION
...thod.

*Mac OS X fires off over 200 warnings related to gsoap about the deprecated register method. CMake has been patched to remove this warning.
*Updated all occurences of finite() to std::isfinite. The method finite() is not standardized by anyone aside from BSD. std::isfinite() however is standarized by C++
*Removed -ncurses and -pthread from OS X compilation. Now that we use Boost and C++11 there is no longer a need for pthread in OS X. All it does is throw a warning. However, ncurses isn't needed either as it's built into the OS X SDK and linked by default.

Note: There are only 5 remaining warnings left when compiling on OS X. I did not attempt to fix these as they were related to 3rd party libraries statically linked into the code. The 5 warnings left are all related to unused variables.
