### PR TITLE
Core/DataStores: Workaround for dbc's locale subfolder generated with extractor

### DIFF
--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -178,7 +178,7 @@ void DB2Manager::LoadStores(std::string const& dataPath)
 {
     uint32 oldMSTime = getMSTime();
 
-    std::string db2Path = dataPath + "dbc/";
+    std::string db2Path = GetDBCLocaleFolder(dataPath + "dbc/");
 
     DB2StoreProblemList bad_db2_files;
     uint32 availableDb2Locales = 0xFF;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -925,13 +925,14 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     boost::filesystem::directory_iterator end_iter;
     std::string detectedLocalePath="";
     int locale=ConfigMgr::instance()->GetIntDefault("DBC.Locale", 0);
-    for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter)
-        if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale)) detectedLocalePath=(*dir_iter).path().string();
+    for(boost::filesystem::directory_iterator dir_iter(dataPath); dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter)
+        if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale))
+            detectedLocalePath=(*dir_iter).path().string(); //Get only the last part of the path, the locale part (esES, esMX, etc)
 
     if (detectedLocalePath.empty())
         TC_LOG_WARN("server.loading", "DBC files detected at DataDir/dbc root folder instead of its locale subfolder, this will be removed in a future");
     else
-        result/=detectedLocalePath;
+        result/=detectedLocalePath; //Append detected locale path to dbc folder
     return result.string();
 }
 

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -303,7 +303,7 @@ inline void LoadGameTable(StoreProblemList& errors, std::string const& tableName
 void LoadDBCStores(const std::string& dataPath)
 {
     uint32 oldMSTime = getMSTime();
-    
+
     std::string dbcPath = GetDBCLocaleFolder(dataPath + "dbc/");
 
     StoreProblemList bad_dbc_files;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -26,7 +26,6 @@
 #include "Config.h"
 
 #include <map>
-#include <boost/filesystem.hpp>
 
 typedef std::map<uint16, uint32> AreaFlagByAreaID;
 typedef std::map<uint32, uint32> AreaFlagByMapID;
@@ -969,5 +968,5 @@ bool DBCLocaleFolderMatch(const boost::filesystem::path& dataPath, const int& lo
 			match=(lastPathItem=="ruRU");
 			break;
 	}
-	return result;
+	return match;
 }

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -926,10 +926,9 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     boost::filesystem::directory_iterator end_iter;
     std::string detectedLocalePath="";
     int locale=ConfigMgr::instance()->GetIntDefault("DBC.Locale", 0);
-    for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter) {
-	    std::string dir=(*(--((*dir_iter).path().end()))).string();
-	    if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(dir, locale)) detectedLocalePath=dir;
-    }
+    for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter)
+	    if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale)) detectedLocalePath=(*dir_iter).string();
+
     if (detectedLocalePath.empty())
 	    TC_LOG_WARN("server.loading", "DBC files detected at DataDir/dbc root folder instead of its locale subfolder, this will be removed in a future");
     else
@@ -937,36 +936,37 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     return result.string();
 }
 
-bool DBCLocaleFolderMatch(const std::string& dataPath, const int& localeID) {
-	bool result=false;
+bool DBCLocaleFolderMatch(const boost::filesystem::path& dataPath, const int& localeID) {
+	const std::string lastPathItem=dataPath.filename().string();
+	bool match=false;
 	switch (localeID) {
 		default:
 		case 0:
-			result=(dataPath=="enGB" || dataPath=="enUS");
+			match=(lastPathItem=="enGB" || lastPathItem=="enUS");
 			break;
 		case 1:
-			result=(dataPath=="koKR");
+			match=(lastPathItem=="koKR");
 			break;
 		case 2:
-			result=(dataPath=="frFR");
+			match=(lastPathItem=="frFR");
 			break;
 		case 3:
-			result=(dataPath=="deDE");
+			match=(lastPathItem=="deDE");
 			break;
 		case 4:
-			result=(dataPath=="zhCN");
+			match=(lastPathItem=="zhCN");
 			break;
 		case 5:
-			result=(dataPath=="zhTW");
+			match=(lastPathItem=="zhTW");
 			break;
 		case 6:
-			result=(dataPath=="esES");
+			match=(lastPathItem=="esES");
 			break;
 		case 7:
-			result=(dataPath=="esMX");
+			match=(lastPathItem=="esMX");
 			break;
 		case 8:
-			result=(dataPath=="ruRU");
+			match=(lastPathItem=="ruRU");
 			break;
 	}
 	return result;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -926,7 +926,7 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     boost::filesystem::directory_iterator end_iter;
     std::string detectedLocalePath="";
     int locale=ConfigMgr::instance()->GetIntDefault("DBC.Locale", 0);
-    for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && !detectedLocalePath.empty(); ++dir_iter) {
+    for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter) {
 	    std::string dir=(*(--((*dir_iter).path().end()))).string();
 	    if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(dir, locale)) detectedLocalePath=dir;
     }

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -927,9 +927,9 @@ std::string GetDBCLocaleFolder(std::string const& dataPath)
 
     const int locale = sConfigMgr->GetIntDefault("DBC.Locale", LOCALE_enUS);
     for(; dir_iter != end_iter; ++dir_iter)
