### PR TITLE
Core/Quest: do not save/load Dungeon Finder/daily/repeatable quests as completed

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15008,8 +15008,12 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
         SetSeasonalQuestStatus(quest_id);
 
     RemoveActiveQuest(quest_id, false);
-    m_RewardedQuests.insert(quest_id);
-    m_RewardedQuestsSave[quest_id] = QUEST_DEFAULT_SAVE_TYPE;
+    if (!quest->IsDFQuest() && !quest->IsDaily() && (!quest->IsRepeatable() || quest->IsWeekly() || quest->IsMonthly() || quest->IsSeasonal()))
+    {
+        // Dungeon Finder/daily/repeatable quests should not be added to the rewarded quest table
+        m_RewardedQuests.insert(quest_id);
+        m_RewardedQuestsSave[quest_id] = QUEST_DEFAULT_SAVE_TYPE;
+    }
 
     // StoreNewItem, mail reward, etc. save data directly to the database
     // to prevent exploitable data desynchronisation we save the quest status to the database too
@@ -18275,6 +18279,10 @@ void Player::_LoadQuestStatusRewarded(PreparedQueryResult result)
                 if (quest->GetBonusTalents())
                     m_questRewardTalentCount += quest->GetBonusTalents();
             }
+
+            // Dungeon Finder/daily/repeatable quests should not be loaded as completed quests from character_queststatus_rewarded table
+            if (quest->IsDFQuest() || quest->IsDaily() || (quest->IsRepeatable() && !quest->IsWeekly() && !quest->IsMonthly() && !quest->IsSeasonal()))
+                continue;
 
             m_RewardedQuests.insert(quest_id);
         }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15008,7 +15008,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
         SetSeasonalQuestStatus(quest_id);
 
     RemoveActiveQuest(quest_id, false);
-    if (!quest->IsDFQuest() && !quest->IsDaily() && (!quest->IsRepeatable() || quest->IsWeekly() || quest->IsMonthly() || quest->IsSeasonal()))
+    if (quest->CanIncreaseRewardedQuestCounters())
     {
         // Dungeon Finder/daily/repeatable quests should not be added to the rewarded quest table
         m_RewardedQuests.insert(quest_id);
@@ -18280,11 +18280,8 @@ void Player::_LoadQuestStatusRewarded(PreparedQueryResult result)
                     m_questRewardTalentCount += quest->GetBonusTalents();
             }
 
-            // Dungeon Finder/daily/repeatable quests should not be loaded as completed quests from character_queststatus_rewarded table
-            if (quest->IsDFQuest() || quest->IsDaily() || (quest->IsRepeatable() && !quest->IsWeekly() && !quest->IsMonthly() && !quest->IsSeasonal()))
-                continue;
-
-            m_RewardedQuests.insert(quest_id);
+            if (quest->CanIncreaseRewardedQuestCounters())
+                m_RewardedQuests.insert(quest_id);
         }
         while (result->NextRow());
     }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15010,7 +15010,6 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     RemoveActiveQuest(quest_id, false);
     if (quest->CanIncreaseRewardedQuestCounters())
     {
-        // Dungeon Finder/daily/repeatable quests should not be added to the rewarded quest table
         m_RewardedQuests.insert(quest_id);
         m_RewardedQuestsSave[quest_id] = QUEST_DEFAULT_SAVE_TYPE;
     }

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -285,3 +285,10 @@ uint32 Quest::CalculateHonorGain(uint8 level) const
 
     return honor;
 }
+
+bool Quest::CanIncreaseRewardedQuestCounters()
+{
+    // Dungeon Finder/Daily/Repeatable (if not weekly, monthly or seasonal) quests are never considered rewarded serverside.
+    // This affects counters and client requests for completed quests.
+    return (!IsDFQuest() && !IsDaily() && (!IsRepeatable() || IsWeekly() || IsMonthly() || IsSeasonal()));
+}

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -286,7 +286,7 @@ uint32 Quest::CalculateHonorGain(uint8 level) const
     return honor;
 }
 
-bool Quest::CanIncreaseRewardedQuestCounters()
+bool Quest::CanIncreaseRewardedQuestCounters() const
 {
     // Dungeon Finder/Daily/Repeatable (if not weekly, monthly or seasonal) quests are never considered rewarded serverside.
     // This affects counters and client requests for completed quests.

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -276,7 +276,7 @@ class TC_GAME_API Quest
         bool   IsAllowedInRaid(Difficulty difficulty) const;
         bool   IsDFQuest() const { return (SpecialFlags & QUEST_SPECIAL_FLAGS_DF_QUEST) != 0; }
         uint32 CalculateHonorGain(uint8 level) const;
-        bool   CanIncreaseRewardedQuestCounters();
+        bool   CanIncreaseRewardedQuestCounters() const;
 
         // multiple values
         std::string ObjectiveText[QUEST_OBJECTIVES_COUNT];

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -276,6 +276,7 @@ class TC_GAME_API Quest
         bool   IsAllowedInRaid(Difficulty difficulty) const;
         bool   IsDFQuest() const { return (SpecialFlags & QUEST_SPECIAL_FLAGS_DF_QUEST) != 0; }
         uint32 CalculateHonorGain(uint8 level) const;
+        bool   CanIncreaseRewardedQuestCounters();
 
         // multiple values
         std::string ObjectiveText[QUEST_OBJECTIVES_COUNT];


### PR DESCRIPTION
**Changes proposed**:
Dungeon Finder/daily/repeatable quests should never be added to the "completed quests" list. Those quests do not count as completed in Loremaster-related achievements as well as other counters in statistics. Only weekly/monthly/seasonal quests count for those criterias.
- Random [source](http://www.wowhead.com/achievement=976/500-daily-quests-complete#comments:id=1633928) to confirm that daily quests don't count for Loremaster-related criterias.
- Random [source](http://www.wowhead.com/quest=8771/target-hiveashi-sandstalkers#comments:id=551784), and another [source](http://www.wowhead.com/quest=9742/more-spore-sacs#comments:id=1628946) (and there's a lot more in almost any repeatable quest's comments on Wowhead) to confirm that repeatable ([non-seasonal](http://www.mmo-champion.com/threads/632249-Horde-3000-Quests-Loremaster?p=5988507&viewfull=1#post5988507), non-weekly (tested on ptr), [non-monthly](http://www.wowhead.com/quest=9887/membership-benefits#comments:id=1611914)) quests don't count for Loremaster-related criterias.

**Target branch(es)**: 335/6x

**Tests performed**: tested and working.

**Known issues and TODO list**:
- [x]  Maybe a better way to check for it? It's a very specific check, so I'm not sure how to shorten it whilst keeping the intended functionality (seems already fine, though).
