### PR TITLE
Core/Build: Removed obsolete SystemConfig.h and made genrev be part of shared library

### DIFF
--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -66,11 +66,11 @@ else()
   endif()
 endif()
 
-# Create the actual revision.h file from the above params
-if(NOT "${rev_hash_cached}" MATCHES "${rev_hash}" OR NOT "${rev_branch_cached}" MATCHES "${rev_branch}" OR NOT EXISTS "${BUILDDIR}/revision.h")
+# Create the actual revision_data.h file from the above params
+if(NOT "${rev_hash_cached}" MATCHES "${rev_hash}" OR NOT "${rev_branch_cached}" MATCHES "${rev_branch}" OR NOT EXISTS "${BUILDDIR}/revision_data.h")
   configure_file(
-    "${CMAKE_SOURCE_DIR}/revision.h.in.cmake"
-    "${BUILDDIR}/revision.h"
+    "${CMAKE_SOURCE_DIR}/revision_data.h.in.cmake"
+    "${BUILDDIR}/revision_data.h"
     @ONLY
   )
   set(rev_hash_cached "${rev_hash}" CACHE INTERNAL "Cached commit-hash")

--- a/revision_data.h.in.cmake
+++ b/revision_data.h.in.cmake
@@ -1,5 +1,5 @@
-#ifndef __REVISION_H__
-#define __REVISION_H__
+#ifndef __REVISION_DATA_H__
+#define __REVISION_DATA_H__
  #define _HASH                      "@rev_hash@"
  #define _DATE                      "@rev_date@"
  #define _BRANCH                    "@rev_branch@"
@@ -12,4 +12,4 @@
  #define VER_FILEVERSION_STR        "@rev_hash@ @rev_date@ (@rev_branch@ branch)"
  #define VER_PRODUCTVERSION         VER_FILEVERSION
  #define VER_PRODUCTVERSION_STR     VER_FILEVERSION_STR
-#endif // __REVISION_H__
+#endif // __REVISION_DATA_H__

