### PR TITLE
[3.3.5/6.x] Game/Entities: Fix math problem "Disk Point Picking" in GetRandomPoint

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1403,7 +1403,8 @@ void WorldObject::GetRandomPoint(const Position &pos, float distance, float &ran
 
     // angle to face `obj` to `this`
     float angle = (float)rand_norm()*static_cast<float>(2*M_PI);
-    float new_dist = (float)rand_norm()*static_cast<float>(distance);
+    float new_dist = (float)rand_norm() + (float)rand_norm();
+    new_dist = distance * (new_dist > 1 ? new_dist - 2 : new_dist);
 
     rand_x = pos.m_positionX + new_dist * std::cos(angle);
     rand_y = pos.m_positionY + new_dist * std::sin(angle);


### PR DESCRIPTION
**Changes proposed**:

The calculations made for GetRandomPoint are wrong.
To generate random points over the unit disk, it is incorrect to use two uniformly distributed variables ![Image](http://mathworld.wolfram.com/images/equations/DiskPointPicking/Inline1.gif) and ![Image](http://mathworld.wolfram.com/images/equations/DiskPointPicking/Inline2.gif) and then take 
![Image](http://mathworld.wolfram.com/images/equations/DiskPointPicking/Inline5.gif)
![Image](http://mathworld.wolfram.com/images/equations/DiskPointPicking/Inline8.gif)

This wrong calculation leads to more points to center as you can see on the LEFT image.
![Image](http://mathworld.wolfram.com/images/eps-gif/CircularDistribution_1000.gif)

More information:
http://mathworld.wolfram.com/DiskPointPicking.html
http://stackoverflow.com/questions/5837572/generate-a-random-point-within-a-circle-uniformly

**Target branch(es)**: 335/6x

**Tests performed**: Tested Ingame, Tested Build
