### PR TITLE
Core/Movement: Clean up and improvements on Unit::SetSpeed

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -245,9 +245,9 @@ void PetAI::UpdateAI(uint32 diff)
     }
 
     // Update speed as needed to prevent dropping too far behind and despawning
-    me->UpdateSpeed(MOVE_RUN, true);
-    me->UpdateSpeed(MOVE_WALK, true);
-    me->UpdateSpeed(MOVE_FLIGHT, true);
+    me->UpdateSpeed(MOVE_RUN);
+    me->UpdateSpeed(MOVE_WALK);
+    me->UpdateSpeed(MOVE_FLIGHT);
 
 }
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -782,7 +782,7 @@ void Creature::DoFleeToGetAssistance()
         cell.Visit(p, grid_creature_searcher, *GetMap(), *this, radius);
 
         SetNoSearchAssistance(true);
-        UpdateSpeed(MOVE_RUN, false);
+        UpdateSpeed(MOVE_RUN);
 
         if (!creature)
             //SetFeared(true, EnsureVictim()->GetGUID(), 0, sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_FLEE_DELAY));
@@ -1620,7 +1620,7 @@ void Creature::setDeathState(DeathState s)
         if (HasSearchedAssistance())
         {
             SetNoSearchAssistance(false);
-            UpdateSpeed(MOVE_RUN, false);
+            UpdateSpeed(MOVE_RUN);
         }
 
         //Dismiss group if is leader

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -381,10 +381,10 @@ bool Creature::InitEntry(uint32 entry, CreatureData const* data /*= nullptr*/)
 
     SetFloatValue(UNIT_MOD_CAST_SPEED, 1.0f);
 
-    SetSpeed(MOVE_WALK,   cinfo->speed_walk);
-    SetSpeed(MOVE_RUN,    cinfo->speed_run);
-    SetSpeed(MOVE_SWIM,   1.0f); // using 1.0 rate
-    SetSpeed(MOVE_FLIGHT, 1.0f); // using 1.0 rate
+    SetSpeedRate(MOVE_WALK,   cinfo->speed_walk);
+    SetSpeedRate(MOVE_RUN,    cinfo->speed_run);
+    SetSpeedRate(MOVE_SWIM,   1.0f); // using 1.0 rate
+    SetSpeedRate(MOVE_FLIGHT, 1.0f); // using 1.0 rate
 
     // Will set UNIT_FIELD_BOUNDINGRADIUS and UNIT_FIELD_COMBATREACH
     SetObjectScale(cinfo->scale);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12493,9 +12493,11 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
                 pet->SetSpeed(mtype, m_speed_rate[mtype], forced);
     }
 
-    if (GetTypeId() == TYPEID_PLAYER && ToPlayer()->m_mover->GetTypeId() == TYPEID_PLAYER)
+    if (m_movedPlayer) 
     {
-        // Send notification to self. only sent to one client (the client of the player concerned by the change).
+        // unit controlled by a player.
+
+        // Send notification to self. this packet is only sent to one client (the client of the player concerned by the change).
         WorldPacket self;
         self.Initialize(moveTypeToOpcode[mtype][1], mtype != MOVE_RUN ? 8 + 4 + 4 : 8 + 4 + 1 + 4);
         self << GetPackGUID();
@@ -12503,7 +12505,7 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
         if (mtype == MOVE_RUN)
             self << uint8(1);                               // unknown byte added in 2.1.0
         self << float(GetSpeed(mtype));
-        ToPlayer()->GetSession()->SendPacket(&self); // this is a hack. technically, players can control some NPcs (like 19405) and it will result in a SMSG_FORCE_RUN_SPEED_CHANGE).
+        m_movedPlayer->GetSession()->SendPacket(&self);
 
         // Send notification to other players. sent to every clients (if in range) except one: the client of the player concerned by the change.
         WorldPacket data;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12455,6 +12455,11 @@ float Unit::GetSpeed(UnitMoveType mtype) const
     return m_speed_rate[mtype]*(IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]);
 }
 
+void Unit::SetSpeed(UnitMoveType mtype, float newValue)
+{
+    SetSpeedRate(mtype, newValue / (IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]));
+}
+
 void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
 {
     if (rate < 0)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9106,7 +9106,7 @@ bool Unit::AttackStop()
         if (creature->HasSearchedAssistance())
         {
             creature->SetNoSearchAssistance(false);
-            UpdateSpeed(MOVE_RUN, false);
+            UpdateSpeed(MOVE_RUN);
         }
     }
 
@@ -11870,9 +11870,9 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
 
         if (IsPet())
         {
-            UpdateSpeed(MOVE_RUN, true);
-            UpdateSpeed(MOVE_SWIM, true);
-            UpdateSpeed(MOVE_FLIGHT, true);
+            UpdateSpeed(MOVE_RUN);
+            UpdateSpeed(MOVE_SWIM);
+            UpdateSpeed(MOVE_FLIGHT);
         }
 
         if (!(creature->GetCreatureTemplate()->type_flags & CREATURE_TYPEFLAGS_MOUNTED_COMBAT))
@@ -12302,7 +12302,7 @@ void Unit::SetVisible(bool x)
     UpdateObjectVisibility();
 }
 
-void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
+void Unit::UpdateSpeed(UnitMoveType mtype)
 {
     int32 main_speed_mod  = 0;
     float stack_bonus     = 1.0f;
@@ -12365,7 +12365,7 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
 
             // Update speed for vehicle if available
             if (GetTypeId() == TYPEID_PLAYER && GetVehicle())
-                GetVehicleBase()->UpdateSpeed(MOVE_FLIGHT, true);
+                GetVehicleBase()->UpdateSpeed(MOVE_FLIGHT);
             break;
         }
         default:

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12493,15 +12493,13 @@ void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
                 pet->SetSpeedRate(mtype, m_speed_rate[mtype]);
     }
 
-    if (m_movedPlayer) 
+    if (m_movedPlayer) // unit controlled by a player.
     {
-        // unit controlled by a player.
-
         // Send notification to self. this packet is only sent to one client (the client of the player concerned by the change).
         WorldPacket self;
         self.Initialize(moveTypeToOpcode[mtype][1], mtype != MOVE_RUN ? 8 + 4 + 4 : 8 + 4 + 1 + 4);
         self << GetPackGUID();
-        self << (uint32)0;                                  // Movement event encounter. Unimplemented at the moment! NUM_PMOVE_EVTS = 0x39Z. 
+        self << (uint32)0;                                  // Movement counter. Unimplemented at the moment! NUM_PMOVE_EVTS = 0x39Z. 
         if (mtype == MOVE_RUN)
             self << uint8(1);                               // unknown byte added in 2.1.0
         self << float(GetSpeed(mtype));
@@ -12515,9 +12513,9 @@ void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
         data << float(GetSpeed(mtype));
         SendMessageToSet(&data, false);
     }
-    else
+    else // unit controlled by AI.
     {
-        // unit controlled by AI. send notification to every clients.
+        // send notification to every clients.
         WorldPacket data;
         data.Initialize(moveTypeToOpcode[mtype][0], 8 + 4);
         data << GetPackGUID();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9440,7 +9440,7 @@ void Unit::SetMinion(Minion *minion, bool apply)
         // FIXME: hack, speed must be set only at follow
         if (GetTypeId() == TYPEID_PLAYER && minion->IsPet())
             for (uint8 i = 0; i < MAX_MOVE_TYPE; ++i)
-                minion->SetSpeed(UnitMoveType(i), m_speed_rate[i], true);
+                minion->SetSpeedRate(UnitMoveType(i), m_speed_rate[i]);
 
         // Ghoul pets have energy instead of mana (is anywhere better place for this code?)
         if (minion->IsPetGhoul() || minion->IsRisenAlly())
@@ -11916,7 +11916,7 @@ void Unit::ClearInCombat()
             if (Unit* owner = GetOwner())
                 for (uint8 i = 0; i < MAX_MOVE_TYPE; ++i)
                     if (owner->GetSpeedRate(UnitMoveType(i)) > GetSpeedRate(UnitMoveType(i)))
-                        SetSpeed(UnitMoveType(i), owner->GetSpeedRate(UnitMoveType(i)), true);
+                        SetSpeedRate(UnitMoveType(i), owner->GetSpeedRate(UnitMoveType(i)));
         }
         else if (!IsCharmed())
             return;
@@ -12447,7 +12447,7 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
             speed = min_speed;
     }
 
-    SetSpeed(mtype, speed, forced);
+    SetSpeedRate(mtype, speed);
 }
 
 float Unit::GetSpeed(UnitMoveType mtype) const
@@ -12455,7 +12455,7 @@ float Unit::GetSpeed(UnitMoveType mtype) const
     return m_speed_rate[mtype]*(IsControlledByPlayer() ? playerBaseMoveSpeed[mtype] : baseMoveSpeed[mtype]);
 }
 
