### PR TITLE
Fix Flightmaster Runetog Wildhammer, Shatter Point

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,1 @@
+UPDATE `gossip_menu_option` SET `option_id` = 4, `npc_option_npcflag` = 8192 WHERE `menu_id` = 8095; -- Fix Flightmaster Runetog Wildhammer, Shatter Point


### PR DESCRIPTION
**Changes proposed**:
Update the gossip_menu_option for Flightmaster Runetog Wildhammer in Shatter Point, Hellfire Peninsula to allow players to correctly view available flight points.

**Target branch(es)**: 335/6x
335

**Issues addressed**: Closes #
#17592

**Tests performed**: (Does it build, tested in-game, etc)
Had multiple players test with Flightmaster Runetog Wildhammer to ensure that they are now able to browse the flight points and fly to other destinations.

**Known issues and TODO list**:
No known issues.
