### PR TITLE
Core/Movement: Fix a bug related to unit movements

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -48,6 +48,9 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T* owner, bool up
     {
         if (!i_offset)
         {
+            if (i_target->IsWithinDistInMap(owner, CONTACT_DISTANCE))
+                return;
+
             // to nearest contact position
             i_target->GetContactPoint(owner, x, y, z);
         }


### PR DESCRIPTION
Fix a bug related to unit movements:
Let's say creature A is attacking unit B. If creature A then starts to attack (or follow) unit C and if unit C is very close to Creature A, Creature A will move away from unit C for a few meters before auto-attacking (or following). This isn't natural looking and it isn't blizz-like behavior.

It is mentioned at least here (and probably at other places): https://github.com/TrinityCore/TrinityCore/pull/16806#issuecomment-198741472 & https://github.com/TrinityCore/TrinityCore/pull/16806#issuecomment-199519967

I have tested the change IG and it looks good.
