### PR TITLE
(Core/Maps) Remove corpses from ObjectAccessor collection, when loading maps.

### DIFF
--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -269,6 +269,19 @@ void ObjectAccessor::RemoveCorpse(Corpse* corpse)
     }
 }
 
+void ObjectAccessor::RemoveAllMapCorpses(uint32 mapId, uint32 instanceId)
+{
+    boost::unique_lock<boost::shared_mutex> lock(_corpseLock);
+
+    for (auto iter = i_player2corpse.begin(); iter != i_player2corpse.end();)
+    {
+        if (iter->second->GetMapId() == mapId && iter->second->GetInstanceId() == instanceId)
+            iter = i_player2corpse.erase(iter);
+        else
+            ++iter;
+    }
+}
+
 void ObjectAccessor::AddCorpse(Corpse* corpse)
 {
     ASSERT(corpse && corpse->GetType() != CORPSE_BONES);

--- a/src/server/game/Globals/ObjectAccessor.h
+++ b/src/server/game/Globals/ObjectAccessor.h
@@ -148,6 +148,7 @@ class ObjectAccessor
         //Thread safe
         Corpse* GetCorpseForPlayerGUID(ObjectGuid const& guid);
         void RemoveCorpse(Corpse* corpse);
+        void RemoveAllMapCorpses(uint32 mapId, uint32 instanceId);
         void AddCorpse(Corpse* corpse);
         void AddCorpsesToGrid(GridCoord const& gridpair, GridType& grid, Map* map);
         Corpse* ConvertCorpseForPlayer(ObjectGuid const& player_guid, bool insignia = false);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3520,6 +3520,9 @@ time_t Map::GetLinkedRespawnTime(ObjectGuid guid) const
 
 void Map::LoadCorpseData()
 {
+    // First remove any existing corpses for this map/instance
+    sObjectAccessor->RemoveAllMapCorpses(GetId(), GetInstanceId());
+
     PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_CORPSES);
     stmt->setUInt32(0, GetId());
     stmt->setUInt32(1, GetInstanceId());


### PR DESCRIPTION
If a map is unloaded (instance maps mainly) with corpses inside, when the players return to the instance, if the server wasn't shutdown in between would load the corpses from DB, and attempt to insert again into the map in ObjectAccessor causing an assert when it already existed.

The ensures that before a game map is loaded, any corpses loaded from DB are first removed from the ObjectAccessor map.