-void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
+void Unit::SetSpeedRate(UnitMoveType mtype, float rate)
 {
     if (rate < 0)
         rate = 0.0f;
@@ -12490,7 +12490,7 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
 
         if (!IsInCombat())
             if (Pet* pet = ToPlayer()->GetPet())
-                pet->SetSpeed(mtype, m_speed_rate[mtype], forced);
+                pet->SetSpeedRate(mtype, m_speed_rate[mtype]);
     }
 
     if (m_movedPlayer) 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1997,7 +1997,7 @@ class Unit : public WorldObject
         void  UpdateSpeed(UnitMoveType mtype, bool forced);
         float GetSpeed(UnitMoveType mtype) const;
         float GetSpeedRate(UnitMoveType mtype) const { return m_speed_rate[mtype]; }
-        void SetSpeed(UnitMoveType mtype, float rate, bool forced = false);
+        void SetSpeedRate(UnitMoveType mtype, float rate);
 
         float ApplyEffectModifiers(SpellInfo const* spellProto, uint8 effect_index, float value) const;
         int32 CalculateSpellDamage(Unit const* target, SpellInfo const* spellProto, uint8 effect_index, int32 const* basePoints = NULL) const;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1997,6 +1997,7 @@ class Unit : public WorldObject
         void  UpdateSpeed(UnitMoveType mtype);
         float GetSpeed(UnitMoveType mtype) const;
         float GetSpeedRate(UnitMoveType mtype) const { return m_speed_rate[mtype]; }
+        void SetSpeed(UnitMoveType mtype, float newValue);
         void SetSpeedRate(UnitMoveType mtype, float rate);
 
         float ApplyEffectModifiers(SpellInfo const* spellProto, uint8 effect_index, float value) const;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1994,7 +1994,7 @@ class Unit : public WorldObject
         void CalcAbsorbResist(Unit* victim, SpellSchoolMask schoolMask, DamageEffectType damagetype, uint32 const damage, uint32* absorb, uint32* resist, SpellInfo const* spellInfo = NULL);
         void CalcHealAbsorb(Unit* victim, SpellInfo const* spellInfo, uint32& healAmount, uint32& absorb);
 
-        void  UpdateSpeed(UnitMoveType mtype, bool forced);
+        void  UpdateSpeed(UnitMoveType mtype);
         float GetSpeed(UnitMoveType mtype) const;
         float GetSpeedRate(UnitMoveType mtype) const { return m_speed_rate[mtype]; }
         void SetSpeedRate(UnitMoveType mtype, float rate);

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -473,7 +473,7 @@ void WorldSession::HandleForceSpeedChangeAck(WorldPacket &recvData)
         {
             TC_LOG_ERROR("network", "%sSpeedChange player %s is NOT correct (must be %f instead %f), force set to correct value",
                 move_type_name[move_type], _player->GetName().c_str(), _player->GetSpeed(move_type), newspeed);
-            _player->SetSpeed(move_type, _player->GetSpeedRate(move_type), true);
+            _player->SetSpeedRate(move_type, _player->GetSpeedRate(move_type));
         }
         else                                                // must be lesser - cheating
         {

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -265,9 +265,9 @@ void FollowMovementGenerator<Creature>::_updateSpeed(Creature* owner)
     if (!owner->IsPet() || !owner->IsInWorld() || !i_target.isValid() || i_target->GetGUID() != owner->GetOwnerGUID())
         return;
 
-    owner->UpdateSpeed(MOVE_RUN, true);
-    owner->UpdateSpeed(MOVE_WALK, true);
-    owner->UpdateSpeed(MOVE_SWIM, true);
+    owner->UpdateSpeed(MOVE_RUN);
+    owner->UpdateSpeed(MOVE_WALK);
+    owner->UpdateSpeed(MOVE_SWIM);
 }
 
 template<>

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2915,7 +2915,7 @@ void AuraEffect::HandleAuraModIncreaseSpeed(AuraApplication const* aurApp, uint8
 
     Unit* target = aurApp->GetTarget();
 
-    target->UpdateSpeed(MOVE_RUN, true);
+    target->UpdateSpeed(MOVE_RUN);
 }
 
 void AuraEffect::HandleAuraModIncreaseMountedSpeed(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -2930,7 +2930,7 @@ void AuraEffect::HandleAuraModIncreaseFlightSpeed(AuraApplication const* aurApp,
 
     Unit* target = aurApp->GetTarget();
     if (mode & AURA_EFFECT_HANDLE_CHANGE_AMOUNT_MASK)
-        target->UpdateSpeed(MOVE_FLIGHT, true);
+        target->UpdateSpeed(MOVE_FLIGHT);
 
     //! Update ability to fly
     if (GetAuraType() == SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED)
@@ -2965,7 +2965,7 @@ void AuraEffect::HandleAuraModIncreaseSwimSpeed(AuraApplication const* aurApp, u
 
     Unit* target = aurApp->GetTarget();
 
-    target->UpdateSpeed(MOVE_SWIM, true);
+    target->UpdateSpeed(MOVE_SWIM);
 }
 
 void AuraEffect::HandleAuraModDecreaseSpeed(AuraApplication const* aurApp, uint8 mode, bool /*apply*/) const
@@ -2975,12 +2975,12 @@ void AuraEffect::HandleAuraModDecreaseSpeed(AuraApplication const* aurApp, uint8
 
     Unit* target = aurApp->GetTarget();
 
-    target->UpdateSpeed(MOVE_RUN, true);
-    target->UpdateSpeed(MOVE_SWIM, true);
-    target->UpdateSpeed(MOVE_FLIGHT, true);
-    target->UpdateSpeed(MOVE_RUN_BACK, true);
-    target->UpdateSpeed(MOVE_SWIM_BACK, true);
-    target->UpdateSpeed(MOVE_FLIGHT_BACK, true);
+    target->UpdateSpeed(MOVE_RUN);
+    target->UpdateSpeed(MOVE_SWIM);
+    target->UpdateSpeed(MOVE_FLIGHT);
+    target->UpdateSpeed(MOVE_RUN_BACK);
+    target->UpdateSpeed(MOVE_SWIM_BACK);
+    target->UpdateSpeed(MOVE_FLIGHT_BACK);
 }
 
 void AuraEffect::HandleAuraModUseNormalSpeed(AuraApplication const* aurApp, uint8 mode, bool /*apply*/) const
@@ -2990,9 +2990,9 @@ void AuraEffect::HandleAuraModUseNormalSpeed(AuraApplication const* aurApp, uint
 
     Unit* target = aurApp->GetTarget();
 
-    target->UpdateSpeed(MOVE_RUN,  true);
-    target->UpdateSpeed(MOVE_SWIM, true);
-    target->UpdateSpeed(MOVE_FLIGHT,  true);
+    target->UpdateSpeed(MOVE_RUN);
+    target->UpdateSpeed(MOVE_SWIM);
+    target->UpdateSpeed(MOVE_FLIGHT);
 }
 
 /*********************************************************/

--- a/src/server/scripts/Commands/cs_modify.cpp
+++ b/src/server/scripts/Commands/cs_modify.cpp
@@ -477,11 +477,11 @@ public:
         if (handler->needReportToTarget(target))
             ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_ASPEED_CHANGED, handler->GetNameLink().c_str(), ASpeed);
 
-        target->SetSpeed(MOVE_WALK,    ASpeed, true);
-        target->SetSpeed(MOVE_RUN,     ASpeed, true);
-        target->SetSpeed(MOVE_SWIM,    ASpeed, true);
-        //target->SetSpeed(MOVE_TURN,    ASpeed, true);
-        target->SetSpeed(MOVE_FLIGHT,     ASpeed, true);
+        target->SetSpeedRate(MOVE_WALK,    ASpeed);
+        target->SetSpeedRate(MOVE_RUN,     ASpeed);
+        target->SetSpeedRate(MOVE_SWIM,    ASpeed);
+        //target->SetSpeedRate(MOVE_TURN,    ASpeed);
+        target->SetSpeedRate(MOVE_FLIGHT,     ASpeed);
         return true;
     }
 
@@ -525,7 +525,7 @@ public:
         if (handler->needReportToTarget(target))
             ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_SPEED_CHANGED, handler->GetNameLink().c_str(), Speed);
 
-        target->SetSpeed(MOVE_RUN, Speed, true);
+        target->SetSpeedRate(MOVE_RUN, Speed);
 
         return true;
     }
@@ -570,7 +570,7 @@ public:
         if (handler->needReportToTarget(target))
             ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_SWIM_SPEED_CHANGED, handler->GetNameLink().c_str(), Swim);
 
-        target->SetSpeed(MOVE_SWIM, Swim, true);
+        target->SetSpeedRate(MOVE_SWIM, Swim);
 
         return true;
     }
@@ -615,7 +615,7 @@ public:
         if (handler->needReportToTarget(target))
             ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_BACK_SPEED_CHANGED, handler->GetNameLink().c_str(), BSpeed);
 
-        target->SetSpeed(MOVE_RUN_BACK, BSpeed, true);
+        target->SetSpeedRate(MOVE_RUN_BACK, BSpeed);
 
         return true;
     }
