### PR TITLE
[6.x] Core: phase update on QuestStatus change

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15119,6 +15119,7 @@ void Player::SendQuestUpdate(uint32 questId)
 
     UpdateForQuestWorldObjects();
     SendUpdatePhasing();
+    UpdateAreaPhase();
 }
 
 QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)


### PR DESCRIPTION
**Changes proposed**:
- phases should be updated on QuestStatus change
- below are few extracts from sniffs to confirm (no spells were casted to update phases):

```
Opcode: SMSG_QUEST_UPDATE_ADD_CREDIT (0x1D8A)
Time: 06:24:29.523
QuestID: 29419
Opcode: SMSG_PHASE_SHIFT_CHANGE (0x137C)
Time: 06:24:29.523

Opcode: SMSG_PHASE_SHIFT_CHANGE (0x137C)
Time: 07:04:31.033
Opcode: SMSG_QUEST_UPDATE_ADD_CREDIT (0x1D8A)
Time: 07:04:31.033
QuestID: 29663

Opcode: SMSG_QUEST_GIVER_QUEST_DETAILS (0x1921) (auto-accepted quest)
Time: 07:17:04.035
QuestID: 29680
Opcode: SMSG_PHASE_SHIFT_CHANGE (0x137C)
Time: 07:17:04.815
```

**Target branch(es)**: 6x

**Tests performed**: tested in-game
