### PR TITLE
Core/Spell: Remove Rigor Mortis casting on DK creation and make Rigor…

### DIFF
--- a/sql/updates/world/2015_08_23_00_world.sql
+++ b/sql/updates/world/2015_08_23_00_world.sql
@@ -1,0 +1,3 @@
+-- Fix rigor mortis being caster upon DK creation which shouldn't
+-- Don't excluding just DK class because original value was 0 (all)
+UPDATE `playercreateinfo_cast_spell` SET `classMask`=925 WHERE `raceMask`=16 AND `spell`=73523;

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2918,6 +2918,7 @@ bool SpellInfo::_IsPositiveEffect(uint32 effIndex, bool deep) const
                 case 62344: // Fists of Stone
                 case 61819: // Manabonked! (item)
                 case 61834: // Manabonked! (minigob)
+                case 73523: // Rigor Mortis
                     return true;
                 default:
                     break;


### PR DESCRIPTION
… Mortis spell be positive instead of negative.
Fix by @Killyana and @killradio
Closes #15248 
