### PR TITLE
Yet another attempt to fix the melee range checks + clean up

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -492,12 +492,7 @@ bool Unit::IsWithinMeleeRange(Unit const* obj) const
 
 float Unit::GetMeleeRange(Unit const* target) const
 {
-    float range = this->GetCombatReach() + 4.0f / 3.0f;
-    if (target)
-        range += target->GetCombatReach();
-    else
-        range += this->GetCombatReach();
-
+    float range = this->GetCombatReach() + target->GetCombatReach() + 4.0f / 3.0f;
     return std::max(range, NOMINAL_MELEE_RANGE);
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -485,9 +485,20 @@ bool Unit::IsWithinMeleeRange(Unit const* obj) const
     float dz = GetPositionZMinusOffset() - obj->GetPositionZMinusOffset();
     float distsq = dx*dx + dy*dy + dz*dz;
 
-    float maxdist = GetCombatReach() + obj->GetCombatReach() + 4.0f / 3.0f;
+    float maxdist = GetMeleeRange(obj);
 
     return distsq <= maxdist * maxdist;
+}
+
+float Unit::GetMeleeRange(Unit const* target) const
+{
+    float range = this->GetCombatReach() + 4.0f / 3.0f;
+    if (target)
+        range += target->GetCombatReach();
+    else
+        range += this->GetCombatReach();
+
+    return std::max(range, NOMINAL_MELEE_RANGE);
 }
 
 void Unit::GetRandomContactPoint(const Unit* obj, float &x, float &y, float &z, float distance2dMin, float distance2dMax) const

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -492,7 +492,7 @@ bool Unit::IsWithinMeleeRange(Unit const* obj) const
 
 float Unit::GetMeleeRange(Unit const* target) const
 {
-    float range = this->GetCombatReach() + target->GetCombatReach() + 4.0f / 3.0f;
+    float range = GetCombatReach() + target->GetCombatReach() + 4.0f / 3.0f;
     return std::max(range, NOMINAL_MELEE_RANGE);
 }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1291,6 +1291,7 @@ class TC_GAME_API Unit : public WorldObject
         float GetCombatReach() const { return m_floatValues[UNIT_FIELD_COMBATREACH]; }
         bool IsWithinCombatRange(const Unit* obj, float dist2compare) const;
         bool IsWithinMeleeRange(Unit const* obj) const;
+        float GetMeleeRange(Unit const* target) const;
         void GetRandomContactPoint(const Unit* target, float &x, float &y, float &z, float distance2dMin, float distance2dMax) const;
         uint32 m_extraAttacks;
         bool m_canDualWield;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5835,7 +5835,7 @@ SpellCastResult Spell::CheckRange(bool strict)
     float minRange = 0.0f;
     float maxRange = 0.0f;
     
-    GetMinMaxRange(strict, &minRange, &maxRange);
+    GetMinMaxRange(strict, minRange, maxRange);
 
     // get square values for sqr distance checks
     minRange *= minRange;
@@ -5866,13 +5866,13 @@ SpellCastResult Spell::CheckRange(bool strict)
     return SPELL_CAST_OK;
 }
 
-void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
+void Spell::GetMinMaxRange(bool strict, float& minRange, float& maxRange)
 {
     Unit* target = m_targets.GetUnitTarget();
     float rangeMod = 0.0f;
     if (strict && IsNextMeleeSwingSpell()) 
     {
-        *maxRange = 100.0f;
+        maxRange = 100.0f;
         return;
     }
 
@@ -5888,15 +5888,16 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
             if (m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED)
                 meleeRange = m_caster->GetMeleeRange(target);
 
-            *minRange = m_caster->GetSpellMinRangeForTarget(target, m_spellInfo) + meleeRange;
-            *maxRange = m_caster->GetSpellMaxRangeForTarget(target, m_spellInfo);
+            minRange = m_caster->GetSpellMinRangeForTarget(target, m_spellInfo) + meleeRange;
+            maxRange = m_caster->GetSpellMaxRangeForTarget(target, m_spellInfo);
 
             if (target || m_targets.GetCorpseTarget())
             {
                 rangeMod = m_caster->GetCombatReach() + (target ? target->GetCombatReach() : m_caster->GetCombatReach());
 
-                if (*minRange > 0.0f && !(m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED))
-                    *minRange += rangeMod;
+
+                if (minRange > 0.0f && !(m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED))
+                    minRange += rangeMod;
             }
         }
 