-        if (boost::filesystem::is_directory(*dir_iter) && GetLocaleByName((*dir_iter).path().filename()) == locale)
+        if (boost::filesystem::is_directory(*dir_iter) && GetLocaleByName((*dir_iter).path().filename().string()) == locale)
             return (boost::filesystem::path(dataPath) / (*dir_iter).path()).string(); //Return the full path appending detected locale folder
     
-    //No subfolder detected but files were present, so we return it unmodified and let the caller throw error if necesary
+    //Empty folder, or it has files but not subfolders (probably the DBC files). Return it unmodified and let caller detect its correctness
     return dataPath;
 }

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -924,46 +924,12 @@ std::string GetDBCLocaleFolder(std::string const& dataPath)
 {
     boost::filesystem::directory_iterator dir_iter(dataPath);
     boost::filesystem::directory_iterator end_iter;
-    
-    if (dir_iter==end_iter)
-	    return dataPath; //Folder is empty, so we return as is, the caller will throw the error
 
-    int locale=sConfigMgr->GetIntDefault("DBC.Locale", LOCALE_enUS);
+    const int locale = sConfigMgr->GetIntDefault("DBC.Locale", LOCALE_enUS);
     for(; dir_iter != end_iter; ++dir_iter)
-        if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale))
-            return (boost::filesystem::path(dataPath)/(*dir_iter).path()).string(); //Return the full path appending detected locale folder
+        if (boost::filesystem::is_directory(*dir_iter) && GetLocaleByName((*dir_iter).path().filename()) == locale)
+            return (boost::filesystem::path(dataPath) / (*dir_iter).path()).string(); //Return the full path appending detected locale folder
     
     //No subfolder detected but files were present, so we return it unmodified and let the caller throw error if necesary
     return dataPath;
-}
-
-bool DBCLocaleFolderMatch(boost::filesystem::path const& dataPath, int const& localeID)
-{
-    const std::string lastPathItem=dataPath.filename().string();
-    switch (localeID) {
-        default:
-        case LOCALE_enUS:
-            //The following is needed for compatibility when extractor generated enGB locale, now it only generates enUS
-            return (lastPathItem=="enGB" || lastPathItem=="enUS");
-        case LOCALE_koKR:
-            return lastPathItem=="koKR";
-        case LOCALE_frFR:
-            return lastPathItem=="frFR";
-        case LOCALE_deDE:
-            return lastPathItem=="deDE";
-        case LOCALE_zhCN:
-            return lastPathItem=="zhCN";
-        case LOCALE_zhTW:
-            return lastPathItem=="zhTW";
-        case LOCALE_esES:
-            return lastPathItem=="esES";
-        case LOCALE_esMX:
-            return lastPathItem=="esMX";
-        case LOCALE_ruRU:
-            return lastPathItem=="ruRU";
-        case LOCALE_ptBR:
-            return lastPathItem=="prBR";
-        case LOCALE_itIT:
-            return lastPathItem=="itIT";
-    }
 }

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -920,7 +920,8 @@ SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, u
     return NULL;
 }
 
