### PR TITLE
Core/PacketIO: Missing changes from 548aa119ac2884bb1c34f80e2fb077a66…

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -344,11 +344,12 @@ WorldSocket::ReadDataHandlerResult WorldSocket::ReadDataHandler()
         default:
         {
             sessionGuard.lock();
+
             LogOpcodeText(opcode, sessionGuard);
+
             if (!_worldSession)
             {
                 TC_LOG_ERROR("network.opcode", "ProcessIncoming: Client not authed opcode = %u", uint32(opcode));
-                CloseSocket();
                 return ReadDataHandlerResult::Error;
             }
 


### PR DESCRIPTION
**Changes proposed**:
- Missing change from 548aa119ac2884bb1c34f80e2fb077a66bcdfd9f (to be precise: 18343a7309fbf53a3509749c0a5ca1f8ea273c57)
- Socket will be closed because of ReadDataHandlerResult::Error. So this call is reduntant
- Can result in a crash due to double locking (i think thats the right term idk)

**Target branch(es)**: 335

**Tests performed**: Builds
## 

Sorry for my broken english.
