### PR TITLE
Scripts/Naxxramas: Thaddius: Complete rewrite

### DIFF
--- a/sql/updates/world/2015_10_PR15523_world.sql
+++ b/sql/updates/world/2015_10_PR15523_world.sql
@@ -1,0 +1,93 @@
+-- creature (2 entries)
+SET @CGUID = 49818;
+-- gameobject (2 entries)
+SET @OGUID = 5747;
+
+-- ensure spell data for difficulties is there
+DELETE FROM `spelldifficulty_dbc` WHERE `id` IN (28134,28135,28167);
+INSERT INTO `spelldifficulty_dbc` (`id`,`spellid0`,`spellid1`,`spellid2`,`spellid3`) VALUES
+(28134,54529,28134,0,0), -- Stalagg - Power Surge (yes, these are supposed to be backwards)
+(28135,28135,54528,0,0), -- Feugen - Static Field
+(28167,28167,54531,0,0); -- Thaddius - Chain Lightning
+
+-- magnetic pull
+DELETE FROM `spell_scripts` WHERE `id`=54517;
+DELETE FROM `spell_script_names` WHERE `spell_id`=54517;
+INSERT INTO `spell_script_names` (`spell_id`,`scriptname`) VALUES (54517,"spell_thaddius_magnetic_pull");
+
+-- thaddius
+UPDATE `creature_template` set `unit_flags`=64 WHERE `entry`=15928;
+UPDATE `creature` set `MovementType`=0 WHERE `id`=15928;
+
+-- tesla coil
+UPDATE `creature_template` set `inhabittype`=4,`unit_flags`=33554688,`unit_flags2`=2048,`ScriptName`="npc_tesla",`MovementType`=0,`flags_extra`=0 WHERE `entry`=16218;
+DELETE FROM `creature_addon` WHERE `guid` IN (select `guid` from `creature` WHERE `id` = 16218);
+DELETE FROM `creature` WHERE `id` = 16218;
+INSERT INTO `creature` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`movementtype`,`VerifiedBuild`) VALUES
+(@CGUID+0,16218,533,3,1,3527.807,-2952.382,319.3258,3.909538,0,0,0,0),
+(@CGUID+1,16218,533,3,1,3487.762,-2911.198,319.4061,3.909538,0,0,0,0);
+INSERT INTO `creature_addon` (`guid`,`auras`) VALUES
+(@CGUID+0,28109),
+(@CGUID+1,28097);
+
+-- tesla coil search trigger range (index 30 is 500 yards)
+UPDATE `spell_dbc` set `EffectRadiusIndex1`=30, `AttributesEx2`=0 WHERE `Id` IN (28098,28110);
+-- tesla coil search ignores LoS
+DELETE FROM `disables` WHERE `sourceType`=0 AND `entry` IN (28096,28098,28110,28111);
+INSERT INTO `disables` (`sourceType`,`entry`,`flags`,`comment`) VALUES
+(0,28098,64,"Stalagg Tesla Periodic - Ignore LoS"),
+(0,28096,64,"Stalagg Tesla Visual - Ignore LoS"),
+(0,28110,64,"Feugen Tesla Periodic - Ignore LoS"),
+(0,28111,64,"Feugen Tesla Visual - Ignore LoS");
+-- tesla coil shock visual needs implicit target
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry` IN (28096,28111,28159);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`Comment`) VALUES
+(13,1,28096,0,0,31,0,3,15929,0,0,"Stalagg Chain Visual - Target Stalagg"),
+(13,1,28111,0,0,31,0,3,15930,0,0,"Feugen Chain Visual - Target Feugen"),
+(13,1,28159,0,0,31,0,3,15928,0,0,"Thaddius Shock Visual - Target Thaddius");
+
+-- tesla coil visual
+DELETE FROM `gameobject` WHERE `id` IN (181477,181478);
+INSERT INTO `gameobject` (`guid`,`id`,`map`,`spawnMask`,`phaseMask`,`position_x`,`position_y`,`position_z`,`orientation`,`rotation0`,`rotation1`,`rotation2`,`rotation3`,`spawntimesecs`,`VerifiedBuild`) VALUES
+(@OGUID+0,181477,533,3,1,3527.94,-2952.263,318.8983,3.141593,0,0,-1,0,0,0),
+(@OGUID+1,181478,533,3,1,3487.324,-2911.383,318.8983,3.141593,0,0,-1,0,0,0);
+
+-- polarity shift scripts
+DELETE FROM `spell_scripts` WHERE `id` IN (28059,28062,28084,28085,28089,29659,29660);
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (28059,28062,28084,28085,28089,29659,29660);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(28062,"spell_thaddius_polarity_charge"),
+(28085,"spell_thaddius_polarity_charge"),
+(28089,"spell_thaddius_polarity_shift");
+
+-- shocking! achievement
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (7604,7605);
+INSERT INTO `achievement_criteria_data` (`criteria_id`,`type`,`value1`,`value2`,`ScriptName`) VALUES
+(7604,11,0,0,"achievement_thaddius_shocking"),
+(7604,12,0,0,""),
+(7605,11,0,0,"achievement_thaddius_shocking"),
+(7605,12,1,0,"");
+
+-- move 20% trigger rate for "killed target" texts from script to DB
+UPDATE `creature_text` set `probability`=20 WHERE `entry`=15929 AND `groupid`=1;
+UPDATE `creature_text` set `probability`=20 WHERE `entry`=15930 AND `groupid`=1;
+UPDATE `creature_text` set `probability`=20 WHERE `entry`=15928 AND `groupid`=2;
+
+-- add missing creature_text entries for thaddius, feugen, stalagg and tesla coil
+DELETE FROM `creature_text` WHERE `entry`=15928 AND `groupid`=6;
+DELETE FROM `creature_text` WHERE `entry` IN (15929,15930) AND `groupid` IN (3,4);
+DELETE FROM `creature_text` WHERE `entry`=16218;
+INSERT INTO `creature_text` (`entry`,`groupid`,`id`,`text`,`type`,`probability`,`BroadcastTextId`,`TextRange`,`comment`) VALUES
+(15928,6,0,"The polarity has shifted!",41,100,32324,3,"Thaddius EMOTE_POLARITY_SHIFTED"),
+(15929,3,0,"%s dies.",16,100,10453,3,"Stalagg EMOTE_FEIGN_DEATH"),
+(15930,3,0,"%s dies.",16,100,10453,3,"Feugen EMOTE_FEIGN_DEATH"),
+(15929,4,0,"%s is jolted back to life!",16,100,12155,3,"Stalagg EMOTE_FEIGN_REVIVE"),
+(15930,4,0,"%s is jolted back to life!",16,100,12155,3,"Feugen EMOTE_FEIGN_REVIVE"),
+(16218,0,0,"%s loses its link!",41,100,12156,3,"Tesla Coil EMOTE_TESLA_LINK_BREAKS"),
+(16218,1,0,"%s overloads!",41,100,12178,3,"Tesla Coil EMOTE_TESLA_OVERLOAD");
+
+
+-- trigger when entering thaddius' room
+DELETE FROM `areatrigger_scripts` WHERE `entry`=4113;
+INSERT INTO `areatrigger_scripts` (`entry`,`ScriptName`) VALUES
+(4113,"at_thaddius_entrance");

--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -19,48 +19,104 @@
 #include "ScriptedCreature.h"
 #include "SpellScript.h"
 #include "Player.h"
+#include "ObjectGuid.h"
 #include "naxxramas.h"
 
-//Stalagg
-enum StalaggYells
+
+enum Phases
 {
-    SAY_STAL_AGGRO          = 0,
-    SAY_STAL_SLAY           = 1,
-    SAY_STAL_DEATH          = 2
+    PHASE_NOT_ENGAGED       = 1,
+    PHASE_PETS,
+    PHASE_TRANSITION,
+    PHASE_THADDIUS,
+    PHASE_RESETTING
 };
 
-enum StalagSpells
+enum AIActions
 {
-    SPELL_POWERSURGE        = 28134,
-    SPELL_MAGNETIC_PULL     = 28338,
-    SPELL_STALAGG_TESLA     = 28097
+    ACTION_RESET_ENCOUNTER_TIMER = -1, // sent from instance AI
+    ACTION_BEGIN_RESET_ENCOUNTER =  0, // sent from thaddius to pets to trigger despawn and encounter reset
+    ACTION_RESET_ENCOUNTER, // sent from thaddius to pets to trigger respawn and full reset
+    ACTION_FEUGEN_DIED, // sent from respective pet to thaddius to indicate death
+    ACTION_STALAGG_DIED, // ^
+    ACTION_FEUGEN_RESET, // pet to thaddius
+    ACTION_STALAGG_RESET, // ^
+    ACTION_FEUGEN_AGGRO, // pet to thaddius on combat start
+    ACTION_STALAGG_AGGRO, // ^
+    ACTION_FEUGEN_REVIVING_FX, // thaddius to pet when pet reports its death
+    ACTION_STALAGG_REVIVING_FX, // ^
+    ACTION_FEUGEN_REVIVED, // thaddius to pet when pet should revive
+    ACTION_STALAGG_REVIVED, // ^
+    ACTION_TRANSITION, // thaddius to pets when transition starts (coil overload anim)
+    ACTION_TRANSITION_2, // thaddius to pets to make the coils shock him
+    ACTION_TRANSITION_3, // thaddius to pets to disable coil GO after spawn
+
+    ACTION_POLARITY_CROSSED // triggers achievement failure, sent from spellscript
 };
 
-//Feugen
-enum FeugenYells
+enum Events
 {
-    SAY_FEUG_AGGRO          = 0,
-    SAY_FEUG_SLAY           = 1,
-    SAY_FEUG_DEATH          = 2
+    EVENT_SHIFT = 1,                // polarity shift
+    EVENT_SHIFT_TALK,               // polarity shift yell (hack? couldn't find any event for cast finish)
+    EVENT_CHAIN,                    // chain lightning
+    EVENT_BERSERK,                  // enrage timer
+    EVENT_REVIVE_FEUGEN,            // timer until feugen is revived (if stalagg still lives)
+    EVENT_REVIVE_STALAGG,           // timer until stalagg is revived (if feugen still lives)
+    EVENT_TRANSITION_1,             // timer until overload emote
+    EVENT_TRANSITION_2,             // timer until thaddius gets zapped by the coils
+    EVENT_TRANSITION_3,             // timer until thaddius engages
+    EVENT_ENABLE_BALL_LIGHTNING     // grace period after thaddius aggro after which he starts being a baller (e.g. tossing ball lightning at out of range targets)
 };
 
-enum FeugenSpells
+enum Misc
 {
-    SPELL_STATICFIELD       = 28135,
-    SPELL_FEUGEN_TESLA      = 28109
+    MAX_POLARITY_10M        =  5,
+    MAX_POLARITY_25M        = 13,
+
+    DATA_POLARITY_CROSSED   =  1,
 };
 
-// Thaddius DoAction
-enum ThaddiusActions
+// Feugen & Stalagg
+enum PetYells
 {
-    ACTION_FEUGEN_RESET,
-    ACTION_FEUGEN_DIED,
-    ACTION_STALAGG_RESET,
-    ACTION_STALAGG_DIED
+    SAY_STALAGG_AGGRO       = 0,
+    SAY_STALAGG_SLAY        = 1,
+    SAY_STALAGG_DEATH       = 2,
+
+    SAY_FEUGEN_AGGRO        = 0,
+    SAY_FEUGEN_SLAY         = 1,
+    SAY_FEUGEN_DEATH        = 2,
+
+    EMOTE_FEIGN_DEATH       = 3,
+    EMOTE_FEIGN_REVIVE      = 4,
+
+    EMOTE_TESLA_LINK_BREAKS = 0,
+    EMOTE_TESLA_OVERLOAD    = 1
 };
 
-//generic
-#define C_TESLA_COIL            16218           //the coils (emotes "Tesla Coil overloads!")
+enum PetSpells
+{
+    SPELL_STALAGG_POWERSURGE        = 28134,
+    //SPELL_STALAGG_TESLA             = 28097,
+    SPELL_STALAGG_TESLA_PERIODIC    = 28098,
+    SPELL_STALAGG_CHAIN_VISUAL      = 28096,
+
+    SPELL_FEUGEN_STATICFIELD        = 28135,
+    //SPELL_FEUGEN_TESLA              = 28109,
+    SPELL_FEUGEN_TESLA_PERIODIC     = 28110,
+    SPELL_FEUGEN_CHAIN_VISUAL       = 28111,
+
+    SPELL_MAGNETIC_PULL             = 54517,
+    SPELL_MAGNETIC_PULL_EFFECT      = 28337,
+
+    SPELL_TESLA_SHOCK               = 28099
+};
+
+enum PetMisc
+{
+    OVERLOAD_DISTANCE       = 28
+};
+
 
 //Thaddius
 enum ThaddiusYells
@@ -70,34 +126,31 @@ enum ThaddiusYells
     SAY_SLAY                = 2,
     SAY_ELECT               = 3,
     SAY_DEATH               = 4,
-    SAY_SCREAM              = 5
+    SAY_SCREAM              = 5,
+
+    EMOTE_POLARITY_SHIFTED  = 6
 };
 
 enum ThaddiusSpells
 {
-    SPELL_POLARITY_SHIFT        = 28089,
-    SPELL_BALL_LIGHTNING        = 28299,
-    SPELL_CHAIN_LIGHTNING       = 28167,
-    SPELL_BERSERK               = 27680,
-    SPELL_POSITIVE_CHARGE       = 28062,
-    SPELL_POSITIVE_CHARGE_STACK = 29659,
-    SPELL_NEGATIVE_CHARGE       = 28085,
-    SPELL_NEGATIVE_CHARGE_STACK = 29660,
-    SPELL_POSITIVE_POLARITY     = 28059,
-    SPELL_NEGATIVE_POLARITY     = 28084,
-};
+    SPELL_THADDIUS_INACTIVE_VISUAL  = 28160,
+    SPELL_THADDIUS_SPARK_VISUAL     = 28136,
+    SPELL_SHOCK_VISUAL              = 28159,
 
-enum Events
-{
-    EVENT_NONE,
-    EVENT_SHIFT,
-    EVENT_CHAIN,
-    EVENT_BERSERK,
-};
+    SPELL_BALL_LIGHTNING            = 28299,
+    SPELL_CHAIN_LIGHTNING           = 28167,
+    SPELL_BERSERK                   = 27680,
 
-enum Achievement
-{
-    DATA_POLARITY_SWITCH    = 76047605,
+    // polarity handling
+    SPELL_POLARITY_SHIFT            = 28089,
+
+    SPELL_POSITIVE_CHARGE_APPLY     = 28059,
+    SPELL_POSITIVE_CHARGE_TICK      = 28062,
+    SPELL_POSITIVE_CHARGE_AMP       = 29659,
+
+    SPELL_NEGATIVE_CHARGE_APPLY     = 28084,
+    SPELL_NEGATIVE_CHARGE_TICK      = 28085,
+    SPELL_NEGATIVE_CHARGE_AMP       = 29660,
 };
 
 class boss_thaddius : public CreatureScript
@@ -112,166 +165,271 @@ public:
 
     struct boss_thaddiusAI : public BossAI
     {
-        boss_thaddiusAI(Creature* creature) : BossAI(creature, BOSS_THADDIUS)
-        {
-            // init is a bit tricky because thaddius shall track the life of both adds, but not if there was a wipe
-            // and, in particular, if there was a crash after both adds were killed (should not respawn)
-
-            // Moreover, the adds may not yet be spawn. So just track down the status if mob is spawn
-            // and each mob will send its status at reset (meaning that it is alive)
-            checkFeugenAlive = false;
-            if (Creature* pFeugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
-                checkFeugenAlive = pFeugen->IsAlive();
-
-            checkStalaggAlive = false;
-            if (Creature* pStalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
-                checkStalaggAlive = pStalagg->IsAlive();
-
-            if (!checkFeugenAlive && !checkStalaggAlive)
+        public:
+            boss_thaddiusAI(Creature* creature) : BossAI(creature, BOSS_THADDIUS), stalaggAlive(true), feugenAlive(true), ballLightningEnabled(false), shockingEligibility(true)
             {
-                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED);
-                me->SetReactState(REACT_AGGRESSIVE);
-            }
-            else
-            {
-                me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED);
-                me->SetReactState(REACT_PASSIVE);
+                if (instance->GetBossState(BOSS_THADDIUS) != DONE)
+                {                    
+                    events.SetPhase(PHASE_NOT_ENGAGED);
+                    SetCombatMovement(false);
+
+                    BeginResetEncounter(); // initialize everything properly, and ensure that the coils are loaded by the time we initialize
+                }
             }
 
-            polaritySwitch = false;
-            uiAddsTimer = 0;
-        }
-
-        bool checkStalaggAlive;
-        bool checkFeugenAlive;
-        bool polaritySwitch;
-        uint32 uiAddsTimer;
-
-        void KilledUnit(Unit* /*victim*/) override
-        {
-            if (!(rand32() % 5))
-                Talk(SAY_SLAY);
-        }
-
-        void JustDied(Unit* /*killer*/) override
-        {
-            _JustDied();
-            Talk(SAY_DEATH);
-        }
-
-        void DoAction(int32 action) override
-        {
-            switch (action)
+            void KilledUnit(Unit* victim) override
             {
-                case ACTION_FEUGEN_RESET:
-                    checkFeugenAlive = true;
-                    break;
-                case ACTION_FEUGEN_DIED:
-                    checkFeugenAlive = false;
-                    break;
-                case ACTION_STALAGG_RESET:
-                    checkStalaggAlive = true;
-                    break;
-                case ACTION_STALAGG_DIED:
-                    checkStalaggAlive = false;
-                    break;
+                if (victim->GetTypeId() == TYPEID_PLAYER)
+                    Talk(SAY_SLAY);
             }
 
-            if (!checkFeugenAlive && !checkStalaggAlive)
+            void Reset() override
             {
-                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED);
-                // REACT_AGGRESSIVE only reset when he takes damage.
-                DoZoneInCombat();
+                if(events.IsInPhase(PHASE_TRANSITION) || events.IsInPhase(PHASE_THADDIUS))
+                    BeginResetEncounter();
             }
-            else
+
+            void JustDied(Unit* /*killer*/) override
             {
-                me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED);
-                me->SetReactState(REACT_PASSIVE);
+                _JustDied();
+                me->setActive(false);
+                if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                    stalagg->setActive(false);
+                if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                    feugen->setActive(false);
+                Talk(SAY_DEATH);
             }
-        }
 
-        void EnterCombat(Unit* /*who*/) override
-        {
-            _EnterCombat();
-            Talk(SAY_AGGRO);
-            events.ScheduleEvent(EVENT_SHIFT, 30000);
-            events.ScheduleEvent(EVENT_CHAIN, urand(10000, 20000));
-            events.ScheduleEvent(EVENT_BERSERK, 360000);
-        }
-
-        void DamageTaken(Unit* /*pDoneBy*/, uint32 & /*uiDamage*/) override
-        {
-            me->SetReactState(REACT_AGGRESSIVE);
-        }
-
-        void SetData(uint32 id, uint32 data) override
-        {
-            if (id == DATA_POLARITY_SWITCH)
-                polaritySwitch = data ? true : false;
-        }
-
-        uint32 GetData(uint32 id) const override
-        {
-            if (id != DATA_POLARITY_SWITCH)
-                return 0;
-
-            return uint32(polaritySwitch);
-        }
-
-        void UpdateAI(uint32 diff) override
-        {
-            if (checkFeugenAlive && checkStalaggAlive)
-                uiAddsTimer = 0;
-
-            if (checkStalaggAlive != checkFeugenAlive)
+            void DoAction(int32 action) override
             {
-                uiAddsTimer += diff;
-                if (uiAddsTimer > 5000)
+                switch (action)
                 {
-                    if (!checkStalaggAlive)
+                    case ACTION_RESET_ENCOUNTER_TIMER:
+                        if (events.IsInPhase(PHASE_RESETTING))
+                            ResetEncounter();
+                        break;
+                    case ACTION_FEUGEN_RESET:
+                    case ACTION_STALAGG_RESET:
+                        if (!events.IsInPhase(PHASE_NOT_ENGAGED) && !events.IsInPhase(PHASE_RESETTING))
+                            BeginResetEncounter();
+                        break;
+                    case ACTION_FEUGEN_AGGRO:
+                    case ACTION_STALAGG_AGGRO:
+                        if (events.IsInPhase(PHASE_RESETTING))
+                            return BeginResetEncounter();
+                        if (!events.IsInPhase(PHASE_NOT_ENGAGED))
+                            return;
+                        events.SetPhase(PHASE_PETS);
+
+                        shockingEligibility = true;
+                        
+                        if (!instance->CheckRequiredBosses(BOSS_THADDIUS))
+                            return BeginResetEncounter();
+                        instance->SetBossState(BOSS_THADDIUS, IN_PROGRESS);
+
+                        me->setActive(true);
+                        if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                            stalagg->setActive(true);
+                        if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                            feugen->setActive(true);
+                        break;
+                    case ACTION_FEUGEN_DIED:
+                        if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                            feugen->AI()->DoAction(ACTION_FEUGEN_REVIVING_FX);
+                        feugenAlive = false;
+                        if (stalaggAlive)
+                            events.ScheduleEvent(EVENT_REVIVE_FEUGEN, 5 * IN_MILLISECONDS, 0, PHASE_PETS);
+                        else
+                            Transition();
+
+                        break;
+                    case ACTION_STALAGG_DIED:
+                        if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                            stalagg->AI()->DoAction(ACTION_STALAGG_REVIVING_FX);
+                        stalaggAlive = false;
+                        if (feugenAlive)
+                            events.ScheduleEvent(EVENT_REVIVE_STALAGG, 5 * IN_MILLISECONDS, 0, PHASE_PETS);
+                        else
+                            Transition();
+
+                        break;
+
+                    case ACTION_POLARITY_CROSSED:
+                        shockingEligibility = false;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            uint32 GetData(uint32 id) const override
+            {
+                return (id == DATA_POLARITY_CROSSED && shockingEligibility) ? 1u : 0u;
+            }
+
+            void Transition() // initiate transition between pet phase and thaddius phase
+            {
+                events.SetPhase(PHASE_TRANSITION);
+
+                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+
+                events.ScheduleEvent(EVENT_TRANSITION_1, 10 * IN_MILLISECONDS, 0, PHASE_TRANSITION);
+                events.ScheduleEvent(EVENT_TRANSITION_2, 12 * IN_MILLISECONDS, 0, PHASE_TRANSITION);
+                events.ScheduleEvent(EVENT_TRANSITION_3, 14 * IN_MILLISECONDS, 0, PHASE_TRANSITION);
+            }
+
+            void BeginResetEncounter()
+            {
+                if (!me->IsAlive())
+                    return;
+                if (events.IsInPhase(PHASE_RESETTING))
+                    return;
+                   
+                instance->ProcessEvent(me, EVENT_THADDIUS_BEGIN_RESET);
+
+                instance->SetBossState(BOSS_THADDIUS, NOT_STARTED);
+
+                // remove polarity shift debuffs on reset
+                instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_POSITIVE_CHARGE_APPLY);
+                instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_NEGATIVE_CHARGE_APPLY);
+
+                me->DespawnOrUnsummon();
+
+                me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED);
+                events.SetPhase(PHASE_RESETTING);
+                if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                    feugen->AI()->DoAction(ACTION_BEGIN_RESET_ENCOUNTER);
+                if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                    stalagg->AI()->DoAction(ACTION_BEGIN_RESET_ENCOUNTER);
+
+                me->setActive(false);
+            }
+
+            void ResetEncounter()
+            {
+                events.SetPhase(PHASE_NOT_ENGAGED);
+                feugenAlive = true;
+                stalaggAlive = true;
+                me->Respawn(true);
+                me->CastSpell(me, SPELL_THADDIUS_INACTIVE_VISUAL);
+
+                if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                    feugen->AI()->DoAction(ACTION_RESET_ENCOUNTER);
+                if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                    stalagg->AI()->DoAction(ACTION_RESET_ENCOUNTER);
+                _Reset();
+            }
+
+            void UpdateAI(uint32 diff) override
+            {
+                if (events.IsInPhase(PHASE_NOT_ENGAGED))
+                    return;
+                if (events.IsInPhase(PHASE_THADDIUS) && !UpdateVictim())
+                    return;
+
+                events.Update(diff);
+                while (uint32 eventId = events.ExecuteEvent())
+                {
+                    switch (eventId)
                     {
-                        if (Creature* pStalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
-                            pStalagg->Respawn();
+                        case EVENT_REVIVE_FEUGEN:
+                            feugenAlive = true;
+                            if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                                feugen->AI()->DoAction(ACTION_FEUGEN_REVIVED);
+                            break;
+                        case EVENT_REVIVE_STALAGG:
+                            stalaggAlive = true;
+                            if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                                stalagg->AI()->DoAction(ACTION_STALAGG_REVIVED);
+                            break;
+                        case EVENT_TRANSITION_1: // tesla coils overload
+                            if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                                feugen->AI()->DoAction(ACTION_TRANSITION);
+                            if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                                stalagg->AI()->DoAction(ACTION_TRANSITION);
+                            break;
+                        case EVENT_TRANSITION_2: // tesla coils shock thaddius
+                            me->CastSpell(me, SPELL_THADDIUS_SPARK_VISUAL, true);
+                            if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                                feugen->AI()->DoAction(ACTION_TRANSITION_2);
+                            if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                                stalagg->AI()->DoAction(ACTION_TRANSITION_2);
+                            break;
+                        case EVENT_TRANSITION_3: // thaddius becomes active
+                            me->CastSpell(me, SPELL_THADDIUS_SPARK_VISUAL, true);
+                            ballLightningEnabled = false;
+                            me->RemoveAura(SPELL_THADDIUS_INACTIVE_VISUAL);
+                            me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
+                            me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                            
+                            DoZoneInCombat();
+                            if (Unit* closest = SelectTarget(SELECT_TARGET_NEAREST, 0, 500.0f))
+                                AttackStart(closest);
+                            else // if there is no nearest target, then there is no target, meaning we should reset
+                                return BeginResetEncounter();
+
+                            if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                                feugen->AI()->DoAction(ACTION_TRANSITION_3);
+                            if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                                stalagg->AI()->DoAction(ACTION_TRANSITION_3);
+
+                            events.SetPhase(PHASE_THADDIUS);
+
+                            Talk(SAY_AGGRO);
+
+                            events.ScheduleEvent(EVENT_ENABLE_BALL_LIGHTNING, 5 * IN_MILLISECONDS, 0, PHASE_THADDIUS);
+                            events.ScheduleEvent(EVENT_SHIFT, 10 * IN_MILLISECONDS, 0, PHASE_THADDIUS);
+                            events.ScheduleEvent(EVENT_CHAIN, urand(10, 20) * IN_MILLISECONDS, 0, PHASE_THADDIUS);
+                            events.ScheduleEvent(EVENT_BERSERK, 6 * MINUTE * IN_MILLISECONDS, 0, PHASE_THADDIUS);
+
+                            break;
+                        case EVENT_ENABLE_BALL_LIGHTNING:
+                            ballLightningEnabled = true;
+                            break;
+                        case EVENT_SHIFT:
+                            me->CastStop(); // shift overrides all other spells
+                            DoCastAOE(SPELL_POLARITY_SHIFT);
+                            events.ScheduleEvent(EVENT_SHIFT_TALK, 3 * IN_MILLISECONDS, PHASE_THADDIUS);
+                            events.ScheduleEvent(EVENT_SHIFT, 30 * IN_MILLISECONDS, PHASE_THADDIUS);
+                            break;
+                        case EVENT_SHIFT_TALK:
+                            Talk(SAY_ELECT);
+                            Talk(EMOTE_POLARITY_SHIFTED);
+                        case EVENT_CHAIN:
+                            if (me->FindCurrentSpellBySpellId(SPELL_POLARITY_SHIFT)) // delay until shift is over
+                                events.ScheduleEvent(EVENT_CHAIN, 3 * IN_MILLISECONDS, 0, PHASE_THADDIUS);
+                            else
+                            {
+                                me->CastStop();
+                                DoCastVictim(SPELL_CHAIN_LIGHTNING);
+                                events.ScheduleEvent(EVENT_CHAIN, urand(10, 20) * IN_MILLISECONDS, PHASE_THADDIUS);
+                            }
+                            break;
+                        case EVENT_BERSERK:
+                            me->CastStop();
+                            DoCast(me, SPELL_BERSERK);
+                            break;
+                        default:
+                            break;
                     }
+                }
+
+                if (events.IsInPhase(PHASE_THADDIUS))
+                {
+                    if (me->IsWithinMeleeRange(me->GetVictim()))
+                        DoMeleeAttackIfReady();
                     else
-                    {
-                        if (Creature* pFeugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
-                            pFeugen->Respawn();
-                    }
+                        if (ballLightningEnabled)
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM))
+                                DoCast(target, SPELL_BALL_LIGHTNING);
                 }
             }
 
-            if (!UpdateVictim())
-                return;
-
-            events.Update(diff);
-
-            if (me->HasUnitState(UNIT_STATE_CASTING))
-                return;
-
-            while (uint32 eventId = events.ExecuteEvent())
-            {
-                switch (eventId)
-                {
-                    case EVENT_SHIFT:
-                        DoCastAOE(SPELL_POLARITY_SHIFT);
-                        events.ScheduleEvent(EVENT_SHIFT, 30000);
-                        return;
-                    case EVENT_CHAIN:
-                        DoCastVictim(SPELL_CHAIN_LIGHTNING);
-                        events.ScheduleEvent(EVENT_CHAIN, urand(10000, 20000));
-                        return;
-                    case EVENT_BERSERK:
-                        DoCast(me, SPELL_BERSERK);
-                        return;
-                }
-            }
-
-            if (events.GetTimer() > 15000 && !me->IsWithinMeleeRange(me->GetVictim()))
-                DoCastVictim(SPELL_BALL_LIGHTNING);
-            else
-                DoMeleeAttackIfReady();
-        }
+        private:
+            bool stalaggAlive;
+            bool feugenAlive;
+            bool ballLightningEnabled;
+            bool shockingEligibility;
     };
 
 };
@@ -288,88 +446,256 @@ public:
 
     struct npc_stalaggAI : public ScriptedAI
     {
-        npc_stalaggAI(Creature* creature) : ScriptedAI(creature)
-        {
-            Initialize();
-            instance = creature->GetInstanceScript();
-        }
-
-        void Initialize()
-        {
-            powerSurgeTimer = urand(20000, 25000);
-            magneticPullTimer = 20000;
-        }
-
-        InstanceScript* instance;
-
-        uint32 powerSurgeTimer;
-        uint32 magneticPullTimer;
-
-        void Reset() override
-        {
-            if (Creature* pThaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
-                if (pThaddius->AI())
-                    pThaddius->AI()->DoAction(ACTION_STALAGG_RESET);
-            Initialize();
-        }
-
-        void KilledUnit(Unit* /*victim*/) override
-        {
-            if (!(rand32() % 5))
-                Talk(SAY_STAL_SLAY);
-        }
-
-        void EnterCombat(Unit* /*who*/) override
-        {
-            Talk(SAY_STAL_AGGRO);
-            DoCast(SPELL_STALAGG_TESLA);
-        }
-
-        void JustDied(Unit* /*killer*/) override
-        {
-            Talk(SAY_STAL_DEATH);
-            if (Creature* pThaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
-                if (pThaddius->AI())
-                    pThaddius->AI()->DoAction(ACTION_STALAGG_DIED);
-        }
-
-        void UpdateAI(uint32 uiDiff) override
-        {
-            if (!UpdateVictim())
-                return;
-
-            if (magneticPullTimer <= uiDiff)
+        public:
+            npc_stalaggAI(Creature* creature) : ScriptedAI(creature), _myCoil(ObjectGuid::Empty), _myCoilGO(ObjectGuid::Empty), isOverloading(false), refreshBeam(false), isFeignDeath(false)
             {
-                if (Creature* pFeugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                Initialize();
+                instance = creature->GetInstanceScript();
+            }
+
+            void Initialize()
+            {
+                if (GameObject* coil = myCoilGO())
+                    coil->SetGoState(GO_STATE_ACTIVE);
+
+                // if the encounter reset while feigning death
+                me->SetStandState(UNIT_STAND_STATE_STAND);
+                me->SetReactState(REACT_AGGRESSIVE);
+                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                isOverloading = false;
+                isFeignDeath = false;
+
+                // force tesla coil state refresh
+                refreshBeam = true;
+
+                powerSurgeTimer = 10 * IN_MILLISECONDS;
+            }
+
+            void Reset() override
+            {
+                if (isFeignDeath || !me->IsAlive())
+                    return;
+                if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                    thaddius->AI()->DoAction(ACTION_STALAGG_RESET);
+            }
+
+            void BeginResetEncounter()
+            {
+                if (GameObject* coil = myCoilGO())
+                    coil->SetGoState(GO_STATE_READY);
+                me->DespawnOrUnsummon();
+                me->setActive(false);
+            }
+
+            void ResetEncounter()
+            {
+                me->Respawn(true);
+                Initialize();
+            }
+
+            void DoAction(int32 action) override
+            {
+                switch (action)
                 {
-                    Unit* pStalaggVictim = me->GetVictim();
-                    Unit* pFeugenVictim = pFeugen->GetVictim();
+                    case ACTION_BEGIN_RESET_ENCOUNTER:
+                        BeginResetEncounter();
+                        break;
+                    case ACTION_RESET_ENCOUNTER:
+                        ResetEncounter();
+                        break;
+                    case ACTION_STALAGG_REVIVING_FX:
+                        break;
+                    case ACTION_STALAGG_REVIVED:
+                        if (!isFeignDeath)
+                            break;
 
-                    if (pFeugenVictim && pStalaggVictim)
+                        me->SetFullHealth();
+                        me->SetStandState(UNIT_STAND_STATE_STAND);
+                        me->SetReactState(REACT_AGGRESSIVE);
+                        me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                        Talk(EMOTE_FEIGN_REVIVE);
+                        isFeignDeath = false;
+                        
+                        refreshBeam = true; // force beam refresh
+
+                        if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                            if (feugen->GetVictim())
+                            {
+                                me->AddThreat(feugen->EnsureVictim(), 0.0f);
+                                me->SetInCombatWith(feugen->EnsureVictim());
+                            }
+                        break;
+                    case ACTION_TRANSITION:
+                        me->Kill(me); // true death
+                        me->DespawnOrUnsummon();
+
+                        if (Creature* coil = myCoil())
+                        {
+                            coil->CastStop();
+                            coil->AI()->Talk(EMOTE_TESLA_OVERLOAD);
+                        }
+                        break;
+                    case ACTION_TRANSITION_2:
+                        if (Creature* coil = myCoil())
+                            if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                                coil->CastSpell(thaddius, SPELL_SHOCK_VISUAL);
+                    case ACTION_TRANSITION_3:
+                        if (GameObject* coil = myCoilGO())
+                            coil->SetGoState(GO_STATE_READY);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            void KilledUnit(Unit* victim) override
+            {
+                if (victim->GetTypeId() == TYPEID_PLAYER)
+                    Talk(SAY_STALAGG_SLAY);
+            }
+
+            void EnterCombat(Unit* who) override
+            {
+                Talk(SAY_STALAGG_AGGRO);
+
+                if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                    thaddius->AI()->DoAction(ACTION_STALAGG_AGGRO);
+
+                if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
+                    if (!feugen->IsInCombat())
                     {
-                        // magnetic pull is not working. So just jump.
+                        feugen->AddThreat(who, 0.0f);
+                        feugen->SetInCombatWith(who);
+                    }
+            }
 
-                        // reset aggro to be sure that feugen will not follow the jump
-                        pFeugen->getThreatManager().modifyThreatPercent(pFeugenVictim, -100);
-                        pFeugenVictim->JumpTo(me, 0.3f);
+            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            {
+                if (damage < me->GetHealth())
+                    return;
 
-                        me->getThreatManager().modifyThreatPercent(pStalaggVictim, -100);
-                        pStalaggVictim->JumpTo(pFeugen, 0.3f);
+                if (isFeignDeath) // don't take damage while feigning death
+                {
+                    damage = 0;
+                    return;
+                }
+                
+                isFeignDeath = true;
+                isOverloading = false;
+
+                Talk(EMOTE_FEIGN_DEATH);
+                if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                    thaddius->AI()->DoAction(ACTION_STALAGG_DIED);
+
+                me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                me->RemoveAllAuras();
+                me->SetReactState(REACT_PASSIVE);
+                me->AttackStop();
+                me->StopMoving();
+                me->SetStandState(UNIT_STAND_STATE_DEAD);
+
+                damage = 0;
+
+                // force beam refresh as we just removed auras
+                refreshBeam = true;
+            }
+
+            void SpellHit(Unit* caster, SpellInfo const* spell) override
+            {
+                if (!caster)
+                    return;
+                if (spell->Id != SPELL_STALAGG_TESLA_PERIODIC)
+                    return;
+                if (!isFeignDeath && me->IsInCombat() && !me->GetHomePosition().IsInDist(me, OVERLOAD_DISTANCE))
+                {
+                    if (!isOverloading)
+                    {
+                        isOverloading = true;
+                        caster->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                        if (Creature* creatureCaster = caster->ToCreature())
+                            creatureCaster->AI()->Talk(EMOTE_TESLA_LINK_BREAKS);
+                        me->RemoveAura(SPELL_STALAGG_CHAIN_VISUAL);
+                    }
+                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM))
+                    {
+                        caster->CastStop(SPELL_TESLA_SHOCK);
+                        caster->CastSpell(target, SPELL_TESLA_SHOCK,true);
                     }
                 }
-
-                magneticPullTimer = 20000;
+                else if (isOverloading || refreshBeam)
+                {
+                    isOverloading = false;
+                    refreshBeam = false;
+                    caster->CastStop();
+                    caster->CastSpell(me, SPELL_STALAGG_CHAIN_VISUAL, true);
+                    caster->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                }
             }
-            else magneticPullTimer -= uiDiff;
 
-            if (powerSurgeTimer <= uiDiff)
+            void UpdateAI(uint32 uiDiff) override
             {
-                DoCast(me, SPELL_POWERSURGE);
-                powerSurgeTimer = urand(15000, 20000);
-            } else powerSurgeTimer -= uiDiff;
+                if(!isFeignDeath)
+                    if (!UpdateVictim())
+                        return;
 
-            DoMeleeAttackIfReady();
-        }
+                if (powerSurgeTimer <= uiDiff)
+                {
+                    if (isFeignDeath) // delay until potential revive
+                        powerSurgeTimer = 0u;
+                    else
+                    {
+                        DoCast(me, SPELL_STALAGG_POWERSURGE);
+                        powerSurgeTimer = urand(25, 30) * IN_MILLISECONDS;
+                    }
+                }
+                else
+                    powerSurgeTimer -= uiDiff;
+
+                if(!isFeignDeath)
+                    DoMeleeAttackIfReady();
+            }
+
+        private:
+            Creature* myCoil()
+            {
+                Creature* coil = nullptr;
+                if (_myCoil)
+                    coil = ObjectAccessor::GetCreature(*me, _myCoil);
+                if (!coil)
+                {
+                    coil = me->FindNearestCreature(NPC_TESLA, 1000.0f, true);
+                    if (coil)
+                    {
+                        _myCoil = coil->GetGUID();
+                        coil->SetReactState(REACT_PASSIVE);
+                    }
+                }
+                return coil;
+            }
+
+            GameObject* myCoilGO()
+            {
+                GameObject* coil = nullptr;
+                if (_myCoilGO)
+                    coil = ObjectAccessor::GetGameObject(*me, _myCoilGO);
+                if (!coil)
+                {
+                    coil = me->FindNearestGameObject(GO_CONS_NOX_TESLA_STALAGG, 1000.0f);
+                    if (coil)
+                        _myCoilGO = coil->GetGUID();
+                }
+                return coil;
+            }
+
+            InstanceScript* instance;
+
+            uint32 powerSurgeTimer;
+
+            ObjectGuid _myCoil;
+            ObjectGuid _myCoilGO;
+            bool isOverloading;
+            bool refreshBeam;
+            bool isFeignDeath;
     };
 
 };
@@ -386,142 +712,380 @@ public:
 
     struct npc_feugenAI : public ScriptedAI
     {
-        npc_feugenAI(Creature* creature) : ScriptedAI(creature)
-        {
-            Initialize();
-            instance = creature->GetInstanceScript();
-        }
-
-        void Initialize()
-        {
-            staticFieldTimer = 5000;
-        }
-
-        InstanceScript* instance;
-
-        uint32 staticFieldTimer;
-
-        void Reset() override
-        {
-            if (Creature* pThaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
-                if (pThaddius->AI())
-                    pThaddius->AI()->DoAction(ACTION_FEUGEN_RESET);
-            Initialize();
-        }
-
-        void KilledUnit(Unit* /*victim*/) override
-        {
-            if (!(rand32() % 5))
-                Talk(SAY_FEUG_SLAY);
-        }
-
-        void EnterCombat(Unit* /*who*/) override
-        {
-            Talk(SAY_FEUG_AGGRO);
-            DoCast(SPELL_FEUGEN_TESLA);
-        }
-
-        void JustDied(Unit* /*killer*/) override
-        {
-            Talk(SAY_FEUG_DEATH);
-            if (Creature* pThaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
-                if (pThaddius->AI())
-                    pThaddius->AI()->DoAction(ACTION_FEUGEN_DIED);
-        }
-
-        void UpdateAI(uint32 uiDiff) override
-        {
-            if (!UpdateVictim())
-                return;
-
-            if (staticFieldTimer <= uiDiff)
+        public:
+            npc_feugenAI(Creature* creature) : ScriptedAI(creature), _myCoil(ObjectGuid::Empty), _myCoilGO(ObjectGuid::Empty), isOverloading(false), refreshBeam(false), isFeignDeath(false)
             {
-                DoCast(me, SPELL_STATICFIELD);
-                staticFieldTimer = 5000;
-            } else staticFieldTimer -= uiDiff;
-
-            DoMeleeAttackIfReady();
-        }
-    };
-
-};
-
-class spell_thaddius_pos_neg_charge : public SpellScriptLoader
-{
-    public:
-        spell_thaddius_pos_neg_charge() : SpellScriptLoader("spell_thaddius_pos_neg_charge") { }
-
-        class spell_thaddius_pos_neg_charge_SpellScript : public SpellScript
-        {
-            PrepareSpellScript(spell_thaddius_pos_neg_charge_SpellScript);
-
-            bool Validate(SpellInfo const* /*spell*/) override
-            {
-                if (!sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE))
-                    return false;
-                if (!sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_STACK))
-                    return false;
-                if (!sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE))
-                    return false;
-                if (!sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_STACK))
-                    return false;
-                return true;
+                Initialize();
+                instance = creature->GetInstanceScript();
             }
 
-            bool Load() override
+            void Initialize()
             {
-                return GetCaster()->GetTypeId() == TYPEID_UNIT;
+                if (GameObject* coil = myCoilGO())
+                    coil->SetGoState(GO_STATE_ACTIVE);
+
+                // if the encounter reset while feigning death
+                me->SetStandState(UNIT_STAND_STATE_STAND);
+                me->SetReactState(REACT_AGGRESSIVE);
+                me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                isOverloading = false;
+                isFeignDeath = false;
+
+                // force coil state to refresh
+                refreshBeam = true;
+
+                staticFieldTimer = 6 * IN_MILLISECONDS;
+                magneticPullTimer = 20 * IN_MILLISECONDS;
             }
 
-            void HandleTargets(std::list<WorldObject*>& targets)
+            void Reset() override
             {
-                uint8 count = 0;
-                for (std::list<WorldObject*>::iterator ihit = targets.begin(); ihit != targets.end(); ++ihit)
-                    if ((*ihit)->GetGUID() != GetCaster()->GetGUID())
-                        if (Player* target = (*ihit)->ToPlayer())
-                            if (target->HasAura(GetTriggeringSpell()->Id))
-                                ++count;
+                if (isFeignDeath || !me->IsAlive())
+                    return;
+                if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                    thaddius->AI()->DoAction(ACTION_FEUGEN_RESET);
+            }
 
-                if (count)
+            void BeginResetEncounter()
+            {
+                if (GameObject* coil = myCoilGO())
+                    coil->SetGoState(GO_STATE_READY);
+                me->DespawnOrUnsummon();
+                me->setActive(false);
+            }
+
+            void ResetEncounter()
+            {
+                me->Respawn(true);
+                Initialize();
+            }
+
+            void DoAction(int32 action) override
+            {
+                switch (action)
                 {
-                    uint32 spellId = 0;
+                    case ACTION_BEGIN_RESET_ENCOUNTER:
+                        BeginResetEncounter();
+                        break;
+                    case ACTION_RESET_ENCOUNTER:
+                        ResetEncounter();
+                        break;
+                    case ACTION_FEUGEN_REVIVING_FX:
+                        break;
+                    case ACTION_FEUGEN_REVIVED:
+                        if (!isFeignDeath)
+                            break;
 
-                    if (GetSpellInfo()->Id == SPELL_POSITIVE_CHARGE)
-                        spellId = SPELL_POSITIVE_CHARGE_STACK;
-                    else // if (GetSpellInfo()->Id == SPELL_NEGATIVE_CHARGE)
-                        spellId = SPELL_NEGATIVE_CHARGE_STACK;
+                        me->SetFullHealth();
+                        me->SetStandState(UNIT_STAND_STATE_STAND);
+                        me->SetReactState(REACT_AGGRESSIVE);
+                        me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                        Talk(EMOTE_FEIGN_REVIVE);
+                        isFeignDeath = false;
+                        
+                        refreshBeam = true; // force beam refresh
 
-                    GetCaster()->SetAuraStack(spellId, GetCaster(), count);
+                        if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                            if (stalagg->GetVictim())
+                            {
+                                me->AddThreat(stalagg->EnsureVictim(), 0.0f);
+                                me->SetInCombatWith(stalagg->EnsureVictim());
+                            }
+                        staticFieldTimer = 6 * IN_MILLISECONDS;
+                        magneticPullTimer = 30 * IN_MILLISECONDS;
+                        break;
+                    case ACTION_TRANSITION:
+                        me->Kill(me); // true death this time around
+                        me->DespawnOrUnsummon();
+
+                        if (Creature* coil = myCoil())
+                        {
+                            coil->CastStop();
+                            coil->AI()->Talk(EMOTE_TESLA_OVERLOAD);
+                        }
+                        break;
+                    case ACTION_TRANSITION_2:
+                        if (Creature* coil = myCoil())
+                            if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                                coil->CastSpell(thaddius, SPELL_SHOCK_VISUAL);
+                    case ACTION_TRANSITION_3:
+                        if (GameObject* coil = myCoilGO())
+                            coil->SetGoState(GO_STATE_READY);
+                    default:
+                        break;
                 }
             }
 
-            void HandleDamage(SpellEffIndex /*effIndex*/)
+            void KilledUnit(Unit* victim) override
+            {
+                if(victim->GetTypeId() == TYPEID_PLAYER)
+                    Talk(SAY_FEUGEN_SLAY);
+            }
+
+            void EnterCombat(Unit* who) override
+            {
+                Talk(SAY_FEUGEN_AGGRO);
+
+                if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                    thaddius->AI()->DoAction(ACTION_STALAGG_AGGRO);
+
+                if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
+                    if (!stalagg->IsInCombat())
+                    {
+                        stalagg->AddThreat(who, 0.0f);
+                        stalagg->SetInCombatWith(who);
+                    }
+            }
+
+            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            {
+                if (damage < me->GetHealth())
+                    return;
+
+                if (isFeignDeath) // don't take damage while feigning death
+                {
+                    damage = 0;
+                    return;
+                }
+
+                isFeignDeath = true;
+                isOverloading = false;
+
+                Talk(EMOTE_FEIGN_DEATH);
+                if (Creature* thaddius = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_THADDIUS)))
+                    thaddius->AI()->DoAction(ACTION_FEUGEN_DIED);
+
+                me->RemoveAllAuras();
+                me->SetReactState(REACT_PASSIVE);
+                me->AttackStop();
+                me->StopMoving();
+                me->SetStandState(UNIT_STAND_STATE_DEAD);
+                me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+
+                damage = 0;
+
+                // force beam refresh as we just removed auras
+                refreshBeam = true;
+            }
+
+            void SpellHit(Unit* caster, SpellInfo const* spell) override
+            {
+                if (!caster)
+                    return;
+                if (spell->Id != SPELL_FEUGEN_TESLA_PERIODIC)
+                    return;
+                if (!isFeignDeath && me->IsInCombat() && !me->GetHomePosition().IsInDist(me, OVERLOAD_DISTANCE))
+                {
+                    if (!isOverloading)
+                    {
+                        isOverloading = true;
+                        caster->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                        if (Creature* creatureCaster = caster->ToCreature())
+                            creatureCaster->AI()->Talk(EMOTE_TESLA_LINK_BREAKS);
+                        me->RemoveAura(SPELL_STALAGG_CHAIN_VISUAL);
+                    }
+                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                    {
+                        caster->CastStop(SPELL_TESLA_SHOCK);
+                        caster->CastSpell(target, SPELL_TESLA_SHOCK,true);
+                    }
+                }
+                else if (isOverloading || refreshBeam)
+                {
+                    isOverloading = false;
+                    refreshBeam = false;
+                    caster->CastStop();
+                    caster->CastSpell(me, SPELL_FEUGEN_CHAIN_VISUAL, true);
+                    caster->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                }
+            }
+
+            void UpdateAI(uint32 uiDiff) override
+            {
+                if (isFeignDeath)
+                    return;
+                if (!UpdateVictim())
+                    return;
+
+                if (magneticPullTimer <= uiDiff)
+                {
+                    DoCast(me, SPELL_MAGNETIC_PULL);
+                    magneticPullTimer = 20 * IN_MILLISECONDS;
+                }
+                else magneticPullTimer -= uiDiff;
+            
+                if (staticFieldTimer <= uiDiff)
+                {
+                    DoCast(me, SPELL_FEUGEN_STATICFIELD);
+                    staticFieldTimer = 6 * IN_MILLISECONDS;
+                }
+                else staticFieldTimer -= uiDiff;
+
+                DoMeleeAttackIfReady();
+            }
+
+        private:
+            Creature* myCoil()
+            {
+                Creature* coil = nullptr;
+                if (_myCoil)
+                    coil = ObjectAccessor::GetCreature(*me, _myCoil);
+                if (!coil)
+                {
+                    coil = me->FindNearestCreature(NPC_TESLA, 1000.0f, true);
+                    if (coil)
+                    {
+                        _myCoil = coil->GetGUID();
+                        coil->SetReactState(REACT_PASSIVE);
+                    }
+                }
+                return coil;
+            }
+
+            GameObject* myCoilGO()
+            {
+                GameObject* coil = nullptr;
+                if (_myCoilGO)
+                    coil = ObjectAccessor::GetGameObject(*me, _myCoilGO);
+                if (!coil)
+                {
+                    coil = me->FindNearestGameObject(GO_CONS_NOX_TESLA_FEUGEN, 1000.0f);
+                    if (coil)
+                        _myCoilGO = coil->GetGUID();
+                }
+                return coil;
+            }
+            InstanceScript* instance;
+
+            uint32 magneticPullTimer;
+            uint32 staticFieldTimer;
+
+            ObjectGuid _myCoil;
+            ObjectGuid _myCoilGO;
+       
+            bool isOverloading;
+            bool refreshBeam;
+            bool isFeignDeath;
+    };
+};
+
+class npc_tesla : public CreatureScript
+{
+public:
+    npc_tesla() : CreatureScript("npc_tesla") { }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetInstanceAI<npc_teslaAI>(creature);
+    }
+
+    struct npc_teslaAI : public ScriptedAI
+    {
+        public:
+            npc_teslaAI(Creature* creature) : ScriptedAI(creature) { }
+            void EnterEvadeMode() override { } // never stop casting due to evade
+            void UpdateAI(uint32 /*diff*/) override { } // never do anything unless told
+            void EnterCombat(Unit* /*who*/) override { }
+            void DamageTaken(Unit* /*who*/, uint32& damage) { damage = 0; } // no, you can't kill it
+    };
+};
+
+class spell_thaddius_polarity_charge : public SpellScriptLoader
+{
+    public:
+        spell_thaddius_polarity_charge() : SpellScriptLoader("spell_thaddius_polarity_charge") { }
+
+        class spell_thaddius_polarity_charge_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_thaddius_polarity_charge_SpellScript);
+
+            bool Validate(SpellInfo const* /*spell*/) override
+            {
+                return (
+                    sSpellMgr->GetSpellInfo(SPELL_POLARITY_SHIFT) &&
+                    sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_APPLY) &&
+                    sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_TICK) &&
+                    sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_AMP) &&
+                    sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_APPLY) &&
+                    sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_TICK) &&
+                    sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_AMP)
+                    );
+            }
+
+            void HandleTargets(std::list<WorldObject*>& targetList)
             {
                 if (!GetTriggeringSpell())
                     return;
 
-                Unit* target = GetHitUnit();
-                Unit* caster = GetCaster();
-
-                if (target->HasAura(GetTriggeringSpell()->Id))
-                    SetHitDamage(0);
-                else
+                uint32 triggeringId = GetTriggeringSpell()->Id;
+                uint32 ampId = 0u;
+                switch (triggeringId)
                 {
-                    if (target->GetTypeId() == TYPEID_PLAYER && caster->IsAIEnabled)
-                        caster->ToCreature()->AI()->SetData(DATA_POLARITY_SWITCH, 1);
+                    case SPELL_POSITIVE_CHARGE_APPLY:
+                        ampId = SPELL_POSITIVE_CHARGE_AMP;
+                        break;
+                    case SPELL_NEGATIVE_CHARGE_APPLY:
+                        ampId = SPELL_NEGATIVE_CHARGE_AMP;
+                        break;
+                    default:
+                        return;
+                }
+
+                uint8 maxStacks = 0;
+                if (GetCaster())
+                    switch (GetCaster()->GetMap()->GetDifficulty())
+                    {
+                        case RAID_DIFFICULTY_10MAN_NORMAL:
+                            maxStacks = MAX_POLARITY_10M;
+                            break;
+                        case RAID_DIFFICULTY_25MAN_NORMAL:
+                            maxStacks = MAX_POLARITY_25M;
+                            break;
+                        default:
+                            break;
+                    }
+
+                uint8 stacksCount = 1; // do we get a stack for our own debuff?
+                std::list<WorldObject*>::iterator it = targetList.begin();
+                while(it != targetList.end())
+                {
+                    if ((*it)->GetTypeId() != TYPEID_PLAYER)
+                    {
+                        it = targetList.erase(it);
+                        continue;
+                    }
+                    if ((*it)->ToPlayer()->HasAura(triggeringId))
+                    {
+                        it = targetList.erase(it);
+                        if (stacksCount < maxStacks)
+                            stacksCount++;
+                        continue;
+                    }
+
+                    // this guy will get hit - achievement failure trigger
+                    if (Creature* thaddius = (*it)->FindNearestCreature(NPC_THADDIUS,200.0f))
+                        thaddius->AI()->DoAction(ACTION_POLARITY_CROSSED);
+
+                    ++it;
+                }
+
+                if (GetCaster() && GetCaster()->ToPlayer())
+                {
+                    if (!GetCaster()->ToPlayer()->HasAura(ampId))
+                        GetCaster()->ToPlayer()->AddAura(ampId, GetCaster());
+                    GetCaster()->ToPlayer()->SetAuraStack(ampId, GetCaster(), stacksCount);
                 }
             }
 
             void Register() override
             {
-                OnEffectHitTarget += SpellEffectFn(spell_thaddius_pos_neg_charge_SpellScript::HandleDamage, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
-                OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_thaddius_pos_neg_charge_SpellScript::HandleTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ALLY);
+                OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_thaddius_polarity_charge_SpellScript::HandleTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ALLY);
             }
         };
 
         SpellScript* GetSpellScript() const override
         {
-            return new spell_thaddius_pos_neg_charge_SpellScript();
+            return new spell_thaddius_polarity_charge_SpellScript;
         }
 };
 
@@ -536,16 +1100,33 @@ class spell_thaddius_polarity_shift : public SpellScriptLoader
 
             bool Validate(SpellInfo const* /*spell*/) override
             {
-                if (!sSpellMgr->GetSpellInfo(SPELL_POSITIVE_POLARITY) || !sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_POLARITY))
-                    return false;
-                return true;
+                return (
+                    sSpellMgr->GetSpellInfo(SPELL_POLARITY_SHIFT) &&
+                    sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_APPLY) &&
+                    sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_TICK) &&
+                    sSpellMgr->GetSpellInfo(SPELL_POSITIVE_CHARGE_AMP) &&
+                    sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_APPLY) &&
+                    sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_TICK) &&
+                    sSpellMgr->GetSpellInfo(SPELL_NEGATIVE_CHARGE_AMP)
+                    );
             }
 
-            void HandleDummy(SpellEffIndex /* effIndex */)
+            void HandleDummy(SpellEffIndex /*effIndex*/)
             {
-                Unit* caster = GetCaster();
                 if (Unit* target = GetHitUnit())
-                    target->CastSpell(target, roll_chance_i(50) ? SPELL_POSITIVE_POLARITY : SPELL_NEGATIVE_POLARITY, true, NULL, NULL, caster->GetGUID());
+                    if (target->GetTypeId() == TYPEID_PLAYER)
+                    {
+                        if (roll_chance_i(50))
+                        { // positive
+                            target->CastSpell(target, SPELL_POSITIVE_CHARGE_APPLY, true);
+                            target->RemoveAura(SPELL_POSITIVE_CHARGE_AMP);
+                        }
+                        else
+                        { // negative
+                            target->CastSpell(target, SPELL_NEGATIVE_CHARGE_APPLY, true);
+                            target->RemoveAura(SPELL_NEGATIVE_CHARGE_AMP);
+                        }
+                    }
             }
 
             void Register() override
@@ -560,23 +1141,131 @@ class spell_thaddius_polarity_shift : public SpellScriptLoader
         }
 };
 
-class achievement_polarity_switch : public AchievementCriteriaScript
+class spell_thaddius_magnetic_pull : public SpellScriptLoader
 {
     public:
-        achievement_polarity_switch() : AchievementCriteriaScript("achievement_polarity_switch") { }
+        spell_thaddius_magnetic_pull() : SpellScriptLoader("spell_thaddius_magnetic_pull") { };
+
+        class spell_thaddius_magnetic_pull_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_thaddius_magnetic_pull_SpellScript);
+
+            bool Validate(SpellInfo const* /*spell*/) override
+            {
+                return sSpellMgr->GetSpellInfo(SPELL_MAGNETIC_PULL) ? true : false;
+            }
+
+            void HandleCast() // only feugen ever casts this according to wowhead data
+            {
+                Unit* feugen = GetCaster();
+                if (!feugen || feugen->GetEntry() != NPC_FEUGEN)
+                    return;
+                
+                Unit* stalagg = ObjectAccessor::GetCreature(*feugen, feugen->GetInstanceScript()->GetGuidData(DATA_STALAGG));
+                if (!stalagg)
+                    return;
+
+                Unit* feugenTank = feugen->GetVictim();
+                Unit* stalaggTank = stalagg->GetVictim();
+
+                if (!feugenTank || !stalaggTank)
+                    return;
+
+                ThreatManager& feugenThreat = feugen->getThreatManager();
+                ThreatManager& stalaggThreat = stalagg->getThreatManager();
+
+                if (feugenTank == stalaggTank) // special behavior if the tanks are the same (taken from retail)
+                {
+                    float feugenTankThreat = feugenThreat.getThreat(feugenTank);
+                    float stalaggTankThreat = stalaggThreat.getThreat(stalaggTank);
+
+                    feugenThreat.addThreat(feugenTank, stalaggTankThreat - feugenTankThreat);
+                    stalaggThreat.addThreat(stalaggTank, feugenTankThreat - stalaggTankThreat);
+
+                    feugen->CastSpell(stalaggTank, SPELL_MAGNETIC_PULL_EFFECT, true);
+                }
+                else // normal case, two tanks
+                {
+                    float feugenTankThreat = feugenThreat.getThreat(feugenTank);
+                    float feugenOtherThreat = feugenThreat.getThreat(stalaggTank);
+                    float stalaggTankThreat = stalaggThreat.getThreat(stalaggTank);
+                    float stalaggOtherThreat = stalaggThreat.getThreat(feugenTank);
+
+                    // set the two entries in feugen's threat table to be equal to the ones in stalagg's
+                    feugenThreat.addThreat(stalaggTank, stalaggTankThreat - feugenOtherThreat);
+                    feugenThreat.addThreat(feugenTank, stalaggOtherThreat - feugenTankThreat);
+
+                    // set the two entries in stalagg's threat table to be equal to the ones in feugen's
+                    stalaggThreat.addThreat(feugenTank, feugenTankThreat - stalaggOtherThreat);
+                    stalaggThreat.addThreat(stalaggTank, feugenOtherThreat - stalaggTankThreat);
+
+                    // pull the two tanks across
+                    feugenTank->CastSpell(stalaggTank, SPELL_MAGNETIC_PULL_EFFECT, true);
+                    stalaggTank->CastSpell(feugenTank, SPELL_MAGNETIC_PULL_EFFECT, true);
+
+                    // and make both attack their respective new tanks
+                    if (feugen->GetAI())
+                        feugen->GetAI()->AttackStart(stalaggTank);
+                    if (stalagg->GetAI())
+                        stalagg->GetAI()->AttackStart(feugenTank);
+                }
+            }
+
+            void Register() override
+            {
+                OnCast += SpellCastFn(spell_thaddius_magnetic_pull_SpellScript::HandleCast);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_thaddius_magnetic_pull_SpellScript();
+        }
+};
+
+class at_thaddius_entrance : public AreaTriggerScript
+{
+    public:
+        at_thaddius_entrance() : AreaTriggerScript("at_thaddius_entrance") { }
+
+        bool OnTrigger(Player* player, AreaTriggerEntry const* /*areaTrigger*/) override
+        {
+            InstanceScript* instance = player->GetInstanceScript();
+            if (!instance || instance->GetData(DATA_HAD_THADDIUS_GREET) || instance->GetBossState(BOSS_THADDIUS) == DONE)
+                return true;
+
+            if (Creature* thaddius = ObjectAccessor::GetCreature(*player, instance->GetGuidData(DATA_THADDIUS)))
+                thaddius->AI()->Talk(SAY_GREET);
+            instance->SetData(DATA_HAD_THADDIUS_GREET, 1u);
+
+            return true;
+        }
+};
+
+class achievement_thaddius_shocking : public AchievementCriteriaScript
+{
+    public:
+        achievement_thaddius_shocking() : AchievementCriteriaScript("achievement_thaddius_shocking") { }
 
         bool OnCheck(Player* /*source*/, Unit* target) override
         {
-            return target && target->GetAI()->GetData(DATA_POLARITY_SWITCH);
+            return target && target->GetAI() && target->GetAI()->GetData(DATA_POLARITY_CROSSED);
         }
 };
+
 
 void AddSC_boss_thaddius()
 {
     new boss_thaddius();
     new npc_stalagg();
     new npc_feugen();
-    new spell_thaddius_pos_neg_charge();
+    new npc_tesla();
+
+    new spell_thaddius_polarity_charge();
     new spell_thaddius_polarity_shift();
-    new achievement_polarity_switch();
+    new spell_thaddius_magnetic_pull();
+
+    new at_thaddius_entrance();
+
+    new achievement_thaddius_shocking();
 }

--- a/src/server/scripts/Northrend/Naxxramas/naxxramas.h
+++ b/src/server/scripts/Northrend/Naxxramas/naxxramas.h
@@ -47,8 +47,8 @@ enum Data
     DATA_GOTHIK_GATE,
     DATA_SAPPHIRON_BIRTH,
     DATA_HAD_ANUBREKHAN_GREET,
-
     DATA_HAD_FAERLINA_GREET,
+    DATA_HAD_THADDIUS_GREET,
 
     DATA_HORSEMEN0,
     DATA_HORSEMEN1,
@@ -91,10 +91,11 @@ enum CreaturesIds
     NPC_LADY                    = 16065,
     NPC_BARON                   = 30549,
     NPC_SIR                     = 16063,
-    NPC_THADDIUS                = 15928,
     NPC_HEIGAN                  = 15936,
+    NPC_THADDIUS                = 15928,
     NPC_FEUGEN                  = 15930,
     NPC_STALAGG                 = 15929,
+    NPC_TESLA                   = 16218,
     NPC_SAPPHIRON               = 15989,
     NPC_KEL_THUZAD              = 15990,
     NPC_CRYPT_GUARD             = 16573,
@@ -173,6 +174,10 @@ enum InstanceEvents
     EVENT_DIALOGUE_GOTHIK_ZELIEK2,
     EVENT_DIALOGUE_GOTHIK_KORTHAZZ2,
     EVENT_DIALOGUE_GOTHIK_RIVENDARE2,
+
+    // Thaddius AI requesting timed encounter respawn
+    EVENT_THADDIUS_BEGIN_RESET,
+    EVENT_THADDIUS_RESET,
 
     // Dialogue that happens after each wing.
     EVENT_KELTHUZAD_WING_TAUNT,


### PR DESCRIPTION
Full rewrite of the Thaddius encounter. Stuff fixed, among others:
- Encounter properly resets if the raid wipes at any point during the encounter (fixes and closes #6888)
- Polarity Shift works properly (fixes and closes #10126)
- Visual spells used properly
- Thaddius is now immobile and will no longer chase the tank
- Tesla Coil leashes on Feugen/Stalagg work properly (cast chain lightning on raid if dragged off the platform)
- Achievement criteria for Shocking! fixed to trigger properly, and only on appropriate difficulty (fixes and closes #4751)
- Way too many other corrections to count

PS: My first full rewrite of a boss AI. Some stuff may be done incorrectly. Please tell me how to do it better. Thanks.
