### PR TITLE
Core/Unit: fix combo points disappearing after NPC dies

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10780,7 +10780,6 @@ void Unit::setDeathState(DeathState s)
         CombatStop();
         DeleteThreatList();
         getHostileRefManager().deleteReferences();
-        ClearComboPointHolders();                           // any combo points pointed to unit lost at it death
 
         if (IsNonMeleeSpellCast(false))
             InterruptNonMeleeSpells(false);
@@ -10822,7 +10821,10 @@ void Unit::setDeathState(DeathState s)
             zoneScript->OnUnitDeath(this);
     }
     else if (s == JUST_RESPAWNED)
+    {
         RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE); // clear skinnable for creature and player (at battleground)
+        ClearComboPointHolders();                          // any combo points pointed to unit lost at its respawn
+    }
 }
 
 /*########################################


### PR DESCRIPTION
Fix combo points disappearing after NPC dies, closes TrinityCore#9138
