### PR TITLE
[3.3.5][6.x]Scripts/Karazhan: Astral Flares will cast Astral Flare Passive

### DIFF
--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_curator.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_curator.cpp
@@ -150,7 +150,7 @@ public:
 
                     if (AstralFlare && target)
                     {
-                        AstralFlare->CastSpell(AstralFlare, SPELL_ASTRAL_FLARE_PASSIVE, false);
+                        AstralFlare->AddAura(SPELL_ASTRAL_FLARE_PASSIVE, AstralFlare);
                         AstralFlare->AI()->AttackStart(target);
                     }
 


### PR DESCRIPTION
- closes #16099
- by @Saben65

Astral Flares will cast Astral Flare Passive however it will display the visual affect for only 3 seconds, then stopped which results in the flare being invisible. It will then not cast Arcing Sear (which is what gives the flare it's visual appearance).
