### PR TITLE
Core/SmartAI: remove unneeded check for SMART_ACTION_FORCE_DESPAWN.

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1037,10 +1037,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         target->DespawnOrUnsummon(e.action.forceDespawn.delay);
                 }
                 else if (GameObject* goTarget = (*itr)->ToGameObject())
-                {
-                    if (IsSmartGO(goTarget))
-                        goTarget->SetRespawnTime(e.action.forceDespawn.delay + 1);
-                }
+                    goTarget->SetRespawnTime(e.action.forceDespawn.delay + 1);
             }
 
             delete targets;


### PR DESCRIPTION
**Changes proposed**: remove unneeded check related to gameobjects targeted with SMART_ACTION_FORCE_DESPAWN. There's no reason to have it, as the despawn functionality doesn't require SmartAI.

**Target branch(es)**: 335

**Tests performed**: tested and working.
