### PR TITLE
Core/Chat: Allow GameObjects to use various talk functions.

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -836,6 +836,17 @@ class GameObject : public WorldObject, public GridObject<GameObject>, public Map
 
         void UpdateModelPosition();
 
+        void Talk(std::string const& text, ChatMsg msgType, Language language, float textRange, WorldObject const* target);
+        void Say(std::string const& text, Language language, WorldObject const* target /*= nullptr*/);
+        void Yell(std::string const& text, Language language, WorldObject const* target /*= nullptr*/);
+        void TextEmote(std::string const& text, WorldObject const* target /*= nullptr*/, bool isBossEmote /*= false*/);
+        void Whisper(std::string const& text, Language language, Player* target, bool isBossWhisper /*= false*/);
+        void Talk(uint32 textId, ChatMsg msgType, float textRange, WorldObject const* target);
+        void Say(uint32 textId, WorldObject const* target /*= nullptr*/);
+        void Yell(uint32 textId, WorldObject const* target /*= nullptr*/);
+        void TextEmote(uint32 textId, WorldObject const* target /*= nullptr*/, bool isBossEmote /*= false*/);
+        void Whisper(uint32 textId, Player* target, bool isBossWhisper /*= false*/);
+
     protected:
         bool AIM_Initialize();
         void UpdateModel();                                 // updates model in case displayId were changed

--- a/src/server/game/Texts/ChatTextBuilder.h
+++ b/src/server/game/Texts/ChatTextBuilder.h
@@ -23,26 +23,31 @@
 
 namespace Trinity
 {
+    // Unit Text Builder
     class BroadcastTextBuilder
     {
         public:
             BroadcastTextBuilder(Unit const* obj, ChatMsg msgType, uint32 textId, WorldObject const* target = nullptr, uint32 achievementId = 0)
                 : _source(obj), _msgType(msgType), _textId(textId), _target(target), _achievementId(achievementId) { }
 
+            BroadcastTextBuilder(GameObject const* obj, ChatMsg msgType, uint32 textId, WorldObject const* target = nullptr, uint32 achievementId = 0)
+                : _source(obj), _msgType(msgType), _textId(textId), _target(target), _achievementId(achievementId) { }
+
+            // Note, Broadcasttexts for GameObjects have the same text for both genders. Thus, we force GENDER_MALE
             void operator()(WorldPacket& data, LocaleConstant locale)
             {
                 BroadcastText const* bct = sObjectMgr->GetBroadcastText(_textId);
-                ChatHandler::BuildChatPacket(data, _msgType, bct ? Language(bct->Language) : LANG_UNIVERSAL, _source, _target, bct ? bct->GetText(locale, _source->getGender()) : "", _achievementId, "", locale);
+                ChatHandler::BuildChatPacket(data, _msgType, bct ? Language(bct->Language) : LANG_UNIVERSAL, _source, _target, bct ? bct->GetText(locale, (_source->GetTypeId() == TYPEID_PLAYER ? _source->ToUnit()->getGender() : GENDER_MALE)) : "", _achievementId, "", locale);
             }
 
             size_t operator()(WorldPacket* data, LocaleConstant locale) const
             {
                 BroadcastText const* bct = sObjectMgr->GetBroadcastText(_textId);
-                return ChatHandler::BuildChatPacket(*data, _msgType, bct ? Language(bct->Language) : LANG_UNIVERSAL, _source, _target, bct ? bct->GetText(locale, _source->getGender()) : "", _achievementId, "", locale);
+                return ChatHandler::BuildChatPacket(*data, _msgType, bct ? Language(bct->Language) : LANG_UNIVERSAL, _source, _target, bct ? bct->GetText(locale, (_source->GetTypeId() == TYPEID_PLAYER ? _source->ToUnit()->getGender() : GENDER_MALE)) : "", _achievementId, "", locale);
             }
 
         private:
-            Unit const* _source;
+            WorldObject const* _source;
             ChatMsg _msgType;
             uint32 _textId;
             WorldObject const* _target;

--- a/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
@@ -37,8 +37,11 @@ enum Sounds
     SOUND_MR_SMITE_ALARM2                                = 5777
 };
 
-#define SAY_MR_SMITE_ALARM1 "You there, check out that noise!"
-#define SAY_MR_SMITE_ALARM2 "We're under attack! A vast, ye swabs! Repel the invaders!"
+enum MrSmiteSay
+{
+    SAY_MR_SMITE_ALARM_1                                 = 1148,
+    SAY_MR_SMITE_ALARM_2                                 = 1149
+};
 
 enum Misc
 {
@@ -93,7 +96,7 @@ class instance_deadmines : public InstanceMapScript
                         CannonBlast_Timer = DATA_CANNON_BLAST_TIMER;
                         // it's a hack - Mr. Smite should do that but his too far away
                         //pIronCladDoor->SetName("Mr. Smite");
-                        //pIronCladDoor->MonsterYell(SAY_MR_SMITE_ALARM1, LANG_UNIVERSAL, NULL);
+                        pIronCladDoor->Yell(SAY_MR_SMITE_ALARM_1, NULL);
                         pIronCladDoor->PlayDirectSound(SOUND_MR_SMITE_ALARM1);
                         State = CANNON_BLAST_INITIATED;
                         break;
@@ -105,7 +108,7 @@ class instance_deadmines : public InstanceMapScript
                             ShootCannon();
                             BlastOutDoor();
                             LeverStucked();
-                            //pIronCladDoor->MonsterYell(SAY_MR_SMITE_ALARM2, LANG_UNIVERSAL, NULL);
+                            pIronCladDoor->Yell(SAY_MR_SMITE_ALARM_2, NULL);
                             pIronCladDoor->PlayDirectSound(SOUND_MR_SMITE_ALARM2);
                             State = PIRATES_ATTACK;
                         } else CannonBlast_Timer -= diff;


### PR DESCRIPTION
Also includes a re-instating of a hacky fix, namely Mr. Smite in Deadmines shouting an alarm.

Note, they are the same as normal talk functions as provided for creatures. There is no actual behavior for gameobjects as it seems, however this allows some customization and/or hacky ways to do talking GOs.
