### PR TITLE
minor Coverity issue fix proposal

### DIFF
--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -488,8 +488,8 @@ int main(int argc, char ** argv)
 #endif
                     ))
             success = (errno == EEXIST);
-    int defaultFirstLocale = -1;
-    int FirstLocale = defaultFirstLocale;
+
+    int FirstLocale = -1;
     for (int i = 0; i < TOTAL_LOCALES; ++i)
     {
         if (i == LOCALE_none)
@@ -510,7 +510,7 @@ int main(int argc, char ** argv)
         break;
     }
 
-    if (FirstLocale == defaultFirstLocale)
+    if (FirstLocale == -1)
     {
         printf("FATAL ERROR: No locales defined, unable to continue.\n");
         return 1;

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -488,8 +488,8 @@ int main(int argc, char ** argv)
 #endif
                     ))
             success = (errno == EEXIST);
-
-    int FirstLocale = -1;
+    int defaultFirstLocale = -1;
+    int FirstLocale = defaultFirstLocale;
     for (int i = 0; i < TOTAL_LOCALES; ++i)
     {
         if (i == LOCALE_none)
@@ -508,6 +508,12 @@ int main(int argc, char ** argv)
 
         printf("Detected client build: %u\n\n", build);
         break;
+    }
+
+    if (FirstLocale == defaultFirstLocale)
+    {
+        printf("FATAL ERROR: No locales defined, unable to continue.\n");
+        return 1;
     }
 
     if (!OpenCascStorage(FirstLocale))


### PR DESCRIPTION
**Changes proposed**:
- Test on unchanged FirstLocale
- Exit with error if first locale is -1 as indicator of undefined locales

**Target branch(es)**: 6x

**Issues addressed**: Fixes Coverity CID 1341054

**Tests performed**: (Does it build, tested in-game, etc)
[x] Performed local build

**Known issues and TODO list**:

none

CID 1341054

In the (very) unlikely event the LOCALE enum is gone missing, the FirstLocale local variable will remain -1, further code would then use a -1 to index an array in the OpenCascStorage(FirstLocale) line.

Two fixes come to mind:
a. check for FirstLocale == -1 and exit with an error message
b. set the default to enUS ( initialize FirstLocale = 0; and declare it as uint instead of int.

I chose the first as in the good flow it won't change anything and I was unsure of the impact if I put enUS as default if no locales were defined at all.
