### PR TITLE
[WIP/ TO REVIEW] Core/Misc: Replace tc's optional with boost::optional.

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1313,7 +1313,7 @@ bool Battleground::HasFreeSlots() const
 void Battleground::BuildPvPLogDataPacket(WorldPackets::Battleground::PVPLogData& pvpLogData)
 {
     if (GetStatus() == STATUS_WAIT_LEAVE)
-        pvpLogData.Winner.Set(GetWinner());
+        pvpLogData.Winner = GetWinner();
 
     pvpLogData.Players.reserve(GetPlayerScoresSize());
     for (auto const& score : PlayerScores)
@@ -1325,12 +1325,10 @@ void Battleground::BuildPvPLogDataPacket(WorldPackets::Battleground::PVPLogData&
         playerData.Faction = score.second->TeamId;
         if (score.second->HonorableKills || score.second->Deaths || score.second->BonusHonor)
         {
-            WorldPackets::Battleground::PVPLogData::HonorData& honorData = playerData.Honor.Value;
-            honorData.HonorKills = score.second->HonorableKills;
-            honorData.Deaths = score.second->Deaths;
-            honorData.ContributionPoints = score.second->BonusHonor;
-
-            playerData.Honor.HasValue = true;
+            playerData.Honor = WorldPackets::Battleground::PVPLogData::HonorData();
+            playerData.Honor->HonorKills = score.second->HonorableKills;
+            playerData.Honor->Deaths = score.second->Deaths;
+            playerData.Honor->ContributionPoints = score.second->BonusHonor;
         }
 
         playerData.DamageDone = score.second->DamageDone;
@@ -1356,15 +1354,14 @@ void Battleground::BuildPvPLogDataPacket(WorldPackets::Battleground::PVPLogData&
 
     if (isRated())
     {
-        WorldPackets::Battleground::PVPLogData::RatingData& ratingData = pvpLogData.Ratings.Value;
+        pvpLogData.Ratings = WorldPackets::Battleground::PVPLogData::RatingData();
+
         for (uint8 i = 0; i < BG_TEAMS_COUNT; ++i)
         {
-            ratingData.Postmatch[i] = _arenaTeamScores[i].NewRating;
-            ratingData.Prematch[i] = _arenaTeamScores[i].OldRating;
-            ratingData.PrematchMMR[i] = _arenaTeamScores[i].MatchmakerRating;
+            pvpLogData.Ratings->Postmatch[i] = _arenaTeamScores[i].NewRating;
+            pvpLogData.Ratings->Prematch[i] = _arenaTeamScores[i].OldRating;
+            pvpLogData.Ratings->PrematchMMR[i] = _arenaTeamScores[i].MatchmakerRating;
         }
-
-        pvpLogData.Ratings.HasValue = true;
     }
 
     pvpLogData.PlayerCount[0] = int8(GetPlayersCountByTeam(HORDE));

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2155,9 +2155,9 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
                 transferPending.MapID = mapid;
                 if (Transport* transport = GetTransport())
                 {
-                    transferPending.Ship.HasValue = true;
-                    transferPending.Ship.Value.ID = transport->GetEntry();
-                    transferPending.Ship.Value.OriginMapID = GetMapId();
+                    transferPending.Ship = WorldPackets::Movement::TransferPending::ShipTransferPending();
+                    transferPending.Ship->ID = transport->GetEntry();
+                    transferPending.Ship->OriginMapID = GetMapId();
                 }
 
                 GetSession()->SendPacket(transferPending.Write());
@@ -6859,9 +6859,9 @@ void Player::SendNewCurrency(uint32 id) const
     WorldPackets::Misc::SetupCurrency::Record record;
     record.Type = entry->ID;
     record.Quantity = itr->second.Quantity;
-    record.WeeklyQuantity.Set(itr->second.WeeklyQuantity);
-    record.MaxWeeklyQuantity.Set(GetCurrencyWeekCap(entry) / ((entry->Flags & CURRENCY_FLAG_HIGH_PRECISION) ? CURRENCY_PRECISION : 1));
-    record.TrackedQuantity.Set(itr->second.TrackedQuantity);
+    record.WeeklyQuantity = itr->second.WeeklyQuantity;
+    record.MaxWeeklyQuantity = GetCurrencyWeekCap(entry) / ((entry->Flags & CURRENCY_FLAG_HIGH_PRECISION) ? CURRENCY_PRECISION : 1);
+    record.TrackedQuantity = itr->second.TrackedQuantity;
     record.Flags = itr->second.Flags;
 
     packet.Data.push_back(record);
@@ -6885,9 +6885,9 @@ void Player::SendCurrencies() const
         WorldPackets::Misc::SetupCurrency::Record record;
         record.Type = entry->ID;
         record.Quantity = itr->second.Quantity;
-        record.WeeklyQuantity.Set(itr->second.WeeklyQuantity);
-        record.MaxWeeklyQuantity.Set(GetCurrencyWeekCap(entry) / ((entry->Flags & CURRENCY_FLAG_HIGH_PRECISION) ? CURRENCY_PRECISION : 1));
-        record.TrackedQuantity.Set(itr->second.TrackedQuantity);
+        record.WeeklyQuantity = itr->second.WeeklyQuantity;
+        record.MaxWeeklyQuantity = GetCurrencyWeekCap(entry) / ((entry->Flags & CURRENCY_FLAG_HIGH_PRECISION) ? CURRENCY_PRECISION : 1);
+        record.TrackedQuantity = itr->second.TrackedQuantity;
         record.Flags = itr->second.Flags;
 
         packet.Data.push_back(record);
@@ -7033,8 +7033,8 @@ void Player::ModifyCurrency(uint32 id, int32 count, bool printLog/* = true*/, bo
         packet.Type = id;
         packet.Quantity = newTotalCount;
         packet.SuppressChatLog = !printLog;
-        packet.WeeklyQuantity.Set(newWeekCount);
-        packet.TrackedQuantity.Set(newTrackedCount);
+        packet.WeeklyQuantity = newWeekCount;
+        packet.TrackedQuantity = newTrackedCount;
         packet.Flags = itr->second.Flags;
 
         GetSession()->SendPacket(packet.Write());
@@ -22538,12 +22538,12 @@ void Player::SendInitialPacketsBeforeAddToMap()
 
     /// SMSG_WORLD_SERVER_INFO
     WorldPackets::Misc::WorldServerInfo worldServerInfo;
-    worldServerInfo.IneligibleForLootMask.Clear();     /// @todo
+    // worldServerInfo.IneligibleForLootMask; /// @todo
     worldServerInfo.WeeklyReset = sWorld->GetNextWeeklyQuestsResetTime() - WEEK;
-    worldServerInfo.InstanceGroupSize.Set(GetMap()->GetMapDifficulty()->MaxPlayers);
-    worldServerInfo.IsTournamentRealm = 0;             /// @todo
-    worldServerInfo.RestrictedAccountMaxLevel.Clear(); /// @todo
-    worldServerInfo.RestrictedAccountMaxMoney.Clear(); /// @todo
+    worldServerInfo.InstanceGroupSize = GetMap()->GetMapDifficulty()->MaxPlayers;
+    worldServerInfo.IsTournamentRealm = 0; /// @todo
+    // worldServerInfo.RestrictedAccountMaxLevel; /// @todo
+    // worldServerInfo.RestrictedAccountMaxMoney; /// @todo
     worldServerInfo.DifficultyID = GetMap()->GetDifficultyID();
     SendDirectMessage(worldServerInfo.Write());
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4914,13 +4914,12 @@ void Unit::SendAttackStateUpdate(CalcDamageInfo* damageInfo)
     int32 overkill = damageInfo->damage - damageInfo->target->GetHealth();
     packet.OverDamage = (overkill < 0 ? -1 : overkill);
 
-    WorldPackets::Combat::SubDamage& subDmg = packet.SubDmg.Value;
-    subDmg.SchoolMask = damageInfo->damageSchoolMask;   // School of sub damage
-    subDmg.FDamage = damageInfo->damage;                // sub damage
-    subDmg.Damage = damageInfo->damage;                 // Sub Damage
-    subDmg.Absorbed = damageInfo->absorb;
-    subDmg.Resisted = damageInfo->resist;
-    packet.SubDmg.HasValue = true;
+    packet.SubDmg = WorldPackets::Combat::SubDamage();
+    packet.SubDmg->SchoolMask = damageInfo->damageSchoolMask;   // School of sub damage
+    packet.SubDmg->FDamage = damageInfo->damage;                // sub damage
+    packet.SubDmg->Damage = damageInfo->damage;                 // Sub Damage
+    packet.SubDmg->Absorbed = damageInfo->absorb;
+    packet.SubDmg->Resisted = damageInfo->resist;
 
     packet.VictimState = damageInfo->TargetState;
     packet.BlockAmount = damageInfo->blocked_amount;
@@ -15422,7 +15421,7 @@ void Unit::SendTeleportPacket(Position& pos)
 
         ObjectGuid transGuid = GetTransGUID();
         if (!transGuid.IsEmpty())
-            selfPacket.TransportGUID.Set(transGuid);
+            selfPacket.TransportGUID = transGuid;
 
         selfPacket.Pos.Relocate(GetPositionX(), GetPositionY(), GetPositionZMinusOffset());
         selfPacket.Facing = GetOrientation();

--- a/src/server/game/Guilds/Guild.cpp
+++ b/src/server/game/Guilds/Guild.cpp
@@ -190,16 +190,16 @@ void Guild::BankEventLogEntry::WritePacket(WorldPackets::Guild:: GuildBankLogQue
     bankLogEntry.EntryType = int8(m_eventType);
 
     if (hasStack)
-        bankLogEntry.Count.Set(int32(m_itemStackCount));
+        bankLogEntry.Count = int32(m_itemStackCount);
 
     if (IsMoneyEvent())
-        bankLogEntry.Money.Set(uint64(m_itemOrMoney));
+        bankLogEntry.Money = uint64(m_itemOrMoney);
 
     if (hasItem)
-        bankLogEntry.ItemID.Set(int32(m_itemOrMoney));
+        bankLogEntry.ItemID = int32(m_itemOrMoney);
 
     if (itemMoved)
-        bankLogEntry.OtherTab.Set(int8(m_destTabId));
+        bankLogEntry.OtherTab = int8(m_destTabId);
 
     packet.Entry.push_back(bankLogEntry);
 }
@@ -236,7 +236,7 @@ void Guild::NewsLogEntry::WritePacket(WorldPackets::Guild::GuildNews& newsPacket
     {
         WorldPackets::Item::ItemInstance itemInstance;
         itemInstance.ItemID = GetValue();
-        newsEvent.Item.Set(itemInstance);
+        newsEvent.Item = itemInstance;
     }
 
     newsPacket.NewsEvents.push_back(newsEvent);
@@ -1313,25 +1313,25 @@ void Guild::SendQueryResponse(WorldSession* session)
 {
     WorldPackets::Guild::QueryGuildInfoResponse response;
     response.GuildGuid = GetGUID();
-    response.Info.HasValue = true;
+    response.Info = WorldPackets::Guild::QueryGuildInfoResponse::GuildInfo();
 
-    response.Info.Value.GuildGUID = GetGUID();
-    response.Info.Value.VirtualRealmAddress = GetVirtualRealmAddress();
+    response.Info->GuildGUID = GetGUID();
+    response.Info->VirtualRealmAddress = GetVirtualRealmAddress();
 
-    response.Info.Value.EmblemStyle = m_emblemInfo.GetStyle();
-    response.Info.Value.EmblemColor = m_emblemInfo.GetColor();
-    response.Info.Value.BorderStyle = m_emblemInfo.GetBorderStyle();
-    response.Info.Value.BorderColor = m_emblemInfo.GetBorderColor();
-    response.Info.Value.BackgroundColor = m_emblemInfo.GetBackgroundColor();
+    response.Info->EmblemStyle = m_emblemInfo.GetStyle();
+    response.Info->EmblemColor = m_emblemInfo.GetColor();
+    response.Info->BorderStyle = m_emblemInfo.GetBorderStyle();
+    response.Info->BorderColor = m_emblemInfo.GetBorderColor();
+    response.Info->BackgroundColor = m_emblemInfo.GetBackgroundColor();
 
     for (uint8 i = 0; i < _GetRanksSize(); ++i)
     {
         WorldPackets::Guild::QueryGuildInfoResponse::GuildInfo::GuildInfoRank info
             (m_ranks[i].GetId(), i, m_ranks[i].GetName());
-        response.Info.Value.Ranks.insert(info);
+        response.Info->Ranks.insert(info);
     }
 
-    response.Info.Value.GuildName = m_name;
+    response.Info->GuildName = m_name;
 
     session->SendPacket(response.Write());
     TC_LOG_DEBUG("guild", "SMSG_GUILD_QUERY_RESPONSE [%s]", session->GetPlayerInfo().c_str());

--- a/src/server/game/Handlers/InspectHandler.cpp
+++ b/src/server/game/Handlers/InspectHandler.cpp
@@ -65,12 +65,10 @@ void WorldSession::HandleInspectOpcode(WorldPackets::Inspect::Inspect& inspect)
 
     if (Guild* guild = sGuildMgr->GetGuildById(player->GetGuildId()))
     {
-        inspectResult.GuildData.HasValue = true;
-
-        WorldPackets::Inspect::InspectGuildData& guildData = inspectResult.GuildData.Value;
-        guildData.GuildGUID = guild->GetGUID();
-        guildData.NumGuildMembers = guild->GetMembersCount();
-        guildData.AchievementPoints = guild->GetAchievementMgr().GetAchievementPoints();
+        inspectResult.GuildData = WorldPackets::Inspect::InspectGuildData();
+        inspectResult.GuildData->GuildGUID = guild->GetGUID();
+        inspectResult.GuildData->NumGuildMembers = guild->GetMembersCount();
+        inspectResult.GuildData->AchievementPoints = guild->GetAchievementMgr().GetAchievementPoints();
     }
 
     inspectResult.InspecteeGUID = inspect.Target;

--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -69,19 +69,19 @@ void WorldSession::SendUpdateTrade(bool trader_data /*= true*/)
             tradeItem.GiftCreator = item->GetGuidValue(ITEM_FIELD_GIFTCREATOR);
             if (!item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FLAG_WRAPPED))
             {
-                WorldPackets::Trade::TradeUpdated::UnwrappedTradeItem* unwrappedItem = &tradeItem.Unwrapped.Value;
-                unwrappedItem->Item.Initialize(item);
-                unwrappedItem->EnchantID = item->GetEnchantmentId(PERM_ENCHANTMENT_SLOT);
-                unwrappedItem->OnUseEnchantmentID = item->GetEnchantmentId(USE_ENCHANTMENT_SLOT);
-                unwrappedItem->Creator = item->GetGuidValue(ITEM_FIELD_CREATOR);
-                unwrappedItem->Charges = item->GetSpellCharges();
-                unwrappedItem->Lock = item->GetTemplate()->GetLockID() && !item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FLAG_UNLOCKED);
-                unwrappedItem->MaxDurability = item->GetUInt32Value(ITEM_FIELD_MAXDURABILITY);
-                unwrappedItem->Durability = item->GetUInt32Value(ITEM_FIELD_DURABILITY);
-                for (uint32 s = SOCK_ENCHANTMENT_SLOT; s < MAX_GEM_SOCKETS; ++s)
-                    unwrappedItem->SocketEnchant[s] = item->GetEnchantmentId(EnchantmentSlot(s + SOCK_ENCHANTMENT_SLOT));
+                tradeItem.Unwrapped = WorldPackets::Trade::TradeUpdated::UnwrappedTradeItem();
 
-                tradeItem.Unwrapped.HasValue = true;
+                tradeItem.Unwrapped->Item.Initialize(item);
+                tradeItem.Unwrapped->EnchantID = item->GetEnchantmentId(PERM_ENCHANTMENT_SLOT);
+                tradeItem.Unwrapped->OnUseEnchantmentID = item->GetEnchantmentId(USE_ENCHANTMENT_SLOT);
+                tradeItem.Unwrapped->Creator = item->GetGuidValue(ITEM_FIELD_CREATOR);
+                tradeItem.Unwrapped->Charges = item->GetSpellCharges();
+                tradeItem.Unwrapped->Lock = item->GetTemplate()->GetLockID() && !item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FLAG_UNLOCKED);
+                tradeItem.Unwrapped->MaxDurability = item->GetUInt32Value(ITEM_FIELD_MAXDURABILITY);
+                tradeItem.Unwrapped->Durability = item->GetUInt32Value(ITEM_FIELD_DURABILITY);
+
+                for (uint32 s = SOCK_ENCHANTMENT_SLOT; s < MAX_GEM_SOCKETS; ++s)
+                    tradeItem.Unwrapped->SocketEnchant[s] = item->GetEnchantmentId(EnchantmentSlot(s + SOCK_ENCHANTMENT_SLOT));
             }
 
             tradeUpdated.Items.push_back(tradeItem);

--- a/src/server/game/Server/Packets/AuthenticationPackets.cpp
+++ b/src/server/game/Server/Packets/AuthenticationPackets.cpp
@@ -53,32 +53,30 @@ void WorldPackets::Auth::AuthSession::Read()
 WorldPackets::Auth::AuthResponse::AuthResponse()
     : ServerPacket(SMSG_AUTH_RESPONSE, 132)
 {
-    WaitInfo.HasValue = false;
-    SuccessInfo.HasValue = false;
 }
 
 WorldPacket const* WorldPackets::Auth::AuthResponse::Write()
 {
     _worldPacket << uint8(Result);
-    _worldPacket.WriteBit(SuccessInfo.HasValue);
-    _worldPacket.WriteBit(WaitInfo.HasValue);
+    _worldPacket.WriteBit(SuccessInfo.is_initialized());
+    _worldPacket.WriteBit(WaitInfo.is_initialized());
 
-    if (SuccessInfo.HasValue)
+    if (SuccessInfo)
     {
-        _worldPacket << uint32(SuccessInfo.Value.VirtualRealmAddress);
-        _worldPacket << uint32(SuccessInfo.Value.VirtualRealms.size());
-        _worldPacket << uint32(SuccessInfo.Value.TimeRemain);
-        _worldPacket << uint32(SuccessInfo.Value.TimeOptions);
-        _worldPacket << uint32(SuccessInfo.Value.TimeRested);
-        _worldPacket << uint8(SuccessInfo.Value.ActiveExpansionLevel);
-        _worldPacket << uint8(SuccessInfo.Value.AccountExpansionLevel);
-        _worldPacket << uint32(SuccessInfo.Value.TimeSecondsUntilPCKick);
-        _worldPacket << uint32(SuccessInfo.Value.AvailableRaces->size());
-        _worldPacket << uint32(SuccessInfo.Value.AvailableClasses->size());
-        _worldPacket << uint32(SuccessInfo.Value.Templates.size());
-        _worldPacket << uint32(SuccessInfo.Value.CurrencyID);
+        _worldPacket << uint32(SuccessInfo->VirtualRealmAddress);
+        _worldPacket << uint32(SuccessInfo->VirtualRealms.size());
+        _worldPacket << uint32(SuccessInfo->TimeRemain);
+        _worldPacket << uint32(SuccessInfo->TimeOptions);
+        _worldPacket << uint32(SuccessInfo->TimeRested);
+        _worldPacket << uint8(SuccessInfo->ActiveExpansionLevel);
+        _worldPacket << uint8(SuccessInfo->AccountExpansionLevel);
+        _worldPacket << uint32(SuccessInfo->TimeSecondsUntilPCKick);
+        _worldPacket << uint32(SuccessInfo->AvailableRaces->size());
+        _worldPacket << uint32(SuccessInfo->AvailableClasses->size());
+        _worldPacket << uint32(SuccessInfo->Templates.size());
+        _worldPacket << uint32(SuccessInfo->CurrencyID);
 
-        for (auto& realm : SuccessInfo.Value.VirtualRealms)
+        for (auto& realm : SuccessInfo->VirtualRealms)
         {
             _worldPacket << uint32(realm.RealmAddress);
             _worldPacket.WriteBit(realm.IsLocal);
@@ -89,19 +87,19 @@ WorldPacket const* WorldPackets::Auth::AuthResponse::Write()
             _worldPacket.WriteString(realm.RealmNameNormalized);
         }
 
-        for (auto& race : *SuccessInfo.Value.AvailableRaces)
+        for (auto& race : *SuccessInfo->AvailableRaces)
         {
             _worldPacket << uint8(race.first); /// the current race
             _worldPacket << uint8(race.second); /// the required Expansion
         }
 
-        for (auto& klass : *SuccessInfo.Value.AvailableClasses)
+        for (auto& klass : *SuccessInfo->AvailableClasses)
         {
             _worldPacket << uint8(klass.first); /// the current class
             _worldPacket << uint8(klass.second); /// the required Expansion
         }
 
-        for (auto& templat : SuccessInfo.Value.Templates)
+        for (auto& templat : SuccessInfo->Templates)
         {
             _worldPacket << uint32(templat.TemplateSetId);
             _worldPacket << uint32(templat.Classes.size());
@@ -117,23 +115,23 @@ WorldPacket const* WorldPackets::Auth::AuthResponse::Write()
             _worldPacket.WriteString(templat.Description);
         }
 
-        _worldPacket.WriteBit(SuccessInfo.Value.IsExpansionTrial);
-        _worldPacket.WriteBit(SuccessInfo.Value.ForceCharacterTemplate);
-        _worldPacket.WriteBit(SuccessInfo.Value.NumPlayersHorde.HasValue);
-        _worldPacket.WriteBit(SuccessInfo.Value.NumPlayersAlliance.HasValue);
-        _worldPacket.WriteBit(SuccessInfo.Value.IsVeteranTrial);
+        _worldPacket.WriteBit(SuccessInfo->IsExpansionTrial);
+        _worldPacket.WriteBit(SuccessInfo->ForceCharacterTemplate);
+        _worldPacket.WriteBit(SuccessInfo->NumPlayersHorde.is_initialized());
+        _worldPacket.WriteBit(SuccessInfo->NumPlayersAlliance.is_initialized());
+        _worldPacket.WriteBit(SuccessInfo->IsVeteranTrial);
 
-        if (SuccessInfo.Value.NumPlayersHorde.HasValue)
-            _worldPacket << uint16(SuccessInfo.Value.NumPlayersHorde.Value);
+        if (SuccessInfo->NumPlayersHorde)
+            _worldPacket << uint16(*SuccessInfo->NumPlayersHorde);
 
-        if (SuccessInfo.Value.NumPlayersAlliance.HasValue)
-            _worldPacket << uint16(SuccessInfo.Value.NumPlayersAlliance.Value);
+        if (SuccessInfo->NumPlayersAlliance)
+            _worldPacket << uint16(*SuccessInfo->NumPlayersAlliance);
     }
 
-    if (WaitInfo.HasValue)
+    if (WaitInfo)
     {
-        _worldPacket << uint32(WaitInfo.Value.WaitCount);
-        _worldPacket.WriteBit(WaitInfo.Value.HasFCM);
+        _worldPacket << uint32(WaitInfo->WaitCount);
+        _worldPacket.WriteBit(WaitInfo->HasFCM);
     }
 
     _worldPacket.FlushBits();

--- a/src/server/game/Server/Packets/AuthenticationPackets.h
+++ b/src/server/game/Server/Packets/AuthenticationPackets.h
@@ -20,7 +20,7 @@
 
 #include "Packet.h"
 #include "ObjectMgr.h"
-#include "Util.h"
+#include "Common.h"
 #include "BigNumber.h"
 #include "SHA1.h"
 #include <boost/asio/ip/tcp.hpp>

--- a/src/server/game/Server/Packets/BattlegroundPackets.cpp
+++ b/src/server/game/Server/Packets/BattlegroundPackets.cpp
@@ -65,27 +65,27 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Battleground::PVPLogData:
 
     data.WriteBit(playerData.Faction);
     data.WriteBit(playerData.IsInWorld);
-    data.WriteBit(playerData.Honor.HasValue);
-    data.WriteBit(playerData.PreMatchRating.HasValue);
-    data.WriteBit(playerData.RatingChange.HasValue);
-    data.WriteBit(playerData.PreMatchMMR.HasValue);
-    data.WriteBit(playerData.MmrChange.HasValue);
+    data.WriteBit(playerData.Honor.is_initialized());
+    data.WriteBit(playerData.PreMatchRating.is_initialized());
+    data.WriteBit(playerData.RatingChange.is_initialized());
+    data.WriteBit(playerData.PreMatchMMR.is_initialized());
+    data.WriteBit(playerData.MmrChange.is_initialized());
     data.FlushBits();
 
-    if (playerData.Honor.HasValue)
-        data << playerData.Honor.Value;
+    if (playerData.Honor)
+        data << *playerData.Honor;
 
-    if (playerData.PreMatchRating.HasValue)
-        data << uint32(playerData.PreMatchRating.Value);
+    if (playerData.PreMatchRating)
+        data << uint32(*playerData.PreMatchRating);
 
-    if (playerData.RatingChange.HasValue)
-        data << uint32(playerData.RatingChange.Value);
+    if (playerData.RatingChange)
+        data << uint32(*playerData.RatingChange);
 
-    if (playerData.PreMatchMMR.HasValue)
-        data << uint32(playerData.PreMatchMMR.Value);
+    if (playerData.PreMatchMMR)
+        data << uint32(*playerData.PreMatchMMR);
 
-    if (playerData.MmrChange.HasValue)
-        data << uint32(playerData.MmrChange.Value);
+    if (playerData.MmrChange)
+        data << uint32(*playerData.MmrChange);
 
     return data;
 }
@@ -94,16 +94,16 @@ WorldPacket const* WorldPackets::Battleground::PVPLogData::Write()
 {
     _worldPacket.reserve(Players.size() * sizeof(PlayerData) + sizeof(PVPLogData));
 
-    _worldPacket.WriteBit(Ratings.HasValue);
-    _worldPacket.WriteBit(Winner.HasValue);
+    _worldPacket.WriteBit(Ratings.is_initialized());
+    _worldPacket.WriteBit(Winner.is_initialized());
     _worldPacket << uint32(Players.size());
     _worldPacket.append(PlayerCount, 2);
 
-    if (Ratings.HasValue)
-        _worldPacket << Ratings.Value;
+    if (Ratings.is_initialized())
+        _worldPacket << *Ratings;
 
-    if (Winner.HasValue)
-        _worldPacket << uint8(Winner.Value);
+    if (Winner)
+        _worldPacket << uint8(*Winner);
 
     for (PlayerData const& player : Players)
         _worldPacket << player;

--- a/src/server/game/Server/Packets/BattlegroundPackets.h
+++ b/src/server/game/Server/Packets/BattlegroundPackets.h
@@ -18,6 +18,7 @@
 #ifndef BattlegroundPackets_h__
 #define BattlegroundPackets_h__
 
+#include "Common.h"
 #include "ObjectGuid.h"
 #include "LFGPackets.h"
 #include "PacketUtilities.h"

--- a/src/server/game/Server/Packets/CharacterPackets.cpp
+++ b/src/server/game/Server/Packets/CharacterPackets.cpp
@@ -170,7 +170,8 @@ void WorldPackets::Character::CreateCharacter::Read()
 {
     CreateInfo.reset(new CharacterCreateInfo());
     uint32 nameLength = _worldPacket.ReadBits(6);
-    CreateInfo->TemplateSet.HasValue = _worldPacket.ReadBit();
+    bool const hasTemplateSet = _worldPacket.ReadBit();
+
     _worldPacket >> CreateInfo->Race;
     _worldPacket >> CreateInfo->Class;
     _worldPacket >> CreateInfo->Sex;
@@ -181,8 +182,8 @@ void WorldPackets::Character::CreateCharacter::Read()
     _worldPacket >> CreateInfo->FacialHairStyle;
     _worldPacket >> CreateInfo->OutfitId;
     CreateInfo->Name = _worldPacket.ReadString(nameLength);
-    if (CreateInfo->TemplateSet.HasValue)
-        _worldPacket >> CreateInfo->TemplateSet.Value;
+    if (hasTemplateSet)
+        CreateInfo->TemplateSet = _worldPacket.read<int32>();
 }
 
 WorldPacket const* WorldPackets::Character::CreateChar::Write()
@@ -212,11 +213,11 @@ void WorldPackets::Character::CharacterRenameRequest::Read()
 WorldPacket const* WorldPackets::Character::CharacterRenameResult::Write()
 {
     _worldPacket << uint8(Result);
-    _worldPacket.WriteBit(Guid.HasValue);
+    _worldPacket.WriteBit(Guid.is_initialized());
     _worldPacket.WriteBits(Name.length(), 6);
 
-    if (Guid.HasValue)
-        _worldPacket << Guid.Value;
+    if (Guid)
+        _worldPacket << *Guid;
 
     _worldPacket.WriteString(Name);
     return &_worldPacket;
@@ -243,11 +244,11 @@ void WorldPackets::Character::CharRaceOrFactionChange::Read()
 
     uint32 nameLength = _worldPacket.ReadBits(6);
 
-    RaceOrFactionChangeInfo->SkinID.HasValue = _worldPacket.ReadBit();
-    RaceOrFactionChangeInfo->HairColorID.HasValue = _worldPacket.ReadBit();
-    RaceOrFactionChangeInfo->HairStyleID.HasValue = _worldPacket.ReadBit();
-    RaceOrFactionChangeInfo->FacialHairStyleID.HasValue = _worldPacket.ReadBit();
-    RaceOrFactionChangeInfo->FaceID.HasValue = _worldPacket.ReadBit();
+    bool const hasSkinID = _worldPacket.ReadBit();
+    bool const hasHairColorID = _worldPacket.ReadBit();
+    bool const hasHairStyleID = _worldPacket.ReadBit();
+    bool const hasFacialHairStyleID = _worldPacket.ReadBit();
+    bool const hasFaceID = _worldPacket.ReadBit();
 
     _worldPacket >> RaceOrFactionChangeInfo->Guid;
     _worldPacket >> RaceOrFactionChangeInfo->SexID;
@@ -255,40 +256,40 @@ void WorldPackets::Character::CharRaceOrFactionChange::Read()
 
     RaceOrFactionChangeInfo->Name = _worldPacket.ReadString(nameLength);
 
-    if (RaceOrFactionChangeInfo->SkinID.HasValue)
-        _worldPacket >> RaceOrFactionChangeInfo->SkinID.Value;
+    if (hasSkinID)
+        RaceOrFactionChangeInfo->SkinID = _worldPacket.read<uint8>();
 
-    if (RaceOrFactionChangeInfo->HairColorID.HasValue)
-        _worldPacket >> RaceOrFactionChangeInfo->HairColorID.Value;
+    if (hasHairColorID)
+        RaceOrFactionChangeInfo->HairColorID = _worldPacket.read<uint8>();
 
-    if (RaceOrFactionChangeInfo->HairStyleID.HasValue)
-        _worldPacket >> RaceOrFactionChangeInfo->HairStyleID.Value;
+    if (hasHairStyleID)
+        RaceOrFactionChangeInfo->HairStyleID = _worldPacket.read<uint8>();
 
-    if (RaceOrFactionChangeInfo->FacialHairStyleID.HasValue)
-        _worldPacket >> RaceOrFactionChangeInfo->FacialHairStyleID.Value;
+    if (hasFacialHairStyleID)
+        RaceOrFactionChangeInfo->FacialHairStyleID = _worldPacket.read<uint8>();
 
-    if (RaceOrFactionChangeInfo->FaceID.HasValue)
-        _worldPacket >> RaceOrFactionChangeInfo->FaceID.Value;
+    if (hasFaceID)
+        RaceOrFactionChangeInfo->FaceID = _worldPacket.read<uint8>();
 }
 
 WorldPacket const* WorldPackets::Character::CharFactionChangeResult::Write()
 {
     _worldPacket << uint8(Result);
     _worldPacket << Guid;
-    _worldPacket.WriteBit(Display.HasValue);
+    _worldPacket.WriteBit(Display.is_initialized());
     _worldPacket.FlushBits();
 
-    if (Display.HasValue)
+    if (Display)
     {
-        _worldPacket.WriteBits(Display.Value.Name.length(), 6);
-        _worldPacket << uint8(Display.Value.SexID);
-        _worldPacket << uint8(Display.Value.SkinID);
-        _worldPacket << uint8(Display.Value.HairColorID);
-        _worldPacket << uint8(Display.Value.HairStyleID);
-        _worldPacket << uint8(Display.Value.FacialHairStyleID);
-        _worldPacket << uint8(Display.Value.FaceID);
-        _worldPacket << uint8(Display.Value.RaceID);
-        _worldPacket.WriteString(Display.Value.Name);
+        _worldPacket.WriteBits(Display->Name.length(), 6);
+        _worldPacket << uint8(Display->SexID);
+        _worldPacket << uint8(Display->SkinID);
+        _worldPacket << uint8(Display->HairColorID);
+        _worldPacket << uint8(Display->HairStyleID);
+        _worldPacket << uint8(Display->FacialHairStyleID);
+        _worldPacket << uint8(Display->FaceID);
+        _worldPacket << uint8(Display->RaceID);
+        _worldPacket.WriteString(Display->Name);
     }
 
     return &_worldPacket;

--- a/src/server/game/Server/Packets/CombatLogPackets.cpp
+++ b/src/server/game/Server/Packets/CombatLogPackets.cpp
@@ -33,11 +33,11 @@ WorldPacket const* WorldPackets::CombatLog::SpellNonMeleeDamageLog::Write()
     _worldPacket.WriteBit(Periodic);
     _worldPacket.WriteBits(Flags, 9);
     _worldPacket.WriteBit(false); // Debug info
-    _worldPacket.WriteBit(LogData.HasValue);
+    _worldPacket.WriteBit(LogData.is_initialized());
     _worldPacket.FlushBits();
 
-    if (LogData.HasValue)
-        _worldPacket << LogData.Value;
+    if (LogData)
+        _worldPacket << *LogData;
 
     return &_worldPacket;
 }
@@ -50,11 +50,11 @@ WorldPacket const* WorldPackets::CombatLog::EnvironmentalDamageLog::Write()
     _worldPacket << Resisted;
     _worldPacket << Absorbed;
 
-    _worldPacket.WriteBit(LogData.HasValue);
+    _worldPacket.WriteBit(LogData.is_initialized());
     _worldPacket.FlushBits();
 
-    if (LogData.HasValue)
-        _worldPacket << LogData.Value;
+    if (LogData)
+        _worldPacket << *LogData;
 
     return &_worldPacket;
 }
@@ -109,11 +109,11 @@ WorldPacket const* WorldPackets::CombatLog::SpellExecuteLog::Write()
             _worldPacket << feedPetTarget.ItemID;
     }
 
-    _worldPacket.WriteBit(LogData.HasValue);
+    _worldPacket.WriteBit(LogData.is_initialized());
     _worldPacket.FlushBits();
 
-    if (LogData.HasValue)
-        _worldPacket << LogData.Value;
+    if (LogData)
+        _worldPacket << *LogData;
 
     return &_worldPacket;
 }
@@ -131,19 +131,19 @@ WorldPacket const* WorldPackets::CombatLog::SpellHealLog::Write()
     _worldPacket.WriteBit(Crit);
     _worldPacket.WriteBit(Multistrike);
 
-    _worldPacket.WriteBit(CritRollMade.HasValue);
-    _worldPacket.WriteBit(CritRollNeeded.HasValue);
-    _worldPacket.WriteBit(LogData.HasValue);
+    _worldPacket.WriteBit(CritRollMade.is_initialized());
+    _worldPacket.WriteBit(CritRollNeeded.is_initialized());
+    _worldPacket.WriteBit(LogData.is_initialized());
     _worldPacket.FlushBits();
 
-    if (CritRollMade.HasValue)
-        _worldPacket << CritRollMade.Value;
+    if (CritRollMade)
+        _worldPacket << *CritRollMade;
 
-    if (CritRollNeeded.HasValue)
-        _worldPacket << CritRollNeeded.Value;
+    if (CritRollNeeded)
+        _worldPacket << *CritRollNeeded;
 
-    if (LogData.HasValue)
-        _worldPacket << LogData.Value;
+    if (LogData)
+        _worldPacket << *LogData;
 
     return &_worldPacket;
 }

