### PR TITLE
Scripts/Spells: added Interrupt effect for Maim/Bash/Hammer of Justice

### DIFF
--- a/sql/updates/world/2014_09_09_01_world_spell_linked_spell.sql
+++ b/sql/updates/world/2014_09_09_01_world_spell_linked_spell.sql
@@ -1,0 +1,11 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (853, 5588, 5589, 10308, 22570, 49802, 5211, 6798, 8983) AND `spell_effect` = 32747;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(853, 32747, 0, 'Hammer of Justice - Interrupt - Rank 1 '),
+(5588, 32747, 0, 'Hammer of Justice - Interrupt - Rank 2'),
+(5589, 32747, 0, 'Hammer of Justice - Interrupt - Rank 3'),
+(10308, 32747, 0, 'Hammer of Justice - Interrupt - Rank 4'),
+(22570, 32747, 0, 'Maim - Interrupt - Rank 1'),
+(49802, 32747, 0, 'Maim - Interrupt - Rank 2'),
+(5211, 32747, 0, 'Bash - Interrupt - Rank 1'),
+(6798, 32747, 0, 'Bash - Interrupt - Rank 2'),
+(8983, 32747, 0, 'Bash - Interrupt - Rank 3');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -3609,6 +3609,36 @@ class spell_gen_eject_all_passengers : public SpellScriptLoader
         }
 };
 
+class spell_gen_interrupt : public SpellScriptLoader
+{
+public:
+    spell_gen_interrupt() : SpellScriptLoader("spell_gen_interrupt") { }
+
+    class spell_gen_interrupt_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_gen_interrupt_SpellScript);
+
+        SpellCastResult CheckCast()
+        {
+            if (Unit* target = GetExplTargetUnit())
+                if (!target->ToCreature())
+                    return SPELL_FAILED_DONT_REPORT;
+
+            return SPELL_CAST_OK;
+        }
+
+        void Register() override
+        {
+            OnCheckCast += SpellCheckCastFn(spell_gen_interrupt_SpellScript::CheckCast);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_gen_interrupt_SpellScript();
+    }
+};
+
 void AddSC_generic_spell_scripts()
 {
     new spell_gen_absorb0_hitlimit1();
@@ -3689,4 +3719,5 @@ void AddSC_generic_spell_scripts()
     new spell_gen_wg_water();
     new spell_gen_whisper_gulch_yogg_saron_whisper();
     new spell_gen_eject_all_passengers();
+    new spell_gen_interrupt();
 }


### PR DESCRIPTION
As per dbc description, those three spells all have: 
Description: Stuns the target for $d and interrupts non-player spellcasting for $32747d
Spell 32747 was not linked to them and need a small script to be applied only to creatures.
