### PR TITLE
Fix logic in Item::CanTransmogrifyItemWithItem

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -1428,12 +1428,12 @@ bool Item::CanTransmogrifyItemWithItem(Item const* transmogrified, WorldPackets:
         ))
         return false;
 
-    if (source->GetInventoryType() != target->GetInventoryType() &&
-        (source->GetClass() != ITEM_CLASS_WEAPON || !((target->IsRangedWeapon() ||
-            ((target->GetInventoryType() == INVTYPE_WEAPONMAINHAND || target->GetInventoryType() == INVTYPE_WEAPONOFFHAND) &&
-                source->GetInventoryType() == INVTYPE_WEAPON)))) ||
-        (source->GetClass() != ITEM_CLASS_ARMOR ||
-            !((source->GetInventoryType() == INVTYPE_CHEST || source->GetInventoryType() == INVTYPE_ROBE) &&
+    if (!(source->GetInventoryType() == target->GetInventoryType() || target->IsRangedWeapon() ||
+        (source->GetClass() == ITEM_CLASS_WEAPON &&
+            (target->GetInventoryType() == INVTYPE_WEAPONMAINHAND || target->GetInventoryType() == INVTYPE_WEAPONOFFHAND) &&
+                source->GetInventoryType() == INVTYPE_WEAPON) ||
+        (source->GetClass() == ITEM_CLASS_ARMOR &&
+            (source->GetInventoryType() == INVTYPE_CHEST || source->GetInventoryType() == INVTYPE_ROBE) &&
                 (target->GetInventoryType() == INVTYPE_CHEST || target->GetInventoryType() == INVTYPE_ROBE))))
         return false;
 

--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -1389,30 +1389,52 @@ bool Item::HasStats(WorldPackets::Item::ItemInstance const& itemInstance, BonusD
 
 bool Item::CanTransmogrifyItemWithItem(Item const* transmogrified, WorldPackets::Item::ItemInstance const& transmogrifier, BonusData const* bonus)
 {
-    ItemTemplate const* proto1 = sObjectMgr->GetItemTemplate(transmogrifier.ItemID); // source
-    ItemTemplate const* proto2 = transmogrified->GetTemplate(); // dest
+    ItemTemplate const* source = sObjectMgr->GetItemTemplate(transmogrifier.ItemID); // source
+    ItemTemplate const* target = transmogrified->GetTemplate(); // dest
 
-    if (sDB2Manager.GetItemDisplayId(proto1->GetId(), bonus->AppearanceModID) == transmogrified->GetDisplayId())
+    if (!source || !target)
+        return false;
+
+    if (sDB2Manager.GetItemDisplayId(source->GetId(), bonus->AppearanceModID) == transmogrified->GetDisplayId())
         return false;
 
     if (!transmogrified->CanTransmogrify() || !CanBeTransmogrified(transmogrifier, bonus))
         return false;
 
-    if (proto1->GetInventoryType() == INVTYPE_BAG ||
-        proto1->GetInventoryType() == INVTYPE_RELIC ||
-        proto1->GetInventoryType() == INVTYPE_BODY ||
-        proto1->GetInventoryType() == INVTYPE_FINGER ||
-        proto1->GetInventoryType() == INVTYPE_TRINKET ||
-        proto1->GetInventoryType() == INVTYPE_AMMO ||
-        proto1->GetInventoryType() == INVTYPE_QUIVER)
+    if (source->GetInventoryType() == INVTYPE_BAG ||
+        source->GetInventoryType() == INVTYPE_RELIC ||
+        source->GetInventoryType() == INVTYPE_BODY ||
+        source->GetInventoryType() == INVTYPE_FINGER ||
+        source->GetInventoryType() == INVTYPE_TRINKET ||
+        source->GetInventoryType() == INVTYPE_AMMO ||
+        source->GetInventoryType() == INVTYPE_QUIVER)
         return false;
 
-    if (proto1->GetSubClass() != proto2->GetSubClass() && (proto1->GetClass() != ITEM_CLASS_WEAPON || !proto2->IsRangedWeapon() || !proto1->IsRangedWeapon()))
+    if (source->IsRangedWeapon() != target->IsRangedWeapon())
         return false;
 
-    if (proto1->GetInventoryType() != proto2->GetInventoryType() &&
-        (proto1->GetClass() != ITEM_CLASS_WEAPON || (proto2->GetInventoryType() != INVTYPE_WEAPONMAINHAND && proto2->GetInventoryType() != INVTYPE_WEAPONOFFHAND)) &&
-        (proto1->GetClass() != ITEM_CLASS_ARMOR || (proto1->GetInventoryType() != INVTYPE_CHEST && proto2->GetInventoryType() != INVTYPE_ROBE && proto1->GetInventoryType() != INVTYPE_ROBE && proto2->GetInventoryType() != INVTYPE_CHEST)))
+    if (source->GetClass() != target->GetClass())
+        return false;
+
+    if (source->GetSubClass() != target->GetSubClass() && !source->IsRangedWeapon() && !(source->GetClass() == ITEM_CLASS_WEAPON &&
+        (
+            ((source->GetSubClass() == ITEM_SUBCLASS_WEAPON_SWORD || source->GetSubClass() == ITEM_SUBCLASS_WEAPON_AXE || source->GetSubClass() == ITEM_SUBCLASS_WEAPON_MACE) &&
+                (target->GetSubClass() == ITEM_SUBCLASS_WEAPON_SWORD || target->GetSubClass() == ITEM_SUBCLASS_WEAPON_AXE || target->GetSubClass() == ITEM_SUBCLASS_WEAPON_MACE)) ||
+            ((source->GetSubClass() == ITEM_SUBCLASS_WEAPON_SWORD2 || source->GetSubClass() == ITEM_SUBCLASS_WEAPON_AXE2 || source->GetSubClass() == ITEM_SUBCLASS_WEAPON_MACE2) &&
+                (target->GetSubClass() == ITEM_SUBCLASS_WEAPON_SWORD2 || target->GetSubClass() == ITEM_SUBCLASS_WEAPON_AXE2 || target->GetSubClass() == ITEM_SUBCLASS_WEAPON_MACE2)) ||
+            ((source->GetSubClass() == ITEM_SUBCLASS_WEAPON_POLEARM || source->GetSubClass() == ITEM_SUBCLASS_WEAPON_STAFF) &&
+                (target->GetSubClass() == ITEM_SUBCLASS_WEAPON_POLEARM || target->GetSubClass() == ITEM_SUBCLASS_WEAPON_STAFF))
+            )
+        ))
+        return false;
+
+    if (source->GetInventoryType() != target->GetInventoryType() &&
+        (source->GetClass() != ITEM_CLASS_WEAPON || !((target->IsRangedWeapon() ||
+            ((target->GetInventoryType() == INVTYPE_WEAPONMAINHAND || target->GetInventoryType() == INVTYPE_WEAPONOFFHAND) &&
+                source->GetInventoryType() == INVTYPE_WEAPON)))) ||
+        (source->GetClass() != ITEM_CLASS_ARMOR ||
+            !((source->GetInventoryType() == INVTYPE_CHEST || source->GetInventoryType() == INVTYPE_ROBE) &&
+                (target->GetInventoryType() == INVTYPE_CHEST || target->GetInventoryType() == INVTYPE_ROBE))))
         return false;
 
     return true;

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -1141,6 +1141,11 @@ void WorldSession::HandleTransmogrifyItems(WorldPackets::Item::TransmogrifyItems
             TC_LOG_DEBUG("network", "WORLD: HandleTransmogrifyItems - Player (%s, name: %s) tried to transmogrify an invalid item in a valid slot (slot: %u).", player->GetGUID().ToString().c_str(), player->GetName().c_str(), transmogItem.Slot);
             return;
         }
+        if (player->CanUseItem(itemTransmogrified->GetTemplate()) != EQUIP_ERR_OK)
+        {
+            TC_LOG_DEBUG("network", "WORLD: HandleTransmogrifyItems - Player (%s, name: %s) tried to transmogrify an unequippable item in a valid slot (slot: %u).", player->GetGUID().ToString().c_str(), player->GetName().c_str(), transmogItem.Slot);
+            return;
+        }
 
         WorldPackets::Item::ItemInstance itemInstance;
         BonusData const* bonus = nullptr;
@@ -1151,6 +1156,11 @@ void WorldSession::HandleTransmogrifyItems(WorldPackets::Item::TransmogrifyItems
             if (!itemTransmogrifier)
             {
                 TC_LOG_DEBUG("network", "WORLD: HandleTransmogrifyItems - Player (%s, name: %s) tried to transmogrify with an invalid item (%s).", player->GetGUID().ToString().c_str(), player->GetName().c_str(), transmogItem.SrcItemGUID->ToString().c_str());
+                return;
+            }
+            if (player->CanUseItem(itemTransmogrifier->GetTemplate()) != EQUIP_ERR_OK)
+            {
+                TC_LOG_DEBUG("network", "WORLD: HandleTransmogrifyItems - Player (%s, name: %s) tried to transmogrify with an unequippable item (%s).", player->GetGUID().ToString().c_str(), player->GetName().c_str(), transmogItem.SrcItemGUID->ToString().c_str());
                 return;
             }
 
@@ -1166,6 +1176,12 @@ void WorldSession::HandleTransmogrifyItems(WorldPackets::Item::TransmogrifyItems
             if (!itemTransmogrifier)
             {
                 TC_LOG_DEBUG("network", "WORLD: HandleTransmogrifyItems - Player (%s, name: %s) tried to transmogrify with an invalid void storage item (%s).", player->GetGUID().ToString().c_str(), player->GetName().c_str(), transmogItem.SrcVoidItemGUID->ToString().c_str());
+                return;
+            }
+            ItemTemplate const * transmogrifierTemplate = sObjectMgr->GetItemTemplate(itemTransmogrifier->ItemEntry);
+            if (player->CanUseItem(transmogrifierTemplate) != EQUIP_ERR_OK)
+            {
+                TC_LOG_DEBUG("network", "WORLD: HandleTransmogrifyItems - Player (%s, name: %s) tried to transmogrify with an unequippable void storage item (%s).", player->GetGUID().ToString().c_str(), player->GetName().c_str(), transmogItem.SrcVoidItemGUID->ToString().c_str());
                 return;
             }
 


### PR DESCRIPTION
Closes https://github.com/TrinityCore/TrinityCore/issues/15475

```
// weapon - one hand weapon transmogrified, can use either main or off (or one hand)
    !(TRANSMOGGED == INVTYPE_WEAPON && TRANSMOGRIFIER == {INVTYPE_WEAPONMAINHAND, INVTYPE_WEAPONOFFHAND)})
<=> (TRANSMOGGED != INVTYPE_WEAPON || TRANSMOGRIFIER != {INVTYPE_WEAPONMAINHAND, INVTYPE_WEAPONOFFHAND)})

// armor - if both pieces are of {chest, robe} allow transmogrify
    !((proto1->GetInventoryType() == INVTYPE_ROBE && proto2->GetInventoryType() == INVTYPE_CHEST) || (proto2->GetInventoryType() == INVTYPE_ROBE && proto1->GetInventoryType() == INVTYPE_CHEST))
<=> ((proto1->GetInventoryType() != INVTYPE_ROBE || proto2->GetInventoryType() == INVTYPE_CHEST) && (proto2->GetInventoryType() != INVTYPE_ROBE || proto1->GetInventoryType() != INVTYPE_CHEST))
```
