### PR TITLE
Core/Player: Always allow accounts with RBAC_PERM_COMMAND_GM to enter…

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1072,6 +1072,7 @@ class Player : public Unit, public GridObject<Player>
         bool isAcceptWhispers() const { return (m_ExtraFlags & PLAYER_EXTRA_ACCEPT_WHISPERS) != 0; }
         void SetAcceptWhispers(bool on) { if (on) m_ExtraFlags |= PLAYER_EXTRA_ACCEPT_WHISPERS; else m_ExtraFlags &= ~PLAYER_EXTRA_ACCEPT_WHISPERS; }
         bool IsGameMaster() const { return (m_ExtraFlags & PLAYER_EXTRA_GM_ON) != 0; }
+        bool CanBeGameMaster() const;
         void SetGameMaster(bool on);
         bool isGMChat() const { return (m_ExtraFlags & PLAYER_EXTRA_GM_CHAT) != 0; }
         void SetGMChat(bool on) { if (on) m_ExtraFlags |= PLAYER_EXTRA_GM_CHAT; else m_ExtraFlags &= ~PLAYER_EXTRA_GM_CHAT; }
@@ -2500,6 +2501,8 @@ class Player : public Unit, public GridObject<Player>
         bool IsHasDelayedTeleport() const { return m_bHasDelayedTeleport; }
         void SetDelayedTeleportFlag(bool setting) { m_bHasDelayedTeleport = setting; }
         void ScheduleDelayedOperation(uint32 operation) { if (operation < DELAYED_END) m_DelayedOperations |= operation; }
+        
+        bool IsInstanceLoginGameMasterException() const;
 
         MapReference m_mapRef;
 


### PR DESCRIPTION
Core/Player: Always allow accounts with RBAC_PERM_COMMAND_GM to enter instances on login

Always allow accounts with RBAC_PERM_COMMAND_GM to enter instances on login even if player had .gm off .
Send an ingame message to notify the user about the avoided kick.

The text should be moved to SQL.
Tested with a GM account and a normal user account in Black Temple, the GM received the ingame message without getting kicked and the user got teleported out.

Closes https://github.com/TrinityCore/TrinityCore/issues/15406
