### PR TITLE
Fix for weapon visual in quest The Endless Hunger

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -152,6 +152,7 @@ public:
             if (id == 1)
             {
                 wait_timer = 5000;
+                me->LoadEquipment(1, true);
                 me->CastSpell(me, SPELL_DK_INITIATE_VISUAL, true);
 
                 if (Player* starter = ObjectAccessor::GetPlayer(*me, playerGUID))


### PR DESCRIPTION
Unworthy Initiate should be wearing a weapon during quest The Endless Hunger. However SPELL_DK_INITIATE_VISUAL isn't changing equipped weapon, that's why I added this code.

PS. Please help with my mistake and .sql file from PR here.
