### PR TITLE
Core/Players: Fix logic regarding HandleCharEnum and DHs

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -266,6 +266,8 @@ void WorldSession::HandleCharEnum(PreparedQueryResult result)
 {
     uint8 demonHunterCount = 0; // We use this counter to allow multiple demon hunter creations when allowed in config
     bool canAlwaysCreateDemonHunter = HasPermission(rbac::RBAC_PERM_SKIP_CHECK_CHARACTER_CREATION_DEMON_HUNTER);
+    if (sWorld->getIntConfig(CONFIG_CHARACTER_CREATING_MIN_LEVEL_FOR_DEMON_HUNTER) == 0) // char level = 0 means this check is disabled, so always true
+        canAlwaysCreateDemonHunter = true;
     WorldPackets::Character::EnumCharactersResult charEnum;
     charEnum.Success = true;
     charEnum.IsDeletedCharacters = false;
@@ -319,7 +321,7 @@ void WorldSession::HandleCharEnum(PreparedQueryResult result)
         while (result->NextRow());
     }
 
-    charEnum.IsDemonHunterCreationAllowed = (!charEnum.HasDemonHunterOnRealm && charEnum.HasLevel70OnRealm);
+    charEnum.IsDemonHunterCreationAllowed = (!charEnum.HasDemonHunterOnRealm && charEnum.HasLevel70OnRealm) || canAlwaysCreateDemonHunter;
 
     SendPacket(charEnum.Write());
 }


### PR DESCRIPTION
**Changes proposed**:
- If CONFIG_CHARACTER_CREATING_MIN_LEVEL_FOR_DEMON_HUNTER was set to 0 (disable in the config), it would still not allow you to create a DH in case there were no prior characters.
- If RBAC_PERM_SKIP_CHECK_CHARACTER_CREATION_DEMON_HUNTER was true (AKA allow DH creation always) it would not allow DH creation regardless of existing characters or not considering canAlwaysCreateDemonHunter was not checked for validity on charEnum.IsDemonHunterCreationAllowed.

**Target branch(es)**: 6x (technically 7x)

**Issues addressed**: Fixed the logic, making canAlwaysCreateDemonHunter actually taken in account and work -always- as it should.

**Tests performed**: (Does it build, tested in-game, etc) It's been tested with an empty character list both with the minimum level being 0 and the SKIP check. Works in all cases after commit.
