### PR TITLE
Fix Battleground List window.

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -901,7 +901,7 @@ void BattlegroundMgr::BuildBattlegroundListPacket(WorldPacket* data, ObjectGuid 
     data->WriteBit(guid[3]);
     data->WriteBit(0);                                      // unk
     data->WriteBit(guid[5]);
-    data->WriteBit(0);                                      // unk
+    data->WriteBit(player->getLevel() != 10 ? 1 : 0);       // hide battleground list window, show only in level 10
 
     data->FlushBits();
 


### PR DESCRIPTION
Hide window after level 10, show only in level 10.
Closes: #13522
