### PR TITLE
Fix build failing since https://github.com/TrinityCore/TrinityCore/commit/52758c1a0b8e37e198d744803460e34600d115b5

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2439,7 +2439,7 @@ uint32 Map::GetAreaId(float x, float y, float z, bool *isOutdoors) const
             atEntry = sAreaTableStore.LookupEntry(wmoEntry->AreaTableID);
     }
 
-    uint32 areaId;
+    uint32 areaId = 0;
 
     if (atEntry)
         areaId = atEntry->ID;


### PR DESCRIPTION
Fix build failing since https://github.com/TrinityCore/TrinityCore/commit/52758c1a0b8e37e198d744803460e34600d115b5

```
/TrinityCore/src/server/game/Maps/Map.cpp:2448:22: fatal error: 
      variable 'areaId' is used uninitialized whenever 'if' condition is false
      [-Wsometimes-uninitialized]
        if (GridMap* gmap = const_cast<Map*>(this)->GetGrid(x, y))
```
