### PR TITLE
Server/DataStores: Updated DBC version checks to 6.2.0 (20216)

### DIFF
--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -482,8 +482,8 @@ void DB2Manager::LoadStores(std::string const& dataPath)
     }
 
     // Check loaded DB2 files proper version
-    if (!sItemStore.LookupEntry(120406)             ||       // last item added in 6.0.3 (19342)
-        !sItemExtendedCostStore.LookupEntry(5491)  )        // last item extended cost added in 6.0.3 (19342)
+    if (!sItemStore.LookupEntry(128706)             ||       // last item added in 6.2.0 (20216)
+        !sItemExtendedCostStore.LookupEntry(5923)  )        // last item extended cost added in 6.2.0 (20216)
     {
         TC_LOG_ERROR("misc", "You have _outdated_ DB2 files. Please extract correct versions from current using client.");
         exit(1);

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -519,11 +519,11 @@ void LoadDBCStores(const std::string& dataPath)
     }
 
     // Check loaded DBC files proper version
-    if (!sAreaStore.LookupEntry(6133)          ||     // last area (areaflag) added in 6.0.3 (19342)
-        !sCharTitlesStore.LookupEntry(444)     ||     // last char title added in 6.0.3 (19342)
-        !sGemPropertiesStore.LookupEntry(2534) ||     // last gem property added in 6.0.3 (19342)
-        !sMapStore.LookupEntry(1447)           ||     // last map added in 6.0.3 (19342)
-        !sSpellStore.LookupEntry(178987)       )      // last spell added in 6.0.3 (19342)
+    if (!sAreaStore.LookupEntry(6420)          ||     // last area (areaflag) added in 6.2.0 (20216)
+        !sCharTitlesStore.LookupEntry(457)     ||     // last char title added in 6.2.0 (20216)
+        !sGemPropertiesStore.LookupEntry(2544) ||     // last gem property added in 6.2.0 (20216)
+        !sMapStore.LookupEntry(1497)           ||     // last map added in 6.2.0 (20216)
+        !sSpellStore.LookupEntry(191981)       )      // last spell added in 6.2.0 (20216)
     {
         TC_LOG_ERROR("misc", "You have _outdated_ DBC files. Please extract correct versions from current using client.");
         exit(1);


### PR DESCRIPTION
 and updated Item.db2 structure for 6.2.0 (20216).

Signed-off-by: AriDEV aridev666@gmail.com
