### PR TITLE
Core/Unit: Add proc cooldown to all units

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13870,9 +13870,8 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* target, uint32 procFlag, u
 
         bool prepare = i->aura->CallScriptPrepareProcHandlers(aurApp, eventInfo);
 
-        // For players set spell cooldown if need
         Milliseconds cooldown = Milliseconds::zero();
-        if (prepare && GetTypeId() == TYPEID_PLAYER && i->spellProcEvent && i->spellProcEvent->cooldown)
+        if (prepare && i->spellProcEvent && i->spellProcEvent->cooldown)
             cooldown = Seconds(i->spellProcEvent->cooldown);
 
         // Note: must SetCantProc(false) before return


### PR DESCRIPTION
**Changes proposed**:
-  Remove Player check when determining proc cooldown. Units (such as pets) can have them.

**Target branch(es)**: 335 + 6.x

**Issues addressed**: Closes #10840

**Tests performed**: Tested in game.

**Known issues and TODO list**: none.
