### PR TITLE
[3.3.5][6.x] Script/Sindragosa: Fixed  ice tomb targets

### DIFF
--- a/sql/updates/world/2016_mm_dd_xx_world.sql
+++ b/sql/updates/world/2016_mm_dd_xx_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_sindragosa_ice_tomb_target';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(69712, 'spell_sindragosa_ice_tomb_target');

--- a/src/server/game/AI/CoreAI/UnitAI.cpp
+++ b/src/server/game/AI/CoreAI/UnitAI.cpp
@@ -340,5 +340,8 @@ bool NonTankTargetSelector::operator()(Unit const* target) const
     if (_playerOnly && target->GetTypeId() != TYPEID_PLAYER)
         return false;
 
+    if (HostileReference* currentVictim = _source->getThreatManager().getCurrentVictim())
+        return target->GetGUID() != currentVictim->getUnitGuid();
+
     return target != _source->GetVictim();
 }

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -107,11 +107,11 @@ struct SpellTargetSelector : public std::unary_function<Unit*, bool>
 struct NonTankTargetSelector : public std::unary_function<Unit*, bool>
 {
     public:
-        NonTankTargetSelector(Creature* source, bool playerOnly = true) : _source(source), _playerOnly(playerOnly) { }
+        NonTankTargetSelector(Unit* source, bool playerOnly = true) : _source(source), _playerOnly(playerOnly) { }
         bool operator()(Unit const* target) const;
 
     private:
-        Creature const* _source;
+        Unit* _source;
         bool _playerOnly;
 };
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -134,6 +134,7 @@ enum FrostwingData
     DATA_WHELP_MARKER           = 2,
     DATA_LINKED_GAMEOBJECT      = 3,
     DATA_TRAPPED_PLAYER         = 4,
+    DATA_IS_THIRD_PHASE         = 5
 };
 
 enum MovementPoints
@@ -196,20 +197,19 @@ class FrostBombExplosion : public BasicEvent
         ObjectGuid _sindragosaGUID;
 };
 
-class FrostBeaconSelector
+class FrostBeaconSelector : NonTankTargetSelector
 {
     public:
-        FrostBeaconSelector(Unit* source) : _source(source) { }
+        FrostBeaconSelector(Unit* source) : NonTankTargetSelector(source, true) { }
 
-        bool operator()(Unit* target) const
+        bool operator()(WorldObject* target) const
         {
-            return target->GetTypeId() == TYPEID_PLAYER &&
-                target != _source->GetVictim() &&
-                !target->HasAura(SPELL_ICE_TOMB_UNTARGETABLE);
-        }
+            if (Unit* unitTarget = target->ToUnit())
+                return !NonTankTargetSelector::operator()(unitTarget) ||
+                    unitTarget->HasAura(SPELL_ICE_TOMB_UNTARGETABLE);
 
-    private:
-        Unit* _source;
+            return false;
+        }
 };
 
 class boss_sindragosa : public CreatureScript
@@ -326,9 +326,15 @@ class boss_sindragosa : public CreatureScript
 
             uint32 GetData(uint32 type) const override
             {
-                if (type == DATA_MYSTIC_BUFFET_STACK)
-                    return _mysticBuffetStack;
-                return 0xFFFFFFFF;
+                switch (type)
+                {
+                    case DATA_MYSTIC_BUFFET_STACK:
+                        return _mysticBuffetStack;
+                    case DATA_IS_THIRD_PHASE:
+                        return _isThirdPhase;
+                    default:
+                        return 0xFFFFFFFF;
+                }
             }
 
             void MovementInform(uint32 type, uint32 point) override
@@ -419,7 +425,6 @@ class boss_sindragosa : public CreatureScript
                     if (spellId == spell->Id)
                         if (Aura const* mysticBuffet = target->GetAura(spell->Id))
                             _mysticBuffetStack = std::max<uint8>(_mysticBuffetStack, mysticBuffet->GetStackAmount());
-
             }
 
             void UpdateAI(uint32 diff) override
@@ -494,11 +499,7 @@ class boss_sindragosa : public CreatureScript
                             me->GetMotionMaster()->MovePoint(POINT_AIR_PHASE_FAR, SindragosaAirPosFar);
                             break;
                         case EVENT_ICE_TOMB:
-                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, FrostBeaconSelector(me)))
-                            {
-                                Talk(EMOTE_WARN_FROZEN_ORB, target);
-                                me->CastCustomSpell(SPELL_ICE_TOMB_TARGET, SPELLVALUE_MAX_TARGETS, 1, nullptr, TRIGGERED_FULL_MASK);
-                            }
+                            me->CastCustomSpell(SPELL_ICE_TOMB_TARGET, SPELLVALUE_MAX_TARGETS, 1, nullptr, TRIGGERED_FULL_MASK);
                             events.ScheduleEvent(EVENT_ICE_TOMB, urand(16000, 23000));
                             break;
                         case EVENT_FROST_BOMB:
@@ -1576,6 +1577,41 @@ class spell_frostwarden_handler_focus_fire : public SpellScriptLoader
         }
 };
 
+class spell_sindragosa_ice_tomb_target : public SpellScriptLoader
+{
+public:
+    spell_sindragosa_ice_tomb_target() : SpellScriptLoader("spell_sindragosa_ice_tomb_target") { }
+
+    class spell_sindragosa_ice_tomb_target_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_sindragosa_ice_tomb_target_SpellScript);
+
+        void FilterTargets(std::list<WorldObject*>& unitList)
+        {
+            Unit* caster = GetCaster();
+            unitList.remove_if(FrostBeaconSelector(caster));
+        }
+
+        void HandleSindragosaTalk(SpellEffIndex /*effIndex*/)
+        {
+            if (Creature* creatureCaster = GetCaster()->ToCreature())
+                if (creatureCaster->GetAI()->GetData(DATA_IS_THIRD_PHASE))
+                    creatureCaster->AI()->Talk(EMOTE_WARN_FROZEN_ORB, GetHitUnit());
+        }
+
+        void Register() override
+        {
+            OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_sindragosa_ice_tomb_target_SpellScript::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+            OnEffectLaunchTarget += SpellEffectFn(spell_sindragosa_ice_tomb_target_SpellScript::HandleSindragosaTalk, EFFECT_0, SPELL_EFFECT_DUMMY);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_sindragosa_ice_tomb_target_SpellScript();
+    }
+};
+
 class at_sindragosa_lair : public AreaTriggerScript
 {
     public:
@@ -1641,6 +1677,7 @@ void AddSC_boss_sindragosa()
     new spell_frostwarden_handler_focus_fire();
     new spell_trigger_spell_from_caster("spell_sindragosa_ice_tomb", SPELL_ICE_TOMB_DUMMY, TRIGGERED_IGNORE_SET_FACING);
     new spell_trigger_spell_from_caster("spell_sindragosa_ice_tomb_dummy", SPELL_FROST_BEACON);
+    new spell_sindragosa_ice_tomb_target();
     new at_sindragosa_lair();
     new achievement_all_you_can_eat();
 }


### PR DESCRIPTION
- Also changed the way NonTankTargetSelector checks who is the tank.

Closes https://github.com/TrinityCore/TrinityCore/issues/16441
Also, the tank won't be ice blocked in air phase (blizzlike)

Any feedback is welcome :)
