### PR TITLE
cleanup of cs_modify.cpp

### DIFF
--- a/src/server/scripts/Commands/cs_modify.cpp
+++ b/src/server/scripts/Commands/cs_modify.cpp
@@ -80,23 +80,32 @@ public:
         return commandTable;
     }
 
-    //Edit Player HP
-    static bool HandleModifyHPCommand(ChatHandler* handler, const char* args)
+    template<typename... Args>
+    static void NotifyModification(ChatHandler* handler, Unit* target, const TrinityStrings resourceMessage, const TrinityStrings resourceReportMessage, Args&&... args)
+    {
+        if (Player* player = target->ToPlayer())
+        {
+            handler->PSendSysMessage(resourceMessage, handler->GetNameLink(player).c_str(), std::forward<Args>(args)...);
+            if (handler->needReportToTarget(player))
+                ChatHandler(player->GetSession()).PSendSysMessage(resourceReportMessage, handler->GetNameLink().c_str(), std::forward<Args>(args)...);
+        }
+    }
+
+    static bool CheckModifyResources(ChatHandler* handler, const char* args, Player* target, int32& res, int32& resmax, const int8 multiplier = 1)
     {
         if (!*args)
             return false;
 
-        int32 hp = atoi((char*)args);
-        int32 hpm = atoi((char*)args);
+        res = atoi((char*)args) * multiplier;
+        resmax = atoi((char*)args) * multiplier;
 
-        if (hp < 1 || hpm < 1 || hpm < hp)
+        if (res < 1 || resmax < 1 || resmax < res)
         {
             handler->SendSysMessage(LANG_BAD_VALUE);
             handler->SetSentErrorMessage(true);
             return false;
         }
 
-        Player* target = handler->getSelectedPlayerOrSelf();
         if (!target)
         {
             handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
@@ -107,164 +116,87 @@ public:
         if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
             return false;
 
-        handler->PSendSysMessage(LANG_YOU_CHANGE_HP, handler->GetNameLink(target).c_str(), hp, hpm);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_HP_CHANGED, handler->GetNameLink().c_str(), hp, hpm);
-
-        target->SetMaxHealth(hpm);
-        target->SetHealth(hp);
-
         return true;
+    }
+
+    //Edit Player HP
+    static bool HandleModifyHPCommand(ChatHandler* handler, const char* args)
+    {
+        int32 hp, hpmax;
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (CheckModifyResources(handler, args, target, hp, hpmax))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_HP, LANG_YOURS_HP_CHANGED, hp, hpmax);
+            target->SetMaxHealth(hpmax);
+            target->SetHealth(hp);
+            return true;
+        }
+        return false;
     }
 
     //Edit Player Mana
     static bool HandleModifyManaCommand(ChatHandler* handler, const char* args)
     {
-        if (!*args)
-            return false;
-
-        int32 mana = atoi((char*)args);
-        int32 manam = atoi((char*)args);
-
-        if (mana <= 0 || manam <= 0 || manam < mana)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
+        int32 mana, manamax;
         Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
+
+        if (CheckModifyResources(handler, args, target, mana, manamax))
         {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
+            NotifyModification(handler, target, LANG_YOU_CHANGE_MANA, LANG_YOURS_MANA_CHANGED, mana, manamax);
+            target->SetMaxPower(POWER_MANA, manamax);
+            target->SetPower(POWER_MANA, mana);
+            return true;
         }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_MANA, handler->GetNameLink(target).c_str(), mana, manam);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_MANA_CHANGED, handler->GetNameLink().c_str(), mana, manam);
