### PR TITLE
New characters gets their spells from database instead of DBC files

### DIFF
--- a/sql/updates/world/2014_09_18_02_world_playercreateinfo_spell.sql
+++ b/sql/updates/world/2014_09_18_02_world_playercreateinfo_spell.sql
@@ -1,0 +1,193 @@
+/*
+MySQL Data Transfer
+Source Host: localhost
+Source Database: ashbringer_tc_world
+Target Host: localhost
+Target Database: ashbringer_tc_world
+Date: 9/18/2014 12:19:46 PM
+*/
+
+SET FOREIGN_KEY_CHECKS=0;
+-- ----------------------------
+-- Table structure for playercreateinfo_spell
+-- ----------------------------
+CREATE TABLE `playercreateinfo_spell` (
+  `racemask` int(4) NOT NULL DEFAULT '0',
+  `classmask` int(4) NOT NULL DEFAULT '0',
+  `Spell` int(4) NOT NULL DEFAULT '0',
+  `skilline` int(4) NOT NULL DEFAULT '0' COMMENT 'DEV ONLY',
+  PRIMARY KEY (`racemask`,`classmask`,`Spell`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- ----------------------------
+-- Records 
+-- ----------------------------
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '128', '168', '6');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '128', '71761', '6');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '128', '133', '8');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1', '78', '26');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1', '2457', '26');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '8', '1752', '38');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '8', '21184', '38');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '4', '2973', '51');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '16', '2050', '56');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '16', '585', '56');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '7341', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('512', '0', '813', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('32', '0', '670', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('690', '0', '669', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('16', '0', '17737', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('32', '0', '20549', '124');
+INSERT INTO `playercreateinfo_spell` VALUES ('32', '0', '20550', '124');
+INSERT INTO `playercreateinfo_spell` VALUES ('32', '0', '20551', '124');
+INSERT INTO `playercreateinfo_spell` VALUES ('32', '0', '20552', '124');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '45', '20572', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '0', '20573', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '0', '20574', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '256', '20575', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '4', '20576', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '1179', '21563', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '256', '33702', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '64', '33697', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '32', '54562', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('2', '64', '65222', '125');
+INSERT INTO `playercreateinfo_spell` VALUES ('8', '0', '20583', '126');
+INSERT INTO `playercreateinfo_spell` VALUES ('8', '0', '20582', '126');
+INSERT INTO `playercreateinfo_spell` VALUES ('8', '0', '20585', '126');
+INSERT INTO `playercreateinfo_spell` VALUES ('8', '0', '58984', '126');
+INSERT INTO `playercreateinfo_spell` VALUES ('8', '1085', '21009', '126');
+INSERT INTO `playercreateinfo_spell` VALUES ('64', '0', '7340', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '4', '75', '163');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '2382', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '3365', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '3050', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '6233', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '6246', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '6247', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '6477', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '6478', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '6603', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '7266', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '7267', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '7355', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '8386', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '9125', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '21651', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '21652', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '22027', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '22810', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '2479', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1024', '27764', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '2', '27762', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '64', '27763', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '4', '34082', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '45927', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '52665', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '61437', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('4095', '1535', '63645', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('4095', '1535', '63644', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '68398', '183');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '2', '60091', '184');
+INSERT INTO `playercreateinfo_spell` VALUES ('16', '0', '5227', '220');
+INSERT INTO `playercreateinfo_spell` VALUES ('16', '0', '7744', '220');
+INSERT INTO `playercreateinfo_spell` VALUES ('16', '0', '20577', '220');
+INSERT INTO `playercreateinfo_spell` VALUES ('16', '0', '20579', '220');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '8', '2098', '253');
+INSERT INTO `playercreateinfo_spell` VALUES ('1791', '8', '75460', '253');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1', '45471', '257');
+INSERT INTO `playercreateinfo_spell` VALUES ('4', '0', '672', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '0', '29932', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '256', '687', '354');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '256', '18822', '354');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '64', '60348', '373');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '64', '331', '374');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '64', '403', '375');
+INSERT INTO `playercreateinfo_spell` VALUES ('1791', '64', '75461', '375');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1024', '5185', '573');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1024', '66530', '573');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1024', '5176', '574');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '256', '686', '593');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '256', '58284', '593');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '256', '75445', '593');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '2', '635', '594');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '2', '20154', '594');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '2', '21084', '594');
+INSERT INTO `playercreateinfo_spell` VALUES ('8', '0', '671', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '20555', '733');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '20557', '733');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '20558', '733');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '26290', '733');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '26297', '733');
+INSERT INTO `playercreateinfo_spell` VALUES ('128', '0', '58943', '733');
+INSERT INTO `playercreateinfo_spell` VALUES ('64', '0', '20589', '753');
+INSERT INTO `playercreateinfo_spell` VALUES ('64', '0', '20591', '753');
+INSERT INTO `playercreateinfo_spell` VALUES ('64', '0', '20593', '753');
+INSERT INTO `playercreateinfo_spell` VALUES ('64', '0', '20592', '753');
+INSERT INTO `playercreateinfo_spell` VALUES ('1', '0', '20599', '754');
+INSERT INTO `playercreateinfo_spell` VALUES ('1', '0', '20597', '754');
+INSERT INTO `playercreateinfo_spell` VALUES ('1', '0', '20598', '754');
+INSERT INTO `playercreateinfo_spell` VALUES ('1', '0', '20864', '754');
+INSERT INTO `playercreateinfo_spell` VALUES ('1', '0', '58985', '754');
+INSERT INTO `playercreateinfo_spell` VALUES ('1', '0', '59752', '754');
+INSERT INTO `playercreateinfo_spell` VALUES ('512', '8', '25046', '756');
+INSERT INTO `playercreateinfo_spell` VALUES ('512', '406', '28730', '756');
+INSERT INTO `playercreateinfo_spell` VALUES ('512', '0', '822', '756');
+INSERT INTO `playercreateinfo_spell` VALUES ('512', '0', '28877', '756');
+INSERT INTO `playercreateinfo_spell` VALUES ('512', '32', '50613', '756');
+INSERT INTO `playercreateinfo_spell` VALUES ('1101', '0', '668', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '39', '6562', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '208', '28878', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '1', '28880', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '0', '28875', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '1', '59221', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '32', '59539', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '4', '59536', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '128', '59541', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '2', '59535', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '16', '59538', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '64', '59540', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '32', '59545', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '4', '59543', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '128', '59548', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '2', '59542', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '16', '59544', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '64', '59547', '760');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '45902', '770');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '48266', '770');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '49410', '770');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '45477', '771');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '56816', '771');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '59921', '771');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '61455', '771');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '45462', '772');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '47541', '772');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '49576', '772');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '59879', '772');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '37', '196', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('650', '4', '264', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('1024', '4', '5011', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('735', '1293', '1180', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '204', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '81', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '67', '107', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('4', '0', '20595', '101');
+INSERT INTO `playercreateinfo_spell` VALUES ('36', '4', '266', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1107', '198', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '200', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '1488', '227', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '39', '201', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('735', '9', '2567', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '37', '197', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '3', '199', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '35', '202', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '203', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('1759', '400', '5009', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '522', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '40', '674', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '750', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '32', '3127', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('0', '0', '1843', '0');
+INSERT INTO `playercreateinfo_spell` VALUES ('4', '0', '59224', '101');
+INSERT INTO `playercreateinfo_spell` VALUES ('4', '0', '20594', '101');
+INSERT INTO `playercreateinfo_spell` VALUES ('4', '0', '20596', '101');
+INSERT INTO `playercreateinfo_spell` VALUES ('4', '0', '2481', '101');

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1138,7 +1138,7 @@ bool Player::Create(uint32 guidlow, CharacterCreateInfo* createInfo)
 
     // original spells
     LearnDefaultSkills();
-    LearnCustomSpells();
+    LearnDefaultSpells();
 
     // original action bar
     for (PlayerCreateInfoActions::const_iterator action_itr = info->action.begin(); action_itr != info->action.end(); ++action_itr)
@@ -17693,7 +17693,7 @@ bool Player::LoadFromDB(ObjectGuid guid, SQLQueryHolder *holder)
     // after spell and quest load
     InitTalentForLevel();
     LearnDefaultSkills();
-    LearnCustomSpells();
+    LearnDefaultSpells();
 
     // must be before inventory (some items required reputation check)
     m_reputationMgr->LoadFromDB(holder->GetPreparedResult(PLAYER_LOGIN_QUERY_LOAD_REPUTATION));
@@ -23091,18 +23091,15 @@ void Player::ResetSpells(bool myClassOnly)
             RemoveSpell(iter->first, false, false);           // only iter->first can be accessed, object by iter->second can be deleted already
 
     LearnDefaultSkills();
-    LearnCustomSpells();
+    LearnDefaultSpells();
     LearnQuestRewardedSpells();
 }
 
-void Player::LearnCustomSpells()
+void Player::LearnDefaultSpells()
 {
-    if (!sWorld->getBoolConfig(CONFIG_START_ALL_SPELLS))
-        return;
-
     // learn default race/class spells
     PlayerInfo const* info = sObjectMgr->GetPlayerInfo(getRace(), getClass());
-    for (PlayerCreateInfoSpells::const_iterator itr = info->customSpells.begin(); itr != info->customSpells.end(); ++itr)
+    for (PlayerCreateInfoSpells::const_iterator itr = info->spells.begin(); itr != info->spells.end(); ++itr)
     {
         uint32 tspell = *itr;
         TC_LOG_DEBUG("entities.player.loading", "PLAYER (Class: %u Race: %u): Adding initial spell, id = %u", uint32(getClass()), uint32(getRace()), tspell);
@@ -23285,7 +23282,7 @@ void Player::LearnSkillRewardedSpells(uint32 skillId, uint32 skillValue)
         if (!sSpellMgr->GetSpellInfo(ability->spellId))
             continue;
 
-        if (ability->AutolearnType != SKILL_LINE_ABILITY_LEARNED_ON_SKILL_VALUE && ability->AutolearnType != SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN)
+        if (ability->AutolearnType != SKILL_LINE_ABILITY_LEARNED_ON_SKILL_VALUE /*&& ability->AutolearnType != SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN*/)
             continue;
 
         // Check race if set

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -269,7 +269,7 @@ struct PlayerInfo
     uint16 displayId_m;
     uint16 displayId_f;
     PlayerCreateInfoItems item;
-    PlayerCreateInfoSpells customSpells;
+    PlayerCreateInfoSpells spells;
     PlayerCreateInfoActions action;
     PlayerCreateInfoSkills skills;
 
@@ -1604,7 +1604,7 @@ class Player : public Unit, public GridObject<Player>
         void LearnSpell(uint32 spell_id, bool dependent, bool fromSkill = false);
         void RemoveSpell(uint32 spell_id, bool disabled = false, bool learn_low_rank = true);
         void ResetSpells(bool myClassOnly = false);
-        void LearnCustomSpells();
+        void LearnDefaultSpells();
         void LearnDefaultSkills();
         void LearnDefaultSkill(uint32 skillId, uint16 rank);
         void LearnQuestRewardedSpells();

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -3399,11 +3399,12 @@ void ObjectMgr::LoadPlayerInfo()
     {
         uint32 oldMSTime = getMSTime();
 
-        QueryResult result = WorldDatabase.PQuery("SELECT racemask, classmask, Spell FROM playercreateinfo_spell_custom");
+        std::string tableName = sWorld->getBoolConfig(CONFIG_START_ALL_SPELLS) ? "playercreateinfo_spell_custom" : "playercreateinfo_spell";
+        QueryResult result = WorldDatabase.PQuery("SELECT racemask, classmask, Spell FROM %s", tableName.c_str());
 
         if (!result)
         {
-            TC_LOG_ERROR("server.loading", ">> Loaded 0 player create spells. DB table `playercreateinfo_spell_custom` is empty.");
+            TC_LOG_ERROR("server.loading", ">> Loaded 0 player create spells. DB table `%s` is empty.", tableName.c_str());
         }
         else
         {
@@ -3418,13 +3419,13 @@ void ObjectMgr::LoadPlayerInfo()
 
                 if (raceMask != 0 && !(raceMask & RACEMASK_ALL_PLAYABLE))
                 {
-                    TC_LOG_ERROR("sql.sql", "Wrong race mask %u in `playercreateinfo_spell_custom` table, ignoring.", raceMask);
+                    TC_LOG_ERROR("sql.sql", "Wrong race mask %u in `%s` table, ignoring.", raceMask, tableName.c_str());
                     continue;
                 }
 
                 if (classMask != 0 && !(classMask & CLASSMASK_ALL_PLAYABLE))
                 {
-                    TC_LOG_ERROR("sql.sql", "Wrong class mask %u in `playercreateinfo_spell_custom` table, ignoring.", classMask);
+                    TC_LOG_ERROR("sql.sql", "Wrong class mask %u in `%s` table, ignoring.", classMask, tableName.c_str());
                     continue;
                 }
 
@@ -3438,7 +3439,7 @@ void ObjectMgr::LoadPlayerInfo()
                             {
                                 if (PlayerInfo* info = _playerInfo[raceIndex][classIndex])
                                 {
-                                    info->customSpells.push_back(spellId);
+                                    info->spells.push_back(spellId);
                                     ++count;
                                 }
                                 // We need something better here, the check is not accounting for spells used by multiple races/classes but not all of them.
@@ -3452,7 +3453,7 @@ void ObjectMgr::LoadPlayerInfo()
             }
             while (result->NextRow());
 
-            TC_LOG_INFO("server.loading", ">> Loaded %u custom player create spells in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
+            TC_LOG_INFO("server.loading", ">> Loaded %u player create spells in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
         }
     }
 

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -333,7 +333,7 @@ public:
             return false;
 
         target->LearnDefaultSkills();
-        target->LearnCustomSpells();
+        target->LearnDefaultSpells();
         target->LearnQuestRewardedSpells();
 
         handler->PSendSysMessage(LANG_COMMAND_LEARN_ALL_DEFAULT_AND_QUEST, handler->GetNameLink(target).c_str());


### PR DESCRIPTION
So, I was looking for this table called playercreateinfo_spell where TC used to store starting spells for players. But apparently, TC decided to get the spells from DBC files instead.
Ref: http://www.trinitycore.org/f/topic/10486-players-starting-spells/

Now, I and some people on forum like them being in database. Also, it's better if someone wants to make a funserver etc and wants to change normal starting spells.

BUT I had some troubles with converting this. It gave me funny numbers and stuff, so PLEASE PLEASE test every race/class combo. I tried to fix most of them. This affects starting spells, languages and weapon skills at least. I'm currently going to a work trip and I can not test, but if you find any erros, I will amend the commit on laptop when I have chance for that.

Also, if any codestyle etc errors, let me know. First pull request evah.
