### PR TITLE
Replace va_args by cppformat calls part 2

### DIFF
--- a/dep/PackageList.txt
+++ b/dep/PackageList.txt
@@ -14,7 +14,7 @@ bzip2 (a freely available, patent free, high-quality data compressor)
 
 cppformat (type safe format library)
   https://github.com/cppformat/cppformat
-  Version: 1.1.0 bf8636c9596fbfddded3d0f5879abc7579c9f4dd
+  Version: 1.1.0 aab64b55a4c5db598c123e1a2770b9eb6507d7d8
 
 G3D (a commercial-grade C++ 3D engine available as Open Source (BSD License)
   http://g3d.sourceforge.net/

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1914,28 +1914,24 @@ void World::DetectDBCLang()
     TC_LOG_INFO("server.loading", "Using %s DBC Locale as default. All available DBC locales: %s", localeNames[m_defaultDbcLocale], availableLocalsStr.empty() ? "<none>" : availableLocalsStr.c_str());
 }
 
-void World::RecordTimeDiff(const char *text, ...)
+void World::ResetTimeDiffRecord()
 {
     if (m_updateTimeCount != 1)
         return;
-    if (!text)
-    {
-        m_currentTime = getMSTime();
+
+    m_currentTime = getMSTime();
+}
+
+void World::RecordTimeDiff(std::string const& text)
+{
+    if (m_updateTimeCount != 1)
         return;
-    }
 
     uint32 thisTime = getMSTime();
     uint32 diff = getMSTimeDiff(m_currentTime, thisTime);
 
     if (diff > m_int_configs[CONFIG_MIN_LOG_UPDATE])
-    {
-        va_list ap;
-        char str[256];
-        va_start(ap, text);
-        vsnprintf(str, 256, text, ap);
-        va_end(ap);
-        TC_LOG_INFO("misc", "Difftime %s: %u.", str, diff);
-    }
+        TC_LOG_INFO("misc", "Difftime %s: %u.", text.c_str(), diff);
 
     m_currentTime = thisTime;
 }
@@ -2052,7 +2048,7 @@ void World::Update(uint32 diff)
     }
 
     /// <li> Handle session updates when the timer has passed
-    RecordTimeDiff(NULL);
+    ResetTimeDiffRecord();
     UpdateSessions(diff);
     RecordTimeDiff("UpdateSessions");
 
@@ -2099,7 +2095,7 @@ void World::Update(uint32 diff)
 
     /// <li> Handle all other objects
     ///- Update objects when the timer has passed (maps, transport, creatures, ...)
-    RecordTimeDiff(NULL);
+    ResetTimeDiffRecord();
     sMapMgr->Update(diff);
     RecordTimeDiff("UpdateMapMgr");
 

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -741,7 +741,8 @@ class World
         void LoadDBVersion();
         char const* GetDBVersion() const { return m_DBVersion.c_str(); }
 
-        void RecordTimeDiff(const char * text, ...);
+        void ResetTimeDiffRecord();
+        void RecordTimeDiff(std::string const& text);
 
         void LoadAutobroadcasts();
 

--- a/src/server/shared/Database/DatabaseWorkerPool.h
+++ b/src/server/shared/Database/DatabaseWorkerPool.h
@@ -28,6 +28,7 @@
 #include "QueryResult.h"
 #include "QueryHolder.h"
 #include "AdhocStatement.h"
+#include "StringFormat.h"
 
 #include <mysqld_error.h>
 #include <memory>
@@ -170,18 +171,13 @@ class DatabaseWorkerPool
 
         //! Enqueues a one-way SQL operation in string format -with variable args- that will be executed asynchronously.
         //! This method should only be used for queries that are only executed once, e.g during startup.
