### PR TITLE
[6.x] Scripts/Monk: Renewing Mist

### DIFF
--- a/sql/updates/world/6.x/9999_99_99_99_world.sql
+++ b/sql/updates/world/6.x/9999_99_99_99_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_monk_renewing_mist', 'spell_monk_renewing_mist_periodic_heal', 'spell_monk_renewing_mist_target_selector');
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(115151,'spell_monk_renewing_mist'),
+(119611,'spell_monk_renewing_mist_periodic_heal'),
+(119607,'spell_monk_renewing_mist_target_selector');

--- a/src/server/scripts/Spells/spell_monk.cpp
+++ b/src/server/scripts/Spells/spell_monk.cpp
@@ -38,7 +38,7 @@ enum MonkSpells
     SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL              = 119611,
     SPELL_MONK_RENEWING_MIST_TARGET_SELECT              = 119607,
     SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL               = 119647,
-    SPELL_MONK_STANCE_OF_THE_SPIRITED_CRANE             = 154436,
+    SPELL_MONK_STANCE_OF_THE_SPIRITED_CRANE             = 154436
 };
 
 // 117952 - Crackling Jade Lightning
@@ -288,10 +288,7 @@ class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
             PrepareSpellScript(spell_monk_renewing_mist_target_selector_SpellScript);
 
         public:
-            spell_monk_renewing_mist_target_selector_SpellScript()
-            {
-                emptyTargets = false;
-            }
+            spell_monk_renewing_mist_target_selector_SpellScript() { }
 
         private:
             bool Validate(SpellInfo const* /*spellInfo*/) override
@@ -311,10 +308,7 @@ class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
                 {
                     targets.remove(GetExplTargetWorldObject());
                     if (targets.empty())
-                    {
-                        emptyTargets = true;
                         return;
-                    }
                     targets.sort(Trinity::HealthPctOrderPred());
                     targets.resize(eff->BasePoints);
                 }
@@ -323,16 +317,15 @@ class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
             void HandleDummy(SpellEffIndex effIndex)
             {
                 PreventHitDefaultEffect(effIndex);
-                if (!emptyTargets)
-                    if (Unit* target = GetHitUnit())
-                        if (Aura* aura = GetExplTargetUnit()->GetAura(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, GetCaster()->GetGUID()))
-                            if (AuraEffect* effect = aura->GetEffect(EFFECT_1))
-                            {
-                                GetExplTargetUnit()->CastSpell(target, SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL, true);
-                                aura->SetCharges(0);
-                                int32 bp1 = std::max(0, effect->GetAmount() - 1);
-                                GetExplTargetUnit()->CastCustomSpell(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, SPELLVALUE_BASE_POINT1, bp1, target, true, 0, effect, GetCaster()->GetGUID());
-                            }
+                if (Unit* target = GetHitUnit())
+                    if (Aura* aura = GetExplTargetUnit()->GetAura(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, GetCaster()->GetGUID()))
+                        if (AuraEffect* effect = aura->GetEffect(EFFECT_1))
+                        {
+                            GetExplTargetUnit()->CastSpell(target, SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL, true);
+                            aura->SetCharges(0);
+                            int32 bp1 = std::max(0, effect->GetAmount() - 1);
+                            GetExplTargetUnit()->CastCustomSpell(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, SPELLVALUE_BASE_POINT1, bp1, target, true, 0, effect, GetCaster()->GetGUID());
+                        }
             }
 
             void Register() override

--- a/src/server/scripts/Spells/spell_monk.cpp
+++ b/src/server/scripts/Spells/spell_monk.cpp
@@ -34,6 +34,10 @@ enum MonkSpells
     SPELL_MONK_CRACKLING_JADE_LIGHTNING_KNOCKBACK_CD    = 117953,
     SPELL_MONK_PROVOKE_SINGLE_TARGET                    = 116189,
     SPELL_MONK_PROVOKE_AOE                              = 118635,
