### PR TITLE
Looting/Group: Do not display looter in tooltip when FFA loot is enabled

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -2274,6 +2274,8 @@ LootMethod Group::GetLootMethod() const
 
 ObjectGuid Group::GetLooterGuid() const
 {
+    if (GetLootMethod() == FREE_FOR_ALL)
+        return ObjectGuid::Empty;
     return m_looterGuid;
 }
 


### PR DESCRIPTION
Just a quickie. Do not display the "Loot: <name>" tag on dead creatures while group has FFA loot on.
