### PR TITLE
Core/Fishing: update fishing skill regardless of success or failure (junk items fished)

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1453,11 +1453,11 @@ void GameObject::Use(Unit* user)
 
                     TC_LOG_DEBUG("misc", "Fishing check (skill: %i zone min skill: %i chance %i roll: %i", skill, zone_skill, chance, roll);
 
-                    // but you will likely cause junk in areas that require a high fishing skill (not yet implemented)
+                    player->UpdateFishingSkill();
+
+                    // but you will likely cause junk in areas that require a high fishing skill
                     if (chance >= roll)
                     {
-                        player->UpdateFishingSkill();
-
                         /// @todo I do not understand this hack. Need some explanation.
                         // prevent removing GO at spell cancel
                         RemoveFromOwner();


### PR DESCRIPTION
**Changes proposed**: when fishing, the player's skill value should update regardless of the result (whether you fish actual fishes or junk loot). [Source](http://wowwiki.wikia.com/wiki/Fishing?oldid=2356392): "Every time you catch something (even junk) you gain fishing experience towards your next skill level." (fishing experience isn't implemented yet, but that's for another PR).

**Target branch(es)**: 335

**Tests performed**: trivial change... but still, tested and working.
