### PR TITLE
Scripts/Spells: Move death grip from DB

### DIFF
--- a/sql/updates/world/2014_12_28_03_world.sql
+++ b/sql/updates/world/2014_12_28_03_world.sql
@@ -1,0 +1,2 @@
+--
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 49576;

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -39,6 +39,7 @@ enum DeathKnightSpells
     SPELL_DK_DEATH_AND_DECAY_DAMAGE             = 52212,
     SPELL_DK_DEATH_COIL_DAMAGE                  = 47632,
     SPELL_DK_DEATH_COIL_HEAL                    = 47633,
+    SPELL_DK_DEATH_GRIP                         = 49560,
     SPELL_DK_DEATH_STRIKE_HEAL                  = 45470,
     SPELL_DK_FROST_FEVER                        = 55095,
     SPELL_DK_FROST_PRESENCE                     = 48263,
@@ -1670,9 +1671,15 @@ public:
             return SPELL_CAST_OK;
         }
 
+        void HandleDummy(SpellEffIndex /*effIndex*/)
+        {
+            GetCaster()->CastSpell(GetHitUnit(), SPELL_DK_DEATH_GRIP, true);
+        }
+
         void Register() override
         {
             OnCheckCast += SpellCheckCastFn(spell_dk_death_grip_initial_SpellScript::CheckCast);
+            OnEffectHitTarget += SpellEffectFn(spell_dk_death_grip_initial_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
         }
     };
 


### PR DESCRIPTION
Moves death grip from DB to spellscript for clarity and to reduce confusion in future.
