### PR TITLE
 Scripts/Zul'Drak: GO Scourge Enclosure - Delay Despawn of Dummy to ensure Explosion

### DIFF
--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -313,7 +313,7 @@ public:
             {
                 player->KilledMonsterCredit(gymerDummy->GetEntry(), gymerDummy->GetGUID());
                 gymerDummy->CastSpell(gymerDummy, SPELL_GYMER_LOCK_EXPLOSION, true);
-                gymerDummy->DespawnOrUnsummon();
+                gymerDummy->DespawnOrUnsummon(4 * IN_MILLISECONDS);
             }
         }
         return true;


### PR DESCRIPTION
- Currently the Explosion is never visisble, because the trigger who should cast the explosion instantly despawn.