--- a/src/server/game/Server/Packets/CombatPackets.cpp
+++ b/src/server/game/Server/Packets/CombatPackets.cpp
@@ -96,8 +96,8 @@ WorldPacket const* WorldPackets::Combat::AIReaction::Write()
 
 WorldPacket const* WorldPackets::Combat::AttackerStateUpdate::Write()
 {
-    if (_worldPacket.WriteBit(LogData.HasValue))
-        _worldPacket << LogData.Value;
+    if (_worldPacket.WriteBit(LogData.is_initialized()))
+        _worldPacket << *LogData;
 
     // Placeholder for size which will be calculated at the end based on packet size
     // Client uses this size to copy remaining packet to another CDataStore
@@ -109,15 +109,16 @@ WorldPacket const* WorldPackets::Combat::AttackerStateUpdate::Write()
     _worldPacket << VictimGUID;
     _worldPacket << Damage;
     _worldPacket << OverDamage;
-    if (_worldPacket.WriteBit(SubDmg.HasValue))
+
+    if (_worldPacket.WriteBit(SubDmg.is_initialized()))
     {
-        _worldPacket << SubDmg.Value.SchoolMask;
-        _worldPacket << SubDmg.Value.FDamage;
-        _worldPacket << SubDmg.Value.Damage;
+        _worldPacket << SubDmg->SchoolMask;
+        _worldPacket << SubDmg->FDamage;
+        _worldPacket << SubDmg->Damage;
         if (HitInfo & (HITINFO_FULL_ABSORB | HITINFO_PARTIAL_ABSORB))
-            _worldPacket << SubDmg.Value.Absorbed;
+            _worldPacket << SubDmg->Absorbed;
         if (HitInfo & (HITINFO_FULL_RESIST | HITINFO_PARTIAL_RESIST))
-            _worldPacket << SubDmg.Value.Resisted;
+            _worldPacket << SubDmg->Resisted;
     }
 
     _worldPacket << VictimState;

--- a/src/server/game/Server/Packets/GuildPackets.cpp
+++ b/src/server/game/Server/Packets/GuildPackets.cpp
@@ -29,20 +29,20 @@ WorldPackets::Guild::QueryGuildInfoResponse::QueryGuildInfoResponse()
 WorldPacket const* WorldPackets::Guild::QueryGuildInfoResponse::Write()
 {
     _worldPacket << GuildGuid;
-    _worldPacket.WriteBit(Info.HasValue);
+    _worldPacket.WriteBit(Info.is_initialized());
 
-    if (Info.HasValue)
+    if (Info)
     {
-        _worldPacket << Info.Value.GuildGUID;
-        _worldPacket << uint32(Info.Value.VirtualRealmAddress);
-        _worldPacket << uint32(Info.Value.Ranks.size());
-        _worldPacket << uint32(Info.Value.EmblemStyle);
-        _worldPacket << uint32(Info.Value.EmblemColor);
-        _worldPacket << uint32(Info.Value.BorderStyle);
-        _worldPacket << uint32(Info.Value.BorderColor);
-        _worldPacket << uint32(Info.Value.BackgroundColor);
+        _worldPacket << Info->GuildGUID;
+        _worldPacket << uint32(Info->VirtualRealmAddress);
+        _worldPacket << uint32(Info->Ranks.size());
+        _worldPacket << uint32(Info->EmblemStyle);
+        _worldPacket << uint32(Info->EmblemColor);
+        _worldPacket << uint32(Info->BorderStyle);
+        _worldPacket << uint32(Info->BorderColor);
+        _worldPacket << uint32(Info->BackgroundColor);
 
-        for (GuildInfo::GuildInfoRank const& rank : Info.Value.Ranks)
+        for (GuildInfo::GuildInfoRank const& rank : Info->Ranks)
         {
             _worldPacket << uint32(rank.RankID);
             _worldPacket << uint32(rank.RankOrder);
@@ -51,8 +51,8 @@ WorldPacket const* WorldPackets::Guild::QueryGuildInfoResponse::Write()
             _worldPacket.WriteString(rank.RankName);
         }
 
-        _worldPacket.WriteBits(Info.Value.GuildName.size(), 7);
-        _worldPacket.WriteString(Info.Value.GuildName);
+        _worldPacket.WriteBits(Info->GuildName.size(), 7);
+        _worldPacket.WriteString(Info->GuildName);
     }
     _worldPacket.FlushBits();
 
@@ -672,30 +672,30 @@ WorldPacket const* WorldPackets::Guild::GuildBankLogQueryResults::Write()
         _worldPacket << logEntry.TimeOffset;
         _worldPacket << logEntry.EntryType;
 
-        _worldPacket.WriteBit(logEntry.Money.HasValue);
-        _worldPacket.WriteBit(logEntry.ItemID.HasValue);
-        _worldPacket.WriteBit(logEntry.Count.HasValue);
-        _worldPacket.WriteBit(logEntry.OtherTab.HasValue);
+        _worldPacket.WriteBit(logEntry.Money.is_initialized());
+        _worldPacket.WriteBit(logEntry.ItemID.is_initialized());
+        _worldPacket.WriteBit(logEntry.Count.is_initialized());
+        _worldPacket.WriteBit(logEntry.OtherTab.is_initialized());
         _worldPacket.FlushBits();
 
-        if (logEntry.Money.HasValue)
-            _worldPacket << logEntry.Money.Value;
+        if (logEntry.Money.is_initialized())
+            _worldPacket << *logEntry.Money;
 
-        if (logEntry.ItemID.HasValue)
-            _worldPacket << logEntry.ItemID.Value;
+        if (logEntry.ItemID.is_initialized())
+            _worldPacket << *logEntry.ItemID;
 
-        if (logEntry.Count.HasValue)
-            _worldPacket << logEntry.Count.Value;
+        if (logEntry.Count.is_initialized())
+            _worldPacket << *logEntry.Count;
 
-        if (logEntry.OtherTab.HasValue)
-            _worldPacket << logEntry.OtherTab.Value;
+        if (logEntry.OtherTab.is_initialized())
+            _worldPacket << *logEntry.OtherTab;
     }
 
-    _worldPacket.WriteBit(WeeklyBonusMoney.HasValue);
+    _worldPacket.WriteBit(WeeklyBonusMoney.is_initialized());
     _worldPacket.FlushBits();
 
-    if (WeeklyBonusMoney.HasValue)
-        _worldPacket << WeeklyBonusMoney.Value;
+    if (WeeklyBonusMoney)
+        _worldPacket << *WeeklyBonusMoney;
 
     return &_worldPacket;
 }
