### PR TITLE
Core/GameObjects DeSpawn GAMEOBJECT_TYPE_SPELL_FOCUS at Use

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1325,6 +1325,9 @@ void GameObject::Use(Unit* user)
 
             return;
         }
+        case GAMEOBJECT_TYPE_SPELL_FOCUS:                   //8
+            SetLootState(GO_JUST_DEACTIVATED);
+            break;
         //big gun, its a spell/aura
         case GAMEOBJECT_TYPE_GOOBER:                        //10
         {


### PR DESCRIPTION
**Changes proposed**:
- DeSpawn GameObject with GAMEOBJECT_TYPE_SPELL_FOCUS at GameObject::Use()
- Used by spells with SPELL_EFFECT_ACTIVATE_OBJECT
- Rough list of affected Objects:

```
180771, Firework Launcher
180850, Firework Launcher
180868, Firework Launcher
184738, Altar of Shadows
185880, Soulgrinder's Altar Spell Focus
186283, Shipwreck Debris
186323, Burning Troll Hut
195308, Mysterious Snow Mound
195309, Mysterious Snow Mound
181288, Midsummer Bonfire
187331, Hauthaa's Anvil Spell Focus
189290, School of Northern Salmon
186949, School of Tasty Reef Fish
180772, Cluster Launcher
180859, Cluster Launcher
180869, Cluster Launcher
180874, Cluster Launcher
181616, School of Red Snapper
185191, Darkstone of Terokk

 Obtained with:
SELECT `entry`, `name` FROM `gameobject_template` WHERE `type`=8 AND `entry` IN (SELECT `ConditionValue2` FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `ConditionTypeOrReference`=31 AND `ConditionValue1`=5);
```

**Target branch(es)**: 335/6x

**Issues addressed**: Closes #17598

**Tests performed**: Built

**Known issues and TODO list**:
- [ ] Feedback
- [ ] Perform more testing
