### PR TITLE
Core/Log: Fix some issues detected by static analysis.

### DIFF
--- a/src/server/shared/Logging/AppenderDB.cpp
+++ b/src/server/shared/Logging/AppenderDB.cpp
@@ -26,7 +26,7 @@ AppenderDB::~AppenderDB() { }
 void AppenderDB::_write(LogMessage const& message)
 {
     // Avoid infinite loop, PExecute triggers Logging with "sql.sql" type
-    if (!enabled || !message.type.find("sql"))
+    if (!enabled || (message.type.find("sql") != std::string::npos))
         return;
 
     PreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_LOG);

--- a/src/server/shared/Logging/Log.cpp
+++ b/src/server/shared/Logging/Log.cpp
@@ -376,7 +376,7 @@ void Log::SetRealmId(uint32 id)
 {
     for (AppenderMap::iterator it = appenders.begin(); it != appenders.end(); ++it)
         if (it->second && it->second->getType() == APPENDER_DB)
-            ((AppenderDB *)it->second)->setRealmId(id);
+            static_cast<AppenderDB*>(it->second)->setRealmId(id);
 }
 
 void Log::Close()


### PR DESCRIPTION
- Either inefficient or wrong usage of string::find(). string::compare() will
  be faster if string::find's result is compared with 0, because it will not scan the whole string.
  If your intention is to check that there are no findings in the string,
  you should compare with std::string::npos.
- C-style pointer casting detected. C++ offers four different kinds of casts as replacements:
  static_cast, const_cast, dynamic_cast and reinterpret_cast.
