### PR TITLE
[3.3.5] Fix bosses losing interest in the person running at them

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -134,7 +134,10 @@ void CreatureAI::MoveInLineOfSight(Unit* who)
         return;
 
     if (me->HasReactState(REACT_AGGRESSIVE) && me->CanStartAttack(who, false))
+    {
+        me->AddThreat(who, 0.0f); // ensure our initial target is the first thing added to threat list so we don't randomly switch off if DoZoneInCombat is called during the EnterCombat hook
         AttackStart(who);
+    }
     //else if (who->GetVictim() && me->IsFriendlyTo(who)
     //    && me->IsWithinDistInMap(who, sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_ASSISTANCE_RADIUS))
     //    && me->CanStartAttack(who->GetVictim(), true)) /// @todo if we use true, it will not attack it when it arrives

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -335,7 +335,7 @@ HostileReference* ThreatContainer::selectNextVictim(Creature* attacker, HostileR
             {
                 // current victim is a second choice target, so don't compare threat with it below
                 if (currentRef == currentVictim)
-                    currentVictim = NULL;
+                    currentVictim = nullptr;
                 ++iter;
                 continue;
             }
@@ -437,12 +437,15 @@ void ThreatManager::_addThreat(Unit* victim, float threat)
 
     if (!ref) // there was no ref => create a new one
     {
+        bool isFirst = iThreatContainer.empty();
                                                             // threat has to be 0 here
         HostileReference* hostileRef = new HostileReference(victim, this, 0);
         iThreatContainer.addReference(hostileRef);
         hostileRef->addThreat(threat); // now we add the real threat
         if (victim->GetTypeId() == TYPEID_PLAYER && victim->ToPlayer()->IsGameMaster())
             hostileRef->setOnlineOfflineState(false); // GM is always offline
+        else if (isFirst)
+            setCurrentVictim(hostileRef);
     }
 }
 

--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -169,7 +169,7 @@ class ThreatContainer
 
         HostileReference* getMostHated() const
         {
-            return iThreatList.empty() ? NULL : iThreatList.front();
+            return iThreatList.empty() ? nullptr : iThreatList.front();
         }
 
         HostileReference* getReferenceByTarget(Unit* victim) const;


### PR DESCRIPTION
Core/Threat: Prevent bosses (and other stuff using DoZoneInCombat) from switching off of the person pulling if they are pulled without generating threat.

Why? Because anything that used DoZoneInCombat in the EnterCombat hook (like the default BossAI implementation) would add players to the threat list in an unpredictable manner (rather than adding the person pulling first), thus causing the boss to go after a random target rather than the one pulling.
