### PR TITLE
Core/SmartAI: delay SMART_ACTION_FLEE_FOR_ASSIST if creature is rooted or stunned

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3356,6 +3356,16 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
             }
         }
 
+        // Delay flee for assist event if stunned or rooted
+        if (e.GetActionType() == SMART_ACTION_FLEE_FOR_ASSIST)
+        {
+            if (me && me->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED))
+            {
+                e.timer = 1;
+                return;
+            }
+        }
+
         e.active = true;//activate events with cooldown
         switch (e.GetEventType())//process ONLY timed events
         {


### PR DESCRIPTION
**Changes proposed**: this prevents creatures from teleporting around when fleeing for assist while stunned or rooted.

**Target branch(es)**: 335

**Tests performed**: tested and working.
