### PR TITLE
[3.3.5] Make Web Wrap / Mutating Injection (and others) properly cancel on immunity (Divine Shield/Ice Block)

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3384,7 +3384,7 @@ void AuraEffect::HandleAuraModSchoolImmunity(AuraApplication const* aurApp, uint
                 && !iter->second->IsPositive()          //Don't remove positive spells
                 && spell->Id != GetId())               //Don't remove self
             {
-                target->RemoveAura(iter);
+                target->RemoveAura(iter, AURA_REMOVE_BY_ENEMY_SPELL);
             }
             else
                 ++iter;

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1221,12 +1221,16 @@ bool SpellInfo::CanDispelAura(SpellInfo const* aura) const
     if (HasAttribute(SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY) && !aura->IsDeathPersistent())
         return true;
 
-    // These auras (like Divine Shield) can't be dispelled
-    if (aura->HasAttribute(SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY))
-        return false;
-
     // These auras (Cyclone for example) are not dispelable
     if (aura->HasAttribute(SPELL_ATTR1_UNAFFECTED_BY_SCHOOL_IMMUNE))
+        return false;
+
+    // Divine Shield etc can dispel auras if they don't ignore school immunity
+    if (HasAttribute(SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY) && !aura->IsDeathPersistent())
+        return true;
+
+    // These auras (like Divine Shield) can't be dispelled
+    if (aura->HasAttribute(SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY))
         return false;
 
     return true;


### PR DESCRIPTION
Core/Spells: Adjust on-apply dispel behavior of Divine Shield / Ice Block etc.
- Now counts as a hostile dispel (triggers on-dispel effects: Grobbulus injection etc)
- Can dispel spells that have ATTR0_UNAFFECTED_BY_INVULNERABILITY (despite the name, this only means they can be applied while immune, not that the aura cannot be removed by immunity), if they do not have SPELL_ATTR1_UNAFFECTED_BY_SCHOOL_IMMUNE (debuffs like recently bandaged etc have this) and do not persist through death (debuffs like deserter etc have this).
