### PR TITLE
Scripts/Quests: Fix Red Snapper - Very Tasty! GOb

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3738,6 +3738,9 @@ void SpellMgr::LoadSpellInfoCorrections()
                 break;
             // ENDOF ISLE OF CONQUEST SPELLS
             //
+            case 29866: // Cast Fishing Net
+                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(140); // 6yd
+                break;
             default:
                 break;
         }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1100,14 +1100,9 @@ class spell_q9452_cast_net: public SpellScriptLoader
             
             SpellCastResult CheckCast()
             {
-                std::list<GameObject*> goList;
-                GetCaster()->GetGameObjectListWithEntryInGrid(goList, GO_SCHOOL_OF_RED_SNAPPER, 3.0f);
-                if (goList.empty())
+                GameObject* go = GetCaster()->FindNearestGameObject(GO_SCHOOL_OF_RED_SNAPPER, 3.0f);
+                if (!go || go->GetRespawnTime())
                     return SPELL_FAILED_REQUIRES_SPELL_FOCUS;
-                    
-                for (std::list<GameObject*>::const_iterator itr = goList.begin(); itr != goList.end(); ++itr)
-                    if (!(*itr) || (*itr)->GetRespawnTime())
-                        return SPELL_FAILED_REQUIRES_SPELL_FOCUS;
                         
                 return SPELL_CAST_OK;
             }

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1076,9 +1076,12 @@ class spell_q14112_14145_chum_the_water: public SpellScriptLoader
 // http://old01.wowhead.com/quest=9452 - Red Snapper - Very Tasty!
 enum RedSnapperVeryTasty
 {
-    SPELL_CAST_NET          = 29866,
-    ITEM_RED_SNAPPER        = 23614,
-    SPELL_NEW_SUMMON_TEST   = 49214,
+    ITEM_RED_SNAPPER             = 23614,
+    
+    SPELL_CAST_NET               = 29866,
+    SPELL_NEW_SUMMON_TEST        = 49214,
+    
+    GO_SCHOOL_OF_RED_SNAPPER     = 181616
 };
 
 class spell_q9452_cast_net: public SpellScriptLoader
@@ -1094,6 +1097,20 @@ class spell_q9452_cast_net: public SpellScriptLoader
             {
                 return GetCaster()->GetTypeId() == TYPEID_PLAYER;
             }
+            
+            SpellCastResult CheckCast()
+            {
+                std::list<GameObject*> goList;
+                GetCaster()->GetGameObjectListWithEntryInGrid(goList, GO_SCHOOL_OF_RED_SNAPPER, 3.0f);
+                if (goList.empty())
+                    return SPELL_FAILED_REQUIRES_SPELL_FOCUS;
+                    
+                for (std::list<GameObject*>::const_iterator itr = goList.begin(); itr != goList.end(); ++itr)
+                    if (!(*itr) || (*itr)->GetRespawnTime())
+                        return SPELL_FAILED_REQUIRES_SPELL_FOCUS;
+                        
+                return SPELL_CAST_OK;
+            }
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
@@ -1103,10 +1120,20 @@ class spell_q9452_cast_net: public SpellScriptLoader
                 else
                     caster->CastSpell(caster, SPELL_NEW_SUMMON_TEST, true);
             }
+            
+            void HandleActiveObject(SpellEffIndex effIndex)
+            {
+                PreventHitDefaultEffect(effIndex);
+                GetHitGObj()->SetRespawnTime(roll_chance_i(50) ? 2 * MINUTE : 3 * MINUTE);
+                GetHitGObj()->Use(GetCaster());
+                GetHitGObj()->SetLootState(GO_JUST_DEACTIVATED);
+            }
 
             void Register() override
             {
+                OnCheckCast += SpellCheckCastFn(spell_q9452_cast_net_SpellScript::CheckCast);
                 OnEffectHit += SpellEffectFn(spell_q9452_cast_net_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+                OnEffectHitTarget += SpellEffectFn(spell_q9452_cast_net_SpellScript::HandleActiveObject, EFFECT_1, SPELL_EFFECT_ACTIVATE_OBJECT);
             }
         };
 


### PR DESCRIPTION
Fix 'School of Red Snapper' now disappear correctly when using 'Draenei Fishing Net', the bug is caused because the GameObject is SpellFocus type.

Fix: #1673
