### PR TITLE
Core/BG: use new GetUniqueBracketID() method to store statistics

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -738,7 +738,7 @@ void Battleground::EndBattleground(uint32 winner)
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_PVPSTATS_BATTLEGROUND);
         stmt->setUInt64(0, battlegroundId);
         stmt->setUInt8(1, GetWinner());
-        stmt->setUInt8(2, m_BracketId + 1);
+        stmt->setUInt8(2, GetUniqueBracketID());
         stmt->setUInt8(3, GetTypeID(true));
         CharacterDatabase.Execute(stmt);
     }
@@ -1831,4 +1831,9 @@ bool Battleground::CheckAchievementCriteriaMeet(uint32 criteriaId, Player const*
 {
     TC_LOG_ERROR("bg.battleground", "Battleground::CheckAchievementCriteriaMeet: No implementation for criteria %u", criteriaId);
     return false;
+}
+
+uint8 Battleground::GetUniqueBracketID()
+{
+    return GetMinLevel()/10;
 }

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -469,6 +469,9 @@ class Battleground
 
         virtual uint32 GetPrematureWinner();
 
+        // because BattleGrounds with different types and same level range has different m_BracketId
+        uint8 GetUniqueBracketID();
+
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground
         void EndNow();


### PR DESCRIPTION
This is because now BattleGrounds with different types and same level range has different m_BracketId

NOTE: GetUniqueBracketID() method should be rewritten for 4.3.4. I'll do that once this PR is merged in master and once master will be merged in 4.3.4.
