### PR TITLE
Core/Unit Do not allow addition of threat to units in evade mode

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12173,7 +12173,7 @@ float Unit::ApplyTotalThreatModifier(float fThreat, SpellSchoolMask schoolMask)
 void Unit::AddThreat(Unit* victim, float fThreat, SpellSchoolMask schoolMask, SpellInfo const* threatSpell)
 {
     // Only mobs can manage threat lists
-    if (CanHaveThreatList())
+    if (CanHaveThreatList() && !HasUnitState(UNIT_STATE_EVADE))
         m_ThreatManager.addThreat(victim, fThreat, schoolMask, threatSpell);
 }
 


### PR DESCRIPTION
**Changes proposed**:
- Check for UNIT_STATE_EVADE before adding threat.
- Fixes one case where creatures get stuck in combat with players.

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #17027

**Tests performed**: Built and tested