-std::string GetDBCLocaleFolder(const std::string& dataPath) {
+std::string GetDBCLocaleFolder(std::string const& dataPath)
+{
     boost::filesystem::path result=dataPath;
     boost::filesystem::directory_iterator end_iter;
     std::string detectedLocalePath="";
@@ -936,37 +937,44 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     return result.string();
 }
 
-bool DBCLocaleFolderMatch(const boost::filesystem::path& dataPath, const int& localeID) {
+bool DBCLocaleFolderMatch(boost::filesystem::path const& dataPath, int const& localeID)
+{
     const std::string lastPathItem=dataPath.filename().string();
     bool match=false;
     switch (localeID) {
         default:
-        case 0:
+        case LOCALE_enUS: //Does this also applies to enGB for european client?
             match=(lastPathItem=="enGB" || lastPathItem=="enUS");
             break;
-        case 1:
+        case LOCALE_koKR:
             match=(lastPathItem=="koKR");
             break;
-        case 2:
+        case LOCALE_frFR:
             match=(lastPathItem=="frFR");
             break;
-        case 3:
+        case LOCALE_deDE:
             match=(lastPathItem=="deDE");
             break;
-        case 4:
+        case LOCALE_zhCN:
             match=(lastPathItem=="zhCN");
             break;
-        case 5:
+        case LOCALE_zhTW:
             match=(lastPathItem=="zhTW");
             break;
-        case 6:
+        case LOCALE_esES:
             match=(lastPathItem=="esES");
             break;
-        case 7:
+        case LOCALE_esMX:
             match=(lastPathItem=="esMX");
             break;
-        case 8:
+        case LOCALE_ruRU:
             match=(lastPathItem=="ruRU");
+            break;
+        case LOCALE_ptBR:
+            match=(lastPathItem=="prBR");
+            break;
+        case LOCALE_itIT:
+            match=(lastPathItem=="itIT");
             break;
     }
     return match;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -26,6 +26,7 @@
 #include "Config.h"
 
 #include <map>
+#include <boost/filesystem.hpp>
 
 typedef std::map<uint16, uint32> AreaFlagByAreaID;
 typedef std::map<uint32, uint32> AreaFlagByMapID;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -303,7 +303,7 @@ inline void LoadGameTable(StoreProblemList& errors, std::string const& tableName
 void LoadDBCStores(const std::string& dataPath)
 {
     uint32 oldMSTime = getMSTime();
-    std::cout << "DETECTED DBC LOCALE: " << GetDBCLocaleFolder(dataPath+"dbc/") << std::endl;
+    
     std::string dbcPath = GetDBCLocaleFolder(dataPath+"dbc/");
 
     StoreProblemList bad_dbc_files;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -940,42 +940,29 @@ std::string GetDBCLocaleFolder(std::string const& dataPath)
 bool DBCLocaleFolderMatch(boost::filesystem::path const& dataPath, int const& localeID)
 {
     const std::string lastPathItem=dataPath.filename().string();
-    bool match=false;
     switch (localeID) {
         default:
         case LOCALE_enUS: //Does this also applies to enGB for european client?
-            match=(lastPathItem=="enGB" || lastPathItem=="enUS");
-            break;
+            return (lastPathItem=="enGB" || lastPathItem=="enUS");
         case LOCALE_koKR:
-            match=(lastPathItem=="koKR");
-            break;
+            return lastPathItem=="koKR";
         case LOCALE_frFR:
-            match=(lastPathItem=="frFR");
-            break;
+            return lastPathItem=="frFR";
         case LOCALE_deDE:
-            match=(lastPathItem=="deDE");
-            break;
+            return lastPathItem=="deDE";
         case LOCALE_zhCN:
-            match=(lastPathItem=="zhCN");
-            break;
+            return lastPathItem=="zhCN";
         case LOCALE_zhTW:
-            match=(lastPathItem=="zhTW");
-            break;
+            return lastPathItem=="zhTW";
         case LOCALE_esES:
-            match=(lastPathItem=="esES");
-            break;
+            return lastPathItem=="esES";
         case LOCALE_esMX:
-            match=(lastPathItem=="esMX");
-            break;
+            return lastPathItem=="esMX";
         case LOCALE_ruRU:
-            match=(lastPathItem=="ruRU");
-            break;
+            return lastPathItem=="ruRU";
         case LOCALE_ptBR:
-            match=(lastPathItem=="prBR");
-            break;
+            return lastPathItem=="prBR";
         case LOCALE_itIT:
-            match=(lastPathItem=="itIT");
-            break;
+            return lastPathItem=="itIT";
     }
-    return match;
 }

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -926,7 +926,7 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     std::string detectedLocalePath="";
     int locale=ConfigMgr::instance()->GetIntDefault("DBC.Locale", 0);
     for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter)
-	    if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale)) detectedLocalePath=(*dir_iter).string();
+	    if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale)) detectedLocalePath=(*dir_iter).path().string();
 
     if (detectedLocalePath.empty())
 	    TC_LOG_WARN("server.loading", "DBC files detected at DataDir/dbc root folder instead of its locale subfolder, this will be removed in a future");

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -303,7 +303,7 @@ inline void LoadGameTable(StoreProblemList& errors, std::string const& tableName
 void LoadDBCStores(const std::string& dataPath)
 {
     uint32 oldMSTime = getMSTime();
-
+    std::cout << "DETECTED DBC LOCALE: " << GetDBCLocaleFolder(dataPath+"dbc/") << std::endl;
     std::string dbcPath = GetDBCLocaleFolder(dataPath+"dbc/");
 
     StoreProblemList bad_dbc_files;
@@ -929,7 +929,7 @@ std::string GetDBCLocaleFolder(std::string const& dataPath)
     const int locale = sConfigMgr->GetIntDefault("DBC.Locale", LOCALE_enUS);
     for(; dir_iter != end_iter; ++dir_iter)
         if (boost::filesystem::is_directory(*dir_iter) && GetLocaleByName((*dir_iter).path().filename().string()) == locale)
-            return (boost::filesystem::path(dataPath) / (*dir_iter).path()).string(); //Return the full path appending detected locale folder
+            return (boost::filesystem::path(dataPath) / (*dir_iter).path().filename()).string(); //Return the full path appending detected locale folder
     
     //Empty folder, or it has files but not subfolders (probably the DBC files). Return it unmodified and let caller detect its correctness
     return dataPath;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -926,47 +926,47 @@ std::string GetDBCLocaleFolder(const std::string& dataPath) {
     std::string detectedLocalePath="";
     int locale=ConfigMgr::instance()->GetIntDefault("DBC.Locale", 0);
     for( boost::filesystem::directory_iterator dir_iter(dataPath) ; dir_iter != end_iter && detectedLocalePath.empty(); ++dir_iter)
-	    if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale)) detectedLocalePath=(*dir_iter).path().string();
+        if (boost::filesystem::is_directory(*dir_iter) && DBCLocaleFolderMatch(*dir_iter, locale)) detectedLocalePath=(*dir_iter).path().string();
 
     if (detectedLocalePath.empty())
-	    TC_LOG_WARN("server.loading", "DBC files detected at DataDir/dbc root folder instead of its locale subfolder, this will be removed in a future");
+        TC_LOG_WARN("server.loading", "DBC files detected at DataDir/dbc root folder instead of its locale subfolder, this will be removed in a future");
     else
-	    result/=detectedLocalePath;
+        result/=detectedLocalePath;
     return result.string();
 }
 
 bool DBCLocaleFolderMatch(const boost::filesystem::path& dataPath, const int& localeID) {
-	const std::string lastPathItem=dataPath.filename().string();
-	bool match=false;
-	switch (localeID) {
-		default:
-		case 0:
-			match=(lastPathItem=="enGB" || lastPathItem=="enUS");
-			break;
-		case 1:
-			match=(lastPathItem=="koKR");
-			break;
-		case 2:
-			match=(lastPathItem=="frFR");
-			break;
-		case 3:
-			match=(lastPathItem=="deDE");
-			break;
-		case 4:
-			match=(lastPathItem=="zhCN");
-			break;
-		case 5:
-			match=(lastPathItem=="zhTW");
-			break;
-		case 6:
-			match=(lastPathItem=="esES");
-			break;
-		case 7:
-			match=(lastPathItem=="esMX");
-			break;
-		case 8:
-			match=(lastPathItem=="ruRU");
-			break;
-	}
-	return match;
+    const std::string lastPathItem=dataPath.filename().string();
+    bool match=false;
+    switch (localeID) {
+        default:
+        case 0:
+            match=(lastPathItem=="enGB" || lastPathItem=="enUS");
+            break;
+        case 1:
+            match=(lastPathItem=="koKR");
+            break;
+        case 2:
+            match=(lastPathItem=="frFR");
+            break;
+        case 3:
+            match=(lastPathItem=="deDE");
+            break;
+        case 4:
+            match=(lastPathItem=="zhCN");
+            break;
+        case 5:
+            match=(lastPathItem=="zhTW");
+            break;
+        case 6:
+            match=(lastPathItem=="esES");
+            break;
+        case 7:
+            match=(lastPathItem=="esMX");
+            break;
+        case 8:
+            match=(lastPathItem=="ruRU");
+            break;
+    }
+    return match;
 }

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -929,7 +929,7 @@ std::string GetDBCLocaleFolder(std::string const& dataPath)
     const int locale = sConfigMgr->GetIntDefault("DBC.Locale", LOCALE_enUS);
     for(; dir_iter != end_iter; ++dir_iter)
         if (boost::filesystem::is_directory(*dir_iter) && GetLocaleByName((*dir_iter).path().filename().string()) == locale)