-
-        target->SetMaxPower(POWER_MANA, manam);
-        target->SetPower(POWER_MANA, mana);
-
-        return true;
+        return false;
     }
 
     //Edit Player Energy
     static bool HandleModifyEnergyCommand(ChatHandler* handler, const char* args)
     {
-        if (!*args)
-            return false;
-
-        int32 energy = atoi((char*)args)*10;
-        int32 energym = atoi((char*)args)*10;
-
-        if (energy <= 0 || energym <= 0 || energym < energy)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
+        int32 energy, energymax;
         Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
+        const int8 energyMultiplier = 10;
+        if (CheckModifyResources(handler, args, target, energy, energymax, energyMultiplier))
         {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
+            NotifyModification(handler, target, LANG_YOU_CHANGE_ENERGY, LANG_YOURS_ENERGY_CHANGED, energy / energyMultiplier, energymax / energyMultiplier);
+            target->SetMaxPower(POWER_ENERGY, energymax);
+            target->SetPower(POWER_ENERGY, energy);
+            TC_LOG_DEBUG("misc", handler->GetTrinityString(LANG_CURRENT_ENERGY), target->GetMaxPower(POWER_ENERGY));
+            return true;
         }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_ENERGY, handler->GetNameLink(target).c_str(), energy/10, energym/10);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_ENERGY_CHANGED, handler->GetNameLink().c_str(), energy/10, energym/10);
-
-        target->SetMaxPower(POWER_ENERGY, energym);
-        target->SetPower(POWER_ENERGY, energy);
-
-        TC_LOG_DEBUG("misc", handler->GetTrinityString(LANG_CURRENT_ENERGY), target->GetMaxPower(POWER_ENERGY));
-
-        return true;
+        return false;
     }
 
     //Edit Player Rage
     static bool HandleModifyRageCommand(ChatHandler* handler, const char* args)
     {
-        if (!*args)
-            return false;
-
-        int32 rage = atoi((char*)args)*10;
-        int32 ragem = atoi((char*)args)*10;
-
-        if (rage <= 0 || ragem <= 0 || ragem < rage)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
+        int32 rage, ragemax;
         Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
+        const int8 rageMultiplier = 10;
+        if (CheckModifyResources(handler, args, target, rage, ragemax, rageMultiplier))
         {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
+            NotifyModification(handler, target, LANG_YOU_CHANGE_RAGE, LANG_YOURS_RAGE_CHANGED, rage / rageMultiplier, ragemax / rageMultiplier);
+            target->SetMaxPower(POWER_RAGE, ragemax);
+            target->SetPower(POWER_RAGE, rage);
+            return true;
         }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_RAGE, handler->GetNameLink(target).c_str(), rage/10, ragem/10);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_RAGE_CHANGED, handler->GetNameLink().c_str(), rage/10, ragem/10);
-
-        target->SetMaxPower(POWER_RAGE, ragem);
-        target->SetPower(POWER_RAGE, rage);
-
-        return true;
+        return false;
     }
 
     // Edit Player Runic Power
     static bool HandleModifyRunicPowerCommand(ChatHandler* handler, const char* args)
     {
-        if (!*args)
-            return false;
-
-        int32 rune = atoi((char*)args)*10;
-        int32 runem = atoi((char*)args)*10;
-
-        if (rune <= 0 || runem <= 0 || runem < rune)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
+        int32 rune, runemax;
         Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
+        const int8 runeMultiplier = 10;
+        if (CheckModifyResources(handler, args, target, rune, runemax, runeMultiplier))
         {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
+            NotifyModification(handler, target, LANG_YOU_CHANGE_RUNIC_POWER, LANG_YOURS_RUNIC_POWER_CHANGED, rune / runeMultiplier, runemax / runeMultiplier);
+            target->SetMaxPower(POWER_RUNIC_POWER, runemax);
+            target->SetPower(POWER_RUNIC_POWER, rune);
+            return true;
         }
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_RUNIC_POWER, handler->GetNameLink(target).c_str(), rune/10, runem/10);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_RUNIC_POWER_CHANGED, handler->GetNameLink().c_str(), rune/10, runem/10);
-
-        target->SetMaxPower(POWER_RUNIC_POWER, runem);
-        target->SetPower(POWER_RUNIC_POWER, rune);
-
-        return true;
+        return false;
     }
 
     //Edit Player Faction
@@ -437,261 +369,127 @@ public:
         return false;
     }
 