+    SPELL_MONK_RENEWING_MIST                            = 115151,
+    SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL              = 119611,
+    SPELL_MONK_RENEWING_MIST_TARGET_SELECT              = 119607,
+    SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL               = 119647,
     SPELL_MONK_STANCE_OF_THE_SPIRITED_CRANE             = 154436,
 };
 
@@ -186,9 +190,172 @@ public:
     }
 };
 
+// 115151 - Renewing Mist
+class spell_monk_renewing_mist : public SpellScriptLoader
+{
+    public:
+        spell_monk_renewing_mist() : SpellScriptLoader("spell_monk_renewing_mist") { }
+
+        class spell_monk_renewing_mist_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_monk_renewing_mist_SpellScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_TARGET_SELECT))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL))
+                    return false;
+                return true;
+            }
+
+            void HandleDummy(SpellEffIndex effIndex)
+            {
+                PreventHitDefaultEffect(effIndex);
+                GetCaster()->CastSpell(GetHitUnit(), SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, true);
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_monk_renewing_mist_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_monk_renewing_mist_SpellScript();
+        }
+};
+
+// 119611 - Renewing Mist Periodic Heal
+class spell_monk_renewing_mist_periodic_heal : public SpellScriptLoader
+{
+    public:
+        spell_monk_renewing_mist_periodic_heal() : SpellScriptLoader("spell_monk_renewing_mist_periodic_heal") { }
+
+        class spell_monk_renewing_mist_periodic_heal_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_monk_renewing_mist_periodic_heal_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_TARGET_SELECT))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL))
+                    return false;
+                return true;
+            }
+
+            void HandlePeriodic(AuraEffect const* aurEff)
+            {
+                if (aurEff->GetBase()->GetCharges() > 1)
+                    if (Unit* originCaster = GetCaster())
+                        originCaster->CastSpell(GetTarget(), SPELL_MONK_RENEWING_MIST_TARGET_SELECT, true);
+            }
+
+            void HandleDummy(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+            {
+                aurEff->GetBase()->SetCharges(aurEff->GetAmount());
+            }
+
+            void Register() override
+            {
+                OnEffectPeriodic += AuraEffectPeriodicFn(spell_monk_renewing_mist_periodic_heal_AuraScript::HandlePeriodic, EFFECT_0, SPELL_AURA_PERIODIC_HEAL);
+                OnEffectApply += AuraEffectApplyFn(spell_monk_renewing_mist_periodic_heal_AuraScript::HandleDummy, EFFECT_1, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new spell_monk_renewing_mist_periodic_heal_AuraScript();
+        }
+};
+
+// 119607 - Renewing Mist Target Selection
+class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
+{
+    public:
+        spell_monk_renewing_mist_target_selector() : SpellScriptLoader("spell_monk_renewing_mist_target_selector") { }
+
+        class spell_monk_renewing_mist_target_selector_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_monk_renewing_mist_target_selector_SpellScript);
+
+        public:
+            spell_monk_renewing_mist_target_selector_SpellScript()
+            {
+                emptyTargets = false;
+            }
+
+        private:
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_TARGET_SELECT))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL))
+                    return false;
+                return true;
+            }
+
+            void FilterTargets(std::list<WorldObject*>& targets)
+            {
+                if (SpellEffectInfo const* eff = GetSpellInfo()->GetEffect(EFFECT_1))
+                {
+                    targets.remove(GetExplTargetWorldObject());
+                    if (targets.empty())
+                    {
+                        emptyTargets = true;
+                        return;
+                    }
+                    targets.sort(Trinity::HealthPctOrderPred());
+                    targets.resize(eff->BasePoints);
+                }
+            }
+
+            void HandleDummy(SpellEffIndex effIndex)
+            {
+                PreventHitDefaultEffect(effIndex);
+                if (!emptyTargets)
+                    if (Unit* target = GetHitUnit())
+                        if (Aura* aura = GetExplTargetUnit()->GetAura(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, GetCaster()->GetGUID()))
+                            if (AuraEffect* effect = aura->GetEffect(EFFECT_1))
+                            {
+                                GetExplTargetUnit()->CastSpell(target, SPELL_MONK_RENEWING_MIST_DUMMY_VISUAL, true);
+                                aura->SetCharges(0);
+                                int32 bp1 = std::max(0, effect->GetAmount() - 1);
+                                GetExplTargetUnit()->CastCustomSpell(SPELL_MONK_RENEWING_MIST_PERIODIC_HEAL, SPELLVALUE_BASE_POINT1, bp1, target, true, 0, effect, GetCaster()->GetGUID());
+                            }
+            }
+
+            void Register() override
+            {
+                OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_monk_renewing_mist_target_selector_SpellScript::FilterTargets, EFFECT_1, TARGET_UNIT_DEST_AREA_ALLY);
+                OnEffectHitTarget += SpellEffectFn(spell_monk_renewing_mist_target_selector_SpellScript::HandleDummy, EFFECT_1, SPELL_EFFECT_DUMMY);
+            }
+
+            bool emptyTargets;
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_monk_renewing_mist_target_selector_SpellScript();
+        }
+};
+
 void AddSC_monk_spell_scripts()
 {
     new spell_monk_crackling_jade_lightning();
     new spell_monk_crackling_jade_lightning_knockback_proc_aura();
     new spell_monk_provoke();
+    new spell_monk_renewing_mist();
+    new spell_monk_renewing_mist_periodic_heal();
+    new spell_monk_renewing_mist_target_selector();
 }

