### PR TITLE
Core/Gameobject: Gameobjects that are spawned by spell despawn after …

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -614,14 +614,13 @@ void GameObject::Update(uint32 diff)
 
             //! If this is summoned by a spell with ie. SPELL_EFFECT_SUMMON_OBJECT_WILD, with or without owner, we check respawn criteria based on spell
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
-            if (GetSpellId() || GetOwnerGUID())
+            if ((GetSpellId() || GetOwnerGUID()) && m_respawnTime > 0)
             {
-                SetRespawnTime(0);
-                Delete();
+                UpdateObjectVisibility();
+                SetLootState(GO_READY);
                 return;
             }
-
-            SetLootState(GO_READY);
+            else Delete();
 
             //burning flags in some battlegrounds, if you find better condition, just add it
             if (GetGOInfo()->IsDespawnAtAction() || GetGoAnimProgress() > 0)

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -615,7 +615,7 @@ void GameObject::Update(uint32 diff)
             //! If this is summoned by a spell with ie. SPELL_EFFECT_SUMMON_OBJECT_WILD, with or without owner, we check respawn criteria based on spell
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
             //! Game objects with flags&4 should not despawn after looting so that other members of the group may loot.
-            if ((GetSpellId() || GetOwnerGUID()) && m_respawnTime > 0 && GetGOInfo()->flags & 4)
+            if ((GetSpellId() || GetOwnerGUID()) && m_respawnTime > 0 && GetGOInfo()->flags & GO_FLAG_INTERACT_COND)
             {
                 UpdateObjectVisibility();
                 SetLootState(GO_READY);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -614,13 +614,18 @@ void GameObject::Update(uint32 diff)
 
             //! If this is summoned by a spell with ie. SPELL_EFFECT_SUMMON_OBJECT_WILD, with or without owner, we check respawn criteria based on spell
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
-            if ((GetSpellId() || GetOwnerGUID()) && m_respawnTime > 0)
+            //! Game objects with flags&4 should not despawn after looting so that other members of the group may loot.
+            if ((GetSpellId() || GetOwnerGUID()) && m_respawnTime > 0 && GetGOInfo()->flags & 4)
             {
                 UpdateObjectVisibility();
                 SetLootState(GO_READY);
                 return;
             }
-            else Delete();
+            else
+            {
+                Delete();
+                return;
+            }
 
             //burning flags in some battlegrounds, if you find better condition, just add it
             if (GetGOInfo()->IsDespawnAtAction() || GetGoAnimProgress() > 0)


### PR DESCRIPTION
**Changes proposed**:
- To stop irritating people that beat a boss and don't get their loot because a spell summons a GO

**Target branch(es)**: 335/6x

**Issues addressed**: Fixes #12842 

**Tests performed**: builds. Tested with .add quest 12842 / .cast 46310. Didn't notice any adverse affects to statically spawned GOs.

**Known issues and TODO list**:
- [ ]  Need to test more spell summoned GOs that have no loot
- [ ] Need to test more spell summoned GOs that should only be lootable by a single player
- [x] Need to make sure that statically spawned GOs are not affected. Statically spawned GOs never get anywhere near that code -- BUT -- had to test anyway.

**NOTE** If your Pull Request is SQL only create a ticket instead

**SUGESTION** If your Pull Request contains SQL give it one imposible date, for example 9999_99_99_99_database.sql on that way it will be free on merge.

…looting. If a GO contains quest loot it should not de-spawn until the de-spawn timer from Spell.dbc expires.

Closes #12842
