### PR TITLE
[3.3.5]Core/Spell: Magic Absorption Calculation

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -418,7 +418,8 @@ int32 SpellEffectInfo::CalcValue(Unit const* caster, int32 const* bp, Unit const
             level = int32(_spellInfo->MaxLevel);
         else if (level < int32(_spellInfo->BaseLevel))
             level = int32(_spellInfo->BaseLevel);
-        level -= int32(_spellInfo->SpellLevel);
+        if (!_spellInfo->IsPassive()) 
+           level -= int32(_spellInfo->SpellLevel);
         basePoints += int32(level * basePointsPerLevel);
     }
 


### PR DESCRIPTION
- closes https://github.com/TrinityCore/TrinityCore/issues/4524
- by @maxxx
- passive spells like Magic Absorption should not be affected by this calulation

what will be fixed with this?
before: mage 80 lvl 79 resistance...
with fix: mage 80 lvl 80 resistance
