### PR TITLE
Core/Unit: Do not remove aura with interrupt flag AURA_INTERRUPT_FLAG_NOT_UNDERWATER when already flying

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3192,7 +3192,7 @@ bool Unit::IsUnderWater() const
 
 void Unit::UpdateUnderwaterState(Map* m, float x, float y, float z)
 {
-    if (!IsPet() && !IsVehicle())
+    if (IsFlying() || (!IsPet() && !IsVehicle()))
         return;
 
     LiquidData liquid_status;


### PR DESCRIPTION
Closes #15266, based on work of @Killyana and @Rushor and their suggestions

Enables you to fly over water, when mount casting item/spell can not be caster in water, like the one in quest mentioned above.
