### PR TITLE
moved GetSkill function to more appropriate ItemTemplate class

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -519,41 +519,11 @@ Player* Item::GetOwner()const
     return ObjectAccessor::FindPlayer(GetOwnerGUID());
 }
 
+// Just a "legacy shortcut" for proto->GetSkill()
 uint32 Item::GetSkill()
 {
-    const static uint32 item_weapon_skills[MAX_ITEM_SUBCLASS_WEAPON] =
-    {
-        SKILL_AXES,     SKILL_2H_AXES,  SKILL_BOWS,          SKILL_GUNS,      SKILL_MACES,
-        SKILL_2H_MACES, SKILL_POLEARMS, SKILL_SWORDS,        SKILL_2H_SWORDS, 0,
-        SKILL_STAVES,   0,              0,                   SKILL_FIST_WEAPONS,   0,
-        SKILL_DAGGERS,  SKILL_THROWN,   SKILL_ASSASSINATION, SKILL_CROSSBOWS, SKILL_WANDS,
-        SKILL_FISHING
-    };
-
-    const static uint32 item_armor_skills[MAX_ITEM_SUBCLASS_ARMOR] =
-    {
-        0, SKILL_CLOTH, SKILL_LEATHER, SKILL_MAIL, SKILL_PLATE_MAIL, 0, SKILL_SHIELD, 0, 0, 0, 0
-    };
-
     ItemTemplate const* proto = GetTemplate();
-
-    switch (proto->Class)
-    {
-        case ITEM_CLASS_WEAPON:
-            if (proto->SubClass >= MAX_ITEM_SUBCLASS_WEAPON)
-                return 0;
-            else
-                return item_weapon_skills[proto->SubClass];
-
-        case ITEM_CLASS_ARMOR:
-            if (proto->SubClass >= MAX_ITEM_SUBCLASS_ARMOR)
-                return 0;
-            else
-                return item_armor_skills[proto->SubClass];
-
-        default:
-            return 0;
-    }
+    return proto->GetSkill();
 }
 
 uint32 Item::GetSpell()

--- a/src/server/game/Entities/Item/ItemPrototype.h
+++ b/src/server/game/Entities/Item/ItemPrototype.h
@@ -737,6 +737,41 @@ struct ItemTemplate
         return std::max<float>(0.f, itemLevel);
     }
 
+    uint32 GetSkill() const
+    {
+        const static uint32 item_weapon_skills[MAX_ITEM_SUBCLASS_WEAPON] =
+        {
+            SKILL_AXES,     SKILL_2H_AXES,  SKILL_BOWS,          SKILL_GUNS,      SKILL_MACES,
+            SKILL_2H_MACES, SKILL_POLEARMS, SKILL_SWORDS,        SKILL_2H_SWORDS, 0,
+            SKILL_STAVES,   0,              0,                   SKILL_FIST_WEAPONS,   0,
+            SKILL_DAGGERS,  SKILL_THROWN,   SKILL_ASSASSINATION, SKILL_CROSSBOWS, SKILL_WANDS,
+            SKILL_FISHING
+        };
+
+        const static uint32 item_armor_skills[MAX_ITEM_SUBCLASS_ARMOR] =
+        {
+            0, SKILL_CLOTH, SKILL_LEATHER, SKILL_MAIL, SKILL_PLATE_MAIL, 0, SKILL_SHIELD, 0, 0, 0, 0
+        };
+
+        switch (Class)
+        {
+            case ITEM_CLASS_WEAPON:
+                if (SubClass >= MAX_ITEM_SUBCLASS_WEAPON)
+                    return 0;
+                else
+                    return item_weapon_skills[SubClass];
+
+            case ITEM_CLASS_ARMOR:
+                if (SubClass >= MAX_ITEM_SUBCLASS_ARMOR)
+                    return 0;
+                else
+                    return item_armor_skills[SubClass];
+
+            default:
+                return 0;
+        }
+    }
+
     bool IsPotion() const { return Class == ITEM_CLASS_CONSUMABLE && SubClass == ITEM_SUBCLASS_POTION; }
     bool IsWeaponVellum() const { return Class == ITEM_CLASS_TRADE_GOODS && SubClass == ITEM_SUBCLASS_WEAPON_ENCHANTMENT; }
     bool IsArmorVellum() const { return Class == ITEM_CLASS_TRADE_GOODS && SubClass == ITEM_SUBCLASS_ARMOR_ENCHANTMENT; }


### PR DESCRIPTION
**Changes proposed**:

GetSkill is an Item function that just do checks on ItemTemplate, so it can be easily moved under ItemTemplate class and be used when you just have a prototype object

**Target branch(es)**: 335

**Tests performed**: Compilation works and supports legacy code
