### PR TITLE
Fixed taunt effects interrupting channeled spells

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -36,8 +36,14 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T* owner, bool up
     if (owner->HasUnitState(UNIT_STATE_NOT_MOVE))
         return;
 
-    if (owner->GetTypeId() == TYPEID_UNIT && !i_target->isInAccessiblePlaceFor(owner->ToCreature()))
-        return;
+    if (owner->GetTypeId() == TYPEID_UNIT)
+    {
+        if (owner->HasUnitState(UNIT_STATE_CASTING))
+            return;
+
+        if (!i_target->isInAccessiblePlaceFor(owner->ToCreature()))
+            return;
+    }
 
     float x, y, z;
 


### PR DESCRIPTION
Fixes issue where creature start to move toward its target while it is casting channeling spell which caused to interrupt it.
This allows them to finish their channeled cast.
closes #13335
