### PR TITLE
Solve many of the creature falling through floor issues.

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2328,9 +2328,9 @@ float Map::GetHeight(float x, float y, float z, bool checkVMap /*= true*/, float
         {
             // we have mapheight and vmapheight and must select more appropriate
 
-            // we are already under the surface or vmap height above map heigt
+            // vmap height above map height
             // or if the distance of the vmap height is less the land height distance
-            if (z < mapHeight || vmapHeight > mapHeight || std::fabs(mapHeight - z) > std::fabs(vmapHeight - z))
+            if (vmapHeight > mapHeight || std::fabs(mapHeight - z) > std::fabs(vmapHeight - z))
                 return vmapHeight;
             else
                 return mapHeight;                           // better use .map surface height


### PR DESCRIPTION
Remove check for map height above current Z in getHeight:

This check has been present forever as far as I can see, but to me the premise seems flawed. Generally getHeight is used to find the correct ground height and more often than not the problems of creatures falling through the terrain are because a relative location to a known good location is used, and often the Z is below the ground the core wants to move the object to. This check limits the ability to choose options above the current ground level to vmap lookups.

This is a PR for a simple change because, it's called EVERYWHERE and has the potential to break a lot of things if it's not a perfect solution. Hence I'd like some testing.

Target Branch: 335, potentially 6x

Tests Performed:

Pet pathing in Sepulcher is resolved, creature pathing around the temple close to Gundrak, and many other places.

**Known issues and TODO list**:

It doesn't resolve even close to all the problems obtaining the Z position. But it seems to improve, and from my testing so far not make matters worse anywhere.

Potentially this could cause problems. But in my testing so far I've not found any examples.
