### PR TITLE
Guardian Spells not honoring Cooldown

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -247,6 +247,8 @@ void PetAI::UpdateAI(uint32 diff)
             }
 
             spell->prepare(&targets);
+            if (!me->HasSpellCooldown(spell->GetSpellInfo()->Id))
+                me->AddCreatureSpellCooldown(spell->GetSpellInfo()->Id);
         }
 
         // deleted cached Spell objects


### PR DESCRIPTION
Added creature cooldown, wasn't working in guardian pets, due to being procesed by HandlePetCastSpellOpcode

Fix for #13450 