-            return (boost::filesystem::path(dataPath) / (*dir_iter).path().filename()).string(); //Return the full path appending detected locale folder
+            return dir_iter->path().string() + "/";
     
     //Empty folder, or it has files but not subfolders (probably the DBC files). Return it unmodified and let caller detect its correctness
     return dataPath;

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -304,7 +304,7 @@ void LoadDBCStores(const std::string& dataPath)
 {
     uint32 oldMSTime = getMSTime();
     
-    std::string dbcPath = GetDBCLocaleFolder(dataPath+"dbc/");
+    std::string dbcPath = GetDBCLocaleFolder(dataPath + "dbc/");
 
     StoreProblemList bad_dbc_files;
     uint32 availableDbcLocales = 0xFFFFFFFF;

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -231,6 +231,5 @@ extern DBCStorage <WorldSafeLocsEntry>           sWorldSafeLocsStore;
 void LoadDBCStores(const std::string& dataPath);
 void LoadGameTables(const std::string& dataPath);
 std::string GetDBCLocaleFolder(std::string const& dataPath);
-bool DBCLocaleFolderMatch(boost::filesystem::path const& dataPath, int const& localeID);
 
 #endif

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -228,5 +228,7 @@ extern DBCStorage <WorldSafeLocsEntry>           sWorldSafeLocsStore;
 
 void LoadDBCStores(const std::string& dataPath);
 void LoadGameTables(const std::string& dataPath);
+std::string GetDBCLocaleFolder(const std::string& dataPath);
+bool DBCLocaleFolderMatch(const std::string& dataPath, const int& localeID);
 
 #endif

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -24,8 +24,6 @@
 #include "DB2Structure.h"
 #include "SharedDefines.h"
 
-#include <boost/filesystem.hpp>
-
 typedef std::list<uint32> SimpleFactionsList;
 SimpleFactionsList const* GetFactionTeamList(uint32 faction);
 

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -24,6 +24,8 @@
 #include "DB2Structure.h"
 #include "SharedDefines.h"
 
+#include <boost/filesystem.hpp>
+
 typedef std::list<uint32> SimpleFactionsList;
 SimpleFactionsList const* GetFactionTeamList(uint32 faction);
 

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -229,6 +229,6 @@ extern DBCStorage <WorldSafeLocsEntry>           sWorldSafeLocsStore;
 void LoadDBCStores(const std::string& dataPath);
 void LoadGameTables(const std::string& dataPath);
 std::string GetDBCLocaleFolder(const std::string& dataPath);
-bool DBCLocaleFolderMatch(const std::string& dataPath, const int& localeID);
+bool DBCLocaleFolderMatch(const boost::filesystem::path& dataPath, const int& localeID);
 
 #endif

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -230,7 +230,7 @@ extern DBCStorage <WorldSafeLocsEntry>           sWorldSafeLocsStore;
 
 void LoadDBCStores(const std::string& dataPath);
 void LoadGameTables(const std::string& dataPath);
-std::string GetDBCLocaleFolder(const std::string& dataPath);
-bool DBCLocaleFolderMatch(const boost::filesystem::path& dataPath, const int& localeID);
+std::string GetDBCLocaleFolder(std::string const& dataPath);
+bool DBCLocaleFolderMatch(boost::filesystem::path const& dataPath, int const& localeID);
 
 #endif


### PR DESCRIPTION
This at least compiles, and the idea is good.
Should work, but needs little testing (just too slow to compile)
