### PR TITLE
[6.x] Core/Spell: scripted spell 114698 (Summon Amberleaf Troublemaker)

### DIFF
--- a/sql/updates/world/2016_04_16_00_world.sql
+++ b/sql/updates/world/2016_04_16_00_world.sql
@@ -2,3 +2,7 @@
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=114710;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (13, 3, 114710, 0, 0, 31, 0, 4, 0, 0, 0, 0, 0, '', 'Forcecast Summon Amberleaf Troublemaker target Player');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`="spell_summon_troublemaker";
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(114698, 'spell_summon_troublemaker');

--- a/sql/updates/world/2016_04_16_00_world.sql
+++ b/sql/updates/world/2016_04_16_00_world.sql
@@ -1,0 +1,4 @@
+-- Forcecast Summon Amberleaf Troublemaker
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=114710;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 3, 114710, 0, 0, 31, 0, 4, 0, 0, 0, 0, 0, '', 'Forcecast Summon Amberleaf Troublemaker target Player');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3511,6 +3511,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 102445: // Summon Master Li Fei
                 const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_0))->TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);
                 break;
+            case 114710: // Forcecast Summon Amberleaf Troublemaker
+                spellInfo->MaxAffectedTargets = 1;
+                break;
             default:
                 break;
         }

--- a/src/server/scripts/Pandaria/pandaria_script_loader.cpp
+++ b/src/server/scripts/Pandaria/pandaria_script_loader.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This is where scripts' loading functions should be declared:
+void AddSC_the_wandering_isle();
+
+// The name of this function should match:
+// void Add${NameOfDirectory}Scripts()
+void AddPandariaScripts()
+{
+    AddSC_the_wandering_isle();
+}

--- a/src/server/scripts/Pandaria/zone_the_wandering_isle.cpp
+++ b/src/server/scripts/Pandaria/zone_the_wandering_isle.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ScriptMgr.h"
+#include "ScriptedCreature.h"
+#include "SpellScript.h"
+#include "Player.h"
+
+class spell_summon_troublemaker : public SpellScriptLoader
+{
+public:
+    spell_summon_troublemaker() : SpellScriptLoader("spell_summon_troublemaker") { }
+
+    class spell_summon_troublemaker_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_summon_troublemaker_SpellScript);
+
+        void HandleSummon(SpellEffIndex effIndex)
+        {
+            PreventHitDefaultEffect(effIndex);
+            uint32 entry = GetSpellInfo()->GetEffect(effIndex)->MiscValue;
+            SummonPropertiesEntry const* properties = sSummonPropertiesStore.LookupEntry(GetSpellInfo()->GetEffect(effIndex)->MiscValueB);
+            if (!entry || !properties)
+                return;
+
+            int32 duration = GetSpellInfo()->GetDuration();
+
+            int32 radius;
+            if (urand(0, 2) == 0)
+                radius = urand(0, 6);
+            else
+                radius = 7;
+            float angle = M_PI * (urand(0, 7) / 7.f);
+            float x = 1181.75f + radius * sin(angle);
+            float y = 3444.5f + radius * cos(angle);
+            float z = 102.9385f;
+
+            GetHitDest()->Relocate(x, y, z);
+
+            Position const SpawnPosition = { x, y, z, 3.285759f };
+
+            if (TempSummon* summon = GetCaster()->GetMap()->SummonCreature(entry, SpawnPosition, properties, duration, GetCaster()))
+                summon->SetTempSummonType(TEMPSUMMON_CORPSE_TIMED_DESPAWN);
+        }
+
+        void Register()
+        {
+            OnEffectHit += SpellEffectFn(spell_summon_troublemaker_SpellScript::HandleSummon, EFFECT_0, SPELL_EFFECT_SUMMON);
+        }
+    };
+
+    SpellScript* GetSpellScript() const
+    {
+        return new spell_summon_troublemaker_SpellScript();
+    }
+};
+
+void AddSC_the_wandering_isle()
+{
+    new spell_summon_troublemaker();
+}


### PR DESCRIPTION
**Changes proposed**:
- changed MaxAffectedTargets of spell 114710 to 1
- scripted summon location of spell 114698 

**Target branch(es)**: 6x

**Tests performed**: tested in-game with 2 players simultaneously

**Referenced PR**: #16811 

**Spell description**:
NPC [Alysa Cludsinger](http://www.wowhead.com/npc=59642/aysa-cloudsinger) periodically casts spell 114710 on players in range. These players then cast summon spell 114698 on a location defined by spell script. (no invisible triggers are present at the spawning location)