--- a/src/genrev/CMakeLists.txt
+++ b/src/genrev/CMakeLists.txt
@@ -9,7 +9,7 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 # Need to pass old ${CMAKE_BINARY_DIR} as param because its different at build stage
-add_custom_target(revision.h ALL
+add_custom_target(revision_data.h ALL
   COMMAND "${CMAKE_COMMAND}" -DBUILDDIR="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/genrev.cmake" "${CMAKE_BINARY_DIR}"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 )

--- a/src/server/authserver/CMakeLists.txt
+++ b/src/server/authserver/CMakeLists.txt
@@ -73,8 +73,6 @@ add_executable(authserver
   ${authserver_PCH_SRC}
 )
 
-add_dependencies(authserver revision.h)
-
 if( NOT WIN32 )
   set_target_properties(authserver PROPERTIES
     COMPILE_DEFINITIONS _TRINITY_REALM_CONFIG="${CONF_DIR}/authserver.conf"

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -33,7 +33,7 @@
 #include "AppenderDB.h"
 #include "ProcessPriority.h"
 #include "RealmList.h"
-#include "SystemConfig.h"
+#include "Revision.h"
 #include "Util.h"
 #include <iostream>
 #include <boost/program_options.hpp>
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
     sLog->RegisterAppender<AppenderDB>();
     sLog->Initialize(nullptr);
 
-    TC_LOG_INFO("server.authserver", "%s (authserver)", _FULLVERSION);
+    TC_LOG_INFO("server.authserver", "%s (authserver)", Revision::GetFullVersion().c_str());
     TC_LOG_INFO("server.authserver", "<Ctrl-C> to stop.\n");
     TC_LOG_INFO("server.authserver", "Using configuration file %s.", configFile.c_str());
     TC_LOG_INFO("server.authserver", "Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
@@ -293,7 +293,7 @@ variables_map GetConsoleArguments(int argc, char** argv, std::string& configFile
     if (variablesMap.count("help"))
         std::cout << all << "\n";
     else if (variablesMap.count("version"))
-        std::cout << _FULLVERSION << "\n";
+        std::cout << Revision::GetFullVersion() << "\n";
 
     return variablesMap;
 }

--- a/src/server/authserver/authserver.rc
+++ b/src/server/authserver/authserver.rc
@@ -17,7 +17,7 @@
  */
 
 #include "resource.h"
-#include "revision.h"
+#include "revision_data.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////

--- a/src/server/game/CMakeLists.txt
+++ b/src/server/game/CMakeLists.txt
@@ -215,8 +215,6 @@ add_library(game STATIC
   ${game_STAT_PCH_SRC}
 )
 
-add_dependencies(game revision.h)
-
 # Generate precompiled header
 if (USE_COREPCH)
   add_cxx_pch(game ${game_STAT_PCH_HDR} ${game_STAT_PCH_SRC})

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -60,7 +60,7 @@
 #include "Pet.h"
 #include "QuestDef.h"
 #include "ReputationMgr.h"
-#include "revision.h"
+#include "Revision.h"
 #include "SkillDiscovery.h"
 #include "SocialMgr.h"
 #include "Spell.h"
@@ -15123,8 +15123,8 @@ void Player::AddQuest(Quest const* quest, Object* questGiver)
         PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_QUEST_TRACK);
         stmt->setUInt32(0, quest_id);
         stmt->setUInt32(1, GetGUIDLow());
-        stmt->setString(2, _HASH);
-        stmt->setString(3, _DATE);
+        stmt->setString(2, Revision::GetHash());
+        stmt->setString(3, Revision::GetDate());
 
         // add to Quest Tracker
         CharacterDatabase.Execute(stmt);

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -36,10 +36,10 @@
 #include "PlayerDump.h"
 #include "Player.h"
 #include "ReputationMgr.h"
+#include "Revision.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "SocialMgr.h"
-#include "SystemConfig.h"
 #include "UpdateMask.h"
 #include "Util.h"
 #include "World.h"
@@ -827,7 +827,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
 
         // send server info
         if (sWorld->getIntConfig(CONFIG_ENABLE_SINFO_LOGIN) == 1)
-            chH.PSendSysMessage(_FULLVERSION);
+            chH.PSendSysMessage(Revision::GetFullVersion().c_str());
 
         TC_LOG_DEBUG("network", "WORLD: Sent server info");
     }

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -51,11 +51,11 @@
 #include "OutdoorPvPMgr.h"
 #include "Player.h"
 #include "PoolMgr.h"
+#include "Revision.h"
 #include "ScriptMgr.h"
 #include "SkillDiscovery.h"
 #include "SkillExtraItems.h"
 #include "SmartAI.h"
-#include "SystemConfig.h"
 #include "TicketMgr.h"
 #include "TransportMgr.h"
 #include "Unit.h"
@@ -1789,7 +1789,7 @@ void World::SetInitialWorldSettings()
     m_startTime = m_gameTime;
 
     LoginDatabase.PExecute("INSERT INTO uptime (realmid, starttime, uptime, revision) VALUES(%u, %u, 0, '%s')",
-                            realmID, uint32(m_startTime), _FULLVERSION);       // One-time query
+                            realmID, uint32(m_startTime), Revision::GetFullVersion().c_str());       // One-time query
 
     m_timers[WUPDATE_WEATHERS].SetInterval(1*IN_MILLISECONDS);
     m_timers[WUPDATE_AUCTIONS].SetInterval(MINUTE*IN_MILLISECONDS);

--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -153,8 +153,6 @@ add_library(scripts STATIC
   ${scripts_STAT_PCH_SRC}
 )
 