-    //Edit Player Aspeed
-    static bool HandleModifyASpeedCommand(ChatHandler* handler, const char* args)
+    static bool CheckModifySpeed(ChatHandler* handler, const char* args, Unit* target, float& speed, const float minimumBound, const float maximumBound, bool checkInFlight = true)
     {
         if (!*args)
             return false;
 
-        float ASpeed = (float)atof((char*)args);
+        speed = (float)atof((char*)args);
 
-        if (ASpeed > 50.0f || ASpeed < 0.1f)
+        if (speed > maximumBound || speed < minimumBound)
         {
             handler->SendSysMessage(LANG_BAD_VALUE);
             handler->SetSentErrorMessage(true);
             return false;
         }
 
-        Player* target = handler->getSelectedPlayerOrSelf();
         if (!target)
         {
             handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
             handler->SetSentErrorMessage(true);
             return false;
         }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        std::string targetNameLink = handler->GetNameLink(target);
-
-        if (target->IsInFlight())
-        {
-            handler->PSendSysMessage(LANG_CHAR_IN_FLIGHT, targetNameLink.c_str());
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_ASPEED, targetNameLink.c_str(), ASpeed);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_ASPEED_CHANGED, handler->GetNameLink().c_str(), ASpeed);
-
-        target->SetSpeedRate(MOVE_WALK,    ASpeed);
-        target->SetSpeedRate(MOVE_RUN,     ASpeed);
-        target->SetSpeedRate(MOVE_SWIM,    ASpeed);
-        //target->SetSpeedRate(MOVE_TURN,    ASpeed);
-        target->SetSpeedRate(MOVE_FLIGHT,     ASpeed);
-        return true;
-    }
-
-    //Edit Player Speed
-    static bool HandleModifySpeedCommand(ChatHandler* handler, const char* args)
-    {
-        if (!*args)
-            return false;
-
-        float Speed = (float)atof((char*)args);
-
-        if (Speed > 50.0f || Speed < 0.1f)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
-        {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        std::string targetNameLink = handler->GetNameLink(target);
-
-        if (target->IsInFlight())
-        {
-            handler->PSendSysMessage(LANG_CHAR_IN_FLIGHT, targetNameLink.c_str());
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_SPEED, targetNameLink.c_str(), Speed);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_SPEED_CHANGED, handler->GetNameLink().c_str(), Speed);
-
-        target->SetSpeedRate(MOVE_RUN, Speed);
-
-        return true;
-    }
-
-    //Edit Player Swim Speed
-    static bool HandleModifySwimCommand(ChatHandler* handler, const char* args)
-    {
-        if (!*args)
-            return false;
-
-        float Swim = (float)atof((char*)args);
-
-        if (Swim > 50.0f || Swim < 0.1f)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
-        {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        std::string targetNameLink = handler->GetNameLink(target);
-
-        if (target->IsInFlight())
-        {
-            handler->PSendSysMessage(LANG_CHAR_IN_FLIGHT, targetNameLink.c_str());
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_SWIM_SPEED, targetNameLink.c_str(), Swim);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_SWIM_SPEED_CHANGED, handler->GetNameLink().c_str(), Swim);
-
-        target->SetSpeedRate(MOVE_SWIM, Swim);
-
-        return true;
-    }
-
-    //Edit Player Walk Speed
-    static bool HandleModifyBWalkCommand(ChatHandler* handler, const char* args)
-    {
-        if (!*args)
-            return false;
-
-        float BSpeed = (float)atof((char*)args);
-
-        if (BSpeed > 50.0f || BSpeed < 0.1f)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
-        {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        std::string targetNameLink = handler->GetNameLink(target);
-
-        if (target->IsInFlight())
-        {
-            handler->PSendSysMessage(LANG_CHAR_IN_FLIGHT, targetNameLink.c_str());
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_BACK_SPEED, targetNameLink.c_str(), BSpeed);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_BACK_SPEED_CHANGED, handler->GetNameLink().c_str(), BSpeed);
-
-        target->SetSpeedRate(MOVE_RUN_BACK, BSpeed);
-
-        return true;
-    }
-
-    //Edit Player Fly
-    static bool HandleModifyFlyCommand(ChatHandler* handler, const char* args)
-    {
-        if (!*args)
-            return false;
-
-        float FSpeed = (float)atof((char*)args);
-
-        if (FSpeed > 50.0f || FSpeed < 0.1f)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        Player* target = handler->getSelectedPlayerOrSelf();
-        if (!target)
-        {
-            handler->SendSysMessage(LANG_NO_CHAR_SELECTED);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        // check online security
-        if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
-            return false;
-
-        handler->PSendSysMessage(LANG_YOU_CHANGE_FLY_SPEED, handler->GetNameLink(target).c_str(), FSpeed);
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_FLY_SPEED_CHANGED, handler->GetNameLink().c_str(), FSpeed);
-
-        target->SetSpeedRate(MOVE_FLIGHT, FSpeed);
-
-        return true;
-    }
-
-    //Edit Player or Creature Scale
-    static bool HandleModifyScaleCommand(ChatHandler* handler, const char* args)
-    {
-        if (!*args)
-            return false;
-
-        float Scale = (float)atof((char*)args);
-        if (Scale > 10.0f || Scale < 0.1f)
-        {
-            handler->SendSysMessage(LANG_BAD_VALUE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
-        Unit* target = handler->getSelectedUnit();
-        if (!target)
-        {
-            handler->SendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
         if (Player* player = target->ToPlayer())
         {
             // check online security
             if (handler->HasLowerSecurity(player, ObjectGuid::Empty))
                 return false;
 
-            handler->PSendSysMessage(LANG_YOU_CHANGE_SIZE, handler->GetNameLink(player).c_str(), Scale);
-            if (handler->needReportToTarget(player))
-                ChatHandler(player->GetSession()).PSendSysMessage(LANG_YOURS_SIZE_CHANGED, handler->GetNameLink().c_str(), Scale);
+            if (player->IsInFlight() && checkInFlight)
+            {
+                handler->PSendSysMessage(LANG_CHAR_IN_FLIGHT, handler->GetNameLink(player).c_str());
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
         }
-
-        target->SetObjectScale(Scale);
-
         return true;
+    }
+
+    //Edit Player Aspeed
+    static bool HandleModifyASpeedCommand(ChatHandler* handler, const char* args)
+    {
+        float allSpeed;
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (CheckModifySpeed(handler, args, target, allSpeed, 0.1f, 50.0f))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_ASPEED, LANG_YOURS_ASPEED_CHANGED, allSpeed);
+            target->SetSpeedRate(MOVE_WALK, allSpeed);
+            target->SetSpeedRate(MOVE_RUN, allSpeed);
+            target->SetSpeedRate(MOVE_SWIM, allSpeed);
+            target->SetSpeedRate(MOVE_FLIGHT, allSpeed);
+            return true;
+        }
+        return false;
+    }
+
+    //Edit Player Speed
+    static bool HandleModifySpeedCommand(ChatHandler* handler, const char* args)
+    {
+        float Speed;
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (CheckModifySpeed(handler, args, target, Speed, 0.1f, 50.0f))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_SPEED, LANG_YOURS_SPEED_CHANGED, Speed);
+            target->SetSpeedRate(MOVE_RUN, Speed);
+            return true;
+        }
+        return false;
+    }
+
+    //Edit Player Swim Speed
+    static bool HandleModifySwimCommand(ChatHandler* handler, const char* args)
+    {
+        float swimSpeed;
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (CheckModifySpeed(handler, args, target, swimSpeed, 0.1f, 50.0f))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_SWIM_SPEED, LANG_YOURS_SWIM_SPEED_CHANGED, swimSpeed);
+            target->SetSpeedRate(MOVE_SWIM, swimSpeed);
+            return true;
+        }
+        return false;
+    }
+
+    //Edit Player Backwards Walk Speed
+    static bool HandleModifyBWalkCommand(ChatHandler* handler, const char* args)
+    {
+        float backSpeed;
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (CheckModifySpeed(handler, args, target, backSpeed, 0.1f, 50.0f))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_BACK_SPEED, LANG_YOURS_BACK_SPEED_CHANGED, backSpeed);
+            target->SetSpeedRate(MOVE_RUN_BACK, backSpeed);
+            return true;
+        }
+        return false;
+    }
+
+    //Edit Player Fly
+    static bool HandleModifyFlyCommand(ChatHandler* handler, const char* args)
+    {
+        float flySpeed;
+        Player* target = handler->getSelectedPlayerOrSelf();
+        if (CheckModifySpeed(handler, args, target, flySpeed, 0.1f, 50.0f, false))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_FLY_SPEED, LANG_YOURS_FLY_SPEED_CHANGED, flySpeed);
+            target->SetSpeedRate(MOVE_FLIGHT, flySpeed);
+            return true;
+        }
+        return false;
+    }
+
+    //Edit Player or Creature Scale
+    static bool HandleModifyScaleCommand(ChatHandler* handler, const char* args)
+    {
+        float Scale;
+        Unit* target = handler->getSelectedUnit();
+        if (CheckModifySpeed(handler, args, target, Scale, 0.1f, 10.0f, false))
+        {
+            NotifyModification(handler, target, LANG_YOU_CHANGE_SIZE, LANG_YOURS_SIZE_CHANGED, Scale);
+            target->SetObjectScale(Scale);
+            return true;
+        }
+        return false;
     }
 
     //Enable Player mount
