### PR TITLE
Core/Mail: implement a way to specify NPC sender for mails when they should be different from the quest ender

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,16 @@
+--
+ALTER TABLE `quest_template_addon` ADD COLUMN `RewardMailSenderEntry` INT(5) UNSIGNED DEFAULT 0 NOT NULL AFTER `ProvidedItemCount`;
+
+UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=11811 WHERE `Id`=8729;  -- Quest The Wrath of Neptulon sends mail from Narain Soothfancy
+UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=18166 WHERE `Id`=10588; -- Quest The Cipher of Damnation sends mail from Archmage Khadgar
+UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=5885 WHERE `Id`=12085; -- Quest A Letter for Home (horde) sends mail from Deino
+UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=2708 WHERE `Id`=12067; -- Quest A Letter for Home (ally) sends mail from Archmage Malin
+UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=27102 WHERE `Id`=12422; -- Quest Tactical Clemency sends mail from Gorgonna
+UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=28930 WHERE `Id`=12711; -- Quest Abandoned Mail sends mail from Dansel Adams
+
+DELETE FROM `quest_template_addon` WHERE `Id` IN (22817, 22818, 28879, 28880);
+INSERT INTO `quest_template_addon` (`Id`, `RewardMailSenderEntry`) VALUES
+(22817, 10967), -- Quest Back to the Orphanage (Blood Elf) sends mail from Blood Elf Orphan
+(22818, 10966), -- Quest Back to the Orphanage (Draenei) sends mail from Draenei Orphan
+(28879, 33533), -- Quest Back To The Orphanage (Oracle) sends mail from Oracle Orphan
+(28880, 33532); -- Quest Back To The Orphanage (Wolvar) sends mail from Wolvar Orphan

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,15 +1,19 @@
 --
-ALTER TABLE `quest_template_addon` ADD COLUMN `RewardMailSenderEntry` INT(5) UNSIGNED DEFAULT 0 NOT NULL AFTER `ProvidedItemCount`;
+DROP TABLE IF EXISTS `quest_mail_sender`;
+CREATE TABLE `quest_mail_sender`
+(
+  `QuestId` INT(5) UNSIGNED NOT NULL DEFAULT 0,
+  `RewardMailSenderEntry` INT(5) UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`QuestId`)
+); 
 
-UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=11811 WHERE `Id`=8729;  -- Quest The Wrath of Neptulon sends mail from Narain Soothfancy
-UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=18166 WHERE `Id`=10588; -- Quest The Cipher of Damnation sends mail from Archmage Khadgar
-UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=5885 WHERE `Id`=12085; -- Quest A Letter for Home (horde) sends mail from Deino
-UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=2708 WHERE `Id`=12067; -- Quest A Letter for Home (ally) sends mail from Archmage Malin
-UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=27102 WHERE `Id`=12422; -- Quest Tactical Clemency sends mail from Gorgonna
-UPDATE `quest_template_addon` SET `RewardMailSenderEntry`=28930 WHERE `Id`=12711; -- Quest Abandoned Mail sends mail from Dansel Adams
-
-DELETE FROM `quest_template_addon` WHERE `Id` IN (22817, 22818, 28879, 28880);
-INSERT INTO `quest_template_addon` (`Id`, `RewardMailSenderEntry`) VALUES
+INSERT INTO `quest_mail_sender` (`QuestId`, `RewardMailSenderEntry`) VALUES
+(8729, 11811), -- Quest The Wrath of Neptulon sends mail from Narain Soothfancy
+(10588, 18166), -- Quest The Cipher of Damnation sends mail from Archmage Khadgar
+(12085, 5885), -- Quest A Letter for Home (Horde) sends mail from Deino
+(12067, 2708), -- Quest A Letter for Home (Alliance) sends mail from Archmage Malin
+(12422, 27102), -- Quest Tactical Clemency sends mail from Gorgonna
+(12711, 28930), -- Quest Abandoned Mail sends mail from Dansel Adams
 (22817, 10967), -- Quest Back to the Orphanage (Blood Elf) sends mail from Blood Elf Orphan
 (22818, 10966), -- Quest Back to the Orphanage (Draenei) sends mail from Draenei Orphan
 (28879, 33533), -- Quest Back To The Orphanage (Oracle) sends mail from Oracle Orphan

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14987,7 +14987,10 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         /// @todo Poor design of mail system
         SQLTransaction trans = CharacterDatabase.BeginTransaction();
