### PR TITLE
Core/Scripts: Cleanup hacks related with SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.cpp
+++ b/src/server/game/AI/CoreAI/UnitAI.cpp
@@ -48,7 +48,7 @@ void UnitAI::AttackStartCaster(Unit* victim, float dist)
 
 void UnitAI::DoMeleeAttackIfReady()
 {
-    if (me->HasUnitState(UNIT_STATE_CASTING))
+    if (me->HasUnitState(UNIT_STATE_CASTING) && !me->CanMoveDuringChannel())
         return;
 
     Unit* victim = me->GetVictim();

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -903,7 +903,6 @@ class spell_putricide_ooze_channel : public SpellScriptLoader
 
             void StartAttack()
             {
-                GetCaster()->ClearUnitState(UNIT_STATE_CASTING);
                 GetCaster()->DeleteThreatList();
                 GetCaster()->ToCreature()->AI()->AttackStart(GetHitUnit());
                 GetCaster()->AddThreat(GetHitUnit(), 500000000.0f);    // value seen in sniff

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
@@ -161,7 +161,6 @@ public:
                         break;
                     case EVENT_RESUME_PULSING_SHOCKWAVE:
                         DoCast(me, SPELL_PULSING_SHOCKWAVE_AURA, true);
-                        me->ClearUnitState(UNIT_STATE_CASTING); // This flag breaks movement.
                         DoCast(me, SPELL_PULSING_SHOCKWAVE, true);
                         break;
                     case EVENT_INTRO_DIALOGUE:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -374,6 +374,7 @@ class boss_flame_leviathan : public CreatureScript
                     return;
 
                 events.Update(diff);
+                DoBatteringRamIfReady();
 
                 if (Shutdown == RAID_MODE(TWO_SEATS, FOUR_SEATS))
                 {
@@ -463,8 +464,6 @@ class boss_flame_leviathan : public CreatureScript
                             break;
                     }
                 }
-
-                DoBatteringRamIfReady();
             }
 
             void SpellHitTarget(Unit* target, SpellInfo const* spell) override
@@ -558,7 +557,7 @@ class boss_flame_leviathan : public CreatureScript
 
                         if (me->IsWithinCombatRange(target, 30.0f))
                         {
-                            DoCast(target, SPELL_BATTERING_RAM);
+                            DoCast(target, SPELL_BATTERING_RAM, true);
                             me->resetAttackTimer();
                         }
                     }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1289,7 +1289,6 @@ class npc_mimiron_assault_bot : public CreatureScript
                     {
                         case EVENT_MAGNETIC_FIELD:
                             DoCastVictim(SPELL_MAGNETIC_FIELD);
-                            me->ClearUnitState(UNIT_STATE_CASTING);
                             events.RescheduleEvent(EVENT_MAGNETIC_FIELD, 30000);
                             break;
                         default:


### PR DESCRIPTION
**Changes proposed**:
- Remove hack `ClearUnitState(UNIT_STATE_CASTING)` for some boss scripts that spell have attr  SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING

If i forgot some boss, let me know that I repair xD
Some boss still need `ClearUnitState(UNIT_STATE_CASTING)` because spell has no SPELL_ATTR5_CAN_CHANNEL_WHEN_MOVING :)

**Target branch(es)**: 335
