### PR TITLE
[3.3.5] Core/Spells: Fix wrong damage calculation for SPELL_AURA_PERIODIC_LEECH

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5998,8 +5998,8 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     caster->CalcAbsorbResist(target, GetSpellInfo()->GetSchoolMask(), DOT, damage, &absorb, &resist, m_spellInfo);
 
-    if (target->GetHealth() < damage)
-        damage = uint32(target->GetHealth());
+    if (target->GetMaxHealth() < damage)
+        damage = target->GetMaxHealth();
 
     TC_LOG_DEBUG("spells.periodic", "PeriodicTick: %s health leech of %s for %u dmg inflicted by %u abs is %u",
         GetCasterGUID().ToString().c_str(), target->GetGUID().ToString().c_str(), damage, GetId(), absorb);


### PR DESCRIPTION
Closes https://github.com/TrinityCore/TrinityCore/issues/16495
Spells with aura attribute `SPELL_AURA_PERIODIC_LEECH` has negative damage calculation.
(For example spell [Devouring Plague](http://wotlk.openwow.com/spell=2944))

Damage should be calculated by `GetMaxHealth()` instead of `GetHealth()` in that case.

> ...GetHealth function will calculate currently amount of HP on target e.g. if target has 500/1000 hp it will calculate amount of 500 and if it's GetMaxHealth function, it will calculate maximal hp of target (1000 HP in this example)...

Thanks to @Goatform for detailed description.
