### PR TITLE
Core/Players: Fix GetNPCIfCanInteractWith when dealing with creatures of...

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2741,11 +2741,8 @@ Creature* Player::GetNPCIfCanInteractWith(uint64 guid, uint32 npcflagmask)
         return NULL;
 
     // not unfriendly
-    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(creature->getFaction()))
-        if (factionTemplate->faction)
-            if (FactionEntry const* faction = sFactionStore.LookupEntry(factionTemplate->faction))
-                if (faction->reputationListID >= 0 && GetReputationMgr().GetRank(faction) <= REP_UNFRIENDLY)
-                    return NULL;
+    if (creature->GetReactionTo(this) <= REP_HOSTILE)
+        return NULL;
 
     // not too far
     if (!creature->IsWithinDistInMap(this, INTERACTION_DISTANCE))


### PR DESCRIPTION
... neutral reputation/forced friendly reputation

pete318: Creating pull request from this change. It's related to https://github.com/TrinityCore/TrinityCore/pull/13590

This is required for the above pull to work. Without this change, the NPCs turn friendly but will not interact with the player while the buff is active.
