### PR TITLE
[3.3.5][6.x]Scripts/Karazhan: Implement Optional Boss Spawn

### DIFF
--- a/sql/updates/world/2016_08_08_08_world.sql
+++ b/sql/updates/world/2016_08_08_08_world.sql
@@ -1,0 +1,14 @@
+-- Karazhan Optional Boss spawn
+-- Hyakiss the Lurker SAI
+SET @ENTRY := 16179;
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=@ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@ENTRY,0,0,0,0,0,100,0,5000,5000,35000,35000,11,29901,0,0,0,0,0,2,0,0,0,0,0,0,0,"Hyakiss the Lurker - In Combat - Cast 'Acidic Fang'");
+
+-- Rokad the Ravager SAI
+SET @ENTRY := 16181;
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=@ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(@ENTRY,0,0,0,0,0,100,0,2000,3000,12000,15000,11,29906,0,0,0,0,0,2,0,0,0,0,0,0,0,"Rokad the Ravager - In Combat - Cast 'Ravage'");

--- a/src/server/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/instance_karazhan.cpp
@@ -44,6 +44,13 @@ EndScriptData */
 11 - Nightbane
 */
 
+const Position OptionalSpawn[] =
+{
+    { -10960.981445f, -1940.138428f, 46.178097f, 4.12f  }, // Hyakiss the Lurker
+    { -10899.903320f, -2085.573730f, 49.474449f, 1.38f  }, // Rokad the Ravager
+    { -10945.769531f, -2040.153320f, 49.474438f, 0.077f } // Shadikith the Glider
+};
+
 class instance_karazhan : public InstanceMapScript
 {
 public:
@@ -64,6 +71,7 @@ public:
             // 1 - OZ, 2 - HOOD, 3 - RAJ, this never gets altered.
             m_uiOperaEvent = urand(1, 3);
             m_uiOzDeathCount = 0;
+            OptionalBossCount = 0;
         }
 
         uint32 m_auiEncounter[MAX_ENCOUNTER];
@@ -71,6 +79,7 @@ public:
 
         uint32 m_uiOperaEvent;
         uint32 m_uiOzDeathCount;
+        uint32 OptionalBossCount;
 
         ObjectGuid m_uiCurtainGUID;
         ObjectGuid m_uiStageDoorLeftGUID;
@@ -107,6 +116,29 @@ public:
             }
         }
 
+        void OnUnitDeath(Unit* unit) override
+        {
+            Creature* creature = unit->ToCreature();
+            if (!creature)
+                return;
+
+            switch (creature->GetEntry())
+            {
+                case NPC_COLDMIST_WIDOW:
+                case NPC_COLDMIST_STALKER:
+                case NPC_SHADOWBAT:
+                case NPC_VAMPIRIC_SHADOWBAT:
+                case NPC_GREATER_SHADOWBAT:
+                case NPC_PHASE_HOUND:
+                case NPC_DREADBEAST:
+                case NPC_SHADOWBEAST:
+                    SetData(TYPE_OPTIONAL_BOSS, NOT_STARTED);
+                    break;
+                default:
+                    break;
+            }
+        }
+
         void SetData(uint32 type, uint32 uiData) override
         {
             switch (type)
@@ -118,7 +150,28 @@ public:
                     m_auiEncounter[1] = uiData;
                     break;
                 case TYPE_MAIDEN:               m_auiEncounter[2] = uiData; break;
-                case TYPE_OPTIONAL_BOSS:        m_auiEncounter[3] = uiData; break;
+                case TYPE_OPTIONAL_BOSS:
+                    m_auiEncounter[3] = uiData;
+                    if (uiData == NOT_STARTED)
+                    {
+                        ++OptionalBossCount;
+                        if (OptionalBossCount == 50)
+                        {
+                            switch (urand(0, 2))
+                            {
+                                case 0:
+                                    instance->SummonCreature(NPC_HYAKISS_THE_LURKER, OptionalSpawn[0]);
+                                    break;
+                                case 1:
+                                    instance->SummonCreature(NPC_ROKAD_THE_RAVAGER, OptionalSpawn[1]);
+                                    break;
+                                case 2:
+                                    instance->SummonCreature(NPC_SHADIKITH_THE_GLIDER, OptionalSpawn[2]);
+                                    break;
+                            }
+                        }
+                    }
+                    break;
                 case TYPE_OPERA:
                     m_auiEncounter[4] = uiData;
                     if (uiData == DONE)

--- a/src/server/scripts/EasternKingdoms/Karazhan/karazhan.h
+++ b/src/server/scripts/EasternKingdoms/Karazhan/karazhan.h
@@ -64,4 +64,20 @@ enum OperaEvents
     EVENT_RAJ                       = 3
 };
 
+enum MiscCreatures
+{
+    NPC_HYAKISS_THE_LURKER          = 16179,
+    NPC_ROKAD_THE_RAVAGER           = 16181,
+    NPC_SHADIKITH_THE_GLIDER        = 16180,
+
+    // Trash
+    NPC_COLDMIST_WIDOW              = 16171,
+    NPC_COLDMIST_STALKER            = 16170,
+    NPC_SHADOWBAT                   = 16173,
+    NPC_VAMPIRIC_SHADOWBAT          = 16175,
+    NPC_GREATER_SHADOWBAT           = 16174,
+    NPC_PHASE_HOUND                 = 16178,
+    NPC_DREADBEAST                  = 16177,
+    NPC_SHADOWBEAST                 = 16176
+};
 #endif


### PR DESCRIPTION
- closes #15756 

http://www.wowhead.com/npc=16179/hyakiss-the-lurker#comments:id=37735

By huntergenwedar (2,138 – 4·15) on 2007/02/18 (Patch 2.0.8)  
This boss is one of three random bosses that can spawn in the basement (Servants Quarter) of Karazhan once you have killed all of the spiders, bats and hounds in the area. You must kill ALL of them and have the entire area clear, no respawns for one to spawn.

The other bosses are:

http://www.wowhead.com/?npc=16181#z0z (hound, Rokad the Ravager)
http://www.wowhead.com/?npc=16179#z0z (bat, Shadikith the Glider)
