### PR TITLE
Core/SAI: Change SmartScript::GetTargets to return an ObjectList instead of an ObjectList*

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -32,7 +32,6 @@ class SmartScript
 {
     public:
         SmartScript();
-        ~SmartScript();
 
         void OnInitialize(WorldObject* obj, AreaTriggerEntry const* at = NULL);
         void GetScript();
@@ -46,8 +45,8 @@ class SmartScript
         void InitTimer(SmartScriptHolder& e);
         void ProcessAction(SmartScriptHolder& e, Unit* unit = NULL, uint32 var0 = 0, uint32 var1 = 0, bool bvar = false, const SpellInfo* spell = NULL, GameObject* gob = NULL);
         void ProcessTimedAction(SmartScriptHolder& e, uint32 const& min, uint32 const& max, Unit* unit = NULL, uint32 var0 = 0, uint32 var1 = 0, bool bvar = false, const SpellInfo* spell = NULL, GameObject* gob = NULL);
-        ObjectList* GetTargets(SmartScriptHolder const& e, Unit* invoker = NULL);
-        ObjectList* GetWorldObjectsInDist(float dist);
+        ObjectList GetTargets(SmartScriptHolder const& e, Unit* invoker = nullptr);
+        ObjectList GetWorldObjectsInDist(float dist);
         void InstallTemplate(SmartScriptHolder const& e);
         SmartScriptHolder CreateEvent(SMART_EVENT e, uint32 event_flags, uint32 event_param1, uint32 event_param2, uint32 event_param3, uint32 event_param4, SMART_ACTION action, uint32 action_param1, uint32 action_param2, uint32 action_param3, uint32 action_param4, uint32 action_param5, uint32 action_param6, SMARTAI_TARGETS t, uint32 target_param1, uint32 target_param2, uint32 target_param3, uint32 phaseMask = 0);
         void AddEvent(SMART_EVENT e, uint32 event_flags, uint32 event_param1, uint32 event_param2, uint32 event_param3, uint32 event_param4, SMART_ACTION action, uint32 action_param1, uint32 action_param2, uint32 action_param3, uint32 action_param4, uint32 action_param5, uint32 action_param6, SMARTAI_TARGETS t, uint32 target_param1, uint32 target_param2, uint32 target_param3, uint32 phaseMask = 0);
@@ -91,21 +90,11 @@ class SmartScript
         void DoFindFriendlyMissingBuff(std::list<Creature*>& list, float range, uint32 spellid);
         Unit* DoFindClosestFriendlyInRange(float range, bool playerOnly);
 
-        void StoreTargetList(ObjectList* targets, uint32 id)
+        void StoreTargetList(ObjectList& targets, uint32 id)
         {
-            if (!targets)
-                return;
-
-            if (mTargetStorage->find(id) != mTargetStorage->end())
-            {
-                // check if already stored
-                if ((*mTargetStorage)[id]->Equals(targets))
-                    return;
-
-                delete (*mTargetStorage)[id];
-            }
-
-            (*mTargetStorage)[id] = new ObjectGuidList(targets, GetBaseObject());
+            // insert or override
+            mTargetStorage.erase(id);
+            mTargetStorage.emplace(id, ObjectGuidList(targets, GetBaseObject()));
         }
 
         bool IsSmart(Creature* c = NULL)
@@ -137,12 +126,12 @@ class SmartScript
             return smart;
         }
 
-        ObjectList* GetTargetList(uint32 id)
+        ObjectList GetTargetList(uint32 id)
         {
-            ObjectListMap::iterator itr = mTargetStorage->find(id);
-            if (itr != mTargetStorage->end())
-                return (*itr).second->GetObjectList();
-            return NULL;
+            ObjectListMap::iterator itr = mTargetStorage.find(id);
+            if (itr != mTargetStorage.end())
+                return itr->second.GetObjectList();
+            return ObjectList();
         }
 
         void StoreCounter(uint32 id, uint32 value, uint32 reset)
@@ -198,7 +187,7 @@ class SmartScript
             return creatureItr != bounds.second ? creatureItr->second : bounds.first->second;
         }
 
-        ObjectListMap* mTargetStorage;
+        ObjectListMap mTargetStorage;
 
         void OnReset();
         void ResetBaseObject()

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1380,39 +1380,38 @@ struct SmartScriptHolder
 
 typedef std::unordered_map<uint32, WayPoint*> WPPath;
 
-typedef std::list<WorldObject*> ObjectList;
+typedef std::vector<WorldObject*> ObjectList;
 
 class ObjectGuidList
 {
-    ObjectList* m_objectList;
-    GuidList* m_guidList;
+    ObjectList m_objectList;
+    GuidList m_guidList;
     WorldObject* m_baseObject;
 
 public:
-    ObjectGuidList(ObjectList* objectList, WorldObject* baseObject)
+    ObjectGuidList(ObjectList objectList, WorldObject* baseObject)
     {
-        ASSERT(objectList != NULL);
+        ASSERT(!objectList.empty());
         m_objectList = objectList;
         m_baseObject = baseObject;
-        m_guidList = new GuidList();
 
-        for (ObjectList::iterator itr = objectList->begin(); itr != objectList->end(); ++itr)
+        for (ObjectList::iterator itr = objectList.begin(); itr != objectList.end(); ++itr)
         {
-            m_guidList->push_back((*itr)->GetGUID());
+            m_guidList.push_back((*itr)->GetGUID());
         }
     }
 
-    ObjectList* GetObjectList()
+    ObjectList& GetObjectList()
     {
         if (m_baseObject)
         {
             //sanitize list using m_guidList
-            m_objectList->clear();
+            m_objectList.clear();
 
-            for (GuidList::iterator itr = m_guidList->begin(); itr != m_guidList->end(); ++itr)
+            for (GuidList::iterator itr = m_guidList.begin(); itr != m_guidList.end(); ++itr)
             {
                 if (WorldObject* obj = ObjectAccessor::GetWorldObject(*m_baseObject, *itr))
-                    m_objectList->push_back(obj);
+                    m_objectList.push_back(obj);
                 else
                     TC_LOG_DEBUG("scripts.ai", "SmartScript::mTargetStorage stores a guid to an invalid object: %s", itr->ToString().c_str());
             }
@@ -1420,19 +1419,8 @@ public:
 
         return m_objectList;
     }
-
-    bool Equals(ObjectList* objectList)
-    {
-        return m_objectList == objectList;
-    }
-
-    ~ObjectGuidList()
-    {
-        delete m_objectList;
-        delete m_guidList;
-    }
 };
-typedef std::unordered_map<uint32, ObjectGuidList*> ObjectListMap;
+typedef std::unordered_map<uint32, ObjectGuidList> ObjectListMap;
 
 class SmartWaypointMgr
 {


### PR DESCRIPTION
Applied the same treatment to GetWorldObjectsInDist.

SmartAI's "ObjectList" is now a std::vector instead of a std::list because no where it was being used as an actual list.

Honestly no idea why the original idea insisted so much on using pointers. No more missing null checks or deletes.
