### PR TITLE
[6.x] Core/Spell: changed target of spell 102445 Summon Master Li Fei

### DIFF
--- a/sql/updates/world/2016_03_08_00_world.sql
+++ b/sql/updates/world/2016_03_08_00_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_target_position` WHERE `ID`=102445;
+INSERT INTO `spell_target_position` (`ID`, `EffectIndex`, `MapID`, `PositionX`, `PositionY`, `PositionZ`, `VerifiedBuild`) VALUES
+(102445, 0, 860, 1130.457, 3435.93, 105.4892, 20886);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3528,6 +3528,9 @@ void SpellMgr::LoadSpellInfoCorrections()
                 break;
             // ENDOF ISLE OF CONQUEST SPELLS
             //
+            case 102445: // Summon Master Li Fei
+                const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_0))->TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
**Changes proposed**:
- change target TARGET_DEST_NEARBY_ENTRY to TARGET_DEST_DB since there is no NPC at that position (in sniffs) and thus cannot cast this spell where needed

**Target branch(es)**: 6x
**Tests performed**: tested in-game
