### PR TITLE
Fix UpdateMovementFlags ignoring DynamicTree height.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2553,7 +2553,7 @@ void Creature::UpdateMovementFlags()
         return;
 
     // Set the movement flags if the creature is in that mode. (Only fly if actually in air, only swim if in water, etc)
-    float ground = GetMap()->GetHeight(GetPositionX(), GetPositionY(), GetPositionZMinusOffset());
+    float ground = GetMap()->GetHeight(GetPhaseMask(), GetPositionX(), GetPositionY(), GetPositionZMinusOffset());
 
     bool isInAir = (G3D::fuzzyGt(GetPositionZMinusOffset(), ground + 0.05f) || G3D::fuzzyLt(GetPositionZMinusOffset(), ground - 0.05f)); // Can be underground too, prevent the falling
 


### PR DESCRIPTION
`Creature::UpdateMovementFlags()` uses an overload of `Map::GetHeight` that doesn't take the height of the DynamicTree into account, this fixes that. More info : https://github.com/TrinityCore/TrinityCore/issues/15161 , the first one on there. Second issue is still WIP.
