### PR TITLE
Scripts/Deadmines: Fix #6624 Mr. Smite's event text, and phase switch…

### DIFF
--- a/sql/updates/world/2016_02_16_00_world.sql
+++ b/sql/updates/world/2016_02_16_00_world.sql
@@ -1,0 +1,7 @@
+-- Add missing creature text for Mr. Smite in Deadmines.
+DELETE FROM creature_text WHERE entry=646;
+INSERT INTO creature_text (`entry`, `groupid`, `id`, `text`, `type`, `language`, `probability`, `emote`, `duration`, `sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(646, 0, 0, 'You there, check out that noise!', 14, 0, 100, 0, 0, 5775, 1148, 2, 'smite SAY_ALARM1'),
+(646, 1, 0, 'We\'re under attack! Avast, ye swabs! Repel the invaders!', 14, 0, 100, 0, 0, 5777, 1149, 2, 'smite SAY_ALARM2'),
+(646, 2, 0, 'You landlubbers are tougher than I thought, I\'ll have to Improvise!', 12, 0, 100, 0, 0, 5778, 1344, 0, 'smite SAY_PHASE_1'),
+(646, 3, 0, 'D\'ah! Now you\'re making me angry!', 12, 0, 100, 0, 0, 5779, 1345, 0, 'smite SAY_PHASE_2');

--- a/src/server/scripts/EasternKingdoms/Deadmines/boss_mr_smite.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/boss_mr_smite.cpp
@@ -25,17 +25,25 @@ EndScriptData */
 #include "ScriptedCreature.h"
 #include "deadmines.h"
 
-enum Spels
+enum Spells
 {
     SPELL_TRASH             = 3391,
     SPELL_SMITE_STOMP       = 6432,
     SPELL_SMITE_SLAM        = 6435,
-    SPELL_NIMBLE_REFLEXES   = 6264,
+    SPELL_NIMBLE_REFLEXES   = 6264
+};
 
+enum Equips
+{
     EQUIP_SWORD             = 5191,
-    EQUIP_MACE              = 7230,
+    EQUIP_AXE               = 5196,
+    EQUIP_MACE              = 7230
+};
 
-    SAY_AGGRO               = 0,
+enum Texts
+{
+    SAY_PHASE_1             = 2,
+    SAY_PHASE_2             = 3
 };
 
 class boss_mr_smite : public CreatureScript
@@ -66,6 +74,8 @@ public:
 
             uiPhase = 0;
             uiTimer = 0;
+
+            uiIsMoving = false;
         }
 
         InstanceScript* instance;
@@ -79,16 +89,19 @@ public:
         uint32 uiPhase;
         uint32 uiTimer;
 
+        bool uiIsMoving;
+
         void Reset() override
         {
             Initialize();
 
             SetEquipmentSlots(false, EQUIP_SWORD, EQUIP_UNEQUIP, EQUIP_NO_CHANGE);
+            me->SetStandState(UNIT_STAND_STATE_STAND);
+            me->SetReactState(REACT_AGGRESSIVE);
         }
 
         void EnterCombat(Unit* /*who*/) override
         {
-           Talk(SAY_AGGRO);
         }
 
         bool bCheckChances()
@@ -105,38 +118,52 @@ public:
             if (!UpdateVictim())
                 return;
 
-        /*START ACID-AI*/
-            if (uiTrashTimer <= uiDiff)
+            if (!uiIsMoving) // halt abilities in between phases
             {
-                if (bCheckChances())
-                    DoCast(me, SPELL_TRASH);
-                uiTrashTimer = urand(6000, 15500);
-            } else uiTrashTimer -= uiDiff;
+                if (uiTrashTimer <= uiDiff)
+                {
+                    if (bCheckChances())
+                        DoCast(me, SPELL_TRASH);
+                    uiTrashTimer = urand(6000, 15500);
+                }
+                else uiTrashTimer -= uiDiff;
 
-            if (uiSlamTimer <= uiDiff)
-            {
-                if (bCheckChances())
-                    DoCastVictim(SPELL_SMITE_SLAM);
-                uiSlamTimer = 11000;
-            } else uiSlamTimer -= uiDiff;
+                if (uiSlamTimer <= uiDiff)
+                {
+                    if (bCheckChances())
+                        DoCastVictim(SPELL_SMITE_SLAM);
+                    uiSlamTimer = 11000;
+                }
+                else uiSlamTimer -= uiDiff;
 
-            if (uiNimbleReflexesTimer <= uiDiff)
-            {
-                if (bCheckChances())
-                    DoCast(me, SPELL_NIMBLE_REFLEXES);
-                uiNimbleReflexesTimer = urand(27300, 60100);
-            } else uiNimbleReflexesTimer -= uiDiff;
-        /*END ACID-AI*/
+                if (uiNimbleReflexesTimer <= uiDiff)
+                {
+                    if (bCheckChances())
+                        DoCast(me, SPELL_NIMBLE_REFLEXES);
+                    uiNimbleReflexesTimer = urand(27300, 60100);
+                }
+                else uiNimbleReflexesTimer -= uiDiff;
+            }
 
             if ((uiHealth == 0 && !HealthAbovePct(66)) || (uiHealth == 1 && !HealthAbovePct(33)))
             {
                 ++uiHealth;
                 DoCastAOE(SPELL_SMITE_STOMP, false);
                 SetCombatMovement(false);
-                if (GameObject* go = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(DATA_SMITE_CHEST)))
+                me->AttackStop();
+                me->InterruptNonMeleeSpells(false);
+                me->SetReactState(REACT_PASSIVE);
+                uiTimer = 2500;
+                uiPhase = 1;
+
+                switch (uiHealth)
                 {
-                    me->GetMotionMaster()->Clear();
-                    me->GetMotionMaster()->MovePoint(1, go->GetPositionX() - 3.0f, go->GetPositionY(), go->GetPositionZ());
+                    case 1:
+                        Talk(SAY_PHASE_1);
+                        break;
+                    case 2:
+                        Talk(SAY_PHASE_2);
+                        break;
                 }
             }
 
@@ -147,21 +174,36 @@ public:
                     switch (uiPhase)
                     {
                         case 1:
-                            me->HandleEmoteCommand(EMOTE_STATE_KNEEL); //dosen't work?
-                            uiTimer = 1000;
-                            uiPhase = 2;
+                        {
+                            if (uiIsMoving)
+                                break;
+
+                            if (GameObject* go = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(DATA_SMITE_CHEST)))
+                            {
+                                me->GetMotionMaster()->Clear();
+                                me->GetMotionMaster()->MovePoint(1, go->GetPositionX() - 1.5f, go->GetPositionY() + 1.4f, go->GetPositionZ());
+                                uiIsMoving = true;
+                            }
                             break;
+                        }
                         case 2:
                             if (uiHealth == 1)
-                                SetEquipmentSlots(false, EQUIP_SWORD, EQUIP_SWORD, EQUIP_NO_CHANGE);
+                                SetEquipmentSlots(false, EQUIP_AXE, EQUIP_AXE, EQUIP_NO_CHANGE);
                             else
                                 SetEquipmentSlots(false, EQUIP_MACE, EQUIP_UNEQUIP, EQUIP_NO_CHANGE);
                             uiTimer = 500;
                             uiPhase = 3;
                             break;
                         case 3:
+                            me->SetStandState(UNIT_STAND_STATE_STAND);
+                            uiTimer = 750;
+                            uiPhase = 4;
+                            break;
+                        case 4:
+                            me->SetReactState(REACT_AGGRESSIVE);
                             SetCombatMovement(true);
                             me->GetMotionMaster()->MoveChase(me->GetVictim(), me->m_CombatDistance);
+                            uiIsMoving = false;
                             uiPhase = 0;
                             break;
                     }
@@ -176,8 +218,11 @@ public:
             if (uiType != POINT_MOTION_TYPE)
                 return;
 
-            uiTimer = 1500;
-            uiPhase = 1;
+            me->SetFacingTo(5.47f);
+            me->SetStandState(UNIT_STAND_STATE_KNEEL);
+
+            uiTimer = 2000;
+            uiPhase = 2;
         }
     };
 };

--- a/src/server/scripts/EasternKingdoms/Deadmines/deadmines.h
+++ b/src/server/scripts/EasternKingdoms/Deadmines/deadmines.h
@@ -26,6 +26,7 @@ enum CannonState
     CANNON_GUNPOWDER_USED,
     CANNON_BLAST_INITIATED,
     PIRATES_ATTACK,
+    SMITE_ALARMED,
     EVENT_DONE
 };
 
@@ -48,4 +49,16 @@ enum GameObjects
     GO_DOOR_LEVER                                          = 101833,
     GO_MR_SMITE_CHEST                                      = 144111
 };
+
+enum CreaturesIds
+{
+    NPC_MR_SMITE   = 646
+};
+
+enum InstanceTexts
+{
+    SAY_ALARM1 = 0,
+    SAY_ALARM2 = 1
+};
+
 #endif

--- a/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/instance_deadmines.cpp
@@ -32,18 +32,14 @@ EndScriptData */
 enum Sounds
 {
     SOUND_CANNONFIRE                                     = 1400,
-    SOUND_DESTROYDOOR                                    = 3079,
-    SOUND_MR_SMITE_ALARM1                                = 5775,
-    SOUND_MR_SMITE_ALARM2                                = 5777
+    SOUND_DESTROYDOOR                                    = 3079
 };
-
-#define SAY_MR_SMITE_ALARM1 "You there, check out that noise!"
-#define SAY_MR_SMITE_ALARM2 "We're under attack! A vast, ye swabs! Repel the invaders!"
 
 enum Misc
 {
     DATA_CANNON_BLAST_TIMER                                = 3000,
-    DATA_PIRATES_DELAY_TIMER                               = 1000
+    DATA_PIRATES_DELAY_TIMER                               = 1000,
+    DATA_SMITE_ALARM_DELAY_TIMER                           = 5000
 };
 
 class instance_deadmines : public InstanceMapScript
@@ -70,10 +66,12 @@ class instance_deadmines : public InstanceMapScript
             ObjectGuid DefiasPirate1GUID;
             ObjectGuid DefiasPirate2GUID;
             ObjectGuid DefiasCompanionGUID;
+            ObjectGuid MrSmiteGUID;
 
             uint32 State;
             uint32 CannonBlast_Timer;
             uint32 PiratesDelay_Timer;
+            uint32 SmiteAlarmDelay_Timer;
             ObjectGuid uiSmiteChestGUID;
 
             virtual void Update(uint32 diff) override
@@ -89,22 +87,20 @@ class instance_deadmines : public InstanceMapScript
                 {
                     case CANNON_GUNPOWDER_USED:
                         CannonBlast_Timer = DATA_CANNON_BLAST_TIMER;
-                        // it's a hack - Mr. Smite should do that but his too far away
-                        //pIronCladDoor->SetName("Mr. Smite");
-                        //pIronCladDoor->MonsterYell(SAY_MR_SMITE_ALARM1, LANG_UNIVERSAL, NULL);
-                        pIronCladDoor->PlayDirectSound(SOUND_MR_SMITE_ALARM1);
                         State = CANNON_BLAST_INITIATED;
                         break;
                     case CANNON_BLAST_INITIATED:
                         PiratesDelay_Timer = DATA_PIRATES_DELAY_TIMER;
+                        SmiteAlarmDelay_Timer = DATA_SMITE_ALARM_DELAY_TIMER;
                         if (CannonBlast_Timer <= diff)
                         {
                             SummonCreatures();
                             ShootCannon();
                             BlastOutDoor();
                             LeverStucked();
-                            //pIronCladDoor->MonsterYell(SAY_MR_SMITE_ALARM2, LANG_UNIVERSAL, NULL);
-                            pIronCladDoor->PlayDirectSound(SOUND_MR_SMITE_ALARM2);
+                            instance->LoadGrid(-22.8f, -797.24f); // Loads Mr. Smite's grid.
+                            if (Creature* smite = instance->GetCreature(MrSmiteGUID)) // goes off when door blows up
+                                smite->AI()->Talk(SAY_ALARM1);
                             State = PIRATES_ATTACK;
                         } else CannonBlast_Timer -= diff;
                         break;
@@ -112,8 +108,16 @@ class instance_deadmines : public InstanceMapScript
                         if (PiratesDelay_Timer <= diff)
                         {
                             MoveCreaturesInside();
-                            State = EVENT_DONE;
+                            State = SMITE_ALARMED;
                         } else PiratesDelay_Timer -= diff;
+                        break;
+                    case SMITE_ALARMED:
+                        if (SmiteAlarmDelay_Timer <= diff)
+                        {
+                            if (Creature* smite = instance->GetCreature(MrSmiteGUID))
+                                smite->AI()->Talk(SAY_ALARM2);
+                            State = EVENT_DONE;
+                        } else SmiteAlarmDelay_Timer -= diff;
                         break;
                 }
             }
@@ -176,6 +180,18 @@ class instance_deadmines : public InstanceMapScript
             {
                 if (GameObject* pDoorLever = instance->GetGameObject(DoorLeverGUID))
                     pDoorLever->SetUInt32Value(GAMEOBJECT_FLAGS, 4);
+            }
+
+            void OnCreatureCreate(Creature* creature) override
+            {
+                switch (creature->GetEntry())
+                {
+                    case NPC_MR_SMITE:
+                        MrSmiteGUID = creature->GetGUID();
+                        break;
+                    default:
+                        break;
+                }
             }
 
             void OnGameObjectCreate(GameObject* go) override


### PR DESCRIPTION
…ing.
- Fixes Mr. Smite announcing to instance once doors have been destroyed.
- Add missing dialogue to encounter phases.
- Now properly runs in front of his chest, kneels down and equips items, stands, and reengages like he's supposed to.
- Fix weapon model for first phase when he switched to double axes.

Closes #6624
