### PR TITLE
DB/Karazhan interaction fix

### DIFF
--- a/sql/updates/world/2015_01_01_00_world.sql
+++ b/sql/updates/world/2015_01_01_00_world.sql
@@ -1,0 +1,8 @@
+-- Fix Karazhan opera event game objects 
+--Interaction fix => Disable player interaction with Door and Curtain
+--Stage Door Left
+UPDATE `gameobject_template` SET `flags` = 16 WHERE  `entry` = 184278;
+--Stage Right Door
+UPDATE `gameobject_template` SET `flags` = 16 WHERE  `entry` = 184279;
+--Stage Curtain
+UPDATE `gameobject_template` SET `flags` = 16 WHERE  `entry` = 183932;


### PR DESCRIPTION
Players were able to use doors in the opera event
