### PR TITLE
Removed redundant cast to c_str() in ConfigMgr::Reload function.

### DIFF
--- a/src/server/shared/Configuration/Config.cpp
+++ b/src/server/shared/Configuration/Config.cpp
@@ -59,7 +59,7 @@ bool ConfigMgr::LoadInitial(std::string const& file, std::string& error)
 
 bool ConfigMgr::Reload(std::string& error)
 {
-    return LoadInitial(_filename.c_str(), error);
+    return LoadInitial(_filename, error);
 }
 
 std::string ConfigMgr::GetStringDefault(std::string const& name, const std::string& def)


### PR DESCRIPTION
cppcheck performance warning:
[src/server/shared/Configuration/Config.cpp:62]: (performance) Passing the
result of c_str() to a function that takes std::string as argument no. 1 is
slow and redundant.
