### PR TITLE
CMake/Added an Option to Cmake that enables the Use_Folders Global Property…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,11 @@ include(CheckIncludeFiles)
 # set default buildoptions and print them
 include(cmake/options.cmake)
 
+if(WITH_VS_FOLDERS)
+    set_property(GLOBAL PROPERTY USE_FOLDERS On)
+endif()
+
+
 # turn off PCH totally if enabled (hidden setting, mainly for devs)
 if( NOPCH )
   set(USE_COREPCH 0)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -17,3 +17,4 @@ option(WITH_WARNINGS    "Show all warnings during compile"                      
 option(WITH_COREDEBUG   "Include additional debug-code in core"                       0)
 option(WITH_MESHEXTRACTOR "Build meshextractor (alpha)"                               0)
 option(WITHOUT_GIT      "Disable the GIT testing routines"                            0)
+option(WITH_VS_FOLDERS  "Enables Organizational Folders in Visual Studio"             0)

--- a/dep/StormLib/CMakeLists.txt
+++ b/dep/StormLib/CMakeLists.txt
@@ -260,6 +260,11 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL Linux)
 endif()
 
 add_library(storm STATIC ${SRC_FILES} ${SRC_ADDITIONAL_FILES})
+if(WITH_VS_FOLDERS)
+    set_target_properties(storm PROPERTIES FOLDER Dep)
+endif()
+
+
 target_link_libraries(storm ${LINK_LIBS})
 
 if(UNIX)

--- a/dep/bzip2/CMakeLists.txt
+++ b/dep/bzip2/CMakeLists.txt
@@ -20,3 +20,6 @@ include_directories(
 )
 
 add_library(bzip2 STATIC ${bzip2_STAT_SRCS})
+if(WITH_VS_FOLDERS)
+    set_target_properties(bzip2 PROPERTIES FOLDER Dep)
+endif()

--- a/dep/g3dlite/CMakeLists.txt
+++ b/dep/g3dlite/CMakeLists.txt
@@ -67,6 +67,9 @@ else()
 endif()
 
 add_library(g3dlib STATIC ${g3dlib_STAT_SRCS})
