### PR TITLE
Kiting / delayed evade fixup

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -239,7 +239,7 @@ bool CreatureAI::_EnterEvadeMode()
     me->LoadCreaturesAddon();
     me->SetLootRecipient(NULL);
     me->ResetPlayerDamageReq();
-    me->SetLastDamagedTime(0);
+    me->ClearCombatPosition();
 
     if (me->IsInEvadeMode())
         return false;

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -421,7 +421,7 @@ void SmartAI::EnterEvadeMode()
     me->LoadCreaturesAddon();
     me->SetLootRecipient(NULL);
     me->ResetPlayerDamageReq();
-    me->SetLastDamagedTime(0);
+    me->ClearCombatPosition();
 
     GetScript()->ProcessEventsFor(SMART_EVENT_EVADE);//must be after aura clear so we can cast spells from db
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2003,7 +2003,7 @@ bool Creature::CanCreatureAttack(Unit const* victim, bool /*force*/) const
     //Use AttackDistance in distance check if threat radius is lower. This prevents creature bounce in and out of combat every update tick.
     float    dist = m_CombatDistance + std::max(GetAttackDistance(victim),
                                                 sWorld->getFloatConfig(CONFIG_THREAT_RADIUS));
-    Position pos  = IsInCombat( ) ? GetCombatPosition() : m_homePosition;
+    Position pos  = IsInCombat() ? GetCombatPosition() : m_homePosition;
     
     return victim->IsWithinDist3d(&pos,dist);
 }

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -685,32 +685,26 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
          * home region to prohibit the players from abusing the mechanism and
          * allowing city guards to kill the mob.
          */
-        void SetCombatPosition() {
+        void SetCombatPosition() 
+        {
             if (!isWorldBoss())
-                m_combatPosition.Relocate(GetPositionX(),GetPositionY(),GetPositionZ());
+                m_combatPosition.Relocate(GetPosition());
             else
                 ClearCombatPosition();
         }
 
         /** 
          * @brief Clear the modified last combat position
+         * 
+         * Reuses the home position t
          */
-        void ClearCombatPosition() {
-            /*
-             * Reuse the home position
-             */
-            m_combatPosition.Relocate(m_homePosition.GetPositionX(),
-                                      m_homePosition.GetPositionY(),
-                                      m_homePosition.GetPositionZ());
-        }
+        void ClearCombatPosition() { m_combatPosition.Relocate(m_homePosition); }
 
         /**
          * Get the last point where combat was started
          * @return combat start position
          */
-        Position GetCombatPosition() const {
-            return m_combatPosition;
-        }
+        Position GetCombatPosition() const { return m_combatPosition; }
 
     protected:
         bool CreateFromProto(uint32 guidlow, uint32 entry, CreatureData const* data = nullptr, uint32 vehId = 0);

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -686,22 +686,22 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
          * allowing city guards to kill the mob.
          */
         void SetCombatPosition() {
-          if (!isWorldBoss())
-            m_combatPosition.Relocate(GetPositionX(),GetPositionY(),GetPositionZ());
-          else
-            ClearCombatPosition();
+            if (!isWorldBoss())
+                m_combatPosition.Relocate(GetPositionX(),GetPositionY(),GetPositionZ());
+            else
+                ClearCombatPosition();
         }
 
         /** 
          * @brief Clear the modified last combat position
          */
         void ClearCombatPosition() {
-          /*
-           * Reuse the home position
-           */
-          m_combatPosition.Relocate(m_homePosition.GetPositionX(),
-                                    m_homePosition.GetPositionY(),
-                                    m_homePosition.GetPositionZ());
+            /*
+             * Reuse the home position
+             */
+            m_combatPosition.Relocate(m_homePosition.GetPositionX(),
+                                      m_homePosition.GetPositionY(),
+                                      m_homePosition.GetPositionZ());
         }
 
         /**
@@ -709,7 +709,7 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
          * @return combat start position
          */
         Position GetCombatPosition() const {
-          return m_combatPosition;
+            return m_combatPosition;
         }
 
     protected:

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -678,6 +678,40 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
         void FocusTarget(Spell const* focusSpell, WorldObject const* target);
         void ReleaseFocus(Spell const* focusSpell);
 
+        /**
+         * @brief Set the combat start position to the current mob map position.
+         * 
+         * World bosses are an exception to the rule, they are force-set to the
+         * home region to prohibit the players from abusing the mechanism and
+         * allowing city guards to kill the mob.
+         */
+        void SetCombatPosition() {
+          if (!isWorldBoss())
+            m_combatPosition.Relocate(GetPositionX(),GetPositionY(),GetPositionZ());
+          else
+            ClearCombatPosition();
+        }
+
+        /** 
+         * @brief Clear the modified last combat position
+         */
+        void ClearCombatPosition() {
+          /*
+           * Reuse the home position
+           */
+          m_combatPosition.Relocate(m_homePosition.GetPositionX(),
+                                    m_homePosition.GetPositionY(),
+                                    m_homePosition.GetPositionZ());
+        }
+
+        /**
+         * Get the last point where combat was started
+         * @return combat start position
+         */
+        Position GetCombatPosition() const {
+          return m_combatPosition;
+        }
+
     protected:
         bool CreateFromProto(uint32 guidlow, uint32 entry, CreatureData const* data = nullptr, uint32 vehId = 0);
         bool InitEntry(uint32 entry, CreatureData const* data = nullptr);
@@ -718,6 +752,7 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
 
         Position m_homePosition;
         Position m_transportHomePosition;
+        Position m_combatPosition;
 
         bool DisableReputationGain;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -741,9 +741,7 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
         {
             victim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE, spellProto ? spellProto->Id : 0);
             if (victim->GetTypeId() == TYPEID_UNIT && !victim->IsPet())
-            {
                 victim->ToCreature()->SetCombatPosition();
-            }
         }
 
         if (victim->GetTypeId() != TYPEID_PLAYER)
