### PR TITLE
CMake OS X: Fixed Debug Mode for Xcode

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -17,3 +17,4 @@ endif()
 # -Wno-narrowing needed to suppress a warning in g3d
 # -Wno-deprecated-register is needed to suppress 185 gsoap warnings on Unix systems.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-narrowing -Wno-deprecated-register")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG=1")


### PR DESCRIPTION
On newer versions of Xcode, the preprocessor macro #DEBUG is not defined by default. In order to set the debug flag it has to be set manually. If this does not happen then in the "Common.h" file the preprocessor will assume that we are building under a release mode instead of the debug mode.
Tested On: ad0cc83c842231fedd1eb9afe962176c17dc72ff
