### PR TITLE
[WIP] Pooling update - Interim commit.

### DIFF
--- a/README-pooling
+++ b/README-pooling
@@ -1,0 +1,27 @@
+The aim of this branch is to update the pooling system as follows:
+
+ - Create a possibility to specify a minimum number of spawned objects
+ - Ensure the maximum value are actually spawned
+ - Ensure that the minumum number are maintained in the world
+
+Completion: 40%
+
+ - Databases and Pool functionality updated to handle minimum value in template: 100%
+ - Added pool information to npc info (creature pool): 100%
+ - Spawn insurance of 100% max spawn if possible: 80% (this seems to work, but I have seen npc info report not all spawned. So need to check)
+
+Creature specific:
+ - When creatures in pool drop below minimum, then process is as follows: (100% but needs testing)
+   - looks for a dead despawned creature in the pool, if found - instant respawn
+   - if none despawned, looks for a looted corpse. If found, despawns corpse
+   - if no looted corpses found, then finds an unlooted corpse and despawns it
+   - Creature class upon creature despawn, will check if an expedited respawn is required. If so, will respawn right away.
+
+ Resource Node (maybe all game objects in pools) specific:
+ - When nodes in pool drop below minimum, then process to be determined to maintain minimum nodes in pool (0%)
+
+ To Do:
+
+ - Currently more is exposed in PoolManager class than needs to be (this is due to extra detail being shows in npc info for debug purposes during development)
+ - I'm not too happy about making the ExplicitlyChanced and EqualChanced lists directly available from PoolGroup. But, it was the fastest way to achieve this.
+   It doesn't seem to pose a terrible problem.

--- a/sql/updates/world/2014_11_25_99_world.sql
+++ b/sql/updates/world/2014_11_25_99_world.sql
@@ -1,0 +1,3 @@
+ALTER TABLE pool_template ADD COLUMN min_limit int(10) unsigned NOT NULL DEFAULT 0 AFTER entry;
+DELETE FROM trinity_string WHERE entry=20078;
+INSERT INTO trinity_string VALUES (20078, 'Pool ID: %u. Template: Minimum: %u, Maximum: %u. Current alive in pool: %u', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -252,6 +252,11 @@ void Creature::RemoveCorpse(bool setSpawnTime)
     GetRespawnPosition(x, y, z, &o);
     SetHomePosition(x, y, z, o);
     GetMap()->CreatureRelocation(this, x, y, z, o);
+
+    // If corpse was just removed, and the creature pool is below minimum
+    // Make a respawn now
+    if (sPoolMgr->NeedExpeditedRespawn(GetGUIDLow()))
+        Respawn();
 }
 
 /**
@@ -1478,6 +1483,11 @@ void Creature::setDeathState(DeathState s)
 
         if ((CanFly() || IsFlying()))
             GetMotionMaster()->MoveFall();
+
+        // Pool function to handle creature death
+        // Mainly checks if there is a need to expedite a despawn/respawn
+        // when pool drops below minumum threshold
+        sPoolMgr->HandleCreatureDeath(GetGUIDLow());
 
         Unit::setDeathState(CORPSE);
     }

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1200,6 +1200,7 @@ enum TrinityStrings
     LANG_BAN_ACCOUNT_YOUPERMBANNEDMESSAGE_WORLD   = 11007,
 
     LANG_NPCINFO_INHABIT_TYPE                     = 11008,
-    LANG_NPCINFO_FLAGS_EXTRA                      = 11009
+    LANG_NPCINFO_FLAGS_EXTRA                      = 11009,
+    LANG_NPCINFO_POOLINFO                         = 20078
 };
 #endif

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -26,6 +26,7 @@
 
 struct PoolTemplateData
 {
+    uint32  MinLimit;
     uint32  MaxLimit;
 };
 
@@ -74,12 +75,12 @@ class PoolGroup
         void SetPoolId(uint32 pool_id) { poolId = pool_id; }
         ~PoolGroup() { };
         bool isEmpty() const { return ExplicitlyChanced.empty() && EqualChanced.empty(); }
-        void AddEntry(PoolObject& poolitem, uint32 maxentries);
+        void AddEntry(PoolObject& poolitem, uint32 minentries, uint32 maxentries);
         bool CheckPool() const;
         PoolObject* RollOne(ActivePoolData& spawns, uint32 triggerFrom);
         void DespawnObject(ActivePoolData& spawns, uint32 guid=0);
         void Despawn1Object(uint32 guid);
-        void SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom);
+        void SpawnObject(ActivePoolData& spawns, uint32 minlimit, uint32 maxlimit, uint32 triggerFrom);
 
         void Spawn1Object(PoolObject* obj);
         void ReSpawn1Object(PoolObject* obj);
@@ -91,6 +92,8 @@ class PoolGroup
             return EqualChanced.front().guid;
         }
         uint32 GetPoolId() const { return poolId; }
+        PoolObjectList GetExplicitlyChanced() const { return ExplicitlyChanced; }
+        PoolObjectList GetEqualChanced() const { return EqualChanced; }
     private:
         uint32 poolId;
         PoolObjectList ExplicitlyChanced;
@@ -103,6 +106,7 @@ typedef std::pair<PooledQuestRelation::iterator, PooledQuestRelation::iterator> 
 
 class PoolMgr
 {
+    typedef std::vector<PoolObject> PoolObjectList;
     private:
         PoolMgr();
         ~PoolMgr() { };
@@ -114,6 +118,8 @@ class PoolMgr
             return &instance;
         }
 
+        PoolTemplateData* GetPoolTemplate(uint32 pool_id);
+        uint32 GetPoolActiveSpawns(uint32 pool_id);
         void LoadFromDB();
         void LoadQuestPools();
         void SaveQuestsToDB();
@@ -122,6 +128,11 @@ class PoolMgr
 
         template<typename T>
         uint32 IsPartOfAPool(uint32 db_guid_or_pool_id) const;
+
+        Creature* FindDeadCreature(uint32 pool_id, bool PreferLooted);
+        void HandleCreatureDeath(uint32 guid);
+        uint32 GetAliveCreatures(uint32 guid);
+        bool NeedExpeditedRespawn(uint32 guid);
 
         template<typename T>
         bool IsSpawnedObject(uint32 db_guid_or_pool_id) const { return mSpawnedData.IsActiveObject<T>(db_guid_or_pool_id); }

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -28,6 +28,7 @@ EndScriptData */
 #include "Transport.h"
 #include "CreatureGroups.h"
 #include "Language.h"
