### PR TITLE
CreatureAI: Adjust AI behavior when a charm ends

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -58,6 +58,12 @@ void PossessedAI::KilledUnit(Unit* victim)
         victim->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
 }
 
+void PossessedAI::OnCharmed(bool /*apply*/)
+{
+    me->NeedChangeAI = true;
+    me->IsAIEnabled = false;
+}
+
 void CritterAI::DamageTaken(Unit* /*done_by*/, uint32&)
 {
     if (!me->HasUnitState(UNIT_STATE_FLEEING))

--- a/src/server/game/AI/CoreAI/PassiveAI.h
+++ b/src/server/game/AI/CoreAI/PassiveAI.h
@@ -46,6 +46,8 @@ class TC_GAME_API PossessedAI : public CreatureAI
         void JustDied(Unit*) override;
         void KilledUnit(Unit* victim) override;
 
+        void OnCharmed(bool /*apply*/) override;
+
         static int Permissible(const Creature*) { return PERMIT_BASE_IDLE;  }
 };
 

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -588,6 +588,12 @@ void PetAI::ReceiveEmote(Player* player, uint32 emote)
         }
 }
 
+void PetAI::OnCharmed(bool /*apply*/)
+{
+    me->NeedChangeAI = true;
+    me->IsAIEnabled = false;
+}
+
 void PetAI::ClearCharmInfoFlags()
 {
     // Quick access to set all flags to FALSE

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -49,6 +49,8 @@ class TC_GAME_API PetAI : public CreatureAI
         void MoveInLineOfSight_Safe(Unit* /*who*/) { } // CreatureAI interferes with returning pets
         void EnterEvadeMode(EvadeReason /*why*/) override { } // For fleeing, pets don't use this type of Evade mechanic
 
+        void OnCharmed(bool /*apply*/) override;
+
     private:
         bool _isVisible(Unit*) const;
         bool _needToStop(void);

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -29,11 +29,13 @@
 #include "Language.h"
 
 //Disable CreatureAI when charmed
-void CreatureAI::OnCharmed(bool /*apply*/)
+void CreatureAI::OnCharmed(bool apply)
 {
-    //me->IsAIEnabled = !apply;*/
-    me->NeedChangeAI = true;
-    me->IsAIEnabled = false;
+    if (apply)
+    {
+        me->NeedChangeAI = true;
+        me->IsAIEnabled = false;
+    }
 }
 
 AISpellInfoType* UnitAI::AISpellInfo;

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -653,8 +653,8 @@ void SmartAI::OnCharmed(bool apply)
 {
     GetScript()->ProcessEventsFor(SMART_EVENT_CHARMED, NULL, 0, 0, apply);
 
-    if (!apply && !me->IsInEvadeMode() && me->GetCharmerGUID())
-        if (Unit* charmer = ObjectAccessor::GetUnit(*me, me->GetCharmerGUID()))
+    if (!apply && !me->IsInEvadeMode())
+        if (Unit* charmer = me->GetCharmer())
             AttackStart(charmer);
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13712,6 +13712,9 @@ void Unit::UpdateCharmAI()
                     delete i_AI;
                     i_AI = i_disabledAI;
                     i_disabledAI = nullptr;
+
+            if (GetTypeId() == TYPEID_UNIT)
+                ToCreature()->AI()->OnCharmed(false);
                 }
             }
             else


### PR DESCRIPTION
CreatureAI: Adjust AI behavior when a charm ends:
- OnCharmed will be invoked on the creature's base (non-charmed) AI, allowing the AI to react to the creature no longer being charmed.
