### PR TITLE
Core/Instance: If a boss kills itself, still save the group to the instance

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13772,12 +13772,19 @@ void Unit::Kill(Unit* victim, bool durabilityLoss)
             Player* creditedPlayer = GetCharmerOrOwnerPlayerOrPlayerItself();
             /// @todo do instance binding anyway if the charmer/owner is offline
 
-            if (instanceMap->IsDungeon() && creditedPlayer)
+            if (instanceMap->IsDungeon() && (creditedPlayer || this == victim))
             {
                 if (instanceMap->IsRaidOrHeroicDungeon())
                 {
                     if (creature->GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_INSTANCE_BIND)
-                        ((InstanceMap*)instanceMap)->PermBindAllPlayers(creditedPlayer);
+                    {
+                        // if the boss killed itself we still need to bind players to the instance
+                        if (!creditedPlayer)
+                            creditedPlayer = ((InstanceMap*)instanceMap)->GetPlayers().getFirst()->GetSource();
+
+                        if (creditedPlayer)
+                            ((InstanceMap*)instanceMap)->PermBindAllPlayers(creditedPlayer);
+                    }
                 }
                 else
                 {
@@ -13785,7 +13792,8 @@ void Unit::Kill(Unit* victim, bool durabilityLoss)
                     // until the players leave the instance
                     time_t resettime = creature->GetRespawnTimeEx() + 2 * HOUR;
                     if (InstanceSave* save = sInstanceSaveMgr->GetInstanceSave(creature->GetInstanceId()))
-                        if (save->GetResetTime() < resettime) save->SetResetTime(resettime);
+                        if (save->GetResetTime() < resettime)
+                            save->SetResetTime(resettime);
                 }
             }
         }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13779,8 +13779,8 @@ void Unit::Kill(Unit* victim, bool durabilityLoss)
                     if (creature->GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_INSTANCE_BIND)
                     {
                         // if the boss killed itself we still need to bind players to the instance
-                        if (!creditedPlayer)
-                            creditedPlayer = ((InstanceMap*)instanceMap)->GetPlayers().getFirst()->GetSource();
+                        if (!creditedPlayer && instanceMap->HavePlayers())
+                            creditedPlayer = instanceMap->GetPlayers().getFirst()->GetSource();
 
                         if (creditedPlayer)
                             ((InstanceMap*)instanceMap)->PermBindAllPlayers(creditedPlayer);


### PR DESCRIPTION
**Changes proposed**:
- Before this change, if an instance boss kills itself, the instance group will not be saved to the instance.
- This change fixes this issue by adding a check to Unit::Kill

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #16971

**Tests performed**: (Does it build, tested in-game, etc)
Builds, Tested by sirikfoll