@@ -9036,9 +9034,9 @@ void Unit::CombatStop(bool includingCast)
     AttackStop();
     RemoveAllAttackers();
     if (GetTypeId() == TYPEID_PLAYER)
-      ToPlayer()->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
+        ToPlayer()->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
     else if (GetTypeId() == TYPEID_UNIT)
-      ToCreature()->ClearCombatPosition();
+        ToCreature()->ClearCombatPosition();
       
     ClearInCombat();
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -163,7 +163,7 @@ Unit::Unit(bool isWorldObject) :
     i_AI(NULL), i_disabledAI(NULL), m_AutoRepeatFirstCast(false), m_procDeep(0),
     m_removedAurasCount(0), i_motionMaster(new MotionMaster(this)), m_regenTimer(0), m_ThreatManager(this),
     m_vehicle(NULL), m_vehicleKit(NULL), m_unitTypeMask(UNIT_MASK_NONE),
-    m_HostileRefManager(this), _lastDamagedTime(0)
+    m_HostileRefManager(this)
 {
     m_objectType |= TYPEMASK_UNIT;
     m_objectTypeId = TYPEID_UNIT;
@@ -741,7 +741,9 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
         {
             victim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE, spellProto ? spellProto->Id : 0);
             if (victim->GetTypeId() == TYPEID_UNIT && !victim->IsPet())
-                victim->SetLastDamagedTime(time(NULL));
+            {
+                victim->ToCreature()->SetCombatPosition();
+            }
         }
 
         if (victim->GetTypeId() != TYPEID_PLAYER)
@@ -8961,13 +8963,15 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (GetTypeId() == TYPEID_UNIT && !ToCreature()->IsPet())
     {
         // should not let player enter combat by right clicking target - doesn't helps
+        Creature* creature = ToCreature();
         SetInCombatWith(victim);
         if (victim->GetTypeId() == TYPEID_PLAYER)
             victim->SetInCombatWith(this);
         AddThreat(victim, 0.0f);
 
-        ToCreature()->SendAIReaction(AI_REACTION_HOSTILE);
-        ToCreature()->CallAssistance();
+        creature->SendAIReaction(AI_REACTION_HOSTILE);
+        creature->CallAssistance();
+        creature->SetCombatPosition();
     }
 
     // delay offhand weapon attack to next attack time
@@ -9032,7 +9036,10 @@ void Unit::CombatStop(bool includingCast)
     AttackStop();
     RemoveAllAttackers();
     if (GetTypeId() == TYPEID_PLAYER)
-        ToPlayer()->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
+      ToPlayer()->SendAttackSwingCancelAttack();     // melee and ranged forced attack cancel
+    else if (GetTypeId() == TYPEID_UNIT)
+      ToCreature()->ClearCombatPosition();
+      
     ClearInCombat();
 }
 
@@ -12713,15 +12720,7 @@ Unit* Creature::SelectVictim()
         SetInFront(target);
         return target;
     }
