### PR TITLE
Scripts/Naxxramas: Patchwerk - quick bugfix (incorrect SpellID)

### DIFF
--- a/sql/updates/world/2015_09_20_00_world.sql
+++ b/sql/updates/world/2015_09_20_00_world.sql
@@ -1,0 +1,3 @@
+-- remove existing entries
+DELETE FROM `spelldifficulty_dbc` WHERE id IN (28308,41926);
+INSERT INTO `spelldifficulty_dbc` (`id`,`spellid0`,`spellid1`) VALUES (28308,28308,59192);

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -21,7 +21,7 @@
 
 enum Spells
 {
-    SPELL_HATEFUL_STRIKE                        = 41926,
+    SPELL_HATEFUL_STRIKE                        = 28308,
     SPELL_FRENZY                                = 28131,
     SPELL_BERSERK                               = 26662,
     SPELL_SLIME_BOLT                            = 32309
@@ -33,7 +33,7 @@ enum Yells
     SAY_SLAY                                    = 1,
     SAY_DEATH                                   = 2,
     EMOTE_BERSERK                               = 3,
-    EMOTE_ENRAGE                                = 4
+    EMOTE_FRENZY                                = 4
 };
 
 enum Events
@@ -185,7 +185,7 @@ public:
             if (!Enraged && HealthBelowPct(5))
             {
                 DoCast(me, SPELL_FRENZY, true);
-                Talk(EMOTE_ENRAGE);
+                Talk(EMOTE_FRENZY);
                 Enraged = true;
             }
 


### PR DESCRIPTION
Fixed an incorrect spellid for Naxx10 Hateful Strike. This is from sniffs.
Previously used spellid is actually the one used by Supremus in BT (which had the same mechanic).
