### PR TITLE
Core/Unit: Correct Handling of SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16369,9 +16369,12 @@ SpellInfo const* Unit::GetCastSpellInfo(SpellInfo const* spellInfo) const
         swaps.insert(swaps.end(), swaps2.begin(), swaps2.end());
 
     for (AuraEffect const* auraEffect : swaps)
-        if (auraEffect->IsAffectingSpell(spellInfo))
-            if (SpellInfo const* newInfo = sSpellMgr->GetSpellInfo(auraEffect->GetAmount()))
-                return newInfo;
+    {
+        if ((!auraEffect->GetSpellEffectInfo()->SpellClassMask && auraEffect->GetMiscValue() == spellInfo->Id) ||
+            (auraEffect->GetSpellEffectInfo()->SpellClassMask && auraEffect->IsAffectingSpell(spellInfo)))
+                if (SpellInfo const* newInfo = sSpellMgr->GetSpellInfo(auraEffect->GetAmount()))
+                    return newInfo;
+    }
 
     return spellInfo;
 }


### PR DESCRIPTION
and SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS_2
- if aura  SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS/*_2 has a ClassMask it changes spells that fit into that classmask
- if aura  SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS/*_2 doesn't have a ClassMask it changes spells with spellId equal to miscValueA

![coolname](https://cloud.githubusercontent.com/assets/799249/7903385/2acdf3f4-07db-11e5-92a3-17da2f5847ed.png)
Spell on left side (108561) has SpellClassMask -> should override spells that fit into it (this part worked before and after this change)
Spell on right side (110909) doesn't have SpellClassMask -> should override spell that has same ID like it's miscValueA (108978) (this part didn't worked before and now works)

"Closes": https://github.com/TrinityCore/TrinityCore/issues/14597 (the spell itself doesn't have core support yet)
