### PR TITLE
Core/Conditions: fix a memory leak

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -954,6 +954,7 @@ void ConditionMgr::LoadConditions(bool isReload)
 
         TC_LOG_INFO("misc", "Re-Loading `gossip_menu_option` Table for Conditions!");
         sObjectMgr->LoadGossipMenuItems();
+
         sSpellMgr->UnloadSpellInfoImplicitTargetConditionLists();
 
         TC_LOG_INFO("misc", "Re-Loading `terrain_phase_info` Table for Conditions!");
@@ -1181,17 +1182,6 @@ void ConditionMgr::LoadConditions(bool isReload)
             }
             continue;
         }
-        else if (cond->SourceType == CONDITION_SOURCE_TYPE_TERRAIN_SWAP)
-        {
-            if (!addToTerrainSwaps(cond))
-            {
-                delete cond;
-                continue;
-            }
-
-            ++count;
-            continue;
-        }
 
         //handle not grouped conditions
         //add new Condition to storage based on Type/Entry
@@ -1359,29 +1349,6 @@ bool ConditionMgr::addToSpellImplicitTargetConditions(Condition* cond) const
         }
     }
     return true;
-}
-
-static bool addToTerrainSwapStore(TerrainPhaseInfo& swaps, Condition* cond)
-{
-    bool added = false;
-    for (auto itr = swaps.begin(); itr != swaps.end(); ++itr)
-        for (auto it2 = itr->second.begin(); it2 != itr->second.end(); ++it2)
-            if (it2->Id == uint32(cond->SourceEntry))
-                it2->Conditions.push_back(cond), added = true;
-
-    return added;
-}
-
-bool ConditionMgr::addToTerrainSwaps(Condition* cond) const
-{
-    bool added = false;
-    added = addToTerrainSwapStore(sObjectMgr->GetPhaseTerrainSwapStoreForLoading(), cond);
-    added = addToTerrainSwapStore(sObjectMgr->GetDefaultTerrainSwapStoreForLoading(), cond) || added;
-    if (added)
-        return true;
-
-    TC_LOG_ERROR("sql.sql", "%s No terrain swap with map %u exists.", cond->ToString().c_str(), cond->SourceEntry);
-    return false;
 }
 
 bool ConditionMgr::addToPhases(Condition* cond) const

--- a/src/server/game/Conditions/ConditionMgr.h
+++ b/src/server/game/Conditions/ConditionMgr.h
@@ -292,7 +292,6 @@ class ConditionMgr
         bool addToGossipMenus(Condition* cond) const;
         bool addToGossipMenuItems(Condition* cond) const;
         bool addToSpellImplicitTargetConditions(Condition* cond) const;
-        bool addToTerrainSwaps(Condition* cond) const;
         bool addToPhases(Condition* cond) const;
         bool IsObjectMeetToConditionList(ConditionSourceInfo& sourceInfo, ConditionContainer const& conditions) const;
 

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -3112,26 +3112,26 @@ void WorldObject::RebuildTerrainSwaps()
     // Check all applied phases for terrain swap and add it only once
     for (uint32 phaseId : _phases)
     {
-        if (std::vector<PhaseInfoStruct> const* swaps = sObjectMgr->GetPhaseTerrainSwaps(phaseId))
+        if (std::vector<uint32> const* swaps = sObjectMgr->GetPhaseTerrainSwaps(phaseId))
         {
-            for (PhaseInfoStruct const& swap : *swaps)
+            for (uint32 const& swap : *swaps)
             {
                 // only add terrain swaps for current map
-                MapEntry const* mapEntry = sMapStore.LookupEntry(swap.Id);
+                MapEntry const* mapEntry = sMapStore.LookupEntry(swap);
                 if (!mapEntry || mapEntry->ParentMapID != int32(GetMapId()))
                     continue;
 
-                if (sConditionMgr->IsObjectMeetToConditions(this, swap.Conditions))
-                    _terrainSwaps.insert(swap.Id);
+                if (sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_TERRAIN_SWAP, swap, this))
+                    _terrainSwaps.insert(swap);
             }
         }
     }
 
     // get default terrain swaps, only for current map always
-    if (std::vector<PhaseInfoStruct> const* mapSwaps = sObjectMgr->GetDefaultTerrainSwaps(GetMapId()))
-        for (PhaseInfoStruct const& swap : *mapSwaps)
-            if (sConditionMgr->IsObjectMeetToConditions(this, swap.Conditions))
-                _terrainSwaps.insert(swap.Id);
+    if (std::vector<uint32> const* mapSwaps = sObjectMgr->GetDefaultTerrainSwaps(GetMapId()))
+        for (uint32 const& swap : *mapSwaps)
+            if (sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_TERRAIN_SWAP, swap, this))
+                _terrainSwaps.insert(swap);
 
     // online players have a game client with world map display
     if (GetTypeId() == TYPEID_PLAYER)
@@ -3147,18 +3147,18 @@ void WorldObject::RebuildWorldMapAreaSwaps()
     // send the worldmaparea for it, to see swapped worldmaparea in client from other maps too, not just from our current
     TerrainPhaseInfo const& defaults = sObjectMgr->GetDefaultTerrainSwapStore();
     for (TerrainPhaseInfo::const_iterator itr = defaults.begin(); itr != defaults.end(); ++itr)
