### PR TITLE
Core/Spells: fix cast time talent bonus of channeled spells

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12908,6 +12908,16 @@ void Unit::ModSpellCastTime(SpellInfo const* spellInfo, int32 & castTime, Spell*
         castTime = 500;
 }
 
+void Unit::ModChanneledSpellCastTime(SpellInfo const* spellInfo, int32 & castTime, Spell* spell)
+{
+    if (!spellInfo || castTime < 0)
+        return;
+
+    // called from caster
+    if (Player* modOwner = GetSpellModOwner())
+        modOwner->ApplySpellMod(spellInfo->Id, SPELLMOD_CASTING_TIME, castTime, spell);
+}
+
 DiminishingLevels Unit::GetDiminishing(DiminishingGroup group)
 {
     for (Diminishing::iterator i = m_Diminishing.begin(); i != m_Diminishing.end(); ++i)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2026,6 +2026,7 @@ class Unit : public WorldObject
         int32 CalcSpellDuration(SpellInfo const* spellProto);
         int32 ModSpellDuration(SpellInfo const* spellProto, Unit const* target, int32 duration, bool positive, uint32 effectMask);
         void  ModSpellCastTime(SpellInfo const* spellProto, int32& castTime, Spell* spell = NULL);
+        void  ModChanneledSpellCastTime(SpellInfo const* spellProto, int32& castTime, Spell* spell = NULL);
         float CalculateLevelPenalty(SpellInfo const* spellProto) const;
 
         void addFollower(FollowerReference* pRef) { m_FollowingRefManager.insertFirst(pRef); }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2098,7 +2098,12 @@ uint32 SpellInfo::CalcCastTime(Spell* spell /*= NULL*/) const
     int32 castTime = CastTimeEntry->CastTime;
 
     if (spell)
+    {
         spell->GetCaster()->ModSpellCastTime(this, castTime, spell);
+
+        if (IsChanneled())
+            spell->GetCaster()->ModChanneledSpellCastTime(this, castTime, spell);
+    }
 
     if (Attributes & SPELL_ATTR0_REQ_AMMO && (!IsAutoRepeatRangedSpell()))
         castTime += 500;


### PR DESCRIPTION
This fixes the cast time talent bonus of channeled spells, including Improved Succubus (https://github.com/TrinityCore/TrinityCore/issues/1543)

---

The problem is that in our spell sources the concept of "duration" of a spell currently refers to:
- "cast time" for non-channeled spells
- "channeled time" for channeled spells

because channeled spells are often istant then they haven't cast time.
But the Seduction spell is one of those few channeled spells which has a cast time, and this creates a messy, for example in Spell.cpp we have:

```
if (m_spellInfo->IsChanneled())
    m_originalCaster->ModSpellCastTime(aurSpellInfo, duration, this);
```

which is no sense, since ModSpellCastTime returns on channeled spells. But we cannot simply edit it without create other disasters.
