### PR TITLE
Core/Movement: fix the issues regarding MovePoint not handling correc…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -15816,7 +15816,9 @@ void Unit::SetRooted(bool apply)
         // setting MOVEMENTFLAG_ROOT
         RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
         AddUnitMovementFlag(MOVEMENTFLAG_ROOT);
-        StopMoving();
+
+        //StopMoving();
+        GetMotionMaster()->ForcedStop();
 
         if (GetTypeId() == TYPEID_PLAYER)
         {
@@ -15851,6 +15853,8 @@ void Unit::SetRooted(bool apply)
             }
 
             RemoveUnitMovementFlag(MOVEMENTFLAG_ROOT);
+            ClearUnitState(UNIT_STATE_ROOT); // hack. this is called later in the stack. however, this is needed here before ResumeMovement() is called.
+            GetMotionMaster()->ResumeMovement();
         }
     }
 }

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -744,3 +744,13 @@ bool MotionMaster::GetDestination(float &x, float &y, float &z)
     z = dest.z;
     return true;
 }
+
+void MotionMaster::ForcedStop()
+{
+    Mutate(&si_idleMovement, MovementSlot::MOTION_SLOT_CONTROLLED);
+}
+
+void MotionMaster::ResumeMovement()
+{
+    MovementExpired();
+}

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -202,6 +202,9 @@ class TC_GAME_API MotionMaster //: private std::stack<MovementGenerator *>
         void MoveDistract(uint32 time);
         void MovePath(uint32 path_id, bool repeatable);
         void MoveRotate(uint32 time, RotateDirection direction);
+        
+        void ForcedStop();
+        void ResumeMovement();
 
         MovementGeneratorType GetCurrentMovementGeneratorType() const;
         MovementGeneratorType GetMotionSlotType(int slot) const;

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
@@ -42,6 +42,8 @@ class PointMovementGenerator : public MovementGeneratorMedium< T, PointMovementG
 
         void GetDestination(float& x, float& y, float& z) const { x = i_x; y = i_y; z = i_z; }
     private:
+        void LaunchMovement(T* unit);
+
         uint32 id;
         float i_x, i_y, i_z;
         float speed;


### PR DESCRIPTION
This fix issues regarding Motionmaster::MovePoint() not handling correctly rooted units:
1. Fix the bug that occurs when MovePoint is called on a rooted npc. The unit would  previously "teleport" to the destination point.
2. Fix the bug that occurs when a unit moving by PointMovementGenerator is rooted. It does not continue its movement after it's unrooted.

The PR is not ready to get merged as is. This is a draft. It needs some polish but the fix seems to be working. 

Testing done:
- call MovePoint() on a static unit and see if that units moves to the point.
- call MovePoint() on a moving unit and see if that units moves to the point
- call MovePoint() on a rooted unit. The unit should resume its movement and move toward the point as soon as the root fades.
- Root (by casting frost nova on it for example) a unit already moving by MovePoint().  The unit should resume its movement and move toward the point as soon as the root fades.

I tried to make the least amount of changes so that the PR is as readable as possible. I think however that the whole movement system needs some serious clean up and this means unreadable and massive PRs in the future I'm afraid.
