### PR TITLE
Core/PacketIO: Update CMSG_REORDER_CHARACTERS for 6.1

### DIFF
--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -690,7 +690,7 @@ void OpcodeTable::Initialize()
     DEFINE_HANDLER(CMSG_RECLAIM_CORPSE,                                     STATUS_UNHANDLED, PROCESS_THREADUNSAFE, WorldPackets::Misc::ReclaimCorpse, &WorldSession::HandleReclaimCorpse);
     DEFINE_OPCODE_HANDLER_OLD(CMSG_RECRUIT_A_FRIEND,                        STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     DEFINE_OPCODE_HANDLER_OLD(CMSG_REGISTER_ADDON_PREFIXES,                 STATUS_UNHANDLED, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonRegisteredPrefixesOpcode);
-    DEFINE_HANDLER(CMSG_REORDER_CHARACTERS,                                 STATUS_UNHANDLED, PROCESS_THREADUNSAFE, WorldPackets::Character::ReorderCharacters, &WorldSession::HandleReorderCharacters);
+    DEFINE_HANDLER(CMSG_REORDER_CHARACTERS,                                 STATUS_AUTHED,    PROCESS_THREADUNSAFE, WorldPackets::Character::ReorderCharacters, &WorldSession::HandleReorderCharacters);
     DEFINE_HANDLER(CMSG_REPAIR_ITEM,                                        STATUS_UNHANDLED, PROCESS_THREADUNSAFE, WorldPackets::Item::RepairItem, &WorldSession::HandleRepairItemOpcode);
     DEFINE_OPCODE_HANDLER_OLD(CMSG_REPLACE_ACCOUNT_DATA,                    STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     DEFINE_OPCODE_HANDLER_OLD(CMSG_REPLACE_TROPHY,                          STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -598,7 +598,7 @@ enum OpcodeClient : uint32
     CMSG_RECLAIM_CORPSE                               = 0xBADD,
     CMSG_RECRUIT_A_FRIEND                             = 0xBADD,
     CMSG_REGISTER_ADDON_PREFIXES                      = 0xBADD,
-    CMSG_REORDER_CHARACTERS                           = 0xBADD,
+    CMSG_REORDER_CHARACTERS                           = 0x1729,
     CMSG_REPAIR_ITEM                                  = 0xBADD,
     CMSG_REPLACE_ACCOUNT_DATA                         = 0xBADD,
     CMSG_REPLACE_TROPHY                               = 0xBADD,


### PR DESCRIPTION
Hello,

i found the Opcode for save char order in character select screen.
