### PR TITLE
Core/Spells: Fixed Range Weapon durability loss

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4387,7 +4387,12 @@ void Spell::TakeAmmo()
         if (!pItem  || pItem->IsBroken() || pItem->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_WAND)
             return;
 
-        if (pItem->GetTemplate()->InventoryType == INVTYPE_THROWN)
+
+        if (pItem->GetTemplate()->InventoryType == INVTYPE_THROWN ||
+            pItem->GetTemplate()->InventoryType == INVTYPE_RANGED ||
+            pItem->GetTemplate()->InventoryType == INVTYPE_RANGEDRIGHT)
+
+        if (roll_chance_f(sWorld->getRate(RATE_DURABILITY_LOSS_DAMAGE)))
         {
             if (pItem->GetMaxStackCount() == 1)
             {


### PR DESCRIPTION
Actually it is like that:

If you hit with Thrown or you hit the creature with 1 of your Attacks as Range (as example Hunter)

you loose always 1 durability on your Range Weapon.. that's wrong!
