### PR TITLE
Instance boundary follow-up

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -80,7 +80,7 @@ class CreatureAI : public UnitAI
         Creature* DoSummonFlyer(uint32 entry, WorldObject* obj, float flightZ, float radius = 5.0f, uint32 despawnTime = 30000, TempSummonType summonType = TEMPSUMMON_CORPSE_TIMED_DESPAWN);
 
         bool CheckBoundary(Position* who = nullptr) const;
-        void SetBoundary(CreatureBoundary const* boundary) { _boundary = boundary; CheckInRoom(); }
+        void SetBoundary(CreatureBoundary const* boundary) { _boundary = boundary; me->DoImmediateBoundaryCheck(); }
     public:
         enum EvadeReason
         {

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -605,6 +605,7 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
         float GetRespawnRadius() const { return m_respawnradius; }
         void SetRespawnRadius(float dist) { m_respawnradius = dist; }
 
+        void DoImmediateBoundaryCheck() { m_boundaryCheckTime = 0; }
         uint32 GetCombatPulseDelay() const { return m_combatPulseDelay; }
         void SetCombatPulseDelay(uint32 delay) // (secs) interval at which the creature pulses the entire zone into combat (only works in dungeons)
         {

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -30,6 +30,12 @@
 #include "WorldSession.h"
 #include "Opcodes.h"
 
+BossBoundaryData::~BossBoundaryData()
+{
+    for (const_iterator it = begin(); it != end(); ++it)
+        delete it->boundary;
+}
+
 void InstanceScript::SaveToDB()
 {
     std::string data = GetSaveData();

--- a/src/server/game/Instances/InstanceScript.h
+++ b/src/server/game/Instances/InstanceScript.h
@@ -78,7 +78,19 @@ struct BossBoundaryEntry
     uint32 const bossId;
     AreaBoundary const* const boundary;
 };
-typedef std::list<BossBoundaryEntry> BossBoundaryData;
+struct BossBoundaryData
+{
+    typedef std::vector<BossBoundaryEntry> StorageType;
+    typedef StorageType::const_iterator const_iterator;
+
+    BossBoundaryData(std::initializer_list<BossBoundaryEntry> data) : _data(data) { }
+    ~BossBoundaryData();
+    const_iterator begin() const { return _data.begin(); }
+    const_iterator end() const { return _data.end(); }
+
+    private:
+        StorageType _data;
+};
 
 struct MinionData
 {

--- a/src/server/game/Maps/AreaBoundary.h
+++ b/src/server/game/Maps/AreaBoundary.h
@@ -32,15 +32,16 @@ class AreaBoundary
             BOUNDARY_PARALLELOGRAM,
             BOUNDARY_Z_RANGE,
         };
+        virtual ~AreaBoundary() { }
         BoundaryType GetBoundaryType() const { return m_boundaryType; }
         bool IsWithinBoundary(const Position* pos) const { return (IsWithinBoundaryArea(pos) != m_isInvertedBoundary); }
 
         struct DoublePosition : Position
         {
             double d_positionX, d_positionY, d_positionZ;
-            DoublePosition(double x = 0, double y = 0, double z = 0, float o = 0)
-                : Position((float)x, (float)y, (float)z, o), d_positionX(x), d_positionY(y), d_positionZ(z) { }
-            DoublePosition(float x = 0, float y = 0, float z = 0, float o = 0)
+            DoublePosition(double x = 0.0, double y = 0.0, double z = 0.0, float o = 0.0)
+                : Position(x, y, z, o), d_positionX(x), d_positionY(y), d_positionZ(z) { }
+            DoublePosition(float x, float y = 0.0f, float z = 0.0f, float o = 0.0f)
                 : Position(x, y, z, o), d_positionX(x), d_positionY(y), d_positionZ(z) { }
             DoublePosition(const Position& pos)
                 : DoublePosition(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation()) { }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -22,12 +22,11 @@
 #include "Player.h"
 #include "TemporarySummon.h"
 
-AreaBoundary const* const mainBoundary = new CircleBoundary(Position(563.26f, 139.6f), 75.0);
 BossBoundaryData const boundaries = {
-    { BOSS_BEASTS, mainBoundary },
-    { BOSS_JARAXXUS, mainBoundary },
-    { BOSS_CRUSADERS, mainBoundary },
-    { BOSS_VALKIRIES, mainBoundary },
+    { BOSS_BEASTS, new CircleBoundary(Position(563.26f, 139.6f), 75.0) },
+    { BOSS_JARAXXUS, new CircleBoundary(Position(563.26f, 139.6f), 75.0) },
+    { BOSS_CRUSADERS, new CircleBoundary(Position(563.26f, 139.6f), 75.0) },
+    { BOSS_VALKIRIES, new CircleBoundary(Position(563.26f, 139.6f), 75.0) },
     { BOSS_ANUBARAK, new EllipseBoundary(Position(746.0f, 135.0f), 100.0, 75.0) }
 };
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -265,7 +265,7 @@ class boss_sindragosa : public CreatureScript
             {
                 if (!instance->CheckRequiredBosses(DATA_SINDRAGOSA, victim->ToPlayer()))
                 {
-                    EnterEvadeMode();
+                    EnterEvadeMode(EVADE_REASON_SEQUENCE_BREAK);
                     instance->DoCastSpellOnPlayers(LIGHT_S_HAMMER_TELEPORT);
                     return;
                 }
@@ -274,6 +274,13 @@ class boss_sindragosa : public CreatureScript
                 DoCast(me, SPELL_FROST_AURA);
                 DoCast(me, SPELL_PERMAEATING_CHILL);
                 Talk(SAY_AGGRO);
+            }
+
+            void EnterEvadeMode(EvadeReason why) override
+            {
+                if (_isInAirPhase && why == EVADE_REASON_BOUNDARY)
+                    return;
+                BossAI::EnterEvadeMode(why);
             }
 
             void JustReachedHome() override


### PR DESCRIPTION
Instance boundary follow-up to stop tools from complaining about leaks. Also, list -> vector, fixing an ambiguous constructor warning, and fixing a bug with spawn behavior on Gormok and Sindragosa (#16280).
