### PR TITLE
Core/BG: use GetTypeID(true) instead of GetTypeID() 

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -764,7 +764,7 @@ void Battleground::EndBattleground(uint32 winner)
     {
         stmt->setUInt64(0, battleground_id);
         stmt->setUInt8(2, m_BracketId + 1);
-        stmt->setUInt8(3, GetTypeID());
+        stmt->setUInt8(3, GetTypeID(true));
         CharacterDatabase.Execute(stmt);
     }
 


### PR DESCRIPTION
This is required to fetch the correct type even if it's a RBG.
