### PR TITLE
Core/UnitAI: SelectTarget correction

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -151,11 +151,11 @@ class TC_GAME_API UnitAI
                 return nullptr;
 
             std::list<Unit*> targetList;
-            HostileReference* currentVictim = me->getThreatManager().getCurrentVictim();
+            Unit* currentVictim = me->getThreatManager().getCurrentVictim()->getTarget();
 
             // Current victim always goes first
             if (predicate(currentVictim))
-                targetList.push_back(currentVictim->getTarget());
+                targetList.push_back(currentVictim);
 
             for (ThreatContainer::StorageType::const_iterator itr = threatlist.begin(); itr != threatlist.end(); ++itr)
                 if ((*itr)->getTarget() != currentVictim && predicate((*itr)->getTarget()))

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -148,15 +148,21 @@ class TC_GAME_API UnitAI
         {
             ThreatContainer::StorageType const& threatlist = me->getThreatManager().getThreatList();
             if (position >= threatlist.size())
-                return NULL;
+                return nullptr;
 
             std::list<Unit*> targetList;
+            HostileReference* currentVictim = me->getThreatManager().getCurrentVictim();
+
+            // Current victim always goes first
+            if (predicate(currentVictim))
+                targetList.push_back(currentVictim->getTarget());
+
             for (ThreatContainer::StorageType::const_iterator itr = threatlist.begin(); itr != threatlist.end(); ++itr)
-                if (predicate((*itr)->getTarget()))
+                if ((*itr)->getTarget() != currentVictim && predicate((*itr)->getTarget()))
                     targetList.push_back((*itr)->getTarget());
 
             if (position >= targetList.size())
-                return NULL;
+                return nullptr;
 
             if (targetType == SELECT_TARGET_NEAREST || targetType == SELECT_TARGET_FARTHEST)
                 targetList.sort(Trinity::ObjectDistanceOrderPred(me));
@@ -187,7 +193,7 @@ class TC_GAME_API UnitAI
                     break;
             }
 
-            return NULL;
+            return nullptr;
         }
 
         void SelectTargetList(std::list<Unit*>& targetList, uint32 num, SelectAggroTarget targetType, float dist = 0.0f, bool playerOnly = false, int32 aura = 0);


### PR DESCRIPTION
Set CurrentVictim as first element on targetList if necessary, which is then filled with the threatlist elements that satisfy the predicate.

ref #17298

**Target branch(es)**: 335/6x
