### PR TITLE
[3.3.5] Core/Scripts/DB Move script npc_myranda_the_hag to SAI

### DIFF
--- a/sql/updates/world/2016_01_31_99_world_335.sql
+++ b/sql/updates/world/2016_01_31_99_world_335.sql
@@ -1,0 +1,28 @@
+UPDATE `gossip_menu_option` SET `option_id`=1 WHERE `menu_id`=3801;
+DELETE FROM `gossip_menu` WHERE `entry`=3801 AND `text_id`=4773;
+INSERT INTO `gossip_menu` (`entry`, `text_id`) VALUES
+(3801, 4773);
+
+UPDATE `creature_template` SET `AIName`='SmartAI', `ScriptName`='' WHERE `entry`=11872;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=11872 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES 
+(11872, 0, 0, 1, 62, 0, 100, 0, 3801, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Myranda the Hag - On Gossip Option 0 Selected - Close Gossip'),
+(11872, 0, 1, 0, 61, 0, 100, 0, 3801, 0, 0, 0, 85, 17961, 2, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Myranda the Hag - On Gossip Option 0 Selected - Invoker Cast \'Scarlet Illusion\'');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=3801;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=14 AND `SourceGroup`=3801;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 3801, 0, 0, 0, 28, 0, 5862,  0, 0, 0, 0, 0, '', 'Only show gossip menu option if quest \'Scarlet Subterfuge\' is complete'),
+(15, 3801, 0, 0, 0, 28, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show gossip menu option if quest \'In Dreams\' is not complete'),
+(15, 3801, 0, 0, 0,  8, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show gossip menu option if quest \'In Dreams\' is not rewarded'),
+(15, 3801, 0, 0, 0,  1, 0, 17961, 0, 0, 1, 0, 0, '', 'Only show gossip menu option if no \'Scarlet Illusion\' Aura'),
+(15, 3801, 0, 0, 1,  8, 0, 5862,  0, 0, 0, 0, 0, '', 'Only show gossip menu option if quest \'Scarlet Subterfuge\' is rewarded'),
+(15, 3801, 0, 0, 1, 28, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show gossip menu option if quest \'In Dreams\' is not complete'),
+(15, 3801, 0, 0, 1,  8, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show gossip menu option if quest \'In Dreams\' is not rewarded'),
+(15, 3801, 0, 0, 1,  1, 0, 17961, 0, 0, 1, 0, 0, '', 'Only show gossip menu option if no \'Scarlet Illusion\' Aura'),
+(14, 3801, 4773, 0, 0, 28, 0, 5862,  0, 0, 0, 0, 0, '', 'Only show text if quest \'Scarlet Subterfuge\' is complete'),
+(14, 3801, 4773, 0, 0, 28, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show text if quest \'In Dreams\' is not complete'),
+(14, 3801, 4773, 0, 0,  8, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show text if quest \'In Dreams\' is not rewarded'),
+(14, 3801, 4773, 0, 1,  8, 0, 5862,  0, 0, 0, 0, 0, '', 'Only show text if quest \'Scarlet Subterfuge\' is rewarded'),
+(14, 3801, 4773, 0, 1, 28, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show text if quest \'In Dreams\' is not complete'),
+(14, 3801, 4773, 0, 1,  8, 0, 5944,  0, 0, 1, 0, 0, '', 'Only show text if quest \'In Dreams\' is not rewarded');

--- a/src/server/scripts/EasternKingdoms/zone_western_plaguelands.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_western_plaguelands.cpp
@@ -25,7 +25,6 @@ EndScriptData */
 
 /* ContentData
 npcs_dithers_and_arbington
-npc_myranda_the_hag
 npc_the_scourge_cauldron
 npc_andorhal_tower
 EndContentData */
@@ -33,7 +32,6 @@ EndContentData */
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "ScriptedGossip.h"
-#include "ScriptedEscortAI.h"
 #include "Player.h"
 #include "WorldSession.h"
 
@@ -120,54 +118,6 @@ public:
 };
 
 /*######
-## npc_myranda_the_hag
-######*/
-
-enum Myranda
-{
-    ILLUSION_GOSSIP         = 4773,
-    QUEST_SUBTERFUGE        = 5862,
-    QUEST_IN_DREAMS         = 5944,
-    SPELL_SCARLET_ILLUSION  = 17961
-};
-
-class npc_myranda_the_hag : public CreatureScript
-{
-public:
-    npc_myranda_the_hag() : CreatureScript("npc_myranda_the_hag") { }
-
-    bool OnGossipSelect(Player* player, Creature* /*creature*/, uint32 /*sender*/, uint32 action) override
-    {
-        player->PlayerTalkClass->ClearMenus();
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-        {
-            player->CLOSE_GOSSIP_MENU();
-            player->CastSpell(player, SPELL_SCARLET_ILLUSION, false);
-        }
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
-        if (player->GetQuestStatus(QUEST_SUBTERFUGE) == QUEST_STATUS_COMPLETE &&
-            player->GetQuestStatus(QUEST_IN_DREAMS) != QUEST_STATUS_COMPLETE &&
-            !player->HasAura(SPELL_SCARLET_ILLUSION))
-        {
-            player->ADD_GOSSIP_ITEM_DB(Player::GetDefaultGossipMenuForSource(creature), 0, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-            player->SEND_GOSSIP_MENU(ILLUSION_GOSSIP, creature->GetGUID());
-            return true;
-        }
-        else
-            player->SEND_GOSSIP_MENU(player->GetGossipTextId(creature), creature->GetGUID());
-
-        return true;
-    }
-};
-
-/*######
 ## npc_the_scourge_cauldron
 ######*/
 
@@ -195,7 +145,7 @@ public:
             me->DealDamage(me, me->GetHealth(), NULL, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, false);
             //override any database `spawntimesecs` to prevent duplicated summons
             uint32 rTime = me->GetRespawnDelay();
-            if (rTime<600)
+            if (rTime < 600)
                 me->SetRespawnDelay(600);
         }
 
@@ -274,7 +224,6 @@ public:
         }
 
         void MoveInLineOfSight(Unit* who) override
-
         {
             if (!who || who->GetTypeId() != TYPEID_PLAYER)
                 return;
@@ -286,14 +235,9 @@ public:
     };
 };
 
-/*######
-##
-######*/
-
 void AddSC_western_plaguelands()
 {
     new npcs_dithers_and_arbington();
-    new npc_myranda_the_hag();
     new npc_the_scourge_cauldron();
     new npc_andorhal_tower();
 }


### PR DESCRIPTION
Moves the entire NPC script to the database and corrects a logic error where players who have rewarded the quest Scarlet Subterfuge and lost the disguise before taking the quest In Dreams were no longer able to get the disguise.
