### PR TITLE
cmake: use $CMAKE_BUILD_TYPE instead of $CONFIGURATION as BUILD_DIRECTIVE

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -1,5 +1,5 @@
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE='"$(CONFIGURATION)"')
+add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
 
 if(WITH_WARNINGS)
   set(WARNING_FLAGS "-W -Wall -Wextra -Winit-self -Wfatal-errors")


### PR DESCRIPTION
$CONFIGURATION does not seem to exist and Ninja will fail for nonexistent variables.
