### PR TITLE
Core/Battlenet: Allow player to switch realm

### DIFF
--- a/src/server/game/Handlers/BattlenetHandler.cpp
+++ b/src/server/game/Handlers/BattlenetHandler.cpp
@@ -31,6 +31,7 @@ void WorldSession::HandleBattlenetRequestRealmListTicket(WorldPackets::Battlenet
 
     WorldPackets::Battlenet::RealmListTicket realmListTicket;
     realmListTicket.Token = requestRealmListTicket.Token;
+    realmListTicket.Allow = true;
     realmListTicket.Ticket << "WorldserverRealmListTicket";
 
     SendPacket(realmListTicket.Write());


### PR DESCRIPTION
Changes proposed: Permit to the player to switch to another realm after joining one.

Target branch(es): 6x

Issues addressed: #17422

Tests performed: Yes and confirmed by @et65 
