### PR TITLE
Rooted vehicle movement (#13342 for example)

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16975,6 +16975,12 @@ void Unit::_EnterVehicle(Vehicle* vehicle, int8 seatId, AuraApplication const* a
         }
     }
 
+    // If vehicle flag for fixed position set (cannons), or if the following hardcoded units, then set state rooted
+    //  30236 | Argent Cannon
+    //  39759 | Tankbuster Cannon
+    if ((vehicle->GetVehicleInfo()->m_flags & VEHICLE_FLAG_FIXED_POSITION) || vehicle->GetBase()->GetEntry() == 30236 || vehicle->GetBase()->GetEntry() == 39759)
+        SetControlled(true, UNIT_STATE_ROOT);
+
     ASSERT(!m_vehicle);
     (void)vehicle->AddPassenger(this, seatId);
 }

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -192,6 +192,12 @@ void Vehicle::ApplyAllImmunities()
         _me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, true);
     }
 
+    // If vehicle flag for fixed position set (cannons), or if the following hardcoded units, then set state rooted
+    //  30236 | Argent Cannon
+    //  39759 | Tankbuster Cannon
+    if ((GetVehicleInfo()->m_flags & VEHICLE_FLAG_FIXED_POSITION) || GetBase()->GetEntry() == 30236 || GetBase()->GetEntry() == 39759)
+        _me->SetControlled(true, UNIT_STATE_ROOT);
+
     // Different immunities for vehicles goes below
     switch (GetVehicleInfo()->m_ID)
     {

--- a/src/server/game/Entities/Vehicle/VehicleDefines.h
+++ b/src/server/game/Entities/Vehicle/VehicleDefines.h
@@ -44,7 +44,8 @@ enum VehicleFlags
     VEHICLE_FLAG_FULLSPEEDPITCHING               = 0x00000020,           // Sets MOVEFLAG2_FULLSPEEDPITCHING
     VEHICLE_FLAG_CUSTOM_PITCH                    = 0x00000040,           // If set use pitchMin and pitchMax from DBC, otherwise pitchMin = -pi/2, pitchMax = pi/2
     VEHICLE_FLAG_ADJUST_AIM_ANGLE                = 0x00000400,           // Lua_IsVehicleAimAngleAdjustable
-    VEHICLE_FLAG_ADJUST_AIM_POWER                = 0x00000800            // Lua_IsVehicleAimPowerAdjustable
+    VEHICLE_FLAG_ADJUST_AIM_POWER                = 0x00000800,           // Lua_IsVehicleAimPowerAdjustable
+    VEHICLE_FLAG_FIXED_POSITION                  = 0x00200000            // Used for cannons, when they should be rooted
 };
 
 enum VehicleSpells


### PR DESCRIPTION
Corrects issue where certain combinations of actions would cause vehicles (usually cannons/artillary) that should be rooted, to be fully movable.

This needs some discussion. Since, there's quite a core change happening here (check WorldSession).

Essentially the issue was that the worldsession protection against spoofed packets assumed that the client would never send movement info, when rooted in place. However, when in a vehicle that is rooted - ~~the client does sent movement messages (for a very short time after first entering, normal movement is sent, and all the time~~ (Turret aiming counts as movement for example).

To that end, I added the proviso that if the player is in a vehicle and database for the player has unit status disabled movement on, then it will not remove a root if it receives movement commands for the rooted unit.

Elsewhere there's a bit more enforcement of root state. Applied on entry, only removed on exit if the unit doesn't have restricting movement flags. Also in ApplyAllImmunities (I think I may try removing this one).

Please test this yourselves and spot anything obvious.

I also think the change in world session could do with some cleaning up. But, I wanted to also get some outside testing/opinions about the solution in the meantime.

~~Of course, this will do nothing, unless you update your creature templates with unit_flag 4. :)~~
The application is based on unit flags and the following hard-coded cannons:

+-------+-------------------+------------+
| entry | name | Hex(Flags) |
+-------+-------------------+------------+
| 30236 | Argent Cannon | 4716125B |
| 39759 | Tankbuster Cannon | 60001027 |
+-------+-------------------+------------+

The cases I knew of that previously caused the failure I've tested for (on the DK scarlet cannon only so far):
- Logging out while in the cannon
- Switching player after combat
- Gaining combat and then leaving cannon while in combat.

~~Example SQL to update a cannon creature to correct unit flag:~~

~~Be aware, you should ADD 4 to the existing flags, not just set to 4. Also ensure the unit is the correct one (many units with the same name exist in game).~~
