### PR TITLE
Core/Scripts Improve Felflame Infernal of Lord Jaraxxus fight

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_world.sql
@@ -1,0 +1,10 @@
+DELETE FROM `spell_script_names` where `ScriptName` IN ('spell_fel_streak_visual');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(66493,'spell_fel_streak_visual');
+
+DELETE FROM `creature_template_addon` WHERE `entry` IN (34815,35262,35263,35264);
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES
+(34815,0,0,0,1,0,'66327'),
+(35262,0,0,0,1,0,'66327'),
+(35263,0,0,0,1,0,'66327'),
+(35264,0,0,0,1,0,'66327');

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp
@@ -67,10 +67,12 @@ enum BossSpells
     SPELL_SHIVAN_SLASH                  = 67098,
     SPELL_SPINNING_STRIKE               = 66283,
     SPELL_MISTRESS_KISS                 = 66336,
-    SPELL_FEL_INFERNO                   = 67047,
-    SPELL_FEL_STREAK                    = 66494,
     SPELL_LORD_HITTIN                   = 66326,   // special effect preventing more specific spells be cast on the same player within 10 seconds
-    SPELL_MISTRESS_KISS_DAMAGE_SILENCE  = 66359
+    SPELL_MISTRESS_KISS_DAMAGE_SILENCE  = 66359,
+
+    // Felflame Infernal
+    SPELL_FEL_STREAK_VISUAL             = 66493,
+    SPELL_FEL_STREAK                    = 66494,
 };
 
 enum Events
@@ -305,18 +307,17 @@ class npc_fel_infernal : public CreatureScript
         {
             npc_fel_infernalAI(Creature* creature) : ScriptedAI(creature)
             {
-                Initialize();
                 _instance = creature->GetInstanceScript();
-            }
-
-            void Initialize()
-            {
-                _felStreakTimer = 30 * IN_MILLISECONDS;
             }
 
             void Reset() override
             {
-                Initialize();
+                _scheduler.Schedule(Seconds(2), [this](TaskContext context)
+                {
+                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0.0f, true))
+                        DoCast(target, SPELL_FEL_STREAK_VISUAL);
+                    context.Repeat(Seconds(15));
+                });
                 me->SetInCombatWithZone();
             }
 
@@ -328,23 +329,20 @@ class npc_fel_infernal : public CreatureScript
                     return;
                 }
 
+                if (me->HasUnitState(UNIT_STATE_CASTING))
+                    return;
+
                 if (!UpdateVictim())
                     return;
 
-                if (_felStreakTimer <= diff)
+                _scheduler.Update(diff, [this]
                 {
-                    if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0.0f, true))
-                        DoCast(target, SPELL_FEL_STREAK);
-                    _felStreakTimer = 30*IN_MILLISECONDS;
-                }
-                else
-                    _felStreakTimer -= diff;
-
-                DoMeleeAttackIfReady();
+                    DoMeleeAttackIfReady();
+                });
             }
             private:
-                uint32 _felStreakTimer;
                 InstanceScript* _instance;
+                TaskScheduler _scheduler;
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -579,6 +577,39 @@ class spell_mistress_kiss_area : public SpellScriptLoader
         }
 };
 
+class spell_fel_streak_visual : public SpellScriptLoader
+{
+public:
+    spell_fel_streak_visual() : SpellScriptLoader("spell_fel_streak_visual") { }
+
+    class spell_fel_streak_visual_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_fel_streak_visual_SpellScript);
+
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            if (!sSpellMgr->GetSpellInfo(SPELL_FEL_STREAK))
+                return false;
+            return true;
+        }
+
+        void HandleScript(SpellEffIndex /*effIndex*/)
+        {
+            GetCaster()->CastSpell(GetHitUnit(), uint32(GetEffectValue()), true);
+        }
+
+        void Register() override
+        {
+            OnEffectHitTarget += SpellEffectFn(spell_fel_streak_visual_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_fel_streak_visual_SpellScript();
+    }
+};
+
 void AddSC_boss_jaraxxus()
 {
     new boss_jaraxxus();
@@ -590,4 +621,5 @@ void AddSC_boss_jaraxxus()
 
     new spell_mistress_kiss();
     new spell_mistress_kiss_area();
+    new spell_fel_streak_visual();
 }


### PR DESCRIPTION
**Changes proposed**:
- Add missing addon-aura : Lord Jaraxxus Hittin' Ya (66327)
- Add visual effect of spell Fel Streak.
- Add script for Fel Streak.
- Remove ununsed spell.

Many thanks for @sirikfoll :+1: 

**Target branch(es)**: 335

**Issues addressed**: No issue about it.

**Tests performed**: Tested in game.

**Known issues**:
- [x] When he casting [Fel Inferno](http://wotlk.openwow.com/spell=66496) and target moves, he moves too and interrupt your own cast.
  This should not happen, because [Fel Inferno Trigger](http://wotlk.openwow.com/spell=66517) apply roots... [Fixed by #17037]

I need help, i dont know how solve issue above =x
