### PR TITLE
Core/Unit: Fix typo

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12341,7 +12341,7 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
                 if (Creature* creature = ToCreature())
                 {
                     uint32 immuneMask = creature->GetCreatureTemplate()->MechanicImmuneMask;
-                    if (immuneMask & (1 << MECHANIC_SNARE) || immuneMask & (1 << MECHANIC_DAZE))
+                    if (immuneMask & (1 << (MECHANIC_SNARE - 1)) || immuneMask & (1 << (MECHANIC_DAZE - 1)))
                         break;
                 }
 


### PR DESCRIPTION
**Changes proposed**: immuneMask needs to be shifted by (mechanic - 1) instead of (mechanic)
- Caused creature to be immune to SPELL_AURA_USE_NORMAL_MOVEMENT_SPEED only when creature had either MECHANIC_STUN or MECHANIC_DISCOVERY in its immunemask, instead of the intended.

**Target branch(es)**: 335/6x

**Tests performed**: (Does it build? Tested in-game?) Aye

**Known issues and TODO list**: None as I know.
