### PR TITLE
Core/Conditions: Fixed a typo

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1310,7 +1310,7 @@ bool ConditionMgr::addToSpellImplicitTargetConditions(Condition* cond)
                 bool assigned = false;
                 for (uint8 i = firstEffIndex; i < MAX_SPELL_EFFECTS; ++i)
                 {
-                    SpellEffectInfo const* eff = spellInfo->GetEffect(DIFFICULTY_NONE, firstEffIndex);
+                    SpellEffectInfo const* eff = spellInfo->GetEffect(DIFFICULTY_NONE, i);
                     if (!eff)
                         continue;
 


### PR DESCRIPTION
Fixed a typo which caused implicit target conditions to only be applied to the first effect
bug was introduced in 926a37a
