### PR TITLE
Add missing GAME_API exports

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -231,7 +231,7 @@ class TC_GAME_API ServerScript : public ScriptObject
         virtual void OnPacketReceive(WorldSession* /*session*/, WorldPacket& /*packet*/) { }
 };
 
-class WorldScript : public ScriptObject
+class TC_GAME_API WorldScript : public ScriptObject
 {
     protected:
 
@@ -264,7 +264,7 @@ class WorldScript : public ScriptObject
         virtual void OnShutdown() { }
 };
 
-class FormulaScript : public ScriptObject
+class TC_GAME_API FormulaScript : public ScriptObject
 {
     protected:
 


### PR DESCRIPTION
**Changes proposed**:
- Add missing GAME_API exports

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes building scripts that use WorldScript or FormulaScript when `WITH_DYNAMIC_LINKING` is on

**Tests performed**: Tested building a custom script that uses WorldScript after the change and it succeeded. Must have dynamic linking on when compiling. Static linking works fine already.

**Known issues and TODO list**:
- [ ] Check if any other script classes or other classes need these.