+if(WITH_VS_FOLDERS)
+    set_target_properties(g3dlib PROPERTIES FOLDER Dep)
+endif()
 
 target_link_libraries(g3dlib
   ${ZLIB_LIBRARIES}

--- a/dep/gsoap/CMakeLists.txt
+++ b/dep/gsoap/CMakeLists.txt
@@ -22,5 +22,7 @@ include_directories(
 add_definitions(-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=0)
 
 add_library(gsoap STATIC ${gsoap_STAT_SRCS})
-
+if(WITH_VS_FOLDERS)
+    set_target_properties(gsoap PROPERTIES FOLDER Dep)
+endif()
 set_target_properties(gsoap PROPERTIES LINKER_LANGUAGE CXX)

--- a/dep/jemalloc/CMakeLists.txt
+++ b/dep/jemalloc/CMakeLists.txt
@@ -58,3 +58,6 @@ include_directories(
 add_definitions(-D_GNU_SOURCE -D_REENTRANT)
 
 add_library(jemalloc STATIC ${jemalloc_STAT_SRC})
+if(WITH_VS_FOLDERS)
+    set_target_properties(jemalloc PROPERTIES FOLDER Dep)
+endif()

--- a/dep/recastnavigation/Detour/CMakeLists.txt
+++ b/dep/recastnavigation/Detour/CMakeLists.txt
@@ -25,5 +25,7 @@ if(WIN32)
 endif()
 
 add_library(Detour STATIC ${Detour_STAT_SRCS})
-
+if(WITH_VS_FOLDERS)
+    set_target_properties(Detour PROPERTIES FOLDER Dep)
+endif()
 target_link_libraries(Detour ${ZLIB_LIBRARIES})

--- a/dep/recastnavigation/Recast/CMakeLists.txt
+++ b/dep/recastnavigation/Recast/CMakeLists.txt
@@ -30,5 +30,7 @@ if(WIN32)
 endif()
 
 add_library(Recast STATIC ${Recast_STAT_SRCS})
-
+if(WITH_VS_FOLDERS)
+    set_target_properties(Recast PROPERTIES FOLDER Dep)
+endif()
 target_link_libraries(Recast ${ZLIB_LIBRARIES})

--- a/dep/zlib/CMakeLists.txt
+++ b/dep/zlib/CMakeLists.txt
@@ -28,3 +28,6 @@ include_directories(
 )
 
 add_library(zlib STATIC ${zlib_STAT_SRCS})
+if(WITH_VS_FOLDERS)
+    set_target_properties(zlib PROPERTIES FOLDER Dep)
+endif()

--- a/dep/zmqpp/CMakeLists.txt
+++ b/dep/zmqpp/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(zmqpp STATIC
   ${zmqpp_STAT_SRCS}
 )
 
+if(WITH_VS_FOLDERS)
+    set_target_properties(zmqpp PROPERTIES FOLDER Dep)
+endif()
+
 if (WIN32)
   add_definitions(-DBUILD_VERSION=\\"3.2.0\\")
 else()

--- a/src/server/ipc/CMakeLists.txt
+++ b/src/server/ipc/CMakeLists.txt
@@ -22,3 +22,6 @@ include_directories(
 )
 
 add_library(ipc STATIC ${ipc_SRCS})
+if(WITH_VS_FOLDERS)
+    set_target_properties(ipc PROPERTIES FOLDER Dep)
+endif()

--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -20,12 +20,19 @@ include(Spells/CMakeLists.txt)
 
 include(Commands/CMakeLists.txt)
 
-set(scripts_STAT_SRCS
-  ${scripts_STAT_SRCS}
+set(sources_AI
   ../game/AI/ScriptedAI/ScriptedEscortAI.cpp
   ../game/AI/ScriptedAI/ScriptedCreature.cpp
   ../game/AI/ScriptedAI/ScriptedFollowerAI.cpp
 )
+
+set(scripts_STAT_SRCS
+  ${scripts_STAT_SRCS}
+  ${sources_AI})
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\ScriptedAI" FILES  ${sources_AI})
+endif()
 
 if(SCRIPTS)
   include(Custom/CMakeLists.txt)

--- a/src/server/scripts/Commands/CMakeLists.txt
+++ b/src/server/scripts/Commands/CMakeLists.txt
@@ -14,5 +14,8 @@ set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
   ${sources_Commands}
 )
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Commands" FILES  ${sources_Commands})
+endif()
 
 message("  -> Prepared: Commands")

--- a/src/server/scripts/EasternKingdoms/CMakeLists.txt
+++ b/src/server/scripts/EasternKingdoms/CMakeLists.txt
@@ -8,8 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-set(scripts_STAT_SRCS
-  ${scripts_STAT_SRCS}
+set(source_EK
   EasternKingdoms/zone_ghostlands.cpp
   EasternKingdoms/AlteracValley/boss_galvangar.cpp
   EasternKingdoms/AlteracValley/boss_balinda.cpp
@@ -211,5 +210,16 @@ set(scripts_STAT_SRCS
   EasternKingdoms/Karazhan/karazhan.h
   EasternKingdoms/TheStockade/instance_the_stockade.cpp
 )
+
+
+  
+set(scripts_STAT_SRCS
+  ${scripts_STAT_SRCS}
+  ${source_EK}
+)
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\EasternKingdoms" FILES  ${source_EK})
+endif()
 
 message("  -> Prepared: Eastern Kingdoms")

--- a/src/server/scripts/Events/CMakeLists.txt
+++ b/src/server/scripts/Events/CMakeLists.txt
@@ -15,4 +15,9 @@ set(scripts_STAT_SRCS
   ${sources_Events}
 )
 
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Events" FILES  ${sources_Events})
+endif()
+
 message("  -> Prepared: Events")

--- a/src/server/scripts/Kalimdor/CMakeLists.txt
+++ b/src/server/scripts/Kalimdor/CMakeLists.txt
@@ -8,8 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-set(scripts_STAT_SRCS
-  ${scripts_STAT_SRCS}
+set(source_Kalimdor
   Kalimdor/zone_stonetalon_mountains.cpp
   Kalimdor/zone_silithus.cpp
   Kalimdor/zone_moonglade.cpp
@@ -126,5 +125,15 @@ set(scripts_STAT_SRCS
   Kalimdor/Firelands/firelands.h
   Kalimdor/Firelands/boss_alysrazor.cpp
 )
+
+
+set(scripts_STAT_SRCS
+  ${scripts_STAT_SRCS}
+  ${source_Kalimdor}
+)
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Kalimdor" FILES  ${source_Kalimdor})
+endif()
 
 message("  -> Prepared: Kalimdor")

--- a/src/server/scripts/Maelstrom/CMakeLists.txt
+++ b/src/server/scripts/Maelstrom/CMakeLists.txt
@@ -6,8 +6,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-set(scripts_STAT_SRCS
-  ${scripts_STAT_SRCS}
+set(source_Maelstrom
   Maelstrom/kezan.cpp
   Maelstrom/Stonecore/instance_stonecore.cpp
   Maelstrom/Stonecore/stonecore.cpp
@@ -17,5 +16,15 @@ set(scripts_STAT_SRCS
   Maelstrom/Stonecore/boss_ozruk.cpp
   Maelstrom/Stonecore/boss_high_priestess_azil.cpp
 )
+
+
+set(scripts_STAT_SRCS
+  ${scripts_STAT_SRCS}
+  ${source_Maelstrom}
+)
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Maelstrom" FILES  ${source_Maelstrom})
+endif()
 
 message("  -> Prepared: The Maelstrom")

--- a/src/server/scripts/Northrend/CMakeLists.txt
+++ b/src/server/scripts/Northrend/CMakeLists.txt
@@ -8,8 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-set(scripts_STAT_SRCS
-  ${scripts_STAT_SRCS}
+set(source_Northrend
   Northrend/zone_wintergrasp.cpp
   Northrend/isle_of_conquest.cpp
   Northrend/zone_storm_peaks.cpp
@@ -196,5 +195,15 @@ set(scripts_STAT_SRCS
   Northrend/DraktharonKeep/boss_tharon_ja.cpp
   Northrend/DraktharonKeep/boss_king_dred.cpp
 )
+
+
+set(scripts_STAT_SRCS
+  ${scripts_STAT_SRCS}
+  ${source_Northrend}
+)
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Northrend" FILES  ${source_Northrend})
+endif()
 
 message("  -> Prepared: Northrend")

--- a/src/server/scripts/OutdoorPvP/CMakeLists.txt
+++ b/src/server/scripts/OutdoorPvP/CMakeLists.txt
@@ -8,18 +8,17 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+
+
+file(GLOB_RECURSE source_OutdoorPvP OutdoorPvP/*.cpp OutdoorPvP/*.h)
+
 set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
-  OutdoorPvP/OutdoorPvPTF.cpp
-  OutdoorPvP/OutdoorPvPSI.cpp
-  OutdoorPvP/OutdoorPvPSI.h
-  OutdoorPvP/OutdoorPvPZM.cpp
-  OutdoorPvP/OutdoorPvPNA.cpp
-  OutdoorPvP/OutdoorPvPHP.cpp
-  OutdoorPvP/OutdoorPvPTF.h
-  OutdoorPvP/OutdoorPvPHP.h
-  OutdoorPvP/OutdoorPvPZM.h
-  OutdoorPvP/OutdoorPvPNA.h
+  ${source_OutdoorPvP}
 )
+
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\OutdoorPvP" FILES  ${source_OutdoorPvP})
+endif()
 
 message("  -> Prepared: Outdoor PVP Zones")

--- a/src/server/scripts/Outland/CMakeLists.txt
+++ b/src/server/scripts/Outland/CMakeLists.txt
@@ -8,8 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-set(scripts_STAT_SRCS
-  ${scripts_STAT_SRCS}
+set(sources_Outland
   Outland/zone_nagrand.cpp
   Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
   Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -123,5 +122,13 @@ set(scripts_STAT_SRCS
   Outland/zone_netherstorm.cpp
   Outland/zone_zangarmarsh.cpp
 )
+
+set(scripts_STAT_SRCS
+  ${scripts_STAT_SRCS}
+    ${sources_Outland}
+)
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Outland" FILES  ${sources_Outland})
+endif()
 
 message("  -> Prepared: Outland")

--- a/src/server/scripts/Pet/CMakeLists.txt
+++ b/src/server/scripts/Pet/CMakeLists.txt
@@ -8,14 +8,15 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+
+file(GLOB_RECURSE sources_Pet Pet/*.cpp Pet/*.h)
+
 set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
-  Pet/pet_dk.cpp
-  Pet/pet_generic.cpp
-  Pet/pet_hunter.cpp
-  Pet/pet_mage.cpp
-  Pet/pet_priest.cpp
-  Pet/pet_shaman.cpp
+  ${sources_Pet}
 )
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Pet" FILES  ${sources_Pet})
+endif()
 
 message("  -> Prepared: Pet")

--- a/src/server/scripts/Spells/CMakeLists.txt
+++ b/src/server/scripts/Spells/CMakeLists.txt
@@ -8,23 +8,15 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
+
+file(GLOB_RECURSE sources_Spells Spells/*.cpp Spells/*.h)
+
 set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
-  Spells/spell_shaman.cpp
-  Spells/spell_hunter.cpp
-  Spells/spell_rogue.cpp
-  Spells/spell_druid.cpp
-  Spells/spell_dk.cpp
-  Spells/spell_quest.cpp
-  Spells/spell_warrior.cpp
-  Spells/spell_generic.cpp
-  Spells/spell_warlock.cpp
-  Spells/spell_priest.cpp
-  Spells/spell_mage.cpp
-  Spells/spell_paladin.cpp
-  Spells/spell_item.cpp
-  Spells/spell_holiday.cpp
-  Spells/spell_pet.cpp
+  ${sources_Spells}
 )
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\Spells" FILES  ${sources_Spells})
+endif()
 
 message("  -> Prepared: Spells")

--- a/src/server/scripts/World/CMakeLists.txt
+++ b/src/server/scripts/World/CMakeLists.txt
@@ -14,5 +14,7 @@ set(scripts_STAT_SRCS
   ${scripts_STAT_SRCS}
   ${sources_World}
 )
-
+if(WITH_VS_FOLDERS)
+	source_group("Source Files\\World" FILES  ${sources_World})
+endif()
 message("  -> Prepared: World")

--- a/src/tools/map_extractor/CMakeLists.txt
+++ b/src/tools/map_extractor/CMakeLists.txt
@@ -23,7 +23,9 @@ include_directories(${include_Dirs})
 add_executable(mapextractor
   ${sources}
 )
-
+if(WITH_VS_FOLDERS)
+    set_target_properties(mapextractor PROPERTIES FOLDER Tools)
+endif()
 target_link_libraries(mapextractor
   ${BZIP2_LIBRARIES}
   ${ZLIB_LIBRARIES}

--- a/src/tools/mesh_extractor/CMakeLists.txt
+++ b/src/tools/mesh_extractor/CMakeLists.txt
@@ -32,6 +32,9 @@ endif()
 include_directories(${include_Base})
 
 add_executable(MeshExtractor ${meshExtract_Sources})
+if(WITH_VS_FOLDERS)
+    set_target_properties(MeshExtractor PROPERTIES FOLDER Tools)
+endif()
 
 target_link_libraries(MeshExtractor
   g3dlib

--- a/src/tools/mmaps_generator/CMakeLists.txt
+++ b/src/tools/mmaps_generator/CMakeLists.txt
@@ -41,6 +41,10 @@ include_directories(${mmap_gen_Includes})
 
 add_executable(mmaps_generator ${mmap_gen_sources})
 
+if(WITH_VS_FOLDERS)
+    set_target_properties(mmaps_generator PROPERTIES FOLDER Tools)
+endif()
+
 target_link_libraries(mmaps_generator
   collision
   g3dlib

--- a/src/tools/vmap4_assembler/CMakeLists.txt
+++ b/src/tools/vmap4_assembler/CMakeLists.txt
@@ -22,6 +22,9 @@ include_directories(
 
 add_executable(vmap4assembler VMapAssembler.cpp)
 add_dependencies(vmap4assembler storm)
+if(WITH_VS_FOLDERS)
+    set_target_properties(vmap4assembler PROPERTIES FOLDER Tools)
+endif()
 
 target_link_libraries(vmap4assembler
   collision

--- a/src/tools/vmap4_extractor/CMakeLists.txt
+++ b/src/tools/vmap4_extractor/CMakeLists.txt
@@ -24,8 +24,11 @@ endif()
 include_directories(
   ${CMAKE_SOURCE_DIR}/dep/StormLib/src
 )
-
 add_executable(vmap4extractor ${sources})
+
+if(WITH_VS_FOLDERS)
+    set_target_properties(vmap4extractor PROPERTIES FOLDER Tools)
+endif()
 
 target_link_libraries(vmap4extractor
   ${BZIP2_LIBRARIES}


### PR DESCRIPTION
…. This then allows for the use of Solution and Source Folders allowing the code to be organized in the IDE.

Some of the changes:
The Tool Statics have been moved into a Tools Solution Folder.
The Third Party Libs are in a Dep Folder.
The scripts are organized according to the underlying FS folders they reside in.

The With_VS_Folders option is off by default. So by default the developer would see no change.

Included with these changes are a few housekeeping items in the script CMakes specifically the replacement of some of the file lists with a Global search *.cpp, *.h instead.
