### PR TITLE
[Core/Spells]Warrior, fixed bladestorm aura remove due to weapon swap

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12150,7 +12150,7 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update)
                 // remove item dependent auras and casts (only weapon and armor slots)
                 if (slot < EQUIPMENT_SLOT_END)
                 {
-                    if(update)
+                    if (update)
                         RemoveItemDependentAurasAndCasts(pItem);
 
                     // remove held enchantments, update expertise

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12150,7 +12150,8 @@ void Player::RemoveItem(uint8 bag, uint8 slot, bool update)
                 // remove item dependent auras and casts (only weapon and armor slots)
                 if (slot < EQUIPMENT_SLOT_END)
                 {
-                    RemoveItemDependentAurasAndCasts(pItem);
+                    if(update)
+                        RemoveItemDependentAurasAndCasts(pItem);
 
                     // remove held enchantments, update expertise
                     if (slot == EQUIPMENT_SLOT_MAINHAND)


### PR DESCRIPTION
https://github.com/TrinityCore/TrinityCore/issues/2909
It works as intended, but it could be improved (es. check if the removed item meets the requirements of the new equipped item ---> skip aura removing)
