### PR TITLE
Core/Quest: Finally delete ALL quest bound items on quest reward, fai…

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14887,9 +14887,9 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
         {
             if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
                 DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
+            else 
+                DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
         }
-        else 
-            DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
     }
     for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
     {
@@ -14897,9 +14897,9 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
         {
             if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
                 DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
+            else
+                DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
         }
-        else
-            DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
     }
 
     RemoveTimedQuest(quest_id);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14888,8 +14888,8 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
             if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
                 DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
         }
-        else if (quest->RequiredItemId[i])
-                DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
+        else 
+            DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
     }
     for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
     {
@@ -14898,8 +14898,8 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
             if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
                 DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
         }
-        else if (quest->ItemDrop[i])
-                DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
+        else
+            DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
     }
 
     RemoveTimedQuest(quest_id);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14882,16 +14882,20 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     uint32 quest_id = quest->GetQuestId();
 
     for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
-        if (quest->RequiredItemId[i])
-            DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true);
-
+    {
+        if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
+            if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
+                DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
+            else if (quest->RequiredItemId[i])
+                     DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
+    }
     for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
     {
-        if (quest->ItemDrop[i])
-        {
-            uint32 count = quest->ItemDropQuantity[i];
-            DestroyItemCount(quest->ItemDrop[i], count ? count : 9999, true);
-        }
+        if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
+            if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
+                DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
+            else if (quest->ItemDrop[i])
+                     DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
     }
 
     RemoveTimedQuest(quest_id);
@@ -15103,12 +15107,12 @@ void Player::FailQuest(uint32 questId)
         for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
             if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
                 if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
-                    DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
+                    DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
 
         for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
             if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
                 if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
-                    DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
+                    DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
     }
 }
 
@@ -15120,12 +15124,12 @@ void Player::AbandonQuest(uint32 questId)
         for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
             if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
                 if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
-                    DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
+                    DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
 
         for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
             if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
                 if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
-                    DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
+                    DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
     }
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14884,22 +14884,22 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
+        {
             if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
-            {
                 DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
-            }
-            else if (quest->RequiredItemId[i])
-                     DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
+        }
+        else if (quest->RequiredItemId[i])
+                DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
     }
     for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
+        {
             if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
-            {
                 DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
-            }
-            else if (quest->ItemDrop[i])
-                     DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
+        }
+        else if (quest->ItemDrop[i])
+                DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
     }
 
     RemoveTimedQuest(quest_id);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14885,7 +14885,9 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
             if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
+            {
                 DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
+            }
             else if (quest->RequiredItemId[i])
                      DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
     }
@@ -14893,7 +14895,9 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
             if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
+            {
                 DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
+            }
             else if (quest->ItemDrop[i])
                      DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);
     }


### PR DESCRIPTION
**Changes proposed**: Currently only the required amount of quest bound items are deleted on reward, fail, or abandon of a quest. However, there are quests like: http://www.wowhead.com/quest=582/headhunting that allow you to collect more than the required amount due to drop rates.
- Fix Player::RewardQuest to delete ALL quest bound items on quest turn in
- Fix Player::AbandonQuest to delete ALL quest bound items -- period
- Fix Player::FailQuest to delete ALL quest bound items -- period

**Target branch(es)**: 335/6x

**Issues addressed**: Closes #

**Tests performed**: (Does it build, tested in-game, etc)
- Builds
- Tested quest turn in with and without quest bound items.
- Tested abandoning quests with greater than the required amount of quest bound items
- Tested failing quests with greater than the required amount of quest bound items
- Tested quest turn in with items that are not quest bound to make sure only the required amount were deleted
- Tested abandoning quests with items that are not quest bound to make sure nothing is deleted since they are just normal drops
- Tested failing quests with items that are not quest bound to make sure nothing is deleted since they are just normal drops
- Think I pretty well covered it...

**Known issues and TODO list**:
- None
