### PR TITLE
Core/Arena: Teams don't lose rating after arena draw

### DIFF
--- a/src/server/game/Battlegrounds/Arena.cpp
+++ b/src/server/game/Battlegrounds/Arena.cpp
@@ -142,15 +142,19 @@ void Arena::EndBattleground(uint32 winner)
         int32  winnerChange           = 0;
         int32  winnerMatchmakerChange = 0;
 
-        ArenaTeam* winnerArenaTeam = sArenaTeamMgr->GetArenaTeamById(GetArenaTeamIdForTeam(winner));
-        ArenaTeam* loserArenaTeam = sArenaTeamMgr->GetArenaTeamById(GetArenaTeamIdForTeam(GetOtherTeam(winner)));
+        // In case of arena draw, follow this logic:
+        // winnerArenaTeam => ALLIANCE, loserArenaTeam => HORDE
+        ArenaTeam* winnerArenaTeam = sArenaTeamMgr->GetArenaTeamById(GetArenaTeamIdForTeam(winner == 0 ? ALLIANCE : winner));
+        ArenaTeam* loserArenaTeam = sArenaTeamMgr->GetArenaTeamById(GetArenaTeamIdForTeam(winner == 0 ? HORDE : GetOtherTeam(winner)));
 
         if (winnerArenaTeam && loserArenaTeam && winnerArenaTeam != loserArenaTeam)
         {
+            // In case of arena draw, follow this logic:
+            // winnerMatchmakerRating => ALLIANCE, loserMatchmakerRating => HORDE
             loserTeamRating = loserArenaTeam->GetRating();
-            loserMatchmakerRating = GetArenaMatchmakerRating(GetOtherTeam(winner));
+            loserMatchmakerRating = GetArenaMatchmakerRating(winner == 0 ? HORDE : GetOtherTeam(winner));
             winnerTeamRating = winnerArenaTeam->GetRating();
-            winnerMatchmakerRating = GetArenaMatchmakerRating(winner);
+            winnerMatchmakerRating = GetArenaMatchmakerRating(winner == 0 ? ALLIANCE : winner);
 
             if (winner != 0)
             {
@@ -206,7 +210,12 @@ void Arena::EndBattleground(uint32 winner)
                     if (team == winner)
                         winnerArenaTeam->OfflineMemberLost(i.first, loserMatchmakerRating, winnerMatchmakerChange);
                     else
+                    {
+                        if (winner == 0)
+                            winnerArenaTeam->OfflineMemberLost(i.first, loserMatchmakerRating, winnerMatchmakerChange);
+
                         loserArenaTeam->OfflineMemberLost(i.first, winnerMatchmakerRating, loserMatchmakerChange);
+                    }
                     continue;
                 }
 
@@ -230,6 +239,9 @@ void Arena::EndBattleground(uint32 winner)
                 }
                 else
                 {
+                    if (winner == 0)
+                        winnerArenaTeam->MemberLost(player, loserMatchmakerRating, winnerMatchmakerChange);
+
                     loserArenaTeam->MemberLost(player, winnerMatchmakerRating, loserMatchmakerChange);
 
                     // Arena lost => reset the win_rated_arena having the "no_lose" condition


### PR DESCRIPTION
Description: When an arena finishes after 47 minutes, the result of the arena is a draw. This should count as a loss for both teams, resulting of losing 16 points (no MMR changes) each one.

Current behaviour: Teams don't lose rating when arena ends after 47 minutes (draw)

Expected behaviour: Each team should lose 16 points.

Steps to reproduce the problem:
1. Have 2 2v2 teams
2. Face them and wait 47 minutes until the arena ends and it results in a draw
3. Teams don't lose rating

Branch(es): 335 only.

**NOTE** If your Pull Request is SQL only create a ticket instead

**SUGESTION** If your Pull Request contains SQL give it one imposible date, for example 9999_99_99_99_database.sql on that way it will be free on merge.

By Raydor, closes #16865
