### PR TITLE
Core/Scripts port _DespawnAtEvade functionality to 3.3.5 branch

### DIFF
--- a/sql/updates/world/2016_02_09_99_world.sql
+++ b/sql/updates/world/2016_02_09_99_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `linked_respawn` WHERE `guid`=150211 AND `linkedGuid`=150211;
+DELETE FROM `creature` WHERE `guid`=150212 AND `id`=38995;

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -547,6 +547,29 @@ void BossAI::UpdateAI(uint32 diff)
     DoMeleeAttackIfReady();
 }
 
+void BossAI::_DespawnAtEvade(uint32 delayToRespawn)
+{
+    if (delayToRespawn < 2)
+    {
+        TC_LOG_ERROR("scripts", "_DespawnAtEvade called with delay of %u seconds, defaulting to 2.", delayToRespawn);
+        delayToRespawn = 2;
+    }
+
+    uint32 corpseDelay = me->GetCorpseDelay();
+    uint32 respawnDelay = me->GetRespawnDelay();
+
+    me->SetCorpseDelay(1);
+    me->SetRespawnDelay(delayToRespawn - 1);
+
+    me->DespawnOrUnsummon();
+
+    me->SetCorpseDelay(corpseDelay);
+    me->SetRespawnDelay(respawnDelay);
+
+    if(instance)
+        instance->SetBossState(_bossId, FAIL);
+}
+
 // WorldBossAI - for non-instanced bosses
 
 WorldBossAI::WorldBossAI(Creature* creature) :

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -365,6 +365,7 @@ class BossAI : public ScriptedAI
         void _EnterCombat();
         void _JustDied();
         void _JustReachedHome() { me->setActive(false); }
+        void _DespawnAtEvade(uint32 delayToRespawn = 30);
 
         void TeleportCheaters();
 


### PR DESCRIPTION
backport @Shauren commit fefee58de7d8c72ba6b34d7f84ee2d626dad59ce to 3.3.5 branch
Also Implement the _DespawnAtEvade functionality to boss Lich King.

I hope to promote discussion on how it should be used.

I used the _DespawnAtEvade found in 6.x, with the addiction of a SetBossState to FAIL and a parameter to allow customize the respawn time, keeping 29s as default.

As for  the Lich kings's script:
- Moved the code from JustReachedHome() and Reset() to InitializeAI() and JustRespawned().
  Thanks @Treeston
- Change npc Highlord Tiirion from permanent spawn to a summon.  I think this is the way it should be, since he despawn along with the Lich King.
- Misc needed changes for turning Tirion into a summon
