### PR TITLE
Core/Loot: Partially fix group loot. Loot rules should not apply to party loot.

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -354,7 +354,7 @@ LootItem::LootItem(LootStoreItem const& li)
 
     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemid);
     freeforall  = proto && (proto->Flags & ITEM_PROTO_FLAG_MULTI_DROP);
-    follow_loot_rules = proto && (proto->FlagsCu & ITEM_FLAGS_CU_FOLLOW_LOOT_RULES !proto->Flags & ITEM_PROTO_FLAG_MULTI_DROP);
+    follow_loot_rules = proto && (proto->FlagsCu & ITEM_FLAGS_CU_FOLLOW_LOOT_RULES && !proto->Flags & ITEM_PROTO_FLAG_MULTI_DROP);
 
     needs_quest = li.needs_quest;
 

--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -354,7 +354,7 @@ LootItem::LootItem(LootStoreItem const& li)
 
     ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemid);
     freeforall  = proto && (proto->Flags & ITEM_PROTO_FLAG_MULTI_DROP);
-    follow_loot_rules = proto && (proto->FlagsCu & ITEM_FLAGS_CU_FOLLOW_LOOT_RULES);
+    follow_loot_rules = proto && (proto->FlagsCu & ITEM_FLAGS_CU_FOLLOW_LOOT_RULES !proto->Flags & ITEM_PROTO_FLAG_MULTI_DROP);
 
     needs_quest = li.needs_quest;
 


### PR DESCRIPTION
**Changes proposed**: Currently if you are in a group, and you all accept a quest, only one member can loot party loot -- no matter the loot mode. An example would be quest 3904 (Milly's Harvest).
The reason I say that this partially fixes the problem is that you have to revert: https://github.com/TrinityCore/TrinityCore/commit/a49544cc187d3a156b4615907d6b82057364fcc4 for this to work correctly. I have not had a chance to look through that commit to find out why, but depending on loot mode, creature->ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS); is getting sent to players that haven't looted yet. No sparkle, no loot. 

If you don't want to back out that patch, the "workaround" is to have the first person in the party that loots leave their loot window open until everyone has looted. 
- Not apply loot rules to party loot

**Target branch(es)**: 335/6x

**Issues addressed**: Closes #

**Tests performed**: (Does it build, tested in-game, etc)
- Builds
- Tested with 3 players .. all were able to receive party loot while in a group.

**Known issues and TODO list**:
- None for this PR. There will be an additional PR when I fully figure out why dynamic flag updates are getting sent to players that haven't looted.
