### PR TITLE
Core/Event: prevent seasonal quests from resetting at server restart

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -139,6 +139,9 @@ bool GameEventMgr::StartEvent(uint16 event_id, bool overwrite)
             if (data.end <= data.start)
                 data.end = data.start + data.length;
         }
+
+        // When event is started, set its worldstate to current time
+        sWorld->setWorldState(event_id, time(NULL));
         return false;
     }
     else
@@ -173,6 +176,9 @@ void GameEventMgr::StopEvent(uint16 event_id, bool overwrite)
 
     RemoveActiveEvent(event_id);
     UnApplyEvent(event_id);
+
+    // When event is stopped, clean up its worldstate
+    sWorld->setWorldState(event_id, 0);
 
     if (overwrite && !serverwide_evt)
     {
@@ -1033,6 +1039,8 @@ uint32 GameEventMgr::Update()                               // return the next e
         }
         else
         {
+            // If event is inactive, periodically clean up its worldstate
+            sWorld->setWorldState(itr, 0);
             //TC_LOG_DEBUG("misc", "GameEvent %u is not active", itr->first);
             if (IsActiveEvent(itr))
                 deactivate.insert(itr);
@@ -1115,8 +1123,9 @@ void GameEventMgr::ApplyNewEvent(uint16 event_id)
     UpdateEventNPCVendor(event_id, true);
     // update bg holiday
     UpdateBattlegroundSettings();
-    // Only reset seasonal quests if event manager is active (after server startup)
-    if (isSystemInit)
+    // If event's worldstate is 0, it means the event hasn't been started yet. In that case, reset seasonal quests.
+    // When event ends (if it expires or if it's stopped via commands) worldstate will be set to 0 again, ready for another seasonal quest reset.
+    if (sWorld->getWorldState(event_id) == 0)
         sWorld->ResetEventSeasonalQuests(event_id);
 }
 

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1115,8 +1115,9 @@ void GameEventMgr::ApplyNewEvent(uint16 event_id)
     UpdateEventNPCVendor(event_id, true);
     // update bg holiday
     UpdateBattlegroundSettings();
-    // check for seasonal quest reset.
-    sWorld->ResetEventSeasonalQuests(event_id);
+    // Only reset seasonal quests if event manager is active (after server startup)
+    if (isSystemInit)
+        sWorld->ResetEventSeasonalQuests(event_id);
 }
 
 void GameEventMgr::UpdateEventNPCFlags(uint16 event_id)


### PR DESCRIPTION
**Changes proposed**:
- Only reset seasonal quests at event startup if event manager is active (after server startup). Prevents seasonal quests from resetting at server restart.

This pr uses worldstates to check if an event has already been started.
- When an event is started, its worldstate is set to the current unix timestamp.
- When an event ends (automatically stopped by the event manager or via commands), the worldstate is set to 0.
- At every event manager update tick (which happens whenever an event is set to be started or stopped), every inactive event has its worldstate set to 0. This allows for cleanup of events that end while the server is offline,

**Target branch(es)**: 335 (but should be cherrypicked to 6.x too).

**Issues addressed**:
Closes #16015.
Closes #16413.

**Tests performed**: tested and working.
