### PR TITLE
Fixed a warning about override keyword missing

### DIFF
--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
@@ -36,7 +36,7 @@ class PointMovementGenerator : public MovementGeneratorMedium< T, PointMovementG
 
         void MovementInform(T*);
 
-        void unitSpeedChanged() { i_recalculateSpeed = true; }
+        void unitSpeedChanged() override { i_recalculateSpeed = true; }
 
         MovementGeneratorType GetMovementGeneratorType() const override { return POINT_MOTION_TYPE; }
 


### PR DESCRIPTION
This fixes a warning about a missing override keyword in a function overriding its parent class function.