@@ -748,11 +748,11 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Guild::GuildNewsEvent con
     for (ObjectGuid memberGuid : newsEvent.MemberList)
         data << memberGuid;
 
-    data.WriteBit(newsEvent.Item.HasValue);
+    data.WriteBit(newsEvent.Item.is_initialized());
     data.FlushBits();
 
-    if (newsEvent.Item.HasValue)
-        data << newsEvent.Item.Value;  // WorldPackets::Item::ItemInstance
+    if (newsEvent.Item)
+        data << *newsEvent.Item;  // WorldPackets::Item::ItemInstance
 
     return data;
 }

--- a/src/server/game/Server/Packets/InspectPackets.cpp
+++ b/src/server/game/Server/Packets/InspectPackets.cpp
@@ -92,11 +92,11 @@ WorldPacket const* WorldPackets::Inspect::InspectResult::Write()
     for (size_t i = 0; i < Talents.size(); ++i)
         _worldPacket << uint16(Talents[i]);
 
-    _worldPacket.WriteBit(GuildData.HasValue);
+    _worldPacket.WriteBit(GuildData.is_initialized());
     _worldPacket.FlushBits();
 
-    if (GuildData.HasValue)
-        _worldPacket << GuildData.Value;
+    if (GuildData)
+        _worldPacket << *GuildData;
 
     return &_worldPacket;
 }

