### PR TITLE
Core/Scripts: Correction to Uncontrollable Frenzy, Queen Lana'thel

### DIFF
--- a/sql/updates/world/3.3.5/2016_05_06_00_world.sql
+++ b/sql/updates/world/3.3.5/2016_05_06_00_world.sql
@@ -1,0 +1,4 @@
+-- Blood Queen Lana'thel - fix issues with Uncontrollable Frenzy being cast on herself
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger`= 70923 and `spell_effect`= 70924;
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_blood_queen_uncontrollable_frenzy';
+INSERT INTO `spell_script_names` VALUES (70923,'spell_blood_queen_uncontrollable_frenzy');

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -50,6 +50,7 @@ enum Spells
     SPELL_ESSENCE_OF_THE_BLOOD_QUEEN_HEAL   = 70872,
     SPELL_FRENZIED_BLOODTHIRST              = 70877,
     SPELL_UNCONTROLLABLE_FRENZY             = 70923,
+    SPELL_UNCONTROLLABLE_FRENZY_EFFECTS     = 70924,
     SPELL_PRESENCE_OF_THE_DARKFALLEN        = 70994,
     SPELL_PRESENCE_OF_THE_DARKFALLEN_2      = 71952,
     SPELL_BLOOD_MIRROR_DAMAGE               = 70821,
@@ -855,6 +856,32 @@ class spell_blood_queen_pact_of_the_darkfallen_dmg_target : public SpellScriptLo
         }
 };
 
+class spell_blood_queen_uncontrollable_frenzy : public SpellScriptLoader
+{
+public:
+    spell_blood_queen_uncontrollable_frenzy() : SpellScriptLoader("spell_blood_queen_uncontrollable_frenzy") { }
+
+    class spell_blood_queen_uncontrollable_frenzy_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_blood_queen_uncontrollable_frenzy_SpellScript);
+
+        void HandleScript(SpellEffIndex /*effIndex*/)
+        {
+            GetHitUnit()->CastSpell(GetHitUnit(), SPELL_UNCONTROLLABLE_FRENZY_EFFECTS, true);
+        }
+
+        void Register() override
+        {
+            OnEffectHitTarget += SpellEffectFn(spell_blood_queen_uncontrollable_frenzy_SpellScript::HandleScript, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_blood_queen_uncontrollable_frenzy_SpellScript();
+    }
+};
+
 class achievement_once_bitten_twice_shy_n : public AchievementCriteriaScript
 {
     public:
@@ -897,6 +924,7 @@ void AddSC_boss_blood_queen_lana_thel()
     new spell_blood_queen_pact_of_the_darkfallen();
     new spell_blood_queen_pact_of_the_darkfallen_dmg();
     new spell_blood_queen_pact_of_the_darkfallen_dmg_target();
+    new spell_blood_queen_uncontrollable_frenzy();
     new achievement_once_bitten_twice_shy_n();
     new achievement_once_bitten_twice_shy_v();
 }


### PR DESCRIPTION
**Target branch:** 335/6x
**Issues addressed:** Prevents queen lana'thel to cast frenzy effects on herself increasing life by 300%
**Tests performed:** Tested in game
**Known issues and TODO list:** none
