### PR TITLE
Core/DB: Implement NULL values instead of 0 when no data is intended

### DIFF
--- a/sql/base/characters_database.sql
+++ b/sql/base/characters_database.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.6.9-rc, for Win64 (x86_64)
+-- MySQL dump 10.15  Distrib 10.0.21-MariaDB, for Linux (x86_64)
 --
 -- Host: localhost    Database: characters335
 -- ------------------------------------------------------
--- Server version	5.6.9-rc
+-- Server version	10.0.21-MariaDB-log
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -192,10 +192,10 @@ CREATE TABLE `auctionhouse` (
   `id` int(10) unsigned NOT NULL DEFAULT '0',
   `auctioneerguid` int(10) unsigned NOT NULL DEFAULT '0',
   `itemguid` int(10) unsigned NOT NULL DEFAULT '0',
-  `itemowner` int(10) unsigned NOT NULL DEFAULT '0',
+  `itemowner` int(10) unsigned DEFAULT NULL,
   `buyoutprice` int(10) unsigned NOT NULL DEFAULT '0',
   `time` int(10) unsigned NOT NULL DEFAULT '0',
-  `buyguid` int(10) unsigned NOT NULL DEFAULT '0',
+  `buyguid` int(10) unsigned DEFAULT NULL,
   `lastbid` int(10) unsigned NOT NULL DEFAULT '0',
   `startbid` int(10) unsigned NOT NULL DEFAULT '0',
   `deposit` int(10) unsigned NOT NULL DEFAULT '0',
@@ -547,7 +547,7 @@ DROP TABLE IF EXISTS `character_battleground_data`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_battleground_data` (
   `guid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
-  `instanceId` int(10) unsigned NOT NULL COMMENT 'Instance Identifier',
+  `instanceId` int(10) unsigned DEFAULT NULL COMMENT 'Instance Identifier',
   `team` smallint(5) unsigned NOT NULL,
   `joinX` float NOT NULL DEFAULT '0',
   `joinY` float NOT NULL DEFAULT '0',
@@ -633,25 +633,25 @@ CREATE TABLE `character_equipmentsets` (
   `name` varchar(31) NOT NULL,
   `iconname` varchar(100) NOT NULL,
   `ignore_mask` int(11) unsigned NOT NULL DEFAULT '0',
-  `item0` int(11) unsigned NOT NULL DEFAULT '0',
-  `item1` int(11) unsigned NOT NULL DEFAULT '0',
-  `item2` int(11) unsigned NOT NULL DEFAULT '0',
-  `item3` int(11) unsigned NOT NULL DEFAULT '0',
-  `item4` int(11) unsigned NOT NULL DEFAULT '0',
-  `item5` int(11) unsigned NOT NULL DEFAULT '0',
-  `item6` int(11) unsigned NOT NULL DEFAULT '0',
-  `item7` int(11) unsigned NOT NULL DEFAULT '0',
-  `item8` int(11) unsigned NOT NULL DEFAULT '0',
-  `item9` int(11) unsigned NOT NULL DEFAULT '0',
-  `item10` int(11) unsigned NOT NULL DEFAULT '0',
-  `item11` int(11) unsigned NOT NULL DEFAULT '0',
-  `item12` int(11) unsigned NOT NULL DEFAULT '0',
-  `item13` int(11) unsigned NOT NULL DEFAULT '0',
-  `item14` int(11) unsigned NOT NULL DEFAULT '0',
-  `item15` int(11) unsigned NOT NULL DEFAULT '0',
-  `item16` int(11) unsigned NOT NULL DEFAULT '0',
-  `item17` int(11) unsigned NOT NULL DEFAULT '0',
-  `item18` int(11) unsigned NOT NULL DEFAULT '0',
+  `item0` int(10) unsigned DEFAULT NULL,
+  `item1` int(10) unsigned DEFAULT NULL,
+  `item2` int(10) unsigned DEFAULT NULL,
+  `item3` int(10) unsigned DEFAULT NULL,
+  `item4` int(10) unsigned DEFAULT NULL,
+  `item5` int(10) unsigned DEFAULT NULL,
+  `item6` int(10) unsigned DEFAULT NULL,
+  `item7` int(10) unsigned DEFAULT NULL,
+  `item8` int(10) unsigned DEFAULT NULL,
+  `item9` int(10) unsigned DEFAULT NULL,
+  `item10` int(10) unsigned DEFAULT NULL,
+  `item11` int(10) unsigned DEFAULT NULL,
+  `item12` int(10) unsigned DEFAULT NULL,
+  `item13` int(10) unsigned DEFAULT NULL,
+  `item14` int(10) unsigned DEFAULT NULL,
+  `item15` int(10) unsigned DEFAULT NULL,
+  `item16` int(10) unsigned DEFAULT NULL,
+  `item17` int(10) unsigned DEFAULT NULL,
+  `item18` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`setguid`),
   UNIQUE KEY `idx_set` (`guid`,`setguid`,`setindex`),
   KEY `Idx_setindex` (`setindex`)
@@ -1349,7 +1349,7 @@ CREATE TABLE `corpse` (
   `dynFlags` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `time` int(10) unsigned NOT NULL DEFAULT '0',
   `corpseType` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `instanceId` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Instance Identifier',
+  `instanceId` int(10) unsigned DEFAULT NULL COMMENT 'Instance Identifier',
   PRIMARY KEY (`corpseGuid`),
   KEY `idx_type` (`corpseType`),
   KEY `idx_instance` (`instanceId`),
@@ -1536,14 +1536,15 @@ CREATE TABLE `gm_ticket` (
   `posY` float NOT NULL DEFAULT '0',
   `posZ` float NOT NULL DEFAULT '0',
   `lastModifiedTime` int(10) unsigned NOT NULL DEFAULT '0',
-  `closedBy` int(10) NOT NULL DEFAULT '0',
-  `assignedTo` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'GUID of admin to whom ticket is assigned',
+  `closedBy` int(10) unsigned DEFAULT NULL,
+  `assignedTo` int(10) unsigned DEFAULT NULL COMMENT 'GUID of admin to whom ticket is assigned',
   `comment` text NOT NULL,
   `response` text NOT NULL,
   `completed` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `escalated` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `viewed` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `needMoreHelp` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `closed` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Player System';
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -2511,7 +2512,7 @@ CREATE TABLE `updates` (
 
 LOCK TABLES `updates` WRITE;
 /*!40000 ALTER TABLE `updates` DISABLE KEYS */;
-INSERT INTO `updates` VALUES ('2015_03_20_00_characters.sql','B761760804EA73BD297F296C5C1919687DF7191C','ARCHIVED','2015-03-21 21:44:15',0),('2015_03_20_01_characters.sql','894F08B70449A5481FFAF394EE5571D7FC4D8A3A','ARCHIVED','2015-03-21 21:44:15',0),('2015_03_20_02_characters.sql','97D7BE0CAADC79F3F11B9FD296B8C6CD40FE593B','ARCHIVED','2015-03-21 21:44:51',0),('2015_06_26_00_characters_335.sql','C2CC6E50AFA1ACCBEBF77CC519AAEB09F3BBAEBC','ARCHIVED','2015-07-13 23:49:22',0);
+INSERT INTO `updates` VALUES ('2015_03_20_00_characters.sql','B761760804EA73BD297F296C5C1919687DF7191C','ARCHIVED','2015-03-21 21:44:15',0),('2015_03_20_01_characters.sql','894F08B70449A5481FFAF394EE5571D7FC4D8A3A','ARCHIVED','2015-03-21 21:44:15',0),('2015_03_20_02_characters.sql','97D7BE0CAADC79F3F11B9FD296B8C6CD40FE593B','ARCHIVED','2015-03-21 21:44:51',0),('2015_06_26_00_characters_335.sql','C2CC6E50AFA1ACCBEBF77CC519AAEB09F3BBAEBC','ARCHIVED','2015-07-13 23:49:22',0),('2015_08_13_00_characters_convert_zero_to_nulls.sql','8DD49553953F05F38CE31A1FC1AEBB6248AA3732','RELEASED','2015-08-21 16:58:57',114);
 /*!40000 ALTER TABLE `updates` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -2596,4 +2597,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-07-14  1:06:50
+-- Dump completed on 2015-08-21 19:06:04

--- a/sql/updates/characters/2015_08_13_00_characters_convert_zero_to_nulls.sql
+++ b/sql/updates/characters/2015_08_13_00_characters_convert_zero_to_nulls.sql
@@ -1,0 +1,66 @@
+-- auctionhouse
+ALTER TABLE `auctionhouse` MODIFY `itemowner` INTEGER(10) UNSIGNED;
+ALTER TABLE `auctionhouse` MODIFY `buyguid` INTEGER(10) UNSIGNED;
+UPDATE `auctionhouse` SET `itemowner` = NULL WHERE `itemowner` = 0;
+UPDATE `auctionhouse` SET `buyguid` = NULL WHERE `buyguid` = 0;
+
+-- channel
+UPDATE `channels` SET `password` = NULL WHERE `password` = '';
+
+-- battleground_data
+ALTER TABLE `character_battleground_data` MODIFY `instanceId` INTEGER(10) UNSIGNED DEFAULT NULL COMMENT 'Instance Identifier';
+UPDATE `character_battleground_data` SET `instanceId` = NULL WHERE `instanceId` = 0;
+
+-- equipmentsets
+ALTER TABLE `character_equipmentsets` MODIFY `item0` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item1` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item2` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item3` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item4` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item5` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item6` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item7` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item8` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item9` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item10` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item11` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item12` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item13` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item14` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item15` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item16` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item17` INTEGER(10) UNSIGNED;
+ALTER TABLE `character_equipmentsets` MODIFY `item18` INTEGER(10) UNSIGNED;
+UPDATE `character_equipmentsets`  SET `item0` = NULL WHERE `item0` = 0;
+UPDATE `character_equipmentsets`  SET `item1` = NULL WHERE `item1` = 0;
+UPDATE `character_equipmentsets`  SET `item2` = NULL WHERE `item2` = 0;
+UPDATE `character_equipmentsets`  SET `item3` = NULL WHERE `item3` = 0;
+UPDATE `character_equipmentsets`  SET `item4` = NULL WHERE `item4` = 0;
+UPDATE `character_equipmentsets`  SET `item5` = NULL WHERE `item5` = 0;
+UPDATE `character_equipmentsets`  SET `item6` = NULL WHERE `item6` = 0;
+UPDATE `character_equipmentsets`  SET `item7` = NULL WHERE `item7` = 0;
+UPDATE `character_equipmentsets`  SET `item8` = NULL WHERE `item8` = 0;
+UPDATE `character_equipmentsets`  SET `item9` = NULL WHERE `item9` = 0;
+UPDATE `character_equipmentsets`  SET `item10` = NULL WHERE `item10` = 0;
+UPDATE `character_equipmentsets`  SET `item11` = NULL WHERE `item11` = 0;
+UPDATE `character_equipmentsets`  SET `item12` = NULL WHERE `item12` = 0;
+UPDATE `character_equipmentsets`  SET `item13` = NULL WHERE `item13` = 0;
+UPDATE `character_equipmentsets`  SET `item14` = NULL WHERE `item14` = 0;
+UPDATE `character_equipmentsets`  SET `item15` = NULL WHERE `item15` = 0;
+UPDATE `character_equipmentsets`  SET `item16` = NULL WHERE `item16` = 0;
+UPDATE `character_equipmentsets`  SET `item17` = NULL WHERE `item17` = 0;
+UPDATE `character_equipmentsets`  SET `item18` = NULL WHERE `item18` = 0;
+
+-- corpse
+ALTER TABLE `corpse` MODIFY `instanceId` INTEGER(10) UNSIGNED DEFAULT NULL COMMENT 'Instance Identifier';
+UPDATE `corpse` SET `instanceId` = NULL WHERE `instanceId` = 0;
+
+-- gmticket
+ALTER TABLE `gm_ticket` MODIFY `closedBy` INTEGER(10) UNSIGNED DEFAULT NULL;
+ALTER TABLE `gm_ticket` MODIFY `assignedTo` INTEGER(10) UNSIGNED DEFAULT NULL COMMENT 'GUID of admin to whom ticket is assigned';
+ALTER TABLE `gm_ticket` ADD closed BOOL NOT NULL DEFAULT FALSE AFTER `needMoreHelp`;
+-- Update closed status via old system's values
+UPDATE `gm_ticket` SET `closed` = TRUE WHERE `closedBy` <> 0;
+-- Fix non existant closedBy characters (posibly deleted characters and/or closed by console)
+UPDATE `gm_ticket` SET `closedBy` = NULL WHERE `closedBy` NOT IN ( SELECT `guid` FROM `characters` );
+UPDATE `gm_ticket` SET `assignedTo` = NULL WHERE `assignedTo` = 0;

--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -336,8 +336,8 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_DEL_GO_RESPAWN_BY_INSTANCE, "DELETE FROM gameobject_respawn WHERE mapId = ? AND instanceId = ?", CONNECTION_ASYNC);
 
     // GM Tickets
-    PrepareStatement(CHAR_SEL_GM_TICKETS, "SELECT id, playerGuid, name, description, createTime, mapId, posX, posY, posZ, lastModifiedTime, closedBy, assignedTo, comment, response, completed, escalated, viewed, needMoreHelp FROM gm_ticket", CONNECTION_SYNCH);
-    PrepareStatement(CHAR_REP_GM_TICKET, "REPLACE INTO gm_ticket (id, playerGuid, name, description, createTime, mapId, posX, posY, posZ, lastModifiedTime, closedBy, assignedTo, comment, response, completed, escalated, viewed, needMoreHelp) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_SEL_GM_TICKETS, "SELECT id, playerGuid, name, description, createTime, mapId, posX, posY, posZ, lastModifiedTime, closedBy, assignedTo, comment, response, completed, escalated, viewed, needMoreHelp, closed FROM gm_ticket", CONNECTION_SYNCH);
+    PrepareStatement(CHAR_REP_GM_TICKET, "REPLACE INTO gm_ticket (id, playerGuid, name, description, createTime, mapId, posX, posY, posZ, lastModifiedTime, closedBy, assignedTo, comment, response, completed, escalated, viewed, needMoreHelp, closed) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_GM_TICKET, "DELETE FROM gm_ticket WHERE id = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_PLAYER_GM_TICKETS, "DELETE FROM gm_ticket WHERE playerGuid = ?", CONNECTION_ASYNC);
 

--- a/src/server/database/Database/PreparedStatement.cpp
+++ b/src/server/database/Database/PreparedStatement.cpp
@@ -82,112 +82,169 @@ void PreparedStatement::BindParameters()
 }
 
 //- Bind to buffer
-void PreparedStatement::setBool(const uint8 index, const bool value)
+void PreparedStatement::setBool(const uint8 index, const bool value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
-    statement_data[index].data.boolean = value;
-    statement_data[index].type = TYPE_BOOL;
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
+        statement_data[index].data.boolean = value;
+        statement_data[index].type = TYPE_BOOL;
+    }
 }
 
-void PreparedStatement::setUInt8(const uint8 index, const uint8 value)
+void PreparedStatement::setUInt8(const uint8 index, const uint8 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
-    statement_data[index].data.ui8 = value;
-    statement_data[index].type = TYPE_UI8;
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
+        statement_data[index].data.ui8 = value;
+        statement_data[index].type = TYPE_UI8;
+    }
 }
 
-void PreparedStatement::setUInt16(const uint8 index, const uint16 value)
+void PreparedStatement::setUInt16(const uint8 index, const uint16 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
-    statement_data[index].data.ui16 = value;
-    statement_data[index].type = TYPE_UI16;
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
+        statement_data[index].data.ui16 = value;
+        statement_data[index].type = TYPE_UI16;
+    }
 }
 
-void PreparedStatement::setUInt32(const uint8 index, const uint32 value)
+void PreparedStatement::setUInt32(const uint8 index, const uint32 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.ui32 = value;
-    statement_data[index].type = TYPE_UI32;
+        statement_data[index].data.ui32 = value;
+        statement_data[index].type = TYPE_UI32;
+    }
 }
 
-void PreparedStatement::setUInt64(const uint8 index, const uint64 value)
+void PreparedStatement::setUInt64(const uint8 index, const uint64 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.ui64 = value;
-    statement_data[index].type = TYPE_UI64;
+        statement_data[index].data.ui64 = value;
+        statement_data[index].type = TYPE_UI64;
+    }
 }
 
-void PreparedStatement::setInt8(const uint8 index, const int8 value)
+void PreparedStatement::setInt8(const uint8 index, const int8 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.i8 = value;
-    statement_data[index].type = TYPE_I8;
+        statement_data[index].data.i8 = value;
+        statement_data[index].type = TYPE_I8;
+    }
 }
 
-void PreparedStatement::setInt16(const uint8 index, const int16 value)
+void PreparedStatement::setInt16(const uint8 index, const int16 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.i16 = value;
-    statement_data[index].type = TYPE_I16;
+        statement_data[index].data.i16 = value;
+        statement_data[index].type = TYPE_I16;
+    }
 }
 
-void PreparedStatement::setInt32(const uint8 index, const int32 value)
+void PreparedStatement::setInt32(const uint8 index, const int32 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.i32 = value;
-    statement_data[index].type = TYPE_I32;
+        statement_data[index].data.i32 = value;
+        statement_data[index].type = TYPE_I32;
+    }
 }
 
-void PreparedStatement::setInt64(const uint8 index, const int64 value)
+void PreparedStatement::setInt64(const uint8 index, const int64 value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.i64 = value;
-    statement_data[index].type = TYPE_I64;
+        statement_data[index].data.i64 = value;
+        statement_data[index].type = TYPE_I64;
+    }
 }
 
-void PreparedStatement::setFloat(const uint8 index, const float value)
+void PreparedStatement::setFloat(const uint8 index, const float value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.f = value;
-    statement_data[index].type = TYPE_FLOAT;
+        statement_data[index].data.f = value;
+        statement_data[index].type = TYPE_FLOAT;
+    }
 }
 
-void PreparedStatement::setDouble(const uint8 index, const double value)
+void PreparedStatement::setDouble(const uint8 index, const double value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && !value)
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].data.d = value;
-    statement_data[index].type = TYPE_DOUBLE;
+        statement_data[index].data.d = value;
+        statement_data[index].type = TYPE_DOUBLE;
+    }
 }
 
-void PreparedStatement::setString(const uint8 index, const std::string& value)
+void PreparedStatement::setString(const uint8 index, const std::string& value, bool setNullIfZero)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
+    if (setNullIfZero && value.empty())
+        setNull(index);
+    else
+    {
+        if (index >= statement_data.size())
+            statement_data.resize(index+1);
 
-    statement_data[index].str = value;
-    statement_data[index].type = TYPE_STRING;
+        statement_data[index].str = value;
+        statement_data[index].type = TYPE_STRING;
+    }
 }
 
 void PreparedStatement::setNull(const uint8 index)

--- a/src/server/database/Database/PreparedStatement.h
+++ b/src/server/database/Database/PreparedStatement.h
@@ -80,18 +80,18 @@ class PreparedStatement
         explicit PreparedStatement(uint32 index);
         ~PreparedStatement();
 
-        void setBool(const uint8 index, const bool value);
-        void setUInt8(const uint8 index, const uint8 value);
-        void setUInt16(const uint8 index, const uint16 value);
-        void setUInt32(const uint8 index, const uint32 value);
-        void setUInt64(const uint8 index, const uint64 value);
-        void setInt8(const uint8 index, const int8 value);
-        void setInt16(const uint8 index, const int16 value);
-        void setInt32(const uint8 index, const int32 value);
-        void setInt64(const uint8 index, const int64 value);
-        void setFloat(const uint8 index, const float value);
-        void setDouble(const uint8 index, const double value);
-        void setString(const uint8 index, const std::string& value);
+        void setBool(const uint8 index, const bool value, bool setNullIfZero = false);
+        void setUInt8(const uint8 index, const uint8 value, bool setNullIfZero = false);
+        void setUInt16(const uint8 index, const uint16 value, bool setNullIfZero = false);
+        void setUInt32(const uint8 index, const uint32 value, bool setNullIfZero = false);
+        void setUInt64(const uint8 index, const uint64 value, bool setNullIfZero = false);
+        void setInt8(const uint8 index, const int8 value, bool setNullIfZero = false);
+        void setInt16(const uint8 index, const int16 value, bool setNullIfZero = false);
+        void setInt32(const uint8 index, const int32 value, bool setNullIfZero = false);
+        void setInt64(const uint8 index, const int64 value, bool setNullIfZero = false);
+        void setFloat(const uint8 index, const float value, bool setNullIfZero = false);
+        void setDouble(const uint8 index, const double value, bool setNullIfZero = false);
+        void setString(const uint8 index, const std::string& value, bool setNullIfZero = false);
         void setNull(const uint8 index);
 
     protected:

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -689,10 +689,10 @@ void AuctionEntry::SaveToDB(SQLTransaction& trans) const
     stmt->setUInt32(0, Id);
     stmt->setUInt32(1, auctioneer);
     stmt->setUInt32(2, itemGUIDLow);
-    stmt->setUInt32(3, owner);
+    stmt->setUInt32(3, owner, true);
     stmt->setUInt32(4, buyout);
     stmt->setUInt32(5, uint32(expire_time));
-    stmt->setUInt32(6, bidder);
+    stmt->setUInt32(6, bidder, true);
     stmt->setUInt32(7, bid);
     stmt->setUInt32(8, startbid);
     stmt->setUInt32(9, deposit);

--- a/src/server/game/Chat/Channels/Channel.cpp
+++ b/src/server/game/Chat/Channels/Channel.cpp
@@ -117,7 +117,7 @@ void Channel::UpdateChannelInDB() const
         PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHANNEL);
         stmt->setBool(0, _announce);
         stmt->setBool(1, _ownership);
-        stmt->setString(2, _password);
+        stmt->setString(2, _password, true);
         stmt->setString(3, banListStr);
         stmt->setString(4, _name);
         stmt->setUInt32(5, _Team);

--- a/src/server/game/Entities/Corpse/Corpse.cpp
+++ b/src/server/game/Entities/Corpse/Corpse.cpp
@@ -116,7 +116,7 @@ void Corpse::SaveToDB()
     stmt->setUInt8 (index++, GetUInt32Value(CORPSE_FIELD_DYNAMIC_FLAGS));             // dynFlags
     stmt->setUInt32(index++, uint32(m_time));                                         // time
     stmt->setUInt8 (index++, GetType());                                              // corpseType
-    stmt->setUInt32(index++, GetInstanceId());                                        // instanceId
+    stmt->setUInt32(index++, GetInstanceId(), true);                                  // instanceId
     stmt->setUInt32(index++, GetPhaseMask());                                         // phaseMask
     trans->Append(stmt);
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25524,7 +25524,7 @@ void Player::_SaveEquipmentSets(SQLTransaction& trans)
                 stmt->setString(j++, eqset.IconName.c_str());
                 stmt->setUInt32(j++, eqset.IgnoreMask);
                 for (uint8 i=0; i<EQUIPMENT_SLOT_END; ++i)
-                    stmt->setUInt32(j++, eqset.Items[i]);
+                    stmt->setUInt32(j++, eqset.Items[i], true);
                 stmt->setUInt32(j++, GetGUIDLow());
                 stmt->setUInt64(j++, eqset.Guid);
                 stmt->setUInt32(j, index);
@@ -25541,7 +25541,7 @@ void Player::_SaveEquipmentSets(SQLTransaction& trans)
                 stmt->setString(j++, eqset.IconName.c_str());
                 stmt->setUInt32(j++, eqset.IgnoreMask);
                 for (uint8 i=0; i<EQUIPMENT_SLOT_END; ++i)
-                    stmt->setUInt32(j++, eqset.Items[i]);
+                    stmt->setUInt32(j++, eqset.Items[i], true);
                 trans->Append(stmt);
                 eqset.state = EQUIPMENT_SET_UNCHANGED;
                 ++itr;
@@ -25564,7 +25564,7 @@ void Player::_SaveBGData(SQLTransaction& trans)
     /* guid, bgInstanceID, bgTeam, x, y, z, o, map, taxi[0], taxi[1], mountSpell */
     stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_PLAYER_BGDATA);
     stmt->setUInt32(0, GetGUIDLow());
-    stmt->setUInt32(1, m_bgData.bgInstanceID);
+    stmt->setUInt32(1, m_bgData.bgInstanceID, true);
     stmt->setUInt16(2, m_bgData.bgTeam);
     stmt->setFloat (3, m_bgData.joinPos.GetPositionX());
     stmt->setFloat (4, m_bgData.joinPos.GetPositionY());

--- a/src/server/game/Tickets/TicketMgr.h
+++ b/src/server/game/Tickets/TicketMgr.h
@@ -84,7 +84,7 @@ public:
     GmTicket(Player* player);
     ~GmTicket();
 
-    bool IsClosed() const { return !_closedBy.IsEmpty(); }
+    bool IsClosed() const { return _closed; }
     bool IsCompleted() const { return _completed; }
     bool IsFromPlayer(ObjectGuid guid) const { return guid == _playerGuid; }
     bool IsAssigned() const { return !_assignedTo.IsEmpty(); }
@@ -118,7 +118,7 @@ public:
         else if (_escalatedStatus == TICKET_UNASSIGNED)
             _escalatedStatus = TICKET_ASSIGNED;
     }
-    void SetClosedBy(ObjectGuid value) { _closedBy = value; }
+    void SetClosedBy(ObjectGuid value) { _closedBy = value; _closed=true; }
     void SetCompleted() { _completed = true; }
     void SetMessage(std::string const& message)
     {
@@ -166,6 +166,7 @@ private:
     bool _viewed;
     bool _needResponse; /// @todo find out the use of this, and then store it in DB
     bool _needMoreHelp;
+    bool _closed;
     std::string _response;
     std::string _chatLog; // No need to store in db, will be refreshed every session client side
 };

--- a/src/server/scripts/Commands/cs_ticket.cpp
+++ b/src/server/scripts/Commands/cs_ticket.cpp
@@ -153,7 +153,7 @@ public:
             return true;
         }
 
-        sTicketMgr->CloseTicket(ticket->GetId(), player ? player->GetGUID() : ObjectGuid(uint64(-1)));
+        sTicketMgr->CloseTicket(ticket->GetId(), player ? player->GetGUID() : ObjectGuid(uint64(0)));
         sTicketMgr->UpdateLastChange();
 
         std::string msg = ticket->FormatMessageString(*handler, player ? player->GetName().c_str() : "Console", NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This PR, will convert all auth and characters database 0 usage to NULL, when no data was intended.
This will enable further FKEY aditions while optimizing database (at least semantically, no longer 0 for no guid present)
