### PR TITLE
Core/SmartAI: change SMART_ACTION_RISE_UP (114) to SMART_ACTION_MOVE_OFFSET and implement offset movement via target fields.

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,2 @@
+UPDATE `smart_scripts` SET `action_type`=114, `target_z`=`action_param1`, `action_param1`=0 WHERE `action_type` = 114 AND `action_param1` != 0;
+UPDATE `smart_scripts` SET `action_type`=114, `target_y`=`action_param1`, `action_param1`=0 WHERE `action_type` = 46 AND `action_param1` != 0;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1123,22 +1123,25 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             delete targets;
             break;
         }
-        case SMART_ACTION_MOVE_FORWARD:
+        case SMART_ACTION_MOVE_OFFSET:
         {
-            if (!me)
-                break;
+            if (ObjectList* targets = GetTargets(e, unit))
+            {
+                for (ObjectList::const_iterator itr = targets->begin(); itr != targets->end(); ++itr)
+                {
+                    if (!IsCreature(*itr))
+                        continue;
 
-            float x, y, z;
-            me->GetClosePoint(x, y, z, me->GetObjectSize() / 3, (float)e.action.moveRandom.distance);
-            me->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, x, y, z);
-            break;
-        }
-        case SMART_ACTION_RISE_UP:
-        {
-            if (!me)
-                break;
+                    Position pos = (*itr)->GetPosition();
+                    Position offset = { e.target.x, e.target.y, e.target.z, 0.0f };
+                    pos.RelocateOffset(offset);
 
-            me->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + (float)e.action.moveRandom.distance);
+                    (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
+                }
+
+                delete targets;
+            }
+
             break;
         }
         case SMART_ACTION_SET_VISIBILITY:
@@ -2406,7 +2409,7 @@ void SmartScript::InstallTemplate(SmartScriptHolder const& e)
                 AddEvent(SMART_EVENT_DATA_SET, 0, 0, 0, 0, 0, SMART_ACTION_SET_RUN, e.action.installTtemplate.param3, 0, 0, 0, 0, 0, SMART_TARGET_NONE, 0, 0, 0, 0);
                 AddEvent(SMART_EVENT_DATA_SET, 0, 0, 0, 0, 0, SMART_ACTION_SET_EVENT_PHASE, 1, 0, 0, 0, 0, 0, SMART_TARGET_NONE, 0, 0, 0, 0);
 
-                AddEvent(SMART_EVENT_UPDATE, SMART_EVENT_FLAG_NOT_REPEATABLE, 1000, 1000, 0, 0, SMART_ACTION_MOVE_FORWARD, e.action.installTtemplate.param4, 0, 0, 0, 0, 0, SMART_TARGET_NONE, 0, 0, 0, 1);
+                AddEvent(SMART_EVENT_UPDATE, SMART_EVENT_FLAG_NOT_REPEATABLE, 1000, 1000, 0, 0, SMART_ACTION_MOVE_OFFSET, 0, 0, 0, 0, 0, 0, SMART_TARGET_SELF, e.action.installTtemplate.param4, 0, 0, 1);
                  //phase 1: give quest credit on movepoint reached
                 AddEvent(SMART_EVENT_MOVEMENTINFORM, 0, POINT_MOTION_TYPE, SMART_RANDOM_POINT, 0, 0, SMART_ACTION_SET_DATA, 0, 0, 0, 0, 0, 0, SMART_TARGET_STORED, 1, 0, 0, 1);
                 //phase 1: despawn after time on movepoint reached

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1134,23 +1134,13 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                     Position pos = (*itr)->GetPosition();
 
-                    if (e.action.offsetMovement.movement)
-                    {
-                        // Use normal WoW axis-based movement
-                        Position offset = { e.target.x, e.target.y, e.target.z, 0.0f };
-                        pos.RelocateOffset(offset);
-                        (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, pos);
-                    }
-                    else
-                    {
-                        // Use forward/backward/left/right cartesian plane movement
-                        float x, y, z, o;
-                        o = pos.GetOrientation();
-                        x = pos.GetPositionX() + (cos(o - (M_PI / 2))*e.target.x) + (cosf(o)*e.target.y);
-                        y = pos.GetPositionY() + (sin(o - (M_PI / 2))*e.target.x) + (sinf(o)*e.target.y);
-                        z = pos.GetPositionZ() + e.target.z;
-                        (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, x, y, z);
-                    }
+                    // Use forward/backward/left/right cartesian plane movement
+                    float x, y, z, o;
+                    o = pos.GetOrientation();
+                    x = pos.GetPositionX() + (std::cos(o - (M_PI / 2))*e.target.x) + (std::cos(o)*e.target.y);
+                    y = pos.GetPositionY() + (std::sin(o - (M_PI / 2))*e.target.x) + (std::sin(o)*e.target.y);
+                    z = pos.GetPositionZ() + e.target.z;
+                    (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, x, y, z);
                 }
 
                 delete targets;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1133,10 +1133,24 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         continue;
 
                     Position pos = (*itr)->GetPosition();