@@ -5907,12 +5908,12 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
 
     if (m_spellInfo->HasAttribute(SPELL_ATTR0_REQ_AMMO) && m_caster->GetTypeId() == TYPEID_PLAYER)
         if (Item* ranged = m_caster->ToPlayer()->GetWeaponForAttack(RANGED_ATTACK, true))
-            *maxRange *= ranged->GetTemplate()->RangedModRange * 0.01f;
+            maxRange *= ranged->GetTemplate()->RangedModRange * 0.01f;
 
     if (Player* modOwner = m_caster->GetSpellModOwner())
-        modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, *maxRange, this);
+        modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, maxRange, this);
 
-    *maxRange += rangeMod;
+    maxRange += rangeMod;
 }
 
 SpellCastResult Spell::CheckPower()

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5870,35 +5870,23 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
 {
     Unit* target = m_targets.GetUnitTarget();
     float rangeMod = 0.0f;
-    if (strict && IsNextMeleeSwingSpell()) {
+    if (strict && IsNextMeleeSwingSpell()) 
+    {
         *maxRange = 100.0f;
         return;
     }
+
     if (m_spellInfo->RangeEntry)
     {
         if (m_spellInfo->RangeEntry->type & SPELL_RANGE_MELEE)
         {
-            rangeMod = m_caster->GetCombatReach() + 4.0f / 3.0f;
-            if (target)
-                rangeMod += target->GetCombatReach();
-            else
-                rangeMod += m_caster->GetCombatReach();
-
-            rangeMod = std::max(rangeMod, NOMINAL_MELEE_RANGE);
+            rangeMod = GetMeleeRange(m_caster, target);
         }
         else
         {
             float meleeRange = 0.0f;
             if (m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED)
-            {
-                meleeRange = m_caster->GetCombatReach() + 4.0f / 3.0f;
-                if (target)
-                    meleeRange += target->GetCombatReach();
-                else
-                    meleeRange += m_caster->GetCombatReach();
-
-                meleeRange = std::max(meleeRange, NOMINAL_MELEE_RANGE);
-            }
+                meleeRange = GetMeleeRange(m_caster, target);
 
             *minRange = m_caster->GetSpellMinRangeForTarget(target, m_spellInfo) + meleeRange;
             *maxRange = m_caster->GetSpellMaxRangeForTarget(target, m_spellInfo);
@@ -5927,6 +5915,17 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
         modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, maxRange, this);
 
     *maxRange += rangeMod;
+}
+
+float Spell::GetMeleeRange(Unit* caster, Unit* target)
+{
+    float range = caster->GetCombatReach() +  4.0f / 3.0f;
+    if (target)
+        range += target->GetCombatReach();
+    else
+        range += caster->GetCombatReach();
+
+    return std::max(range, NOMINAL_MELEE_RANGE);
 }
 
 SpellCastResult Spell::CheckPower()

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5880,13 +5880,13 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
     {
         if (m_spellInfo->RangeEntry->type & SPELL_RANGE_MELEE)
         {
-            rangeMod = GetMeleeRange(m_caster, target);
+            rangeMod = m_caster->GetMeleeRange(target);
         }
         else
         {
             float meleeRange = 0.0f;
             if (m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED)
-                meleeRange = GetMeleeRange(m_caster, target);
+                meleeRange = m_caster->GetMeleeRange(target);
 
             *minRange = m_caster->GetSpellMinRangeForTarget(target, m_spellInfo) + meleeRange;
             *maxRange = m_caster->GetSpellMaxRangeForTarget(target, m_spellInfo);
@@ -5915,17 +5915,6 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
         modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, maxRange, this);
 
     *maxRange += rangeMod;
-}
-
-float Spell::GetMeleeRange(Unit* caster, Unit* target)
-{
-    float range = caster->GetCombatReach() +  4.0f / 3.0f;
-    if (target)
-        range += target->GetCombatReach();
-    else
-        range += caster->GetCombatReach();
-
-    return std::max(range, NOMINAL_MELEE_RANGE);
 }
 
 SpellCastResult Spell::CheckPower()

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5868,8 +5868,7 @@ std::pair<float, float> Spell::GetMinMaxRange(bool strict)
     float rangeMod = 0.0f;
     float minRange = 0.0f;
     float maxRange = 0.0f;
-
-    if (strict && IsNextMeleeSwingSpell()) 
+    if (strict && IsNextMeleeSwingSpell())
     {
         maxRange = 100.0f;
         return std::pair<float, float>(minRange, maxRange);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5912,7 +5912,7 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
             *maxRange *= ranged->GetTemplate()->RangedModRange * 0.01f;
 
     if (Player* modOwner = m_caster->GetSpellModOwner())
-        modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, maxRange, this);
+        modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, *maxRange, this);
 
     *maxRange += rangeMod;
 }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5893,9 +5893,7 @@ void Spell::GetMinMaxRange(bool strict, float* minRange, float* maxRange)
 
             if (target || m_targets.GetCorpseTarget())
             {
-                rangeMod = m_caster->GetCombatReach();
-                if (target)
-                    rangeMod += target->GetCombatReach();
+                rangeMod = m_caster->GetCombatReach() + (target ? target->GetCombatReach() : m_caster->GetCombatReach());
 
                 if (*minRange > 0.0f && !(m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED))
                     *minRange += rangeMod;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5831,7 +5831,6 @@ SpellCastResult Spell::CheckRange(bool strict)
     if (!strict && m_casttime == 0)
         return SPELL_CAST_OK;
 
-    Unit* target = m_targets.GetUnitTarget();
     float minRange = 0.0f;
     float maxRange = 0.0f;
     

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5831,10 +5831,8 @@ SpellCastResult Spell::CheckRange(bool strict)
     if (!strict && m_casttime == 0)
         return SPELL_CAST_OK;
 
-    float minRange = 0.0f;
-    float maxRange = 0.0f;
-    
-    GetMinMaxRange(strict, minRange, maxRange);
+    float minRange, maxRange;
+    std::tie(minRange, maxRange) = GetMinMaxRange(strict);
 
     // get square values for sqr distance checks
     minRange *= minRange;
@@ -5865,18 +5863,21 @@ SpellCastResult Spell::CheckRange(bool strict)
     return SPELL_CAST_OK;
 }
 
