### PR TITLE
[6.x] Fix Rogue talent: Burst Of Speed

### DIFF
--- a/sql/updates/world/9999_99_99_00_world.sql
+++ b/sql/updates/world/9999_99_99_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 108212;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (108212, 137681, 0, 'Burst of Speed - Rogue Talent');


### PR DESCRIPTION
**Changes proposed**:
- Talent http://www.wowhead.com/spell=108212/burst-of-speed will now work
- Linked spells together, speed and slow remove is now working

**Target branch(es)**: 6.x

**Issues addressed**: No Issue Yet

**Tests performed**: Tested Ingame, Building
