### PR TITLE
Misc/Buildsystem: Use correct variable name for Clang builds

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -1,5 +1,5 @@
 # Set build-directive (used in core to tell which buildtype we used)
-add_definitions(-D_BUILD_DIRECTIVE='"$(CONFIGURATION)"')
+add_definitions(-D_BUILD_DIRECTIVE='"${CMAKE_BUILD_TYPE}"')
 
 if(WITH_WARNINGS)
   set(WARNING_FLAGS "-W -Wall -Wextra -Winit-self -Wfatal-errors -Wno-mismatched-tags")


### PR DESCRIPTION
**Changes proposed**: Clang does not show build type due to bad variable name being passed

**Target branch(es)**: 335