+#include "PoolMgr.h"
 #include "TargetedMovementGenerator.h"                      // for HandleNpcUnFollowCommand
 #include "CreatureAI.h"
 #include "Player.h"
@@ -725,6 +726,8 @@ public:
         uint32 displayid = target->GetDisplayId();
         uint32 nativeid = target->GetNativeDisplayId();
         uint32 Entry = target->GetEntry();
+        uint32 npcPool = sPoolMgr->IsPartOfAPool<Creature>(target->GetDBTableGUIDLow());
+        PoolTemplateData *tempPoolTemp;
 
         int64 curRespawnDelay = target->GetRespawnTimeEx()-time(NULL);
         if (curRespawnDelay < 0)
@@ -733,6 +736,9 @@ public:
         std::string defRespawnDelayStr = secsToTimeString(target->GetRespawnDelay(), true);
 
         handler->PSendSysMessage(LANG_NPCINFO_CHAR,  target->GetDBTableGUIDLow(), target->GetGUIDLow(), faction, npcflags, Entry, displayid, nativeid);
+        if (npcPool)
+            handler->PSendSysMessage(LANG_NPCINFO_POOLINFO, npcPool, sPoolMgr->GetPoolTemplate(npcPool)->MinLimit, sPoolMgr->GetPoolTemplate(npcPool)->MaxLimit, sPoolMgr->GetAliveCreatures(target->GetDBTableGUIDLow()));
+
         handler->PSendSysMessage(LANG_NPCINFO_LEVEL, target->getLevel());
         handler->PSendSysMessage(LANG_NPCINFO_EQUIPMENT, target->GetCurrentEquipmentId(), target->GetOriginalEquipmentId());
         handler->PSendSysMessage(LANG_NPCINFO_HEALTH, target->GetCreateHealth(), target->GetMaxHealth(), target->GetHealth());


### PR DESCRIPTION
Making a PR, as suggested in forum to get some thoughts, and maybe some testers.

The aim of this branch is to update the pooling system as follows:
- Create a possibility to specify a minimum number of spawned objects
- Ensure the maximum value are actually spawned
- Ensure that the minumum number are maintained in the world

Completion: 40%
- Databases and Pool functionality updated to handle minimum value in template: 100%
- Added pool information to npc info (creature pool): 100%
- Spawn ensured of 100% max spawn if possible: 80% (this seems to work, but I have seen npc info report not all spawned. So need to check). Also due to the random nature it could take many iterations to complete on 1:1 or close to 1:1 pools. But, I think this function is only called on startup (and maybe .respawn). So possibly not so serious.

Creature specific:
- When creatures in pool drop below minimum, then process is as follows: (100% but needs testing)
  - looks for a dead despawned creature in the pool, if found - instant respawn
  - if none despawned, looks for a looted corpse. If found, despawns corpse
  - if no looted corpses found, then finds an unlooted corpse and despawns it
  - Creature class upon creature despawn, will check if an expedited respawn is required. If so, will respawn right away.
  
  Resource Node (maybe all game objects in pools) specific:
- When nodes in pool drop below minimum, then process to be determined to maintain minimum nodes in pool (0%)
  
  To Do:
- Currently more is exposed in PoolManager class than needs to be (this is due to extra detail being shows in npc info for debug purposes during development)
- I'm not too happy about making the ExplicitlyChanced and EqualChanced lists directly available from PoolGroup. But, it was the fastest way to achieve this.
  It doesn't seem to pose a terrible problem.