@@ -651,7 +651,7 @@ public:
         if (handler->needReportToTarget(target))
             ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_FLY_SPEED_CHANGED, handler->GetNameLink().c_str(), FSpeed);
 
-        target->SetSpeed(MOVE_FLIGHT, FSpeed, true);
+        target->SetSpeedRate(MOVE_FLIGHT, FSpeed);
 
         return true;
     }

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -138,7 +138,7 @@ public:
         {
             Initialize();
 
-            me->SetSpeed(MOVE_RUN, 2.0f);
+            me->SetSpeedRate(MOVE_RUN, 2.0f);
             me->SetDisableGravity(true);
             me->SetWalk(false);
             me->setActive(true);

--- a/src/server/scripts/EasternKingdoms/Karazhan/karazhan.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/karazhan.cpp
@@ -562,7 +562,7 @@ public:
                     arca->GetMotionMaster()->MovePoint(0, -11010.82f, -1761.18f, 156.47f);
                     arca->setActive(true);
                     arca->InterruptNonMeleeSpells(true);
-                    arca->SetSpeed(MOVE_FLIGHT, 2.0f);
+                    arca->SetSpeedRate(MOVE_FLIGHT, 2.0f);
                 }
                 return 10000;
             case 13:

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -405,7 +405,7 @@ public:
                                     Creature* Orb = DoSpawnCreature(CREATURE_ARCANE_SPHERE, 5, 5, 0, 0, TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 30000);
                                     if (Orb && target)
                                     {
-                                        Orb->SetSpeed(MOVE_RUN, 0.5f);
+                                        Orb->SetSpeedRate(MOVE_RUN, 0.5f);
                                         Orb->AddThreat(target, 1000000.0f);
                                         Orb->AI()->AttackStart(target);
                                     }

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -396,7 +396,7 @@ class npc_eye_of_acherus : public CreatureScript
                             if (Player* owner = me->GetCharmerOrOwner()->ToPlayer())
                             {
                                 for (uint8 i = 0; i < MAX_MOVE_TYPE; ++i)
-                                    me->SetSpeed(UnitMoveType(i), owner->GetSpeedRate(UnitMoveType(i)), true);
+                                    me->SetSpeedRate(UnitMoveType(i), owner->GetSpeedRate(UnitMoveType(i)));
                                 Talk(TALK_MOVE_START, owner);
                             }
                             me->GetMotionMaster()->MovePath(me->GetEntry() * 100, false);
@@ -419,7 +419,7 @@ class npc_eye_of_acherus : public CreatureScript
                     {
                         owner->RemoveAura(SPELL_EYE_FLIGHT_BOOST);
                         for (uint8 i = 0; i < MAX_MOVE_TYPE; ++i)
-                            me->SetSpeed(UnitMoveType(i), owner->GetSpeedRate(UnitMoveType(i)), true);
+                            me->SetSpeedRate(UnitMoveType(i), owner->GetSpeedRate(UnitMoveType(i)));
 
                         Talk(TALK_CONTROL, owner);
                     }
@@ -703,7 +703,7 @@ class npc_dark_rider_of_acherus : public CreatureScript
 
                 TargetGUID = who->GetGUID();
                 me->SetWalk(true);
-                me->SetSpeed(MOVE_RUN, 0.4f);
+                me->SetSpeedRate(MOVE_RUN, 0.4f);
                 me->GetMotionMaster()->MoveChase(who);
                 me->SetTarget(TargetGUID);
                 Intro = true;
@@ -1050,7 +1050,7 @@ class npc_scarlet_miner_cart : public CreatureScript
 
                     // Not 100% correct, but movement is smooth. Sometimes miner walks faster
                     // than normal, this speed is fast enough to keep up at those times.
-                    me->SetSpeed(MOVE_RUN, 1.25f);
+                    me->SetSpeedRate(MOVE_RUN, 1.25f);
 
                     me->GetMotionMaster()->MoveFollow(miner, 1.0f, 0);
                 }

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
@@ -923,7 +923,7 @@ public:
                             if (ObjectAccessor::GetCreature(*me, uiLichKingGUID))
                                 DoCast(me, SPELL_MOGRAINE_CHARGE); // jumping charge
                             // doesn't make it looks well, so workarounds, Darion charges, looks better
-                            me->SetSpeed(MOVE_RUN, 3.0f);
+                            me->SetSpeedRate(MOVE_RUN, 3.0f);
                             me->SetWalk(false);
                             SetHoldState(false);
                             JumpToNextStep(0);
@@ -935,7 +935,7 @@ public:
                                 temp->HandleEmoteCommand(EMOTE_ONESHOT_KICK);
                                 temp->AI()->Talk(SAY_LIGHT_OF_DAWN46);
                             }
-                            me->SetSpeed(MOVE_RUN, 6.0f);
+                            me->SetSpeedRate(MOVE_RUN, 6.0f);
                             me->SetStandState(UNIT_STAND_STATE_DEAD);
                             SetHoldState(false); // Darion got kicked by lich king
                             JumpToNextStep(0);
@@ -997,7 +997,7 @@ public:
                                     Unit* temp = me->SummonCreature(NPC_DEFENDER_OF_THE_LIGHT, LightofDawnLoc[0].GetPositionWithOffset({ float(rand32() % 10), float(rand32() % 10), 0.0f, 0.0f }), TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 10000);
                                     temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_ATTACK_UNARMED);
                                     temp->SetWalk(false);
-                                    temp->SetSpeed(MOVE_RUN, 2.0f);
+                                    temp->SetSpeedRate(MOVE_RUN, 2.0f);
                                     temp->setFaction(me->getFaction());
                                     temp->GetMotionMaster()->MovePoint(0, fLichPositionX, fLichPositionY, fLichPositionZ);
                                     uiDefenderGUID[0] = temp->GetGUID();
@@ -1005,7 +1005,7 @@ public:
                                     temp = me->SummonCreature(NPC_RIMBLAT_EARTHSHATTER, LightofDawnLoc[0].GetPositionWithOffset({ float(rand32() % 10), float(rand32() % 10), 0.0f, 0.0f }), TEMPSUMMON_TIMED_OR_CORPSE_DESPAWN, 10000);
                                     temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_ATTACK_UNARMED);
                                     temp->SetWalk(false);
-                                    temp->SetSpeed(MOVE_RUN, 2.0f);
+                                    temp->SetSpeedRate(MOVE_RUN, 2.0f);
                                     temp->setFaction(me->getFaction());
                                     temp->GetMotionMaster()->MovePoint(0, fLichPositionX, fLichPositionY, fLichPositionZ);
                                     uiEarthshatterGUID[0] = temp->GetGUID();
@@ -1014,7 +1014,7 @@ public:
                                 {
                                     temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_ATTACK_UNARMED);
                                     temp->SetWalk(false);
-                                    temp->SetSpeed(MOVE_RUN, 2.0f);
+                                    temp->SetSpeedRate(MOVE_RUN, 2.0f);
                                     temp->GetMotionMaster()->MovePoint(0, fLichPositionX, fLichPositionY, fLichPositionZ);
                                     temp->AI()->Talk(SAY_LIGHT_OF_DAWN50);
                                 }
@@ -1022,7 +1022,7 @@ public:
                                 {
                                     temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_ATTACK_UNARMED);
                                     temp->SetWalk(false);
-                                    temp->SetSpeed(MOVE_RUN, 2.0f);
+                                    temp->SetSpeedRate(MOVE_RUN, 2.0f);
                                     temp->HandleEmoteCommand(EMOTE_STATE_ATTACK_UNARMED);
                                     temp->GetMotionMaster()->MovePoint(0, fLichPositionX, fLichPositionY, fLichPositionZ);
                                 }
@@ -1030,7 +1030,7 @@ public:
                                 {
                                     temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_ATTACK_UNARMED);
                                     temp->SetWalk(false);
-                                    temp->SetSpeed(MOVE_RUN, 2.0f);
+                                    temp->SetSpeedRate(MOVE_RUN, 2.0f);
                                     temp->GetMotionMaster()->MovePoint(0, fLichPositionX, fLichPositionY, fLichPositionZ);
                                 }
                             }
@@ -1044,33 +1044,33 @@ public:
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiMaxwellGUID))
                             {
                                 temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
-                                temp->SetSpeed(MOVE_RUN, 6.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 6.0f);
                                 temp->SetStandState(UNIT_STAND_STATE_DEAD);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[14]);
                             }
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiKorfaxGUID))
                             {
                                 temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
-                                temp->SetSpeed(MOVE_RUN, 6.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 6.0f);
                                 temp->SetStandState(UNIT_STAND_STATE_DEAD);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[11]);
                             }
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiEligorGUID))
                             {
                                 temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
-                                temp->SetSpeed(MOVE_RUN, 6.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 6.0f);
                                 temp->SetStandState(UNIT_STAND_STATE_DEAD);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[17]);
                             }
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiDefenderGUID[0]))
                             {
-                                temp->SetSpeed(MOVE_RUN, 6.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 6.0f);
                                 temp->SetStandState(UNIT_STAND_STATE_DEAD);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[0].GetPositionWithOffset({ float(rand32() % 10), float(rand32() % 10), 0.0f, 0.0f }));
                             }
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiEarthshatterGUID[0]))
                             {
-                                temp->SetSpeed(MOVE_RUN, 6.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 6.0f);
                                 temp->SetStandState(UNIT_STAND_STATE_DEAD);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[0].GetPositionWithOffset({ float(rand32() % 10), float(rand32() % 10), 0.0f, 0.0f }));
                             }
