### PR TITLE
Updated openssl macro

### DIFF
--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -1,227 +1,208 @@
-# - Try to find the OpenSSL encryption library
+# - Try to find OpenSSL
 # Once done this will define
 #
 #  OPENSSL_ROOT_DIR - Set this variable to the root installation of OpenSSL
 #
 # Read-Only variables:
-#  OPENSSL_FOUND - system has the OpenSSL library
-#  OPENSSL_INCLUDE_DIR - the OpenSSL include directory
-#  OPENSSL_LIBRARIES - The libraries needed to use OpenSSL
-
-#=============================================================================
-# Copyright 2006-2009 Kitware, Inc.
-# Copyright 2006 Alexander Neundorf <neundorf@kde.org>
-# Copyright 2009-2010 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+#  OPENSSL_FOUND - system has OpenSSL
+#  OPENSSL_INCLUDE_DIRS - the OpenSSL include directory
+#  OPENSSL_LIBRARIES - Link these to use OpenSSL
+#  OPENSSL_DEFINITIONS - Compiler switches required for using OpenSSL
 #
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
 #=============================================================================
-# (To distributed this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#  Copyright (c) 2006-2009 Kitware, Inc.
+#  Copyright (c) 2006      Alexander Neundorf <neundorf@kde.org>
+#  Copyright (c) 2009-2010 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+#  Copyright (c) 2011      Andreas Schneider <asn@cryptomilk.org>
+#
+#  Distributed under the OSI-approved BSD License (the "License");
+#  see accompanying file Copyright.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even the
+#  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the License for more information.
+#=============================================================================
+#
 
-# http://www.slproweb.com/products/Win32OpenSSL.html
+if (OPENSSL_LIBRARIES AND OPENSSL_INCLUDE_DIRS)
+    # in cache already
+    set(OPENSSL_FOUND TRUE)
+else (OPENSSL_LIBRARIES AND OPENSSL_INCLUDE_DIRS)
 
-SET(_OPENSSL_ROOT_HINTS
-  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"
-  "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;Inno Setup: App Path]"
-  )
+    if (UNIX)
+        find_package(PkgConfig)
+        if (PKG_CONFIG_FOUND)
+            pkg_check_modules(_OPENSSL openssl)
+        endif (PKG_CONFIG_FOUND)
+    endif (UNIX)
 
-IF(PLATFORM EQUAL 64)
-  SET(_OPENSSL_ROOT_PATHS
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;InstallLocation]"
-    "C:/OpenSSL-Win64/"
-    "C:/OpenSSL/"
-  )
-ELSE()
-  SET(_OPENSSL_ROOT_PATHS
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;InstallLocation]"
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;InstallLocation]"
-    "C:/OpenSSL/"
-  )
-ENDIF()
-
-FIND_PATH(OPENSSL_ROOT_DIR
-  NAMES
-    include/openssl/ssl.h
-  HINTS
-    ${_OPENSSL_ROOT_HINTS}
-  PATHS
-    ${_OPENSSL_ROOT_PATHS}
-)
-MARK_AS_ADVANCED(OPENSSL_ROOT_DIR)
-
-# Re-use the previous path:
-FIND_PATH(OPENSSL_INCLUDE_DIR openssl/ssl.h
-  ${OPENSSL_ROOT_DIR}/include
-)
-
-IF(WIN32 AND NOT CYGWIN)
-  # MINGW should go here too
-  IF(MSVC)
-    # /MD and /MDd are the standard values - if someone wants to use
-    # others, the libnames have to change here too
-    # use also ssl and ssleay32 in debug as fallback for openssl < 0.9.8b
-    # TODO: handle /MT and static lib
-    # In Visual C++ naming convention each of these four kinds of Windows libraries has it's standard suffix:
-    #   * MD for dynamic-release
-    #   * MDd for dynamic-debug
-    #   * MT for static-release
-    #   * MTd for static-debug
-
-    # Implementation details:
-    # We are using the libraries located in the VC subdir instead of the parent directory eventhough :
-    # libeay32MD.lib is identical to ../libeay32.lib, and
-    # ssleay32MD.lib is identical to ../ssleay32.lib
-
-    FIND_LIBRARY(LIB_EAY_DEBUG
-      NAMES
-        libeay32MDd libeay32
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib/VC
+    # http://www.slproweb.com/products/Win32OpenSSL.html
+    set(_OPENSSL_ROOT_HINTS
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;Inno Setup: App Path]"
     )
 
