### PR TITLE
Core/Spell: do not activate PVP flag on selfcast

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2495,8 +2495,8 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
         // Needs to be called after dealing damage/healing to not remove breaking on damage auras
         DoTriggersOnSpellHit(spellHitTarget, mask);
 
-        // if target is fallged for pvp also flag caster if a player
-        if (unit->IsPvP() && m_caster->GetTypeId() == TYPEID_PLAYER)
+        // if it's not selfcast and target is flagged for pvp also flag caster if a player
+        if (unit != m_caster && unit->IsPvP() && m_caster->GetTypeId() == TYPEID_PLAYER)
             m_caster->ToPlayer()->UpdatePvP(true);
 
         CallScriptAfterHitHandlers();


### PR DESCRIPTION
**Changes proposed**:
- Do not activate PVP flags when a spell is a selfcast

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #9766

**Tests performed**: Builds and tested in game

**Known issues and TODO list**:
- none (had this for a while running)
