### PR TITLE
Scripts/Commands: Learn Spells working for all players

### DIFF
--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -329,7 +329,7 @@ public:
         return true;
     }
 
-    static bool HandleLearnAllDefaultCommand(ChatHandler* handler, char const* args)
+    static bool HandleLearnAllDefaultCommand(ChatHandler* handler, char const* /*args*/)
     {
         Player* player = handler->getSelectedPlayerOrSelf();
 

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -341,7 +341,7 @@ public:
         return true;
     }
 
-    static bool HandleLearnAllCraftsCommand(ChatHandler* handler, char const* args)
+    static bool HandleLearnAllCraftsCommand(ChatHandler* handler, char const* /*args*/)
     {
         Player* player = handler->getSelectedPlayerOrSelf();
 


### PR DESCRIPTION
In order to correct **.learn** functions, rename all target variables to player, and use **getSelectedPlayerOrSelf()**.

As this will select always a player, the player checking can also be removed if it is not really useful.
Consider also merging **.learn all my** with **.learn all**

This is because I want to learn all spells for another player (GM -> player).
