### PR TITLE
Core/AI Prevent bosses respawn when BossState is set to DONE

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -507,6 +507,14 @@ void BossAI::_EnterCombat()
     ScheduleTasks();
 }
 
+bool BossAI::CanRespawn()
+{
+    if (instance && instance->GetBossState(_bossId) == DONE)
+        return false;
+
+    return true;
+}
+
 void BossAI::TeleportCheaters()
 {
     float x, y, z;

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -361,6 +361,7 @@ class TC_GAME_API BossAI : public ScriptedAI
         void JustReachedHome() override { _JustReachedHome(); }
 
         bool CanAIAttack(Unit const* target) const override { return CheckBoundary(target); }
+        bool CanRespawn() override;
 
     protected:
         void _Reset();


### PR DESCRIPTION
**Changes proposed**:
- If bossState is set to DONE, then block respawn.
- Currently, the only thing that prevents their respawn, is if they are linked in `linked_respawn`, which is not very effective anymore, since we need to remove that in order to use `_DespawnAtEvade`, for example. Also, just set `spawntimesecs` to a high value isn't enough because now instance cooldowns can be extended.

**Target branch(es)**: 335/6x

**Tests performed**: Built and tested
