### PR TITLE
Scripts/Naxxramas: Thaddius follow-up

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
@@ -193,9 +193,10 @@ class instance_naxxramas : public InstanceMapScript
                 switch (eventId)
                 {
                     case EVENT_THADDIUS_BEGIN_RESET:
-                        if (!source->ToCreature() || source->ToCreature()->GetEntry() != NPC_THADDIUS)
-                            return;
-                        events.ScheduleEvent(EVENT_THADDIUS_RESET, 30 * IN_MILLISECONDS);
+                        if (GetBossState(BOSS_THADDIUS) == SPECIAL) // this is the initial spawn, we want a shorter spawn time
+                            events.ScheduleEvent(EVENT_THADDIUS_RESET, 5 * IN_MILLISECONDS);
+                        else
+                            events.ScheduleEvent(EVENT_THADDIUS_RESET, 30 * IN_MILLISECONDS);
                         break;
                 }
             }

--- a/src/server/scripts/Northrend/Naxxramas/naxxramas.h
+++ b/src/server/scripts/Northrend/Naxxramas/naxxramas.h
@@ -175,7 +175,7 @@ enum InstanceEvents
     EVENT_DIALOGUE_GOTHIK_KORTHAZZ2,
     EVENT_DIALOGUE_GOTHIK_RIVENDARE2,
 
-    // Thaddius AI requesting timed encounter respawn
+    // Thaddius AI requesting timed encounter (re-)spawn
     EVENT_THADDIUS_BEGIN_RESET,
     EVENT_THADDIUS_RESET,
 


### PR DESCRIPTION
Thaddius follow-up:
- Reduce initial spawn timer on the encounter from 30 seconds to 5 seconds
- Rearrange respawn logic to fix the "petrified" visual from not showing properly
- Fix a potential infinite respawn loop that could prevent the encounter from initializing properly (fixes and closes #15898)