@@ -1093,7 +1093,7 @@ public:
                             break;
 
                         case 46: // Darion stand up, "not today"
-                            me->SetSpeed(MOVE_RUN, 1.0f);
+                            me->SetSpeedRate(MOVE_RUN, 1.0f);
                             me->SetWalk(true);
                             me->SetStandState(UNIT_STAND_STATE_STAND);
                             Talk(SAY_LIGHT_OF_DAWN53);
@@ -1153,7 +1153,7 @@ public:
                                 temp->AI()->Talk(EMOTE_LIGHT_OF_DAWN16);
                                 temp->CastSpell(temp, SPELL_TIRION_CHARGE, false); // jumping charge
                                 temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_READY2H);
-                                temp->SetSpeed(MOVE_RUN, 3.0f); // workarounds, make Tirion still running
+                                temp->SetSpeedRate(MOVE_RUN, 3.0f); // workarounds, make Tirion still running
                                 temp->SetWalk(false);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[2]);
                                 if (Creature* lktemp = ObjectAccessor::GetCreature(*me, uiLichKingGUID))
@@ -1171,7 +1171,7 @@ public:
                         case 54:
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiLichKingGUID))
                             {
-                                temp->SetSpeed(MOVE_RUN, 1.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 1.0f);
                                 me->SetWalk(true);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[29]); // 26
                             }
@@ -1208,7 +1208,7 @@ public:
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiTirionGUID)) // Tirion runs to Darion
                             {
                                 temp->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
-                                temp->SetSpeed(MOVE_RUN, 1.0f);
+                                temp->SetSpeedRate(MOVE_RUN, 1.0f);
                                 temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[6]);
                             }
                             JumpToNextStep(2500);

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_headless_horseman.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_headless_horseman.cpp
@@ -450,7 +450,7 @@ public:
             me->SetVisible(false);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
             me->SetDisableGravity(true);
-            me->SetSpeed(MOVE_WALK, 5.0f, true);
+            me->SetSpeedRate(MOVE_WALK, 5.0f);
             wp_reached = false;
             count = 0;
             say_timer = 3000;

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
@@ -249,7 +249,7 @@ public:
                     me->CastStop(SPELL_FOG_BREATH);
                     me->RemoveAurasDueToSpell(SPELL_FOG_BREATH);
                     me->StopMoving();
-                    me->SetSpeed(MOVE_RUN, 2.0f);
+                    me->SetSpeedRate(MOVE_RUN, 2.0f);
 
                     events.ScheduleEvent(EVENT_CLEAVE, urand(5000, 10000));
                     events.ScheduleEvent(EVENT_CORROSION, urand(10000, 20000));
@@ -530,7 +530,7 @@ public:
         npc_felmyst_vaporAI(Creature* creature) : ScriptedAI(creature)
         {
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-            me->SetSpeed(MOVE_RUN, 0.8f);
+            me->SetSpeedRate(MOVE_RUN, 0.8f);
         }
 
         void Reset() override { }

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_akilzon.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_akilzon.cpp
@@ -425,7 +425,7 @@ class npc_akilzon_eagle : public CreatureScript
                     if (Unit* target = ObjectAccessor::GetUnit(*me, TargetGUID))
                         DoCast(target, SPELL_EAGLE_SWOOP, true);
                     TargetGUID.Clear();
-                    me->SetSpeed(MOVE_RUN, 1.2f);
+                    me->SetSpeedRate(MOVE_RUN, 1.2f);
                     EagleSwoop_Timer = urand(5000, 10000);
                 }
             }
@@ -454,7 +454,7 @@ class npc_akilzon_eagle : public CreatureScript
                         {
                             target->GetContactPoint(me, x, y, z);
                             z += 2;
-                            me->SetSpeed(MOVE_RUN, 5.0f);
+                            me->SetSpeedRate(MOVE_RUN, 5.0f);
                             TargetGUID = target->GetGUID();
                         }
                         me->GetMotionMaster()->MovePoint(0, x, y, z);

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_nalorakk.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_nalorakk.cpp
@@ -142,7 +142,7 @@ class boss_nalorakk : public CreatureScript
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     inMove = false;
                     waitTimer = 0;
-                    me->SetSpeed(MOVE_RUN, 2);
+                    me->SetSpeedRate(MOVE_RUN, 2);
                     me->SetWalk(false);
                 }else
                 {

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
@@ -347,7 +347,7 @@ class boss_zuljin : public CreatureScript
                                 Vortex->CastSpell(Vortex, SPELL_CYCLONE_PASSIVE, true);
                                 Vortex->CastSpell(Vortex, SPELL_CYCLONE_VISUAL, true);
                                 Vortex->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-                                Vortex->SetSpeed(MOVE_RUN, 1.0f);
+                                Vortex->SetSpeedRate(MOVE_RUN, 1.0f);
                                 Vortex->AI()->AttackStart(SelectTarget(SELECT_TARGET_RANDOM, 0));
                                 DoZoneInCombat(Vortex);
                             }
@@ -438,7 +438,7 @@ class boss_zuljin : public CreatureScript
                             {
                                 if (me->GetVictim())
                                     TankGUID = me->EnsureVictim()->GetGUID();
-                                me->SetSpeed(MOVE_RUN, 5.0f);
+                                me->SetSpeedRate(MOVE_RUN, 5.0f);
                                 AttackStart(target); // change victim
                                 Claw_Rage_Timer = 0;
                                 Claw_Loop_Timer = 500;
@@ -462,7 +462,7 @@ class boss_zuljin : public CreatureScript
                                         if (Claw_Counter == 12)
                                         {
                                             Claw_Rage_Timer = urand(15000, 20000);
-                                            me->SetSpeed(MOVE_RUN, 1.2f);
+                                            me->SetSpeedRate(MOVE_RUN, 1.2f);
                                             AttackStart(ObjectAccessor::GetUnit(*me, TankGUID));
                                             TankGUID.Clear();
                                             return;
@@ -487,7 +487,7 @@ class boss_zuljin : public CreatureScript
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                             {
                                 TankGUID = me->EnsureVictim()->GetGUID();
-                                me->SetSpeed(MOVE_RUN, 5.0f);
+                                me->SetSpeedRate(MOVE_RUN, 5.0f);
                                 AttackStart(target); // change victim
                                 Lynx_Rush_Timer = 0;
                                 Claw_Counter = 0;
@@ -510,7 +510,7 @@ class boss_zuljin : public CreatureScript
                                     if (Claw_Counter == 9)
                                     {
                                         Lynx_Rush_Timer = urand(15000, 20000);
-                                        me->SetSpeed(MOVE_RUN, 1.2f);
+                                        me->SetSpeedRate(MOVE_RUN, 1.2f);
                                         AttackStart(ObjectAccessor::GetUnit(*me, TankGUID));
                                         TankGUID.Clear();
                                     }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
@@ -479,12 +479,12 @@ public:
         void DoMount()
         {
             me->Mount(SKARLOC_MOUNT_MODEL);
-            me->SetSpeed(MOVE_RUN, SPEED_MOUNT);
+            me->SetSpeedRate(MOVE_RUN, SPEED_MOUNT);
         }
         void DoUnmount()
         {
             me->Dismount();
-            me->SetSpeed(MOVE_RUN, SPEED_RUN);
+            me->SetSpeedRate(MOVE_RUN, SPEED_RUN);
         }
         void EnterCombat(Unit* /*who*/) override
         {

--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -205,7 +205,7 @@ public:
                 PointData = GetMoveData();
                 MovePoint = PointData->LocIdEnd;
 
-                me->SetSpeed(MOVE_FLIGHT, 1.5f);
+                me->SetSpeedRate(MOVE_FLIGHT, 1.5f);
                 me->GetMotionMaster()->MovePoint(8, MiddleRoomLocation);
             }
         }
@@ -220,7 +220,7 @@ public:
                         PointData = GetMoveData();
                         if (PointData)
                         {
-                            me->SetSpeed(MOVE_FLIGHT, 1.0f);
+                            me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                             me->GetMotionMaster()->MovePoint(PointData->LocId, PointData->fX, PointData->fY, PointData->fZ);
                         }
                         break;
@@ -250,7 +250,7 @@ public:
                         if (Creature * trigger = me->SummonCreature(NPC_TRIGGER, MiddleRoomLocation, TEMPSUMMON_CORPSE_DESPAWN))
                             triggerGUID = trigger->GetGUID();
                         me->GetMotionMaster()->MoveTakeoff(11, Phase2Floating);
-                        me->SetSpeed(MOVE_FLIGHT, 1.0f);
+                        me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                         Talk(SAY_PHASE_2_TRANS);
                         instance->SetData(DATA_ONYXIA_PHASE, Phase);
                         events.ScheduleEvent(EVENT_WHELP_SPAWN, 5000);

--- a/src/server/scripts/Kalimdor/zone_azshara.cpp
+++ b/src/server/scripts/Kalimdor/zone_azshara.cpp
@@ -404,7 +404,7 @@ public:
                     DoCast(me, SPELL_PERIODIC_DEPTH_CHARGE);
                     me->SetHover(true);
                     me->SetSwim(true);
-                    me->SetSpeed(MOVE_RUN, 0.85f, true);
+                    me->SetSpeedRate(MOVE_RUN, 0.85f);
                     me->GetMotionMaster()->MovementExpired();
                     me->GetMotionMaster()->MovePoint(CurrWP, WPs[CurrWP]);
                     Escape = true;

--- a/src/server/scripts/Kalimdor/zone_desolace.cpp
+++ b/src/server/scripts/Kalimdor/zone_desolace.cpp
@@ -89,7 +89,7 @@ public:
                     me->UpdateEntry(NPC_TAMED_KODO);
                     me->CombatStop();
                     me->DeleteThreatList();
-                    me->SetSpeed(MOVE_RUN, 0.6f, true);
+                    me->SetSpeedRate(MOVE_RUN, 0.6f);
                     me->GetMotionMaster()->MoveFollow(caster, PET_FOLLOW_DIST, me->GetFollowAngle());
                     me->setActive(true);
                 }

--- a/src/server/scripts/Kalimdor/zone_durotar.cpp
+++ b/src/server/scripts/Kalimdor/zone_durotar.cpp
@@ -483,8 +483,8 @@ class spell_mount_check : public SpellScriptLoader
                 else if (!owner->IsMounted() && target->IsMounted())
                     target->Dismount();
 
-                target->SetSpeed(MOVE_RUN, owner->GetSpeedRate(MOVE_RUN));
-                target->SetSpeed(MOVE_WALK, owner->GetSpeedRate(MOVE_WALK));
+                target->SetSpeedRate(MOVE_RUN, owner->GetSpeedRate(MOVE_RUN));
+                target->SetSpeedRate(MOVE_WALK, owner->GetSpeedRate(MOVE_WALK));
             }
 
             void Register() override

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
@@ -454,11 +454,11 @@ public:
                     float distance = me->GetDistance(JedogaPosition[1]);
 
                     if (distance < 9.0f)
