### PR TITLE
Core/Movement Fixed minimum speed check

### DIFF
--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -206,7 +206,7 @@ bool MoveSplineInitArgs::Validate(Unit* unit) const
         return false;\
     }
     CHECK(path.size() > 1);
-    CHECK(velocity > 0.1f);
+    CHECK(velocity > 0.01f);
     CHECK(time_perc >= 0.f && time_perc <= 1.f);
     //CHECK(_checkPathBounds());
     return true;


### PR DESCRIPTION
- Some creatures like Shade of Akama can have movespeed < 0.1f

> ServerToClient: SMSG_MOVE_SPLINE_SET_RUN_SPEED (0x2D33) Length: 19 ConnIdx: 0 Time: 06/30/2016 19:12:58.687 Number: 47919
> Guid: Full: 0x202F3C4680164E4000625100007596E4 Creature/0 R3023/S25169 Map: 564 (Black Temple) Entry: 22841 (Shade of Akama) Low: 7706340
> Speed: 0.04

**Target branch(es)**: 335

**Issues addressed**: Update #17540

**Tests performed**: Tested in game
