### PR TITLE
Core/Gameobject: handle despawning/respawning of nearby linked traps on gameobject despawn/respawn

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -429,9 +429,8 @@ void GameObject::Update(uint32 diff)
                     m_usetimes = 0;
 
                     // If nearby linked trap exists, respawn it
-                    if (uint32 linkedEntry = GetGOInfo()->GetLinkedGameObjectEntry())
-                        if (GameObject* linkedTrap = FindNearestGameObject(linkedEntry, 10.0f))
-                            linkedTrap->SetLootState(GO_READY);
+                    if (GameObject* linkedTrap = GetLinkedTrap())
+                        linkedTrap->SetLootState(GO_READY);
 
                     switch (GetGoType())
                     {
@@ -619,9 +618,8 @@ void GameObject::Update(uint32 diff)
         case GO_JUST_DEACTIVATED:
         {
             // If nearby linked trap exists, despawn it
-            if (uint32 linkedEntry = GetGOInfo()->GetLinkedGameObjectEntry())
-                if (GameObject* linkedTrap = FindNearestGameObject(linkedEntry, 10.0f))
-                    linkedTrap->SetLootState(GO_JUST_DEACTIVATED);
+            if (GameObject* linkedTrap = GetLinkedTrap())
+                linkedTrap->SetLootState(GO_JUST_DEACTIVATED);
 
             //if Gameobject should cast spell, then this, but some GOs (type = 10) should be destroyed
             if (GetGoType() == GAMEOBJECT_TYPE_GOOBER)
@@ -2235,6 +2233,27 @@ bool GameObject::IsLootAllowedFor(Player const* player) const
         return false;                                           // if go doesnt have group bound it means it was solo killed by someone else
 
     return true;
+}
+
+GameObject* GameObject::GetLinkedTrap()
+{
+    uint32 linkedEntry = GetGOInfo()->GetLinkedGameObjectEntry();
+
+    if (!linkedEntry)
+        return nullptr;
+
+    GameObject* linkedTrap = nullptr;
+
+    if (m_linkedTrap.Empty())
+    {
+        linkedTrap = FindNearestGameObject(GetGOInfo()->GetLinkedGameObjectEntry(), 10.0f);
+        if (linkedTrap)
+            m_linkedTrap = linkedTrap->GetGUID();
+    }
+    else
+        linkedTrap = ObjectAccessor::GetGameObject(*this, m_linkedTrap);
+
+    return linkedTrap;
 }
 
 void GameObject::BuildValuesUpdate(uint8 updateType, ByteBuffer* data, Player* target) const

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -428,6 +428,11 @@ void GameObject::Update(uint32 diff)
                     m_SkillupList.clear();
                     m_usetimes = 0;
 
+                    // If nearby linked trap exists, respawn it
+                    if (uint32 linkedEntry = GetGOInfo()->GetLinkedGameObjectEntry())
+                        if (GameObject* linkedTrap = FindNearestGameObject(linkedEntry, 10.0f))
+                            linkedTrap->SetLootState(GO_READY);
+
                     switch (GetGoType())
                     {
                         case GAMEOBJECT_TYPE_FISHINGNODE:   //  can't fish now
@@ -613,6 +618,11 @@ void GameObject::Update(uint32 diff)
         }
         case GO_JUST_DEACTIVATED:
         {
+            // If nearby linked trap exists, despawn it
+            if (uint32 linkedEntry = GetGOInfo()->GetLinkedGameObjectEntry())
+                if (GameObject* linkedTrap = FindNearestGameObject(linkedEntry, 10.0f))
+                    linkedTrap->SetLootState(GO_JUST_DEACTIVATED);
+
             //if Gameobject should cast spell, then this, but some GOs (type = 10) should be destroyed
             if (GetGoType() == GAMEOBJECT_TYPE_GOOBER)
             {

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -818,6 +818,8 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         uint32 m_groupLootTimer;                            // (msecs)timer used for group loot
         ObjectGuid::LowType lootingGroupLowGUID;                         // used to find group which is looting
 
+        GameObject* GetLinkedTrap();
+
         bool hasQuest(uint32 quest_id) const override;
         bool hasInvolvedQuest(uint32 quest_id) const override;
         bool ActivateToQuest(Player* target) const;
@@ -925,6 +927,8 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         ObjectGuid m_lootRecipient;
         uint32 m_lootRecipientGroup;
         uint16 m_LootMode;                                  // bitmask, default LOOT_MODE_DEFAULT, determines what loot will be lootable
+
+        ObjectGuid m_linkedTrap;
     private:
         void RemoveFromOwner();
         void SwitchDoorOrButton(bool activate, bool alternative = false);


### PR DESCRIPTION
**Changes proposed**:

While we don't know whether or not linked traps are permanently spawned, or if the gameobject itself spawns them, what we know is that they should respawn when the parent gameobject is respawned, and despawned when the parent is despawned.

**Target branch(es)**: 335

**Issues addressed**: Closes #12139, Updates #15927

**Tests performed**: tested and working.
