### PR TITLE
Core/Misc: Correct some wrong integer types in DB query results

### DIFF
--- a/sql/updates/world/2015_02_19_00_world.sql
+++ b/sql/updates/world/2015_02_19_00_world.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `quest_template` CHANGE COLUMN `RewardXPDifficulty` `RewardXPDifficulty` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `RewardNextQuest`;

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -733,7 +733,7 @@ void AchievementMgr<Guild>::LoadFromDB(PreparedQueryResult achievementResult, Pr
         {
             Field* fields = criteriaResult->Fetch();
             uint32 id      = fields[0].GetUInt32();
-            uint32 counter = fields[1].GetUInt32();
+            uint64 counter = fields[1].GetUInt64();
             time_t date    = time_t(fields[2].GetUInt32());
             ObjectGuid::LowType guid = fields[3].GetUInt64();
 

--- a/src/server/game/Server/Packets/CharacterPackets.cpp
+++ b/src/server/game/Server/Packets/CharacterPackets.cpp
@@ -46,7 +46,7 @@ WorldPackets::Character::EnumCharactersResult::CharacterInfo::CharacterInfo(Fiel
     PreLoadPosition.y = fields[11].GetFloat();
     PreLoadPosition.z = fields[12].GetFloat();
 
-    if (uint32 guildId = fields[13].GetUInt32())
+    if (ObjectGuid::LowType guildId = fields[13].GetUInt64())
         GuildGuid = ObjectGuid::Create<HighGuid::Guild>(guildId);
 
     uint32 playerFlags  = fields[14].GetUInt32();


### PR DESCRIPTION
Fixes errors when running a worldserver compiled using WITH_COREDEBUG cmake option

( https://github.com/TrinityCore/TrinityCore/blob/6.x/src/server/shared/Database/Field.h#L118 )