-        void PExecute(const char* sql, ...)
+        template<typename... Args>
+        void PExecute(const char* sql, Args const&... args)
         {
             if (!sql)
                 return;
 
-            va_list ap;
-            char szQuery[MAX_QUERY_LEN];
-            va_start(ap, sql);
-            vsnprintf(szQuery, MAX_QUERY_LEN, sql, ap);
-            va_end(ap);
-
-            Execute(szQuery);
+            Execute(Trinity::StringFormat(sql, args...).c_str());
         }
 
         //! Enqueues a one-way SQL operation in prepared statement format that will be executed asynchronously.
@@ -210,18 +206,13 @@ class DatabaseWorkerPool
 
         //! Directly executes a one-way SQL operation in string format -with variable args-, that will block the calling thread until finished.
         //! This method should only be used for queries that are only executed once, e.g during startup.
-        void DirectPExecute(const char* sql, ...)
+        template<typename... Args>
+        void DirectPExecute(const char* sql, Args const&... args)
         {
             if (!sql)
                 return;
 
-            va_list ap;
-            char szQuery[MAX_QUERY_LEN];
-            va_start(ap, sql);
-            vsnprintf(szQuery, MAX_QUERY_LEN, sql, ap);
-            va_end(ap);
-
-            return DirectExecute(szQuery);
+            DirectExecute(Trinity::StringFormat(sql, args...).c_str());
         }
 
         //! Directly executes a one-way SQL operation in prepared statement format, that will block the calling thread until finished.
@@ -260,34 +251,24 @@ class DatabaseWorkerPool
 
         //! Directly executes an SQL query in string format -with variable args- that will block the calling thread until finished.
         //! Returns reference counted auto pointer, no need for manual memory management in upper level code.
-        QueryResult PQuery(const char* sql, T* conn, ...)
+        template<typename... Args>
+        QueryResult PQuery(const char* sql, T* conn, Args const&... args)
         {
             if (!sql)
                 return QueryResult(NULL);
 
-            va_list ap;
-            char szQuery[MAX_QUERY_LEN];
-            va_start(ap, conn);
-            vsnprintf(szQuery, MAX_QUERY_LEN, sql, ap);
-            va_end(ap);
-
-            return Query(szQuery, conn);
+            return Query(Trinity::StringFormat(sql, args...).c_str(), conn);
         }
 
         //! Directly executes an SQL query in string format -with variable args- that will block the calling thread until finished.
         //! Returns reference counted auto pointer, no need for manual memory management in upper level code.
-        QueryResult PQuery(const char* sql, ...)
+        template<typename... Args>
+        QueryResult PQuery(const char* sql, Args const&... args)
         {
             if (!sql)
                 return QueryResult(NULL);
 
-            va_list ap;
-            char szQuery[MAX_QUERY_LEN];
-            va_start(ap, sql);
-            vsnprintf(szQuery, MAX_QUERY_LEN, sql, ap);
-            va_end(ap);
-
-            return Query(szQuery);
+            return Query(Trinity::StringFormat(sql, args...).c_str());
         }
 
         //! Directly executes an SQL query in prepared format that will block the calling thread until finished.
@@ -328,15 +309,10 @@ class DatabaseWorkerPool
 
         //! Enqueues a query in string format -with variable args- that will set the value of the QueryResultFuture return object as soon as the query is executed.
         //! The return value is then processed in ProcessQueryCallback methods.
-        QueryResultFuture AsyncPQuery(const char* sql, ...)
+        template<typename... Args>
+        QueryResultFuture AsyncPQuery(const char* sql, Args const&... args)
         {
-            va_list ap;
-            char szQuery[MAX_QUERY_LEN];
-            va_start(ap, sql);
-            vsnprintf(szQuery, MAX_QUERY_LEN, sql, ap);
-            va_end(ap);
-
-            return AsyncQuery(szQuery);
+            return AsyncQuery(Trinity::StringFormat(sql, args...).c_str());
         }
 
         //! Enqueues a query in prepared format that will set the value of the PreparedQueryResultFuture return object as soon as the query is executed.

--- a/src/server/shared/Database/QueryHolder.cpp
+++ b/src/server/shared/Database/QueryHolder.cpp
@@ -40,29 +40,6 @@ bool SQLQueryHolder::SetQuery(size_t index, const char *sql)
     return true;
 }
 
