### PR TITLE
Split worldSocket bind fix 

### DIFF
--- a/src/server/bnetserver/Main.cpp
+++ b/src/server/bnetserver/Main.cpp
@@ -142,8 +142,10 @@ int main(int argc, char** argv)
 
     _ioService = new boost::asio::io_service();
 
+    std::string bindIp = sConfigMgr->GetStringDefault("BindIP", "0.0.0.0");
+
     // Get the list of realms for the server
-    sRealmList->Initialize(*_ioService, sConfigMgr->GetIntDefault("RealmsStateUpdateDelay", 10), worldListenPort);
+    sRealmList->Initialize(*_ioService, sConfigMgr->GetIntDefault("RealmsStateUpdateDelay", 10), bindIp, worldListenPort);
 
     // Start the listening port (acceptor) for auth connections
     int32 bnport = sConfigMgr->GetIntDefault("BattlenetPort", 1119);
@@ -154,8 +156,6 @@ int main(int argc, char** argv)
         delete _ioService;
         return 1;
     }
-
-    std::string bindIp = sConfigMgr->GetStringDefault("BindIP", "0.0.0.0");
 
     sSessionMgr.StartNetwork(*_ioService, bindIp, bnport);
 

--- a/src/server/bnetserver/Realms/RealmList.cpp
+++ b/src/server/bnetserver/Realms/RealmList.cpp
@@ -36,7 +36,7 @@ RealmList::~RealmList()
 }
 
 // Load the realm list from the database
-void RealmList::Initialize(boost::asio::io_service& ioService, uint32 updateInterval, uint16 worldListenPort)
+void RealmList::Initialize(boost::asio::io_service& ioService, uint32 updateInterval, const std::string & bindIp, uint16 worldListenPort)
 {
     _updateInterval = updateInterval;
     _updateTimer = new boost::asio::deadline_timer(ioService);
@@ -45,7 +45,7 @@ void RealmList::Initialize(boost::asio::io_service& ioService, uint32 updateInte
     // Get the content of the realmlist table in the database
     UpdateRealms(boost::system::error_code());
 
-    _worldListener = new WorldListener(worldListenPort);
+    _worldListener = new WorldListener(bindIp, worldListenPort);
     _worldListener->Start();
 }
 

--- a/src/server/bnetserver/Realms/RealmList.h
+++ b/src/server/bnetserver/Realms/RealmList.h
@@ -43,7 +43,7 @@ public:
 
     ~RealmList();
 
-    void Initialize(boost::asio::io_service& ioService, uint32 updateInterval, uint16 worldListenPort);
+    void Initialize(boost::asio::io_service& ioService, uint32 updateInterval, const std::string & bindIp, uint16 worldListenPort);
     void Close();
 
     RealmMap const& GetRealms() const { return _realms; }

--- a/src/server/bnetserver/Realms/WorldListener.cpp
+++ b/src/server/bnetserver/Realms/WorldListener.cpp
@@ -32,8 +32,9 @@ WorldListener::HandlerTable::HandlerTable()
 #undef DEFINE_HANDLER
 }
 
-WorldListener::WorldListener(uint16 worldListenPort) : _worldListenPort(worldListenPort)
+WorldListener::WorldListener(const std::string & bindIp, uint16 worldListenPort) : _worldListenPort(worldListenPort)
 {
+    _bindIp = bindIp;
     _worldSocket = sIpcContext->CreateNewSocket(zmqpp::socket_type::pull);
 }
 
@@ -65,7 +66,7 @@ void WorldListener::HandleOpen()
 {
     try
     {
-        _worldSocket->bind(std::string("tcp://*:") + std::to_string(_worldListenPort));
+        _worldSocket->bind(std::string("tcp://"+_bindIp+":") + std::to_string(_worldListenPort));
     }
     catch (zmqpp::zmq_internal_exception& ex)
     {

--- a/src/server/bnetserver/Realms/WorldListener.h
+++ b/src/server/bnetserver/Realms/WorldListener.h
@@ -24,7 +24,7 @@
 class WorldListener : public ZMQTask
 {
 public:
-    explicit WorldListener(uint16 worldListenPort);
+    explicit WorldListener(const std::string & bindIp, uint16 worldListenPort);
     ~WorldListener();
     void Run() override;
 
@@ -57,6 +57,7 @@ private:
 
     zmqpp::socket* _worldSocket;
     uint16 _worldListenPort;
+    std::string _bindIp;
     static HandlerTable const _handlers;
 };
 


### PR DESCRIPTION
Split from PR #15422

The existing code creates a ZMQ socket bound to all addresses, which is somewhat unexpected on a multihomed server (and an issue if you decide to run multiple servers bound to IPs).

This simply passes the BindIp parameter to RealmList so it obeys the user configuration.
