### PR TITLE
Adjustment to Player::SetViewpoint to allow for Mind Vision "hops".

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23968,7 +23968,7 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
         // farsight dynobj or puppet may be very far away
         UpdateVisibilityOf(target);
 
-        if (target->isType(TYPEMASK_UNIT | TYPEMASK_PLAYER) && target != GetVehicleBase())
+        if (target->isType(TYPEMASK_UNIT) && target != GetVehicleBase())
         {
             static_cast<Unit*>(target)->AddPlayerToVision(this);
             SetSeer(target);
@@ -23984,7 +23984,7 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
             return;
         }
 
-        if (target->isType(TYPEMASK_UNIT | TYPEMASK_PLAYER) && target != GetVehicleBase())
+        if (target->isType(TYPEMASK_UNIT) && target != GetVehicleBase())
             static_cast<Unit*>(target)->RemovePlayerFromVision(this);
 
         //must immediately set seer back otherwise may crash

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23968,7 +23968,7 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
         // farsight dynobj or puppet may be very far away
         UpdateVisibilityOf(target);
 
-        if (target->isType(TYPEMASK_SEER) && target != GetVehicleBase())
+        if (target->isType(TYPEMASK_UNIT | TYPEMASK_PLAYER) && target != GetVehicleBase())
         {
             static_cast<Unit*>(target)->AddPlayerToVision(this);
             SetSeer(target);
@@ -23984,7 +23984,7 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
             return;
         }
 
-        if (target->isType(TYPEMASK_UNIT) && target != GetVehicleBase())
+        if (target->isType(TYPEMASK_UNIT | TYPEMASK_PLAYER) && target != GetVehicleBase())
             static_cast<Unit*>(target)->RemovePlayerFromVision(this);
 
         //must immediately set seer back otherwise may crash

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23969,10 +23969,8 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
         UpdateVisibilityOf(target);
 
         if (target->isType(TYPEMASK_UNIT) && target != GetVehicleBase())
-        {
             static_cast<Unit*>(target)->AddPlayerToVision(this);
-            SetSeer(target);
-        }
+        SetSeer(target);
     }
     else
     {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23968,8 +23968,11 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
         // farsight dynobj or puppet may be very far away
         UpdateVisibilityOf(target);
 
-        if (target->isType(TYPEMASK_UNIT) && target != GetVehicleBase())
+        if (target->isType(TYPEMASK_SEER) && target != GetVehicleBase())
+        {
             static_cast<Unit*>(target)->AddPlayerToVision(this);
+            SetSeer(target);
+        }
     }
     else
     {
@@ -23985,7 +23988,7 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
             static_cast<Unit*>(target)->RemovePlayerFromVision(this);
 
         //must immediately set seer back otherwise may crash
-        m_seer = this;
+        SetSeer(this);
 
         //WorldPacket data(SMSG_CLEAR_FAR_SIGHT_IMMEDIATE, 0);
         //GetSession()->SendPacket(&data);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23968,7 +23968,7 @@ void Player::SetViewpoint(WorldObject* target, bool apply)
         // farsight dynobj or puppet may be very far away
         UpdateVisibilityOf(target);
 
-        if (target->isType(TYPEMASK_SEER) && target != GetVehicleBase())
+        if (target->isType(TYPEMASK_UNIT | TYPEMASK_PLAYER) && target != GetVehicleBase())
         {
             static_cast<Unit*>(target)->AddPlayerToVision(this);
             SetSeer(target);


### PR DESCRIPTION
**Changes proposed**:

Import of changes applied to resolve OregonCore/OregonCore#1212 that are outstanding in TrinityCore.
- When Mind Vision "hops" (casting on a new target while currently casting on another target) to another seer-able-unit, unit visibility should be updated so that the .
- Adjusted a direct assignment of `m_seer` to use `SetSeer`

**Target branch(es)**: 335

**Tests performed**: (Does it build, tested in-game, etc)
1. Cast Mind Vision (Rank 2, spell ID 10909) on a party member over 100-ish yards away on the same continent. The main goal is to mind vision something that is out of your normal sight range.
2. Refresh Mind Vision on the same target, or target another creature in range.

After doing these two steps, you should still see when the target of mind vision moves, and NPCs will continue to move. Without this change, players will stand or run in place, as will NPCs once they have finished the last waypoint that they told the caster's client about.
