### PR TITLE
Core/Build: Renamed Revision.h to GitRevision.h to avoid compile failure when old revision.h file is present

### DIFF
--- a/src/common/Debugging/WheatyExceptionReport.cpp
+++ b/src/common/Debugging/WheatyExceptionReport.cpp
@@ -20,7 +20,7 @@
 #include "WheatyExceptionReport.h"
 
 #include "Common.h"
-#include "Revision.h"
+#include "GitRevision.h"
 
 #define CrashFolder _T("Crashes")
 #pragma comment(linker, "/DEFAULTLIB:dbghelp.lib")
@@ -130,10 +130,10 @@ PEXCEPTION_POINTERS pExceptionInfo)
     SYSTEMTIME systime;
     GetLocalTime(&systime);
     sprintf(m_szDumpFileName, "%s\\%s_%s_[%u-%u_%u-%u-%u].dmp",
-        crash_folder_path, Revision::GetHash(), pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
+        crash_folder_path, GitRevision::GetHash(), pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
 
     sprintf(m_szLogFileName, "%s\\%s_%s_[%u-%u_%u-%u-%u].txt",
-        crash_folder_path, Revision::GetHash(), pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
+        crash_folder_path, GitRevision::GetHash(), pos, systime.wDay, systime.wMonth, systime.wHour, systime.wMinute, systime.wSecond);
 
     m_hDumpFile = CreateFile(m_szDumpFileName,
         GENERIC_WRITE,
@@ -439,7 +439,7 @@ PEXCEPTION_POINTERS pExceptionInfo)
         GetLocalTime(&systime);
 
         // Start out with a banner
-        _tprintf(_T("Revision: %s\r\n"), Revision::GetFullVersion());
+        _tprintf(_T("Revision: %s\r\n"), GitRevision::GetFullVersion());
         _tprintf(_T("Date %u:%u:%u. Time %u:%u \r\n"), systime.wDay, systime.wMonth, systime.wYear, systime.wHour, systime.wMinute);
         PEXCEPTION_RECORD pExceptionRecord = pExceptionInfo->ExceptionRecord;
 

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -33,7 +33,7 @@
 #include "AppenderDB.h"
 #include "ProcessPriority.h"
 #include "RealmList.h"
-#include "Revision.h"
+#include "GitRevision.h"
 #include "Util.h"
 #include <iostream>
 #include <boost/program_options.hpp>
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
     sLog->RegisterAppender<AppenderDB>();
     sLog->Initialize(nullptr);
 
-    TC_LOG_INFO("server.authserver", "%s (authserver)", Revision::GetFullVersion());
+    TC_LOG_INFO("server.authserver", "%s (authserver)", GitRevision::GetFullVersion());
     TC_LOG_INFO("server.authserver", "<Ctrl-C> to stop.\n");
     TC_LOG_INFO("server.authserver", "Using configuration file %s.", configFile.c_str());
     TC_LOG_INFO("server.authserver", "Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
@@ -293,7 +293,7 @@ variables_map GetConsoleArguments(int argc, char** argv, std::string& configFile
     if (variablesMap.count("help"))
         std::cout << all << "\n";
     else if (variablesMap.count("version"))
-        std::cout << Revision::GetFullVersion() << "\n";
+        std::cout << GitRevision::GetFullVersion() << "\n";
 
     return variablesMap;
 }

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -17,7 +17,7 @@
 
 #include "DBUpdater.h"
 #include "Log.h"
-#include "Revision.h"
+#include "GitRevision.h"
 #include "UpdateFetcher.h"
 #include "DatabaseLoader.h"
 #include "Config.h"
@@ -40,7 +40,7 @@ std::string DBUpdater<T>::GetSourceDirectory()
     if (!entry.empty())
         return entry;
     else
-        return Revision::GetSourceDirectory();
+        return GitRevision::GetSourceDirectory();
 }
 
 template<class T>
@@ -50,7 +50,7 @@ std::string DBUpdater<T>::GetMySqlCli()
     if (!entry.empty())
         return entry;
     else
-        return Revision::GetMySQLExecutable();
+        return GitRevision::GetMySQLExecutable();
 }
 
 // Auth Database
@@ -95,7 +95,7 @@ std::string DBUpdater<WorldDatabaseConnection>::GetTableName()
 template<>
 std::string DBUpdater<WorldDatabaseConnection>::GetBaseFile()
 {
-    return Revision::GetFullDatabase();
+    return GitRevision::GetFullDatabase();
 }
 
 template<>

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -60,7 +60,7 @@
 #include "Pet.h"
 #include "QuestDef.h"
 #include "ReputationMgr.h"
