### PR TITLE
Core/Spell: allow use of ground mounts while swimming

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5498,7 +5498,7 @@ SpellCastResult Spell::CheckCast(bool strict)
             }
             case SPELL_AURA_MOUNTED:
             {
-                if (m_caster->IsInWater())
+                if (m_caster->IsInWater() && m_spellInfo->HasAura(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED))
                     return SPELL_FAILED_ONLY_ABOVEWATER;
 
                 // Ignore map check if spell have AreaId. AreaId already checked and this prevent special mount spells


### PR DESCRIPTION
**Changes proposed**: title says it all. Ground (but not flying) mounts should be usable while swimming. Client checks are quite accurate in this case, and allow ground mounts when in water. Also, source [here](http://wowwiki.wikia.com/wiki/Swim?oldid=2300441): `Unlike ground mounts, flying mounts cannot be mounted while in water.`

Proof [here](https://youtu.be/FlGxBOs2YTw?t=22)! (thanks @Aokromes!)

**Target branch(es)**: 335

**Tests performed**: tested and working.