-void Spell::GetMinMaxRange(bool strict, float& minRange, float& maxRange)
+std::pair<float, float> Spell::GetMinMaxRange(bool strict)
 {
-    Unit* target = m_targets.GetUnitTarget();
     float rangeMod = 0.0f;
+    float minRange = 0.0f;
+    float maxRange = 0.0f;
+
     if (strict && IsNextMeleeSwingSpell()) 
     {
         maxRange = 100.0f;
-        return;
+        return std::pair<float, float>(minRange, maxRange);
     }
 
     if (m_spellInfo->RangeEntry)
     {
+        Unit* target = m_targets.GetUnitTarget();
         if (m_spellInfo->RangeEntry->type & SPELL_RANGE_MELEE)
         {
             rangeMod = m_caster->GetMeleeRange(target ? target : m_caster); // when the target is not a unit, take the caster's combat reach as the target's combat reach.
@@ -5913,6 +5914,8 @@ void Spell::GetMinMaxRange(bool strict, float& minRange, float& maxRange)
         modOwner->ApplySpellMod(m_spellInfo->Id, SPELLMOD_RANGE, maxRange, this);
 
     maxRange += rangeMod;
+
+    return std::pair<float, float>(minRange, maxRange);
 }
 
 SpellCastResult Spell::CheckPower()

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5880,13 +5880,13 @@ void Spell::GetMinMaxRange(bool strict, float& minRange, float& maxRange)
     {
         if (m_spellInfo->RangeEntry->type & SPELL_RANGE_MELEE)
         {
-            rangeMod = m_caster->GetMeleeRange(target);
+            rangeMod = m_caster->GetMeleeRange(target ? target : m_caster); // when the target is not a unit, take the caster's combat reach as the target's combat reach.
         }
         else
         {
             float meleeRange = 0.0f;
             if (m_spellInfo->RangeEntry->type & SPELL_RANGE_RANGED)
-                meleeRange = m_caster->GetMeleeRange(target);
+                meleeRange = m_caster->GetMeleeRange(target ? target : m_caster); // when the target is not a unit, take the caster's combat reach as the target's combat reach.
 
             minRange = m_caster->GetSpellMinRangeForTarget(target, m_spellInfo) + meleeRange;
             maxRange = m_caster->GetSpellMaxRangeForTarget(target, m_spellInfo);

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -507,7 +507,7 @@ class TC_GAME_API Spell
         void CancelGlobalCooldown();
 
         void SendLoot(ObjectGuid guid, LootType loottype);
-        void GetMinMaxRange(bool strict, float& minRange, float& maxRange);
+        std::pair<float, float> GetMinMaxRange(bool strict);
 
         Unit* const m_caster;
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -507,7 +507,7 @@ class TC_GAME_API Spell
         void CancelGlobalCooldown();
 
         void SendLoot(ObjectGuid guid, LootType loottype);
-        void GetMinMaxRange(bool strict, float* minRange, float* maxRange);
+        void GetMinMaxRange(bool strict, float& minRange, float& maxRange);
 
         Unit* const m_caster;
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -508,7 +508,6 @@ class TC_GAME_API Spell
 
         void SendLoot(ObjectGuid guid, LootType loottype);
         void GetMinMaxRange(bool strict, float* minRange, float* maxRange);
-        float GetMeleeRange(Unit* caster, Unit* target);
 
         Unit* const m_caster;
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -508,6 +508,7 @@ class TC_GAME_API Spell
 
         void SendLoot(ObjectGuid guid, LootType loottype);
         void GetMinMaxRange(bool strict, float* minRange, float* maxRange);
+        float GetMeleeRange(Unit* caster, Unit* target);
 
         Unit* const m_caster;
 

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -507,6 +507,7 @@ class TC_GAME_API Spell
         void CancelGlobalCooldown();
 
         void SendLoot(ObjectGuid guid, LootType loottype);
+        void GetMinMaxRange(bool strict, float* minRange, float* maxRange);
 
         Unit* const m_caster;
 


### PR DESCRIPTION
**Changes proposed**:
- Duplication of logic is bad. So I tried to regroup the "melee range" logic into one function and let the other parts of the game reuse that function.
- I simplyfied Spell::CheckRange() and broke it into 2 functions.
- Fix what is mentioned [here
  ](https://github.com/TrinityCore/TrinityCore/commit/14b93c04ee07e9fe6e2767460e7fc7cc2b3e6808#commitcomment-18191617) and [here](https://github.com/TrinityCore/TrinityCore/commit/e6a52d4aae9e8facc46c3b05e0560d540a928d73#commitcomment-18104786)
- Fix a potential issue regarding non melee spell ranges on non unit targets:
  In order to write [this commit](https://github.com/TrinityCore/TrinityCore/commit/e6a52d4aae9e8facc46c3b05e0560d540a928d73), @Shauren used [this decompiled code ](http://paste2.org/2FUCZ4Ix)of wow client 6.2.3 (cf https://community.trinitycore.org/topic/12515-unambiguously-defining-auto-attack-and-spell-range). In it, we can see how the client manages the range validation. And long story short, Shauren didn't translate completely the line 86 from the decompiled code. This is how I wrote this fix.

**Target branch(es)**: 335

**Issues addressed**: https://github.com/TrinityCore/TrinityCore/issues/17539 (which is strange because the ticket is closed but the issue is still unsolved)

**Tests performed**: It builds. Did not test IG to be honest.

**Left to do**: Clean up SpellTargetSelector::operator() in UnitAI.cpp which also duplicate logic :(

This PR is easier to read commit by commit I think.
