### PR TITLE
Core/Spells GameObjects needs to be spawned in order to be acceptable as a SpellFocus

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -620,6 +620,9 @@ namespace Trinity
                 if (go->GetGOInfo()->spellFocus.focusId != i_focusId)
                     return false;
 
+                if (!go->isSpawned())
+                    return false;
+
                 float dist = go->GetGOInfo()->spellFocus.dist / 2.f;
 
                 return go->IsWithinDistInMap(i_unit, dist);

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -1080,9 +1080,7 @@ enum RedSnapperVeryTasty
     ITEM_RED_SNAPPER             = 23614,
 
     SPELL_CAST_NET               = 29866,
-    SPELL_NEW_SUMMON_TEST        = 49214,
-
-    GO_SCHOOL_OF_RED_SNAPPER     = 181616
+    SPELL_NEW_SUMMON_TEST        = 49214
 };
 
 class spell_q9452_cast_net: public SpellScriptLoader
@@ -1097,15 +1095,6 @@ class spell_q9452_cast_net: public SpellScriptLoader
             bool Load() override
             {
                 return GetCaster()->GetTypeId() == TYPEID_PLAYER;
-            }
-
-            SpellCastResult CheckCast()
-            {
-                GameObject* go = GetCaster()->FindNearestGameObject(GO_SCHOOL_OF_RED_SNAPPER, 3.0f);
-                if (!go || go->GetRespawnTime())
-                    return SPELL_FAILED_REQUIRES_SPELL_FOCUS;
-
-                return SPELL_CAST_OK;
             }
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
@@ -1127,7 +1116,6 @@ class spell_q9452_cast_net: public SpellScriptLoader
 
             void Register() override
             {
-                OnCheckCast += SpellCheckCastFn(spell_q9452_cast_net_SpellScript::CheckCast);
                 OnEffectHit += SpellEffectFn(spell_q9452_cast_net_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
                 OnEffectHitTarget += SpellEffectFn(spell_q9452_cast_net_SpellScript::HandleActiveObject, EFFECT_1, SPELL_EFFECT_ACTIVATE_OBJECT);
             }


### PR DESCRIPTION
**Changes proposed**:
- If the GameObject is not spawned, then return SPELL_FAILED_REQUIRES_SPELL_FOCUS
- Remove outdated code due to the change above

**Target branch(es)**: 335/6x

**Tests performed**: Built and tested with quest wotlk.openwow.com/quest=9452
