### PR TITLE
[4.3.4]Fix building with Cmake

### DIFF
--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -186,7 +186,7 @@ if (OPENSSL_INCLUDE_DIR)
     set(OPENSSL_VERSION "${_OPENSSL_VERSION}")
   else (_OPENSSL_VERSION)
     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
-         REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9][0-9][0-9][0-9].*")
+         REGEX "^# *define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9][0-9][0-9][0-9].*")
 
     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
     # The status gives if this is a developer or prerelease and is ignored here.


### PR DESCRIPTION
building fix for Windows where give you "CMake Error at cmake/macros/FindOpenSSL.cmake:188 (file):"
