### PR TITLE
Core/Spells: Prayer of Mending should scale with talents

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -557,17 +557,17 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
 {
     public:
         spell_pri_prayer_of_mending_heal() : SpellScriptLoader("spell_pri_prayer_of_mending_heal") { }
-    
+
         class spell_pri_prayer_of_mending_heal_SpellScript : public SpellScript
         {
             PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript);
-    
+
             void HandleHeal(SpellEffIndex /*effIndex*/)
             {
                 if (Unit* caster = GetOriginalCaster())
                 {
                     int32 heal = GetHitHeal();
-    
+
                     if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2_PIECE,EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
@@ -576,17 +576,17 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
                         AddPctN(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_TWIN_DISC, EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());
-    
+
                     SetHitHeal(heal);
                 }
             }
-    
+
             void Register() OVERRIDE
             {
                 OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending_heal_SpellScript::HandleHeal, EFFECT_0, SPELL_EFFECT_HEAL);
             }
         };
-    
+
         SpellScript* GetSpellScript() const OVERRIDE
         {
             return new spell_pri_prayer_of_mending_heal_SpellScript();

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -568,7 +568,7 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
                 {
                     int32 heal = GetHitHeal();
 
-                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2_PIECE,EFFECT_0))
+                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2,EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -552,45 +552,45 @@ class spell_pri_power_word_shield : public SpellScriptLoader
         }
 };
 
-// Prayer of Mending Heal
+// 33110 - Prayer of Mending Heal
 class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
 {
-public:
-    spell_pri_prayer_of_mending_heal() : SpellScriptLoader("spell_pri_prayer_of_mending_heal") { }
-
-    class spell_pri_prayer_of_mending_heal_SpellScript : public SpellScript
-    {
-        PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript);
-
-        void HandleHeal(SpellEffIndex /*effIndex*/)
+    public:
+        spell_pri_prayer_of_mending_heal() : SpellScriptLoader("spell_pri_prayer_of_mending_heal") { }
+    
+        class spell_pri_prayer_of_mending_heal_SpellScript : public SpellScript
         {
-            if (Unit* caster = GetOriginalCaster())
+            PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript);
+    
+            void HandleHeal(SpellEffIndex /*effIndex*/)
             {
-                int32 heal = GetHitHeal();
-
-                if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2_PIECE,EFFECT_0))
-                    AddPctN(heal, aurEff->GetAmount());
-                if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
-                    AddPctN(heal, aurEff->GetAmount());
-                if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_DIVINE_PROVIDENCE, EFFECT_0))
-                    AddPctN(heal, aurEff->GetAmount());
-                if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_TWIN_DISC, EFFECT_0))
-                    AddPctN(heal, aurEff->GetAmount());
-
-                SetHitHeal(heal);
+                if (Unit* caster = GetOriginalCaster())
+                {
+                    int32 heal = GetHitHeal();
+    
+                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2_PIECE,EFFECT_0))
+                        AddPctN(heal, aurEff->GetAmount());
+                    if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
+                        AddPctN(heal, aurEff->GetAmount());
+                    if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_DIVINE_PROVIDENCE, EFFECT_0))
+                        AddPctN(heal, aurEff->GetAmount());
+                    if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_TWIN_DISC, EFFECT_0))
+                        AddPctN(heal, aurEff->GetAmount());
+    
+                    SetHitHeal(heal);
+                }
             }
-        }
-
-        void Register()
+    
+            void Register() OVERRIDE
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending_heal_SpellScript::HandleHeal, EFFECT_0, SPELL_EFFECT_HEAL);
+            }
+        };
+    
+        SpellScript* GetSpellScript() const OVERRIDE
         {
-            OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending_heal_SpellScript::HandleHeal, EFFECT_0, SPELL_EFFECT_HEAL);
+            return new spell_pri_prayer_of_mending_heal_SpellScript();
         }
-    };
-
-    SpellScript* GetSpellScript() const
-    {
-        return new spell_pri_prayer_of_mending_heal_SpellScript();
-    }
 };
 
 // -139 - Renew

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -569,13 +569,13 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
                     int32 heal = GetHitHeal();
 
                     if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_PRIEST_T9_HEALING_2P,EFFECT_0))
