### PR TITLE
[WIP] Add docker support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,10 @@
+sudo: false
 language: cpp
 compiler:
   - clang
 
 git:
   depth: 1
-
-before_install:
-  - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
-  - echo "yes" | sudo add-apt-repository ppa:boost-latest/ppa
-  - echo "yes" | sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install build-essential libtool gcc-4.8 g++-4.8 make cmake openssl
-  - sudo apt-get -qq install libssl-dev libmysqlclient-dev libmysql++-dev libreadline6-dev zlib1g-dev libbz2-dev libzmq3-dev
-  - sudo apt-get -qq install libboost1.55-dev libboost-thread1.55-dev libboost-filesystem1.55-dev libboost-system1.55-dev libboost-program-options1.55-dev libboost-iostreams1.55-dev
 
 install:
   - mysql -uroot -e 'create database test_mysql;'
@@ -32,3 +24,31 @@ script:
   - mysql -uroot < sql/create/drop_mysql.sql
   - cd bin
   - make -j 10
+
+addons:
+  apt:
+    sources:
+      - kalakris-cmake
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - build-essential
+      - libtool
+      - gcc-4.8
+      - g++-4.8
+      - make
+      - cmake
+      - openssl
+      - libssl-dev
+      - libmysqlclient-dev
+      - libmysql++-dev
+      - libreadline6-dev
+      - zlib1g-dev
+      - libbz2-dev
+      - libzmq3-dev
+      - libboost1.55-dev
+      - libboost-thread1.55-dev
+      - libboost-system1.55-dev
+      - libboost-program-options1.55-dev
+      - libboost-filesystem1.55-dev
+      - libboost-iostreams1.55-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
+
 language: cpp
+
 compiler:
   - clang
 


### PR DESCRIPTION
Adds support for faster, sudo-less docker containers on travis-ci.

_Note that this file contains "experimental" code that has yet to be pulled to Travis-CI, so it will not work as everything stands._

Specifically, the kalakris-cmake alias is nonexistent for the whitelisted apt sources at this point (travis-ci/travis-ci#3722), as well as the specific boost packages although the source is whitelisted (travis-ci/travis-ci#3759).

I'm just leaving this here for convenience for when it can later function properly.
