### PR TITLE
Core/Spell: fix Pursuit of Justice's increase mount movement speed effect

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11890,7 +11890,8 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
             else             // Use not mount (shapeshift for example) auras (should stack)
                 main_speed_mod  = GetTotalAuraModifier(SPELL_AURA_MOD_INCREASE_FLIGHT_SPEED) + GetTotalAuraModifier(SPELL_AURA_MOD_INCREASE_VEHICLE_FLIGHT_SPEED);
 
-            non_stack_bonus += GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACK) / 100.0f;
+            // SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK should increase flying mount speed as well.
+            non_stack_bonus += std::max(GetMaxPositiveAuraModifier(SPELL_AURA_MOD_FLIGHT_SPEED_NOT_STACK), GetMaxPositiveAuraModifier(SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK)) / 100.0f;
 
             // Update speed for vehicle if available
             if (GetTypeId() == TYPEID_PLAYER && GetVehicle())

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2935,6 +2935,16 @@ void SpellMgr::LoadSpellInfoCorrections()
 
         switch (spellInfo->Id)
         {
+            case 26022: // Pursuit of Justice rank 1
+                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK;
+                spellInfo->Effects[EFFECT_1].BasePoints = 8;
+                break;
+            case 26023: // Pursuit of Justice rank 2
+                spellInfo->Effects[EFFECT_1].Effect = SPELL_EFFECT_APPLY_AURA;
+                spellInfo->Effects[EFFECT_1].ApplyAuraName = SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK;
+                spellInfo->Effects[EFFECT_1].BasePoints = 15;
+                break;
             case 63026: // Force Cast (HACK: Target shouldn't be changed)
             case 63137: // Force Cast (HACK: Target shouldn't be changed; summon position should be untied from spell destination)
                 spellInfo->Effects[0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DB);


### PR DESCRIPTION
**Changes proposed**: the "increase mounted movement speed" part of this talent has been broken for a long while. The spell has EFFECT_0 and EFFECT_2 defined in dbc files, but is missing EFFECT_1.

I think this effect should be "SPELL_AURA_MOD_MOUNTED_SPEED_NOT_STACK", and that it should affect flying mount's movement speed too.

There are no cases (to my knowledge, atleast) where flying mounted speed is increased but ground mounted speed is not. So the maximum of the two values should be used.

**Target branch(es)**: 335

**Issues addressed**: Closes #14262

**Tests performed**: tested and working.
