### PR TITLE
Channel Followup: avoid setting an invisible gm as Channel owner

### DIFF
--- a/src/server/game/Chat/Channels/Channel.cpp
+++ b/src/server/game/Chat/Channels/Channel.cpp
@@ -29,6 +29,7 @@ Channel::Channel(std::string const& name, uint32 channelId, uint32 team /*= 0*/)
     _announceEnabled(true),
     _ownershipEnabled(true),
     _persistentChannel(false),
+    _isOwnerInvisible(false),
     _channelFlags(0),
     _channelId(channelId),
     _channelTeam(team),
@@ -197,8 +198,11 @@ void Channel::JoinChannel(Player* player, std::string const& pass)
         SendToAll(&data);
     }
 
+    bool newChannel = _playersStore.empty();
+
     PlayerInfo& pinfo = _playersStore[guid];
     pinfo.flags = MEMBER_FLAG_NONE;
+    pinfo.invisible = !player->isGMVisible();
 
     WorldPacket data;
     MakeYouJoined(&data);
@@ -213,9 +217,13 @@ void Channel::JoinChannel(Player* player, std::string const& pass)
         UpdateChannelUseageInDB();
 
         // If the channel has no owner yet and ownership is allowed, set the new owner.
-        if (!_ownerGuid && _ownershipEnabled)
+        // or if the owner was a GM with .gm visible off
+        // don't do this if the new player is, too, an invis GM, unless the channel was empty
+        if (_ownershipEnabled && (newChannel || !pinfo.IsInvisible()) && (!_ownerGuid || _isOwnerInvisible))
         {
-            SetOwner(guid, _playersStore.size() > 1);
+            _isOwnerInvisible = pinfo.IsInvisible();
+
+            SetOwner(guid, !newChannel && !_isOwnerInvisible);
             pinfo.SetModerator(true);
         }
     }
@@ -262,13 +270,28 @@ void Channel::LeaveChannel(Player* player, bool send)
         // Update last_used timestamp in db
         UpdateChannelUseageInDB();
 
-        // If the channel owner left and there are still players inside, pick a new owner
+        // If the channel owner left and there are players still inside, pick a new owner
+        // do not pick invisible gm owner unless there only invisible gms in that channel (rare)
         if (changeowner && _ownershipEnabled && !_playersStore.empty())
         {
-            auto itr = _playersStore.begin();
-            ObjectGuid newowner = itr->first;
-            itr->second.SetModerator(true);
-            SetOwner(newowner);
+            bool found = false;
+            PlayerContainer::iterator itr;
+            for (itr = _playersStore.begin(); itr != _playersStore.end(); ++itr)
+            {
+                if (!itr->second.IsInvisible())
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            auto itr2 = found ? itr : _playersStore.begin();
+            ObjectGuid newOwner = itr2->first;
+            itr2->second.SetModerator(true);
+
+            SetOwner(newOwner);
+            if (!found) // new owner is invisible gm, set flag to automatically choose a new owner
+                _isOwnerInvisible = true;
         }
     }
 }
@@ -466,6 +489,19 @@ void Channel::SetMode(Player const* player, std::string const& p2n, bool mod, bo
         SetModerator(newp->GetGUID(), set);
     else
         SetMute(newp->GetGUID(), set);
+}
+
+void Channel::SetInvisible(Player const* player, bool on)
+{
+    auto itr = _playersStore.find(player->GetGUID());
+    if (itr == _playersStore.end())
+        return;
+
+    itr->second.SetInvisible(on);
+
+    // we happen to be owner too, update flag
+    if (_ownerGuid == player->GetGUID())
+        _isOwnerInvisible = on;
 }
 
 void Channel::SetOwner(Player const* player, std::string const& newname)

--- a/src/server/game/Chat/Channels/Channel.cpp
+++ b/src/server/game/Chat/Channels/Channel.cpp
@@ -271,26 +271,26 @@ void Channel::LeaveChannel(Player* player, bool send)
         UpdateChannelUseageInDB();
 
         // If the channel owner left and there are players still inside, pick a new owner
-        // do not pick invisible gm owner unless there only invisible gms in that channel (rare)
+        // do not pick invisible gm owner unless there are only invisible gms in that channel (rare)
         if (changeowner && _ownershipEnabled && !_playersStore.empty())
         {
-            bool found = false;
             PlayerContainer::iterator itr;
             for (itr = _playersStore.begin(); itr != _playersStore.end(); ++itr)
             {
                 if (!itr->second.IsInvisible())
-                {
-                    found = true;
                     break;
-                }
             }
 
-            auto itr2 = found ? itr : _playersStore.begin();
-            ObjectGuid newOwner = itr2->first;
-            itr2->second.SetModerator(true);
+            if (itr == _playersStore.end())
+                itr = _playersStore.begin();
+
+            ObjectGuid newOwner = itr->first;
+            itr->second.SetModerator(true);
 
             SetOwner(newOwner);
-            if (!found) // new owner is invisible gm, set flag to automatically choose a new owner
+
+            // if the new owner is invisible gm, set flag to automatically choose a new owner
+            if (itr->second.IsInvisible())
                 _isOwnerInvisible = true;
         }
     }

--- a/src/server/game/Chat/Channels/Channel.h
+++ b/src/server/game/Chat/Channels/Channel.h
@@ -119,6 +119,10 @@ class TC_GAME_API Channel
     struct PlayerInfo
     {
         uint8 flags;
+        bool invisible;
+
+        bool IsInvisible() const { return invisible; }
+        void SetInvisible(bool on) { invisible = on; }
 
         bool HasFlag(uint8 flag) const { return (flags & flag) != 0; }
         void SetFlag(uint8 flag) { flags |= flag; }
@@ -180,6 +184,8 @@ class TC_GAME_API Channel
         void UnsetModerator(Player const* player, std::string const& newname) { SetMode(player, newname, true, false); }
         void SetMute(Player const* player, std::string const& newname) { SetMode(player, newname, false, true); }
         void UnsetMute(Player const* player, std::string const& newname) { SetMode(player, newname, false, false); }
+
+        void SetInvisible(Player const* player, bool on);
 
         void SetOwner(ObjectGuid guid, bool exclaim = true);
         void SetOwner(Player const* player, std::string const& name);
@@ -291,6 +297,7 @@ class TC_GAME_API Channel
         bool _announceEnabled;          //< Whether we should broadcast a packet whenever a player joins/exits the channel
         bool _ownershipEnabled;         //< Whether the channel has to maintain an owner
         bool _persistentChannel;        //< Whether the channel is saved to DB
+        bool _isOwnerInvisible;         //< Whether the channel is owned by invisible GM, ownership should change to first player that joins channel
 
         uint8 _channelFlags;
         uint32 _channelId;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2606,6 +2606,9 @@ void Player::SetGMVisible(bool on)
 
         m_serverSideVisibility.SetValue(SERVERSIDE_VISIBILITY_GM, GetSession()->GetSecurity());
     }
+
+    for (Channel* channel : m_channels)
+        channel->SetInvisible(this, !on);
 }
 
 bool Player::IsGroupVisibleFor(Player const* p) const


### PR DESCRIPTION
**Changes proposed**:
- Avoid setting an invisible gm (as in .gm visible off) as channel owner, giving it away to other players.
- This can now only happen if the channel is empty or when every other member is an invisible gm, too.

**Target branch(es)**: 335/6x

**Issues addressed**: Closes #17424 

**Tests performed**: It builds correctly, tested it with a couple of gm accounts and a player account, it consistently gave channel owner to player when the gms were invisible, and then player joined the channel
