### PR TITLE
Core/Battleground: fixed possible mount abuse after leaving BG

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -844,11 +844,13 @@ void Battleground::RemovePlayerAtLeave(uint64 guid, bool Transport, bool SendPac
 
     Player* player = ObjectAccessor::FindPlayer(guid);
 
-    // should remove spirit of redemption
     if (player)
     {
+        // should remove spirit of redemption
         if (player->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION))
             player->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+
+        player->RemoveAurasByType(SPELL_AURA_MOUNTED);
 
         if (!player->IsAlive())                              // resurrect on exit
         {


### PR DESCRIPTION
How to reproduce the bug:
- Talk with a flight master and take a fly to somewhere
- Join a BattleGround while flying
- Mount when you are still in the BG, and then left BG while mounted

Result:

While flight is ended, the mount icon is still enabled and the speed is set as you are mounted (your mount speed). But you are not actually mounted, so you are able to cast spells and fight against NPCs.
So you can play with the mounted speed, even if you are not really mounted.
