### PR TITLE
Core/Spells: Fixed gcc-4.7.x compile

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -690,6 +690,8 @@ class Spell
         // Targets store structures and data
         struct TargetInfo
         {
+            // a bug in gcc-4.7 needs a destructor to call move operator instead of copy operator in std::vector remove
+            ~TargetInfo() { }
             ObjectGuid targetGUID;
             uint64 timeDelay;
             SpellMissInfo missCondition:8;


### PR DESCRIPTION
This fixes the error while compiling 6.x with gcc-4.7.X due to a bug in compiler.
Source: http://stackoverflow.com/a/18655996