-
-    // Case where mob is being kited.
-    // Mob may not be in range to attack or may have dropped target. In any case,
-    //  don't evade if damage received within the last 10 seconds
-    // Does not apply to world bosses to prevent kiting to cities
-    if (!isWorldBoss() && !GetInstanceId())
-        if (time(NULL) - GetLastDamagedTime() <= MAX_AGGRO_RESET_TIME)
-            return target;
-
+    
     // last case when creature must not go to evade mode:
     // it in combat but attacker not make any damage and not enter to aggro radius to have record in threat list
     // for example at owner command to pet attack some far away creature

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -270,7 +270,6 @@ enum UnitRename
 #define MAX_SPELL_POSSESS       8
 #define MAX_SPELL_CONTROL_BAR   10
 
-#define MAX_AGGRO_RESET_TIME 10 // in seconds
 #define MAX_AGGRO_RADIUS 45.0f  // yards
 
 enum Swing

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2154,10 +2154,6 @@ class Unit : public WorldObject
         // Movement info
         Movement::MoveSpline * movespline;
 
-        // Part of Evade mechanics
-        time_t GetLastDamagedTime() const { return _lastDamagedTime; }
-        void SetLastDamagedTime(time_t val) { _lastDamagedTime = val; }
-
         int32 GetHighestExclusiveSameEffectSpellGroupValue(AuraEffect const* aurEff, AuraType auraType, bool checkMiscValue = false, int32 miscValue = 0) const;
         bool IsHighestExclusiveAura(Aura const* aura, bool removeOtherAuraApplications = false);
 
@@ -2291,8 +2287,6 @@ class Unit : public WorldObject
 
         uint32 _oldFactionId;           ///< faction before charm
         bool _isWalkingBeforeCharm;     ///< Are we walking before we were charmed?
-
-        time_t _lastDamagedTime; // Part of Evade mechanics
 };
 
 namespace Trinity

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -751,7 +751,7 @@ void AuraEffect::Update(uint32 diff, Unit* caster)
             m_periodicTimer -= diff;
         else // tick also at m_periodicTimer == 0 to prevent lost last tick in case max m_duration == (max m_periodicTimer)*N
         {
-            ++m_tickNumber;
+            if ( ++m_tickNumber == 0 ) m_tickNumber = 2; // Only first go can be 1
 
             // update before tick (aura can be removed in TriggerSpell or PeriodicTick calls)
             m_periodicTimer += m_amplitude - diff;
@@ -5946,6 +5946,10 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     caster->ProcDamageAndSpell(target, procAttacker, procVictim, procEx, damage, BASE_ATTACK, GetSpellInfo());
 
     caster->DealDamage(target, damage, &cleanDamage, DOT, GetSpellInfo()->GetSchoolMask(), GetSpellInfo(), true);
+
+    if ((target->IsAlive()) && (GetTickNumber()==1))
+      if (Creature* creature = target->ToCreature())
+        creature->SetCombatPosition();
 }
 
 void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) const
@@ -5977,7 +5981,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
     if (isAreaAura)
         damage = caster->SpellDamageBonusDone(target, GetSpellInfo(), damage, DOT, GetBase()->GetStackAmount()) * caster->SpellDamagePctDone(target, m_spellInfo, DOT);
     else
-    	damage = std::max(int32(damage * GetDonePct()), 0);
+        damage = std::max(int32(damage * GetDonePct()), 0);
 
     damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT, GetBase()->GetStackAmount());
 
@@ -6040,6 +6044,10 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
         int32 gain = caster->HealBySpell(caster, GetSpellInfo(), heal);
         caster->getHostileRefManager().threatAssist(caster, gain * 0.5f, GetSpellInfo());
     }
+
+    if ((target->IsAlive()) && (GetTickNumber()==1))
+      if (Creature* creature = target->ToCreature())
+        creature->SetCombatPosition();
 }
 
 void AuraEffect::HandlePeriodicHealthFunnelAuraTick(Unit* target, Unit* caster) const

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -751,7 +751,7 @@ void AuraEffect::Update(uint32 diff, Unit* caster)
             m_periodicTimer -= diff;
         else // tick also at m_periodicTimer == 0 to prevent lost last tick in case max m_duration == (max m_periodicTimer)*N
         {
-            if ( ++m_tickNumber == 0 ) m_tickNumber = 2; // Only first go can be 1
+            if (++m_tickNumber == 0) m_tickNumber = 2; // Only first go can be 1
 
             // update before tick (aura can be removed in TriggerSpell or PeriodicTick calls)
             m_periodicTimer += m_amplitude - diff;


### PR DESCRIPTION
Modified mob behavior to use the radial aggro of the last point of attack (direct and initial DOT tick).

Reason:  Ran into a couple instances where the mob that I was attacking would prematurely disengage even when the character was within combat range.

Example: ran into the (cave-)yeti cave in hillsbrad foothills, attacked and killed 4-5 yet one yeti from the inside the cave paced, took one DOT and evaded.
