### PR TITLE
Core/Spells: check database conditions for targets of chain spells

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1935,6 +1935,17 @@ void Spell::SearchChainTargets(std::list<WorldObject*>& targets, uint32 chainTar
             break;
         target = *foundItr;
         tempTargets.erase(foundItr);
+
+        // check spell cast conditions from database
+        {
+            ConditionSourceInfo condInfo = ConditionSourceInfo(m_caster, target);
+            if (!sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_SPELL, m_spellInfo->Id, condInfo))
+            {
+                --chainTargets;
+                continue;
+            }
+        }
+
         targets.push_back(target);
         --chainTargets;
     }


### PR DESCRIPTION
**Changes proposed**:

This additional check (partly taken from Spell::CheckCast()) allows database conditions to filter targets of chained spells. For example, the "Searing Wrath" spell used by red drakes in Oculus. The spell should only hit the other dragons, but if you go near the construct and any other NPC, the chain spell will hit them too (in this case, conditions to prevent this already exist in the database, but aren't actually checked against).

**Target branch(es)**: 335

**Tests performed**: tested and working.
