### PR TITLE
Scripts/Icecrown Citadel: The Teleporters in ICC are now Blizzlike

### DIFF
--- a/sql/updates/world/2014_08_14_01_world_gameobject.sql
+++ b/sql/updates/world/2014_08_14_01_world_gameobject.sql
@@ -1,0 +1,3 @@
+SET @OBJECT := xxxxxx;
+INSERT INTO `gameobject` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`animprogress`,`state`) VALUES
+(@OBJECT,201818,631,15,1,4149.65,2779.59,350.962,0,25,0,1);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -298,7 +298,13 @@ class boss_deathbringer_saurfang : public CreatureScript
                 }
 
                 _introDone = true;
-
+                
+                if (GameObject* teleporter = GameObject::GetGameObject(*me, instance->GetData64(GO_SCOURGE_TRANSPORTER_DEATHBRINGER)))
+                {
+                    instance->HandleGameObject(0, false, teleporter);
+                    teleporter->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
+                }
+                
                 Talk(SAY_AGGRO);
                 events.ScheduleEvent(EVENT_SUMMON_BLOOD_BEAST, 30000, 0, PHASE_COMBAT);
                 events.ScheduleEvent(EVENT_BERSERK, IsHeroic() ? 360000 : 480000, 0, PHASE_COMBAT);
@@ -538,12 +544,6 @@ class boss_deathbringer_saurfang : public CreatureScript
                     case PHASE_INTRO_A:
                     case PHASE_INTRO_H:
                     {
-                        if (GameObject* teleporter = GameObject::GetGameObject(*me, instance->GetData64(GO_SCOURGE_TRANSPORTER_SAURFANG)))
-                        {
-                            instance->HandleGameObject(0, false, teleporter);
-                            teleporter->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
-                        }
-
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         // controls what events will execute
                         events.SetPhase(uint32(action));

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -2102,7 +2102,15 @@ class at_icc_shutdown_traps : public AreaTriggerScript
         bool OnTrigger(Player* player, AreaTriggerEntry const* /*areaTrigger*/) override
         {
             if (InstanceScript* instance = player->GetInstanceScript())
-                instance->SetData(DATA_COLDFLAME_JETS, DONE);
+            {
+                instance->SetData(DATA_UPPERSPIRE_TELE_ACT, DONE);
+                uint64 teleporterGUID = instance->GetData64(GO_SCOURGE_TRANSPORTER_UPPERSPIRE);
+                if (GameObject* go = instance->instance->GetGameObject(teleporterGUID))
+                {
+                    go->SetGoState(GO_STATE_ACTIVE);
+                    go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
+                }
+            }
             return true;
         }
 };

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
@@ -116,7 +116,8 @@ enum DataTypes
     DATA_HIGHLORD_TIRION_FORDRING   = 37,
     DATA_ARTHAS_PLATFORM            = 38,
     DATA_TERENAS_MENETHIL           = 39,
-    DATA_ENEMY_GUNSHIP              = 40
+    DATA_ENEMY_GUNSHIP              = 40,
+    DATA_UPPERSPIRE_TELE_ACT        = 41,
 };
 
 enum CreaturesIds