-                        me->SetSpeed(MOVE_WALK, 0.5f, true);
+                        me->SetSpeedRate(MOVE_WALK, 0.5f);
                     else if (distance < 15.0f)
-                        me->SetSpeed(MOVE_WALK, 0.75f, true);
+                        me->SetSpeedRate(MOVE_WALK, 0.75f);
                     else if (distance < 20.0f)
-                        me->SetSpeed(MOVE_WALK, 1.0f, true);
+                        me->SetSpeedRate(MOVE_WALK, 1.0f);
 
                     me->GetMotionMaster()->Clear(false);
                     me->GetMotionMaster()->MovePoint(1, JedogaPosition[1]);

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
@@ -178,7 +178,7 @@ class boss_prince_taldaram : public CreatureScript
                             if (Unit* embraceTarget = GetEmbraceTarget())
                             {
                                 me->GetMotionMaster()->Clear();
-                                me->SetSpeed(MOVE_WALK, 2.0f, true);
+                                me->SetSpeedRate(MOVE_WALK, 2.0f);
                                 me->GetMotionMaster()->MoveChase(embraceTarget);
                             }
                             events.ScheduleEvent(EVENT_VANISHED, 1300);
@@ -188,7 +188,7 @@ class boss_prince_taldaram : public CreatureScript
                                 DoCast(embraceTarget, SPELL_EMBRACE_OF_THE_VAMPYR);
                             Talk(SAY_FEED);
                             me->GetMotionMaster()->Clear();
-                            me->SetSpeed(MOVE_WALK, 1.0f, true);
+                            me->SetSpeedRate(MOVE_WALK, 1.0f);
                             me->GetMotionMaster()->MoveChase(me->GetVictim());
                             events.ScheduleEvent(EVENT_FEEDING, 20000);
                             break;

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -804,7 +804,7 @@ class npc_anubarak_spike : public CreatureScript
             void StartChase(Unit* who)
             {
                 DoCast(who, SPELL_MARK);
-                me->SetSpeed(MOVE_RUN, 0.5f);
+                me->SetSpeedRate(MOVE_RUN, 0.5f);
                 // make sure the Spine will really follow the one he should
                 me->getThreatManager().clearReferences();
                 me->SetInCombatWithZone();

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -2580,7 +2580,7 @@ class npc_quel_delar_sword : public CreatureScript
             void Reset() override
             {
                 _events.Reset();
-                me->SetSpeed(MOVE_FLIGHT, 4.5f, true);
+                me->SetSpeedRate(MOVE_FLIGHT, 4.5f);
                 DoCast(SPELL_WHIRLWIND_VISUAL);
                 if (_intro)
                     _events.ScheduleEvent(EVENT_QUEL_DELAR_INIT, 0);

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -418,7 +418,7 @@ class boss_krick : public CreatureScript
                         case EVENT_OUTRO_6:
                             if (Creature* tyrannus = ObjectAccessor::GetCreature(*me, _instanceScript->GetGuidData(DATA_TYRANNUS_EVENT)))
                             {
-                                tyrannus->SetSpeed(MOVE_FLIGHT, 3.5f, true);
+                                tyrannus->SetSpeedRate(MOVE_FLIGHT, 3.5f);
                                 tyrannus->GetMotionMaster()->MovePoint(1, outroPos[4]);
                                 _tyrannusGUID = tyrannus->GetGUID();
                             }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -1069,7 +1069,7 @@ class npc_blood_queen_lana_thel : public CreatureScript
                             if (Creature* summon = DoSummon(NPC_FLOATING_TRIGGER, triggerPos, 15000, TEMPSUMMON_TIMED_DESPAWN))
                             {
                                 summon->CastSpell(summon, SPELL_OOC_INVOCATION_VISUAL, true);
-                                summon->SetSpeed(MOVE_FLIGHT, 0.15f, true); // todo: creature is swimming, check if this is blizzlike or not.
+                                summon->SetSpeedRate(MOVE_FLIGHT, 0.15f); // todo: creature is swimming, check if this is blizzlike or not.
                                 summon->GetMotionMaster()->MovePoint(0, triggerEndPos);
                             }
                         }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -142,7 +142,7 @@ class boss_lord_marrowgar : public CreatureScript
             void Reset() override
             {
                 _Reset();
-                me->SetSpeed(MOVE_RUN, _baseSpeed, true);
+                me->SetSpeedRate(MOVE_RUN, _baseSpeed);
                 me->RemoveAurasDueToSpell(SPELL_BONE_STORM);
                 me->RemoveAurasDueToSpell(SPELL_BERSERK);
                 events.ScheduleEvent(EVENT_ENABLE_BONE_SLICE, 10000);
@@ -224,7 +224,7 @@ class boss_lord_marrowgar : public CreatureScript
                         case EVENT_BONE_STORM_BEGIN:
                             if (Aura* pStorm = me->GetAura(SPELL_BONE_STORM))
                                 pStorm->SetDuration(int32(_boneStormDuration));
-                            me->SetSpeed(MOVE_RUN, _baseSpeed*3.0f, true);
+                            me->SetSpeedRate(MOVE_RUN, _baseSpeed*3.0f);
                             Talk(SAY_BONE_STORM);
                             events.ScheduleEvent(EVENT_BONE_STORM_END, _boneStormDuration+1);
                             // no break here
@@ -242,7 +242,7 @@ class boss_lord_marrowgar : public CreatureScript
                             if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE)
                                 me->GetMotionMaster()->MovementExpired();
                             me->GetMotionMaster()->MoveChase(me->GetVictim());
-                            me->SetSpeed(MOVE_RUN, _baseSpeed, true);
+                            me->SetSpeedRate(MOVE_RUN, _baseSpeed);
                             events.CancelEvent(EVENT_BONE_STORM_MOVE);
                             events.ScheduleEvent(EVENT_ENABLE_BONE_SLICE, 10000);
                             if (!IsHeroic())

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -369,21 +369,21 @@ class boss_professor_putricide : public CreatureScript
                 {
                     case POINT_FESTERGUT:
                         instance->SetBossState(DATA_FESTERGUT, IN_PROGRESS); // needed here for delayed gate close
-                        me->SetSpeed(MOVE_RUN, _baseSpeed, true);
+                        me->SetSpeedRate(MOVE_RUN, _baseSpeed);
                         DoAction(ACTION_FESTERGUT_GAS);
                         if (Creature* festergut = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FESTERGUT)))
                             festergut->CastSpell(festergut, SPELL_GASEOUS_BLIGHT_LARGE, false, NULL, NULL, festergut->GetGUID());
                         break;
                     case POINT_ROTFACE:
                         instance->SetBossState(DATA_ROTFACE, IN_PROGRESS);   // needed here for delayed gate close
