### PR TITLE
Core/Spells: fix client crash caused by pressing ESC after using spel…

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3750,6 +3750,8 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 45257: // Using Steam Tonk Controller
             case 45440: // Steam Tonk Controller
             case 60256: // Collect Sample
+            case 45634: // Neural Needle
+            case 54897: // Flaming Arrow
                 // Crashes client on pressing ESC
                 spellInfo->AttributesEx4 &= ~SPELL_ATTR4_CAN_CAST_WHILE_CASTING;
                 break;


### PR DESCRIPTION
**Changes proposed**:  Neural Needle is cast during the quest "[The Art of Persuasion](http://www.wowhead.com/quest=11648/the-art-of-persuasion)". Flaming Arrow is available from creature/vehicle [Icefang](www.wowhead.com/npc=29598/icefang). Pressing the ESC key after casting one of those will crash the client.

**Target branch(es)**: 335

**Tests performed**: tested and working.