--- a/src/server/game/Server/Packets/MailPackets.cpp
+++ b/src/server/game/Server/Packets/MailPackets.cpp
@@ -70,13 +70,13 @@ WorldPackets::Mail::MailListEntry::MailListEntry(::Mail const* mail, ::Player* p
     switch (mail->messageType)
     {
         case MAIL_NORMAL:
-            SenderCharacter.Set(ObjectGuid::Create<HighGuid::Player>(mail->sender));
+            SenderCharacter = ObjectGuid::Create<HighGuid::Player>(mail->sender);
             break;
         case MAIL_CREATURE:
         case MAIL_GAMEOBJECT:
         case MAIL_AUCTION:
         case MAIL_CALENDAR:
-            AltSenderID.Set(mail->sender);
+            AltSenderID = mail->sender;
             break;
     }
 
@@ -115,18 +115,18 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Mail::MailListEntry const
     for (auto const& att : entry.Attachments)
         data << att;
 
-    data.WriteBit(entry.SenderCharacter.HasValue);
-    data.WriteBit(entry.AltSenderID.HasValue);
+    data.WriteBit(entry.SenderCharacter.is_initialized());
+    data.WriteBit(entry.AltSenderID.is_initialized());
 
     data.WriteBits(entry.Subject.size(), 8);
     data.WriteBits(entry.Body.size(), 13);
     data.FlushBits();
 
-    if (entry.SenderCharacter.HasValue)
-        data << entry.SenderCharacter.Value;
+    if (entry.SenderCharacter)
+        data << *entry.SenderCharacter;
 
-    if (entry.AltSenderID.HasValue)
-        data << int32(entry.AltSenderID.Value);
+    if (entry.AltSenderID)
+        data << int32(*entry.AltSenderID);
 
     data.WriteString(entry.Subject);
     data.WriteString(entry.Body);

--- a/src/server/game/Server/Packets/MiscPackets.cpp
+++ b/src/server/game/Server/Packets/MiscPackets.cpp
@@ -50,15 +50,15 @@ WorldPacket const* WorldPackets::Misc::SetCurrency::Write()
     _worldPacket << uint32(Type);
     _worldPacket << uint32(Quantity);
     _worldPacket << uint32(Flags);
-    _worldPacket.WriteBit(WeeklyQuantity.HasValue);
-    _worldPacket.WriteBit(TrackedQuantity.HasValue);
+    _worldPacket.WriteBit(WeeklyQuantity.is_initialized());
+    _worldPacket.WriteBit(TrackedQuantity.is_initialized());
     _worldPacket.WriteBit(SuppressChatLog);
 
-    if (WeeklyQuantity.HasValue)
-        _worldPacket << uint32(WeeklyQuantity.Value);
+    if (WeeklyQuantity)
+        _worldPacket << uint32(*WeeklyQuantity);
 
-    if (TrackedQuantity.HasValue)
-        _worldPacket << uint32(TrackedQuantity.Value);
+    if (TrackedQuantity)
+        _worldPacket << uint32(*TrackedQuantity);
 
     _worldPacket.FlushBits();
 
@@ -79,18 +79,18 @@ WorldPacket const* WorldPackets::Misc::SetupCurrency::Write()
         _worldPacket << uint32(data.Type);
         _worldPacket << uint32(data.Quantity);
 
-        _worldPacket.WriteBit(data.WeeklyQuantity.HasValue);
-        _worldPacket.WriteBit(data.MaxWeeklyQuantity.HasValue);
-        _worldPacket.WriteBit(data.TrackedQuantity.HasValue);
+        _worldPacket.WriteBit(data.WeeklyQuantity.is_initialized());
+        _worldPacket.WriteBit(data.MaxWeeklyQuantity.is_initialized());
+        _worldPacket.WriteBit(data.TrackedQuantity.is_initialized());
 
         _worldPacket.WriteBits(data.Flags, 5);
 
-        if (data.WeeklyQuantity.HasValue)
-            _worldPacket << uint32(data.WeeklyQuantity.Value);
-        if (data.MaxWeeklyQuantity.HasValue)
-            _worldPacket << uint32(data.MaxWeeklyQuantity.Value);
-        if (data.TrackedQuantity.HasValue)
-            _worldPacket << uint32(data.TrackedQuantity.Value);
+        if (data.WeeklyQuantity)
+            _worldPacket << uint32(*data.WeeklyQuantity);
+        if (data.MaxWeeklyQuantity)
+            _worldPacket << uint32(*data.MaxWeeklyQuantity);
+        if (data.TrackedQuantity)
+            _worldPacket << uint32(*data.TrackedQuantity);
     }
 
     _worldPacket.FlushBits();
