### PR TITLE
Script/BoreanTundra: Fix dialog for quest 11570

### DIFF
--- a/sql/updates/world/2015_09_01_00_world.sql
+++ b/sql/updates/world/2015_09_01_00_world.sql
@@ -1,0 +1,3 @@
+--
+-- Waypoint fix for quest "Escape from the Winterfin Caverns" (11570)
+UPDATE `script_waypoint` SET `location_x`=4279.54, `location_y`=6187.932, `location_z`=0.294670 WHERE `entry`=25208 AND `pointid`=41;

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -539,8 +539,9 @@ enum Lurgglbr
     FACTION_ESCORTEE_A                  = 774,
     FACTION_ESCORTEE_H                  = 775,
 
-    SAY_START_1                         = 0,
-    SAY_START_2                         = 1,
+    // Note: Intentionally out of order
+    SAY_START_1                         = 1,
+    SAY_START_2                         = 0,
     SAY_END_1                           = 2,
     SAY_END_2                           = 3
 };
@@ -596,12 +597,13 @@ public:
                     switch (IntroPhase)
                     {
                         case 1:
-                            Talk(SAY_START_1);
+                            if (Player* player = GetPlayerForEscort())
+                                Talk(SAY_START_1,player);
                             IntroPhase = 2;
                             IntroTimer = 7500;
                             break;
                         case 2:
-                            Talk(SAY_END_1);
+                            Talk(SAY_START_2);
                             IntroPhase = 3;
                             IntroTimer = 7500;
                             break;
@@ -611,12 +613,13 @@ public:
                             IntroTimer = 0;
                             break;
                         case 4:
-                            Talk(SAY_START_2);
+                            Talk(SAY_END_1);
                             IntroPhase = 5;
                             IntroTimer = 8000;
                             break;
                         case 5:
-                            Talk(SAY_END_2);
+                            if (Player* player = GetPlayerForEscort())
+                                Talk(SAY_END_2,player);
                             IntroPhase = 6;
                             IntroTimer = 2500;
                             break;


### PR DESCRIPTION
"Escape from the Winterfin Caverns"

This fixes the following bugs:
- Escortee NPC quotes are out of order (see https://github.com/TrinityCore/TrinityCore/pull/15396#issuecomment-136508740)
- Final escort waypoint is located incorrectly and causes the escorted NPC to drop all the way to the bottom of the ocean before quest completion is awarded.