-                    Position offset = { e.target.x, e.target.y, e.target.z, 0.0f };
-                    pos.RelocateOffset(offset);
 
-                    (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
+                    if (e.action.offsetMovement.movement)
+                    {
+                        // Use normal WoW axis-based movement
+                        Position offset = { e.target.x, e.target.y, e.target.z, 0.0f };
+                        pos.RelocateOffset(offset);
+                        (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, pos);
+                    }
+                    else
+                    {
+                        // Use forward/backward/left/right cartesian plane movement
+                        float x, y, z, o;
+                        o = pos.GetOrientation();
+                        x = pos.GetPositionX() + (cos(o - (M_PI / 2))*e.target.x) + (cosf(o)*e.target.y);
+                        y = pos.GetPositionY() + (sin(o - (M_PI / 2))*e.target.x) + (sinf(o)*e.target.y);
+                        z = pos.GetPositionZ() + e.target.z;
+                        (*itr)->ToCreature()->GetMotionMaster()->MovePoint(SMART_RANDOM_POINT, x, y, z);
+                    }
                 }
 
                 delete targets;
@@ -2409,7 +2423,7 @@ void SmartScript::InstallTemplate(SmartScriptHolder const& e)
                 AddEvent(SMART_EVENT_DATA_SET, 0, 0, 0, 0, 0, SMART_ACTION_SET_RUN, e.action.installTtemplate.param3, 0, 0, 0, 0, 0, SMART_TARGET_NONE, 0, 0, 0, 0);
                 AddEvent(SMART_EVENT_DATA_SET, 0, 0, 0, 0, 0, SMART_ACTION_SET_EVENT_PHASE, 1, 0, 0, 0, 0, 0, SMART_TARGET_NONE, 0, 0, 0, 0);
 
-                AddEvent(SMART_EVENT_UPDATE, SMART_EVENT_FLAG_NOT_REPEATABLE, 1000, 1000, 0, 0, SMART_ACTION_MOVE_OFFSET, 0, 0, 0, 0, 0, 0, SMART_TARGET_SELF, e.action.installTtemplate.param4, 0, 0, 1);
+                AddEvent(SMART_EVENT_UPDATE, SMART_EVENT_FLAG_NOT_REPEATABLE, 1000, 1000, 0, 0, SMART_ACTION_MOVE_OFFSET, 0, 0, 0, 0, 0, 0, SMART_TARGET_SELF, 0, e.action.installTtemplate.param4, 0, 1);
                  //phase 1: give quest credit on movepoint reached
                 AddEvent(SMART_EVENT_MOVEMENTINFORM, 0, POINT_MOTION_TYPE, SMART_RANDOM_POINT, 0, 0, SMART_ACTION_SET_DATA, 0, 0, 0, 0, 0, 0, SMART_TARGET_STORED, 1, 0, 0, 1);
                 //phase 1: despawn after time on movepoint reached

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1179,7 +1179,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_ALLOW_COMBAT_MOVEMENT:
         case SMART_ACTION_CALL_FOR_HELP:
         case SMART_ACTION_SET_DATA:
-        case SMART_ACTION_MOVE_FORWARD:
         case SMART_ACTION_SET_VISIBILITY:
         case SMART_ACTION_WP_PAUSE:
         case SMART_ACTION_SET_FLY:
@@ -1225,7 +1224,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_ADD_GO_FLAG:
         case SMART_ACTION_REMOVE_GO_FLAG:
         case SMART_ACTION_SUMMON_CREATURE_GROUP:
-        case SMART_ACTION_RISE_UP:
+        case SMART_ACTION_MOVE_OFFSET:
         case SMART_ACTION_SET_CORPSE_DELAY:
             break;
         default:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -481,7 +481,6 @@ enum SMART_ACTION
     SMART_ACTION_MOUNT_TO_ENTRY_OR_MODEL            = 43,     // Creature_template entry(param1) OR ModelId (param2) (or 0 for both to dismount)
     SMART_ACTION_SET_INGAME_PHASE_MASK              = 44,     // mask
     SMART_ACTION_SET_DATA                           = 45,     // Field, Data (only creature @todo)