-    FIND_LIBRARY(LIB_EAY_RELEASE
-      NAMES
-        libeay32MD libeay32
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib/VC
+    set(_OPENSSL_ROOT_PATHS
+        "C:/OpenSSL/"
+        "C:/OpenSSL-Win32/"
+        "C:/OpenSSL-Win64/"
+        "$ENV{PROGRAMFILES}/OpenSSL"
+        "$ENV{PROGRAMFILES}/OpenSSL-Win32"
+        "$ENV{PROGRAMFILES}/OpenSSL-Win64"
     )
 
-    FIND_LIBRARY(SSL_EAY_DEBUG
-      NAMES
-        ssleay32MDd ssleay32 ssl
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib/VC
+    find_path(OPENSSL_ROOT_DIR
+        NAMES
+            include/openssl/ssl.h
+        HINTS
+            ${_OPENSSL_ROOT_HINTS}
+        PATHS
+            ${_OPENSSL_ROOT_PATHS}
+    )
+    mark_as_advanced(OPENSSL_ROOT_DIR)
+
+    find_path(OPENSSL_INCLUDE_DIR
+        NAMES
+            openssl/ssl.h
+        PATHS
+            /usr/local/include
+            /opt/local/include
+            /sw/include
+            /usr/lib/sfw/include
+            ${OPENSSL_ROOT_DIR}/include
     )
 
-    FIND_LIBRARY(SSL_EAY_RELEASE
-      NAMES
-        ssleay32MD ssleay32 ssl
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib/VC
-    )
+    set(OPENSSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+    mark_as_advanced(OPENSSL_INCLUDE_DIRS)
 
-    if( CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE )
-      set( OPENSSL_LIBRARIES
-        optimized ${SSL_EAY_RELEASE} ${LIB_EAY_RELEASE}
-        debug ${SSL_EAY_DEBUG} ${LIB_EAY_DEBUG}
-      )
-    else()
-      set( OPENSSL_LIBRARIES
-        ${SSL_EAY_RELEASE}
-        ${LIB_EAY_RELEASE}
-      )
-    endif()
+    if (WIN32 AND NOT CYGWIN)
+        # MINGW should go here too
+        if (MSVC)
+            # /MD and /MDd are the standard values - if someone wants to use
+            # others, the libnames have to change here too
+            # use also ssl and ssleay32 in debug as fallback for openssl < 0.9.8b
+            # TODO: handle /MT and static lib
+            # In Visual C++ naming convention each of these four kinds of Windows libraries has it's standard suffix:
+            #   * MD for dynamic-release
+            #   * MDd for dynamic-debug
+            #   * MT for static-release
+            #   * MTd for static-debug
 
-    MARK_AS_ADVANCED(SSL_EAY_DEBUG SSL_EAY_RELEASE LIB_EAY_DEBUG LIB_EAY_RELEASE)
-  ELSEIF(MINGW)
+            # Implementation details:
+            # We are using the libraries located in the VC subdir instead of the parent directory eventhough :
+            # libeay32MD.lib is identical to ../libeay32.lib, and
+            # ssleay32MD.lib is identical to ../ssleay32.lib
+            find_library(LIB_EAY_DEBUG
+                NAMES
+                    libeay32MDd
+                    libeay32
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib/VC
+            )
 
-    # same player, for MingW
-    FIND_LIBRARY(LIB_EAY
-      NAMES
-        libeay32
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib/MinGW
-    )
+            find_library(LIB_EAY_RELEASE
+                NAMES
+                    libeay32MD
+                    libeay32
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib/VC
+            )
 
-    FIND_LIBRARY(SSL_EAY NAMES
-      NAMES
-        ssleay32
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib/MinGW
-    )
+            find_library(SSL_EAY_DEBUG
+                NAMES
+                    ssleay32MDd
+                    ssleay32
+                    ssl
+                PATHS ${OPENSSL_ROOT_DIR}/lib/VC
+            )
 
-    MARK_AS_ADVANCED(SSL_EAY LIB_EAY)
+            find_library(SSL_EAY_RELEASE
+                NAMES
+                    ssleay32MD
+                    ssleay32
+                    ssl
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib/VC
+            )
 
-    set( OPENSSL_LIBRARIES
-      ${SSL_EAY}
-      ${LIB_EAY}
-    )
-  ELSE(MSVC)
-    # Not sure what to pick for -say- intel, let's use the toplevel ones and hope someone report issues:
-    FIND_LIBRARY(LIB_EAY
-      NAMES
-        libeay32
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib
-        ${OPENSSL_ROOT_DIR}/lib/VC
-    )
+            if (CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE)
+                set(OPENSSL_LIBRARIES
+                    optimized ${SSL_EAY_RELEASE} debug ${SSL_EAY_DEBUG}
+                    optimized ${LIB_EAY_RELEASE} debug ${LIB_EAY_DEBUG}
+                )
+            else (CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE)
+                set( OPENSSL_LIBRARIES ${SSL_EAY_RELEASE} ${LIB_EAY_RELEASE} )
+            endif (CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE)
 
-    FIND_LIBRARY(SSL_EAY
-      NAMES
-        ssleay32
-      PATHS
-        ${OPENSSL_ROOT_DIR}/lib
-        ${OPENSSL_ROOT_DIR}/lib/VC
-    )
-    MARK_AS_ADVANCED(SSL_EAY LIB_EAY)
+            mark_as_advanced(SSL_EAY_DEBUG SSL_EAY_RELEASE)
+            mark_as_advanced(LIB_EAY_DEBUG LIB_EAY_RELEASE)
+        elseif (MINGW)
+            # same player, for MingW
+            find_library(LIB_EAY
+                NAMES
+                    libeay32
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib/MinGW
+            )
 
-    SET( OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY} )
-  ENDIF(MSVC)
-ELSE(WIN32 AND NOT CYGWIN)
-  FIND_LIBRARY(OPENSSL_SSL_LIBRARIES NAMES ssl ssleay32 ssleay32MD)
-  FIND_LIBRARY(OPENSSL_CRYPTO_LIBRARIES NAMES crypto)
-  MARK_AS_ADVANCED(OPENSSL_CRYPTO_LIBRARIES OPENSSL_SSL_LIBRARIES)
+            find_library(SSL_EAY
+                NAMES
+                    ssleay32
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib/MinGW
+            )
 
-  SET(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
+            mark_as_advanced(SSL_EAY LIB_EAY)
+            set(OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY})
+        else(MSVC)
+            # Not sure what to pick for -say- intel, let's use the toplevel ones and hope someone report issues:
+            find_library(LIB_EAY
+                NAMES
+                    libeay32
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib
+            )
 
-ENDIF(WIN32 AND NOT CYGWIN)
+            find_library(SSL_EAY
+                NAMES
+                    ssleay32
+                PATHS
+                    ${OPENSSL_ROOT_DIR}/lib
+            )
 
-if (NOT OPENSSL_INCLUDE_DIR)
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(OpenSSL DEFAULT_MSG
-    OPENSSL_LIBRARIES
-    OPENSSL_INCLUDE_DIR
-  )
-endif()
+            mark_as_advanced(SSL_EAY LIB_EAY)
+            set(OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY})
+        endif(MSVC)
+    else (WIN32 AND NOT CYGWIN)
+        find_library(OPENSSL_SSL_LIBRARIES
+            NAMES
+                ssl
+                ssleay32
+                ssleay32MD
+            PATHS
+                ${_OPENSSL_LIBDIR}
+                /opt/local/lib
+                /sw/lib
+                /usr/sfw/lib/64
+                /usr/sfw/lib
+        )
 
-if (OPENSSL_INCLUDE_DIR)
-  message( STATUS "Found OpenSSL library: ${OPENSSL_LIBRARIES}")
-  message( STATUS "Found OpenSSL headers: ${OPENSSL_INCLUDE_DIR}")
-  if (_OPENSSL_VERSION)
-    set(OPENSSL_VERSION "${_OPENSSL_VERSION}")
-  else (_OPENSSL_VERSION)
-    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
-         REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9][0-9][0-9][0-9].*")
+        find_library(OPENSSL_CRYPTO_LIBRARIES
+            NAMES
+                crypto
+            PATHS
+                ${_OPENSSL_LIBDIR}
+                /opt/local/lib
+                /sw/lib
+                /usr/sfw/lib/64
+                /usr/sfw/lib
+        )
 
