### PR TITLE
Fix spell cooldown for guardian pets

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3438,7 +3438,7 @@ void Spell::SendSpellCooldown()
     {
         // Handle pet cooldowns here if needed instead of in PetAI to avoid hidden cooldown restarts
         Creature* _creature = m_caster->ToCreature();
-        if (_creature && _creature->IsPet())
+        if (_creature && (_creature->IsPet() || _creature->IsGuardian()))
             _creature->AddCreatureSpellCooldown(m_spellInfo->Id);
 
         return;


### PR DESCRIPTION
Fix for #13450, replaces proposed fix by PR #13452 per discussion in that thread.

Thanks: @Frytiks for research and testing.

Note: Cloned and edited directly on Github.
