### PR TITLE
Core/Vehicles: Renamed VEHICLE_SEAT_FLAG_UNK3 to VEHICLE_SEAT_FLAG_HAS_EXTRA_SEAT

### DIFF
--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -687,7 +687,7 @@ enum VehicleSeatFlags
 {
     VEHICLE_SEAT_FLAG_HAS_LOWER_ANIM_FOR_ENTER                         = 0x00000001,
     VEHICLE_SEAT_FLAG_HAS_LOWER_ANIM_FOR_RIDE                          = 0x00000002,
-    VEHICLE_SEAT_FLAG_UNK3                                             = 0x00000004,
+    VEHICLE_SEAT_FLAG_HAS_EXTRA_SEAT                                   = 0x00000004, // For vehicles having 3 seats instead of 1 or 2 which is common (guess from sniff and quest #12973)
     VEHICLE_SEAT_FLAG_SHOULD_USE_VEH_SEAT_EXIT_ANIM_ON_VOLUNTARY_EXIT  = 0x00000008,
     VEHICLE_SEAT_FLAG_UNK5                                             = 0x00000010,
     VEHICLE_SEAT_FLAG_UNK6                                             = 0x00000020,

--- a/src/server/game/DataStores/DBCStructure.h
+++ b/src/server/game/DataStores/DBCStructure.h
@@ -1550,7 +1550,8 @@ struct VehicleSeatEntry
     uint32          FlagsC;                                 // 64
     uint32          UISkinFileDataID;                       // 65
 
-    bool CanEnterOrExit() const { return (Flags & VEHICLE_SEAT_FLAG_CAN_ENTER_OR_EXIT) != 0; }
+    bool CanEnterOrExit() const { return (Flags & (VEHICLE_SEAT_FLAG_CAN_ENTER_OR_EXIT | VEHICLE_SEAT_FLAG_HAS_EXTRA_SEAT)) || CanEnterOrExitReserved(); }
+    bool CanEnterOrExitReserved() const { return Flags & (VEHICLE_SEAT_FLAG_HAS_LOWER_ANIM_FOR_ENTER | VEHICLE_SEAT_FLAG_HAS_LOWER_ANIM_FOR_RIDE); }  // Veh Id 700 for example.
     bool CanSwitchFromSeat() const { return (Flags & VEHICLE_SEAT_FLAG_CAN_SWITCH) != 0; }
     bool IsUsableByOverride() const { return (Flags & (VEHICLE_SEAT_FLAG_UNCONTROLLED | VEHICLE_SEAT_FLAG_UNK18)
                                     || (FlagsB & (VEHICLE_SEAT_FLAG_B_USABLE_FORCED | VEHICLE_SEAT_FLAG_B_USABLE_FORCED_2 |


### PR DESCRIPTION
This, enables a few vehicles (like the one for quest 12973), which has (unlike near all the others), 3 seats instead of 1 or 2.

EXPERIMENTAL, Should be tested along with info contained in issue #9889 

Help in testing / feedback needed

Based on work by @SeTM

(For 3.3.5 see PR #15377)
