### PR TITLE
SmartAI: Incorrect removal of movement at SetCombatMove

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -763,6 +763,9 @@ void SmartAI::SetCombatMove(bool on)
         }
         else
         {
+            if (me->HasUnitState(UNIT_STATE_CONFUSED_MOVE | UNIT_STATE_FLEEING_MOVE))
+                return;
+
             me->GetMotionMaster()->MovementExpired();
             me->GetMotionMaster()->Clear(true);
             me->StopMoving();


### PR DESCRIPTION
Fixed a bug where creatures would clear movement flags when they shouldn't at SetCombatMove.
This is caused by void SmartAI::SetCombatMove(bool on). It will call me->GetMotionMaster()->Clear(true); which will remove the confused state.

Issue: #15002