@@ -154,22 +154,22 @@ WorldPacket const* WorldPackets::Misc::WorldServerInfo::Write()
     _worldPacket << uint32(DifficultyID);
     _worldPacket << uint8(IsTournamentRealm);
     _worldPacket << uint32(WeeklyReset);
-    _worldPacket.WriteBit(RestrictedAccountMaxLevel.HasValue);
-    _worldPacket.WriteBit(RestrictedAccountMaxMoney.HasValue);
-    _worldPacket.WriteBit(IneligibleForLootMask.HasValue);
-    _worldPacket.WriteBit(InstanceGroupSize.HasValue);
+    _worldPacket.WriteBit(RestrictedAccountMaxLevel.is_initialized());
+    _worldPacket.WriteBit(RestrictedAccountMaxMoney.is_initialized());
+    _worldPacket.WriteBit(IneligibleForLootMask.is_initialized());
+    _worldPacket.WriteBit(InstanceGroupSize.is_initialized());
 
-    if (RestrictedAccountMaxLevel.HasValue)
-        _worldPacket << uint32(RestrictedAccountMaxLevel.Value);
+    if (RestrictedAccountMaxLevel)
+        _worldPacket << uint32(*RestrictedAccountMaxLevel);
 
-    if (RestrictedAccountMaxMoney.HasValue)
-        _worldPacket << uint32(RestrictedAccountMaxMoney.Value);
+    if (RestrictedAccountMaxMoney)
+        _worldPacket << uint32(*RestrictedAccountMaxMoney);
 
-    if (IneligibleForLootMask.HasValue)
-        _worldPacket << uint32(IneligibleForLootMask.Value);
+    if (IneligibleForLootMask)
+        _worldPacket << uint32(*IneligibleForLootMask);
 
-    if (InstanceGroupSize.HasValue)
-        _worldPacket << uint32(InstanceGroupSize.Value);
+    if (InstanceGroupSize)
+        _worldPacket << uint32(*InstanceGroupSize);
 
     _worldPacket.FlushBits();
 

--- a/src/server/game/Server/Packets/MovementPackets.cpp
+++ b/src/server/game/Server/Packets/MovementPackets.cpp
@@ -227,7 +227,7 @@ ByteBuffer& WorldPackets::operator<<(ByteBuffer& data, Movement::MovementSpline 
     for (G3D::Vector3 const& pos : movementSpline.PackedDeltas)
         data.appendPackXYZ(pos.x, pos.y, pos.z);
     data.WriteBits(movementSpline.Face, 2);
-    data.WriteBit(movementSpline.SplineFilter.HasValue);
+    data.WriteBit(movementSpline.SplineFilter.is_initialized());
     data.FlushBits();
 
     switch (movementSpline.Face)
@@ -244,8 +244,8 @@ ByteBuffer& WorldPackets::operator<<(ByteBuffer& data, Movement::MovementSpline 
             break;
     }
 
-    if (movementSpline.SplineFilter.HasValue)
-        data << movementSpline.SplineFilter.Value;
+    if (movementSpline.SplineFilter)
+        data << *movementSpline.SplineFilter;
 
     return data;
 }
@@ -479,16 +479,16 @@ WorldPacket const* WorldPackets::Movement::MoveUpdate::Write()
 WorldPacket const* WorldPackets::Movement::TransferPending::Write()
 {
     _worldPacket << int32(MapID);
-    _worldPacket.WriteBit(Ship.HasValue);
-    _worldPacket.WriteBit(TransferSpellID.HasValue);
-    if (Ship.HasValue)
+    _worldPacket.WriteBit(Ship.is_initialized());
+    _worldPacket.WriteBit(TransferSpellID.is_initialized());
+    if (Ship)
     {
-        _worldPacket << uint32(Ship.Value.ID);
-        _worldPacket << int32(Ship.Value.OriginMapID);
+        _worldPacket << uint32(Ship->ID);
+        _worldPacket << int32(Ship->OriginMapID);
     }
 
-    if (TransferSpellID.HasValue)
-        _worldPacket << int32(TransferSpellID.Value);
+    if (TransferSpellID)
+        _worldPacket << int32(*TransferSpellID);
 
     _worldPacket.FlushBits();
 
@@ -519,18 +519,18 @@ WorldPacket const* WorldPackets::Movement::MoveTeleport::Write()
     _worldPacket << Pos.PositionXYZStream();
     _worldPacket << Facing;
 
-    _worldPacket.WriteBit(TransportGUID.HasValue);
-    _worldPacket.WriteBit(Vehicle.HasValue);
+    _worldPacket.WriteBit(TransportGUID.is_initialized());
+    _worldPacket.WriteBit(Vehicle.is_initialized());
     _worldPacket.FlushBits();
 
-    if (TransportGUID.HasValue)
-        _worldPacket << TransportGUID.Value;
+    if (TransportGUID)
+        _worldPacket << *TransportGUID;
 
-    if (Vehicle.HasValue)
+    if (Vehicle)
     {
-        _worldPacket << Vehicle.Value.VehicleSeatIndex;
-        _worldPacket.WriteBit(Vehicle.Value.VehicleExitVoluntary);
-        _worldPacket.WriteBit(Vehicle.Value.VehicleExitTeleport);
+        _worldPacket << Vehicle->VehicleSeatIndex;
+        _worldPacket.WriteBit(Vehicle->VehicleExitVoluntary);
+        _worldPacket.WriteBit(Vehicle->VehicleExitTeleport);
         _worldPacket.FlushBits();
     }
 
@@ -552,44 +552,44 @@ WorldPacket const* WorldPackets::Movement::MoveUpdateTeleport::Write()
         _worldPacket.FlushBits();
     }
 
-    _worldPacket.WriteBit(WalkSpeed.HasValue);
-    _worldPacket.WriteBit(RunSpeed.HasValue);
-    _worldPacket.WriteBit(RunBackSpeed.HasValue);
-    _worldPacket.WriteBit(SwimSpeed.HasValue);
-    _worldPacket.WriteBit(SwimBackSpeed.HasValue);
-    _worldPacket.WriteBit(FlightSpeed.HasValue);
-    _worldPacket.WriteBit(FlightBackSpeed.HasValue);
-    _worldPacket.WriteBit(TurnRate.HasValue);
-    _worldPacket.WriteBit(PitchRate.HasValue);
+    _worldPacket.WriteBit(WalkSpeed.is_initialized());
+    _worldPacket.WriteBit(RunSpeed.is_initialized());
+    _worldPacket.WriteBit(RunBackSpeed.is_initialized());
+    _worldPacket.WriteBit(SwimSpeed.is_initialized());
+    _worldPacket.WriteBit(SwimBackSpeed.is_initialized());
+    _worldPacket.WriteBit(FlightSpeed.is_initialized());
+    _worldPacket.WriteBit(FlightBackSpeed.is_initialized());
+    _worldPacket.WriteBit(TurnRate.is_initialized());
+    _worldPacket.WriteBit(PitchRate.is_initialized());
 
     _worldPacket.FlushBits();
 
-    if (WalkSpeed.HasValue)
-        _worldPacket << WalkSpeed.Value;
+    if (WalkSpeed)
+        _worldPacket << *WalkSpeed;
 
-    if (RunSpeed.HasValue)
-        _worldPacket << RunSpeed.Value;
+    if (RunSpeed)
+        _worldPacket << *RunSpeed;
 
-    if (RunBackSpeed.HasValue)
-        _worldPacket << RunBackSpeed.Value;
+    if (RunBackSpeed)
+        _worldPacket << *RunBackSpeed;
 
