### PR TITLE
Core/Pet: Fixed pets dont lose auras on join arena

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -329,6 +329,9 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petEntry, uint32 petnumber, bool c
         _LoadSpellCooldowns();
         LearnPetPassives();
         InitLevelupSpellsForLevel();
+        if (map->IsBattleArena())
+            RemoveArenaAuras();
+
         CastPetAuras(current);
     }
 


### PR DESCRIPTION
**Changes proposed**:
- Add check for Pets in arena maps lose some auras.

**Target branch(es)**: 335

**Issues addressed**: Closes #16118

**Tests performed**: Builded, tested in game.

Author: @cemak
