### PR TITLE
[3.3.5] Game/SpellMgr: DBC correction for Pestilence

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3337,6 +3337,10 @@ void SpellMgr::LoadSpellInfoCorrections()
                 //! HACK: This spell break quest complete for alliance and on retail not used °_O
                 spellInfo->Effects[EFFECT_0].Effect = 0;
                 break;
+            case 50842: // Pestilence
+                // original has cone effect which does not seem to make sense
+                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+                break;
             // VIOLET HOLD SPELLS
             //
             case 54258: // Water Globule (Ichoron)


### PR DESCRIPTION
**Changes proposed**:
- Pestilence currently only works for targets infront of the DK, remove cone effect which makes no sense

**Target branch(es)**: 335

**Issues addressed**: https://github.com/TrinityCore/TrinityCore/issues/15040

**Tests performed**: Ingame tested

**Known issues and TODO list**:     --------
