### PR TITLE
Creature/SmartAI: Fix creature aggression behavior

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.cpp
+++ b/src/server/game/AI/CoreAI/UnitAI.cpp
@@ -29,7 +29,15 @@
 void UnitAI::AttackStart(Unit* victim)
 {
     if (victim && me->Attack(victim, true))
+    {
+        // Clear distracted state on attacking
+        if (me->HasUnitState(UNIT_STATE_DISTRACTED))
+        {
+            me->ClearUnitState(UNIT_STATE_DISTRACTED);
+            me->GetMotionMaster()->Clear();
+        }
         me->GetMotionMaster()->MoveChase(victim);
+    }
 }
 
 void UnitAI::AttackStartCaster(Unit* victim, float dist)

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -453,45 +453,15 @@ void SmartAI::MoveInLineOfSight(Unit* who)
 
     GetScript()->OnMoveInLineOfSight(who);
 
-    if (me->HasReactState(REACT_PASSIVE) || AssistPlayerInCombat(who))
+    if (AssistPlayerInCombat(who))
         return;
 
-    if (!CanAIAttack(who))
-        return;
-
-    if (!me->CanStartAttack(who, false))
-        return;
-
-    if (me->IsHostileTo(who))
-    {
-        float fAttackRadius = me->GetAttackDistance(who);
-        if (me->IsWithinDistInMap(who, fAttackRadius) && me->IsWithinLOSInMap(who))
-        {
-            if (!me->GetVictim())
-            {
-                // Clear distracted state on combat
-                if (me->HasUnitState(UNIT_STATE_DISTRACTED))
-                {
-                   me->ClearUnitState(UNIT_STATE_DISTRACTED);
-                   me->GetMotionMaster()->Clear();
-                }
-
-                AttackStart(who);
-            }
-            else/* if (me->GetMap()->IsDungeon())*/
-            {
-                who->SetInCombatWith(me);
-                me->AddThreat(who, 0.0f);
-            }
-        }
-    }
+    CreatureAI::MoveInLineOfSight(who);
 }
 
 bool SmartAI::CanAIAttack(const Unit* /*who*/) const
 {
-    if (me->GetReactState() == REACT_PASSIVE)
-        return false;
-    return true;
+    return !(me->HasReactState(REACT_PASSIVE));
 }
 
 bool SmartAI::AssistPlayerInCombat(Unit* who)


### PR DESCRIPTION
Clean up SmartAI::MoveInLineOfSight. Remove tons of duplicate logic and forward to CreatureAI::MoveInLineOfSight instead of using its own (incorrect) implementation.

Fixes and closes #15482.

Justifications for removed checks:

```
HasReactState(REACT_PASSIVE)? Handled in Creature::CanCreatureAttack
CanAIAttack? Is called by Creature::CanCreatureAttack (to check the above)
CanStartAttack? Is checked by CreatureAI::MoveInLineOfSight
IsHostileTo? Checked by Unit::_IsValidAttackTarget (called from Creature::CanCreatureAttack)
IsWithinDistInMap? Done by Creature::CanStartAttack
IsWithinLOSInMap? Done by Creature::CanStartAttack
```

Also fixes non-SAI creatures not moving to engage while affected by Rogue distract. This fixes and closes #7197.
