### PR TITLE
Correctly displaying error message when libZMQ is not found

### DIFF
--- a/cmake/macros/FindZMQ.cmake
+++ b/cmake/macros/FindZMQ.cmake
@@ -72,7 +72,7 @@ find_library(ZMQ_LIBRARY
     "${ZMQ_ROOT_DIR}/lib"
 )
 
-if (ZMQ_INCLUDE_DIR AND ZMQ_LIBRARY)
+if (ZMQ_INCLUDE_DIR AND ZMQ_LIBRARY AND NOT ZMQ_LIBRARY-NOTFOUND)
   set(ZMQ_FOUND 1)
   message(STATUS "Found ZMQ library: ${ZMQ_LIBRARY}")
   message(STATUS "Found ZMQ headers: ${ZMQ_INCLUDE_DIR}")


### PR DESCRIPTION
 This will make cmake configure stage to fail if libZMQ is not found instead of saying it found it.
