### PR TITLE
Core/Instance: Implement Dynamic Difficulty Map

### DIFF
--- a/src/server/game/Maps/MapInstanced.cpp
+++ b/src/server/game/Maps/MapInstanced.cpp
@@ -140,7 +140,15 @@ Map* MapInstanced::CreateInstanceForPlayer(const uint32 mapId, Player* player)
     }
     else
     {
-        InstancePlayerBind* pBind = player->GetBoundInstance(GetId(), player->GetDifficulty(IsRaid()));
+        uint32 BindDifficulty;
+        const MapEntry* mapEntry = sMapStore.LookupEntry(mapId);
+
+        if (mapEntry->IsDynamicDifficultyMap())
+            BindDifficulty = player->GetDifficulty(IsRaid()) >= RAID_DIFFICULTY_10MAN_HEROIC ? player->GetDifficulty(IsRaid()) - RAID_DIFFICULTY_10MAN_HEROIC : player->GetDifficulty(IsRaid());
+        else
+            BindDifficulty = player->GetDifficulty(IsRaid());
+
+        InstancePlayerBind* pBind = player->GetBoundInstance(GetId(), (Difficulty)BindDifficulty);
         InstanceSave* pSave = pBind ? pBind->save : NULL;
 
         // the player's permanent player bind is taken into consideration first
@@ -164,9 +172,9 @@ Map* MapInstanced::CreateInstanceForPlayer(const uint32 mapId, Player* player)
             map = FindInstanceMap(newInstanceId);
             // it is possible that the save exists but the map doesn't
             if (!map)
-                map = CreateInstance(newInstanceId, pSave, pSave->GetDifficulty());
+                map = CreateInstance(newInstanceId, pSave, player->GetDifficulty(IsRaid()));
         }
-        else
+        else // if (!pSave)
         {
             // if no instanceId via group members or instance saves is found
             // the instance will be created for the first time


### PR DESCRIPTION
this solves issue where player only should get one instance id for 10man and 25man

1part for #2374