-                        me->SetSpeed(MOVE_RUN, _baseSpeed, true);
+                        me->SetSpeedRate(MOVE_RUN, _baseSpeed);
                         DoAction(ACTION_ROTFACE_OOZE);
                         events.ScheduleEvent(EVENT_ROTFACE_OOZE_FLOOD, 25000, 0, PHASE_ROTFACE);
                         break;
                     case POINT_TABLE:
                         // stop attack
                         me->GetMotionMaster()->MoveIdle();
-                        me->SetSpeed(MOVE_RUN, _baseSpeed, true);
+                        me->SetSpeedRate(MOVE_RUN, _baseSpeed);
                         if (GameObject* table = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(DATA_PUTRICIDE_TABLE)))
                             me->SetFacingToObject(table);
                         // operating on new phase already
@@ -418,7 +418,7 @@ class boss_professor_putricide : public CreatureScript
                 {
                     case ACTION_FESTERGUT_COMBAT:
                         SetPhase(PHASE_FESTERGUT);
-                        me->SetSpeed(MOVE_RUN, _baseSpeed*2.0f, true);
+                        me->SetSpeedRate(MOVE_RUN, _baseSpeed*2.0f);
                         me->GetMotionMaster()->MovePoint(POINT_FESTERGUT, festergutWatchPos);
                         me->SetReactState(REACT_PASSIVE);
                         DoZoneInCombat(me);
@@ -435,7 +435,7 @@ class boss_professor_putricide : public CreatureScript
                     case ACTION_ROTFACE_COMBAT:
                     {
                         SetPhase(PHASE_ROTFACE);
-                        me->SetSpeed(MOVE_RUN, _baseSpeed*2.0f, true);
+                        me->SetSpeedRate(MOVE_RUN, _baseSpeed*2.0f);
                         me->GetMotionMaster()->MovePoint(POINT_ROTFACE, rotfaceWatchPos);
                         me->SetReactState(REACT_PASSIVE);
                         _oozeFloodStage = 0;
@@ -477,7 +477,7 @@ class boss_professor_putricide : public CreatureScript
                         events.ScheduleEvent(EVENT_ROTFACE_DIES, 4500, 0, PHASE_ROTFACE);
                         break;
                     case ACTION_CHANGE_PHASE:
-                        me->SetSpeed(MOVE_RUN, _baseSpeed*2.0f, true);
+                        me->SetSpeedRate(MOVE_RUN, _baseSpeed*2.0f);
                         events.DelayEvents(30000);
                         me->AttackStop();
                         if (!IsHeroic())

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -315,7 +315,7 @@ class boss_sindragosa : public CreatureScript
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
                     me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
-                    me->SetSpeed(MOVE_FLIGHT, 4.0f);
+                    me->SetSpeedRate(MOVE_FLIGHT, 4.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     float moveTime = me->GetExactDist(&SindragosaFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
                     me->m_Events.AddEvent(new FrostwyrmLandEvent(*me, SindragosaLandPos), me->m_Events.CalculateTime(uint64(moveTime) + 250));
@@ -351,7 +351,7 @@ class boss_sindragosa : public CreatureScript
                         me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetHomePosition(SindragosaLandPos);
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                        me->SetSpeed(MOVE_FLIGHT, 2.5f);
+                        me->SetSpeedRate(MOVE_FLIGHT, 2.5f);
 
                         // Sindragosa enters combat as soon as she lands
                         DoZoneInCombat();
@@ -697,7 +697,7 @@ class npc_spinestalker : public CreatureScript
                         return;
 
                     me->setActive(true);
-                    me->SetSpeed(MOVE_FLIGHT, 2.0f);
+                    me->SetSpeedRate(MOVE_FLIGHT, 2.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     float moveTime = me->GetExactDist(&SpinestalkerFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
                     me->m_Events.AddEvent(new FrostwyrmLandEvent(*me, SpinestalkerLandPos), me->m_Events.CalculateTime(uint64(moveTime) + 250));
@@ -834,7 +834,7 @@ class npc_rimefang : public CreatureScript
                         return;
 
                     me->setActive(true);
-                    me->SetSpeed(MOVE_FLIGHT, 2.0f);
+                    me->SetSpeedRate(MOVE_FLIGHT, 2.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
                     float moveTime = me->GetExactDist(&RimefangFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
                     me->m_Events.AddEvent(new FrostwyrmLandEvent(*me, RimefangLandPos), me->m_Events.CalculateTime(uint64(moveTime) + 250));

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -763,7 +763,7 @@ class boss_the_lich_king : public CreatureScript
                     {
                         summons.Summon(summon);
                         summon->SetReactState(REACT_PASSIVE);
-                        summon->SetSpeed(MOVE_FLIGHT, 0.5f);
+                        summon->SetSpeedRate(MOVE_FLIGHT, 0.5f);
                         summon->GetMotionMaster()->MoveRandom(10.0f);
                         if (!events.IsInPhase(PHASE_FROSTMOURNE))
                             summon->m_Events.AddEvent(new VileSpiritActivateEvent(summon), summon->m_Events.CalculateTime(15000));
@@ -1448,7 +1448,7 @@ class npc_valkyr_shadowguard : public CreatureScript
                 _events.Reset();
                 me->SetReactState(REACT_PASSIVE);
                 DoCast(me, SPELL_WINGS_OF_THE_DAMNED, false);
-                me->SetSpeed(MOVE_FLIGHT, 0.642857f, true);
+                me->SetSpeedRate(MOVE_FLIGHT, 0.642857f);
             }
 
             void IsSummonedBy(Unit* /*summoner*/) override

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -377,7 +377,7 @@ public:
             me->SetDisableGravity(true);
             me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             // TO DO: find what in core is making boss slower than in retail (when correct speed data) or find missing movement flag update or forced spline change
-            me->SetSpeed(MOVE_FLIGHT, _flySpeed * 0.25f);
+            me->SetSpeedRate(MOVE_FLIGHT, _flySpeed * 0.25f);
             if (_despawned)
                 DoAction(ACTION_HANDLE_RESPAWN);
 
@@ -603,7 +603,7 @@ public:
             me->SetRespawnDelay(respawnDelay);
 
             // Set speed to normal value
-            me->SetSpeed(MOVE_FLIGHT, _flySpeed);
+            me->SetSpeedRate(MOVE_FLIGHT, _flySpeed);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             me->RemoveAllAuras();
@@ -1165,7 +1165,7 @@ public:
             _instance = creature->GetInstanceScript();
             me->SetReactState(REACT_PASSIVE);
             // TO DO: These were a bit faster than what they should be. Not sure what is the reason.
-            me->SetSpeed(MOVE_FLIGHT, 1.25f);
+            me->SetSpeedRate(MOVE_FLIGHT, 1.25f);
         }
 
         void Initialize()
@@ -1274,7 +1274,7 @@ public:
             me->SetReactState(REACT_PASSIVE);
             // TO DO: Something is wrong with calculations for flying creatures that are on WP/Cyclic path.
             // They should get the same difference as to when at ground from run creature switch to walk.
-            me->SetSpeed(MOVE_FLIGHT, 0.45f);
+            me->SetSpeedRate(MOVE_FLIGHT, 0.45f);
         }
 
         void Reset() override
@@ -1566,7 +1566,7 @@ public:
             {
                 me->DespawnOrUnsummon(2050);
                 me->SetOrientation(2.5f);
-                me->SetSpeed(MOVE_FLIGHT, 1.0f, true);
+                me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                 Position pos = me->GetPosition();
                 pos.m_positionX += 10.0f;
                 pos.m_positionY += 10.0f;

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.cpp
@@ -375,7 +375,7 @@ class npc_ruby_emerald_amber_drake : public CreatureScript
                         {
                             me->DespawnOrUnsummon(2050);
                             me->SetOrientation(2.5f);
-                            me->SetSpeed(MOVE_FLIGHT, 1.0f, true);
+                            me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                             Talk(SAY_DRAKES_TAKEOFF);
                             Position pos = me->GetPosition();
                             Position offset = { 10.0f, 10.0f, 12.0f, 0.0f };

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
@@ -174,7 +174,7 @@ public:
                 {
                     if (pSpark->IsAlive())
                     {
-                        pSpark->SetSpeed(MOVE_RUN, 2.0f);
+                        pSpark->SetSpeedRate(MOVE_RUN, 2.0f);
                         pSpark->GetMotionMaster()->Clear();
                         pSpark->GetMotionMaster()->MovePoint(DATA_POINT_CALLBACK, pos);
                     }
@@ -355,7 +355,7 @@ public:
                     {
                         Position pos = ionar->GetPosition();
 
-                        me->SetSpeed(MOVE_RUN, 2.0f);
+                        me->SetSpeedRate(MOVE_RUN, 2.0f);
                         me->GetMotionMaster()->Clear();
                         me->GetMotionMaster()->MovePoint(DATA_POINT_CALLBACK, pos);
                     }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -703,7 +703,7 @@ class boss_leviathan_mk_ii : public CreatureScript
                         if (Unit* turret = me->GetVehicleKit()->GetPassenger(3))
                             turret->KillSelf();
 
-                        me->SetSpeed(MOVE_RUN, 1.5f, true);
+                        me->SetSpeedRate(MOVE_RUN, 1.5f);
                         me->GetMotionMaster()->MovePoint(WP_MKII_P1_IDLE, VehicleRelocation[WP_MKII_P1_IDLE]);
                     }
                     else if (events.IsInPhase(PHASE_VOL7RON))

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -366,7 +366,7 @@ class boss_razorscale : public CreatureScript
                 _EnterCombat();
                 if (Creature* controller = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_RAZORSCALE_CONTROL)))
                     controller->AI()->DoAction(ACTION_HARPOON_BUILD);
-                me->SetSpeed(MOVE_FLIGHT, 3.0f, true);
+                me->SetSpeedRate(MOVE_FLIGHT, 3.0f);
                 me->SetReactState(REACT_PASSIVE);
                 phase = PHASE_GROUND;
                 events.SetPhase(PHASE_GROUND);
@@ -550,7 +550,7 @@ class boss_razorscale : public CreatureScript
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED | UNIT_FLAG_PACIFIED);
                 me->SetReactState(REACT_AGGRESSIVE);
                 me->RemoveAurasDueToSpell(SPELL_HARPOON_TRIGGER);
-                me->SetSpeed(MOVE_FLIGHT, 1.0f, true);
+                me->SetSpeedRate(MOVE_FLIGHT, 1.0f);
                 PermaGround = true;
                 DoCastAOE(SPELL_FLAMEBREATH);
                 events.ScheduleEvent(EVENT_FLAME, 15000, 0, PHASE_PERMAGROUND);
@@ -677,7 +677,7 @@ class npc_expedition_commander : public CreatureScript
                                 if (Creature* summonedEngineer = me->SummonCreature(NPC_ENGINEER, PosEngSpawn, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 3000))
                                 {
                                     summonedEngineer->SetWalk(false);
-                                    summonedEngineer->SetSpeed(MOVE_RUN, 0.5f);
+                                    summonedEngineer->SetSpeedRate(MOVE_RUN, 0.5f);
                                     summonedEngineer->SetHomePosition(PosEngRepair[n]);
                                     summonedEngineer->GetMotionMaster()->MoveTargetedHome();
                                     Engineer[n] = summonedEngineer->GetGUID();

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_palehoof.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_palehoof.cpp
@@ -746,7 +746,7 @@ public:
             //! HACK: Creature's can't have MOVEMENTFLAG_FLYING
             me->AddUnitMovementFlag(MOVEMENTFLAG_FLYING);
             me->RemoveAurasDueToSpell(SPELL_ORB_VISUAL);
-            me->SetSpeed(MOVE_FLIGHT, 0.5f);
+            me->SetSpeedRate(MOVE_FLIGHT, 0.5f);
         }
 
         void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -209,7 +209,7 @@ public:
             Initialize();
 
             Summons.DespawnAll();
-            me->SetSpeed(MOVE_FLIGHT, 3.0f);
+            me->SetSpeedRate(MOVE_FLIGHT, 3.0f);
             if ((ObjectAccessor::GetCreature(*me, m_uiGraufGUID) == NULL) && !me->IsMounted())
                  me->SummonCreature(NPC_GRAUF, Location[0].GetPositionX(), Location[0].GetPositionY(), Location[0].GetPositionZ(), 3.0f);
             instance->SetBossState(DATA_SKADI_THE_RUTHLESS, NOT_STARTED);

--- a/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
@@ -745,7 +745,7 @@ public:
             if (!Trigger)
                 return;
 
-            Trigger->SetSpeed(MOVE_WALK, 3);
+            Trigger->SetSpeedRate(MOVE_WALK, 3);
             Trigger->SetWalk(true);
             Trigger->GetMotionMaster()->MovePoint(0, final.x, final.y, final.z);
 
@@ -1524,7 +1524,7 @@ public:
         void BeginWalk()
         {
             me->SetWalk(false);
-            me->SetSpeed(MOVE_RUN, 1.0f);
+            me->SetSpeedRate(MOVE_RUN, 1.0f);
             me->GetMotionMaster()->MovePoint(0, AkamaWP[WalkCount].x, AkamaWP[WalkCount].y, AkamaWP[WalkCount].z);
         }
 

--- a/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
@@ -238,8 +238,8 @@ public:
             if (me->GetAuraCount(SPELL_SHADE_SOUL_CHANNEL_2) <= 3)
             {
                 moveSpeed = (2.0f - (0.6f * me->GetAuraCount(SPELL_SHADE_SOUL_CHANNEL_2)));
-                me->SetSpeed(MOVE_WALK, moveSpeed / 2.5f);
-                me->SetSpeed(MOVE_RUN, (moveSpeed * 2) / 7);
+                me->SetSpeedRate(MOVE_WALK, moveSpeed / 2.5f);
+                me->SetSpeedRate(MOVE_RUN, (moveSpeed * 2) / 7);
                 me->ClearUnitState(UNIT_STATE_ROOT);
             }
             else

--- a/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
@@ -117,7 +117,7 @@ public:
                 DummyEntryCheckPredicate pred;
                 summons.DoAction(EVENT_VOLCANO, pred);
                 events.ScheduleEvent(EVENT_HATEFUL_STRIKE, 5000, GCD_CAST, PHASE_STRIKE);
-                me->SetSpeed(MOVE_RUN, 1.2f);
+                me->SetSpeedRate(MOVE_RUN, 1.2f);
                 me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_TAUNT, false);
                 me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_ATTACK_ME, false);
             }
@@ -126,7 +126,7 @@ public:
                 phase = PHASE_CHASE;
                 events.ScheduleEvent(EVENT_VOLCANO, 5000, GCD_CAST, PHASE_CHASE);
                 events.ScheduleEvent(EVENT_SWITCH_TARGET, 10000, 0, PHASE_CHASE);
-                me->SetSpeed(MOVE_RUN, 0.9f);
+                me->SetSpeedRate(MOVE_RUN, 0.9f);
                 me->ApplySpellImmune(0, IMMUNITY_STATE, SPELL_AURA_MOD_TAUNT, true);
                 me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_ATTACK_ME, true);
             }

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
@@ -585,8 +585,8 @@ public:
 
         void Reset() override
         {
-            me->SetSpeed(MOVE_WALK, 0.6f); // walk
-            me->SetSpeed(MOVE_RUN, 0.6f); // run
+            me->SetSpeedRate(MOVE_WALK, 0.6f); // walk
+            me->SetSpeedRate(MOVE_RUN, 0.6f); // run
             Initialize();
 
             //search for nearest waypoint (up on stairs)

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
@@ -244,7 +244,7 @@ public:
             CheckChannelers();
             Initialize();
             me->SetCanDualWield(true);
-            me->SetSpeed(MOVE_RUN, 2.0f, true);
+            me->SetSpeedRate(MOVE_RUN, 2.0f);
             me->SetDisplayId(MODEL_NIGHTELF);
             me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID  , 0);
             me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID+1, 0);

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -372,7 +372,7 @@ class boss_vazruden_the_herald : public CreatureScript
                 if (summon->GetEntry() == NPC_NAZAN)
                 {
                     summon->SetDisableGravity(true);
-                    summon->SetSpeed(MOVE_FLIGHT, 2.5f);
+                    summon->SetSpeedRate(MOVE_FLIGHT, 2.5f);
                     if (victim)
                         AttackStartNoMove(victim);
                 }

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_warchief_kargath_bladefist.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_warchief_kargath_bladefist.cpp
@@ -109,7 +109,7 @@ class boss_warchief_kargath_bladefist : public CreatureScript
             {
                 removeAdds();
                 _Reset();
-                me->SetSpeed(MOVE_RUN, 2);
+                me->SetSpeedRate(MOVE_RUN, 2);
                 me->SetWalk(false);
 
                 Initialize();
@@ -231,7 +231,7 @@ class boss_warchief_kargath_bladefist : public CreatureScript
                             {
                                 // stop bladedance
                                 InBlade = false;
-                                me->SetSpeed(MOVE_RUN, 2);
+                                me->SetSpeedRate(MOVE_RUN, 2);
                                 me->GetMotionMaster()->MoveChase(me->GetVictim());
                                 Blade_Dance_Timer = 30000;
                                 Wait_Timer = 0;
@@ -264,7 +264,7 @@ class boss_warchief_kargath_bladefist : public CreatureScript
                             Wait_Timer = 1;
                             InBlade = true;
                             Blade_Dance_Timer = 0;
-                            me->SetSpeed(MOVE_RUN, 4);
+                            me->SetSpeedRate(MOVE_RUN, 4);
                             return;
                         }
                         else

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
@@ -130,7 +130,7 @@ class boss_alar : public CreatureScript
                 _Reset();
 
                 me->SetDisplayId(me->GetNativeDisplayId());
-                me->SetSpeed(MOVE_RUN, DefaultMoveSpeedRate);
+                me->SetSpeedRate(MOVE_RUN, DefaultMoveSpeedRate);
                 //me->SetFloatValue(UNIT_FIELD_BOUNDINGRADIUS, 10);
                 //me->SetFloatValue(UNIT_FIELD_COMBATREACH, 10);
                 me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_FIRE, true);
