### PR TITLE
Add HoverHeight to GetMeleeReach() so that IsWithinMeleeRange() returns correct value on hovering units.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -432,10 +432,6 @@ void Unit::resetAttackTimer(WeaponAttackType type)
 float Unit::GetMeleeReach() const
 {
     float reach = m_floatValues[UNIT_FIELD_COMBATREACH];
-
-    if (IsHovering())
-        reach += m_floatValues[UNIT_FIELD_HOVERHEIGHT];
-
     return reach > MIN_MELEE_REACH ? reach : MIN_MELEE_REACH;
 }
 
@@ -462,7 +458,7 @@ bool Unit::IsWithinMeleeRange(const Unit* obj, float dist) const
 
     float dx = GetPositionX() - obj->GetPositionX();
     float dy = GetPositionY() - obj->GetPositionY();
-    float dz = GetPositionZ() - obj->GetPositionZ();
+    float dz = GetPositionZMinusOffset() - obj->GetPositionZMinusOffset();
     float distsq = dx*dx + dy*dy + dz*dz;
 
     float sizefactor = GetMeleeReach() + obj->GetMeleeReach();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -432,6 +432,10 @@ void Unit::resetAttackTimer(WeaponAttackType type)
 float Unit::GetMeleeReach() const
 {
     float reach = m_floatValues[UNIT_FIELD_COMBATREACH];
+
+    if (IsHovering())
+        reach += m_floatValues[UNIT_FIELD_HOVERHEIGHT];
+
     return reach > MIN_MELEE_REACH ? reach : MIN_MELEE_REACH;
 }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1619,6 +1619,7 @@ class Unit : public WorldObject
 
         bool IsLevitating() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY); }
         bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING); }
+        bool IsHovering() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_HOVER); }
         virtual bool SetWalk(bool enable);
         virtual bool SetDisableGravity(bool disable, bool packetOnly = false);
         virtual bool SetSwim(bool enable);


### PR DESCRIPTION
Solves issues related to hovering units with high hoverheight values: they couldn't be auto-attacked.