-    if (SwimSpeed.HasValue)
-        _worldPacket << SwimSpeed.Value;
+    if (SwimSpeed)
+        _worldPacket << *SwimSpeed;
 
-    if (SwimBackSpeed.HasValue)
-        _worldPacket << SwimBackSpeed.Value;
+    if (SwimBackSpeed)
+        _worldPacket << *SwimBackSpeed;
 
-    if (FlightSpeed.HasValue)
-        _worldPacket << FlightSpeed.Value;
+    if (FlightSpeed)
+        _worldPacket << *FlightSpeed;
 
-    if (FlightBackSpeed.HasValue)
-        _worldPacket << FlightBackSpeed.Value;
+    if (FlightBackSpeed)
+        _worldPacket << *FlightBackSpeed;
 
-    if (TurnRate.HasValue)
-        _worldPacket << TurnRate.Value;
+    if (TurnRate)
+        _worldPacket << *TurnRate;
 
-    if (PitchRate.HasValue)
-        _worldPacket << PitchRate.Value;
+    if (PitchRate)
+        _worldPacket << *PitchRate;
 
     return &_worldPacket;
 }

--- a/src/server/game/Server/Packets/MovementPackets.h
+++ b/src/server/game/Server/Packets/MovementPackets.h
@@ -175,13 +175,13 @@ namespace WorldPackets
 
         class TransferPending final : public ServerPacket
         {
+        public:
             struct ShipTransferPending
             {
                 uint32 ID = 0;              ///< gameobject_template.entry of the transport the player is teleporting on
                 int32 OriginMapID = -1;     ///< Map id the player is currently on (before teleport)
             };
 
-        public:
             TransferPending() : ServerPacket(SMSG_TRANSFER_PENDING, 16) { }
 
             WorldPacket const* Write() override;

--- a/src/server/game/Server/Packets/PacketUtilities.h
+++ b/src/server/game/Server/Packets/PacketUtilities.h
@@ -49,9 +49,35 @@ inline ByteBuffer& operator>>(ByteBuffer& data, G3D::Vector3& v)
 namespace WorldPackets
 {
     template <typename T>
-    struct CompactArray
+    class CompactArray
     {
     public:
+        CompactArray() : _mask(0) { }
+
+        CompactArray(CompactArray const& right)
+            : _mask(right._mask), _contents(right._contents) { }
+
+        CompactArray(CompactArray&& right)
+            : _mask(right._mask), _contents(std::move(right._contents))
+        {
+            right._mask = 0;
+        }
+
+        CompactArray& operator= (CompactArray const& right)
+        {
+            _mask = right._mask;
+            _contents = right._contents;
+            return *this;
+        }
+
+        CompactArray& operator= (CompactArray&& right)
+        {
+            _mask = right._mask;
+            right._mask = 0;
+            _contents = std::move(right._contents);
+            return *this;
+        }
+
         uint32 GetMask() const { return _mask; }
         T const& operator[](size_t index) const { return _contents.at(index); }
         size_t GetSize() const { return _contents.size(); }
@@ -73,7 +99,7 @@ namespace WorldPackets
         }
 
     private:
-        uint32 _mask = 0;
+        uint32 _mask;
         std::vector<T> _contents;
     };
 

--- a/src/server/game/Server/Packets/QueryPackets.cpp
+++ b/src/server/game/Server/Packets/QueryPackets.cpp
@@ -100,15 +100,15 @@ void WorldPackets::Query::QueryPlayerName::Read()
 
 ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Query::PlayerGuidLookupHint const& lookupHint)
 {
-    data.WriteBit(lookupHint.VirtualRealmAddress.HasValue);
-    data.WriteBit(lookupHint.NativeRealmAddress.HasValue);
+    data.WriteBit(lookupHint.VirtualRealmAddress.is_initialized());
+    data.WriteBit(lookupHint.NativeRealmAddress.is_initialized());
     data.FlushBits();
 
-    if (lookupHint.VirtualRealmAddress.HasValue)
-        data << uint32(lookupHint.VirtualRealmAddress.Value);
+    if (lookupHint.VirtualRealmAddress)
+        data << uint32(*lookupHint.VirtualRealmAddress);
 
-    if (lookupHint.NativeRealmAddress.HasValue)
-        data << uint32(lookupHint.NativeRealmAddress.Value);
+    if (lookupHint.NativeRealmAddress)
+        data << uint32(*lookupHint.NativeRealmAddress);
 
     return data;
 }

--- a/src/server/game/Server/Packets/SpellPackets.cpp
+++ b/src/server/game/Server/Packets/SpellPackets.cpp
@@ -104,9 +104,9 @@ WorldPacket const* WorldPackets::Spells::AuraUpdate::Write()
     for (auto& aura : Auras)
     {
         _worldPacket << aura.Slot;
-        if (_worldPacket.WriteBit(aura.AuraData.HasValue))
+        if (_worldPacket.WriteBit(aura.AuraData.is_initialized()))
         {
-            AuraDataInfo const& data = aura.AuraData.Value;
+            AuraDataInfo const& data = *aura.AuraData;
             _worldPacket << uint32(data.SpellID);
             _worldPacket << uint8(data.Flags);
             _worldPacket << uint32(data.ActiveFlags);
@@ -121,18 +121,18 @@ WorldPacket const* WorldPackets::Spells::AuraUpdate::Write()
             if (!data.EstimatedPoints.empty())
                 _worldPacket.append(data.EstimatedPoints.data(), data.EstimatedPoints.size());
 
-            _worldPacket.WriteBit(data.CastUnit.HasValue);
-            _worldPacket.WriteBit(data.Duration.HasValue);
-            _worldPacket.WriteBit(data.Remaining.HasValue);
+            _worldPacket.WriteBit(data.CastUnit.is_initialized());
+            _worldPacket.WriteBit(data.Duration.is_initialized());
+            _worldPacket.WriteBit(data.Remaining.is_initialized());
 
-            if (data.CastUnit.HasValue)
-                _worldPacket << data.CastUnit.Value;
+            if (data.CastUnit)
+                _worldPacket << *data.CastUnit;
 
-            if (data.Duration.HasValue)
-                _worldPacket << uint32(data.Duration.Value);
+            if (data.Duration)
+                _worldPacket << uint32(*data.Duration);
 
-            if (data.Remaining.HasValue)
-                _worldPacket << uint32(data.Remaining.Value);
+            if (data.Remaining)
+                _worldPacket << uint32(*data.Remaining);
         }
 
         _worldPacket.FlushBits();
@@ -141,12 +141,13 @@ WorldPacket const* WorldPackets::Spells::AuraUpdate::Write()
     return &_worldPacket;
 }
 
-ByteBuffer& operator>>(ByteBuffer& buffer, WorldPackets::Spells::TargetLocation& location)
+ByteBuffer& operator>>(ByteBuffer& buffer, Optional<WorldPackets::Spells::TargetLocation>& location)
 {
-    buffer >> location.Transport;
-    buffer >> location.Location.m_positionX;
-    buffer >> location.Location.m_positionY;
-    buffer >> location.Location.m_positionZ;
+    location = WorldPackets::Spells::TargetLocation();
+    buffer >> location->Transport;
+    buffer >> location->Location.m_positionX;
+    buffer >> location->Location.m_positionY;
+    buffer >> location->Location.m_positionZ;
     return buffer;
 }
 
