### PR TITLE
Core/Spells: Stormstrike should stack for different casters

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3312,6 +3312,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 59630: // Black Magic
                 spellInfo->Attributes |= SPELL_ATTR0_PASSIVE;
                 break;
+            case 17364: // Stormstrike
+                spellInfo->AttributesEx3 |= SPELL_ATTR3_STACK_FOR_DIFF_CASTERS;
+                break;
             // ULDUAR SPELLS
             //
             case 62374: // Pursued (Flame Leviathan)


### PR DESCRIPTION
Solve issue when 2 enhancement shamans are attacking same target,
there must be different stormstrike debuffs on the target

I just add this for the moment, as my previous modifications on other spells need more research.
