### PR TITLE
Core/Spells: Make players immune to taunt

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2510,6 +2510,17 @@ void Player::RemoveFromWorld()
     }
 }
 
+bool Player::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index) const
+{
+    // players are immune to taunt (the aura and the spell effect).
+    if (spellInfo->Effects[index].IsAura(SPELL_AURA_MOD_TAUNT))
+        return true;
+    if (spellInfo->Effects[index].IsEffect(SPELL_EFFECT_ATTACK_ME))
+        return true;
+    
+    return Unit::IsImmunedToSpellEffect(spellInfo, index);
+}
+
 void Player::RegenerateAll()
 {
     //if (m_regenTimer <= 500)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1118,6 +1118,8 @@ class Player : public Unit, public GridObject<Player>
 
         static bool BuildEnumData(PreparedQueryResult result, WorldPacket* data);
 
+        bool IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index) const override; // override Unit::IsImmunedToSpellEffect
+
         void SetInWater(bool apply);
 
         bool IsInWater() const override { return m_isInWater; }


### PR DESCRIPTION
Fixes https://github.com/TrinityCore/TrinityCore/issues/14968.

It makes players immune to both the spell effect ATTACK ME and the taunt aura. Also, the "immune" message correctly shows up when a taunt ability (warrior, druid, ..) is used against a player. An exception to this being Death Grip (see https://github.com/TrinityCore/TrinityCore/pull/15354#issuecomment-138095254). That should be the concern of another PR.

edit: update to the PR current situation.
