### PR TITLE
Collision/MMap: Fix a memleak reported by valgrind

### DIFF
--- a/src/common/Collision/Management/MMapManager.cpp
+++ b/src/common/Collision/Management/MMapManager.cpp
@@ -179,7 +179,7 @@ namespace MMAP
         dtTileRef tileRef = 0;
 
         // memory allocated for data is now managed by detour, and will be deallocated when the tile is removed
-        if (dtStatusSucceed(mmap->navMesh->addTile(data, fileHeader.size, 0/*DT_TILE_FREE_DATA*/, 0, &tileRef)))
+        if (dtStatusSucceed(mmap->navMesh->addTile(data, fileHeader.size, DT_TILE_FREE_DATA, 0, &tileRef)))
         {
             mmap->loadedTileRefs.insert(std::pair<uint32, dtTileRef>(packedGridPos, tileRef));
             ++loadedTiles;


### PR DESCRIPTION
Tiles which are owned by the mesh should have DT_TILE_FREE_DATA to ensure the deallocation of the memory on removal from the mesh.

Log:
==23516== 6,181,976 bytes in 6 blocks are definitely lost in loss record 15 of 15
==23516==    at 0x4C298A0: operator new[](unsigned long) (vg_replace_malloc.c:389)
==23516==    by 0x2052660: dtCustomAlloc(int, dtAllocHint) (Memory.h:11)
==23516==    by 0x29D7FDA: dtAlloc(int, dtAllocHint) (DetourAlloc.cpp:43)
==23516==    by 0x230AA70: MMAP::MMapManager::loadMap(std::string const&, unsigned int, int, int) (MMapManager.cpp:166)
==23516==    by 0x1DD585B: Map::LoadMMap(int, int) (Map.cpp:125)
==23516==    by 0x1DD7266: Map::LoadMapAndVMap(int, int) (Map.cpp:200)
==23516==    by 0x1DD93C6: Map::EnsureGridCreated_i(CoordPair<64u> const&) (Map.cpp:453)
==23516==    by 0x1DD9129: Map::EnsureGridCreated(CoordPair<64u> const&) (Map.cpp:429)
==23516==    by 0x1DED100: Map::GetGrid(float, float) (Map.cpp:2200)
==23516==    by 0x1DE0F4C: Map::GetAreaFlag(float, float, float, bool*) const (Map.cpp:2349)
==23516==    by 0x198521B: Map::GetZoneId(float, float, float) const (Map.h:353)
==23516==    by 0x197CFF0: WorldObject::GetZoneId() const (Object.cpp:1277)
