### PR TITLE
Core/Conditions Exclude creatures not spawned from CONDITION_NEAR_CREATURE search

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -651,6 +651,11 @@ Creature* GetClosestCreatureWithEntry(WorldObject* source, uint32 entry, float m
     return source->FindNearestCreature(entry, maxSearchRange, alive);
 }
 
+Creature* GetClosestSpawnedCreatureWithEntry(WorldObject* source, uint32 entry, float maxSearchRange, bool alive /*= true*/)
+{
+    return source->FindNearestSpawnedCreature(entry, maxSearchRange, alive);
+}
+
 GameObject* GetClosestGameObjectWithEntry(WorldObject* source, uint32 entry, float maxSearchRange)
 {
     return source->FindNearestGameObject(entry, maxSearchRange);

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -413,6 +413,7 @@ class TC_GAME_API WorldBossAI : public ScriptedAI
 
 // SD2 grid searchers.
 TC_GAME_API Creature* GetClosestCreatureWithEntry(WorldObject* source, uint32 entry, float maxSearchRange, bool alive = true);
+TC_GAME_API Creature* GetClosestSpawnedCreatureWithEntry(WorldObject* source, uint32 entry, float maxSearchRange, bool alive = true);
 TC_GAME_API GameObject* GetClosestGameObjectWithEntry(WorldObject* source, uint32 entry, float maxSearchRange);
 TC_GAME_API void GetCreatureListWithEntryInGrid(std::list<Creature*>& list, WorldObject* source, uint32 entry, float maxSearchRange);
 TC_GAME_API void GetGameObjectListWithEntryInGrid(std::list<GameObject*>& list, WorldObject* source, uint32 entry, float maxSearchRange);

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -284,11 +284,7 @@ bool Condition::Meets(ConditionSourceInfo& sourceInfo) const
         }
         case CONDITION_NEAR_CREATURE:
         {
-            Creature* crea = GetClosestCreatureWithEntry(object, ConditionValue1, (float)ConditionValue2, bool(!ConditionValue3));
-            if (!crea || (ConditionValue3 && crea->getDeathState() == DEAD))
-                condMeets = false;
-            else
-                condMeets = true;
+            condMeets = GetClosestSpawnedCreatureWithEntry(object, ConditionValue1, (float)ConditionValue2, bool(!ConditionValue3)) ? true : false;
             break;
         }
         case CONDITION_NEAR_GAMEOBJECT:

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -284,7 +284,11 @@ bool Condition::Meets(ConditionSourceInfo& sourceInfo) const
         }
         case CONDITION_NEAR_CREATURE:
         {
-            condMeets = GetClosestCreatureWithEntry(object, ConditionValue1, (float)ConditionValue2, bool(!ConditionValue3)) ? true : false;
+            Creature* crea = GetClosestCreatureWithEntry(object, ConditionValue1, (float)ConditionValue2, bool(!ConditionValue3));
+            if (!crea || (ConditionValue3 && crea->getDeathState() == DEAD))
+                condMeets = false;
+            else
+                condMeets = true;
             break;
         }
         case CONDITION_NEAR_GAMEOBJECT:

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2101,6 +2101,15 @@ Creature* WorldObject::FindNearestCreature(uint32 entry, float range, bool alive
     return creature;
 }
 
+Creature* WorldObject::FindNearestSpawnedCreature(uint32 entry, float range, bool alive) const
+{
+    Creature* creature = NULL;
+    Trinity::NearestSpawnedCreatureEntryWithLiveStateInObjectRangeCheck checker(*this, entry, alive, range);
+    Trinity::CreatureLastSearcher<Trinity::NearestSpawnedCreatureEntryWithLiveStateInObjectRangeCheck> searcher(this, creature, checker);
+    VisitNearbyObject(range, searcher);
+    return creature;
+}
+
 GameObject* WorldObject::FindNearestGameObject(uint32 entry, float range) const
 {
     GameObject* go = NULL;

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -550,6 +550,7 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         void SummonCreatureGroup(uint8 group, std::list<TempSummon*>* list = NULL);
 
         Creature*   FindNearestCreature(uint32 entry, float range, bool alive = true) const;
+        Creature*   FindNearestSpawnedCreature(uint32 entry, float range, bool alive = true) const;
         GameObject* FindNearestGameObject(uint32 entry, float range) const;
         GameObject* FindNearestGameObjectOfType(GameobjectTypes type, float range) const;
 

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1174,6 +1174,32 @@ namespace Trinity
             NearestCreatureEntryWithLiveStateInObjectRangeCheck(NearestCreatureEntryWithLiveStateInObjectRangeCheck const&);
     };
 
+    class NearestSpawnedCreatureEntryWithLiveStateInObjectRangeCheck
+    {
+        public:
+            NearestSpawnedCreatureEntryWithLiveStateInObjectRangeCheck(WorldObject const& obj, uint32 entry, bool alive, float range)
+                : i_obj(obj), i_entry(entry), i_alive(alive), i_range(range) { }
+
+            bool operator()(Creature* u)
+            {
+                if (u->GetEntry() == i_entry && u->IsAlive() == i_alive && u->getDeathState() != DEAD && i_obj.IsWithinDistInMap(u, i_range))
+                {
+                    i_range = i_obj.GetDistance(u);         // use found unit range as new range limit for next check
+                    return true;
+                }
+                return false;
+            }
+            float GetLastRange() const { return i_range; }
+        private:
+            WorldObject const& i_obj;
+            uint32 i_entry;
+            bool   i_alive;
+            float  i_range;
+
+            // prevent clone this object
+            NearestSpawnedCreatureEntryWithLiveStateInObjectRangeCheck(NearestSpawnedCreatureEntryWithLiveStateInObjectRangeCheck const&);
+    };
+
     class AnyPlayerInObjectRangeCheck
     {
         public:


### PR DESCRIPTION
**Changes proposed:**
-  Exclude creatures not spawned from CONDITION_NEAR_CREATURE

**Target branch(es):** 3.3.5/6.x

**Issues addressed:** Updates #11418

**Tests performed:** Built and tested with quest The Big Bone Worm(10930)
