### PR TITLE
Code/Battleground Opening a game object(banner) under absorb effects …

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -634,7 +634,7 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
                    if (spell->getState() == SPELL_STATE_PREPARING)
                    {
                        uint32 interruptFlags = spell->m_spellInfo->InterruptFlags;
-                       if (interruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG)
+                       if ((interruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG) != 0)
                            victim->InterruptNonMeleeSpells(false);
                    }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -627,6 +627,17 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
         else
             victim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TAKE_DAMAGE, 0);
 
+       // interrupt spells with SPELL_INTERRUPT_FLAG_ABORT_ON_DMG on absorbed damage (no dots)
+       if (!damage && damagetype != DOT && cleanDamage && cleanDamage->absorbed_damage)
+           if (victim != this && victim->GetTypeId() == TYPEID_PLAYER)
+               if (Spell* spell = victim->m_currentSpells[CURRENT_GENERIC_SPELL])
+                   if (spell->getState() == SPELL_STATE_PREPARING)
+                   {
+                       uint32 interruptFlags = spell->m_spellInfo->InterruptFlags;
+                       if (interruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG)
+                           victim->InterruptNonMeleeSpells(false);
+                   }
+
         // We're going to call functions which can modify content of the list during iteration over it's elements
         // Let's copy the list so we can prevent iterator invalidation
         AuraEffectList vCopyDamageCopy(victim->GetAuraEffectsByType(SPELL_AURA_SHARE_DAMAGE_PCT));


### PR DESCRIPTION
**Changes proposed**:
- If you're opening a banner for example at arathi basin and got hit by an enemy player, your current opening should be interupted. Problem is that it doesn't work on players with absorbing shields (like Ice barrier and so on)

**Target branch(es)**: 335/6x

**Issues addressed**: Closes #6222

**Tests performed**: (Does it build, tested in-game, etc)

…in battlegrounds should result an interupt

By zwerg, closes #6222
