### PR TITLE
Core/Spell: Fix eviscerate AP coefficient

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -556,7 +556,7 @@ void Spell::EffectSchoolDMG(SpellEffIndex effIndex)
                         if (uint32 combo = player->GetComboPoints())
                         {
                             float ap = m_caster->GetTotalAttackPowerValue(BASE_ATTACK);
-                            damage += irand(int32(ap * combo * 0.03f), int32(ap * combo * 0.07f));
+                            damage += std::lroundf(ap * combo * 0.07f);
 
                             // Eviscerate and Envenom Bonus Damage (item set effect)
                             if (m_caster->HasAura(37169))


### PR DESCRIPTION
**Changes proposed**: Correct the AP coefficient of Eviscerate spell
- Without this, AP coeff was indeed "random"
- Sources (quoted from https://github.com/TrinityCore/TrinityCore/issues/154#issuecomment-122590931):

> DrDamage v1.7.8_release : Rogue.lua lines 357-372:
> Aldriana's Combat Spreadsheet v1.5.2 "Calcs" hidden sheet, 972 row "N pt Eviscerate Base Damage":

**Target branch(es)**: 335

**Issues addressed**: Closes #154

**Tests performed**: Everything seems fine

**Known issues and TODO list**:
