### PR TITLE
Core/Spells Fix Spell Inferno, used by boss Baron Geddon

### DIFF
--- a/sql/updates/world/2016_04_15_99_world.sql
+++ b/sql/updates/world/2016_04_15_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_baron_geddon_inferno';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(19695, 'spell_baron_geddon_inferno');

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_baron_geddon.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_baron_geddon.cpp
@@ -27,6 +27,8 @@ EndScriptData */
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "molten_core.h"
+#include "SpellAuraEffects.h"
+#include "SpellScript.h"
 
 enum Emotes
 {
@@ -36,9 +38,10 @@ enum Emotes
 enum Spells
 {
     SPELL_INFERNO       = 19695,
+    SPELL_INFERNO_DMG   = 19698,
     SPELL_IGNITE_MANA   = 19659,
     SPELL_LIVING_BOMB   = 20475,
-    SPELL_ARMAGEDDON    = 20479,
+    SPELL_ARMAGEDDON    = 20478,
 };
 
 enum Events
@@ -119,7 +122,36 @@ class boss_baron_geddon : public CreatureScript
         }
 };
 
+class spell_baron_geddon_inferno : public SpellScriptLoader
+{
+    public:
+        spell_baron_geddon_inferno() : SpellScriptLoader("spell_baron_geddon_inferno") { }
+
+        class spell_baron_geddon_inferno_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_baron_geddon_inferno_AuraScript);
+
+            void OnPeriodic(AuraEffect const* aurEff)
+            {
+                PreventDefaultAction();
+                int32 damageForTick[8] = { 500, 500, 1000, 1000, 2000, 2000, 3000, 5000 };
+                GetTarget()->CastCustomSpell(SPELL_INFERNO_DMG, SPELLVALUE_BASE_POINT0, damageForTick[aurEff->GetTickNumber() - 1], (Unit*)nullptr, TRIGGERED_FULL_MASK, nullptr, aurEff);
+            }
+
+            void Register() override
+            {
+                OnEffectPeriodic += AuraEffectPeriodicFn(spell_baron_geddon_inferno_AuraScript::OnPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new spell_baron_geddon_inferno_AuraScript();
+        }
+};
+
 void AddSC_boss_baron_geddon()
 {
     new boss_baron_geddon();
+    new spell_baron_geddon_inferno();
 }


### PR DESCRIPTION
**Changes proposed**:
- Script spell Inferno, to do damage, which increases along with the number of ticks
- Correct spellId for Armageddon

**Target branch(es)**: 335/6x

**Tests performed**: Built and tested

This is based on the cmangos fix https://github.com/cmangos/mangos-classic/commit/7556165b3e15f574602fcb0ea4188db8186ccee6

Also correct the spellId of Armageddon spell
