### PR TITLE
Core/SmartScripts: Fix typo

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -209,7 +209,7 @@ class SmartScript
 
             if (lookupRoot)
             {
-                if (!meOrigGUID)
+                if (!meOrigGUID.IsEmpty())
                 {
                     if (Creature* m = ObjectAccessor::GetCreature(*lookupRoot, meOrigGUID))
                     {
@@ -217,7 +217,8 @@ class SmartScript
                         go = NULL;
                     }
                 }
-                if (!goOrigGUID)
+
+                if (!goOrigGUID.IsEmpty())
                 {
                     if (GameObject* o = ObjectAccessor::GetGameObject(*lookupRoot, goOrigGUID))
                     {


### PR DESCRIPTION
Fix porting typo after dcb7082277447c21b11c4a1d59f105fa342c172e
