### PR TITLE
Core/Channels: fixed possible exploit with channel password

### DIFF
--- a/src/server/game/Chat/Channels/ChannelMgr.h
+++ b/src/server/game/Chat/Channels/ChannelMgr.h
@@ -26,6 +26,8 @@
 
 #include "World.h"
 
+#define MAX_CHANNEL_PASS_STR 31
+
 class ChannelMgr
 {
     typedef std::map<std::wstring, Channel*> ChannelMap;

--- a/src/server/game/Handlers/ChannelHandler.cpp
+++ b/src/server/game/Handlers/ChannelHandler.cpp
@@ -100,6 +100,9 @@ void WorldSession::HandleChannelPassword(WorldPacket& recvPacket)
     TC_LOG_DEBUG("chat.system", "CMSG_CHANNEL_PASSWORD %s Channel: %s, Password: %s",
         GetPlayerInfo().c_str(), channelName.c_str(), password.c_str());
 
+    if (password.length() > MAX_CHANNEL_PASS_STR)
+        return;
+
     if (ChannelMgr* cMgr = ChannelMgr::forTeam(GetPlayer()->GetTeam()))
         if (Channel* channel = cMgr->GetChannel(channelName, GetPlayer()))
             channel->Password(GetPlayer(), password);


### PR DESCRIPTION
You were able to setup longer password than you can write into the dialog window. Limit in dialog is 31 chars, in DB is varchar(32) but there was no limit in command /pass <channel> <password>, so that was the problem.
