### PR TITLE
Core/Quest: don't save queststatus for autocomplete quests

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15692,10 +15692,12 @@ bool Player::CanShareQuest(uint32 quest_id) const
 
 void Player::SetQuestStatus(uint32 questId, QuestStatus status, bool update /*= true*/)
 {
-    if (sObjectMgr->GetQuestTemplate(questId))
+    if (Quest const* quest = sObjectMgr->GetQuestTemplate(questId))
     {
         m_QuestStatus[questId].Status = status;
-        m_QuestStatusSave[questId] = QUEST_DEFAULT_SAVE_TYPE;
+        
+        if (!quest->IsAutoComplete())
+            m_QuestStatusSave[questId] = QUEST_DEFAULT_SAVE_TYPE;
     }
 
     if (update)


### PR DESCRIPTION
**Changes proposed**: currently, under certain circumstances, the core saves queststatus for autocomplete quests. When this happens, the players will find said quest in their questlog after a relog.

**How to reproduce**:
- .go creature id 15192 and .mod rep 910 42999
- Complete one of the three quests offered by the NPC.
- Click on the next quest, click continue, and stop there.
- Delete the epic ring you received from the previously completed quest.
- Click "Complete Quest". You'll receive a "Item not found" error.
- Relog.
- The quest you failed to complete is now in your quest log.

**Target branch(es)**: 335

**Tests performed**: tested and working.
