### PR TITLE
Core/Scripts: fix console spam

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7859,6 +7859,10 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, uint32 damage, AuraEffect* trigg
                             RemoveAurasDueToSpell(50240);
                         break;
                     }
+                    // Battle Experience
+                    // already handled in gunship battle script
+                    case 71201:
+                        return false;
                 }
                 break;
             case SPELLFAMILY_MAGE:


### PR DESCRIPTION
**Changes proposed**: Adds a case label for Battle Experience, already handled elsewhere in the code

Fixes more annoying console spam:
`Unit::HandleProcTriggerSpell: Spell 71201 (effIndex: 0) has unknown TriggerSpell 0. Unhandled custom case?`

**Target branch(es)**: 335/6x

**Issues addressed**:  

**Tests performed**: Everything seems fine

**Known issues and TODO list**:  