@@ -322,6 +323,15 @@ enum CreaturesIds
 
 enum GameObjectsIds
 {
+    // ICC Teleporters
+    GO_SCOURGE_TRANSPORTER_LICHKING         = 202223,
+    GO_SCOURGE_TRANSPORTER_UPPERSPIRE       = 202235,
+    GO_SCOURGE_TRANSPORTER_LIGHTSHAMMER     = 202242,
+    GO_SCOURGE_TRANSPORTER_RAMPART          = 202243,
+    GO_SCOURGE_TRANSPORTER_DEATHBRINGER     = 202244,
+    GO_SCOURGE_TRANSPORTER_ORATORY          = 202245,
+    GO_SCOURGE_TRANSPORTER_SINDRAGOSA       = 202246,
+    
     // Lower Spire Trash
     GO_SPIRIT_ALARM_1                       = 201814,
     GO_SPIRIT_ALARM_2                       = 201815,
@@ -359,7 +369,6 @@ enum GameObjectsIds
     GO_DEATHBRINGER_S_CACHE_25N             = 202240,
     GO_DEATHBRINGER_S_CACHE_10H             = 202238,
     GO_DEATHBRINGER_S_CACHE_25H             = 202241,
-    GO_SCOURGE_TRANSPORTER_SAURFANG         = 202244,
 
     // Professor Putricide
     GO_ORANGE_PLAGUE_MONSTER_ENTRANCE       = 201371,
@@ -404,7 +413,6 @@ enum GameObjectsIds
     GO_SIGIL_OF_THE_FROSTWING               = 202181,
 
     // The Lich King
-    GO_SCOURGE_TRANSPORTER_LK               = 202223,
     GO_ARTHAS_PLATFORM                      = 202161,
     GO_ARTHAS_PRECIPICE                     = 202078,
     GO_DOODAD_ICECROWN_THRONEFROSTYWIND01   = 202188,

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel_teleport.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel_teleport.cpp
@@ -31,19 +31,23 @@ class icecrown_citadel_teleport : public GameObjectScript
 
         bool OnGossipHello(Player* player, GameObject* go) override
         {
-            player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to Light's Hammer.", GOSSIP_SENDER_ICC_PORT, LIGHT_S_HAMMER_TELEPORT);
             if (InstanceScript* instance = go->GetInstanceScript())
             {
                 if (instance->GetBossState(DATA_LORD_MARROWGAR) == DONE)
-                    player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to the Oratory of the Damned.", GOSSIP_SENDER_ICC_PORT, ORATORY_OF_THE_DAMNED_TELEPORT);
-                if (instance->GetBossState(DATA_LADY_DEATHWHISPER) == DONE)
+                {
+                    if (go->GetEntry() != GO_SCOURGE_TRANSPORTER_LIGHTSHAMMER)
+                        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to Light's Hammer.", GOSSIP_SENDER_ICC_PORT, LIGHT_S_HAMMER_TELEPORT);
+                    if (go->GetEntry() != GO_SCOURGE_TRANSPORTER_ORATORY)
+                        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to the Oratory of the Damned.", GOSSIP_SENDER_ICC_PORT, ORATORY_OF_THE_DAMNED_TELEPORT);
+                }
+                if (instance->GetBossState(DATA_LADY_DEATHWHISPER) == DONE && go->GetEntry() != GO_SCOURGE_TRANSPORTER_RAMPART)
                     player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to the Rampart of Skulls.", GOSSIP_SENDER_ICC_PORT, RAMPART_OF_SKULLS_TELEPORT);
-                if (instance->GetBossState(DATA_ICECROWN_GUNSHIP_BATTLE) == DONE)
+                if (instance->GetBossState(DATA_ICECROWN_GUNSHIP_BATTLE) == DONE && go->GetEntry() != GO_SCOURGE_TRANSPORTER_DEATHBRINGER)
                     player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to the Deathbringer's Rise.", GOSSIP_SENDER_ICC_PORT, DEATHBRINGER_S_RISE_TELEPORT);
-                if (instance->GetData(DATA_COLDFLAME_JETS) == DONE)
+                if (instance->GetData(DATA_UPPERSPIRE_TELE_ACT) == DONE && go->GetEntry() != GO_SCOURGE_TRANSPORTER_UPPERSPIRE)
                     player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to the Upper Spire.", GOSSIP_SENDER_ICC_PORT, UPPER_SPIRE_TELEPORT);
                 /// @todo Gauntlet event before Sindragosa
-                if (instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == DONE)
+                if (instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == DONE && go->GetEntry() != GO_SCOURGE_TRANSPORTER_SINDRAGOSA)
                     player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport to Sindragosa's Lair", GOSSIP_SENDER_ICC_PORT, SINDRAGOSA_S_LAIR_TELEPORT);
             }
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -127,7 +127,13 @@ class instance_icecrown_citadel : public InstanceMapScript
                 DeathbringerSaurfangDoorGUID = 0;
                 DeathbringerSaurfangEventGUID = 0;
                 DeathbringersCacheGUID = 0;
-                SaurfangTeleportGUID = 0;
+                TeleporterLichKingGUID = 0;
+                TeleporterUpperSpireGUID = 0;
+                TeleporterLightsHammerGUID = 0;
+                TeleporterRampartsGUID = 0;
+                TeleporterDeathBringerGUID = 0;
+                TeleporterOratoryGUID = 0;
+                TeleporterSindragosaGUID = 0;
                 PlagueSigilGUID = 0;
                 BloodwingSigilGUID = 0;
                 FrostwingSigilGUID = 0;
@@ -164,8 +170,24 @@ class instance_icecrown_citadel : public InstanceMapScript
                 IsNauseaEligible = true;
                 IsOrbWhispererEligible = true;
                 ColdflameJetsState = NOT_STARTED;
+                UpperSpireTeleporterActiveState = NOT_STARTED;
                 BloodQuickeningState = NOT_STARTED;
                 BloodQuickeningMinutes = 0;
+            }
+            
+            // A function to help reduce the number of lines for teleporter management.
+            void SetTeleporterState(GameObject* go, bool usable)
+            {
+                if (usable)
+                {
+                    go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
+                    go->SetGoState(GO_STATE_ACTIVE);
+                }
+                else
+                {
+                    go->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
+                    go->SetGoState(GO_STATE_READY);
+                }
             }
 
             void FillInitialWorldStates(WorldPacket& data) override
@@ -542,8 +564,37 @@ class instance_icecrown_citadel : public InstanceMapScript
                     case GO_DEATHBRINGER_S_CACHE_25H:
                         DeathbringersCacheGUID = go->GetGUID();
                         break;
-                    case GO_SCOURGE_TRANSPORTER_SAURFANG:
-                        SaurfangTeleportGUID = go->GetGUID();
+                    case GO_SCOURGE_TRANSPORTER_LICHKING:
+                        TeleporterLichKingGUID = go->GetGUID();
+                        if (GetBossState(DATA_PROFESSOR_PUTRICIDE) == DONE && GetBossState(DATA_BLOOD_QUEEN_LANA_THEL) == DONE && GetBossState(DATA_SINDRAGOSA) == DONE)
+                            go->SetGoState(GO_STATE_ACTIVE);
+                        break;
+                    case GO_SCOURGE_TRANSPORTER_UPPERSPIRE:
+                        TeleporterUpperSpireGUID = go->GetGUID();
+                        if (GetBossState(DATA_DEATHBRINGER_SAURFANG) != DONE || GetData(DATA_UPPERSPIRE_TELE_ACT) != DONE)
+                            SetTeleporterState(go, false);
+                        else
+                            SetTeleporterState(go, true);
+                        break;
+                    case GO_SCOURGE_TRANSPORTER_LIGHTSHAMMER:
+                        TeleporterLightsHammerGUID = go->GetGUID();
+                        SetTeleporterState(go, GetBossState(DATA_LORD_MARROWGAR) == DONE);
+                        break;
+                    case GO_SCOURGE_TRANSPORTER_RAMPART:
+                        TeleporterRampartsGUID = go->GetGUID();
+                        SetTeleporterState(go, GetBossState(DATA_LADY_DEATHWHISPER) == DONE);
+                        break;
+                    case GO_SCOURGE_TRANSPORTER_DEATHBRINGER:
+                        TeleporterDeathBringerGUID = go->GetGUID();
+                        SetTeleporterState(go, GetBossState(DATA_ICECROWN_GUNSHIP_BATTLE) == DONE);
+                        break;
+                    case GO_SCOURGE_TRANSPORTER_ORATORY:
+                        TeleporterOratoryGUID = go->GetGUID();
+                        SetTeleporterState(go, GetBossState(DATA_LORD_MARROWGAR) == DONE);
+                        break;
+                    case GO_SCOURGE_TRANSPORTER_SINDRAGOSA:
+                        TeleporterSindragosaGUID = go->GetGUID();
+                        SetTeleporterState(go, GetBossState(DATA_VALITHRIA_DREAMWALKER) == DONE);
                         break;
                     case GO_PLAGUE_SIGIL:
                         PlagueSigilGUID = go->GetGUID();
@@ -599,11 +650,6 @@ class instance_icecrown_citadel : public InstanceMapScript
                         if (Creature* valithria = instance->GetCreature(ValithriaDreamwalkerGUID))
                             go->SetLootRecipient(valithria->GetLootRecipient());
                         go->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
-                        break;
-                    case GO_SCOURGE_TRANSPORTER_LK:
-                        TheLichKingTeleportGUID = go->GetGUID();
-                        if (GetBossState(DATA_PROFESSOR_PUTRICIDE) == DONE && GetBossState(DATA_BLOOD_QUEEN_LANA_THEL) == DONE && GetBossState(DATA_SINDRAGOSA) == DONE)
-                            go->SetGoState(GO_STATE_ACTIVE);
                         break;
                     case GO_ARTHAS_PLATFORM:
                         // this enables movement at The Frozen Throne, when printed this value is 0.000000f
@@ -694,6 +740,8 @@ class instance_icecrown_citadel : public InstanceMapScript
                         return RimefangTrash.size();
                     case DATA_COLDFLAME_JETS:
                         return ColdflameJetsState;
+                    case DATA_UPPERSPIRE_TELE_ACT:
+                        return UpperSpireTeleporterActiveState;
                     case DATA_TEAM_IN_INSTANCE:
                         return TeamInInstance;
                     case DATA_BLOOD_QUICKENING_STATE:
@@ -721,8 +769,20 @@ class instance_icecrown_citadel : public InstanceMapScript
                         return DeathbringerSaurfangEventGUID;
                     case GO_SAURFANG_S_DOOR:
                         return DeathbringerSaurfangDoorGUID;
-                    case GO_SCOURGE_TRANSPORTER_SAURFANG:
-                        return SaurfangTeleportGUID;
+                    case GO_SCOURGE_TRANSPORTER_LICHKING:
+                        return TeleporterLichKingGUID;
+                    case GO_SCOURGE_TRANSPORTER_UPPERSPIRE:
+                        return TeleporterUpperSpireGUID;
+                    case GO_SCOURGE_TRANSPORTER_LIGHTSHAMMER:
+                        return TeleporterLightsHammerGUID;
+                    case GO_SCOURGE_TRANSPORTER_RAMPART:
+                        return TeleporterRampartsGUID;
+                    case GO_SCOURGE_TRANSPORTER_DEATHBRINGER:
+                        return TeleporterDeathBringerGUID;
+                    case GO_SCOURGE_TRANSPORTER_ORATORY:
+                        return TeleporterOratoryGUID;
+                    case GO_SCOURGE_TRANSPORTER_SINDRAGOSA:
+                        return TeleporterSindragosaGUID;
                     case DATA_FESTERGUT:
                         return FestergutGUID;
                     case DATA_ROTFACE:
@@ -784,10 +844,24 @@ class instance_icecrown_citadel : public InstanceMapScript
 
                 switch (type)
                 {
+                    case DATA_LORD_MARROWGAR:
+                    {
+                        if (state == DONE)
+                        {
+                            if (GameObject* teleporter = instance->GetGameObject(TeleporterLightsHammerGUID))
+                                SetTeleporterState(teleporter, true);
+                            if (GameObject* teleporter = instance->GetGameObject(TeleporterOratoryGUID))
+                                SetTeleporterState(teleporter, true);
+                        }
+                        break;
+                    }
                     case DATA_LADY_DEATHWHISPER:
                     {
                         if (state == DONE)
                         {
+                            if (GameObject* teleporter = instance->GetGameObject(TeleporterRampartsGUID))
+                                SetTeleporterState(teleporter, true);
+                            
                             if (GameObject* elevator = instance->GetGameObject(LadyDeathwisperElevatorGUID))
                             {
                                 elevator->SetUInt32Value(GAMEOBJECT_LEVEL, 0);
@@ -801,6 +875,9 @@ class instance_icecrown_citadel : public InstanceMapScript
                     case DATA_ICECROWN_GUNSHIP_BATTLE:
                         if (state == DONE)
                         {
+                            if (GameObject* teleporter = instance->GetGameObject(TeleporterDeathBringerGUID))
+                                SetTeleporterState(teleporter, true);
+                            
                             if (GameObject* loot = instance->GetGameObject(GunshipArmoryGUID))
                                 loot->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
                         }
@@ -811,20 +888,28 @@ class instance_icecrown_citadel : public InstanceMapScript
                         switch (state)
                         {
                             case DONE:
+                            {
                                 if (GameObject* loot = instance->GetGameObject(DeathbringersCacheGUID))
                                 {
                                     if (Creature* deathbringer = instance->GetCreature(DeathbringerSaurfangGUID))
                                         loot->SetLootRecipient(deathbringer->GetLootRecipient());
                                     loot->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_LOCKED | GO_FLAG_NOT_SELECTABLE | GO_FLAG_NODESPAWN);
                                 }
-                                // no break
-                            case NOT_STARTED:
-                                if (GameObject* teleporter = instance->GetGameObject(SaurfangTeleportGUID))
-                                {
-                                    HandleGameObject(SaurfangTeleportGUID, true, teleporter);
-                                    teleporter->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
-                                }
+                                
+                                if (GameObject* teleporter = instance->GetGameObject(TeleporterUpperSpireGUID))
+                                    SetTeleporterState(teleporter, true);
+                                
+                                if (GameObject* teleporter = instance->GetGameObject(TeleporterDeathBringerGUID))
+                                    SetTeleporterState(teleporter, true);
                                 break;
+                            }
+                            case NOT_STARTED:
+                            {
+                                if (GameObject* teleporter = instance->GetGameObject(TeleporterDeathBringerGUID))
+                                    SetTeleporterState(teleporter, true);
+                                
+                                break;
+                            }
                             default:
                                 break;
                         }
@@ -896,6 +981,9 @@ class instance_icecrown_citadel : public InstanceMapScript
                     case DATA_VALITHRIA_DREAMWALKER:
                         if (state == DONE && sPoolMgr->IsSpawnedObject<Quest>(WeeklyQuestData[8].questId[instance->GetSpawnMode() & 1]))
                             instance->SummonCreature(NPC_VALITHRIA_DREAMWALKER_QUEST, ValithriaSpawnPos);
+                        if (state == DONE)
+                            if (GameObject* teleporter = instance->GetGameObject(TeleporterSindragosaGUID))
+                                SetTeleporterState(teleporter, true);
                         break;
                     case DATA_SINDRAGOSA:
                         HandleGameObject(FrostwingSigilGUID, state != DONE);
@@ -1029,6 +1117,11 @@ class instance_icecrown_citadel : public InstanceMapScript
                         SaveToDB();
                         break;
                     }
+                    case DATA_UPPERSPIRE_TELE_ACT:
+                        UpperSpireTeleporterActiveState = data;
+                        if (UpperSpireTeleporterActiveState == DONE)
+                            SaveToDB();
+                        break;
                     default:
                         break;
                 }
@@ -1235,7 +1328,7 @@ class instance_icecrown_citadel : public InstanceMapScript
 
                 std::ostringstream saveStream;
                 saveStream << "I C " << GetBossSaveData() << HeroicAttempts << ' '
-                    << ColdflameJetsState << ' ' << BloodQuickeningState << ' ' << BloodQuickeningMinutes;
+                    << ColdflameJetsState << ' ' << BloodQuickeningState << ' ' << BloodQuickeningMinutes << ' ' << UpperSpireTeleporterActiveState;
 
                 OUT_SAVE_INST_DATA_COMPLETE;
                 return saveStream.str();
@@ -1271,11 +1364,17 @@ class instance_icecrown_citadel : public InstanceMapScript
 
                     uint32 temp = 0;
                     loadStream >> temp;
-                    ColdflameJetsState = temp ? DONE : NOT_STARTED;
+                    if (temp == IN_PROGRESS)
+                        ColdflameJetsState = NOT_STARTED;
+                    else
+                        ColdflameJetsState = temp ? DONE : NOT_STARTED;
 
                     loadStream >> temp;
                     BloodQuickeningState = temp ? DONE : NOT_STARTED;   // DONE means finished (not success/fail)
                     loadStream >> BloodQuickeningMinutes;
+                    
+                    loadStream >> temp;
+                    UpperSpireTeleporterActiveState = temp ? DONE : NOT_STARTED;
                 }
                 else
                     OUT_LOAD_INST_DATA_FAIL;
@@ -1416,7 +1515,13 @@ class instance_icecrown_citadel : public InstanceMapScript
             uint64 DeathbringerSaurfangDoorGUID;
             uint64 DeathbringerSaurfangEventGUID;   // Muradin Bronzebeard or High Overlord Saurfang
             uint64 DeathbringersCacheGUID;
-            uint64 SaurfangTeleportGUID;
+            uint64 TeleporterLichKingGUID;
+            uint64 TeleporterUpperSpireGUID;
+            uint64 TeleporterLightsHammerGUID;
+            uint64 TeleporterRampartsGUID;
+            uint64 TeleporterDeathBringerGUID;
+            uint64 TeleporterOratoryGUID;
+            uint64 TeleporterSindragosaGUID;
             uint64 PlagueSigilGUID;
             uint64 BloodwingSigilGUID;
             uint64 FrostwingSigilGUID;
@@ -1453,6 +1558,7 @@ class instance_icecrown_citadel : public InstanceMapScript
             uint64 PillarsUnchainedGUID;
             uint32 TeamInInstance;
             uint32 ColdflameJetsState;
+            uint32 UpperSpireTeleporterActiveState;
             std::set<uint32> FrostwyrmGUIDs;
             std::set<uint32> SpinestalkerTrash;
             std::set<uint32> RimefangTrash;


### PR DESCRIPTION
*Upon entering the raid, the Lights Hammer teleporter is no longer immediately active. Both the Light's Hammer and the Oratory Portal will pop up after the completion of Lord Marrowgar as it does on official during 3.3.5a.
*A teleporter in ICC can no longer teleport you to itself.
*There is no longer a reason to allow GMs to use portals without available GOSSIP text and teleport locations. Therefore the teleports now use GO_FLAG_NOT_SELECTABLE when they are unavailable. In the future we can enable GMs to use portals without bosses defeated, however for now all it does is break the instance if some bosses are done out of order.
*Currently the Upper Spire teleporter cannot be visited unless the event ColdFlameTraps is completed. This isn't blizz-like. During WotLK retail, the teleporter in the upper spire can be visited once any member has walked over an AreaTrigger which is located the moment you enter the UpperSpire Facade. The cold flame event has nothing to do with the teleporter, the cold flame event instead should be triggered to "DONE" when a rogue instead disarms it.
*A bug has been addressed that causes the ColdFlameTraps event to not start back up after a server restart. The event will now restart as long as the player goes through the Saurfang->Upper Spire doorway; I'm not sure who required the doorway to be an area trigger, but it's hacky and not blizzlike. I have not yet addressed the area trigger problem with the doorway in this commit, mainly because the point of this commit is to make the ICC teleporters extremely Blizz-Like.
*The "Conspicuous Lever" will now spawn inside of ICC. (From Sniff on Retail) While the lever currently doesn't do anything, in the future it will turn off the ColdFlame Traps. In the future only rogues should see this lever and only they can disable the traps using "Disarm Trap".
*The teleporter near Saurfang is not supposed to disable during the Intro. It disables whenever Saurfang enters combat with the players. The teleporter then enablers again when combat stops.
