### PR TITLE
Core/Items: bags will now get equipped automaticly

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11662,7 +11662,7 @@ Item* Player::StoreNewItem(ItemPosCountVec const& pos, uint32 itemId, bool updat
 
         // Since 4.x bags are getting equipped automaticly when they have no bind on equip boundary
         // This includes looted bags, bags from quest rewards and purchased bags from vendors
-        if (item->IsBag() && item->GetTemplate()->GetBonding() != BIND_WHEN_EQUIPED)
+        if (item->IsBag() && item->GetTemplate()->GetBonding() != BIND_ON_EQUIP)
             item = StoreItem(pos, item, update, true);
         else
             item = StoreItem(pos, item, update, false);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11660,7 +11660,12 @@ Item* Player::StoreNewItem(ItemPosCountVec const& pos, uint32 itemId, bool updat
         for (int32 bonusListID : bonusListIDs)
             item->AddBonuses(bonusListID);
 
-        item = StoreItem(pos, item, update);
+        // Since 4.x bags are getting equipped automaticly when they have no bind on equip boundary
+        // This includes looted bags, bags from quest rewards and purchased bags from vendors
+        if (item->IsBag() && item->GetTemplate()->GetBonding() != BIND_WHEN_EQUIPED)
+            item = StoreItem(pos, item, update, true);
+        else
+            item = StoreItem(pos, item, update, false);
 
         if (allowedLooters.size() > 1 && item->GetTemplate()->GetMaxStackSize() == 1 && item->IsSoulBound())
         {
@@ -11703,12 +11708,22 @@ Item* Player::StoreNewItem(ItemPosCountVec const& pos, uint32 itemId, bool updat
     return item;
 }
 
-Item* Player::StoreItem(ItemPosCountVec const& dest, Item* pItem, bool update)
+Item* Player::StoreItem(ItemPosCountVec const& dest, Item* pItem, bool update, bool lootedBag /*= false*/)
 {
     if (!pItem)
         return nullptr;
 
     Item* lastItem = pItem;
+    if (lootedBag && pItem->GetTemplate()->GetClass() == ITEM_CLASS_CONTAINER && pItem->GetTemplate()->GetSubClass() == ITEM_SUBCLASS_CONTAINER)
+        for (uint32 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; i++)
+        {
+            if (!m_items[i])
+            {
+                EquipNewItem(i, pItem->GetEntry(), true);
+                return lastItem;
+            }
+        }
+
     for (ItemPosCountVec::const_iterator itr = dest.begin(); itr != dest.end();)
     {
         uint16 pos = itr->pos;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1209,7 +1209,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         InventoryResult CanUseItem(ItemTemplate const* pItem) const;
         InventoryResult CanRollForItemInLFG(ItemTemplate const* item, WorldObject const* lootedObject) const;
         Item* StoreNewItem(ItemPosCountVec const& pos, uint32 itemId, bool update, ItemRandomEnchantmentId const& randomPropertyId = {}, GuidSet const& allowedLooters = GuidSet(), uint8 context = 0, std::vector<int32> const& bonusListIDs = std::vector<int32>(), bool addToCollection = true);
-        Item* StoreItem(ItemPosCountVec const& pos, Item* pItem, bool update);
+        Item* StoreItem(ItemPosCountVec const& pos, Item* pItem, bool update, bool lootedBag = false);
         Item* EquipNewItem(uint16 pos, uint32 item, bool update);
         Item* EquipItem(uint16 pos, Item* pItem, bool update);
         void AutoUnequipOffhandIfNeed(bool force = false);


### PR DESCRIPTION
**Changes proposed**:
- Bags that has been looted, purchased and are not getting soulbound on equip and quest rewards will now get equipped automaticly as it is a default mechanic since patch 4.x

**Target branch(es)**: 6x

**Tests performed**: Tested ingame, works as intended.
