### PR TITLE
[3.3.5/6.x] Scripts/Spells: Add generic spell to handle ClearDebuffs spell

### DIFF
--- a/sql/updates/world/2016_03_27_00_world.sql
+++ b/sql/updates/world/2016_03_27_00_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_gen_clear_debuffs';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(34098, 'spell_gen_clear_debuffs');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -4155,6 +4155,40 @@ public:
     }
 };
 
+// 34098 - ClearAllDebuffs
+class spell_gen_clear_debuffs : public SpellScriptLoader
+{
+    public:
+        spell_gen_clear_debuffs() : SpellScriptLoader("spell_gen_clear_debuffs") { }
+
+        class spell_gen_clear_debuffs_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_gen_clear_debuffs_SpellScript);
+
+            void HandleScript(SpellEffIndex /*effIndex*/)
+            {
+                if (Unit* target = GetHitUnit())
+                {
+                    target->RemoveOwnedAuras([](Aura const* aura)
+                    {
+                        SpellInfo const* spellInfo = aura->GetSpellInfo();
+                        return !spellInfo->IsPositive() && !spellInfo->IsPassive();
+                    });
+                }
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_gen_clear_debuffs_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_gen_clear_debuffs_SpellScript();
+        }
+};
+
 void AddSC_generic_spell_scripts()
 {
     new spell_gen_absorb0_hitlimit1();
@@ -4241,4 +4275,5 @@ void AddSC_generic_spell_scripts()
     new spell_gen_stand();
     new spell_gen_mixology_bonus();
     new spell_gen_landmine_knockback_achievement();
+    new spell_gen_clear_debuffs();
 }


### PR DESCRIPTION
**Changes proposed**:
- Add generic spell for http://wotlk.openwow.com/spell=34098
- Will remove all not self applied auras

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes https://github.com/TrinityCore/TrinityCore/issues/16846

**Tests performed**: Not tested

**Discussion:**
- Correct function used?
