### PR TITLE
[3.3.5/Core/Scripts] Fix Living Constellation not activating during Algalon encounter

### DIFF
--- a/sql/updates/world/2016_03_15_00_world.sql
+++ b/sql/updates/world/2016_03_15_00_world.sql
@@ -1,0 +1,4 @@
+SET @ENTRY := 62266;
+DELETE FROM `disables` WHERE `sourceType`=0 AND `entry` = @ENTRY;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0,@ENTRY,64,0,0,'Disable LOS for Spell Trigger 3 adds');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -1164,6 +1164,7 @@ class spell_algalon_trigger_3_adds : public SpellScriptLoader
             void Register() override
             {
                 OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_algalon_trigger_3_adds_SpellScript::SelectTarget, EFFECT_0, TARGET_UNIT_SRC_AREA_ENTRY);
+                OnEffectHitTarget += SpellEffectFn(spell_algalon_trigger_3_adds_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
             }
         };
 


### PR DESCRIPTION
**Changes proposed**:
- Fix missing assign the function on spellscript. by @ariel- 
- Spell need ignore LoS for active All stars.

**Description**:
Living Constellation is part of Algalon room, and helps Algalon in your fight. But in Algalon scenario has invisible walls that make some stars, get out of the line of sight of Algalon. 

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #15042

**Tests performed**: Build and test in game.
