### PR TITLE
Use source_groups to represent the source tree in some IDE's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ endif()
 
 include(CheckPlatform)
 
+include(GroupSources)
+
 # basic packagesearching and setup (further support will be needed, this is a preliminary release!)
 set(OPENSSL_EXPECTED_VERSION 1.0.0)
 

--- a/cmake/macros/GroupSources.cmake
+++ b/cmake/macros/GroupSources.cmake
@@ -1,0 +1,46 @@
+# Copyright (C) 2008-2015 TrinityCore <http://www.trinitycore.org/>
+#
+# This file is free software; as a special exception the author gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+macro(GroupSources dir)
+  # Skip this if WITH_SOURCE_TREE is not set (empty string).
+  if (NOT ${_WITH_SOURCE_TREE} STREQUAL "")
+    # Include all header and c files
+    file(GLOB_RECURSE elements RELATIVE ${dir} *.h *.hpp *.c *.cpp *.cc)
+
+    foreach(element ${elements})
+      # Extract filename and directory
+      get_filename_component(element_name ${element} NAME)
+      get_filename_component(element_dir ${element} DIRECTORY)
+
+      if (NOT ${element_dir} STREQUAL "")
+        # If the file is in a subdirectory use it as source group.
+        if (${_WITH_SOURCE_TREE} STREQUAL "flat")
+          # Build flat structure by using only the first subdirectory.
+          string(FIND ${element_dir} "/" delemiter_pos)
+          if (NOT ${delemiter_pos} EQUAL -1)
+            string(SUBSTRING ${element_dir} 0 ${delemiter_pos} group_name)
+            source_group("${group_name}" FILES ${dir}/${element})
+          else()
+            # Build hierarchical structure.
+            # File is in root directory.
+            source_group("${element_dir}" FILES ${dir}/${element})
+          endif()
+        else()
+          # Use the full hierarchical structure to build source_groups.
+          string(REPLACE "/" "\\" group_name ${element_dir})
+          source_group("${group_name}" FILES ${dir}/${element})
+        endif()
+      else()
+        # If the file is in the root directory, place it in the root source_group.
+        source_group("\\" FILES ${dir}/${element})
+      endif()
+    endforeach()
+  endif()
+endmacro()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -15,4 +15,6 @@ option(USE_SCRIPTPCH    "Use precompiled headers when compiling scripts"        
 option(USE_COREPCH      "Use precompiled headers when compiling servers"              1)
 option(WITH_WARNINGS    "Show all warnings during compile"                            0)
 option(WITH_COREDEBUG   "Include additional debug-code in core"                       0)
+set(WITH_SOURCE_TREE "no" CACHE STRING "Build the source tree for IDE's.")
+set_property(CACHE WITH_SOURCE_TREE PROPERTY STRINGS no flat hierarchical)
 option(WITHOUT_GIT      "Disable the GIT testing routines"                            0)

--- a/cmake/showoptions.cmake
+++ b/cmake/showoptions.cmake
@@ -62,6 +62,29 @@ else()
   message("* Use coreside debug     : No  (default)")
 endif()
 
+if( WITH_SOURCE_TREE STREQUAL "flat" OR WITH_SOURCE_TREE STREQUAL "hierarchical" )
+  # TODO: Remove this after Debian 8 is released and set general required version to 2.8.12
+  #       Debian 7 is shipped with CMake 2.8.9 . But DIRECTORY flag of get_filename_component requires 2.8.12 .
+  if (NOT CMAKE_VERSION VERSION_LESS 2.8.12)
+    message("* Show source tree       : Yes - ${WITH_SOURCE_TREE}")
+    set(_WITH_SOURCE_TREE ${WITH_SOURCE_TREE} CACHE INTERNAL "WITH_SOURCE_TREE support enabled.")
+  else()
+    message("* Show source tree       : No  (default)")
+    
+    message("")
+    message(" *** WITH_SOURCE_TREE - WARNING!")
+    message(" *** This functionality is ONLY supported on CMake 2.8.12 or higher.")
+    message(" *** You are running ${CMAKE_VERSION}, which does not have the functions needed")
+    message(" *** to create a sourcetree - this option is thus forced to disabled!")
+    message("")
+
+    set(_WITH_SOURCE_TREE "" CACHE INTERNAL "WITH_SOURCE_TREE support disabled.")
+  endif()
+else()
+  message("* Show source tree       : No  (default)")
+  set(_WITH_SOURCE_TREE "" CACHE INTERNAL "WITH_SOURCE_TREE support disabled.")
+endif()
+
 if ( WITHOUT_GIT )
   message("* Use GIT revision hash  : No")
   message("")

--- a/src/server/authserver/CMakeLists.txt
+++ b/src/server/authserver/CMakeLists.txt
@@ -66,6 +66,8 @@ include_directories(
   ${VALGRIND_INCLUDE_DIR}
 )
 
+GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(authserver
   ${authserver_SRCS}
   ${authserver_PCH_SRC}

--- a/src/server/collision/CMakeLists.txt
+++ b/src/server/collision/CMakeLists.txt
@@ -80,6 +80,8 @@ include_directories(
   ${VALGRIND_INCLUDE_DIR}
 )
 
+GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(collision STATIC
   ${collision_STAT_SRCS}
   ${collision_STAT_PCH_SRC}

--- a/src/server/game/CMakeLists.txt
+++ b/src/server/game/CMakeLists.txt
@@ -208,6 +208,8 @@ include_directories(
   ${VALGRIND_INCLUDE_DIR}
 )
 
+GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(game STATIC
   ${game_STAT_SRCS}
   ${game_STAT_PCH_SRC}

--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -146,6 +146,8 @@ include_directories(
   ${VALGRIND_INCLUDE_DIR}
 )
 
+GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(scripts STATIC
   ${scripts_STAT_SRCS}
   ${scripts_STAT_PCH_SRC}

--- a/src/server/shared/CMakeLists.txt
+++ b/src/server/shared/CMakeLists.txt
@@ -84,6 +84,8 @@ include_directories(
   ${VALGRIND_INCLUDE_DIR}
 )
 
+GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(shared STATIC
   ${shared_STAT_SRCS}
   ${shared_STAT_PCH_SRC}

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -144,6 +144,8 @@ include_directories(
   ${VALGRIND_INCLUDE_DIR}
 )
 
+GroupSources(${CMAKE_CURRENT_SOURCE_DIR})
+
 add_executable(worldserver
   ${worldserver_SRCS}
   ${worldserver_PCH_SRC}


### PR DESCRIPTION
## Overview

This commit makes it possible to show the source tree inside ide's.

![screenshot_1](https://cloud.githubusercontent.com/assets/1146834/6883226/d36dc198-d5a3-11e4-94a2-5d9a57cd273f.png)

I know there were disucssions about it in the past where @LordJZ [CMake change](https://github.com/LordJZ/CMake/commits/master-msvc-tree?author=LordJZ) was pointed out as the solution but it has several disadvantages:
- Nobody wants to recompile cmake!
- If you upgrade cmake you need to recompile it from scratch.
- Too "heavy" for unexperienced users.

**-> No real solution**

CMake is not able to build the source tree structure, it offers [source_groups](http://www.cmake.org/cmake/help/v3.0/command/source_group.html) to group source files in IDE's.

This approach offers several advantages:
- You can enable/ disable it if you want
- Its disabled by default
- It dynamically creates the source_groups, you don't have to care about it when adding new files.
- You don't need to create a full projection of the directories, you can combine it however you want.
## Configuration

This PR supports 3 modes:

![screenshot_2](https://cloud.githubusercontent.com/assets/1146834/6883781/6829b7ca-d5c6-11e4-8ec8-ec118a1a7853.png)
- **`No`:** disabled off or whatever.
- **`Flat`:** packs all files into the first subdirectory (all scripts from Eastern Kingdoms into Eastern Kingdoms), useful if you just want an overview over the files. **If you don't like the idea of a full subdirectory structure probably `flat` mode is the way to go for you.**
- **`Hierarchical`:** represents the full hierarchical subdirectory structure.

This is probably the thing that annoyed me most on working with the plain tc source, If nobody has a reason against it i will merge this in 1-2 days.
