### PR TITLE
Core/Scripts: Fix crash related to extractQuotedArg

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -1131,7 +1131,7 @@ void ChatHandler::extractOptFirstArg(char* args, char** arg1, char** arg2)
 
 char* ChatHandler::extractQuotedArg(char* args)
 {
-    if (!*args)
+    if (!args || !*args)
         return NULL;
 
     if (*args == '"')


### PR DESCRIPTION
strtok may return null which crashes in the `ChatHandler::extractQuotedArg`.
See https://github.com/TrinityCore/TrinityCore/blob/c92faf627712d26a7abdce2db62ffb8b938a4522/src/server/scripts/Commands/cs_guild.cpp#L212
