### PR TITLE
Core/Script: small improvement for quest "The Hunt is On"

### DIFF
--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2275,6 +2275,7 @@ public:
         {
             me->StopMoving();
             me->SetUInt32Value(UNIT_NPC_FLAGS, 0);
+            me->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
             if (Player* player = ObjectAccessor::GetPlayer(*me, uiPlayerGUID))
                 me->SetFacingToObject(player);
             uiEventTimer = 3000;
@@ -2303,7 +2304,6 @@ public:
                         switch (me->GetEntry())
                         {
                             case NPC_SALTY_JOHN_THORPE:
-                                me->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
                                 Talk(SAY_HIDDEN_CULTIST_1);
                                 uiEventTimer = 5000;
                                 uiEventPhase = 2;


### PR DESCRIPTION
**Changes proposed**: reset the emote state a bit earlier in the script, so that the npc doesn't keep executing it while turning and talking for the first time.

**Target branch(es)**: 335

**Tests performed**: tested and working.
