### PR TITLE
Core/Session: Fixed a crash in WorldSocket::ReadDataHandler

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -133,6 +133,8 @@ WorldSession::WorldSession(uint32 id, uint32 battlenetAccountId, std::shared_ptr
     forceExit(false),
     m_currentBankerGUID()
 {
+    Lock();
+
     memset(_tutorials, 0, sizeof(_tutorials));
 
     if (sock)
@@ -145,11 +147,15 @@ WorldSession::WorldSession(uint32 id, uint32 battlenetAccountId, std::shared_ptr
     m_Socket[CONNECTION_TYPE_REALM] = sock;
 
     InitializeQueryCallbackParameters();
+
+    Unlock();
 }
 
 /// WorldSession destructor
 WorldSession::~WorldSession()
 {
+    Lock();
+
     ///- unload player if not unloaded
     if (_player)
         LogoutPlayer (true);
@@ -173,6 +179,8 @@ WorldSession::~WorldSession()
         delete packet;
 
     LoginDatabase.PExecute("UPDATE account SET online = 0 WHERE id = %u;", GetAccountId());     // One-time query
+
+    Unlock();
 }
 
 std::string const & WorldSession::GetPlayerName() const

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -99,7 +99,34 @@ void WorldSocket::HandleSendAuthSession()
     SendPacket(*challenge.Write());
 }
 
+bool WorldSocket::LockSession()
+{
+    if (_worldSession)
+    {
+        _worldSession->Lock();
+        return true;
+    }
+
+    return false;
+}
+
+void WorldSocket::UnlockSession(bool HasLock)
+{
+    if (!HasLock)
+        return;
+
+    ASSERT(_worldSession && "WorldSocket::UnlockSession session doesn't exist!");
+    _worldSession->Unlock();
+}
+
 void WorldSocket::ReadHandler()
+{
+    bool l = LockSession();
+    _ReadHandler();
+    UnlockSession(l);
+}
+
+void WorldSocket::_ReadHandler()
 {
     if (!IsOpen())
         return;

--- a/src/server/game/Server/WorldSocket.h
+++ b/src/server/game/Server/WorldSocket.h
@@ -87,8 +87,12 @@ public:
 
 protected:
     void ReadHandler() override;
+    void _ReadHandler();
     bool ReadHeaderHandler();
     bool ReadDataHandler();
+
+    bool LockSession();
+    void UnlockSession(bool HasLock);
 
 private:
     void WritePacketToBuffer(WorldPacket const& packet, MessageBuffer& buffer);


### PR DESCRIPTION
Fixed a crash happening when a WorldSession is deleted while WorldSocket::ReadDataHandler is active
