### PR TITLE
Core/Socket: Removed Magic Number

### DIFF
--- a/src/server/shared/Common.h
+++ b/src/server/shared/Common.h
@@ -160,4 +160,6 @@ struct LocalizedString
 
 #define MAX_QUERY_LEN 32*1024
 
+#define READ_BLOCK_SIZE 4096
+
 #endif

--- a/src/server/shared/Networking/MessageBuffer.h
+++ b/src/server/shared/Networking/MessageBuffer.h
@@ -28,7 +28,7 @@ class MessageBuffer
 public:
     MessageBuffer() : _wpos(0), _rpos(0), _storage()
     {
-        _storage.resize(4096);
+        _storage.resize(READ_BLOCK_SIZE);
     }
 
     explicit MessageBuffer(std::size_t initialSize) : _wpos(0), _rpos(0), _storage()

--- a/src/server/shared/Networking/Socket.h
+++ b/src/server/shared/Networking/Socket.h
@@ -18,6 +18,7 @@
 #ifndef __SOCKET_H__
 #define __SOCKET_H__
 
+#include "Common.h"
 #include "MessageBuffer.h"
 #include "Log.h"
 #include <atomic>
@@ -33,7 +34,6 @@
 
 using boost::asio::ip::tcp;
 
-#define READ_BLOCK_SIZE 4096
 #ifdef BOOST_ASIO_HAS_IOCP
 #define TC_SOCKET_USE_IOCP
 #endif


### PR DESCRIPTION
*Removed the magic 4096 number in the MessageBuffer. This could cause potential issues if the buffer size was ever changed inside the Socket.h file. Now the MessageQueue will use the size from the Socket.h define.