-add_dependencies(scripts revision.h)
-
 # Generate precompiled header
 if (USE_SCRIPTPCH)
   add_cxx_pch(scripts ${scripts_STAT_PCH_HDR} ${scripts_STAT_PCH_SRC})

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -28,7 +28,7 @@ EndScriptData */
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "ScriptMgr.h"
-#include "SystemConfig.h"
+#include "Revision.h"
 
 class server_commandscript : public CommandScript
 {
@@ -115,7 +115,7 @@ public:
         std::string uptime          = secsToTimeString(sWorld->GetUptime());
         uint32 updateTime           = sWorld->GetUpdateTime();
 
-        handler->SendSysMessage(_FULLVERSION);
+        handler->SendSysMessage(Revision::GetFullVersion().c_str());
         handler->PSendSysMessage(LANG_CONNECTED_PLAYERS, playersNum, maxPlayersNum);
         handler->PSendSysMessage(LANG_CONNECTED_USERS, activeClientsNum, maxActiveClientsNum, queuedClientsNum, maxQueuedClientsNum);
         handler->PSendSysMessage(LANG_UPTIME, uptime.c_str());

--- a/src/server/shared/CMakeLists.txt
+++ b/src/server/shared/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(shared STATIC
   ${shared_STAT_PCH_SRC}
 )
 
+add_dependencies(shared revision_data.h)
+
 # Generate precompiled header
 if (USE_COREPCH)
   add_cxx_pch(shared ${shared_STAT_PCH_HDR} ${shared_STAT_PCH_SRC})

--- a/src/server/shared/Debugging/WheatyExceptionReport.cpp
+++ b/src/server/shared/Debugging/WheatyExceptionReport.cpp
@@ -20,8 +20,7 @@
 #include "WheatyExceptionReport.h"
 
 #include "Common.h"
-#include "SystemConfig.h"
-#include "revision.h"
+#include "Revision.h"
 
 #define CrashFolder _T("Crashes")
 #pragma comment(linker, "/DEFAULTLIB:dbghelp.lib")
@@ -131,10 +130,10 @@ PEXCEPTION_POINTERS pExceptionInfo)
     SYSTEMTIME systime;
     GetLocalTime(&systime);
     sprintf(m_szDumpFileName, "%s\\%s_%s_[%u-%u_%u-%u-%u].dmp",
-        crash_folder_path, _HASH, pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
+        crash_folder_path, Revision::GetHash().c_str(), pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
 
     sprintf(m_szLogFileName, "%s\\%s_%s_[%u-%u_%u-%u-%u].txt",
-        crash_folder_path, _HASH, pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
+        crash_folder_path, Revision::GetHash().c_str(), pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
 
     m_hDumpFile = CreateFile(m_szDumpFileName,
         GENERIC_WRITE,
@@ -440,7 +439,7 @@ PEXCEPTION_POINTERS pExceptionInfo)
         GetLocalTime(&systime);
 
         // Start out with a banner
-        _tprintf(_T("Revision: %s\r\n"), _FULLVERSION);
+        _tprintf(_T("Revision: %s\r\n"), Revision::GetFullVersion().c_str());
         _tprintf(_T("Date %u:%u:%u. Time %u:%u \r\n"), systime.wDay, systime.wMonth, systime.wYear, systime.wHour, systime.wMinute);
         PEXCEPTION_RECORD pExceptionRecord = pExceptionInfo->ExceptionRecord;
 

--- a/src/server/shared/PrecompiledHeaders/sharedPCH.h
+++ b/src/server/shared/PrecompiledHeaders/sharedPCH.h
@@ -8,3 +8,4 @@
 #include "TypeList.h"
 #include "TaskScheduler.h"
 #include "EventMap.h"
+#include "Revision.h"

--- a/src/server/shared/Revision.cpp
+++ b/src/server/shared/Revision.cpp
@@ -1,0 +1,66 @@
+#include "Revision.h"
+#include "CompilerDefs.h"
+#include "revision_data.h"
+
+std::string Revision::GetHash()
+{
+    return _HASH;
+}
+
+std::string Revision::GetDate()
+{
+    return _DATE;
+}
+
+std::string Revision::GetBranch()
+{
+    return _BRANCH;
+}
+
+std::string Revision::GetSourceDirectory()
+{
+    return _SOURCE_DIRECTORY;
+}
+
+std::string Revision::GetMySQLExecutable()
+{
+    return _MYSQL_EXECUTABLE;
+}
+
+std::string Revision::GetFullDatabase()
+{
+    return _FULL_DATABASE;
+}
+
+std::string Revision::GetFullVersion()
+{
+#if PLATFORM == PLATFORM_WINDOWS
+# ifdef _WIN64
+    return std::string(_PACKAGENAME) + " rev. " + VER_PRODUCTVERSION_STR + " (Win64, " + _BUILD_DIRECTIVE + ")";
+# else
+    return std::string(_PACKAGENAME) + " rev. " + VER_PRODUCTVERSION_STR + " (Win32, " + _BUILD_DIRECTIVE + ")";
+# endif
+#else
+    return std::string(_PACKAGENAME) + " rev. " + VER_PRODUCTVERSION_STR + " (Unix, " + _BUILD_DIRECTIVE + ")";
+#endif
+}
+
+std::string GetCompanyNameStr()
+{
+    return VER_COMPANYNAME_STR;
+}
+
+std::string GetLegalCopyrightStr()
+{
+    return VER_LEGALCOPYRIGHT_STR;
+}
+
+std::string GetFileVersionStr()
+{
+    return VER_FILEVERSION_STR;
+}
+
+std::string GetProductVersionStr()
+{
+    return VER_PRODUCTVERSION_STR;
+}

--- a/src/server/shared/Revision.h
+++ b/src/server/shared/Revision.h
@@ -15,30 +15,25 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-// THIS FILE IS DEPRECATED
-
-#ifndef TRINITY_SYSTEMCONFIG_H
-#define TRINITY_SYSTEMCONFIG_H
-
-#include "Define.h"
-#include "revision.h"
+#ifndef __REVISION_H__
+#define __REVISION_H__
 
 #define _PACKAGENAME "TrinityCore"
 
-#if TRINITY_ENDIAN == TRINITY_BIGENDIAN
-# define _ENDIAN_STRING "big-endian"
-#else
-# define _ENDIAN_STRING "little-endian"
-#endif
+#include <string>
 
-#if PLATFORM == PLATFORM_WINDOWS
-# ifdef _WIN64
-#  define _FULLVERSION _PACKAGENAME " rev. " VER_PRODUCTVERSION_STR " (Win64, " _BUILD_DIRECTIVE ")"
-# else
-#  define _FULLVERSION _PACKAGENAME " rev. " VER_PRODUCTVERSION_STR " (Win32, " _BUILD_DIRECTIVE ")"
-# endif
-#else
-#  define _FULLVERSION _PACKAGENAME " rev. " VER_PRODUCTVERSION_STR " (Unix, " _BUILD_DIRECTIVE ")"
-#endif
+namespace Revision {
+    std::string GetHash();
+    std::string GetDate();
+    std::string GetBranch();
+    std::string GetSourceDirectory();
+    std::string GetMySQLExecutable();
+    std::string GetFullDatabase();
+    std::string GetFullVersion();
+    std::string GetCompanyNameStr();
+    std::string GetLegalCopyrightStr();
+    std::string GetFileVersionStr();
+    std::string GetProductVersionStr();
+}
+
 #endif

--- a/src/server/shared/Revision.h
+++ b/src/server/shared/Revision.h
@@ -22,7 +22,8 @@
 
 #include <string>
 
-namespace Revision {
+namespace Revision
+{
     std::string GetHash();
     std::string GetDate();
     std::string GetBranch();

--- a/src/server/shared/Updater/DBUpdater.cpp
+++ b/src/server/shared/Updater/DBUpdater.cpp
@@ -17,7 +17,7 @@
 
 #include "DBUpdater.h"
 #include "Log.h"
-#include "revision.h"
+#include "Revision.h"
 #include "UpdateFetcher.h"
 #include "DatabaseLoader.h"
 #include "Config.h"
@@ -40,7 +40,7 @@ std::string DBUpdater<T>::GetSourceDirectory()
     if (!entry.empty())
         return entry;
     else
-        return _SOURCE_DIRECTORY;
+        return Revision::GetSourceDirectory();
 }
 
 template<class T>
@@ -50,7 +50,7 @@ std::string DBUpdater<T>::GetMySqlCli()
     if (!entry.empty())
         return entry;
     else
-        return _MYSQL_EXECUTABLE;
+        return Revision::GetMySQLExecutable();
 }
 
 // Auth Database
@@ -95,7 +95,7 @@ std::string DBUpdater<WorldDatabaseConnection>::GetTableName()
 template<>
 std::string DBUpdater<WorldDatabaseConnection>::GetBaseFile()
 {
-    return _FULL_DATABASE;
+    return Revision::GetFullDatabase();
 }
 
 template<>

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -157,8 +157,6 @@ if( NOT WIN32 )
   )
 endif()
 
-add_dependencies(worldserver revision.h)
-
 if( UNIX AND NOT NOJEM AND NOT APPLE )
   set(worldserver_LINK_FLAGS "-pthread -lncurses ${worldserver_LINK_FLAGS}")
 endif()

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -44,7 +44,7 @@
 #include "BattlegroundMgr.h"
 #include "TCSoap.h"
 #include "CliRunnable.h"
-#include "SystemConfig.h"
+#include "Revision.h"
 #include "WorldSocket.h"
 #include "WorldSocketMgr.h"
 #include "DatabaseLoader.h"
@@ -125,7 +125,7 @@ extern int main(int argc, char** argv)
     // If logs are supposed to be handled async then we need to pass the io_service into the Log singleton
     sLog->Initialize(sConfigMgr->GetBoolDefault("Log.Async.Enable", false) ? &_ioService : nullptr);
 
-    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon)", _FULLVERSION);
+    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon)", Revision::GetFullVersion().c_str());
     TC_LOG_INFO("server.worldserver", "<Ctrl-C> to stop.\n");
     TC_LOG_INFO("server.worldserver", " ______                       __");
     TC_LOG_INFO("server.worldserver", "/\\__  _\\       __          __/\\ \\__");