-    # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
-    # The status gives if this is a developer or prerelease and is ignored here.
-    # Major, minor, and fix directly translate into the version numbers shown in
-    # the string. The patch field translates to the single character suffix that
-    # indicates the bug fix state, which 00 -> nothing, 01 -> a, 02 -> b and so
-    # on.
+        mark_as_advanced(OPENSSL_CRYPTO_LIBRARIES OPENSSL_SSL_LIBRARIES)
+        set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARIES} ${OPENSSL_CRYPTO_LIBRARIES})
+    endif (WIN32 AND NOT CYGWIN)
 
-    string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-f])([0-9a-f][0-9a-f])([0-9a-f][0-9a-f])([0-9a-f][0-9a-f])([0-9a-f]).*$"
-           "\\1;\\2;\\3;\\4;\\5" OPENSSL_VERSION_LIST "${openssl_version_str}")
-    list(GET OPENSSL_VERSION_LIST 0 OPENSSL_VERSION_MAJOR)
-    list(GET OPENSSL_VERSION_LIST 1 OPENSSL_VERSION_MINOR)
-    list(GET OPENSSL_VERSION_LIST 2 OPENSSL_VERSION_FIX)
-    list(GET OPENSSL_VERSION_LIST 3 OPENSSL_VERSION_PATCH)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(OpenSSL DEFAULT_MSG OPENSSL_LIBRARIES OPENSSL_INCLUDE_DIRS)
 
