### PR TITLE
Core/Spells: Fixed - Warrior Meat Cleaver double Cleav proc

### DIFF
--- a/sql/updates/world/2014_08_05_00_spell_script_names.sql
+++ b/sql/updates/world/2014_08_05_00_spell_script_names.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_proc_event` WHERE `entry` IN (12950, 12329);
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES 
+(-12329, 0, 4, 0, 4, 0, 4112, 0, 0, 0, 0);
+
+DELETE FROM spell_script_names WHERE ScriptName = 'spell_warr_cleave';
+INSERT INTO spell_script_names VALUES
+(845, 'spell_warr_cleave');

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -61,7 +61,11 @@ enum WarriorSpells
     SPELL_WARRIOR_UNRELENTING_ASSAULT_TRIGGER_1     = 64849,
     SPELL_WARRIOR_UNRELENTING_ASSAULT_TRIGGER_2     = 64850,
     SPELL_WARRIOR_VIGILANCE_PROC                    = 50725,
-    SPELL_WARRIOR_VENGEANCE                         = 76691
+    SPELL_WARRIOR_VENGEANCE                         = 76691,
+    SPELL_WARRIOR_MEAT_CLEAVER_R1                   = 12329,
+    SPELL_WARRIOR_MEAT_CLEAVER_R2                   = 12950,
+    SPELL_WARRIOR_MEAT_CLEAVER_R1_PROC              = 85738,
+    SPELL_WARRIOR_MEAT_CLEAVER_R2_PROC              = 85739,
 };
 
 enum WarriorSpellIcons
@@ -1053,6 +1057,51 @@ class spell_warr_vigilance_trigger : public SpellScriptLoader
         }
 };
 
+class spell_warr_cleave : public SpellScriptLoader
+{
+public:
+    spell_warr_cleave() : SpellScriptLoader("spell_warr_cleave") { }
+
+    class spell_warr_cleave_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_warr_cleave_SpellScript);
+
+        bool Load() OVERRIDE
+        {
+            meatCleaverCount = 0;
+            return true;
+        }
+
+        void HandleMeatCleaver(SpellEffIndex effect)
+        {
+            if (Unit* caster = GetCaster())
+            {
+                if (++meatCleaverCount == 1)
+                {
+                    if (caster->HasAura(SPELL_WARRIOR_MEAT_CLEAVER_R1))
+                        caster->CastSpell(caster, SPELL_WARRIOR_MEAT_CLEAVER_R1_PROC, true);
+
+                    if (caster->HasAura(SPELL_WARRIOR_MEAT_CLEAVER_R2))
+                        caster->CastSpell(caster, SPELL_WARRIOR_MEAT_CLEAVER_R2_PROC, true);
+                }
+            }
+        }
+
+        void Register()
+        {
+            OnEffectHitTarget += SpellEffectFn(spell_warr_cleave::spell_warr_cleave_SpellScript::HandleMeatCleaver, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+        }
+
+    private:
+        int8 meatCleaverCount;
+    };
+
+    SpellScript* GetSpellScript() const
+    {
+        return new spell_warr_cleave_SpellScript();
+    }
+};
+
 void AddSC_warrior_spell_scripts()
 {
     new spell_warr_bloodthirst();
@@ -1080,4 +1129,5 @@ void AddSC_warrior_spell_scripts()
     new spell_warr_victorious();
     new spell_warr_vigilance();
     new spell_warr_vigilance_trigger();
+    new spell_warr_cleave();
 }


### PR DESCRIPTION
Meat Cleaver will not proc now from each Cleave Hit.

Now it will only proc from the first hit from Cleave
