### PR TITLE
Game/Spells: 'AoD Specials' should only target one Unit

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2959,6 +2959,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         switch (spellInfo->Id)
         {
             case 53096: // Quetz'lun's Judgment
+            case 70743: // AoD Special
+            case 70614: // AoD Special - Vegard
                 spellInfo->MaxAffectedTargets = 1;
                 break;
             case 42436: // Drink! (Brewfest)


### PR DESCRIPTION
- this removes ugly visual behaviour during the Quest: Light's Vengeance
  Given Result by Quoting Dr-J:
  so periodic spells to summon ghouls only targets single target at once not all targets.