@@ -234,7 +234,7 @@ extern int main(int argc, char** argv)
         TC_LOG_INFO("server.worldserver", "Starting up anti-freeze thread (%u seconds max stuck time)...", coreStuckTime);
     }
 
-    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon) ready...", _FULLVERSION);
+    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon) ready...", Revision::GetFullVersion().c_str());
 
     sScriptMgr->OnStartup();
 
@@ -470,7 +470,7 @@ bool StartDB()
     ClearOnlineAccounts();
 
     ///- Insert version info into DB
-    WorldDatabase.PExecute("UPDATE version SET core_version = '%s', core_revision = '%s'", _FULLVERSION, _HASH);        // One-time query
+    WorldDatabase.PExecute("UPDATE version SET core_version = '%s', core_revision = '%s'", Revision::GetFullVersion().c_str(), Revision::GetHash().c_str());        // One-time query
 
     sWorld->LoadDBVersion();
 
@@ -536,7 +536,7 @@ variables_map GetConsoleArguments(int argc, char** argv, std::string& configFile
     }
     else if (vm.count("version"))
     {
-        std::cout << _FULLVERSION << "\n";
+        std::cout << Revision::GetFullVersion() << "\n";
     }
 
     return vm;

--- a/src/server/worldserver/worldserver.rc
+++ b/src/server/worldserver/worldserver.rc
@@ -17,7 +17,7 @@
  */
 
 #include "resource.h"
-#include "revision.h"
+#include "revision_data.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is will allow more cache hits (ccache or PCH) when revision changed, as revision.h is no longer a header full of #defines that changes every compile unit it is included in.

I reported it back on 2010 without being properly handled: https://code.google.com/p/trinitycore/issues/detail?id=3406
Tested and working in linux
