### PR TITLE
[3.3.5] Core/Spell Fix cooldown check talent Rapture (Priest)

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1487,7 +1487,7 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                             {
                                 // This additional check is needed to add a minimal delay before cooldown in in effect
                                 // to allow all bubbles broken by a single damage source proc mana return
-                                if (caster->GetSpellHistory()->GetRemainingCooldown(aura->GetSpellInfo()) <= 11)
+                                if (caster->GetSpellHistory()->GetRemainingCooldown(aura->GetSpellInfo()) <= 11 * IN_MILLISECONDS)
                                     break;
                             }
                             else    // and add if needed


### PR DESCRIPTION
The cooldown check of the spell is not being activated properly, because it is made comparison between milliseconds and seconds, then the condition is never true.

(Sorry bad english, google translate)

PS: Thanks to @Treeston for you help :+1: 
