### PR TITLE
[3.3.5] Core/Spells: Fix Glyph of Arcane Shot

### DIFF
--- a/sql/updates/world/2016_02_15_01_world_335.sql
+++ b/sql/updates/world/2016_02_15_01_world_335.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `spell_proc_event` WHERE `entry`= 56841;
+INSERT INTO `spell_proc_event` (`entry`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `procFlags`, `procEx`, `ppmRate`, `CustomChance`, `Cooldown`) VALUES 
+(56841, 0, 9, 0x800, 0x800, 0x800, 0x100, 0, 0, 0, 0);
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_hun_glyph_of_arcane_shot';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(56841,'spell_hun_glyph_of_arcane_shot');

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -40,6 +40,7 @@ enum HunterSpells
     SPELL_HUNTER_CHIMERA_SHOT_SERPENT               = 53353,
     SPELL_HUNTER_CHIMERA_SHOT_VIPER                 = 53358,
     SPELL_HUNTER_CHIMERA_SHOT_SCORPID               = 53359,
+    SPELL_HUNTER_GLYPH_OF_ARCANE_SHOT               = 61389,
     SPELL_HUNTER_GLYPH_OF_ASPECT_OF_THE_VIPER       = 56851,
     SPELL_HUNTER_IMPROVED_MEND_PET                  = 24406,
     SPELL_HUNTER_INVIGORATION_TRIGGERED             = 53398,
@@ -296,6 +297,65 @@ class spell_hun_disengage : public SpellScriptLoader
         }
 };
 
+// 56841 - Glyph of Arcane Shot
+class spell_hun_glyph_of_arcane_shot : public SpellScriptLoader
+{
+    public:
+        spell_hun_glyph_of_arcane_shot() : SpellScriptLoader("spell_hun_glyph_of_arcane_shot") { }
+
+        class spell_hun_glyph_of_arcane_shot_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_hun_glyph_of_arcane_shot_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_HUNTER_GLYPH_OF_ARCANE_SHOT))
+                    return false;
+                return true;
+            }
+
+            bool CheckProc(ProcEventInfo& eventInfo)
+            {
+                if (Unit* procTarget = eventInfo.GetProcTarget())
+                {
+                    Unit::AuraApplicationMap& auras = procTarget->GetAppliedAuras();
+                    for (Unit::AuraApplicationMap::const_iterator i = auras.begin(); i != auras.end(); ++i)
+                    {
+                        SpellInfo const* spellInfo = i->second->GetBase()->GetSpellInfo();
+                        // Search only Serpent Sting, Viper Sting, Scorpid Sting, Wyvern Sting
+                        if (spellInfo->SpellFamilyFlags.HasFlag(0xC000, 0x1080) && spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER)
+                            return true;
+                    }
+                }
+                return false;
+            }
+
+            void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
+            {
+                PreventDefaultAction();
+                SpellInfo const* procSpell = eventInfo.GetSpellInfo();
+                if (!procSpell)
+                    return;
+
+                int32 mana = procSpell->CalcPowerCost(GetTarget(), procSpell->GetSchoolMask());
+                ApplyPct(mana, aurEff->GetAmount());
+
+                GetTarget()->CastCustomSpell(SPELL_HUNTER_GLYPH_OF_ARCANE_SHOT, SPELLVALUE_BASE_POINT0, mana, GetTarget());
+            }
+
+            void Register() override
+            {
+                DoCheckProc += AuraCheckProcFn(spell_hun_glyph_of_arcane_shot_AuraScript::CheckProc);
+                OnEffectProc += AuraEffectProcFn(spell_hun_glyph_of_arcane_shot_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new spell_hun_glyph_of_arcane_shot_AuraScript();
+        }
+};
+
 // -19572 - Improved Mend Pet
 class spell_hun_improved_mend_pet : public SpellScriptLoader
 {
@@ -336,6 +396,7 @@ class spell_hun_improved_mend_pet : public SpellScriptLoader
             return new spell_hun_improved_mend_pet_AuraScript();
         }
 };
+
 // 53412 - Invigoration
 class spell_hun_invigoration : public SpellScriptLoader
 {
@@ -952,6 +1013,7 @@ void AddSC_hunter_spell_scripts()
     new spell_hun_ascpect_of_the_viper();
     new spell_hun_chimera_shot();
     new spell_hun_disengage();
+    new spell_hun_glyph_of_arcane_shot();
     new spell_hun_improved_mend_pet();
     new spell_hun_invigoration();
     new spell_hun_last_stand_pet();


### PR DESCRIPTION
Takeover of https://github.com/TrinityCore/TrinityCore/pull/16531 with recommended changes.

Closes https://github.com/TrinityCore/TrinityCore/issues/16500 and https://github.com/TrinityCore/TrinityCore/pull/16531

(Thanks to https://github.com/Eliminationzx)
