### PR TITLE
[6.x] Core/Spell: Restore SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN behavior

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8033,6 +8033,10 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, ui
                 TakenTotalCasterMod += (float((*i)->GetAmount()));
         }
 
+        // from positive and negative SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN
+        // multiplicative bonus, for example Dispersion + Shadowform (0.10*0.85=0.085)
+        TakenTotalMod *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN, spellProto->GetSchoolMask());
+
         // From caster spells
         AuraEffectList const& mOwnerTaken = GetAuraEffectsByType(SPELL_AURA_MOD_SPELL_DAMAGE_FROM_CASTER);
         for (AuraEffectList::const_iterator i = mOwnerTaken.begin(); i != mOwnerTaken.end(); ++i)


### PR DESCRIPTION
**Changes proposed:**

Restore SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN behavior on spells cases. Currently is working on melee damage

**Target branch(es):** 6.x

**Issues addressed:** None i think

**Tests performed:** (Does it build, tested in-game, etc):
.unaura all
.aura 60988
/cast Dispersion

Tested on a shadow priest lvl 110
Currenty the damage taken is around 610 per tick, if you activate Dispersion you still take 610 per tick.
With this fix 610 is reduced to 244 which is correct according to the 60% damage reduction.

This commit only restore these lines https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Unit/Unit.cpp#L9977-L9979 as they are missing in 6.x branch