@@ -178,7 +178,7 @@ class boss_alar : public CreatureScript
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                         me->AttackStop();
                         me->SetTarget(ObjectGuid::Empty);
-                        me->SetSpeed(MOVE_RUN, 5.0f);
+                        me->SetSpeedRate(MOVE_RUN, 5.0f);
                         me->GetMotionMaster()->Clear();
                         me->GetMotionMaster()->MovePoint(0, waypoint[5][0], waypoint[5][1], waypoint[5][2]);
                     }
@@ -261,7 +261,7 @@ class boss_alar : public CreatureScript
                             case WE_REVIVE:
                                 me->SetUInt32Value(UNIT_FIELD_BYTES_1, UNIT_STAND_STATE_STAND);
                                 me->SetFullHealth();
-                                me->SetSpeed(MOVE_RUN, DefaultMoveSpeedRate);
+                                me->SetSpeedRate(MOVE_RUN, DefaultMoveSpeedRate);
                                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                                 DoZoneInCombat();
                                 DoCast(me, SPELL_REBIRTH, true);

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
@@ -176,7 +176,7 @@ class npc_ragin_flames : public CreatureScript
                     Initialize();
                     me->ApplySpellImmune(0, IMMUNITY_DAMAGE, SPELL_SCHOOL_MASK_MAGIC, true);
                     me->ApplySpellImmune(0, IMMUNITY_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, true);
