### PR TITLE
Spells/SpellMgr: Add a LoadSpellInfoCorrection case for Remove Weapon…

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2999,6 +2999,9 @@ void SpellMgr::LoadSpellInfoCorrections()
 
         switch (spellInfo->Id)
         {
+            case 108055: // Remove Weapon (should have TARGET_UNIT_CASTER instead of NO_TARGET)
+                const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_1))->TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+                break;
             case 63026: // Summon Aspirant Test NPC (HACK: Target shouldn't be changed)
             case 63137: // Summon Valiant Test (HACK: Target shouldn't be changed; summon position should be untied from spell destination)
                 const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_0))->TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);


### PR DESCRIPTION
**Changes proposed**:

Spell named **Remove Weapon** (_108055_) will be used at you if you create a Pandaren Mage character. This spell job is to delete your main and off-hand weapon, however without this correction, off-hand weapon isn't deleted. This bug is caused by wrong data in Spell Effect 1. Instead of target TARGET_UNIT_CASTER there is a NO_TARGET set.

One may argue whether this kind of correction is really needed and I think the answer for this question is: yes.

Mage is not the only one character which is using main and off-hand weapon. There is also a rogue and shaman. Rogue is using spell with ID: _108058_ and shaman spell with ID: _108056_. This spells have the same Spell Effects structure as _108055_ do, however for Spell Effect 1 they use TARGET_UNIT_CASTER instead of NO_TARGET which is not the case for _108055_.

After making 108055 identical to mentioned spells in case of target, everything is working well.

**Target branch(es)**: 6x

**Issues addressed**: I haven't been able to find issues related to this problem.

**Tests performed**: I have built it myself and tested, everything was working well.

**Known issues and TODO list**:

I don't know any other issues related to this matter and there is nothing left to do.
