### PR TITLE
[3.3.5] Fix strings for Dwarven and Troll Dices

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3789,7 +3789,7 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
                     const char *gender = "his";
                     if (m_caster->getGender() > 0)
                         gender = "her";
-                    sprintf(buf, "%s rubs %s [Decahedral Dwarven Dice] between %s hands and rolls. One %u and one %u.", m_caster->GetName().c_str(), gender, gender, urand(1, 10), urand(1, 10));
+                    sprintf(buf, "rubs %s [Decahedral Dwarven Dice] between %s hands and rolls. One %u and one %u.", gender, gender, urand(1, 10), urand(1, 10));
                     m_caster->TextEmote(buf);
                     break;
                 }
@@ -3800,7 +3800,7 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
                     const char *gender = "his";
                     if (m_caster->getGender() > 0)
                         gender = "her";
-                    sprintf(buf, "%s causually tosses %s [Worn Troll Dice]. One %u and one %u.", m_caster->GetName().c_str(), gender, urand(1, 6), urand(1, 6));
+                    sprintf(buf, "casually tosses %s [Worn Troll Dice]. One %u and one %u.", gender, urand(1, 6), urand(1, 6));
                     m_caster->TextEmote(buf);
                     break;
                 }


### PR DESCRIPTION
TextEmote() starts already with the playername. No need to add it once more.
