### PR TITLE
Core/Spell - Fix Remove Aura "The Eye of Acherus"

### DIFF
--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2101,6 +2101,11 @@ class spell_q12641_death_comes_from_on_high : public SpellScriptLoader
 };
 
 // 52694 - Recall Eye of Acherus
+enum Recall_Eye_of_Acherus
+{
+	THE_EYE_OF_ACHERUS = 51852
+};
+
 class spell_q12641_recall_eye_of_acherus : public SpellScriptLoader
 {
     public:
@@ -2114,7 +2119,9 @@ class spell_q12641_recall_eye_of_acherus : public SpellScriptLoader
             {
                 if (Player* player = GetCaster()->GetCharmerOrOwner()->ToPlayer())
                 {
-                    player->RemoveAura(51852);
+                    player->StopCastingCharm();
+                    player->StopCastingBindSight();
+					player->RemoveAura(THE_EYE_OF_ACHERUS);
                 }
             }
 

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2121,7 +2121,7 @@ class spell_q12641_recall_eye_of_acherus : public SpellScriptLoader
                 {
                     player->StopCastingCharm();
                     player->StopCastingBindSight();
-					player->RemoveAura(THE_EYE_OF_ACHERUS);
+		    player->RemoveAura(THE_EYE_OF_ACHERUS);
                 }
             }
 

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2121,7 +2121,7 @@ class spell_q12641_recall_eye_of_acherus : public SpellScriptLoader
                 {
                     player->StopCastingCharm();
                     player->StopCastingBindSight();
-		    player->RemoveAura(THE_EYE_OF_ACHERUS);
+		     player->RemoveAura(THE_EYE_OF_ACHERUS);
                 }
             }
 

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2114,8 +2114,7 @@ class spell_q12641_recall_eye_of_acherus : public SpellScriptLoader
             {
                 if (Player* player = GetCaster()->GetCharmerOrOwner()->ToPlayer())
                 {
-                    player->StopCastingCharm();
-                    player->StopCastingBindSight();
+                    player->RemoveAura(51852);
                 }
             }
 


### PR DESCRIPTION
Fixed remove aura "The Eye of Acherus" http://www.wowhead.com/spell=51852 after use "Recall Eye of Acherus" http://www.wowhead.com/spell=52694 . 
Earlier, after using the player remained under the aura.
