### PR TITLE
[6.x/7.x-Prepatch] Scripts/Spells: Fix Shaman talent Earthen Rage

### DIFF
--- a/sql/updates/world/6.x/2016_xx_xx_xx_world.sql
+++ b/sql/updates/world/6.x/2016_xx_xx_xx_world.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (170374, 170377); 
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(170374, 'spell_sha_earthen_rage_passive'),
+(170377, 'spell_sha_earthen_rage_proc_aura');

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -22,6 +22,7 @@
 #include "SpellAuraDefines.h"
 #include "SpellInfo.h"
 #include "Unit.h"
+#include <boost/any.hpp>
 
 class SpellInfo;
 struct SpellModifier;
@@ -294,6 +295,16 @@ class TC_GAME_API Aura
         SpellEffectInfoVector GetSpellEffectInfos() const { return _spelEffectInfos; }
         SpellEffectInfo const* GetSpellEffectInfo(uint32 index) const;
 
+        template<typename T>
+        T const* GetCastExtraParam(std::string const& key) const
+        {
+            auto itr = m_castExtraParams.find(key);
+            if (itr != m_castExtraParams.end())
+                return boost::any_cast<T>(&itr->second);
+            return nullptr;
+        }
+        void SetCastExtraParam(std::string const& keyVal, boost::any&& value) { m_castExtraParams[keyVal] = value; }
+
     private:
         void _DeleteRemovedApplications();
     protected:
@@ -326,6 +337,9 @@ class TC_GAME_API Aura
 
         std::chrono::steady_clock::time_point m_lastProcAttemptTime;
         std::chrono::steady_clock::time_point m_lastProcSuccessTime;
+
+        // Used to store extra parameters for an aura, eg. data across different auras
+        std::unordered_map<std::string, boost::any> m_castExtraParams;
 
     private:
         Unit::AuraApplicationList m_removedApplications;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -24,7 +24,6 @@
 #include "ObjectMgr.h"
 #include "SpellInfo.h"
 #include "PathGenerator.h"
-#include <boost/any.hpp>
 
 namespace WorldPackets
 {

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -24,6 +24,7 @@
 #include "ObjectMgr.h"
 #include "SpellInfo.h"
 #include "PathGenerator.h"
+#include <boost/any.hpp>
 
 namespace WorldPackets
 {
@@ -654,6 +655,16 @@ class TC_GAME_API Spell
 
         int32 GetTimer() const { return m_timer; }
 
+        template<typename T>
+        T const* GetCastExtraParam(std::string const& key) const
+        {
+            auto itr = m_castExtraParams.find(key);
+            if (itr != m_castExtraParams.end())
+                return boost::any_cast<T>(&itr->second);
+            return nullptr;
+        }
+        void SetCastExtraParam(std::string const& keyVal, boost::any&& value) { m_castExtraParams[keyVal] = value; }
+
     protected:
         bool HasGlobalCooldown() const;
         void TriggerGlobalCooldown();
@@ -690,6 +701,9 @@ class TC_GAME_API Spell
             m_delayAtDamageCount++;
             return false;
         }
+
+        // Used to store extra parameters for a spell, eg. data across different spells
+        std::unordered_map<std::string, boost::any> m_castExtraParams;
 
         // Delayed spells system
         uint64 m_delayStart;                                // time of spell delay start, filled by event handler, zero = just started

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -655,16 +655,6 @@ class TC_GAME_API Spell
 
         int32 GetTimer() const { return m_timer; }
 
-        template<typename T>
-        T const* GetCastExtraParam(std::string const& key) const
-        {
-            auto itr = m_castExtraParams.find(key);
-            if (itr != m_castExtraParams.end())
-                return boost::any_cast<T>(&itr->second);
-            return nullptr;
-        }
-        void SetCastExtraParam(std::string const& keyVal, boost::any&& value) { m_castExtraParams[keyVal] = value; }
-
     protected:
         bool HasGlobalCooldown() const;
         void TriggerGlobalCooldown();
@@ -701,9 +691,6 @@ class TC_GAME_API Spell
             m_delayAtDamageCount++;
             return false;
         }
-
-        // Used to store extra parameters for a spell, eg. data across different spells
-        std::unordered_map<std::string, boost::any> m_castExtraParams;
 
         // Delayed spells system
         uint64 m_delayStart;                                // time of spell delay start, filled by event handler, zero = just started

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -341,15 +341,8 @@ class spell_sha_earthen_rage_proc_aura : public SpellScriptLoader
                 }
             }
 
