### PR TITLE
[3.3.5/6.x] Core/Player: Fix dungeonfinder quests not rewarding

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15475,7 +15475,7 @@ bool Player::SatisfyQuestDay(Quest const* qInfo, bool msg)
 
     if (qInfo->IsDFQuest())
     {
-        if (!m_DFQuests.empty())
+        if (m_DFQuests.find(qInfo->GetQuestId()) != m_DFQuests.end())
             return false;
 
         return true;


### PR DESCRIPTION
**Changes proposed**:
Seasonal Quests will now also reward and not take the first reward of the day reward 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes https://github.com/TrinityCore/TrinityCore/issues/9307

**Tests performed**:: Yes it builds and yes it was tested ingame.

**Known issues and TODO list**: Double check it.
