### PR TITLE
Core/Packets: Send correct messages about server first achievements d…

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -647,12 +647,18 @@ void AchievementMgr::SendAchievementEarned(AchievementEntry const* achievement) 
     if (achievement->flags & (ACHIEVEMENT_FLAG_REALM_FIRST_KILL | ACHIEVEMENT_FLAG_REALM_FIRST_REACH))
     {
         // broadcast realm first reached
+
+        uint32 team = Player::TeamForRace(GetPlayer()->getRace());
+
         WorldPacket data(SMSG_SERVER_FIRST_ACHIEVEMENT, GetPlayer()->GetName().size() + 1 + 8 + 4 + 4);
         data << GetPlayer()->GetName();
         data << uint64(GetPlayer()->GetGUID());
         data << uint32(achievement->ID);
-        data << uint32(0);                                  // 1=link supplied string as player name, 0=display plain string
-        sWorld->SendGlobalMessage(&data);
+        data << uint32(1);                                  // link supplied string as player name
+        sWorld->SendGlobalMessage(&data, nullptr, team);
+        data.wpos(data.wpos() - 4);
+        data << uint32(0);                                  // display plain string
+        sWorld->SendGlobalMessage(&data, nullptr, team == ALLIANCE ? HORDE : ALLIANCE);
     }
     // if player is in world he can tell his friends about new achievement
     else if (GetPlayer()->IsInWorld())


### PR DESCRIPTION
…epending on faction.

Allies of player who earned achievement will see his nickname as link and enemies - as just string.
