### PR TITLE
NPC Interaction change for unfriendly reputation. (See PR #13619)

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2765,16 +2765,9 @@ Creature* Player::GetNPCIfCanInteractWith(ObjectGuid guid, uint32 npcflagmask)
     if (creature->GetCharmerGUID())
         return NULL;
 
-    // not enemy
-    if (creature->IsHostileTo(this))
-        return NULL;
-
-    // not unfriendly
-    if (FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(creature->getFaction()))
-        if (factionTemplate->faction)
-            if (FactionEntry const* faction = sFactionStore.LookupEntry(factionTemplate->faction))
-                if (faction->reputationListID >= 0 && GetReputationMgr().GetRank(faction) <= REP_UNFRIENDLY)
-                    return NULL;
+    // not unfriendly/hostile
+    if (creature->GetReactionTo(this) <= REP_UNFRIENDLY)
+         return NULL;
 
     // not too far
     if (!creature->IsWithinDistInMap(this, INTERACTION_DISTANCE))


### PR DESCRIPTION
For units with unfriendly reputation, check using the normal reaction function, instead of reading faction directly.

This allows specific buffs that alter creature reaction to work on the player, this allowing players to complete quests.

Note: This change is required for the PR https://github.com/TrinityCore/TrinityCore/pull/13619 to be effective.

This changes a core aspect so it made into a separate PR for traceability reasons.

With regard to the actual change.

``` C++
bool Unit::IsHostileTo(Unit const* unit) const
{
    return GetReactionTo(unit) <= REP_HOSTILE;
}
```

So, checking for <= REP_UNFRIENDLY and returning NULL if not, includes this check. So it'd be overkill to do both.

The change to retrieve faction from the GetReactionTo rather than use the faction template has a small chance to cause a problem. But, I couldn't myself find an instance where it would.
