### PR TITLE
Fix MSG_MOVE_SET_* opcodes. The GUID was missing.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12505,6 +12505,7 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
                 return;
         }
 
+        data << GetPackGUID();
         BuildMovementPacket(&data);
         data << float(GetSpeed(mtype));
         SendMessageToSet(&data, true);


### PR DESCRIPTION
MSG_MOVE_SET_\* packets were malformed by the core. The GUID of the unit concerned by the change is missing from the packet.

Target branch: 3.3.5

This is from a parsed sniff of retail (3.3.5):

> ServerToClient: MSG_MOVE_SET_RUN_SPEED (0x00CD) Length: 40 ConnIdx: 0 Time: 07/15/2010 19:14:08.000 Number: 4103
> GUID: Full: ****************\* Type: Player Low: ******\* Name: ********
> Movement Flags: None (0)
> Extra Movement Flags: None (0)
> Time: -679006016
> Position: X: 501.3554 Y: 759.6469 Z: 812.948
> Orientation: 5.529202
> Fall Time: 1111
> Speed: 5.599999

This is the result of parsing one `MSG_MOVE_SET_RUN_SPEED` sent by TC at the moment:

> ServerToClient: MSG_MOVE_SET_RUN_SPEED (0x00CD) Length: 34 ConnIdx: 0 EP: 127.0.0.1:50211 Time: 03/13/2016 14:17:42.761 Number: 9021
> GUID: 0x0
> Movement Flags: None (0)
> Extra Movement Flags: PreventChangePitch, InterpolateTurning (2560)
> Time: 1258291537
> Position: X: 1.449564E-37 Y: 7.107108E+18 Z: -3.873886E+30
> Orientation: 5.895841E-39
> Fall Time: 0
> System.IO.EndOfStreamException
> Impossible de lire au-delà de la fin du flux.
>    à System.IO.BinaryReader.FillBuffer(Int32 numBytes)
>    à System.IO.BinaryReader.ReadSingle()
>    à WowPacketParser.Misc.Packet.ReadSingle(String name, Object[] indexes) dans F:\Sniffer\WowPacketParser\WowPacketParser\Misc\PacketReads.cs:ligne 288
>    à WowPacketParser.Parsing.Handler.Parse(Packet packet, Boolean isMultiple) dans F:\Sniffer\WowPacketParser\WowPacketParser\Parsing\Handler.cs:ligne 144

And after the fix, this is the result:

> ServerToClient: MSG_MOVE_SET_RUN_SPEED (0x00CD) Length: 41 ConnIdx: 0 EP: 127.0.0.1:50241 Time: 03/13/2016 14:22:27.668 Number: 8434
> GUID: Full: 0xF130003E3C000309 Type: Creature Entry: 15932 Low: 777
> Movement Flags: None (0)
> Extra Movement Flags: None (0)
> Time: 60789
> Position: X: 3299.827 Y: -3167.127 Z: 297.7011
> Orientation: 0.1880638
> Fall Time: 0
> Speed: 36
