### PR TITLE
Vmap Extractor - fix "-l" option

### DIFF
--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -382,7 +382,6 @@ bool processArgv(int argc, char ** argv, const char *versionString)
 {
     bool result = true;
     hasInputPathParam = false;
-    preciseVectorData = false;
 
     for(int i = 1; i < argc; ++i)
     {


### PR DESCRIPTION
global bool preciseVectorData is overriden by local one, so global one is not modified and always false.
This causes "-l" and "-s" options to do nothing.

Anyway there is one more thing to consider for you:
"-s" should set preciseVectorData to false, it is useless by design cause that bool is false by default.
"-l" should enable preciseVectorData. If you check your code, preciseVectorData determines only whether non-colliding triangles should be added to world model mesh or not. Enabling this feature causes triangles that in client data are non-colliding to become colliding in server data.
So basicaly whole "-l", "-s" and "preciseVectorData" stuff are useless and can be removed.
