### PR TITLE
Core/Spells: Disallow druid flight form while shapeshifted

### DIFF
--- a/sql/updates/world/2016_02_12_FLIGHTFORMSCRIPT.sql
+++ b/sql/updates/world/2016_02_12_FLIGHTFORMSCRIPT.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (-33943, 33943, 40120);
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES (-33943, "spell_dru_flight_form");

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -991,6 +991,37 @@ class spell_dru_swift_flight_passive : public SpellScriptLoader
         }
 };
 
+// -33943 - Flight Form
+class spell_dru_flight_form : public SpellScriptLoader
+{
+    public:
+        spell_dru_flight_form() : SpellScriptLoader("spell_dru_flight_form") { }
+
+        class spell_dru_flight_form_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_dru_flight_form_SpellScript);
+
+            SpellCastResult CheckCast()
+            {
+                Unit* caster = GetCaster();
+                if (caster->IsInDisallowedMountForm())
+                    return SPELL_FAILED_NOT_SHAPESHIFT;
+
+                return SPELL_CAST_OK;
+            }
+
+            void Register() override
+            {
+                OnCheckCast += SpellCheckCastFn(spell_dru_flight_form_SpellScript::CheckCast);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_dru_flight_form_SpellScript();
+        }
+};
+
 // -5217 - Tiger's Fury
 class spell_dru_tiger_s_fury : public SpellScriptLoader
 {
@@ -1196,6 +1227,7 @@ void AddSC_druid_spell_scripts()
     new spell_dru_starfall_dummy();
     new spell_dru_survival_instincts();
     new spell_dru_swift_flight_passive();
+    new spell_dru_flight_form();
     new spell_dru_tiger_s_fury();
     new spell_dru_typhoon();
     new spell_dru_t10_restoration_4p_bonus();


### PR DESCRIPTION
Core/Spells: Disallow druid flight form while in shapeshift forms that prevent mounting. No more swimming zombies. Closes #16354.
