### PR TITLE
[3.3.5] Add target boundary check to BossAI CanCreatureAttack call

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -350,7 +350,7 @@ int32 CreatureAI::VisualizeBoundary(uint32 duration, Unit* owner, bool fill) con
     return boundsWarning ? LANG_CREATURE_MOVEMENT_MAYBE_UNBOUNDED : 0;
 }
 
-bool CreatureAI::CheckBoundary(Position* who) const
+bool CreatureAI::CheckBoundary(Position const* who) const
 {
     if (!who)
         who = me;

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -79,7 +79,7 @@ class CreatureAI : public UnitAI
         Creature* DoSummon(uint32 entry, WorldObject* obj, float radius = 5.0f, uint32 despawnTime = 30000, TempSummonType summonType = TEMPSUMMON_CORPSE_TIMED_DESPAWN);
         Creature* DoSummonFlyer(uint32 entry, WorldObject* obj, float flightZ, float radius = 5.0f, uint32 despawnTime = 30000, TempSummonType summonType = TEMPSUMMON_CORPSE_TIMED_DESPAWN);
 
-        bool CheckBoundary(Position* who = nullptr) const;
+        bool CheckBoundary(Position const* who = nullptr) const;
         void SetBoundary(CreatureBoundary const* boundary) { _boundary = boundary; me->DoImmediateBoundaryCheck(); }
     public:
         enum EvadeReason

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -360,6 +360,8 @@ class BossAI : public ScriptedAI
         void JustDied(Unit* /*killer*/) override { _JustDied(); }
         void JustReachedHome() override { _JustReachedHome(); }
 
+        bool CanAIAttack(Unit const* target) const override { return CheckBoundary(target); }
+
     protected:
         void _Reset();
         void _EnterCombat();

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_general_zarithrian.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_general_zarithrian.cpp
@@ -135,9 +135,9 @@ class boss_general_zarithrian : public CreatureScript
                     Talk(SAY_KILL);
             }
 
-            bool CanAIAttack(Unit const* /*target*/) const override
+            bool CanAIAttack(Unit const* target) const override
             {
-                return (instance->GetBossState(DATA_SAVIANA_RAGEFIRE) == DONE && instance->GetBossState(DATA_BALTHARUS_THE_WARBORN) == DONE);
+                return (instance->GetBossState(DATA_SAVIANA_RAGEFIRE) == DONE && instance->GetBossState(DATA_BALTHARUS_THE_WARBORN) == DONE && BossAI::CanAIAttack(target));
             }
 
             void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -598,7 +598,7 @@ class boss_deathbringer_saurfang : public CreatureScript
                 if (target->GetTransport())
                     return false;
 
-                return true;
+                return BossAI::CanAIAttack(target);
             }
 
             static uint32 const FightWonValue;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -578,7 +578,7 @@ class boss_the_lich_king : public CreatureScript
             bool CanAIAttack(Unit const* target) const override
             {
                 // The Lich King must not select targets in frostmourne room if he killed everyone outside
-                return !target->HasAura(SPELL_IN_FROSTMOURNE_ROOM);
+                return !target->HasAura(SPELL_IN_FROSTMOURNE_ROOM) && BossAI::CanAIAttack(target);
             }
 
             void EnterEvadeMode(EvadeReason why) override


### PR DESCRIPTION
AI/BossAI: Make creature never chase targets that are out of bounds
- Add missing const attribute on CheckBoundary arg.
- Prevent AI from attacking a target that is out of bounds. This prevents exploids such as killing Gluth/Deathbringer from out of bounds.
