### PR TITLE
DB/Quest: Fields of Grief: Captured Scarlet Zealot should die after b…

### DIFF
--- a/sql/updates/world/2016_04_14_00_world.sql
+++ b/sql/updates/world/2016_04_14_00_world.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `smart_scripts` SET `action_type`=51, `action_param1`=0 WHERE `entryorguid`=193100 AND `id`=7;


### PR DESCRIPTION
**Changes proposed**:

The issue that I'm submitting a fix for affects the "Fields of Grief" quest. When the "Captured Scarlet Zealot" (entry 1931, guid 44548) is fed a pumpkin for "Fields of Grief" (Quest no. 407), he is supposted to become a ghoul, wander around, and then die. He becomes a ghoul as intended, but does not die. The Zealot will not respawn on account of his own scripting, requiring a  GM intervention.

Steps to replicate:
- Complete Fields of Grief (Quest 407)

**Target branch(es)**: 335 

**Issues addressed**:  #16959 

**Tests performed**: (Does it build, tested in-game, etc)

The problem seems to be linked to the extra protections around Death Touch (spell 5) that prevent non-GMs from using it. To confirm this problem, instead try setting the spell to be cast to something else. For a laugh, I replaced the spell cast with the shrinking "Transporter Malfunction" for my proof-of-concept and had the spell successfully cast: 

``` sql
UPDATE `smart_scripts` SET `action_param1`=36893 WHERE `entryorguid`=193100 AND `id`=7;
```

This is the one and only entry in `smart_scripts` that tries to cast Death Touch, so for a fix I'd like to adjust the script to instead perform a SMART_ACTION_KILL_UNIT action instead of writing in a zany edge cast to the cheat spell check.

For an actual fix:

``` sql
UPDATE `smart_scripts` SET `action_type`=51, `action_param1`=0 WHERE `entryorguid`=193100 AND `id`=7;
```
