### PR TITLE
Core/BG: Fix score in AB

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundAB.h
@@ -132,7 +132,7 @@ enum BG_AB_Timers
 enum BG_AB_Score
 {
     BG_AB_WARNING_NEAR_VICTORY_SCORE    = 1400,
-    BG_AB_MAX_TEAM_SCORE                = 1600
+    BG_AB_MAX_TEAM_SCORE                = 1500
 };
 
 /* do NOT change the order, else wrong behaviour */


### PR DESCRIPTION
Battleground Arathi basin have max score 1500.
