### PR TITLE
Auth: Allows the client with ptBR language to login in the server

### DIFF
--- a/sql/updates/auth/2014_12_28_00_auth.sql
+++ b/sql/updates/auth/2014_12_28_00_auth.sql
@@ -1,0 +1,2 @@
+DELETE FROM `battlenet_components` WHERE `Platform` = 'ptBR';
+INSERT INTO `battlenet_components` (`Program`, `Platform`, `Build`) VALUES ('WoW', 'ptBR', 0);


### PR DESCRIPTION
Fix the error when someone using the game client with ptBR language try
to login in the game.
