### PR TITLE
Fixed bug in CascOpenFile

### DIFF
--- a/dep/CascLib/src/CascBuildCfg.cpp
+++ b/dep/CascLib/src/CascBuildCfg.cpp
@@ -52,7 +52,7 @@ static DWORD GetLocaleMask(const char * szTag)
         return CASC_LOCALE_DEDE;
 
     if(!strcmp(szTag, "zhCN"))
-        return CASC_LOCALE_DEDE;
+        return CASC_LOCALE_ZHCN;
 
     if(!strcmp(szTag, "esES"))
         return CASC_LOCALE_ESES;

--- a/dep/CascLib/src/CascBuildCfg.cpp
+++ b/dep/CascLib/src/CascBuildCfg.cpp
@@ -37,6 +37,56 @@ static void FreeCascBlob(PQUERY_KEY pBlob)
     }
 }
 
+static DWORD GetLocaleMask(const char * szTag)
+{
+    if(!strcmp(szTag, "enUS"))
+        return CASC_LOCALE_ENUS;
+
+    if(!strcmp(szTag, "koKR"))
+        return CASC_LOCALE_KOKR;
+
+    if(!strcmp(szTag, "frFR"))
+        return CASC_LOCALE_FRFR;
+
+    if(!strcmp(szTag, "deDE"))
+        return CASC_LOCALE_DEDE;
+
+    if(!strcmp(szTag, "zhCN"))
+        return CASC_LOCALE_DEDE;
+
+    if(!strcmp(szTag, "esES"))
+        return CASC_LOCALE_ESES;
+
+    if(!strcmp(szTag, "ahTW"))
+        return CASC_LOCALE_ZHTW;
+
+    if(!strcmp(szTag, "enGB"))
+        return CASC_LOCALE_ENGB;
+
+    if(!strcmp(szTag, "enCN"))
+        return CASC_LOCALE_ENCN;
+
+    if(!strcmp(szTag, "enTW"))
+        return CASC_LOCALE_ENTW;
+
+    if(!strcmp(szTag, "esMX"))
+        return CASC_LOCALE_ESMX;
+
+    if(!strcmp(szTag, "ruRU"))
+        return CASC_LOCALE_RURU;
+
+    if(!strcmp(szTag, "ptBR"))
+        return CASC_LOCALE_PTBR;
+
+    if(!strcmp(szTag, "itIT"))
+        return CASC_LOCALE_ITIT;
+
+    if(!strcmp(szTag, "ptPT"))
+        return CASC_LOCALE_PTPT;
+
+    return 0;
+}
+
 static bool IsInfoVariable(const char * szLineBegin, const char * szLineEnd, const char * szVarName, const char * szVarType)
 {
     size_t nLength;
@@ -513,6 +563,37 @@ static int GetBuildNumber(TCascStorage * hs, LPBYTE pbVarBegin, LPBYTE pbLineEnd
     return (dwBuildNumber != 0) ? ERROR_SUCCESS : ERROR_BAD_FORMAT;
 }
 
+static int GetDefaultLocaleMask(TCascStorage * hs, PQUERY_KEY pTagsString)
+{
+    char * szTagEnd = (char *)pTagsString->pbData + pTagsString->cbData;
+    char * szTagPtr = (char *)pTagsString->pbData;
+    char * szNext;
+    DWORD dwLocaleMask = 0;
+
+    while(szTagPtr < szTagEnd)
+    {
+        // Get the next part
+        szNext = strchr(szTagPtr, ' ');
+        if(szNext != NULL)
+            *szNext++ = 0;
+
+        // Check whether the current tag is a language identifier
+        dwLocaleMask = dwLocaleMask | GetLocaleMask(szTagPtr);
+
+        // Get the next part
+        if(szNext == NULL)
+            break;
+        
+        // Skip spaces
+        while(szNext < szTagEnd && szNext[0] == ' ')
+            szNext++;
+        szTagPtr = szNext;
+    }
+
+    hs->dwDefaultLocale = dwLocaleMask;
+    return ERROR_SUCCESS;
+}
+
 static int FetchAndVerifyConfigFile(TCascStorage * hs, PQUERY_KEY pFileKey, PQUERY_KEY pFileBlob)
 {
     TCHAR * szFileName;
@@ -544,6 +625,7 @@ static int FetchAndVerifyConfigFile(TCascStorage * hs, PQUERY_KEY pFileKey, PQUE
 
 static int ParseInfoFile(TCascStorage * hs, PQUERY_KEY pFileBlob)
 {
+    QUERY_KEY TagString = {NULL, 0};
     QUERY_KEY CdnHost = {NULL, 0};
     QUERY_KEY CdnPath = {NULL, 0};
     const char * szLineBegin1 = NULL;
@@ -598,6 +680,8 @@ static int ParseInfoFile(TCascStorage * hs, PQUERY_KEY pFileBlob)
             LoadInfoVariable(&CdnHost, szLineBegin2, szLineEnd2, false);
         if(IsInfoVariable(szLineBegin1, szLineEnd1, "CDN Path", "STRING"))
             LoadInfoVariable(&CdnPath, szLineBegin2, szLineEnd2, false);
+        if(IsInfoVariable(szLineBegin1, szLineEnd1, "Tags", "STRING"))
+            LoadInfoVariable(&TagString, szLineBegin2, szLineEnd2, false);
 
         // Move both line pointers
         szLineBegin1 = SkipInfoVariable(szLineBegin1, szLineEnd1);
@@ -625,8 +709,13 @@ static int ParseInfoFile(TCascStorage * hs, PQUERY_KEY pFileBlob)
         }
     }
 
+    // If we found tags, we can extract language build from it
+    if(TagString.pbData != NULL)
+        GetDefaultLocaleMask(hs, &TagString);
+
     FreeCascBlob(&CdnHost);
     FreeCascBlob(&CdnPath);
+    FreeCascBlob(&TagString);
     return nError;
 }
 

--- a/dep/CascLib/src/CascCommon.h
+++ b/dep/CascLib/src/CascCommon.h
@@ -259,7 +259,8 @@ typedef struct _TCascStorage
     DWORD dwGameInfo;                               // Game type
     DWORD dwBuildNumber;                            // Game build number
     DWORD dwFileBeginDelta;                         // This is number of bytes to shift back from archive offset (from index entry) to actual begin of file data
-    
+    DWORD dwDefaultLocale;                          // Default locale, read from ".build.info"
+
     QUERY_KEY CdnConfigKey;
     QUERY_KEY CdnBuildKey;
 

--- a/dep/CascLib/src/CascOpenStorage.cpp
+++ b/dep/CascLib/src/CascOpenStorage.cpp
@@ -1105,9 +1105,9 @@ static int LoadRootFile(TCascStorage * hs, DWORD dwLocaleMask)
     assert(hs->ppEncodingEntries != NULL);
 
     // Locale: The default parameter is 0 - in that case,
-    // we load enUS+enGB
+    // We assign the default locale, loaded from the .build.info file
     if(dwLocaleMask == 0)
-        dwLocaleMask = CASC_LOCALE_ENUS | CASC_LOCALE_ENGB;
+        dwLocaleMask = hs->dwDefaultLocale;
 
     // The root file is either MNDX file (Heroes of the Storm)
     // or a file containing an array of root entries (World of Warcraft 6.0+)
@@ -1243,6 +1243,7 @@ bool WINAPI CascOpenStorage(const TCHAR * szDataPath, DWORD dwLocaleMask, HANDLE
         memset(hs, 0, sizeof(TCascStorage));
         hs->szClassName = "TCascStorage";
         hs->dwFileBeginDelta = 0xFFFFFFFF;
+        hs->dwDefaultLocale = CASC_LOCALE_ENUS | CASC_LOCALE_ENGB;
         hs->dwRefCount = 1;
         nError = InitializeCascDirectories(hs, szDataPath);
     }


### PR DESCRIPTION
CascLib now determines default storage locale and uses it when 0 is
passed as dwLocaleMask.
Thanks @Shauren to point and @Ladislav_Zezula for fix.
Closes #13965
