### PR TITLE
[3.3.5] Add condition for unit sitting/standing

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.h
+++ b/src/server/game/Conditions/ConditionMgr.h
@@ -71,7 +71,8 @@ enum ConditionTypes
     CONDITION_HP_PCT                = 38,                   // hpPct            ComparisonType 0                  true if unit's hp matches given pct
     CONDITION_REALM_ACHIEVEMENT     = 39,                   // achievement_id   0              0                  true if realm achievement is complete
     CONDITION_IN_WATER              = 40,                   // 0                0              0                  true if unit in water
-    CONDITION_MAX                   = 41                    // MAX
+    CONDITION_STAND_STATE           = 41,                   // stateType        state          0                  true if unit matches specified sitstate (0,x: has exactly state x; 1,0: any standing state; 1,1: any sitting state;)
+    CONDITION_MAX                   = 42                    // MAX
 };
 
 /*! Documentation on implementing a new ConditionSourceType:


### PR DESCRIPTION
 DB/Conditions: Add new `CONDITION_STAND_STATE` (41). value1 selects the type of state check to apply, value2 specifies the particular state we are looking for.

Valuing:
- `0,x` - has exactly state `x`
- `1,0` - has any standing state
- `1,1` - has any sitting state
