### PR TITLE
Core/Scripts/DB: move Gryphoneer Windbellow to SAI

### DIFF
--- a/sql/updates/world/2016_01_03_05_world.sql
+++ b/sql/updates/world/2016_01_03_05_world.sql
@@ -1,0 +1,25 @@
+-- Add sniffed gossip texts to menu
+DELETE FROM `gossip_menu_option` WHERE `menu_id` IN (8095, 8096, 8100);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `OptionBroadcastTextID`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `box_coded`, `box_money`, `box_text`, `BoxBroadcastTextID`) VALUES
+(8095, 0, 2, 'Show me where I can fly.',12271,1,1,0,0,0,0,'',0),
+(8096, 0, 0, 'Send me to Honor Point!',18200,1,1,0,0,0,0,'',0),
+(8096, 1, 0, 'Send me to the Abyssal Shelf!',17936,1,1,0,0,0,0,'',0),
+(8100, 0, 0, 'Send me to Shatter Point!',17937,1,1,0,0,0,0,'',0);
+
+-- Migrate NPC to use SmartAI
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '', `gossip_menu_id` = 8096 WHERE `entry` = 20235;
+
+-- Condition: Gossip menu ID 0 needs either quest ID 10163 or quest ID 10346 to be incomplete.
+-- Condition: Gossip menu ID 1 needs quest ID 10382 to be complete
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`= 15 AND `SourceGroup` = 8096 AND `SourceEntry`IN (0,1);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(15,8096,0,0,0,9,0,10163,0,0,0,0,'','Gryphoneer Windbellow - Show gossip option 0 if player has taken quest ID 10163'),
+(15,8096,0,0,1,9,0,10346,0,0,0,0,'','Gryphoneer Windbellow - Show gossip option 0 if player has taken quest ID 10346'),
+(15,8096,1,0,0,28,0,10382,0,0,0,0,'','Gryphoneer Windbellow - Show gossip option 1 if quest ID 10382 is completed');
+
+-- Create SmartAI for Gryphoneer Windbellow
+DELETE FROM `smart_scripts` WHERE (source_type = 0 AND entryorguid = 20235);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(20235,0,0,2,62,0,100,0,8096,0,0,0,11,33899,0,0,0,0,0,7,0,0,0,0,0,0,0,'Gryphoneer Windbellow - On Gossip Option 0 Selected - Cast Spell 33899'),
+(20235,0,1,2,62,0,100,0,8096,1,0,0,11,35065,0,0,0,0,0,7,0,0,0,0,0,0,0,'Gryphoneer Windbellow - On Gossip Option 1 Selected - Cast Spell 35065'),
+(20235,0,2,0,61,0,100,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,'Gryphoneer Windbellow - On Linked Actions - Close Gossip');

--- a/src/server/scripts/World/npc_taxi.cpp
+++ b/src/server/scripts/World/npc_taxi.cpp
@@ -36,8 +36,6 @@ EndScriptData
 #define GOSSIP_IRONWING         "I'd like to take a flight around Stormwind Harbor."
 #define GOSSIP_DABIREE1         "Fly me to Murketh and Shaadraz Gateways"
 #define GOSSIP_DABIREE2         "Fly me to Shatter Point"
-#define GOSSIP_WINDBELLOW1      "Fly me to The Abyssal Shelf"
-#define GOSSIP_WINDBELLOW2      "Fly me to Honor Point"
 #define GOSSIP_BRACK1           "Fly me to Murketh and Shaadraz Gateways"
 #define GOSSIP_BRACK2           "Fly me to The Abyssal Shelf"
 #define GOSSIP_BRACK3           "Fly me to Spinebreaker Post"
@@ -83,15 +81,6 @@ public:
             //Shatter Point
             if (!player->GetQuestRewardStatus(10340))
                 player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_DABIREE2, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 5);
-            break;
-        case 20235: // Hellfire Peninsula - Gryphoneer Windbellow
-            //Mission: The Abyssal Shelf || Return to the Abyssal Shelf
-            if (player->GetQuestStatus(10163) == QUEST_STATUS_INCOMPLETE || player->GetQuestStatus(10346) == QUEST_STATUS_INCOMPLETE)
-                player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_WINDBELLOW1, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 6);
-
-            //Go to the Front
-            if (player->GetQuestStatus(10382) != QUEST_STATUS_NONE && !player->GetQuestRewardStatus(10382))
-                player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_WINDBELLOW2, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 7);
             break;
         case 19401: // Hellfire Peninsula - Wing Commander Brack
             //Mission: The Murketh and Shaadraz Gateways
@@ -174,14 +163,6 @@ public:
         case GOSSIP_ACTION_INFO_DEF + 5:
             player->CLOSE_GOSSIP_MENU();
             player->CastSpell(player, 35069, true);               //TaxiPath 612 (Taxi - Hellfire Peninsula - Expedition Point to Shatter Point)
-            break;
-        case GOSSIP_ACTION_INFO_DEF + 6:
-            player->CLOSE_GOSSIP_MENU();
-            player->CastSpell(player, 33899, true);               //TaxiPath 589 (Aerial Assault Flight (Alliance))
-            break;
-        case GOSSIP_ACTION_INFO_DEF + 7:
-            player->CLOSE_GOSSIP_MENU();
-            player->CastSpell(player, 35065, true);               //TaxiPath 607 (Taxi - Hellfire Peninsula - Shatter Point to Beach Head)
             break;
         case GOSSIP_ACTION_INFO_DEF + 8:
             player->CLOSE_GOSSIP_MENU();


### PR DESCRIPTION
This should correctly migrate Gryphoneer Windbellow, NPC 20235, to SAI / database. Feedback on conditions SQL would be appreciated; I want to make sure that I am using ElseGroup correctly. Will remove excess comments after code review, but wanted to make sure everything was clear for this. When testing, the behavior was identical to the current npc_taxi script.

If someone has a live account with a conveniently correct-level character (I do not), it would be nice to see whether the Shatter Point -> Honor Point flight point is indeed only valid while a player has the quest, or whether it continues to be available after the quest "Go to the Front" (ID: 10382) has been turned in. The behavior in the existing C++ script and in this PR is that it becomes unavailable after the quest is turned in.

Will squash when it's deemed ready to merge!
