### PR TITLE
Core/Quests Fix Quests Borrowed Technology, Volatility and The Soluti…

### DIFF
--- a/sql/updates/world/2016_04_15_00_world.sql
+++ b/sql/updates/world/2016_04_15_00_world.sql
@@ -1,0 +1,2 @@
+UPDATE `npc_spellclick_spells` SET `spell_id`=46598 WHERE `npc_entry`=31583 and`spell_id`=59319;
+UPDATE `smart_scripts` SET `action_param2`=2 WHERE `entryorguid`=31578 and`source_type`=0 and`id`=3;

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -712,7 +712,7 @@ enum BorrowedTechnologyAndVolatility
     SPELL_PING_BUNNY       = 59375,
     SPELL_IMMOLATION       = 54690,
     SPELL_EXPLOSION        = 59335,
-    SPELL_RIDE             = 56687,
+    SPELL_RIDE             = 59319,
 
     // Points
     POINT_GRAB_DECOY       = 1,

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1707,7 +1707,7 @@ enum Quest13291_13292_13239_13261Data
     NPC_SKYTALON       = 31583,
     NPC_DECOY          = 31578,
     // Spells
-    SPELL_RIDE         = 56687
+    SPELL_RIDE         = 59319
 };
 
 class spell_q13291_q13292_q13239_q13261_frostbrood_skytalon_grab_decoy : public SpellScriptLoader


### PR DESCRIPTION
**Changes proposed**:
- Correct the spells used to ride the frostwyrm
- Make the quest credit triggered, otherwise won't be casted

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #5757

**Tests performed**: Built and tested doing quest Volatility
