### PR TITLE
Game/Entities: Player- Allow non-empty bags to be swapped with larger bag.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10233,9 +10233,6 @@ InventoryResult Player::CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemP
 
     uint32 need_space;
 
-    if (pSrcItem && pSrcItem->IsNotEmptyBag() && !IsBagPos(uint16(bag) << 8 | slot))
-        return EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS;
-
     // empty specific slot - check item fit to slot
     if (!pItem2 || swap)
     {


### PR DESCRIPTION
**Changes proposed**:
Allow an equipped bag with items to be swapped with a bag of the same size or larger.

**Target branch(es)**: 335

**Tests performed**: (Does it build, tested in-game, etc)
It builds and runs. When tested the bags swap and the items are put into the new bag. Gives appropriate error message if the bag size is too small or of the wrong type.
