### PR TITLE
[3.3.5/6.x] Game/Spell: Do not proc when player is dead

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -14075,6 +14075,9 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* target, uint32 procFlag, u
     // Player is loaded now - do not allow passive spell casts to proc
     if (GetTypeId() == TYPEID_PLAYER && ToPlayer()->GetSession()->PlayerLoading())
         return;
+    // Player is dead - do not proc on dead player
+    if (!IsAlive())
+        return;
     // For melee/ranged based attack need update skills and set some Aura states if victim present
     if (procFlag & MELEE_BASED_TRIGGER_MASK && target)
     {


### PR DESCRIPTION
**Changes proposed**:
- Procs will no longer proc when the "proccer" is dead

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes https://github.com/TrinityCore/TrinityCore/issues/16836

**Tests performed**: Not tested ingame

is this the right position for this check?
