### PR TITLE
Tools/ConnectionPatcher: Add 'versions' patching method

### DIFF
--- a/src/tools/connection_patcher/Patches/Mac.hpp
+++ b/src/tools/connection_patcher/Patches/Mac.hpp
@@ -32,6 +32,7 @@ namespace Connection_Patcher
                 static const std::vector<unsigned char> BNet     () { return { 0xB8, 0xD5, 0xF8, 0x7F, 0x82, 0x89, 0x47, 0x0C, 0x5D, 0xC3, 0x90, 0x90, 0x90 }; }
                 static const std::vector<unsigned char> Password () { return { 0x0F, 0x85 }; }
                 static const std::vector<unsigned char> Signature() { return { 0x41, 0xB6, 0x01, 0x41, 0xBF, 0x02, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; }
+                static const std::vector<unsigned char> Versions () { return { 't', 'r', 'i', 'n', 'i', 't', 'y', '6' , '.', 'g', 'i', 't', 'h', 'u', 'b', '.', 'i', 'o', '/', 't', 'c', '/', '%', 's', '/', '%', 's', '/', 'v', 'e', 'r', 's', 'i', 'o', 'n', 's' }; }
             };
         };
     }

--- a/src/tools/connection_patcher/Patches/Windows.hpp
+++ b/src/tools/connection_patcher/Patches/Windows.hpp
@@ -32,6 +32,7 @@ namespace Connection_Patcher
                 static const std::vector<unsigned char> BNet     () { return { 0xC7, 0x40, 0x0C, 0xD5, 0xF8, 0x7F, 0x82 }; }
                 static const std::vector<unsigned char> Password () { return { 0x75 }; }
                 static const std::vector<unsigned char> Signature() { return { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0xEB }; }
+                static const std::vector<unsigned char> Versions () { return { 't', 'r', 'i', 'n', 'i', 't', 'y', '6' , '.', 'g', 'i', 't', 'h', 'u', 'b', '.', 'i', 'o', '/', 't', 'c', '/', '%', 's', '/', '%', 's', '/', 'v', 'e', 'r', 's', 'i', 'o', 'n', 's' }; }
             };
 
             struct x64
@@ -39,6 +40,7 @@ namespace Connection_Patcher
                 static const std::vector<unsigned char> BNet     () { return { 0xB8, 0xD5, 0xF8, 0x7F, 0x82, 0x89, 0x41, 0x0C, 0x48, 0x8B, 0xC1, 0xC3 }; }
                 static const std::vector<unsigned char> Password () { return { 0x75 }; }
                 static const std::vector<unsigned char> Signature() { return { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0xE9 }; }
+                static const std::vector<unsigned char> Versions () { return { 't', 'r', 'i', 'n', 'i', 't', 'y', '6' , '.', 'g', 'i', 't', 'h', 'u', 'b', '.', 'i', 'o', '/', 't', 'c', '/', '%', 's', '/', '%', 's', '/', 'v', 'e', 'r', 's', 'i', 'o', 'n', 's' }; }
             };
         };
     }

--- a/src/tools/connection_patcher/Patterns/Mac.hpp
+++ b/src/tools/connection_patcher/Patterns/Mac.hpp
@@ -32,6 +32,7 @@ namespace Connection_Patcher
                 static const std::vector<unsigned char> BNet     () { return { 0x8B, 0x06, 0x89, 0x47, 0x0C, 0x5D, 0xC3 }; }
                 static const std::vector<unsigned char> Password () { return { 0x0F, 0x84, 0x00, 0xFF, 0xFF, 0xFF, 0x49, 0x8B, 0x45, 0x00, 0xB9, 0x40 }; }
                 static const std::vector<unsigned char> Signature() { return { 0x45, 0x31, 0xF6, 0x31, 0xF6, 0x31, 0xD2, 0x4C, 0x89, 0xE7, 0xE8, 0x00, 0x00, 0x00, 0x00, 0x41, 0xBF, 0x04, 0x00, 0x00, 0x00 }; }
+                static const std::vector<unsigned char> Versions () { return { '%', 's', '.', 'p', 'a', 't', 'c', 'h', '.', 'b', 'a', 't', 't', 'l', 'e', '.', 'n', 'e', 't', ':', '1', '1', '1', '9', '/', '%', 's', '/', 'v', 'e', 'r', 's', 'i', 'o', 'n', 's' }; }
             };
         };
     }

--- a/src/tools/connection_patcher/Patterns/Windows.hpp
+++ b/src/tools/connection_patcher/Patterns/Windows.hpp
@@ -32,6 +32,7 @@ namespace Connection_Patcher
                 static const std::vector<unsigned char> BNet     () { return { 0x8B, 0x75, 0x08, 0x8D, 0x78, 0x0C }; }
                 static const std::vector<unsigned char> Password () { return { 0x74, 0x89, 0x8B, 0x16, 0x8B, 0x42, 0x04 }; }
                 static const std::vector<unsigned char> Signature() { return { 0xE8, 0x00, 0x00, 0x00, 0x00, 0x84, 0xC0, 0x75, 0x5F, 0x33, 0xC0 }; }
+                static const std::vector<unsigned char> Versions () { return { '%', 's', '.', 'p', 'a', 't', 'c', 'h', '.', 'b', 'a', 't', 't', 'l', 'e', '.', 'n', 'e', 't', ':', '1', '1', '1', '9', '/', '%', 's', '/', 'v', 'e', 'r', 's', 'i', 'o', 'n', 's' }; }
             };
 
             struct x64
@@ -39,6 +40,7 @@ namespace Connection_Patcher
                 static const std::vector<unsigned char> BNet     () { return { 0x8B, 0x02, 0x89, 0x41, 0x0C, 0x48, 0x8B, 0xC1, 0xC3 }; }
                 static const std::vector<unsigned char> Password () { return { 0x74, 0x84, 0x48, 0x8B, 0x03 }; }
                 static const std::vector<unsigned char> Signature() { return { 0xE8, 0x00, 0x00, 0x00, 0x00, 0x84, 0xC0, 0x0F, 0x85, 0x88, 0x00, 0x00, 0x00, 0x45, 0x33, 0xC0 }; }
+                static const std::vector<unsigned char> Versions () { return { '%', 's', '.', 'p', 'a', 't', 'c', 'h', '.', 'b', 'a', 't', 't', 'l', 'e', '.', 'n', 'e', 't', ':', '1', '1', '1', '9', '/', '%', 's', '/', 'v', 'e', 'r', 's', 'i', 'o', 'n', 's' }; }
             };
         };
     }

--- a/src/tools/connection_patcher/Program.cpp
+++ b/src/tools/connection_patcher/Program.cpp
@@ -121,6 +121,11 @@ namespace Connection_Patcher
             // Creep::Instance::LoadModule() to allow for unsigned auth module
             patcher->Patch(PATCH::Signature(), PATTERN::Signature());
 
+            std::cout << "patching Versions\n";
+            // sever the connection to blizzard's versions file to stop it from updating and replace with custom version
+            // hardcode http://%s.patch.battle.net:1119/%s/versions into http://trinity6.github.io/tc/%s/%s/versions
+            patcher->Patch(PATCH::Versions(), PATTERN::Versions());
+
             patcher->Finish(output);
 
             std::cout << "Patching done.\n";


### PR DESCRIPTION
- This is necessary to allow connection to 6.1.2 after the 6.2.0 update released
- Link is hardcoded to a github page after suggestion from @Aokromes, it is not tied to any server this way
