### PR TITLE
Core/Spell: Remove all raid auras on party leave

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4289,6 +4289,20 @@ void Unit::RemoveAllAurasExceptType(AuraType type1, AuraType type2)
     }
 }
 
+void Unit::RemoveAllGroupBuffsFromCaster(ObjectGuid casterGUID)
+{
+    for (AuraMap::iterator iter = m_ownedAuras.begin(); iter != m_ownedAuras.end();)
+    {
+        Aura* aura = iter->second;
+        if (aura->GetCasterGUID() == casterGUID && aura->GetSpellInfo()->IsGroupBuff())
+        {
+            RemoveOwnedAura(iter);
+            continue;
+        }
+        ++iter;
+    }
+}
+
 void Unit::DelayOwnedAuras(uint32 spellId, ObjectGuid caster, int32 delaytime)
 {
     AuraMapBoundsNonConst range = m_ownedAuras.equal_range(spellId);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1760,6 +1760,7 @@ class TC_GAME_API Unit : public WorldObject
         void RemoveAllAurasRequiringDeadTarget();
         void RemoveAllAurasExceptType(AuraType type);
         void RemoveAllAurasExceptType(AuraType type1, AuraType type2); /// @todo: once we support variadic templates use them here
+        void RemoveAllGroupBuffsFromCaster(ObjectGuid casterGUID);
         void DelayOwnedAuras(uint32 spellId, ObjectGuid caster, int32 delaytime);
 
         void _RemoveAllAuraStatMods();

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -34,6 +34,7 @@
 #include "Util.h"
 #include "LFGMgr.h"
 #include "UpdateFieldFlags.h"
+#include "SpellAuras.h"
 
 Roll::Roll(ObjectGuid _guid, LootItem const& li) : itemGUID(_guid), itemid(li.itemid),
 itemRandomPropId(li.randomPropertyId), itemRandomSuffix(li.randomSuffix), itemCount(li.count),

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -488,34 +488,15 @@ bool Group::RemoveMember(ObjectGuid guid, const RemoveMethod& method /*= GROUP_R
     Player* player = ObjectAccessor::FindConnectedPlayer(guid);
     if (player)
     {
-        Unit::AuraMap const& ownedAuras = player->GetOwnedAuras();
-        for (Unit::AuraMap::const_iterator itr = ownedAuras.begin(); itr != ownedAuras.end(); ++itr)
+        for (GroupReference* itr = GetFirstMember(); itr != nullptr; itr = itr->next())
         {
-            Aura* aura = itr->second;
-            if (!aura->GetApplicationOfTarget(player->GetGUID()))
-                continue;
-
-            if (aura->GetSpellInfo()->IsRaidMemberTarget() && aura->GetCasterGUID() != guid)
-                player->RemoveAura(aura);
-        }
-
-        for (member_witerator witr = m_memberSlots.begin(); witr != m_memberSlots.end(); ++witr)
-        {
-            if (witr->guid == guid)
-                continue;
-
-            if (Player* groupMember = ObjectAccessor::FindConnectedPlayer(witr->guid))
+            if (Player* groupMember = itr->GetSource())
             {
-                Unit::AuraMap const& memberAuras = groupMember->GetOwnedAuras();
-                for (Unit::AuraMap::const_iterator itr = memberAuras.begin(); itr != memberAuras.end(); ++itr)
-                {
-                    Aura* aura = itr->second;
-                    if (!aura->GetApplicationOfTarget(groupMember->GetGUID()))
-                        continue;
+                if (groupMember->GetGUID() == guid)
+                    continue;
 
-                    if (aura->GetSpellInfo()->IsRaidMemberTarget() && aura->GetCasterGUID() == guid)
-                        groupMember->RemoveAura(aura);
-                }
+                groupMember->RemoveAllGroupBuffsFromCaster(guid);
+                player->RemoveAllGroupBuffsFromCaster(groupMember->GetGUID());
             }
         }
     }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1134,22 +1134,8 @@ bool SpellInfo::IsAllowingDeadTarget() const
 bool SpellInfo::IsGroupBuff() const
 {
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-    {
-        switch (Effects[i].TargetA.GetTarget())
-        {
-            case TARGET_UNIT_CASTER_AREA_RAID:
-            case TARGET_UNIT_TARGET_RAID:
-            case TARGET_UNIT_TARGET_AREA_RAID_CLASS:
-                if (IsPositiveEffect(i) &&
-                    (Effects[i].Effect == SPELL_EFFECT_APPLY_AURA ||
-                        Effects[i].Effect == SPELL_EFFECT_APPLY_AREA_AURA_PARTY ||
-                        Effects[i].Effect == SPELL_EFFECT_APPLY_AREA_AURA_RAID))
-                    return true;
-                break;
-            default:
-                break;
-        }
-    }
+        if (Effects[i].TargetA.GetCheckType() & (TARGET_CHECK_PARTY | TARGET_CHECK_RAID | TARGET_CHECK_RAID_CLASS))
+            return true;
 
     return false;
 }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1134,8 +1134,17 @@ bool SpellInfo::IsAllowingDeadTarget() const
 bool SpellInfo::IsGroupBuff() const
 {
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        if (Effects[i].TargetA.GetCheckType() & (TARGET_CHECK_PARTY | TARGET_CHECK_RAID | TARGET_CHECK_RAID_CLASS))
-            return true;
+    {
+        switch (Effects[i].TargetA.GetCheckType())
+        {
+            case TARGET_CHECK_PARTY:
+            case TARGET_CHECK_RAID:
+            case TARGET_CHECK_RAID_CLASS:
+                return true;
+            default:
+                break;
+        }
+    }
 
     return false;
 }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1131,11 +1131,26 @@ bool SpellInfo::IsAllowingDeadTarget() const
     return HasAttribute(SPELL_ATTR2_CAN_TARGET_DEAD) || Targets & (TARGET_FLAG_CORPSE_ALLY | TARGET_FLAG_CORPSE_ENEMY | TARGET_FLAG_UNIT_DEAD);
 }
 
-bool SpellInfo::IsRaidMemberTarget() const
+bool SpellInfo::IsGroupBuff() const
 {
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        if (Effects[i].IsEffect() && (Effects[i].TargetA.GetTarget() & (TARGET_UNIT_CASTER_AREA_RAID | TARGET_UNIT_TARGET_RAID | TARGET_UNIT_TARGET_AREA_RAID_CLASS)))
-            return true;
+    {
+        switch (Effects[i].TargetA.GetTarget())
+        {
+            case TARGET_UNIT_CASTER_AREA_RAID:
+            case TARGET_UNIT_TARGET_RAID:
+            case TARGET_UNIT_TARGET_AREA_RAID_CLASS:
+                if (IsPositiveEffect(i) &&
+                    (Effects[i].Effect == SPELL_EFFECT_APPLY_AURA ||
+                        Effects[i].Effect == SPELL_EFFECT_APPLY_AREA_AURA_PARTY ||
+                        Effects[i].Effect == SPELL_EFFECT_APPLY_AREA_AURA_RAID))
+                    return true;
+                break;
+            default:
+                break;
+        }
+    }
+
     return false;
 }
 

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1131,6 +1131,14 @@ bool SpellInfo::IsAllowingDeadTarget() const
     return HasAttribute(SPELL_ATTR2_CAN_TARGET_DEAD) || Targets & (TARGET_FLAG_CORPSE_ALLY | TARGET_FLAG_CORPSE_ENEMY | TARGET_FLAG_UNIT_DEAD);
 }
 
+bool SpellInfo::IsRaidMemberTarget() const
+{
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        if (Effects[i].IsEffect() && (Effects[i].TargetA.GetTarget() & (TARGET_UNIT_CASTER_AREA_RAID | TARGET_UNIT_TARGET_RAID | TARGET_UNIT_TARGET_AREA_RAID_CLASS)))
+            return true;
+    return false;
+}
+
 bool SpellInfo::CanBeUsedInCombat() const
 {
     return !HasAttribute(SPELL_ATTR0_CANT_USED_IN_COMBAT);

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -413,6 +413,7 @@ public:
     bool IsDeathPersistent() const;
     bool IsRequiringDeadTarget() const;
     bool IsAllowingDeadTarget() const;
+    bool IsRaidMemberTarget() const;
     bool CanBeUsedInCombat() const;
     bool IsPositive() const;
     bool IsPositiveEffect(uint8 effIndex) const;

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -413,7 +413,7 @@ public:
     bool IsDeathPersistent() const;
     bool IsRequiringDeadTarget() const;
     bool IsAllowingDeadTarget() const;
-    bool IsRaidMemberTarget() const;
+    bool IsGroupBuff() const;
     bool CanBeUsedInCombat() const;
     bool IsPositive() const;
     bool IsPositiveEffect(uint8 effIndex) const;


### PR DESCRIPTION
**Changes proposed**:
- Remove all raid auras on party leave (https://youtu.be/S2znqLUQZzo?t=1m28s)
- As of Patch 2.1, "... In addition, the soulstone buff will now be removed if the target or caster leaves the party or raid." 

**Target branch(es)**: 335/6x

**Tests performed**: (Does it build, tested in-game, etc)
Tested in-game

**Known issues and TODO list**:
- [x] Find a better way 
