### PR TITLE
Core/Quest: remove duplicated call to SendQuestComplete().

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14839,12 +14839,8 @@ void Player::CompleteQuest(uint32 quest_id)
             SetQuestSlotState(log_slot, QUEST_STATE_COMPLETE);
 
         if (Quest const* qInfo = sObjectMgr->GetQuestTemplate(quest_id))
-        {
             if (qInfo->HasFlag(QUEST_FLAGS_TRACKING))
                 RewardQuest(qInfo, 0, this, false);
-            else
-                SendQuestComplete(quest_id);
-        }
     }
 
     if (sWorld->getBoolConfig(CONFIG_QUEST_ENABLE_QUEST_TRACKER)) // check if Quest Tracker is enabled


### PR DESCRIPTION
**Changes proposed**:
- Remove wrong call to SendQuestComplete() that caused a wrong "Objective complete" to pop up in the client.

**Target branch(es)**: 335.

**Issues addressed**: Fixes #15613.

**Tests performed**: Tested with quests that call AreaExploredOrEventHappens(), like 2520 and 938.
