### PR TITLE
Core/AI Remove Reset() call from JustRespawned() hook

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -137,8 +137,8 @@ class CreatureAI : public UnitAI
         virtual void AttackedBy(Unit* /*attacker*/) { }
         virtual bool IsEscorted() const { return false; }
 
-        // Called when creature is spawned or respawned (for reseting variables)
-        virtual void JustRespawned() { Reset(); }
+        // Called when creature is spawned or respawned
+        virtual void JustRespawned() { }
 
         // Called at waypoint reached or point movement finished
         virtual void MovementInform(uint32 /*type*/, uint32 /*id*/) { }


### PR DESCRIPTION
**Changes proposed**:
- With the current implementation Reset() hook is called twice at creature respawn
- So, I propose to remove it from JustRespawned()
- Why this shouldn't break anything:
- Reset is called at creature spawn in https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/AI/CoreAI/UnitAI.h#L130
- Reset is called at creature respawn in https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Creature/Creature.cpp#L1718

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #16672

**Tests performed**: Built and tested

**Known issues and TODO list**:
- Didn't found any so far
