### PR TITLE
Scripts/Icecrown Citadel: Minor fixes to LK and BPC

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -410,7 +410,7 @@ class boss_prince_keleseth_icc : public CreatureScript
                 if (IsHeroic())
                 {
                     me->AddAura(SPELL_SHADOW_PRISON, me);
-                    DoCast(me, SPELL_SHADOW_PRISON_DUMMY);
+                    DoCast(me, SPELL_SHADOW_PRISON_DUMMY, true);
                 }
             }
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -2417,6 +2417,7 @@ class spell_the_lich_king_defile : public SpellScriptLoader
             void CorrectRange(std::list<WorldObject*>& targets)
             {
                 targets.remove_if(ExactDistanceCheck(GetCaster(), 10.0f * GetCaster()->GetObjectScale()));
+                targets.remove_if(Trinity::UnitAuraCheck(true, SPELL_HARVEST_SOUL_VALKYR));
             }
 
             void ChangeDamageAndGrow()


### PR DESCRIPTION
- Defile should not grow when player grabbed by Val'kyr is moved across (As discussed here #14119)
- fix Shadow Prison so it is casted instantly

At the start of Heroic mode BPC fight the spell Shadow
Prison(http://www.wowhead.com/spell=73001) should be casted by
Keleseth(http://www.wowhead.com/npc=37972), the spell has a 2.5second
Cast time and in that short period if the boss gets taunted(which he
usually does by the tank in chanrge of holding him) the cast will
interupt and theere will be no debuff for the entire fight on players,
To prevent that we should simply add the Triggered flag to the spell.
(can change the casttime to 0 in SpellMgr but this seemed more simple)