@@ -932,9 +730,7 @@ public:
         if (handler->HasLowerSecurity(target, ObjectGuid::Empty))
             return false;
 
-        handler->PSendSysMessage(LANG_YOU_GIVE_MOUNT, handler->GetNameLink(target).c_str());
-        if (handler->needReportToTarget(target))
-            ChatHandler(target->GetSession()).PSendSysMessage(LANG_MOUNT_GIVED, handler->GetNameLink().c_str());
+        NotifyModification(handler, target, LANG_YOU_GIVE_MOUNT, LANG_MOUNT_GIVED);
 
         target->SetUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP);
         target->Mount(mId);
@@ -988,10 +784,7 @@ public:
             TC_LOG_DEBUG("misc", handler->GetTrinityString(LANG_CURRENT_MONEY), targetMoney, moneyToAdd, newmoney);
             if (newmoney <= 0)
             {
-                handler->PSendSysMessage(LANG_YOU_TAKE_ALL_MONEY, handler->GetNameLink(target).c_str());
-                if (handler->needReportToTarget(target))
-                    ChatHandler(target->GetSession()).PSendSysMessage(LANG_YOURS_ALL_MONEY_GONE, handler->GetNameLink().c_str());
-
+                NotifyModification(handler, target, LANG_YOU_TAKE_ALL_MONEY, LANG_YOURS_ALL_MONEY_GONE);
                 target->SetMoney(0);
             }
             else