-            void CalcPeriodic(AuraEffect const* /*aurEff*/, bool& /*isPeriodic*/, int32& amplitude)
-            {
-                // On retail there have been 1-6 procs randomly distributed over the duration
-                amplitude = urand(1000, 4000);
-            }
-
             void Register() override
             {
-                DoEffectCalcPeriodic += AuraEffectCalcPeriodicFn(spell_sha_earthen_rage_proc_aura_AuraScript::CalcPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
                 OnEffectPeriodic += AuraEffectPeriodicFn(spell_sha_earthen_rage_proc_aura_AuraScript::HandleEffectPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
             }
         };

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -34,6 +34,9 @@ enum ShamanSpells
 {
     SPELL_SHAMAN_EARTH_SHIELD_HEAL              = 379,
     SPELL_SHAMAN_EARTH_SHOCK                    = 8042,
+    SPELL_SHAMAN_EARTHEN_RAGE_PASSIVE           = 170374,
+    SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC          = 170377,
+    SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE            = 170379,
     SPELL_SHAMAN_ELEMENTAL_BLAST_CRIT           = 118522,
     SPELL_SHAMAN_ELEMENTAL_BLAST_HASTE          = 173183,
     SPELL_SHAMAN_ELEMENTAL_BLAST_MASTERY        = 173184,
@@ -263,6 +266,97 @@ class spell_sha_earth_shield : public SpellScriptLoader
         AuraScript* GetAuraScript() const override
         {
             return new spell_sha_earth_shield_AuraScript();
+        }
+};
+
+// 170374 - Earthen Rage (Passive)
+class spell_sha_earthen_rage_passive : public SpellScriptLoader
+{
+    public:
+        spell_sha_earthen_rage_passive() : SpellScriptLoader("spell_sha_earthen_rage_passive") { }
+
+        class spell_sha_earthen_rage_passive_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_sha_earthen_rage_passive_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PASSIVE))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE))
+                    return false;
+                return true;
+            }
+
+            void HandleEffectProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+            {
+                PreventDefaultAction();
+                GetAura()->SetCastExtraParam("procTargetGUID", eventInfo.GetProcTarget()->GetGUID());
+                eventInfo.GetActor()->CastSpell(eventInfo.GetActor(), SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC, true);
+            }
+
+            void Register() override
+            {
+                OnEffectProc += AuraEffectProcFn(spell_sha_earthen_rage_passive_AuraScript::HandleEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new  spell_sha_earthen_rage_passive_AuraScript();
+        }
+};
+
+// 170377 - Earthen Rage (Proc Aura)
+class spell_sha_earthen_rage_proc_aura : public SpellScriptLoader
+{
+    public:
+        spell_sha_earthen_rage_proc_aura() : SpellScriptLoader("spell_sha_earthen_rage_proc_aura") { }
+
+        class spell_sha_earthen_rage_proc_aura_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_sha_earthen_rage_proc_aura_AuraScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PASSIVE))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC))
+                    return false;
+                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE))
+                    return false;
+                return true;
+            }
+
+            void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
+            {
+                PreventDefaultAction();
+                if (Aura* aura = GetCaster()->GetAura(SPELL_SHAMAN_EARTHEN_RAGE_PASSIVE))
+                {
+                    ObjectGuid const* procTargetGUID = aura->GetCastExtraParam<ObjectGuid>("procTargetGUID");
+                    if (Unit* procTarget = ObjectAccessor::GetUnit(*GetCaster(), *procTargetGUID))
+                        GetTarget()->CastSpell(procTarget, SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE, true);
+                }
+            }
+
+            void CalcPeriodic(AuraEffect const* /*aurEff*/, bool& /*isPeriodic*/, int32& amplitude)
+            {
+                // On retail there have been 1-6 procs randomly distributed over the duration
+                amplitude = urand(1000, 4000);
+            }
+
+            void Register() override
+            {
+                DoEffectCalcPeriodic += AuraEffectCalcPeriodicFn(spell_sha_earthen_rage_proc_aura_AuraScript::CalcPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
+                OnEffectPeriodic += AuraEffectPeriodicFn(spell_sha_earthen_rage_proc_aura_AuraScript::HandleEffectPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new  spell_sha_earthen_rage_proc_aura_AuraScript();
         }
 };
 
@@ -1213,6 +1307,8 @@ void AddSC_shaman_spell_scripts()
     new spell_sha_bloodlust();
     new spell_sha_chain_heal();
     new spell_sha_earth_shield();
+    new spell_sha_earthen_rage_passive();
+    new spell_sha_earthen_rage_proc_aura();
     new spell_sha_elemental_blast();
     new spell_sha_fire_nova();
     new spell_sha_flametongue();

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -281,8 +281,6 @@ class spell_sha_earthen_rage_passive : public SpellScriptLoader
 
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
-                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PASSIVE))
-                    return false;
                 if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC))
                     return false;
                 if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE))
@@ -322,8 +320,6 @@ class spell_sha_earthen_rage_proc_aura : public SpellScriptLoader
             bool Validate(SpellInfo const* /*spellInfo*/) override
             {
                 if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PASSIVE))
-                    return false;
-                if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC))
                     return false;
                 if (!sSpellMgr->GetSpellInfo(SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE))
                     return false;


### PR DESCRIPTION
**Changes proposed**:
- Fix Earthen Rage (http://www.wowhead.com/spell=170374)
- Shoots stones at last damaged target, as spell description says

**Target branch(es)**: 6.x/7.x-Prepatch

**Tests performed**: Working ingame
