### PR TITLE
[6.x] Core/Spells: Fix rogue talent "Death From Above"

### DIFF
--- a/sql/updates/world/6.x/9999_99_99_99_world.sql
+++ b/sql/updates/world/6.x/9999_99_99_99_world.sql
@@ -1,0 +1,14 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 152150;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES (152150, 163786, 0, 'Rogue - Talent Death From Above Damage Mods');
+
+DELETE FROM `disables` WHERE `sourceType`=0 AND `entry` = 156327;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES 
+(0, 156327, 64, '', '', 'Ignore LOS on Death from Above Jump');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` LIKE 'spell_rog_death_from_above%';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(152150, 'spell_rog_death_from_above'),
+(156327, 'spell_rog_death_from_above_jump_target'),
+(178070, 'spell_rog_death_from_above_damage'),
+(163786, 'spell_rog_death_from_above_dmg_aura'),
+(178236, 'spell_rog_death_from_above_pre_jump');

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -483,7 +483,7 @@ void MotionMaster::MoveFall(uint32 id /*=0*/)
     Mutate(new EffectMovementGenerator(id), MOTION_SLOT_CONTROLLED);
 }
 
-void MotionMaster::MoveCharge(float x, float y, float z, float speed /*= SPEED_CHARGE*/, uint32 id /*= EVENT_CHARGE*/, bool generatePath /*= false*/)
+void MotionMaster::MoveCharge(float x, float y, float z, float speed /*= SPEED_CHARGE*/, uint32 id /*= EVENT_CHARGE*/, bool generatePath /*= false*/, uint32 arrivalSpellId /*= 0*/, ObjectGuid const& arrivalSpellTargetGuid /*= ObjectGuid::Empty*/)
 {
     if (Impl[MOTION_SLOT_CONTROLLED] && Impl[MOTION_SLOT_CONTROLLED]->GetMovementGeneratorType() != DISTRACT_MOTION_TYPE)
         return;
@@ -491,13 +491,13 @@ void MotionMaster::MoveCharge(float x, float y, float z, float speed /*= SPEED_C
     if (_owner->GetTypeId() == TYPEID_PLAYER)
     {
         TC_LOG_DEBUG("misc", "Player (%s) charged point (X: %f Y: %f Z: %f).", _owner->GetGUID().ToString().c_str(), x, y, z);
-        Mutate(new PointMovementGenerator<Player>(id, x, y, z, generatePath, speed), MOTION_SLOT_CONTROLLED);
+        Mutate(new PointMovementGenerator<Player>(id, x, y, z, generatePath, speed, arrivalSpellId, arrivalSpellTargetGuid), MOTION_SLOT_CONTROLLED);
     }
     else
     {
         TC_LOG_DEBUG("misc", "Creature (Entry: %u %s) charged point (X: %f Y: %f Z: %f).",
             _owner->GetEntry(), _owner->GetGUID().ToString().c_str(), x, y, z);
-        Mutate(new PointMovementGenerator<Creature>(id, x, y, z, generatePath, speed), MOTION_SLOT_CONTROLLED);
+        Mutate(new PointMovementGenerator<Creature>(id, x, y, z, generatePath, speed, arrivalSpellId, arrivalSpellTargetGuid), MOTION_SLOT_CONTROLLED);
     }
 }
 

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -183,7 +183,7 @@ class TC_GAME_API MotionMaster //: private std::stack<MovementGenerator *>
         void MoveLand(uint32 id, Position const& pos);
         void MoveTakeoff(uint32 id, Position const& pos);
 
-        void MoveCharge(float x, float y, float z, float speed = SPEED_CHARGE, uint32 id = EVENT_CHARGE, bool generatePath = false);
+        void MoveCharge(float x, float y, float z, float speed = SPEED_CHARGE, uint32 id = EVENT_CHARGE, bool generatePath = false, uint32 arrivalSpellId = 0, ObjectGuid const& arrivalSpellTargetGuid = ObjectGuid::Empty);
         void MoveCharge(PathGenerator const& path, float speed = SPEED_CHARGE);
         void MoveKnockbackFrom(float srcX, float srcY, float speedXY, float speedZ);
         void MoveJumpTo(float angle, float speedXY, float speedZ);

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -86,6 +86,9 @@ bool PointMovementGenerator<T>::DoUpdate(T* unit, uint32 /*diff*/)
 template<class T>
 void PointMovementGenerator<T>::DoFinalize(T* unit)
 {
+    if (_arrivalSpellId)
+        unit->CastSpell(ObjectAccessor::GetUnit(*unit, _arrivalSpellTargetGuid), _arrivalSpellId, true);
+
     if (unit->HasUnitState(UNIT_STATE_CHARGING))
         unit->ClearUnitState(UNIT_STATE_ROAMING | UNIT_STATE_ROAMING_MOVE);
 

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
@@ -26,8 +26,10 @@ template<class T>
 class PointMovementGenerator : public MovementGeneratorMedium< T, PointMovementGenerator<T> >
 {
     public:
-        PointMovementGenerator(uint32 _id, float _x, float _y, float _z, bool _generatePath, float _speed = 0.0f) : id(_id),
-            i_x(_x), i_y(_y), i_z(_z), speed(_speed), m_generatePath(_generatePath), i_recalculateSpeed(false) { }
+        PointMovementGenerator(uint32 _id, float _x, float _y, float _z, bool _generatePath, float _speed = 0.0f, 
+            uint32 arrivalSpellId = 0, ObjectGuid const& arrivalSpellTargetGuid = ObjectGuid::Empty) : id(_id),
+            i_x(_x), i_y(_y), i_z(_z), speed(_speed), m_generatePath(_generatePath), i_recalculateSpeed(false),
+            _arrivalSpellId(arrivalSpellId), _arrivalSpellTargetGuid(arrivalSpellTargetGuid) { }
 
         void DoInitialize(T*);
         void DoFinalize(T*);
@@ -47,6 +49,8 @@ class PointMovementGenerator : public MovementGeneratorMedium< T, PointMovementG
         float speed;
         bool m_generatePath;
         bool i_recalculateSpeed;
+        uint32 _arrivalSpellId;
+        ObjectGuid _arrivalSpellTargetGuid;
 };
 
 class AssistanceMovementGenerator : public PointMovementGenerator<Creature>

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3073,6 +3073,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 44544: // Fingers of Frost
                 const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_0))->SpellClassMask = flag128(685904631, 1151048, 0, 0);
                 break;
+            case 152150: // Death from above Pre Jump
+                const_cast<SpellEffectInfo*>(spellInfo->GetEffect(EFFECT_6))->TriggerSpell = 178236;
+                break;
             case 28200: // Ascendance (Talisman of Ascendance trinket)
                 spellInfo->ProcCharges = 6;
                 break;

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -57,11 +57,268 @@ enum RogueSpells
     SPELL_ROGUE_HONOR_AMONG_THIEVES                 = 51698,
     SPELL_ROGUE_HONOR_AMONG_THIEVES_PROC            = 51699,
     SPELL_ROGUE_T5_2P_SET_BONUS                     = 37169
+    SPELL_ROGUE_TALENT_DFA_PREJUMP                  = 178236, // Executed with Base talent
+    SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD               = 163786, // Applied with Base talent
+    SPELL_ROGUE_TALENT_DFA                          = 152150, // Base talent
+    SPELL_ROGUE_TALENT_DFA_JUMP                     = 156327, // Jump - Triggered by Base Talent (jump to target)
+    SPELL_ROGUE_TALENT_DFA_JUMP_DUMMY               = 156527, // Triggered by Jump
+    SPELL_ROGUE_TALENT_DFA_DUMMY                    = 178070, // Casted after Jump
+    SPELL_ROGUE_ENVENOM                             = 32645,
+    SPELL_ROGUE_EVISCERATE                          = 2098,
 };
 
 enum RogueSpellIcons
 {
-    ICON_ROGUE_IMPROVED_RECUPERATE                  = 4819
+    ICON_ROGUE_IMPROVED_RECUPERATE = 4819
+};
+
+// 163786 - Death from above
+#define DFA_DmgModScriptName "spell_rog_death_from_above_dmg_aura"
+class spell_rog_death_from_above_dmg_aura : public SpellScriptLoader
+{
+public:
+    spell_rog_death_from_above_dmg_aura() : SpellScriptLoader(DFA_DmgModScriptName) { }
+
+    class spell_rog_death_from_above_dmg_aura_AuraScript : public AuraScript
+    {
+        PrepareAuraScript(spell_rog_death_from_above_dmg_aura_AuraScript);
+
+        void Register() override
+        {
+            // maybe needed
+        }
+
+    public:
+        void SetCpSpent(uint8 n)
+        {
+            cpSpent = n;
+        }
+        uint8 GetCpSpent()
+        {
+            return cpSpent;
+        }
+
+    private:
+        uint8 cpSpent;
+    };
+
+    AuraScript* GetAuraScript() const override
+    {
+        return new spell_rog_death_from_above_dmg_aura_AuraScript();
+    }
+};
+
+// 152150 - Death from above
+#define DFAScriptName "spell_rog_death_from_above"
+class spell_rog_death_from_above : public SpellScriptLoader
+{
+public:
+    spell_rog_death_from_above() : SpellScriptLoader(DFAScriptName) { }
+
+    class spell_rog_death_from_above_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_rog_death_from_above_SpellScript);
+
+        void HandleAfterHit()
+        {
+            if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD))
+            {
+                if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName(DFA_DmgModScriptName)))
+                    script->SetCpSpent(GetCaster()->ToPlayer()->GetComboPoints());
+            }
+            if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA))
+            {
+                if (spell_rog_death_from_above_AuraScript* script = dynamic_cast<spell_rog_death_from_above_AuraScript*>(aura->GetScriptByName(DFAScriptName)))
+                    script->SetTarget(GetExplTargetUnit()->GetGUID());
+            }
+        }
+
+        void Register() override
+        {
+            AfterHit += SpellHitFn(spell_rog_death_from_above_SpellScript::HandleAfterHit);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_rog_death_from_above_SpellScript();
+    }
+
+    class spell_rog_death_from_above_AuraScript : public AuraScript
+    {
+        PrepareAuraScript(spell_rog_death_from_above_AuraScript);
+
+        void HandlePeriodic(AuraEffect const* /*aurEff*/)
+        {
+            PreventDefaultAction();
+
+            if (Unit* affectedByAura = GetTarget())
+                if (Unit* target = ObjectAccessor::GetUnit(*GetTarget(), spellTarget))
+                    if (target->IsAlive() && !target->HasStealthAura() && !target->HasInvisibilityAura())
+                    {
+                        affectedByAura->CastSpell(target, SPELL_ROGUE_TALENT_DFA_JUMP, true);
+                        return;
+                    }
+            
+            GetCaster()->SetCanFly(false);
+        }
+
+        void EffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+        {
+            GetTarget()->SetCanFly(true);
+            GetTarget()->AddAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD, GetTarget());
+        }
+
+        void Register() override
+        {
+            OnEffectPeriodic += AuraEffectPeriodicFn(spell_rog_death_from_above_AuraScript::HandlePeriodic, EFFECT_5, SPELL_AURA_PERIODIC_DUMMY);
+            OnEffectApply += AuraEffectApplyFn(spell_rog_death_from_above_AuraScript::EffectApply, EFFECT_5, SPELL_AURA_PERIODIC_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        }
+
+    public:
+        void SetTarget(ObjectGuid target)
+        {
+            spellTarget = target;
+        }
+
+    private:
+        ObjectGuid spellTarget;
+    };
+
+    AuraScript* GetAuraScript() const override
+    {
+        return new spell_rog_death_from_above_AuraScript();
+    }
+};
+
+// 178070 - Death from above After jump to target dummy (damage)
+class spell_rog_death_from_above_damage : public SpellScriptLoader
+{
+public:
+    spell_rog_death_from_above_damage() : SpellScriptLoader("spell_rog_death_from_above_damage") { }
+
+    class spell_rog_death_from_above_damage_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_rog_death_from_above_damage_SpellScript);
+        
+        void HandleCast()
+        {
+            if (Unit* target = GetExplTargetUnit())
+            {
+                if (Unit* caster = GetCaster())
+                {
+                    caster->CastSpell(caster, SPELL_ROGUE_TALENT_DFA_JUMP_DUMMY);
+                    if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD))
+                    {
+                        if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName(DFA_DmgModScriptName)))
+                        {
+                            if (Player* player = caster->ToPlayer())
+                            {
+                                player->AddComboPoints(script->GetCpSpent());
+                                if (player->GetSpecId(player->GetActiveTalentGroup()) == TALENT_SPEC_ROGUE_ASSASSINATION)
+                                    caster->CastSpell(target, SPELL_ROGUE_ENVENOM, TRIGGERED_IGNORE_GCD);
+                                else
+                                    caster->CastSpell(target, SPELL_ROGUE_EVISCERATE, TRIGGERED_IGNORE_GCD);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void Register() override
+        {
+            OnCast += SpellCastFn(spell_rog_death_from_above_damage_SpellScript::HandleCast);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_rog_death_from_above_damage_SpellScript();
+    }
+};
+
+// 156327 - Death from above Jump to target
+class spell_rog_death_from_above_jump_target : public SpellScriptLoader
+{
+public:
+    spell_rog_death_from_above_jump_target() : SpellScriptLoader("spell_rog_death_from_above_jump_target") { }
+
+    class spell_rog_death_from_above_jump_target_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_rog_death_from_above_jump_target_SpellScript);
+        
+        void HandleLaunch(SpellEffIndex effIndex)
+        {
+            PreventHitEffect(EFFECT_1);
+        }
+
+        void HandleCast()
+        {
+            if (Unit* target = GetExplTargetUnit())
+            {
+                ObjectGuid const& targetGuid = target->GetGUID();
+                float x, y, z;
+                x = target->GetPositionX();
+                y = target->GetPositionY();
+                z = target->GetPositionZ();
+                GetCaster()->GetMotionMaster()->MoveCharge(x, y, z, 60.0f, EVENT_CHARGE, false, SPELL_ROGUE_TALENT_DFA_DUMMY, targetGuid);
+            }
+        }
+
+        void HandleAfter()
+        {
+            GetCaster()->SetCanFly(false);
+        }
+
+        void Register() override
+        {
+            OnEffectLaunch += SpellEffectFn(spell_rog_death_from_above_jump_target_SpellScript::HandleLaunch, EFFECT_1, SPELL_EFFECT_JUMP);
+            OnCast += SpellCastFn(spell_rog_death_from_above_jump_target_SpellScript::HandleCast);
+            AfterHit += SpellHitFn(spell_rog_death_from_above_jump_target_SpellScript::HandleAfter);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_rog_death_from_above_jump_target_SpellScript();
+    }
+};
+
+// 178236 - Death from above Pre Jump
+class spell_rog_death_from_above_pre_jump : public SpellScriptLoader
+{
+public:
+    spell_rog_death_from_above_pre_jump() : SpellScriptLoader("spell_rog_death_from_above_pre_jump") { }
+
+    class spell_rog_death_from_above_pre_jump_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_rog_death_from_above_pre_jump_SpellScript);
+
+        void HandleCast()
+        {
+            if (Unit* caster = GetCaster())
+            {
+                float casterX = caster->GetPositionX();
+                float casterY = caster->GetPositionY();
+                // float x = -std::cos(caster->GetRelativeAngle(casterX, casterY)) + caster->GetPositionX();
+                // float y = std::sin(caster->GetRelativeAngle(casterX, casterY)) + caster->GetPositionY();
+                float z = caster->GetPositionZ() + 8.0f;
+
+                caster->GetMotionMaster()->MoveJump(casterX, casterY, z, 9.0f, 9.0f);
+            }
+        }
+
+        void Register() override
+        {
+            OnCast += SpellCastFn(spell_rog_death_from_above_pre_jump_SpellScript::HandleCast);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_rog_death_from_above_pre_jump_SpellScript();
+    }
 };
 
 // 13877, 33735, (check 51211, 65956) - Blade Flurry
@@ -1052,6 +1309,11 @@ public:
 
 void AddSC_rogue_spell_scripts()
 {
+    new spell_rog_death_from_above_pre_jump();
+    new spell_rog_death_from_above();
+    new spell_rog_death_from_above_jump_target();
+    new spell_rog_death_from_above_damage();
+    new spell_rog_death_from_above_dmg_aura();
     new spell_rog_blade_flurry();
     new spell_rog_cheat_death();
     new spell_rog_crippling_poison();

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -64,7 +64,7 @@ enum RogueSpells
     SPELL_ROGUE_TALENT_DFA_JUMP_DUMMY               = 156527, // Triggered by Jump
     SPELL_ROGUE_TALENT_DFA_DUMMY                    = 178070, // Casted after Jump
     SPELL_ROGUE_ENVENOM                             = 32645,
-    SPELL_ROGUE_EVISCERATE                          = 2098,
+    SPELL_ROGUE_EVISCERATE                          = 2098
 };
 
 enum RogueSpellIcons
@@ -120,15 +120,12 @@ public:
         void HandleAfterHit()
         {
             if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD))
-            {
                 if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName("spell_rog_death_from_above_dmg_aura")))
                     script->SetCpSpent(GetCaster()->ToPlayer()->GetComboPoints());
-            }
+
             if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA))
-            {
                 if (spell_rog_death_from_above_AuraScript* script = dynamic_cast<spell_rog_death_from_above_AuraScript*>(aura->GetScriptByName("spell_rog_death_from_above")))
                     script->SetTarget(GetExplTargetUnit()->GetGUID());
-            }
         }
 
         void Register() override
@@ -207,9 +204,7 @@ public:
                 {
                     caster->CastSpell(caster, SPELL_ROGUE_TALENT_DFA_JUMP_DUMMY);
                     if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD))
-                    {
                         if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName("spell_rog_death_from_above_dmg_aura")))
-                        {
                             if (Player* player = caster->ToPlayer())
                             {
                                 player->AddComboPoints(script->GetCpSpent());
@@ -218,8 +213,6 @@ public:
                                 else
                                     caster->CastSpell(target, SPELL_ROGUE_EVISCERATE, TRIGGERED_IGNORE_GCD);
                             }
-                        }
-                    }
                 }
             }
         }
@@ -256,11 +249,7 @@ public:
             if (Unit* target = GetExplTargetUnit())
             {
                 ObjectGuid const& targetGuid = target->GetGUID();
-                float x, y, z;
-                x = target->GetPositionX();
-                y = target->GetPositionY();
-                z = target->GetPositionZ();
-                GetCaster()->GetMotionMaster()->MoveCharge(x, y, z, 60.0f, EVENT_CHARGE, false, SPELL_ROGUE_TALENT_DFA_DUMMY, targetGuid);
+                GetCaster()->GetMotionMaster()->MoveCharge(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), 60.0f, EVENT_CHARGE, false, SPELL_ROGUE_TALENT_DFA_DUMMY, targetGuid);
             }
         }
 
@@ -296,15 +285,7 @@ public:
         void HandleCast()
         {
             if (Unit* caster = GetCaster())
-            {
-                float casterX = caster->GetPositionX();
-                float casterY = caster->GetPositionY();
-                // float x = -std::cos(caster->GetRelativeAngle(casterX, casterY)) + caster->GetPositionX();
-                // float y = std::sin(caster->GetRelativeAngle(casterX, casterY)) + caster->GetPositionY();
-                float z = caster->GetPositionZ() + 8.0f;
-
-                caster->GetMotionMaster()->MoveJump(casterX, casterY, z, caster->GetOrientation(), 9.0f, 9.0f);
-            }
+                caster->GetMotionMaster()->MoveJump(caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ() + 8.0f, caster->GetOrientation(), 9.0f, 9.0f);
         }
 
         void Register() override

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -73,11 +73,10 @@ enum RogueSpellIcons
 };
 
 // 163786 - Death from above
-#define DFA_DmgModScriptName "spell_rog_death_from_above_dmg_aura"
 class spell_rog_death_from_above_dmg_aura : public SpellScriptLoader
 {
 public:
-    spell_rog_death_from_above_dmg_aura() : SpellScriptLoader(DFA_DmgModScriptName) { }
+    spell_rog_death_from_above_dmg_aura() : SpellScriptLoader("spell_rog_death_from_above_dmg_aura") { }
 
     class spell_rog_death_from_above_dmg_aura_AuraScript : public AuraScript
     {
@@ -109,11 +108,10 @@ public:
 };
 
 // 152150 - Death from above
-#define DFAScriptName "spell_rog_death_from_above"
 class spell_rog_death_from_above : public SpellScriptLoader
 {
 public:
-    spell_rog_death_from_above() : SpellScriptLoader(DFAScriptName) { }
+    spell_rog_death_from_above() : SpellScriptLoader("spell_rog_death_from_above") { }
 
     class spell_rog_death_from_above_SpellScript : public SpellScript
     {
@@ -123,12 +121,12 @@ public:
         {
             if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD))
             {
-                if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName(DFA_DmgModScriptName)))
+                if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName("spell_rog_death_from_above_dmg_aura")))
                     script->SetCpSpent(GetCaster()->ToPlayer()->GetComboPoints());
             }
             if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA))
             {
-                if (spell_rog_death_from_above_AuraScript* script = dynamic_cast<spell_rog_death_from_above_AuraScript*>(aura->GetScriptByName(DFAScriptName)))
+                if (spell_rog_death_from_above_AuraScript* script = dynamic_cast<spell_rog_death_from_above_AuraScript*>(aura->GetScriptByName("spell_rog_death_from_above")))
                     script->SetTarget(GetExplTargetUnit()->GetGUID());
             }
         }
@@ -210,7 +208,7 @@ public:
                     caster->CastSpell(caster, SPELL_ROGUE_TALENT_DFA_JUMP_DUMMY);
                     if (Aura* aura = GetCaster()->GetAura(SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD))
                     {
-                        if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName(DFA_DmgModScriptName)))
+                        if (spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript* script = dynamic_cast<spell_rog_death_from_above_dmg_aura::spell_rog_death_from_above_dmg_aura_AuraScript*>(aura->GetScriptByName("spell_rog_death_from_above_dmg_aura")))
                         {
                             if (Player* player = caster->ToPlayer())
                             {
@@ -248,7 +246,7 @@ public:
     {
         PrepareSpellScript(spell_rog_death_from_above_jump_target_SpellScript);
         
-        void HandleLaunch(SpellEffIndex effIndex)
+        void HandleLaunch(SpellEffIndex /*effIndex*/)
         {
             PreventHitEffect(EFFECT_1);
         }

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -303,7 +303,7 @@ public:
                 // float y = std::sin(caster->GetRelativeAngle(casterX, casterY)) + caster->GetPositionY();
                 float z = caster->GetPositionZ() + 8.0f;
 
-                caster->GetMotionMaster()->MoveJump(casterX, casterY, z, 9.0f, 9.0f);
+                caster->GetMotionMaster()->MoveJump(casterX, casterY, z, caster->GetOrientation(), 9.0f, 9.0f);
             }
         }
 

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -56,7 +56,7 @@ enum RogueSpells
     SPELL_ROGUE_RUPTURE                             = 1943,
     SPELL_ROGUE_HONOR_AMONG_THIEVES                 = 51698,
     SPELL_ROGUE_HONOR_AMONG_THIEVES_PROC            = 51699,
-    SPELL_ROGUE_T5_2P_SET_BONUS                     = 37169
+    SPELL_ROGUE_T5_2P_SET_BONUS                     = 37169,
     SPELL_ROGUE_TALENT_DFA_PREJUMP                  = 178236, // Executed with Base talent
     SPELL_ROGUE_TALENT_DFA_DAMAGE_MOD               = 163786, // Applied with Base talent
     SPELL_ROGUE_TALENT_DFA                          = 152150, // Base talent


### PR DESCRIPTION
**Changes proposed**:
- Fixes Talent http://www.wowhead.com/spell=152150
- Sniffed all the spells to use them correctly
- Code needs improvement (!!!)

**Target branch(es)**: 6x

**Tests performed**: Tested Ingame https://www.youtube.com/watch?v=jmPTmxH01Uc&feature=youtu.be

**Known issues and TODO list**:
- [ ] Overall code improvements
- [ ] CastSpell() needs some parameter to make a spell cast with a certain amount of combopoints

Combopoints are currently saved on first spell use and then cleared & reapplied on last spell use (HACKY)

Please beware, that this code is maybe not final - So stop nasty nit picking and start contributing to this base code for Death from Above.