-        for (PhaseInfoStruct const& swap : itr->second)
-            if (std::vector<uint32> const* uiMapSwaps = sObjectMgr->GetTerrainWorldMaps(swap.Id))
-                if (sConditionMgr->IsObjectMeetToConditions(this, swap.Conditions))
+        for (uint32 const& swap : itr->second)
+            if (std::vector<uint32> const* uiMapSwaps = sObjectMgr->GetTerrainWorldMaps(swap))
+                if (sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_TERRAIN_SWAP, swap, this))
                     for (uint32 worldMapAreaId : *uiMapSwaps)
                         _worldMapAreaSwaps.insert(worldMapAreaId);
 
     // Check all applied phases for world map area swaps
     for (uint32 phaseId : _phases)
-        if (std::vector<PhaseInfoStruct> const* swaps = sObjectMgr->GetPhaseTerrainSwaps(phaseId))
-            for (PhaseInfoStruct const& swap : *swaps)
-                if (std::vector<uint32> const* uiMapSwaps = sObjectMgr->GetTerrainWorldMaps(swap.Id))
-                    if (sConditionMgr->IsObjectMeetToConditions(this, swap.Conditions))
+        if (std::vector<uint32> const* swaps = sObjectMgr->GetPhaseTerrainSwaps(phaseId))
+            for (uint32 const& swap : *swaps)
+                if (std::vector<uint32> const* uiMapSwaps = sObjectMgr->GetTerrainWorldMaps(swap))
+                    if (sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_TERRAIN_SWAP, swap, this))
                         for (uint32 worldMapAreaId : *uiMapSwaps)
                             _worldMapAreaSwaps.insert(worldMapAreaId);
 }

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8967,9 +8967,7 @@ void ObjectMgr::LoadTerrainSwapDefaults()
             continue;
         }
 
-        PhaseInfoStruct defaultSwap;
-        defaultSwap.Id = terrainSwap;
-        _terrainMapDefaultStore[mapId].push_back(defaultSwap);
+        _terrainMapDefaultStore[mapId].push_back(terrainSwap);
 
         ++count;
     } while (result->NextRow());
@@ -9006,8 +9004,7 @@ void ObjectMgr::LoadTerrainPhaseInfo()
             continue;
         }
 
-        PhaseInfoStruct terrainSwap;
-        terrainSwap.Id = fields[1].GetUInt32();
+        uint32 terrainSwap = fields[1].GetUInt32();
 
         _terrainPhaseInfoStore[phaseId].push_back(terrainSwap);
 

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -687,7 +687,7 @@ struct PhaseInfoStruct
     ConditionContainer Conditions;
 };
 
-typedef std::unordered_map<uint32, std::vector<PhaseInfoStruct>> TerrainPhaseInfo; // terrain swap
+typedef std::unordered_map<uint32, std::vector<uint32 /*id*/>> TerrainPhaseInfo; // terrain swap
 typedef std::unordered_map<uint32, std::vector<uint32>> TerrainUIPhaseInfo; // worldmaparea swap
 typedef std::unordered_map<uint32, std::vector<PhaseInfoStruct>> PhaseInfo; // phase
 
@@ -1300,12 +1300,12 @@ class ObjectMgr
             return _gossipMenuItemsStore.equal_range(uiMenuId);
         }
 
-        std::vector<PhaseInfoStruct> const* GetPhaseTerrainSwaps(uint32 phaseid) const
+        std::vector<uint32> const* GetPhaseTerrainSwaps(uint32 phaseid) const
         {
             auto itr = _terrainPhaseInfoStore.find(phaseid);
             return itr != _terrainPhaseInfoStore.end() ? &itr->second : nullptr;
         }
-        std::vector<PhaseInfoStruct> const* GetDefaultTerrainSwaps(uint32 mapid) const
+        std::vector<uint32> const* GetDefaultTerrainSwaps(uint32 mapid) const
         {
             auto itr = _terrainMapDefaultStore.find(mapid);
             return itr != _terrainMapDefaultStore.end() ? &itr->second : nullptr;
@@ -1328,8 +1328,6 @@ class ObjectMgr
             auto itr = _phases.find(area);
             return itr != _phases.end() ? &itr->second : nullptr;
         }
-        TerrainPhaseInfo& GetPhaseTerrainSwapStoreForLoading() { return _terrainPhaseInfoStore; }
-        TerrainPhaseInfo& GetDefaultTerrainSwapStoreForLoading() { return _terrainMapDefaultStore; }
         PhaseInfo& GetAreaPhasesForLoading() { return _phases; }
 
         // for wintergrasp only


### PR DESCRIPTION
**Changes proposed**: Conditions with source type CONDITION_SOURCE_TYPE_TERRAIN_SWAP leak due to this type being handled differently, this PR streamlines condition requirement check, since it's ungrouped anyways.

**Target branch(es)**: 6x

**Issues addressed**: Related Valgrind log:

```
==23705== 56 bytes in 1 blocks are definitely lost in loss record 4 of 5
==23705==    at 0x4C29180: operator new(unsigned long) (vg_replace_malloc.c:324)
==23705==    by 0x1F942DA: ConditionMgr::LoadConditions(bool) (in /home/aokromes/bin/434/bin/worldserver)
==23705==    by 0x1E0B94C: World::SetInitialWorldSettings() (in /home/aokromes/bin/434/bin/worldserver)
==23705==    by 0x13DD97F: main (in /home/aokromes/bin/434/bin/worldserver)
```

**Tests performed**: (Does it build, tested in-game, etc) It builds correctly.

**Known issues and TODO list**: 