-        MailDraft(mail_template_id).SendMailTo(trans, this, questGiver, MAIL_CHECK_MASK_HAS_BODY, quest->GetRewMailDelaySecs());
+        if (quest->GetRewMailSenderEntry() != 0)
+            MailDraft(mail_template_id).SendMailTo(trans, this, quest->GetRewMailSenderEntry(), MAIL_CHECK_MASK_HAS_BODY, quest->GetRewMailDelaySecs());
+        else
+            MailDraft(mail_template_id).SendMailTo(trans, this, questGiver, MAIL_CHECK_MASK_HAS_BODY, quest->GetRewMailDelaySecs());
         CharacterDatabase.CommitTransaction(trans);
     }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4112,7 +4112,7 @@ void ObjectMgr::LoadQuests()
     //                                   0   1         2                 3              4            5            6               7                     8
     result = WorldDatabase.Query("SELECT ID, MaxLevel, AllowableClasses, SourceSpellID, PrevQuestID, NextQuestID, ExclusiveGroup, RewardMailTemplateID, RewardMailDelay, "
         //9               10                   11                     12                     13                   14                   15                 16                     17
-        "RequiredSkillID, RequiredSkillPoints, RequiredMinRepFaction, RequiredMaxRepFaction, RequiredMinRepValue, RequiredMaxRepValue, ProvidedItemCount, RewardMailSenderEntry, SpecialFlags FROM quest_template_addon");
+        "RequiredSkillID, RequiredSkillPoints, RequiredMinRepFaction, RequiredMaxRepFaction, RequiredMinRepValue, RequiredMaxRepValue, ProvidedItemCount, RewardMailSenderEntry, SpecialFlags FROM quest_template_addon LEFT JOIN quest_mail_sender ON Id=QuestId");
 
     if (!result)
     {

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4111,8 +4111,8 @@ void ObjectMgr::LoadQuests()
     // Load `quest_template_addon`
     //                                   0   1         2                 3              4            5            6               7                     8
     result = WorldDatabase.Query("SELECT ID, MaxLevel, AllowableClasses, SourceSpellID, PrevQuestID, NextQuestID, ExclusiveGroup, RewardMailTemplateID, RewardMailDelay, "
-        //9               10                   11                     12                     13                   14                   15                 16
-        "RequiredSkillID, RequiredSkillPoints, RequiredMinRepFaction, RequiredMaxRepFaction, RequiredMinRepValue, RequiredMaxRepValue, ProvidedItemCount, SpecialFlags FROM quest_template_addon");
+        //9               10                   11                     12                     13                   14                   15                 16                     17
+        "RequiredSkillID, RequiredSkillPoints, RequiredMinRepFaction, RequiredMaxRepFaction, RequiredMinRepValue, RequiredMaxRepValue, ProvidedItemCount, RewardMailSenderEntry, SpecialFlags FROM quest_template_addon");
 
     if (!result)
     {
@@ -4616,6 +4616,7 @@ void ObjectMgr::LoadQuests()
                     qinfo->GetQuestId(), qinfo->RewardMailTemplateId, qinfo->RewardMailTemplateId);
                 qinfo->RewardMailTemplateId = 0;               // no mail will send to player
                 qinfo->RewardMailDelay = 0;                // no mail will send to player