-bool SQLQueryHolder::SetPQuery(size_t index, const char *format, ...)
-{
-    if (!format)
-    {
-        TC_LOG_ERROR("sql.sql", "Query (index: %u) is empty.", uint32(index));
-        return false;
-    }
-
-    va_list ap;
-    char szQuery [MAX_QUERY_LEN];
-    va_start(ap, format);
-    int res = vsnprintf(szQuery, MAX_QUERY_LEN, format, ap);
-    va_end(ap);
-
-    if (res == -1)
-    {
-        TC_LOG_ERROR("sql.sql", "SQL Query truncated (and not execute) for format: %s", format);
-        return false;
-    }
-
-    return SetQuery(index, szQuery);
-}
-
 bool SQLQueryHolder::SetPreparedQuery(size_t index, PreparedStatement* stmt)
 {
     if (m_queries.size() <= index)

--- a/src/server/shared/Database/QueryHolder.h
+++ b/src/server/shared/Database/QueryHolder.h
@@ -29,8 +29,9 @@ class SQLQueryHolder
     public:
         SQLQueryHolder() { }
         ~SQLQueryHolder();
-        bool SetQuery(size_t index, const char *sql);
-        bool SetPQuery(size_t index, const char *format, ...) ATTR_PRINTF(3, 4);
+        bool SetQuery(size_t index, const char* sql);
+        template<typename... Args>
+        bool SetPQuery(size_t index, const char* sql, Args const&... args) { return SetQuery(index, Trinity::StringFormat(sql, args...).c_str()); }
         bool SetPreparedQuery(size_t index, PreparedStatement* stmt);
         void SetSize(size_t size);
         QueryResult GetResult(size_t index);

--- a/src/server/shared/Database/Transaction.cpp
+++ b/src/server/shared/Database/Transaction.cpp
@@ -30,17 +30,6 @@ void Transaction::Append(const char* sql)
     m_queries.push_back(data);
 }
 
-void Transaction::PAppend(const char* sql, ...)
-{
-    va_list ap;
-    char szQuery [MAX_QUERY_LEN];
-    va_start(ap, sql);
-    vsnprintf(szQuery, MAX_QUERY_LEN, sql, ap);
-    va_end(ap);
-
-    Append(szQuery);
-}
-
 //- Append a prepared statement to the transaction
 void Transaction::Append(PreparedStatement* stmt)
 {

--- a/src/server/shared/Database/Transaction.h
+++ b/src/server/shared/Database/Transaction.h
@@ -19,6 +19,7 @@
 #define _TRANSACTION_H
 
 #include "SQLOperation.h"
+#include "StringFormat.h"
 
 //- Forward declare (don't include header to prevent circular includes)
 class PreparedStatement;
@@ -38,7 +39,8 @@ class Transaction
 
         void Append(PreparedStatement* statement);
         void Append(const char* sql);
-        void PAppend(const char* sql, ...);
+        template<typename... Args>
+        void PAppend(const char* sql, Args const&... args) { Append(Trinity::StringFormat(sql, args...).c_str()); }
 
         size_t GetSize() const { return m_queries.size(); }
 


### PR DESCRIPTION
Please review @Shauren , @DDuarte 

```
<Warpten>I'm not a big fan of that
<Warpten>the fact that it is typesafe introduce runtime slowdown
<Warpten>I,d rather see this in debug builds only
<Warpten>the point of a database layer is to be fast, not super safe
<Naios>the main advantage of this commits are that you route everything to Trinity::StringFormat
<Naios>you can just replace the implementation of Trinity::StringFormat by everything you want, also the old sprintf
<Naios>i'm not sure that it is that much slower, it supports dynamic alloc so we aren't forced to create char arrays with a size of 1024 * 32 anymore
<Naios>Warpten: Also it removes dealing with va_lists which is a clutter at the moment, it would be also a improvement if we forward the args by template variable arguments to a sprintf in Trinity::StringFormat
```

What do you think about the speed?
