### PR TITLE
Event/Midsummer: improve pole ribbon functionality

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -11,10 +11,12 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (13, 1, 29726, 0, 0, 31, 0, 3, 17066, 0, 0, 0, 0, "", "Spell 'Test Ribbon Pole Channel' targets creature 'Ribbon Pole Debug Target'");
 UPDATE `gameobject_template` SET `ScriptName`="go_midsummer_ribbon_pole" WHERE `entry`=181605;
 
-DELETE FROM `disables` WHERE `sourceType`=0 AND `entry`=46842;
+DELETE FROM `disables` WHERE `sourceType`=0 AND `entry` IN (46836, 46842);
 INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0, 46836, 64, 0, "", "Spell Flame Patch - Ignore LOS"),
 (0, 46842, 64, 0, "", "Spell Flame Ring - Ignore LOS");
 
 UPDATE `creature_template_addon` SET `bytes1`=33554688 WHERE `entry`=17066;
 DELETE FROM `creature_addon` WHERE `guid` IN (SELECT `guid` FROM `creature` WHERE `id`=17066);
 UPDATE `creature` SET `MovementType`=0, `spawndist`=0 WHERE `id`=17066;
+UPDATE `creature_template` SET `ScriptName`="npc_midsummer_bunny_pole" WHERE `entry`=17066;

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,20 @@
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (29531, 45390, 29726); 
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(29726, 45406, 1, "Holiday - Midsummer, Ribbon Pole Periodic Visual");
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (45390, 45406);
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(45406, "spell_gen_ribbon_pole_dancer_check");
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`=29726;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 29726, 0, 0, 31, 0, 3, 17066, 0, 0, 0, 0, "", "Spell 'Test Ribbon Pole Channel' targets creature 'Ribbon Pole Debug Target'");
+UPDATE `gameobject_template` SET `ScriptName`="go_midsummer_ribbon_pole" WHERE `entry`=181605;
+
+DELETE FROM `disables` WHERE `sourceType`=0 AND `entry`=46842;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0, 46842, 64, 0, "", "Spell Flame Ring - Ignore LOS");
+
+UPDATE `creature_template_addon` SET `bytes1`=33554688 WHERE `entry`=17066;
+DELETE FROM `creature_addon` WHERE `guid` IN (SELECT `guid` FROM `creature` WHERE `id`=17066);
+UPDATE `creature` SET `MovementType`=0, `spawndist`=0 WHERE `id`=17066;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3350,7 +3350,11 @@ void SpellMgr::LoadSpellInfoCorrections()
                 spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
                 break;
             case 46842: // Flame Ring
+            case 46836: // Flame Patch
                 spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo();
+                break;
+            case 29726: // Test Ribbon Pole Channel
+                spellInfo->InterruptFlags &= ~AURA_INTERRUPT_FLAG_CAST;
                 break;
             // VIOLET HOLD SPELLS
             //

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3349,6 +3349,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 42492: // Cast Energized
                 spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
                 break;
+            case 46842: // Flame Ring
+                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo();
+                break;
             // VIOLET HOLD SPELLS
             //
             case 54258: // Water Globule (Ichoron)

--- a/src/server/scripts/Spells/spell_holiday.cpp
+++ b/src/server/scripts/Spells/spell_holiday.cpp
@@ -1187,6 +1187,7 @@ enum RibbonPoleData
 {
     SPELL_HAS_FULL_MIDSUMMER_SET        = 58933,
     SPELL_BURNING_HOT_POLE_DANCE        = 58934,
+    SPELL_RIBBON_DANCE_COSMETIC         = 29726,
     SPELL_RIBBON_DANCE                  = 29175,
     GO_RIBBON_POLE                      = 181605,
 };
@@ -1214,10 +1215,11 @@ class spell_gen_ribbon_pole_dancer_check : public SpellScriptLoader
                 Unit* target = GetTarget();
 
                 // check if aura needs to be removed
-                if (!target->FindNearestGameObject(GO_RIBBON_POLE, 20.0f) || !target->HasUnitState(UNIT_STATE_CASTING))
+                if (!target->FindNearestGameObject(GO_RIBBON_POLE, 8.0f) || !target->HasUnitState(UNIT_STATE_CASTING))
                 {
                     target->InterruptNonMeleeSpells(false);
                     target->RemoveAurasDueToSpell(GetId());
+                    target->RemoveAura(SPELL_RIBBON_DANCE_COSMETIC);
                     return;
                 }
 

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1197,6 +1197,28 @@ public:
     }
 };
 
+enum MidsummerPoleRibbon
+{
+    SPELL_POLE_DANCE      = 29726,
+    SPELL_BLUE_FIRE_RING  = 46842,
+    NPC_POLE_RIBBON_BUNNY = 17066
+};
+
+class go_midsummer_ribbon_pole : public GameObjectScript
+{
+public:
+    go_midsummer_ribbon_pole() : GameObjectScript("go_midsummer_ribbon_pole") { }
+
+    bool OnGossipHello(Player* player, GameObject* go) override
+    {
+        if (Creature* creature = go->FindNearestCreature(NPC_POLE_RIBBON_BUNNY, 10.0f))
+        {
+            creature->CastSpell(go, SPELL_BLUE_FIRE_RING, true);
+            player->CastSpell(creature, SPELL_POLE_DANCE);
+        }
+        return true;
+    }
+};
 
 enum ToyTrainSpells
 {
@@ -1274,5 +1296,6 @@ void AddSC_go_scripts()
     new go_veil_skith_cage();
     new go_frostblade_shrine();
     new go_midsummer_bonfire();
+    new go_midsummer_ribbon_pole();
     new go_toy_train_set();
 }

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1213,8 +1213,8 @@ public:
     {
         if (Creature* creature = go->FindNearestCreature(NPC_POLE_RIBBON_BUNNY, 10.0f))
         {
-            creature->CastSpell(go, SPELL_BLUE_FIRE_RING, true);
-            player->CastSpell(creature, SPELL_POLE_DANCE);
+            creature->GetAI()->SetData(0, 0);
+            player->CastSpell(creature, SPELL_POLE_DANCE, true);
         }
         return true;
     }

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1201,7 +1201,8 @@ enum MidsummerPoleRibbon
 {
     SPELL_POLE_DANCE      = 29726,
     SPELL_BLUE_FIRE_RING  = 46842,
-    NPC_POLE_RIBBON_BUNNY = 17066
+    NPC_POLE_RIBBON_BUNNY = 17066,
+    ACTION_COSMETIC_FIRES = 0
 };
 
 class go_midsummer_ribbon_pole : public GameObjectScript
@@ -1213,7 +1214,7 @@ public:
     {
         if (Creature* creature = go->FindNearestCreature(NPC_POLE_RIBBON_BUNNY, 10.0f))
         {
-            creature->GetAI()->SetData(0, 0);
+            creature->GetAI()->DoAction(ACTION_COSMETIC_FIRES);
             player->CastSpell(creature, SPELL_POLE_DANCE, true);
         }
         return true;

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -580,6 +580,107 @@ public:
 };
 
 /*######
+## npc_midsummer_bunny_pole
+######*/
+
+enum RibbonPoleData
+{
+    GO_RIBBON_POLE              = 181605,
+    SPELL_RIBBON_DANCE_COSMETIC = 29726,
+    SPELL_RED_FIRE_RING         = 46836,
+    SPELL_BLUE_FIRE_RING        = 46842,
+    EVENT_CAST_RED_FIRE_RING    = 1,
+    EVENT_CAST_BLUE_FIRE_RING   = 2
+};
+
+class npc_midsummer_bunny_pole : public CreatureScript
+{
+public:
+    npc_midsummer_bunny_pole() : CreatureScript("npc_midsummer_bunny_pole") { }
+
+    struct npc_midsummer_bunny_poleAI : public ScriptedAI
+    {
+        npc_midsummer_bunny_poleAI(Creature* creature) : ScriptedAI(creature) { Reset(); }
+
+        void Reset() override
+        {
+            events.Reset();
+            running = false;
+        }
+
+        void SetData(uint32 type, uint32 uiData) override
+        {
+            // Don't start event if it's already running.
+            if (running)
+                return;
+
+            running = true;
+            events.ScheduleEvent(EVENT_CAST_RED_FIRE_RING, 1);
+        }
+
+        bool checkNearbyPlayers()
+        {
+            // Returns true if no nearby player has aura "Test Ribbon Pole Channel".
+            std::list<Player*> players;
+            Trinity::UnitAuraCheck check(true, SPELL_RIBBON_DANCE_COSMETIC);
+            Trinity::PlayerListSearcher<Trinity::UnitAuraCheck> searcher(me, players, check);
+            me->VisitNearbyWorldObject(10.0f, searcher);
+
+            return players.empty();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (!running)
+                return;
+
+            events.Update(diff);
+
+            switch (events.ExecuteEvent())
+            {
+            case EVENT_CAST_RED_FIRE_RING:
+            {
+                if (checkNearbyPlayers())
+                {
+                    Reset();
+                    return;
+                }
+
+                if (GameObject* go = me->FindNearestGameObject(GO_RIBBON_POLE, 10.0f))
+                    me->CastSpell(go, SPELL_RED_FIRE_RING, true);
+
+                events.ScheduleEvent(EVENT_CAST_BLUE_FIRE_RING, 5000);
+            }
+            break;
+            case EVENT_CAST_BLUE_FIRE_RING:
+            {
+                if (checkNearbyPlayers())
+                {
+                    Reset();
+                    return;
+                }
+
+                if (GameObject* go = me->FindNearestGameObject(GO_RIBBON_POLE, 10.0f))
+                    me->CastSpell(go, SPELL_BLUE_FIRE_RING, true);
+
+                events.ScheduleEvent(EVENT_CAST_RED_FIRE_RING, 5000);
+            }
+            break;
+            }
+        }
+
+    private:
+        EventMap events;
+        bool running;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_midsummer_bunny_poleAI(creature);
+    }
+};
+
+/*######
 ## Triage quest
 ######*/
 
@@ -2447,6 +2548,7 @@ void AddSC_npcs_special()
     new npc_chicken_cluck();
     new npc_dancing_flames();
     new npc_torch_tossing_target_bunny_controller();
+    new npc_midsummer_bunny_pole();
     new npc_doctor();
     new npc_injured_patient();
     new npc_garments_of_quests();

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -649,7 +649,7 @@ public:
                 if (GameObject* go = me->FindNearestGameObject(GO_RIBBON_POLE, 10.0f))
                     me->CastSpell(go, SPELL_RED_FIRE_RING, true);
 
-                events.ScheduleEvent(EVENT_CAST_BLUE_FIRE_RING, 5000);
+                events.ScheduleEvent(EVENT_CAST_BLUE_FIRE_RING, Seconds(5));
             }
             break;
             case EVENT_CAST_BLUE_FIRE_RING:
@@ -663,7 +663,7 @@ public:
                 if (GameObject* go = me->FindNearestGameObject(GO_RIBBON_POLE, 10.0f))
                     me->CastSpell(go, SPELL_BLUE_FIRE_RING, true);
 
-                events.ScheduleEvent(EVENT_CAST_RED_FIRE_RING, 5000);
+                events.ScheduleEvent(EVENT_CAST_RED_FIRE_RING, Seconds(5));
             }
             break;
             }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -600,7 +600,7 @@ public:
 
     struct npc_midsummer_bunny_poleAI : public ScriptedAI
     {
-        npc_midsummer_bunny_poleAI(Creature* creature) : ScriptedAI(creature) { Reset(); }
+        npc_midsummer_bunny_poleAI(Creature* creature) : ScriptedAI(creature) { }
 
         void Reset() override
         {
@@ -608,7 +608,7 @@ public:
             running = false;
         }
 
-        void SetData(uint32 /*type*/, uint32 /*uiData*/) override
+        void DoAction(int32 /*action*/) override
         {
             // Don't start event if it's already running.
             if (running)

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -600,12 +600,20 @@ public:
 
     struct npc_midsummer_bunny_poleAI : public ScriptedAI
     {
-        npc_midsummer_bunny_poleAI(Creature* creature) : ScriptedAI(creature) { }
+        npc_midsummer_bunny_poleAI(Creature* creature) : ScriptedAI(creature)
+        {
+            Initialize();
+        }
 
-        void Reset() override
+        void Initialize()
         {
             events.Reset();
             running = false;
+        }
+        
+        void Reset() override
+        {
+            Initialize();
         }
 
         void DoAction(int32 /*action*/) override

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -608,7 +608,7 @@ public:
             running = false;
         }
 
-        void SetData(uint32 type, uint32 uiData) override
+        void SetData(uint32 /*type*/, uint32 /*uiData*/) override
         {
             // Don't start event if it's already running.
             if (running)


### PR DESCRIPTION
**Changes proposed**:
- Bunny creature should hover, which puts it in the intended position.
- Use correct visual and internal spells to handle cosmetics and timers.

**Target branch(es)**: 335

**Tests performed**: tested and working.

**Known issues and TODO list**:
- [x] The [bunny npc](http://www.wowhead.com/npc=17066/ribbon-pole-debug-target) should alternate between casting [this spell](http://www.wowhead.com/spell=46842/flame-ring) and [this other one](http://www.wowhead.com/spell=46836/flame-patch) roughly every five seconds, as long as atleast one player is using the ribbon pole. Haven't been able to find a not-abominable way to implement it yet.
- [x] [This other spell](http://www.wowhead.com/spell=45407/reveler-applause-cheer) is triggered at set intervals, but functionality is (probably?) not yet implemented. (this is unrelated to this PR though, should be fixed separately)
