### PR TITLE
Core/TempSummons: avoid use MoveInLineOfSight before InitSummon

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -227,6 +227,11 @@ void TempSummon::InitSummon()
     }
 }
 
+void TempSummon::UpdateObjectVisibilityOnCreate()
+{
+    WorldObject::UpdateObjectVisibility(true);
+}
+
 void TempSummon::SetTempSummonType(TempSummonType type)
 {
     m_type = type;

--- a/src/server/game/Entities/Creature/TemporarySummon.h
+++ b/src/server/game/Entities/Creature/TemporarySummon.h
@@ -45,6 +45,7 @@ class TempSummon : public Creature
         void Update(uint32 time) override;
         virtual void InitStats(uint32 lifetime);
         virtual void InitSummon();
+        void UpdateObjectVisibilityOnCreate() override;
         virtual void UnSummon(uint32 msTime = 0);
         void RemoveFromWorld() override;
         void SetTempSummonType(TempSummonType type);

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1878,7 +1878,9 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
     AddToMap(summon->ToCreature());
     summon->InitSummon();
 
-    //ObjectAccessor::UpdateObjectVisibility(summon);
+    // call MoveInLineOfSight for nearby creatures
+    Trinity::AIRelocationNotifier notifier(*summon);
+    summon->VisitNearbyObject(GetVisibilityRange(), notifier);
 
     return summon;
 }

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -555,6 +555,11 @@ class WorldObject : public Object, public WorldLocation
 
         void DestroyForNearbyPlayers();
         virtual void UpdateObjectVisibility(bool forced = true);
+        virtual void UpdateObjectVisibilityOnCreate()
+        {
+            UpdateObjectVisibility(true);
+        }
+
         void BuildUpdate(UpdateDataMapType&) override;
 
         void AddToObjectUpdate() override;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -594,7 +594,7 @@ bool Map::AddToMap(T* obj)
 
     //something, such as vehicle, needs to be update immediately
     //also, trigger needs to cast spell, if not update, cannot see visual
-    obj->UpdateObjectVisibility(true);
+    obj->UpdateObjectVisibilityOnCreate();
     return true;
 }
 


### PR DESCRIPTION
**Changes proposed**:

Core/TempSummons: avoid use MoveInLineOfSight before InitSummon

**Target branch(es)**: 335/6x
335

**Issues addressed**: Fixes #
#16547 probably more

**Tests performed**: (Does it build? Tested in-game?)
Tested by @sirikfoll

**Known issues and TODO list**:
None
