### PR TITLE
AHBot "rebuild" command update

### DIFF
--- a/sql/updates/world/2015_09_02_05_world_ahbot_expire_by_house.sql
+++ b/sql/updates/world/2015_09_02_05_world_ahbot_expire_by_house.sql
@@ -1,0 +1,2 @@
+DELETE FROM `command` WHERE `name` = 'ahbot rebuild';
+INSERT INTO `command` (`name`, `permission`, `help`) values('ahbot rebuild','791','Syntax: .ahbot rebuild [all] [[a]lliance [h]orde [n]eutral]\r\n\r\nExpire all actual auction of ahbot except bided by player. Binded auctions included to expire if \"all\" option used. If one of \"a\" \"h\" or \"n\" option is used, only the auctions of that house will expire otherwise all houses will expire. Ahbot re-fill auctions base at current settings then.');

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -398,10 +398,13 @@ void AuctionHouseBot::PrepareStatusInfos(AuctionHouseBotStatusInfo& statusInfo)
     }
 }
 
-void AuctionHouseBot::Rebuild(bool all)
+void AuctionHouseBot::Rebuild(bool all, uint32 houseId)
 {
     for (uint32 i = 0; i < MAX_AUCTION_HOUSE_TYPE; ++i)
     {
+        if ((houseId != MAX_AUCTION_HOUSE_TYPE) && (i != houseId))
+            continue; // if specific house ID sent, increment until we get a match
+
         AuctionHouseObject* auctionHouse = sAuctionMgr->GetAuctionsMap(AuctionHouseType(i));
         for (AuctionHouseObject::AuctionEntryMap::const_iterator itr = auctionHouse->GetAuctionsBegin(); itr != auctionHouse->GetAuctionsEnd(); ++itr)
             if (!itr->second->owner)                        // ahbot auction

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.h
@@ -283,7 +283,7 @@ public:
     void SetItemsAmount(uint32(&vals)[MAX_AUCTION_QUALITY]);
     void SetItemsAmountForQuality(AuctionQuality quality, uint32 val);
     void ReloadAllConfig();
-    void Rebuild(bool all);
+    void Rebuild(bool all, uint32 houseId);
 
     void PrepareStatusInfos(AuctionHouseBotStatusInfo& statusInfo);
 private:

--- a/src/server/scripts/Commands/cs_ahbot.cpp
+++ b/src/server/scripts/Commands/cs_ahbot.cpp
@@ -146,12 +146,35 @@ public:
     static bool HandleAHBotRebuildCommand(ChatHandler* /*handler*/, const char* args)
     {
         char* arg = strtok((char*)args, " ");
+        char* ahMapIdStr = strtok(NULL, " ");
+        uint32 ahMapID = MAX_AUCTION_HOUSE_TYPE;
 
         bool all = false;
         if (arg && strcmp(arg, "all") == 0)
             all = true;
 
-        sAuctionBot->Rebuild(all);
+        if (ahMapIdStr)
+        {
+            switch (ahMapIdStr[0])
+            {
+                case 'n':
+                case 'N':
+                    ahMapID = AUCTION_HOUSE_NEUTRAL;
+                    break;
+                case 'a':
+                case 'A':
+                    ahMapID = AUCTION_HOUSE_ALLIANCE;
+                    break;
+                case 'h':
+                case 'H':
+                    ahMapID = AUCTION_HOUSE_HORDE;
+                    break;
+                default:
+                    break;
+            }
+        }
+        
+        sAuctionBot->Rebuild(all, ahMapID);
         return true;
     }
 


### PR DESCRIPTION
Update AHBot "rebuild" command to allow specifying a single house to expire auctions from.

example (neutral only): .ahbot rebuild all n
example (alliance only): .ahbot rebuild all a