-    SMART_ACTION_MOVE_FORWARD                       = 46,     // distance
     SMART_ACTION_SET_VISIBILITY                     = 47,     // on/off
     SMART_ACTION_SET_ACTIVE                         = 48,     // on/off
     SMART_ACTION_ATTACK_START                       = 49,     //
@@ -549,7 +548,7 @@ enum SMART_ACTION
     SMART_ACTION_GAME_EVENT_STOP                    = 111,    // GameEventId
     SMART_ACTION_GAME_EVENT_START                   = 112,    // GameEventId
     SMART_ACTION_START_CLOSEST_WAYPOINT             = 113,    // wp1, wp2, wp3, wp4, wp5, wp6, wp7
-    SMART_ACTION_RISE_UP                            = 114,    // distance
+    SMART_ACTION_MOVE_OFFSET                        = 114,
     SMART_ACTION_RANDOM_SOUND                       = 115,    // soundId1, soundId2, soundId3, soundId4, soundId5, onlySelf
     SMART_ACTION_SET_CORPSE_DELAY                   = 116,    // timer
 

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -548,7 +548,7 @@ enum SMART_ACTION
     SMART_ACTION_GAME_EVENT_STOP                    = 111,    // GameEventId
     SMART_ACTION_GAME_EVENT_START                   = 112,    // GameEventId
     SMART_ACTION_START_CLOSEST_WAYPOINT             = 113,    // wp1, wp2, wp3, wp4, wp5, wp6, wp7
-    SMART_ACTION_MOVE_OFFSET                        = 114,    // movement
+    SMART_ACTION_MOVE_OFFSET                        = 114,
     SMART_ACTION_RANDOM_SOUND                       = 115,    // soundId1, soundId2, soundId3, soundId4, soundId5, onlySelf
     SMART_ACTION_SET_CORPSE_DELAY                   = 116,    // timer
 

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1030,6 +1030,11 @@ struct SmartAction
 
         struct
         {
+            uint32 movement;
+        } offsetMovement;
+
+        struct
+        {
             std::array<uint32, SMART_ACTION_PARAM_COUNT - 1> sounds;
             uint32 onlySelf;
         } randomSound;
@@ -1038,11 +1043,6 @@ struct SmartAction
         {
             uint32 timer;
         } corpseDelay;
-
-        struct
-        {
-            uint32 movement;
-        } offsetMovement;
 
         //! Note for any new future actions
         //! All parameters must have type uint32

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1030,11 +1030,6 @@ struct SmartAction
 
         struct
         {
-            uint32 movement;
-        } offsetMovement;
-
-        struct
-        {
             std::array<uint32, SMART_ACTION_PARAM_COUNT - 1> sounds;
             uint32 onlySelf;
         } randomSound;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -548,7 +548,7 @@ enum SMART_ACTION
     SMART_ACTION_GAME_EVENT_STOP                    = 111,    // GameEventId
     SMART_ACTION_GAME_EVENT_START                   = 112,    // GameEventId
     SMART_ACTION_START_CLOSEST_WAYPOINT             = 113,    // wp1, wp2, wp3, wp4, wp5, wp6, wp7
-    SMART_ACTION_MOVE_OFFSET                        = 114,
+    SMART_ACTION_MOVE_OFFSET                        = 114,    // movement
     SMART_ACTION_RANDOM_SOUND                       = 115,    // soundId1, soundId2, soundId3, soundId4, soundId5, onlySelf
     SMART_ACTION_SET_CORPSE_DELAY                   = 116,    // timer
 
@@ -1038,6 +1038,11 @@ struct SmartAction
         {
             uint32 timer;
         } corpseDelay;
+
+        struct
+        {
+            uint32 movement;
+        } offsetMovement;
 
         //! Note for any new future actions
         //! All parameters must have type uint32


### PR DESCRIPTION
**Changes proposed**:
Core/SmartAI: change SMART_ACTION_RISE_UP (114) to
 SMART_ACTION_MOVE_OFFSET and implement offset movement via target fields.

If action_param1 is set to 0, movement offset is calculated from orientation and will result in a forward (positive target_y), backward (negative target_y), right (positive target_x) or left (negative target_y) movement. Those can be combined to result in different directions.

If action_param1 is set to 1, movement is calculated using Position::RelocateOffset() which corresponds to how the game calculates offsets, resulting in different movement directions.

target_z controls height.

Also remove SMART_ACTION_MOVE_FORWARD.

Math taken from [LittleCarl's warp command](https://gist.github.com/Lillecarl/5378801).

**Target branch(es)**: 335

**Tests performed**: tested and working.

**Known issues and TODO list**:
- [x] Suggestions for a more appropriate name are still very welcome.
