### PR TITLE
DB/Misc: Fix wrong npcflag's

### DIFF
--- a/sql/updates/world/2015_11_24_00_world.sql
+++ b/sql/updates/world/2015_11_24_00_world.sql
@@ -1,0 +1,18 @@
+-- Human Start Location 
+UPDATE `creature_template` SET `npcflag`=0 WHERE `entry`=49871; -- Blackrock Battle Worg
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=49874; -- Blackrock Spy
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=50039; -- Goblin Assassin
+-- Dwarf Start Location
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=37070; -- Rockjaw Invader
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=706; -- Frostmane Troll Whelp
+-- Gnome Start Location
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=46363; -- Crazed Leper Gnome
+-- Draenei Start Location
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=16516; -- Volatile Mutation
+-- Undead Start Location
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=1501; -- Mindless Zombie
+-- Troll Start Location
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=38038; -- Tiki Target
+-- Blood Elf Start Location
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=15274; -- Mana Wyrm
+UPDATE `creature_template` SET `npcflag`=0 WHERE entry=15271; -- Tender


### PR DESCRIPTION
This small fixes wrong npc flags on start location's.
Before fix:
![wowscrnshot_112415_100434](https://cloud.githubusercontent.com/assets/2673447/11360599/200e7d7a-9297-11e5-8481-693c042bc3cf.jpg)
