### PR TITLE
Core/Unit: Player-summoned creatures reduce PlayerDamageReq

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -721,7 +721,7 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
         if (!victim->ToCreature()->hasLootRecipient())
             victim->ToCreature()->SetLootRecipient(this);
 
-        if (IsControlledByPlayer())
+        if (IsControlledByPlayer() || (ToTempSummon() && ToTempSummon()->GetSummoner() && ToTempSummon()->GetSummoner()->GetTypeId() == TYPEID_PLAYER))
             victim->ToCreature()->LowerPlayerDamageReq(health < damage ?  health : damage);
     }
 


### PR DESCRIPTION
Allow player-created temporary summons (quest "helper" NPCs summoned by item etc.) to contribute to the 50% player damage requirement for kill credit.

Fixes quests such as "Valduran the Stormborn" (12984) or "The Air Stands Still" (13125) which previously required the player to out-damage the "helper" NPC to get credit.