--- a/src/server/scripts/Spells/spell_monk.cpp
+++ b/src/server/scripts/Spells/spell_monk.cpp
@@ -310,7 +310,7 @@ class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
                     if (targets.empty())
                         return;
                     targets.sort(Trinity::HealthPctOrderPred());
-                    targets.resize(eff->BasePoints);
+                    targets.resize(1);
                 }
             }
 
@@ -333,8 +333,6 @@ class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
                 OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_monk_renewing_mist_target_selector_SpellScript::FilterTargets, EFFECT_1, TARGET_UNIT_DEST_AREA_ALLY);
                 OnEffectHitTarget += SpellEffectFn(spell_monk_renewing_mist_target_selector_SpellScript::HandleDummy, EFFECT_1, SPELL_EFFECT_DUMMY);
             }
-
-            bool emptyTargets;
         };
 
         SpellScript* GetSpellScript() const override

--- a/src/server/scripts/Spells/spell_monk.cpp
+++ b/src/server/scripts/Spells/spell_monk.cpp
@@ -304,14 +304,11 @@ class spell_monk_renewing_mist_target_selector : public SpellScriptLoader
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
-                if (SpellEffectInfo const* eff = GetSpellInfo()->GetEffect(EFFECT_1))
-                {
-                    targets.remove(GetExplTargetWorldObject());
-                    if (targets.empty())
-                        return;
-                    targets.sort(Trinity::HealthPctOrderPred());
-                    targets.resize(1);
-                }
+                targets.remove(GetExplTargetWorldObject());
+                if (targets.empty())
+                    return;
+                targets.sort(Trinity::HealthPctOrderPred());
+                targets.resize(1);
             }
 
             void HandleDummy(SpellEffIndex effIndex)


### PR DESCRIPTION
**Changes proposed**:
- Renewing Mist jumps from target to target and applies the heal
- Sniffs: http://npaste.de/p/GJbK/

**Target branch(es)**: 6x

**Tests performed**: See TODO list

**Known issues and TODO list**:
- [x] Test Ingame
- [ ] Code Improvements (!!)
- [ ] Bug: Aura is not "Reapplied" when the monk casts it again on a target which has it already (and thus basepoints are not set back to original value of 3.