-    string(REGEX REPLACE "^0(.)" "\\1" OPENSSL_VERSION_MINOR "${OPENSSL_VERSION_MINOR}")
-    string(REGEX REPLACE "^0(.)" "\\1" OPENSSL_VERSION_FIX "${OPENSSL_VERSION_FIX}")
-
-    if (NOT OPENSSL_VERSION_PATCH STREQUAL "00")
-      # 96 is the ASCII code of 'a' minus 1
-      math(EXPR OPENSSL_VERSION_PATCH_ASCII "${OPENSSL_VERSION_PATCH} + 96")
-      # Once anyone knows how OpenSSL would call the patch versions beyond 'z'
-      # this should be updated to handle that, too. This has not happened yet
-      # so it is simply ignored here for now.
-      string(ASCII "${OPENSSL_VERSION_PATCH_ASCII}" OPENSSL_VERSION_PATCH_STRING)
-    endif (NOT OPENSSL_VERSION_PATCH STREQUAL "00")
-
-    set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
-  endif (_OPENSSL_VERSION)
-
-  include(EnsureVersion)
-  ENSURE_VERSION( "${OPENSSL_EXPECTED_VERSION}" "${OPENSSL_VERSION}" OPENSSL_VERSION_OK)
-  if (NOT OPENSSL_VERSION_OK)
-      message(FATAL_ERROR "TrinityCore needs OpenSSL version ${OPENSSL_EXPECTED_VERSION} but found version ${OPENSSL_VERSION}")
-  endif()
-endif (OPENSSL_INCLUDE_DIR)
-
-MARK_AS_ADVANCED(OPENSSL_INCLUDE_DIR OPENSSL_LIBRARIES)
+endif (OPENSSL_LIBRARIES AND OPENSSL_INCLUDE_DIRS)


### PR DESCRIPTION
Windows 8.1 and cmake had a disagreement over old Cmake macro for openssl. updated macro and cleared the issue associated with empty stack calls.
