### PR TITLE
Scripts/Arcatraz: Harbinger Skyriss Adds - Remove Unattackable Flag on Spawn

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/arcatraz/boss_harbinger_skyriss.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/boss_harbinger_skyriss.cpp
@@ -283,7 +283,10 @@ class boss_harbinger_skyriss_illusion : public CreatureScript
         {
             boss_harbinger_skyriss_illusionAI(Creature* creature) : ScriptedAI(creature) { }
 
-            void Reset() override { }
+            void Reset() override 
+            {
+                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
+            }
 
             void EnterCombat(Unit* /*who*/) override { }
         };


### PR DESCRIPTION
- Currently they were always unattackable on Spawn. Because there were Unitflags in the DB, this Flags should probably be removed in their script.
