### PR TITLE
Core/Spells Create fallback for item-cast spells while character is still logging in

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2861,7 +2861,22 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
     {
         m_castItemGUID = m_CastItem->GetGUID();
         m_castItemEntry = m_CastItem->GetEntry();
-        m_castItemLevel = int32(m_CastItem->GetItemLevel(m_CastItem->GetOwner()));
+
+        Player* owner = dynamic_cast<Player*>(targets->GetUnitTarget());
+        if (m_CastItem->GetOwner() != nullptr)
+        {
+            m_castItemLevel = int32(m_CastItem->GetItemLevel(m_CastItem->GetOwner()));
+        }
+        else if (owner)
+        {
+            m_castItemLevel = int32(m_CastItem->GetItemLevel(owner));
+        }
+        else
+        {
+            SendCastResult(SPELL_FAILED_EQUIPPED_ITEM);
+            finish(false);
+            return;
+        }
     }
 
     InitExplicitTargets(*targets);


### PR DESCRIPTION
**Changes proposed**:
- Create a fallback for spellcasting items to cover character-loading.
- Create an early-exit if both primary and secondary method of items casting spells fail

**Target branch(es)**: 6x

**Issues addressed**: Fixes #16604

**Tests performed**: (Does it build? Tested in-game?)

After building, I used a low level character and straight upon logging in killed a creature of the same type and level. A couple of times while logging in in full heirloom gear and several times without to ensure the XP bonus is active.

**Known issues and TODO list**:

no known issues due to presumibly small testset (only used full heirloom agi leather + jewelry/trinkets)

closes #16604
