### PR TITLE
Core/Spells: Death and Decay

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5461,7 +5461,7 @@ void AuraEffect::HandlePeriodicDummyAuraTick(Unit* target, Unit* caster) const
             if (GetSpellInfo()->SpellFamilyFlags[0] & 0x20)
             {
                 if (caster)
-                    caster->CastCustomSpell(target, 52212, &m_amount, NULL, NULL, true, 0, this);
+                    target->CastCustomSpell(target, 52212, &m_amount, NULL, NULL, true, 0, this, caster->GetGUID());
                 break;
             }
             // Blood of the North


### PR DESCRIPTION
Solves problems with Death and Decay doing LoS check using the caster instead of the center of AOE.
Fix by @PKX. Taken from 3307a7a1fab124a11266fc5bb5e1b5d4aab475b9
Closes #6345
