### PR TITLE
Spells/Penance: Fix erroneous cooldown on misplaced hostile target

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -617,8 +617,13 @@ class spell_pri_penance : public SpellScriptLoader
             {
                 Player* caster = GetCaster()->ToPlayer();
                 if (Unit* target = GetExplTargetUnit())
-                    if (!caster->IsFriendlyTo(target) && !caster->IsValidAttackTarget(target))
-                        return SPELL_FAILED_BAD_TARGETS;
+                    if (!caster->IsFriendlyTo(target))
+                    {
+                        if (!caster->IsValidAttackTarget(target))
+                            return SPELL_FAILED_BAD_TARGETS;
+                        if (!caster->isInFront(target))
+                            return SPELL_FAILED_UNIT_NOT_INFRONT;
+                    }
                 return SPELL_CAST_OK;
             }
 


### PR DESCRIPTION
Spells/Penance: If hostile target is not in front, now fails in the initial cast rather than the triggered cast, thus not erroneously causing a cooldown.

Thanks @P-Kito