-#include "Revision.h"
+#include "GitRevision.h"
 #include "SkillDiscovery.h"
 #include "SocialMgr.h"
 #include "Spell.h"
@@ -15123,8 +15123,8 @@ void Player::AddQuest(Quest const* quest, Object* questGiver)
         PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_QUEST_TRACK);
         stmt->setUInt32(0, quest_id);
         stmt->setUInt32(1, GetGUIDLow());
-        stmt->setString(2, Revision::GetHash());
-        stmt->setString(3, Revision::GetDate());
+        stmt->setString(2, GitRevision::GetHash());
+        stmt->setString(3, GitRevision::GetDate());
 
         // add to Quest Tracker
         CharacterDatabase.Execute(stmt);

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -36,7 +36,7 @@
 #include "PlayerDump.h"
 #include "Player.h"
 #include "ReputationMgr.h"
-#include "Revision.h"
+#include "GitRevision.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
 #include "SocialMgr.h"
@@ -827,7 +827,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
 
         // send server info
         if (sWorld->getIntConfig(CONFIG_ENABLE_SINFO_LOGIN) == 1)
-            chH.PSendSysMessage(Revision::GetFullVersion());
+            chH.PSendSysMessage(GitRevision::GetFullVersion());
 
         TC_LOG_DEBUG("network", "WORLD: Sent server info");
     }

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -51,7 +51,7 @@
 #include "OutdoorPvPMgr.h"
 #include "Player.h"
 #include "PoolMgr.h"
-#include "Revision.h"
+#include "GitRevision.h"
 #include "ScriptMgr.h"
 #include "SkillDiscovery.h"
 #include "SkillExtraItems.h"
