### PR TITLE
Game/Entities: Player- Allow an empty bag of equal or larger size to be swapped with an equipped bag containing items.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10233,7 +10233,7 @@ InventoryResult Player::CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemP
 
     uint32 need_space;
 
-    if (pSrcItem && pSrcItem->IsNotEmptyBag() && !IsBagPos(uint16(bag) << 8 | slot))
+	if (pSrcItem && pSrcItem->IsNotEmptyBag() && !IsBagPos(uint16(bag) << 8 | slot) && !swap)
         return EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS;
 
     // empty specific slot - check item fit to slot

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10233,7 +10233,7 @@ InventoryResult Player::CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemP
 
     uint32 need_space;
 
-	if (pSrcItem && pSrcItem->IsNotEmptyBag() && !IsBagPos(uint16(bag) << 8 | slot) && !swap)
+    if (pSrcItem && pSrcItem->IsNotEmptyBag() && !IsBagPos(uint16(bag) << 8 | slot) && !swap)
         return EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS;
 
     // empty specific slot - check item fit to slot


### PR DESCRIPTION
**Changes proposed**:
Allow an empty bag of equal or larger size to be swapped with an equipped bag containing items.

**Target branch(es)**: 335

**Tests performed**: (Does it build, tested in-game, etc)
It builds and was tested in game. It now allows an empty bag to be swapped with an equipped bag containing items as long as there is room for all the items in the new bag. Equipped bags with items cannot be moved into the inventory.
