### PR TITLE
Core/Spells: Attempt at defining and using SPELL_ATTR6_UNK23

### DIFF
--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -515,7 +515,7 @@ enum SpellAttr6
     SPELL_ATTR6_ONLY_VISIBLE_TO_CASTER           = 0x00100000, // 20 Auras with this attribute are only visible to their caster (or pet's owner)
     SPELL_ATTR6_CLIENT_UI_TARGET_EFFECTS         = 0x00200000, // 21 it's only client-side attribute
     SPELL_ATTR6_UNK22                            = 0x00400000, // 22 only 72054
-    SPELL_ATTR6_UNK23                            = 0x00800000, // 23
+    SPELL_ATTR6_HARMFUL_SPELL_EFFECTS            = 0x00800000, // 23 All spell effects are harmful
     SPELL_ATTR6_CAN_TARGET_UNTARGETABLE          = 0x01000000, // 24
     SPELL_ATTR6_UNK25                            = 0x02000000, // 25 Exorcism, Flash of Light
     SPELL_ATTR6_UNK26                            = 0x04000000, // 26 related to player castable positive buff

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2365,8 +2365,8 @@ void SpellInfo::_InitializeExplicitTargetMask()
 
 bool SpellInfo::_IsPositiveEffect(uint8 effIndex, bool deep) const
 {
-    // not found a single positive spell with this attribute
-    if (HasAttribute(SPELL_ATTR0_NEGATIVE_1))
+    // not found a single positive spell with these attributes
+    if (HasAttribute(SPELL_ATTR0_NEGATIVE_1) || HasAttribute(SPELL_ATTR6_HARMFUL_SPELL_EFFECTS))
         return false;
 
     switch (SpellFamilyName)


### PR DESCRIPTION
Inspired by http://www.wowhead.com/spell=370/purge where the second flag is "All spell effects are harmful". I know that since wowhead is about the patches 6.X now, this is in no way a proof though.

However, I've not found a single spells with non harmful spell effect and that flag set to true, except _maybe_ Righteous Defense (spell ID 31790) and Scare Beast (1513).