@@ -1789,7 +1789,7 @@ void World::SetInitialWorldSettings()
     m_startTime = m_gameTime;
 
     LoginDatabase.PExecute("INSERT INTO uptime (realmid, starttime, uptime, revision) VALUES(%u, %u, 0, '%s')",
-                            realmID, uint32(m_startTime), Revision::GetFullVersion());       // One-time query
+                            realmID, uint32(m_startTime), GitRevision::GetFullVersion());       // One-time query
 
     m_timers[WUPDATE_WEATHERS].SetInterval(1*IN_MILLISECONDS);
     m_timers[WUPDATE_AUCTIONS].SetInterval(MINUTE*IN_MILLISECONDS);

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -28,7 +28,7 @@ EndScriptData */
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "ScriptMgr.h"
-#include "Revision.h"
+#include "GitRevision.h"
 
 class server_commandscript : public CommandScript
 {
@@ -115,7 +115,7 @@ public:
         std::string uptime          = secsToTimeString(sWorld->GetUptime());
         uint32 updateTime           = sWorld->GetUpdateTime();
 
-        handler->SendSysMessage(Revision::GetFullVersion());
+        handler->SendSysMessage(GitRevision::GetFullVersion());
         handler->PSendSysMessage(LANG_CONNECTED_PLAYERS, playersNum, maxPlayersNum);
         handler->PSendSysMessage(LANG_CONNECTED_USERS, activeClientsNum, maxActiveClientsNum, queuedClientsNum, maxQueuedClientsNum);
         handler->PSendSysMessage(LANG_UPTIME, uptime.c_str());

--- a/src/server/shared/GitRevision.cpp
+++ b/src/server/shared/GitRevision.cpp
@@ -1,40 +1,40 @@
-#include "Revision.h"
+#include "GitRevision.h"
 #include "CompilerDefs.h"
 #include "revision_data.h"
 
-char const* Revision::GetHash()
+char const* GitRevision::GetHash()
 {
     return _HASH;
 }
 
-char const* Revision::GetDate()
+char const* GitRevision::GetDate()
 {
     return _DATE;
 }
 
-char const* Revision::GetBranch()
+char const* GitRevision::GetBranch()
 {
     return _BRANCH;
 }
 
-char const* Revision::GetSourceDirectory()
+char const* GitRevision::GetSourceDirectory()
 {
     return _SOURCE_DIRECTORY;
 }
 
-char const* Revision::GetMySQLExecutable()
+char const* GitRevision::GetMySQLExecutable()
 {
     return _MYSQL_EXECUTABLE;
 }
 
-char const* Revision::GetFullDatabase()
+char const* GitRevision::GetFullDatabase()
 {
     return _FULL_DATABASE;
 }
 
 #define _PACKAGENAME "TrinityCore"
 
-char const* Revision::GetFullVersion()
+char const* GitRevision::GetFullVersion()
 {
 #if PLATFORM == PLATFORM_WINDOWS
 # ifdef _WIN64
@@ -47,22 +47,22 @@ char const* Revision::GetFullVersion()
 #endif
 }
 
-char const* GetCompanyNameStr()
+char const* GitRevision::GetCompanyNameStr()
 {
     return VER_COMPANYNAME_STR;
 }
 
-char const* GetLegalCopyrightStr()
+char const* GitRevision::GetLegalCopyrightStr()
 {
     return VER_LEGALCOPYRIGHT_STR;
 }
 
-char const* GetFileVersionStr()
+char const* GitRevision::GetFileVersionStr()
 {
     return VER_FILEVERSION_STR;
 }
 
-char const* GetProductVersionStr()
+char const* GitRevision::GetProductVersionStr()
 {
     return VER_PRODUCTVERSION_STR;
 }

--- a/src/server/shared/GitRevision.h
+++ b/src/server/shared/GitRevision.h
@@ -15,12 +15,12 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __REVISION_H__
-#define __REVISION_H__
+#ifndef __GITREVISION_H__
+#define __GITREVISION_H__
 
 #include <string>
 
-namespace Revision
+namespace GitRevision
 {
     char const* GetHash();
     char const* GetDate();

--- a/src/server/shared/PrecompiledHeaders/sharedPCH.h
+++ b/src/server/shared/PrecompiledHeaders/sharedPCH.h
@@ -1,4 +1,4 @@
 //add here most rarely modified headers to speed up debug build compilation
 
 #include "TypeList.h"
-#include "Revision.h"
+#include "GitRevision.h"

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -44,7 +44,7 @@
 #include "BattlegroundMgr.h"
 #include "TCSoap.h"
 #include "CliRunnable.h"
-#include "Revision.h"
+#include "GitRevision.h"
 #include "WorldSocket.h"
 #include "WorldSocketMgr.h"
 #include "DatabaseLoader.h"
@@ -125,7 +125,7 @@ extern int main(int argc, char** argv)
     // If logs are supposed to be handled async then we need to pass the io_service into the Log singleton
     sLog->Initialize(sConfigMgr->GetBoolDefault("Log.Async.Enable", false) ? &_ioService : nullptr);
 
-    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon)", Revision::GetFullVersion());
+    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon)", GitRevision::GetFullVersion());
     TC_LOG_INFO("server.worldserver", "<Ctrl-C> to stop.\n");
     TC_LOG_INFO("server.worldserver", " ______                       __");
     TC_LOG_INFO("server.worldserver", "/\\__  _\\       __          __/\\ \\__");
@@ -234,7 +234,7 @@ extern int main(int argc, char** argv)
         TC_LOG_INFO("server.worldserver", "Starting up anti-freeze thread (%u seconds max stuck time)...", coreStuckTime);
     }
 
-    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon) ready...", Revision::GetFullVersion());
+    TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon) ready...", GitRevision::GetFullVersion());
 
     sScriptMgr->OnStartup();
 
@@ -470,7 +470,7 @@ bool StartDB()
     ClearOnlineAccounts();
 
     ///- Insert version info into DB
-    WorldDatabase.PExecute("UPDATE version SET core_version = '%s', core_revision = '%s'", Revision::GetFullVersion(), Revision::GetHash());        // One-time query
+    WorldDatabase.PExecute("UPDATE version SET core_version = '%s', core_revision = '%s'", GitRevision::GetFullVersion(), GitRevision::GetHash());        // One-time query
 
     sWorld->LoadDBVersion();
 
@@ -536,7 +536,7 @@ variables_map GetConsoleArguments(int argc, char** argv, std::string& configFile
     }
     else if (vm.count("version"))
     {
-        std::cout << Revision::GetFullVersion() << "\n";
+        std::cout << GitRevision::GetFullVersion() << "\n";
     }
 
     return vm;


### PR DESCRIPTION
This should fix the problems encountered in VS when build directory was not clean, introduced in rev 94f69fb1bcef103392ca27074ebb31ef2ebd27fb