-                        AddPctN(heal, aurEff->GetAmount());
+                        AddPct(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
-                        AddPctN(heal, aurEff->GetAmount());
+                        AddPct(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_DIVINE_PROVIDENCE, EFFECT_0))
-                        AddPctN(heal, aurEff->GetAmount());
+                        AddPct(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_TWIN_DISC, EFFECT_0))
-                        AddPctN(heal, aurEff->GetAmount());
+                        AddPct(heal, aurEff->GetAmount());
 
                     SetHitHeal(heal);
                 }

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -568,7 +568,7 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
                 {
                     int32 heal = GetHitHeal();
 
-                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2,EFFECT_0))
+                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2P,EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -44,6 +44,9 @@ enum PriestSpells
     SPELL_PRIEST_SHADOW_WORD_DEATH                  = 32409,
     SPELL_PRIEST_T9_HEALING_2P                      = 67201,
     SPELL_PRIEST_VAMPIRIC_TOUCH_DISPEL              = 64085,
+    SPELL_SPIRITUAL_HEAL                            = 14898,
+    SPELL_DIVINE_PROVIDENCE                         = 47562,
+    SPELL_TWIN_DISC                                 = 47586,
 };
 
 enum PriestSpellIcons
@@ -549,39 +552,45 @@ class spell_pri_power_word_shield : public SpellScriptLoader
         }
 };
 
-// 33110 - Prayer of Mending Heal
+// Prayer of Mending Heal
 class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
 {
-    public:
-        spell_pri_prayer_of_mending_heal() : SpellScriptLoader("spell_pri_prayer_of_mending_heal") { }
+public:
+    spell_pri_prayer_of_mending_heal() : SpellScriptLoader("spell_pri_prayer_of_mending_heal") { }
 
-        class spell_pri_prayer_of_mending_heal_SpellScript : public SpellScript
+    class spell_pri_prayer_of_mending_heal_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript);
+
+        void HandleHeal(SpellEffIndex /*effIndex*/)
         {
-            PrepareSpellScript(spell_pri_prayer_of_mending_heal_SpellScript);
-
-            void HandleHeal(SpellEffIndex /*effIndex*/)
+            if (Unit* caster = GetOriginalCaster())
             {
-                if (Unit* caster = GetOriginalCaster())
-                {
-                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_PRIEST_T9_HEALING_2P, EFFECT_0))
-                    {
-                        int32 heal = GetHitHeal();
-                        AddPct(heal, aurEff->GetAmount());
-                        SetHitHeal(heal);
-                    }
-                }
-            }
+                int32 heal = GetHitHeal();
 
-            void Register() OVERRIDE
-            {
-                OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending_heal_SpellScript::HandleHeal, EFFECT_0, SPELL_EFFECT_HEAL);
-            }
-        };
+                if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2_PIECE,EFFECT_0))
+                    AddPctN(heal, aurEff->GetAmount());
+                if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
+                    AddPctN(heal, aurEff->GetAmount());
+                if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_DIVINE_PROVIDENCE, EFFECT_0))
+                    AddPctN(heal, aurEff->GetAmount());
+                if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_TWIN_DISC, EFFECT_0))
+                    AddPctN(heal, aurEff->GetAmount());
 
-        SpellScript* GetSpellScript() const OVERRIDE
-        {
-            return new spell_pri_prayer_of_mending_heal_SpellScript();
+                SetHitHeal(heal);
+            }
         }
+
+        void Register()
+        {
+            OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending_heal_SpellScript::HandleHeal, EFFECT_0, SPELL_EFFECT_HEAL);
+        }
+    };
+
+    SpellScript* GetSpellScript() const
+    {
+        return new spell_pri_prayer_of_mending_heal_SpellScript();
+    }
 };
 
 // -139 - Renew

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -568,7 +568,7 @@ class spell_pri_prayer_of_mending_heal : public SpellScriptLoader
                 {
                     int32 heal = GetHitHeal();
 
-                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_T9_HEALING_2P,EFFECT_0))
+                    if (AuraEffect* aurEff = caster->GetAuraEffect(SPELL_PRIEST_T9_HEALING_2P,EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());
                     if (AuraEffect* aurEff = caster->GetAuraEffectOfRankedSpell(SPELL_SPIRITUAL_HEAL, EFFECT_0))
                         AddPctN(heal, aurEff->GetAmount());


### PR DESCRIPTION
This affects:
Spiritual Healing - http://wotlk.openwow.com/spell=15356
Twin Disciplines - http://wotlk.openwow.com/spell=47586
Divine Providence - http://wotlk.openwow.com/spell=47567

I am not sure if I did everything right with latest TC (since I am behind latest TC version a bit) but you may find your use.

Sorry.
