### PR TITLE
Core/Spells: Update Stuck effect 6.0.3 and codestyle

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3930,7 +3930,7 @@ void Spell::EffectStuck(SpellEffIndex /*effIndex*/)
     TC_LOG_DEBUG("spells", "Spell Effect: Stuck");
     TC_LOG_INFO("spells", "Player %s (%s) used auto-unstuck future at map %u (%f, %f, %f)", player->GetName().c_str(), player->GetGUID().ToString().c_str(), player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
 
-    if (player->IsInFlight())
+    if (player->IsInFlight() || player->isDead())
         return;
 
     // the player is teleported to home

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3930,8 +3930,17 @@ void Spell::EffectStuck(SpellEffIndex /*effIndex*/)
     TC_LOG_DEBUG("spells", "Spell Effect: Stuck");
     TC_LOG_INFO("spells", "Player %s (%s) used auto-unstuck future at map %u (%f, %f, %f)", player->GetName().c_str(), player->GetGUID().ToString().c_str(), player->GetMapId(), player->GetPositionX(), player->GetPositionY(), player->GetPositionZ());
 
-    if (player->IsInFlight() || player->isDead())
+    if (player->IsInFlight())
         return;
+        
+    // if player is dead without death timer is teleported to graveyard, otherwise not apply the effect
+    if (player->isDead())
+    {
+        if (!player->GetDeathTimer())
+            player->RepopAtGraveyard();
+            
+        return;
+    }
 
     // the player is teleported to home
     player->TeleportTo(player->m_homebindMapId, player->m_homebindX, player->m_homebindY, player->m_homebindZ, player->GetOrientation(), TELE_TO_SPELL);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3933,16 +3933,15 @@ void Spell::EffectStuck(SpellEffIndex /*effIndex*/)
     if (player->IsInFlight())
         return;
 
-    player->TeleportTo(player->GetStartPosition(), TELE_TO_SPELL);
-    // homebind location is loaded always
-    // target->TeleportTo(target->m_homebindMapId, target->m_homebindX, target->m_homebindY, target->m_homebindZ, target->GetOrientation(), (m_caster == m_caster ? TELE_TO_SPELL : 0));
+    // the player is teleported to home
+    player->TeleportTo(player->m_homebindMapId, player->m_homebindX, player->m_homebindY, player->m_homebindZ, player->GetOrientation(), TELE_TO_SPELL);
 
     // Stuck spell trigger Hearthstone cooldown
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(8690);
-    if (!spellInfo)
-        return;
-    Spell spell(player, spellInfo, TRIGGERED_FULL_MASK);
-    spell.SendSpellCooldown();
+    if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(8690))
+    {
+        Spell spell(player, spellInfo, TRIGGERED_FULL_MASK);
+        spell.SendSpellCooldown();
+    }
 }
 
 void Spell::EffectSummonPlayer(SpellEffIndex /*effIndex*/)


### PR DESCRIPTION
The stuck effect in Cataclysm and MoP the player dies, in WoD the player is teleported to home.