@@ -155,22 +156,22 @@ ByteBuffer& operator>>(ByteBuffer& buffer, WorldPackets::Spells::SpellTargetData
     buffer.ResetBitPos();
 
     targetData.Flags = buffer.ReadBits(23);
-    targetData.SrcLocation.HasValue = buffer.ReadBit();
-    targetData.DstLocation.HasValue = buffer.ReadBit();
-    targetData.Orientation.HasValue = buffer.ReadBit();
+    bool const hasSrcLocation = buffer.ReadBit();
+    bool const hasDstLocation = buffer.ReadBit();
+    bool const hasOrientation = buffer.ReadBit();
     uint32 nameLength = buffer.ReadBits(7);
 
     buffer >> targetData.Unit;
     buffer >> targetData.Item;
 
-    if (targetData.SrcLocation.HasValue)
-        buffer >> targetData.SrcLocation.Value;
+    if (hasSrcLocation)
+        buffer >> targetData.SrcLocation;
 
-    if (targetData.DstLocation.HasValue)
-        buffer >> targetData.DstLocation.Value;
+    if (hasDstLocation)
+        buffer >> targetData.DstLocation;
 
-    if (targetData.Orientation.HasValue)
-        buffer >> targetData.Orientation.Value;
+    if (hasOrientation)
+        targetData.Orientation = buffer.read<float>();
 
     targetData.Name = buffer.ReadString(nameLength);
 
@@ -195,11 +196,15 @@ ByteBuffer& operator>>(ByteBuffer& buffer, WorldPackets::Spells::SpellCastReques
 
     buffer.ResetBitPos();
     request.SendCastFlags = buffer.ReadBits(5);
-    request.MoveUpdate.HasValue = buffer.ReadBit();
+    bool const hasMoveUpdate = buffer.ReadBit();
     request.Weight.resize(buffer.ReadBits(2));
 
-    if (request.MoveUpdate.HasValue)
-        buffer >> request.MoveUpdate.Value;
+    if (hasMoveUpdate)
+    {
+        MovementInfo movementInfo;
+        buffer >> movementInfo;
+        request.MoveUpdate = movementInfo;
+    }
 
     for (WorldPackets::Spells::SpellWeight& weight : request.Weight)
     {
@@ -244,23 +249,23 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Spells::TargetLocation co
 ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Spells::SpellTargetData const& spellTargetData)
 {
     data.WriteBits(spellTargetData.Flags, 23);
-    data.WriteBit(spellTargetData.SrcLocation.HasValue);
-    data.WriteBit(spellTargetData.DstLocation.HasValue);
-    data.WriteBit(spellTargetData.Orientation.HasValue);
+    data.WriteBit(spellTargetData.SrcLocation.is_initialized());
+    data.WriteBit(spellTargetData.DstLocation.is_initialized());
+    data.WriteBit(spellTargetData.Orientation.is_initialized());
     data.WriteBits(spellTargetData.Name.size(), 7);
     data.FlushBits();
 
     data << spellTargetData.Unit;
     data << spellTargetData.Item;
 
-    if (spellTargetData.SrcLocation.HasValue)
-        data << spellTargetData.SrcLocation.Value;
+    if (spellTargetData.SrcLocation)
+        data << *spellTargetData.SrcLocation;
 
-    if (spellTargetData.DstLocation.HasValue)
-        data << spellTargetData.DstLocation.Value;
+    if (spellTargetData.DstLocation)
+        data << *spellTargetData.DstLocation;
 
-    if (spellTargetData.Orientation.HasValue)
-        data << spellTargetData.Orientation.Value;
+    if (spellTargetData.Orientation)
+        data << *spellTargetData.Orientation;
 
     data.WriteString(spellTargetData.Name);
 
@@ -368,15 +373,15 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Spells::SpellCastData con
         data << targetLoc;
 
     data.WriteBits(spellCastData.CastFlagsEx, 18);
-    data.WriteBit(spellCastData.RemainingRunes.HasValue);
-    data.WriteBit(spellCastData.ProjectileVisual.HasValue);
+    data.WriteBit(spellCastData.RemainingRunes.is_initialized());
+    data.WriteBit(spellCastData.ProjectileVisual.is_initialized());
     data.FlushBits();
 
-    if (spellCastData.RemainingRunes.HasValue)
-        data << spellCastData.RemainingRunes.Value;
+    if (spellCastData.RemainingRunes)
+        data << *spellCastData.RemainingRunes;
 
-    if (spellCastData.ProjectileVisual.HasValue)
-        data << spellCastData.ProjectileVisual.Value;
+    if (spellCastData.ProjectileVisual)
+        data << *spellCastData.ProjectileVisual;
 
     return data;
 }
@@ -392,11 +397,11 @@ WorldPacket const* WorldPackets::Spells::SpellGo::Write()
 {
     _worldPacket << Cast;
 
-    _worldPacket.WriteBit(LogData.HasValue);
+    _worldPacket.WriteBit(LogData.is_initialized());
     _worldPacket.FlushBits();
 
-    if (LogData.HasValue)
-        _worldPacket << LogData.Value;
+    if (LogData)
+        _worldPacket << *LogData;
 
     return &_worldPacket;
 }
@@ -658,15 +663,15 @@ WorldPacket const* WorldPackets::Spells::SpellChannelStart::Write()
     _worldPacket << CasterGUID;
     _worldPacket << int32(SpellID);
     _worldPacket << uint32(ChannelDuration);
-    _worldPacket.WriteBit(InterruptImmunities.HasValue);
-    _worldPacket.WriteBit(HealPrediction.HasValue);
+    _worldPacket.WriteBit(InterruptImmunities.is_initialized());
+    _worldPacket.WriteBit(HealPrediction.is_initialized());
     _worldPacket.FlushBits();
 
-    if (InterruptImmunities.HasValue)
-        _worldPacket << InterruptImmunities.Value;
+    if (InterruptImmunities)
+        _worldPacket << *InterruptImmunities;
 
-    if (HealPrediction.HasValue)
-        _worldPacket << HealPrediction.Value;
+    if (HealPrediction)
+        _worldPacket << *HealPrediction;
 
     return &_worldPacket;
 }

--- a/src/server/game/Server/Packets/SystemPackets.cpp
+++ b/src/server/game/Server/Packets/SystemPackets.cpp
@@ -31,14 +31,14 @@ WorldPacket const* WorldPackets::System::FeatureSystemStatus::Write()
     _worldPacket << uint32(TokenRedeemIndex);
 
     _worldPacket.WriteBit(VoiceEnabled);
-    _worldPacket.WriteBit(EuropaTicketSystemStatus.HasValue);
+    _worldPacket.WriteBit(EuropaTicketSystemStatus.is_initialized());
     _worldPacket.WriteBit(ScrollOfResurrectionEnabled);
     _worldPacket.WriteBit(BpayStoreEnabled);
     _worldPacket.WriteBit(BpayStoreAvailable);
     _worldPacket.WriteBit(BpayStoreDisabledByParentalControls);
     _worldPacket.WriteBit(ItemRestorationButtonEnabled);
     _worldPacket.WriteBit(BrowserEnabled);
-    _worldPacket.WriteBit(SessionAlert.HasValue);
+    _worldPacket.WriteBit(SessionAlert.is_initialized());
     _worldPacket.WriteBit(RecruitAFriendSendingEnabled);
     _worldPacket.WriteBit(CharUndeleteEnabled);
     _worldPacket.WriteBit(RestrictedAccount);
@@ -52,24 +52,24 @@ WorldPacket const* WorldPackets::System::FeatureSystemStatus::Write()
 
     _worldPacket.FlushBits();
 
-    if (EuropaTicketSystemStatus.HasValue)
+    if (EuropaTicketSystemStatus)
     {
-        _worldPacket.WriteBit(EuropaTicketSystemStatus.Value.TicketsEnabled);
-        _worldPacket.WriteBit(EuropaTicketSystemStatus.Value.BugsEnabled);
-        _worldPacket.WriteBit(EuropaTicketSystemStatus.Value.ComplaintsEnabled);
-        _worldPacket.WriteBit(EuropaTicketSystemStatus.Value.SuggestionsEnabled);
+        _worldPacket.WriteBit(EuropaTicketSystemStatus->TicketsEnabled);
+        _worldPacket.WriteBit(EuropaTicketSystemStatus->BugsEnabled);
+        _worldPacket.WriteBit(EuropaTicketSystemStatus->ComplaintsEnabled);
+        _worldPacket.WriteBit(EuropaTicketSystemStatus->SuggestionsEnabled);
 
-        _worldPacket << uint32(EuropaTicketSystemStatus.Value.ThrottleState.MaxTries);
-        _worldPacket << uint32(EuropaTicketSystemStatus.Value.ThrottleState.PerMilliseconds);
-        _worldPacket << uint32(EuropaTicketSystemStatus.Value.ThrottleState.TryCount);
-        _worldPacket << uint32(EuropaTicketSystemStatus.Value.ThrottleState.LastResetTimeBeforeNow);
+        _worldPacket << uint32(EuropaTicketSystemStatus->ThrottleState.MaxTries);
+        _worldPacket << uint32(EuropaTicketSystemStatus->ThrottleState.PerMilliseconds);
+        _worldPacket << uint32(EuropaTicketSystemStatus->ThrottleState.TryCount);
+        _worldPacket << uint32(EuropaTicketSystemStatus->ThrottleState.LastResetTimeBeforeNow);
     }
 
-    if (SessionAlert.HasValue)
+    if (SessionAlert)
     {
-        _worldPacket << int32(SessionAlert.Value.Delay);
-        _worldPacket << int32(SessionAlert.Value.Period);
-        _worldPacket << int32(SessionAlert.Value.DisplayTime);
+        _worldPacket << int32(SessionAlert->Delay);
+        _worldPacket << int32(SessionAlert->Period);
+        _worldPacket << int32(SessionAlert->DisplayTime);
     }
 
     /*if (bit61)

--- a/src/server/game/Server/Packets/TicketPackets.cpp
+++ b/src/server/game/Server/Packets/TicketPackets.cpp
@@ -69,24 +69,24 @@ void WorldPackets::Ticket::GMTicketAcknowledgeSurvey::Read()
 WorldPacket const* WorldPackets::Ticket::GMTicketGetTicketResponse::Write()
 {
     _worldPacket << Result;
-    _worldPacket.WriteBit(Info.HasValue);
+    _worldPacket.WriteBit(Info.is_initialized());
 
-    if (Info.HasValue)
+    if (Info)
     {
-        _worldPacket << int32(Info.Value.TicketID);
-        _worldPacket << uint8(Info.Value.Category);
-        _worldPacket.AppendPackedTime(Info.Value.TicketOpenTime);
-        _worldPacket.AppendPackedTime(Info.Value.OldestTicketTime);
-        _worldPacket.AppendPackedTime(Info.Value.UpdateTime);
-        _worldPacket << uint8(Info.Value.AssignedToGM);
-        _worldPacket << uint8(Info.Value.OpenedByGM);
-        _worldPacket << int32(Info.Value.WaitTimeOverrideMinutes);
+        _worldPacket << int32(Info->TicketID);
+        _worldPacket << uint8(Info->Category);
+        _worldPacket.AppendPackedTime(Info->TicketOpenTime);
+        _worldPacket.AppendPackedTime(Info->OldestTicketTime);
+        _worldPacket.AppendPackedTime(Info->UpdateTime);
+        _worldPacket << uint8(Info->AssignedToGM);
+        _worldPacket << uint8(Info->OpenedByGM);
+        _worldPacket << int32(Info->WaitTimeOverrideMinutes);
 
-        _worldPacket.WriteBits(Info.Value.TicketDescription.size(), 11);
-        _worldPacket.WriteBits(Info.Value.WaitTimeOverrideMessage.size(), 10);
+        _worldPacket.WriteBits(Info->TicketDescription.size(), 11);
+        _worldPacket.WriteBits(Info->WaitTimeOverrideMessage.size(), 10);
 
-        _worldPacket.WriteString(Info.Value.TicketDescription);
-        _worldPacket.WriteString(Info.Value.WaitTimeOverrideMessage);
+        _worldPacket.WriteString(Info->TicketDescription);
+        _worldPacket.WriteString(Info->WaitTimeOverrideMessage);
     }
 
     _worldPacket.FlushBits();
@@ -227,82 +227,88 @@ ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubm
 
     bool hasReportLineIndex = data.ReadBit();
     if (hasReportLineIndex)
-        chatlog.ReportLineIndex.Set(data.read<uint32>());
+        chatlog.ReportLineIndex = data.read<uint32>();
 
     data.ResetBitPos();
 
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketMailInfo& mail)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketMailInfo>& mail)
 {
-    data >> mail.MailID;
+    mail = WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketMailInfo();
+
+    data >> mail->MailID;
     uint16 bodyLength = data.ReadBits(13);
     uint16 subjectLength = data.ReadBits(9);
 
-    mail.MailBody = data.ReadString(bodyLength);
-    mail.MailSubject = data.ReadString(subjectLength);
+    mail->MailBody = data.ReadString(bodyLength);
+    mail->MailSubject = data.ReadString(subjectLength);
 
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketCalendarEventInfo& event)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketCalendarEventInfo>& event)
 {
-    data >> event.EventID;
-    data >> event.InviteID;
+    event = WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketCalendarEventInfo();
+    data >> event->EventID;
+    data >> event->InviteID;
     uint8 titleLength = data.ReadBits(8);
 
-    event.EventTitle = data.ReadString(titleLength);
+    event->EventTitle = data.ReadString(titleLength);
 
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketPetInfo& pet)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketPetInfo>& pet)
 {
-    data >> pet.PetID;
+    pet = WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketPetInfo();
+    data >> pet->PetID;
     uint8 nameLength = data.ReadBits(8);
 
-    pet.PetName = data.ReadString(nameLength);
+    pet->PetName = data.ReadString(nameLength);
 
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketGuildInfo& guild)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketGuildInfo>& guild)
 {
-    data >> guild.GuildID;
+    guild = WorldPackets::Ticket::SupportTicketSubmitComplaint::SupportTicketGuildInfo();
+    data >> guild->GuildID;
     uint8 nameLength = data.ReadBits(8);
 
-    guild.GuildName = data.ReadString(nameLength);
+    guild->GuildName = data.ReadString(nameLength);
 
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubmitComplaint::Struct5E4383& str)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Ticket::SupportTicketSubmitComplaint::Struct5E4383>& str)
 {
-    data >> str.RideTicket;
-    data >> str._40;
-    data >> str._56;
-    data >> str._72;
+    str = WorldPackets::Ticket::SupportTicketSubmitComplaint::Struct5E4383();
+    data >> str->RideTicket;
+    data >> str->_40;
+    data >> str->_56;
+    data >> str->_72;
 
     uint8 _88Length = data.ReadBits(8);
     uint8 _217Length = data.ReadBits(8);
     uint8 _1242Length = data.ReadBits(8);
 
-    str._88 = data.ReadString(_88Length);
-    str._217 = data.ReadString(_217Length);
-    str._1242 = data.ReadString(_1242Length);
+    str->_88 = data.ReadString(_88Length);
+    str->_217 = data.ReadString(_217Length);
+    str->_1242 = data.ReadString(_1242Length);
 
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Ticket::SupportTicketSubmitComplaint::Struct5E3DFB& str)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Ticket::SupportTicketSubmitComplaint::Struct5E3DFB>& str)
 {
-    data >> str.RideTicket;
+    data >> str->RideTicket;
 
     uint16 _32Length = data.ReadBits(9);
     data.ResetBitPos();
 
-    str._32 = data.ReadString(_32Length);
+    str->_32 = data.ReadString(_32Length);
 
     return data;
 }
@@ -327,40 +333,22 @@ void WorldPackets::Ticket::SupportTicketSubmitComplaint::Read()
     Note = _worldPacket.ReadString(noteLength);
 
     if (hasMailInfo)
-    {
-        _worldPacket >> MailInfo.Value;
-        MailInfo.HasValue = true;
-    }
+        _worldPacket >> MailInfo;
 
     if (hasCalendarInfo)
-    {
-        _worldPacket >> CalenderInfo.Value;
-        CalenderInfo.HasValue = true;
-    }
+        _worldPacket >> CalenderInfo;
 
     if (hasPetInfo)
-    {
-        _worldPacket >> PetInfo.Value;
-        PetInfo.HasValue = true;
-    }
+        _worldPacket >> PetInfo;
 
     if (hasGuildInfo)
-    {
-        _worldPacket >> GuildInfo.Value;
-        GuildInfo.HasValue = true;
-    }
+        _worldPacket >> GuildInfo;
 
     if (has5E4383)
-    {
-        _worldPacket >> _5E4383.Value;
-        _5E4383.HasValue = true;
-    }
+        _worldPacket >> _5E4383;
 
     if (has5E3DFB)
-    {
-        _worldPacket >> _5E3DFB.Value;
-        _5E3DFB.HasValue = true;
-    }
+        _worldPacket >> _5E3DFB;
 }
 
 WorldPacket const* WorldPackets::Ticket::ComplaintResult::Write()

--- a/src/server/game/Server/Packets/TradePackets.cpp
+++ b/src/server/game/Server/Packets/TradePackets.cpp
@@ -104,8 +104,8 @@ ByteBuffer& operator<<(ByteBuffer& buffer, WorldPackets::Trade::TradeUpdated::Tr
     buffer << uint32(tradeItem.EntryID);
     buffer << uint32(tradeItem.StackCount);
     buffer << tradeItem.GiftCreator;
-    if (buffer.WriteBit(tradeItem.Unwrapped.HasValue))
-        buffer << tradeItem.Unwrapped.Value;
+    if (buffer.WriteBit(tradeItem.Unwrapped.is_initialized()))
+        buffer << *tradeItem.Unwrapped;
 
     return buffer;
 }

--- a/src/server/game/Server/Packets/WhoPackets.cpp
+++ b/src/server/game/Server/Packets/WhoPackets.cpp
@@ -39,11 +39,13 @@ ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Who::WhoWord& word)
     return data;
 }
 
-ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Who::WhoRequestServerInfo& serverInfo)
+ByteBuffer& operator>>(ByteBuffer& data, Optional<WorldPackets::Who::WhoRequestServerInfo>& serverInfo)
 {
-    data >> serverInfo.FactionGroup;
-    data >> serverInfo.Locale;
-    data >> serverInfo.RequesterVirtualRealmAddress;
+    serverInfo = WorldPackets::Who::WhoRequestServerInfo();
+
+    data >> serverInfo->FactionGroup;
+    data >> serverInfo->Locale;
+    data >> serverInfo->RequesterVirtualRealmAddress;
 
     return data;
 }
@@ -64,7 +66,8 @@ ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Who::WhoRequest& request)
     request.ShowEnemies = data.ReadBit();
     request.ShowArenaPlayers = data.ReadBit();
     request.ExactName = data.ReadBit();
-    request.ServerInfo.HasValue = data.ReadBit();
+
+    bool const hasWhoRequest = data.ReadBit();
 
     request.Name = data.ReadString(nameLength);
     request.VirtualRealmName = data.ReadString(virtualRealmNameLength);
@@ -73,9 +76,8 @@ ByteBuffer& operator>>(ByteBuffer& data, WorldPackets::Who::WhoRequest& request)
 
     for (size_t i = 0; i < request.Words.size(); ++i)
         data >> request.Words[i];
-
-    if (request.ServerInfo.HasValue)
-        data >> request.ServerInfo.Value;
+    if (hasWhoRequest)
+        data >> request.ServerInfo;
 
     return data;
 }

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -775,8 +775,6 @@ void WorldSocket::HandleConnectToFailed(WorldPackets::Auth::ConnectToFailed& con
 void WorldSocket::SendAuthResponseError(uint8 code)
 {
     WorldPackets::Auth::AuthResponse response;
-    response.SuccessInfo.HasValue = false;
-    response.WaitInfo.HasValue = false;
     response.Result = code;
     SendPacketAndLogOpcode(*response.Write());
 }

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -213,12 +213,12 @@ void AuraApplication::BuildUpdatePacket(WorldPackets::Spells::AuraInfo& auraInfo
     // stack amount has priority over charges (checked on retail with spell 50262)
     auraData.Applications = aura->GetSpellInfo()->StackAmount ? aura->GetStackAmount() : aura->GetCharges();
     if (!(auraData.Flags & AFLAG_NOCASTER))
-        auraData.CastUnit.Set(aura->GetCasterGUID());
+        auraData.CastUnit = aura->GetCasterGUID();
 
     if (auraData.Flags & AFLAG_DURATION)
     {
-        auraData.Duration.Set(aura->GetMaxDuration());
-        auraData.Remaining.Set(aura->GetDuration());
+        auraData.Duration = aura->GetMaxDuration();
+        auraData.Remaining = aura->GetDuration();
     }
 
     if (auraData.Flags & AFLAG_SCALABLE)
@@ -229,7 +229,7 @@ void AuraApplication::BuildUpdatePacket(WorldPackets::Spells::AuraInfo& auraInfo
                 auraData.Points[effect->GetEffIndex()] = float(effect->GetAmount());
     }
 
-    auraInfo.AuraData.Set(auraData);
+    auraInfo.AuraData = auraData;
 }
 
 void AuraApplication::ClientUpdate(bool remove)

--- a/src/server/game/Support/SupportMgr.cpp
+++ b/src/server/game/Support/SupportMgr.cpp
@@ -322,7 +322,7 @@ void ComplaintTicket::LoadFromDB(Field* fields)
     _complaintType          = GMSupportComplaintType(fields[++idx].GetUInt8());
     int32 reportLineIndex = fields[++idx].GetInt32();
     if (reportLineIndex != -1)
-        _chatLog.ReportLineIndex.Set(reportLineIndex);
+        _chatLog.ReportLineIndex = reportLineIndex;
 
     int64 closedBy = fields[++idx].GetInt64();
     if (closedBy == 0)
@@ -364,8 +364,8 @@ void ComplaintTicket::SaveToDB(SQLTransaction& trans) const
     stmt->setFloat(++idx, _facing);
     stmt->setUInt64(++idx, _targetCharacterGuid.GetCounter());
     stmt->setUInt8(++idx, _complaintType);
-    if (_chatLog.ReportLineIndex.HasValue)
-        stmt->setInt32(++idx, _chatLog.ReportLineIndex.Value);
+    if (_chatLog.ReportLineIndex)
+        stmt->setInt32(++idx, *_chatLog.ReportLineIndex);
     else
         stmt->setInt32(++idx, -1); // empty ReportLineIndex
     stmt->setInt64(++idx, _closedBy.GetCounter());
@@ -1056,18 +1056,18 @@ void SupportMgr::SendGmTicket(WorldSession* session, GmTicket* ticket) const
     if (ticket)
     {
         response.Result = GMTICKET_STATUS_HASTEXT;
-        response.Info.HasValue = true;
+        response.Info = WorldPackets::Ticket::GMTicketGetTicketResponse::GMTicketInfo();
 
-        response.Info.Value.TicketID = ticket->GetId();
-        response.Info.Value.TicketDescription = ticket->GetDescription();
-        response.Info.Value.Category = 1;
-        response.Info.Value.TicketOpenTime = GetAge(ticket->GetLastModifiedTime());
-        response.Info.Value.OldestTicketTime = sSupportMgr->GetOldestOpenTicket() ? GetAge(sSupportMgr->GetOldestOpenTicket()->GetLastModifiedTime()) : float(0);
-        response.Info.Value.UpdateTime = GetAge(sSupportMgr->GetLastChange());
-        response.Info.Value.AssignedToGM = ticket->GetAssigendToStatus();
-        response.Info.Value.OpenedByGM = ticket->GetOpenedByGmStatus();
-        response.Info.Value.WaitTimeOverrideMessage = "";
-        response.Info.Value.WaitTimeOverrideMinutes = 0;
+        response.Info->TicketID = ticket->GetId();
+        response.Info->TicketDescription = ticket->GetDescription();
+        response.Info->Category = 1;
+        response.Info->TicketOpenTime = GetAge(ticket->GetLastModifiedTime());
+        response.Info->OldestTicketTime = sSupportMgr->GetOldestOpenTicket() ? GetAge(sSupportMgr->GetOldestOpenTicket()->GetLastModifiedTime()) : float(0);
+        response.Info->UpdateTime = GetAge(sSupportMgr->GetLastChange());
+        response.Info->AssignedToGM = ticket->GetAssigendToStatus();
+        response.Info->OpenedByGM = ticket->GetOpenedByGmStatus();
+        response.Info->WaitTimeOverrideMessage = "";
+        response.Info->WaitTimeOverrideMinutes = 0;
     }
     else
         response.Result = GMTICKET_STATUS_DEFAULT;

--- a/src/server/shared/Common.h
+++ b/src/server/shared/Common.h
@@ -39,6 +39,8 @@
 #include <sstream>
 #include <algorithm>
 
+#include <boost/optional.hpp>
+
 #include "Debugging/Errors.h"
 
 #include "Threading/LockedQueue.h"
@@ -156,5 +158,9 @@ struct LocalizedString
 #endif
 
 #define MAX_QUERY_LEN 32*1024
+
+//! Optional helper class to wrap optional values within.
+template <typename T>
+using Optional = boost::optional<T>;
 
 #endif

--- a/src/server/shared/Utilities/Util.h
+++ b/src/server/shared/Utilities/Util.h
@@ -30,27 +30,6 @@
 #include <stdarg.h>
 #include <cstring>
 
-template<typename T>
-struct Optional
-{
-    Optional() : Value(), HasValue(false) { }
-
-    T Value;
-    bool HasValue;
-
-    inline void Set(T const& v)
-    {
-        HasValue = true;
-        Value = v;
-    }
-
-    inline void Clear()
-    {
-        HasValue = false;
-        Value = T();
-    }
-};
-
 // Searcher for map of structs
 template<typename T, class S> struct Finder
 {


### PR DESCRIPTION
- benefits from empty optimization (objects are only constructed if needed).
- supports r-value references (move semantics) (boost >= 1.56.0).
- preparation for c++14's std::optional and std::none_t which is in experimental phase currently.
- add optional overloads to the ByteBuffer to use optional values in place.

ToDo:
- [ ] @Shauren could you review the code please?
- [ ] Point out if we want to use Optional Bytebuffer overloads for in and out operators (<<, >>).
