### PR TITLE
Fixed a math error in SmartScript::DecPhase(int32)

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -247,7 +247,7 @@ class SmartScript
                 DecPhase(abs(p));
         }
 
-        void DecPhase(int32 p = 1) { mEventPhase  -= (mEventPhase < (uint32)p ? (uint32)p - mEventPhase : (uint32)p); }
+        void DecPhase(int32 p = 1) { mEventPhase  -= (mEventPhase < (uint32)p ? (uint32)p - ((uint32)p - mEventPhase) : (uint32)p); }
         bool IsInPhase(uint32 p) const { return ((1 << (mEventPhase - 1)) & p) != 0; }
         void SetPhase(uint32 p = 0) { mEventPhase = p; }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -247,7 +247,14 @@ class SmartScript
                 DecPhase(abs(p));
         }
 
-        void DecPhase(int32 p = 1) { mEventPhase  -= (mEventPhase < (uint32)p ? (uint32)p - ((uint32)p - mEventPhase) : (uint32)p); }
+        void DecPhase(int32 p = 1) 
+        { 
+            if(mEventPhase > (uint32)p)
+                mEventPhase -= (uint32)p; 
+            else
+                mEventPhase = 0;
+        }
+
         bool IsInPhase(uint32 p) const { return ((1 << (mEventPhase - 1)) & p) != 0; }
         void SetPhase(uint32 p = 0) { mEventPhase = p; }
 


### PR DESCRIPTION
This was wrong when p > mEventPhase. Decreasing a phase could cause a rollover.
For example :
p = 4 and mEventPhase = 1 would result in `1 -= 4 - 1 = 4294967293`
p = 1 and mEventPhase = 0 would result in `0 -= 1 - 0 = 4294967295`
Some like p = 2 and mEventPhase = 1 would work by chance `1 -= 2 - 1 = 0`.