-                    me->SetSpeed(MOVE_RUN, DUNGEON_MODE(0.5f, 0.7f));
+                    me->SetSpeedRate(MOVE_RUN, DUNGEON_MODE(0.5f, 0.7f));
                 }
 
                 void EnterCombat(Unit* /*who*/) override

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_warp_splinter.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_warp_splinter.cpp
@@ -167,7 +167,7 @@ class boss_warp_splinter : public CreatureScript
             {
                 Initialize();
 
-                me->SetSpeed(MOVE_RUN, 0.7f, true);
+                me->SetSpeedRate(MOVE_RUN, 0.7f);
             }
 
             void EnterCombat(Unit* /*who*/) override

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -159,7 +159,7 @@ public:
             else
                 TC_LOG_ERROR("scripts", "TRINITY: npc_ancestral_wolf can not obtain owner or owner is not a player.");
 
-            creature->SetSpeed(MOVE_WALK, 1.5f);
+            creature->SetSpeedRate(MOVE_WALK, 1.5f);
             Reset();
         }
 
@@ -192,7 +192,7 @@ public:
                         if (ryga->IsAlive() && !ryga->IsInCombat())
                         {
                             ryga->SetWalk(true);
-                            ryga->SetSpeed(MOVE_WALK, 1.5f);
+                            ryga->SetSpeedRate(MOVE_WALK, 1.5f);
                             ryga->GetMotionMaster()->MovePoint(0, 517.340698f, 3885.03975f, 190.455978f, true);
                             Reset();
                         }
@@ -778,7 +778,7 @@ public:
                     me->AddAura(SPELL_JULES_THREATENS_AURA, me);
 
                     me->SetCanFly(true);
-                    me->SetSpeed(MOVE_RUN, 0.2f);
+                    me->SetSpeedRate(MOVE_RUN, 0.2f);
 
                     me->SetFacingTo(3.207566f);
                     me->GetMotionMaster()->MoveJump(exorcismPos[2], 2.0f, 2.0f);
@@ -798,7 +798,7 @@ public:
                     break;
                 case ACTION_JULES_MOVE_HOME:
                     wpreached = false;
-                    me->SetSpeed(MOVE_RUN, 1.0f);
+                    me->SetSpeedRate(MOVE_RUN, 1.0f);
                     me->GetMotionMaster()->MovePoint(11, exorcismPos[2]);
 
                     events.CancelEvent(EVENT_SUMMON_SKULL);

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -103,8 +103,8 @@ class npc_pet_dk_ebon_gargoyle : public CreatureScript
                 //! HACK: Creature's can't have MOVEMENTFLAG_FLYING
                 // Fly Away
                 me->SetCanFly(true);
-                me->SetSpeed(MOVE_FLIGHT, 0.75f, true);
-                me->SetSpeed(MOVE_RUN, 0.75f, true);
+                me->SetSpeedRate(MOVE_FLIGHT, 0.75f);
+                me->SetSpeedRate(MOVE_RUN, 0.75f);
                 float x = me->GetPositionX() + 20 * std::cos(me->GetOrientation());
                 float y = me->GetPositionY() + 20 * std::sin(me->GetOrientation());
                 float z = me->GetPositionZ() + 40;

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -205,7 +205,7 @@ class npc_dream_fog : public CreatureScript
                     }
                     // Seeping fog movement is slow enough for a player to be able to walk backwards and still outpace it
                     me->SetWalk(true);
-                    me->SetSpeed(MOVE_WALK, 0.75f);
+                    me->SetSpeedRate(MOVE_WALK, 0.75f);
                 }
                 else
                     _roamTimer -= diff;


### PR DESCRIPTION
Clean up of Unit::SetSpeed. The biggest changes are:
- the opcodes used to send the change of the speed of a unit were reworked. until now, MSG_MOVE_SET_\* were sent for every units which isn't like retail behavior (more info in the comments of the code). 
- removed the method argument "forced" from Unit::SetSpeed since it is nor used nor useful.
- removed the method argument "forced" from Unit::UpdateSpeed since it is nor used nor useful.

Minor changes of the PR:
- renamed Unit::SetSpeed to Unit::SetSpeedRate (to stay coherent with the methods GetSpeed and GetSpeedRate)
- added a utility method Unit::SetSpeed (which takes into parameter the flat new value)

---

About the testing done:

Test when unit::SetSpeed() is called on a player. Test done with 2 players on the map:

> ServerToClient: SMSG_FORCE_RUN_SPEED_CHANGE (0x00E2) Length: 11 ConnIdx: 0 EP: 127.0.0.1:49302 Time: 03/26/2016 12:06:14.844 Number: 3500
> Guid: Full: 0x00000004 Type: Player Low: 4 Name: Druiderino
> MoveEvent: 0
> Unk Byte: 1
> New Speed: 7
> 
> ServerToClient: MSG_MOVE_SET_RUN_SPEED (0x00CD) Length: 52 ConnIdx: 0 EP: 127.0.0.1:49298 Time: 03/26/2016 12:06:14.844 Number: 3501
> GUID: Full: 0x00000004 Type: Player Low: 4 Name: Druiderino
> Movement Flags: Forward, StrafeLeft, Falling (4101)
> Extra Movement Flags: None (0)
> Time: 64753
> Position: X: 3672.161 Y: -1265.754 Z: 243.5119
> Orientation: 2.537083
> Fall Time: 0
> Fall Velocity: -7.955547
> Fall Sin Angle: -0.9836842
> Fall Cos Angle: -0.179904
> Fall Speed: 11.9
> Speed: 7
> 
> ClientToServer: CMSG_FORCE_RUN_SPEED_CHANGE_ACK (0x00E3) Length: 56 ConnIdx: 0 EP: 127.0.0.1:49302 Time: 03/26/2016 12:06:14.847 Number: 3516
> Guid: Full: 0x00000004 Type: Player Low: 4 Name: Druiderino
> Movement Counter: 0
> Movement Flags: Forward, StrafeLeft, Falling (4101)
> Extra Movement Flags: None (0)
> Time: 493594943
> Position: X: 3670.382 Y: -1266.079 Z: 244.4983
> Orientation: 2.588134
> Fall Time: 152
> Fall Velocity: -7.955547
> Fall Sin Angle: -0.9836842
> Fall Cos Angle: -0.179904
> Fall Speed: 11.9
> New Speed: 7

---

Test when unit::SetSpeed() is called on a NPC. Test done with 2 players on the map:

> ServerToClient: SMSG_MOVE_SPLINE_SET_RUN_SPEED (0x02FE) Length: 11 ConnIdx: 0 EP: 127.0.0.1:49348 Time: 03/26/2016 12:10:06.259 Number: 9460
> GUID: Full: 0xF130003E3C000309 Type: Creature Entry: 15932 Low: 777
> Amount: 36
> 
> ServerToClient: SMSG_MOVE_SPLINE_SET_RUN_SPEED (0x02FE) Length: 11 ConnIdx: 0 EP: 127.0.0.1:49350 Time: 03/26/2016 12:10:06.259 Number: 9461
> GUID: Full: 0xF130003E3C000309 Type: Creature Entry: 15932 Low: 777
> Amount: 36

In both cases, the right packets are sent to the right destinations. No more no less.