+                qinfo->RewardMailSenderEntry = 0;
             }
             else if (usedMailTemplates.find(qinfo->RewardMailTemplateId) != usedMailTemplates.end())
             {
@@ -4624,6 +4625,7 @@ void ObjectMgr::LoadQuests()
                     qinfo->GetQuestId(), qinfo->RewardMailTemplateId, qinfo->RewardMailTemplateId, used_mt_itr->second);
                 qinfo->RewardMailTemplateId = 0;               // no mail will send to player
                 qinfo->RewardMailDelay = 0;                // no mail will send to player
+                qinfo->RewardMailSenderEntry = 0;
             }
             else
                 usedMailTemplates[qinfo->RewardMailTemplateId] = qinfo->GetQuestId();

--- a/src/server/game/Mails/Mail.cpp
+++ b/src/server/game/Mails/Mail.cpp
@@ -70,6 +70,13 @@ MailSender::MailSender(Player* sender)
     m_senderId = sender->GetGUID().GetCounter();
 }
 
+MailSender::MailSender(uint32 senderEntry)
+{
+    m_messageType = MAIL_CREATURE;
+    m_senderId = senderEntry;
+    m_stationery = MAIL_STATIONERY_DEFAULT;
+}
+
 MailReceiver::MailReceiver(Player* receiver) : m_receiver(receiver), m_receiver_lowguid(receiver->GetGUID().GetCounter()) { }
 
 MailReceiver::MailReceiver(Player* receiver, ObjectGuid::LowType receiver_lowguid) : m_receiver(receiver), m_receiver_lowguid(receiver_lowguid)

--- a/src/server/game/Mails/Mail.h
+++ b/src/server/game/Mails/Mail.h
@@ -90,6 +90,7 @@ class TC_GAME_API MailSender
         MailSender(CalendarEvent* sender);
         MailSender(AuctionEntry* sender);
         MailSender(Player* sender);
+        MailSender(uint32 senderEntry);
     public:                                                 // Accessors
         MailMessageType GetMailMessageType() const { return m_messageType; }
         ObjectGuid::LowType GetSenderId() const { return m_senderId; }

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -196,7 +196,8 @@ void Quest::LoadQuestTemplateAddon(Field* fields)
     RequiredMinRepValue = fields[13].GetInt32();
     RequiredMaxRepValue = fields[14].GetInt32();
     StartItemCount = fields[15].GetUInt8();
-    SpecialFlags = fields[16].GetUInt8();
+    RewardMailSenderEntry = fields[16].GetUInt32();
+    SpecialFlags = fields[17].GetUInt8();
 
     if (SpecialFlags & QUEST_SPECIAL_FLAGS_AUTO_ACCEPT)
         Flags |= QUEST_FLAGS_AUTO_ACCEPT;

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -257,6 +257,7 @@ class TC_GAME_API Quest
         int32  GetRewSpellCast() const { return RewardSpell; }
         uint32 GetRewMailTemplateId() const { return RewardMailTemplateId; }
         uint32 GetRewMailDelaySecs() const { return RewardMailDelay; }
+        uint32 GetRewMailSenderEntry() const { return RewardMailSenderEntry; }
         uint32 GetPOIContinent() const { return POIContinent; }
         float  GetPOIx() const { return POIx; }
         float  GetPOIy() const { return POIy; }
@@ -374,6 +375,7 @@ class TC_GAME_API Quest
         uint32 RequiredMaxRepFaction = 0;
         int32  RequiredMaxRepValue   = 0;
         uint32 StartItemCount        = 0;
+        uint32 RewardMailSenderEntry = 0;
         uint32 SpecialFlags          = 0; // custom flags, not sniffed/WDB
 };
 


### PR DESCRIPTION
**Changes proposed**:

Right now, all mails sent by NPCs when turning in a quest show as being sent by the questender NPC. However, some mails are sent by a different NPC.

Adding ~~a column in quest_template_addon~~ a new table to specify a different NPC's entry to show as sender seems the more sane way to handle the few mails that behave like that.

**Target branch(es)**: 335

**Tests performed**: testing in progress...
