### PR TITLE
Core: fixed typo at locale checking on GameTables loading

### DIFF
--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -252,7 +252,7 @@ inline void LoadGameTable(StoreProblemList& errors, std::string const& tableName
 
             for (uint32 l = 0; l < TOTAL_LOCALES; ++l)
             {
-                if (i != LOCALE_none && tableName == gt->Name->Str[l])
+                if (l != LOCALE_none && tableName == gt->Name->Str[l])
                 {
                     found = true;
                     storage.SetGameTableEntry(gt);


### PR DESCRIPTION
**Target branch(es)**: 6x
closes #16748
