### PR TITLE
Core/Guilds: Disallow sending invite to people already in a guild

### DIFF
--- a/src/server/game/Guilds/Guild.cpp
+++ b/src/server/game/Guilds/Guild.cpp
@@ -1602,11 +1602,11 @@ void Guild::HandleInviteMember(WorldSession* session, std::string const& name)
     }
 
     // Invited player cannot be in another guild
-    /*if (pInvitee->GetGuildId())
+    if (pInvitee->GetGuildId())
     {
         SendCommandResult(session, GUILD_COMMAND_INVITE_PLAYER, ERR_ALREADY_IN_GUILD_S, name);
         return;
-    }*/
+    }
 
     // Invited player cannot be invited
     if (pInvitee->GetGuildIdInvited())


### PR DESCRIPTION
- In the case this would happen the player was able to join two (or more) guilds and bug themself out heavily
- If the player declined the invite, they instead were removed from their current guild until restart. This allowed the above to loop endlessly
