### PR TITLE
SmartScript: Added SetBossState support

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -929,9 +929,21 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 break;
             }
 
-            instance->SetData(e.action.setInstanceData.field, e.action.setInstanceData.data);
-            TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_SET_INST_DATA: Field: %u, data: %u",
-                e.action.setInstanceData.field, e.action.setInstanceData.data);
+            switch (e.action.setInstanceData.type)
+            {
+                case 0:
+                    instance->SetData(e.action.setInstanceData.field, e.action.setInstanceData.data);
+                    TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_SET_INST_DATA: SetData Field: %u, data: %u",
+                        e.action.setInstanceData.field, e.action.setInstanceData.data);
+                    break;
+                case 1:
+                    instance->SetBossState(e.action.setInstanceData.field, static_cast<EncounterState>(e.action.setInstanceData.data));
+                    TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_SET_INST_DATA: SetBossState BossId: %u, State: %u (%s)",
+                        e.action.setInstanceData.field, e.action.setInstanceData.data, InstanceScript::GetBossStateName(e.action.setInstanceData.data).c_str());
+                    break;
+                default: // Static analysis
+                    break;
+            }
             break;
         }
         case SMART_ACTION_SET_INST_DATA64:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -19,6 +19,7 @@
 #include "ObjectMgr.h"
 #include "GridDefines.h"
 #include "GridNotifiers.h"
+#include "InstanceScript.h"
 #include "SpellMgr.h"
 #include "Cell.h"
 #include "GameEventMgr.h"
@@ -1144,6 +1145,23 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             }
             break;
         }
+        case SMART_ACTION_SET_INST_DATA:
+        {
+            if (e.action.setInstanceData.type > 1)
+            {
+                TC_LOG_ERROR("sql.sql", "Entry %u SourceType %u Event %u Action %u uses invalid data type %u (value range 0-1), skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.setInstanceData.type);
+                return false;
+            }
+            else if (e.action.setInstanceData.type == 1)
+            {
+                if (e.action.setInstanceData.data > TO_BE_DECIDED)
+                {
+                    TC_LOG_ERROR("sql.sql", "Entry %u SourceType %u Event %u Action %u uses invalid boss state %u (value range 0-5), skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.setInstanceData.data);
+                    return false;
+                }
+            }
+            break;
+        }
         case SMART_ACTION_START_CLOSEST_WAYPOINT:
         case SMART_ACTION_FOLLOW:
         case SMART_ACTION_SET_ORIENTATION:
@@ -1161,7 +1179,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_ATTACK_START:
         case SMART_ACTION_THREAT_ALL_PCT:
         case SMART_ACTION_THREAT_SINGLE_PCT:
-        case SMART_ACTION_SET_INST_DATA:
         case SMART_ACTION_SET_INST_DATA64:
         case SMART_ACTION_AUTO_ATTACK:
         case SMART_ACTION_ALLOW_COMBAT_MOVEMENT:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -469,7 +469,7 @@ enum SMART_ACTION
     SMART_ACTION_RANDOM_PHASE_RANGE                 = 31,     // PhaseMin, PhaseMax
     SMART_ACTION_RESET_GOBJECT                      = 32,     //
     SMART_ACTION_CALL_KILLEDMONSTER                 = 33,     // CreatureId,
-    SMART_ACTION_SET_INST_DATA                      = 34,     // Field, Data
+    SMART_ACTION_SET_INST_DATA                      = 34,     // Field, Data, Type (0 = SetData, 1 = SetBossState)
     SMART_ACTION_SET_INST_DATA64                    = 35,     // Field,
     SMART_ACTION_UPDATE_TEMPLATE                    = 36,     // Entry
     SMART_ACTION_DIE                                = 37,     // No Params
@@ -716,6 +716,7 @@ struct SmartAction
         {
             uint32 field;
             uint32 data;
+            uint32 type;
         } setInstanceData;
 
         struct

--- a/src/server/scripts/Kalimdor/DireMaul/instance_dire_maul.cpp
+++ b/src/server/scripts/Kalimdor/DireMaul/instance_dire_maul.cpp
@@ -25,20 +25,49 @@ gets instead the deserter debuff.
 #include "ScriptMgr.h"
 #include "InstanceScript.h"
 
+// Bosses (East)
+// 0 - Pusillin
+// 1 - Lethtendris
+// 2 - Hydrospawn
+// 3 - Zevrim Thornhoof
+// 4 - Alzzin the Wildshaper
+
+// West
+// 5 - Tendris Warpwood
+// 6 - Magister Kalendris
+// 7 - Tsu'zee
+// 8 - Illyanna Ravenoak
+// 9 - Immol'thar
+// 10 - Prince Tortheldrin
+
+// North
+// 11 - Guard Mol'dar
+// 12 - Stomper Kreeg
+// 13 - Guard Fengus
+// 14 - Guard Slip'kik
+// 15 - Captain Kromcrush
+// 16 - King Gordok
+
+uint8 const EncounterCount = 17;
+
 class instance_dire_maul : public InstanceMapScript
 {
 public:
     instance_dire_maul() : InstanceMapScript("instance_dire_maul", 429) { }
+
+    struct instance_dire_maul_InstanceMapScript : public InstanceScript
+    {
+        instance_dire_maul_InstanceMapScript(Map* map) : InstanceScript(map)
+        {
+            SetBossNumber(EncounterCount);
+        }
+    };
 
     InstanceScript* GetInstanceScript(InstanceMap* map) const override
     {
         return new instance_dire_maul_InstanceMapScript(map);
     }
 
-    struct instance_dire_maul_InstanceMapScript : public InstanceScript
-    {
-        instance_dire_maul_InstanceMapScript(Map* map) : InstanceScript(map) { }
-    };
 };
 
 void AddSC_instance_dire_maul()


### PR DESCRIPTION
**Changes proposed**:
- Adds Boss State capability to smart scripts, making it possible to fully script simple bosses using DB
- Still needs SetBossNumber set on instance .cpp, done this for DIre Maul, which has every boss with SmartAI

**Target branch(es)**: 335/6x

**Issues addressed**: Will help fixing DM tribute run (commit referenced)

**Tests performed**: (Does it build, tested in-game, etc)  Build correct

**Known issues and TODO list**: None as I know
