### PR TITLE
Core/Spells: Fix logic in SpellEffect::EffectWeaponDmg

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2934,8 +2934,9 @@ void Spell::EffectWeaponDmg(SpellEffIndex /*effIndex*/)
     // multiple weapon dmg effect workaround
     // execute only the last weapon damage
     // and handle all effects at once
-    for (SpellEffectInfo const* effect : GetEffects())
+    for (uint8 index = effIndex + 1; index < MAX_SPELL_EFFECTS; index++)
     {
+        SpellEffectInfo const* effect = GetEffect(index);
         if (!effect)
             continue;
         switch (effect->Effect)


### PR DESCRIPTION
Fix logic in SpellEffect::EffectWeaponDmg, it should fix SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL, SPELL_EFFECT_WEAPON_PERCENT_DAMAGE, SPELL_EFFECT_WEAPON_DAMAGE and SPELL_EFFECT_NORMALIZED_WEAPON_DMG.

Closes: #14675