### PR DESCRIPTION
**Changes proposed**:
- Remove a bunch of duplicate code

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes

**Tests performed**: (Does it build, tested in-game, etc)
- [x] Build
- [x] Run

Commands tested for expected results (ie changes on valid input, error message on invalid input):
- [x] .modify hp 15000
- [x] .modify hp -1000 
- [x] .modify hp aaa
- [x] .modify energy 100
- [x] .modify energy -10
- [x] .modify energy aaa
- [x] .modify money 1000
- [x] .modify money 1000g
- [x] .modify money -1000g
- [x] .modify money -10000000g
- [x] .modify scale 2
- [x] .modify scale 0.5
- [x] .modify scale -1

Commands tested on other player:
- [x] Same list as above but on another player

**Known issues and TODO list**:

A number of notification messages still have a "wrong" order compared to the new NotifyModification which uses Namelink , value in both the regular handle and in the reporting notification. Whereas (for example)HandleModifyGenderCommand and HandleModifyMoneyCommand still use inconsistent order versions of notifications. @Nyeriah Fixed a couple of these order issues in https://github.com/TrinityCore/TrinityCore/commit/c1905771f064e374a09720f470116f04b03e5a42

Modifying powers (energy) currently has a awkward *10 modifier. This can potentially be removed completely as it also gives inconsistent results. ie. .modify energy 200 actually set your rogue's energy to 2000. For whatever reason, this does not apply for rage and runicpower even though these also have the initial x10 multiplier.

Furthermore this PR is based on @chaodhib  refactoring of SetSpeed: https://github.com/TrinityCore/TrinityCore/pull/16843/commits/4f0973bd3534839caf7b834958775acaff963fd9
So his PR should probably be merged in before this one is considered.

I don't know what has to be done to change the parameter order as @Nyeriah has done, so perhaps she could look into that?
