### PR TITLE
Core/Spells: Implemented the function to set the next crit/noncrit of a spell

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2707,6 +2707,12 @@ void Unit::_UpdateSpells(uint32 time)
         }
     }
 
+    for (auto nexctSpellCrit : m_spellCritMap)
+    {
+        if (!nexctSpellCrit.first.first)
+            m_spellCritMap.erase(nexctSpellCrit.first);
+    }
+
     _spellHistory->Update();
 }
 
@@ -16189,30 +16195,30 @@ bool Unit::VisibleAuraSlotCompare::operator()(AuraApplication* left, AuraApplica
 
 bool Unit::IsNextSpellACrit(Unit* target, uint32 spellId) const
 {
-    auto itr = m_spellCritMap.find(std::pair<Unit*, uint32>(target, spellId));
+    auto itr = m_spellCritMap.find(std::make_pair(target, spellId));
 
     return itr != m_spellCritMap.end() && itr->second == true;
 }
 
 void Unit::SetNextSpellCrit(Unit* target, uint32 spellId, bool crit)
 {
-    auto itr = m_spellCritMap.find(std::pair<Unit*, uint32>(target, spellId));
+    auto itr = m_spellCritMap.find(std::make_pair(target, spellId));
 
     if (itr == m_spellCritMap.end())
-        m_spellCritMap.emplace(std::pair<Unit*, uint32>(target, spellId), crit);
+        m_spellCritMap.emplace(std::make_pair(target, spellId), crit);
 }
 
 bool Unit::HasNextSpellCritData(Unit* target, uint32 spellId) const
 {
-    auto itr = m_spellCritMap.find(std::pair<Unit*, uint32>(target, spellId));
+    auto itr = m_spellCritMap.find(std::make_pair(target, spellId));
 
     return itr != m_spellCritMap.end();
 }
 
 void Unit::RemoveNextSpellCritData(Unit* target, uint32 spellId)
 {
-    auto itr = m_spellCritMap.find(std::pair<Unit*, uint32>(target, spellId));
+    auto itr = m_spellCritMap.find(std::make_pair(target, spellId));
 
     if (itr != m_spellCritMap.end() && !m_spellCritMap.empty())
-        m_spellCritMap.erase(std::pair<Unit*, uint32>(target, spellId));
+        m_spellCritMap.erase(std::make_pair(target, spellId));
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16201,6 +16201,7 @@ void Unit::SetNextSpellCrit(Unit* target, uint32 spellId, bool crit)
     if (itr == m_spellCritMap.end())
         m_spellCritMap.emplace(std::pair<Unit*, uint32>(target, spellId), crit);
 }
+
 bool Unit::HasNextSpellCritData(Unit* target, uint32 spellId) const
 {
     auto itr = m_spellCritMap.find(std::pair<Unit*, uint32>(target, spellId));
@@ -16212,8 +16213,6 @@ void Unit::RemoveNextSpellCritData(Unit* target, uint32 spellId)
 {
     auto itr = m_spellCritMap.find(std::pair<Unit*, uint32>(target, spellId));
 
-    if (itr != m_spellCritMap.end() && !m_spellCritMap.empty()) {
-
+    if (itr != m_spellCritMap.end() && !m_spellCritMap.empty())
         m_spellCritMap.erase(std::pair<Unit*, uint32>(target, spellId));
-    }
 }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -162,7 +162,8 @@ enum SpellValueMod
     SPELLVALUE_BASE_POINT_END,
     SPELLVALUE_RADIUS_MOD,
     SPELLVALUE_MAX_TARGETS,
-    SPELLVALUE_AURA_STACK
+    SPELLVALUE_AURA_STACK,
+    SPELLVALUE_CRIT_FLAG,
 };
 
 class CustomSpellValues
@@ -1323,7 +1324,7 @@ class TC_GAME_API Unit : public WorldObject
     public:
         typedef std::set<Unit*> AttackerSet;
         typedef std::set<Unit*> ControlList;
-		
+
         typedef std::unordered_map<std::pair<Unit* /*target*/, uint32 /*spellId*/>, bool /*IsSpellCrit*/> NextSpellCritMap;
 
         typedef std::multimap<uint32, Aura*> AuraMap;
@@ -1959,7 +1960,7 @@ class TC_GAME_API Unit : public WorldObject
         bool IsInFeralForm() const;
 
         bool IsInDisallowedMountForm() const;
-		
+
         bool IsNextSpellACrit(Unit* target, uint32 spellId) const;
         void SetNextSpellCrit(Unit* target, uint32 spellId, bool crit);
         bool HasNextSpellCritData(Unit* target, uint32 spellId) const;
@@ -2399,7 +2400,7 @@ class TC_GAME_API Unit : public WorldObject
         time_t _lastDamagedTime; // Part of Evade mechanics
 
         SpellHistory* _spellHistory;
-		
+
         NextSpellCritMap m_spellCritMap;
 };
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1323,6 +1323,8 @@ class TC_GAME_API Unit : public WorldObject
     public:
         typedef std::set<Unit*> AttackerSet;
         typedef std::set<Unit*> ControlList;
+		
+        typedef std::unordered_map<std::pair<Unit* /*target*/, uint32 /*spellId*/>, bool /*IsSpellCrit*/> NextSpellCritMap;
 
         typedef std::multimap<uint32, Aura*> AuraMap;
         typedef std::pair<AuraMap::const_iterator, AuraMap::const_iterator> AuraMapBounds;
@@ -1957,6 +1959,11 @@ class TC_GAME_API Unit : public WorldObject
         bool IsInFeralForm() const;
 
         bool IsInDisallowedMountForm() const;
+		
+        bool IsNextSpellACrit(Unit* target, uint32 spellId) const;
+        void SetNextSpellCrit(Unit* target, uint32 spellId, bool crit);
+        bool HasNextSpellCritData(Unit* target, uint32 spellId) const;
+        void RemoveNextSpellCritData(Unit* target, uint32 spellId);
 
         float m_modMeleeHitChance;
         float m_modRangedHitChance;
@@ -2392,6 +2399,8 @@ class TC_GAME_API Unit : public WorldObject
         time_t _lastDamagedTime; // Part of Evade mechanics
 
         SpellHistory* _spellHistory;
+		
+        NextSpellCritMap m_spellCritMap;
 };
 
 namespace Trinity

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -496,6 +496,7 @@ SpellValue::SpellValue(Difficulty diff, SpellInfo const* proto)
     MaxAffectedTargets = proto->MaxAffectedTargets;
     RadiusMod = 1.0f;
     AuraStackAmount = 1;
+    CritFlag = SPELLVALUE_CRIT_FLAG_NONE;
 }
 
 Spell::Spell(Unit* caster, SpellInfo const* info, TriggerCastFlags triggerFlags, ObjectGuid originalCasterGUID, bool skipCheck) :
@@ -6941,7 +6942,10 @@ void Spell::DoAllEffectOnLaunchTarget(TargetInfo& targetInfo, float* multiplier)
         }
     }
 
-    targetInfo.crit = m_caster->IsSpellCrit(unit, m_spellInfo, m_spellSchoolMask, m_attackType);
+    if (m_spellValue->CritFlag != SPELLVALUE_CRIT_FLAG_NONE)
+        targetInfo.crit = m_spellValue->CritFlag == SPELLVALUE_CRIT_FLAG_CRIT ? true : false;
+    else
+        targetInfo.crit = m_caster->IsSpellCrit(unit, m_spellInfo, m_spellSchoolMask, m_attackType);
 }
 
 SpellCastResult Spell::CanOpenLock(uint32 effIndex, uint32 lockId, SkillType& skillId, int32& reqSkillValue, int32& skillValue)
@@ -7032,6 +7036,9 @@ void Spell::SetSpellValue(SpellValueMod mod, int32 value)
             break;
         case SPELLVALUE_AURA_STACK:
             m_spellValue->AuraStackAmount = uint8(value);
+            break;
+        case SPELLVALUE_CRIT_FLAG:
+            m_spellValue->CritFlag = SpellValueCritFlag(value);
             break;
         default:
             break;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -274,6 +274,13 @@ class TC_GAME_API SpellCastTargets
         std::string m_strTarget;
 };
 
+enum SpellValueCritFlag : uint8
+{
+    SPELLVALUE_CRIT_FLAG_NONE = 0,
+    SPELLVALUE_CRIT_FLAG_NONCRIT = 1,
+    SPELLVALUE_CRIT_FLAG_CRIT = 2,
+};
+
 struct SpellValue
 {
     explicit  SpellValue(Difficulty diff, SpellInfo const* proto);
@@ -282,13 +289,6 @@ struct SpellValue
     float     RadiusMod;
     uint8     AuraStackAmount;
     SpellValueCritFlag CritFlag;
-};
-
-enum SpellValueCritFlag : uint8
-{
-    SPELLVALUE_CRIT_FLAG_NONE = 0,
-    SPELLVALUE_CRIT_FLAG_NONCRIT = 1,
-    SPELLVALUE_CRIT_FLAG_CRIT = 2,
 };
 
 enum SpellState

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -281,6 +281,14 @@ struct SpellValue
     uint32    MaxAffectedTargets;
     float     RadiusMod;
     uint8     AuraStackAmount;
+    SpellValueCritFlag CritFlag;
+};
+
+enum SpellValueCritFlag : uint8
+{
+    SPELLVALUE_CRIT_FLAG_NONE = 0,
+    SPELLVALUE_CRIT_FLAG_NONCRIT = 1,
+    SPELLVALUE_CRIT_FLAG_CRIT = 2,
 };
 
 enum SpellState

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -684,6 +684,11 @@ SpellValue const* SpellScript::GetSpellValue()
     return m_spell->m_spellValue;
 }
 
+void SpellScript::SetSpellValue(SpellValueMod mod, int32 value)
+{
+    m_spell->SetSpellValue(mod, value);
+}
+
 SpellEffectInfo const* SpellScript::GetEffectInfo(SpellEffIndex effIndex) const
 {
     return m_spell->GetEffect(effIndex);

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -651,6 +651,17 @@ SpellInfo const* SpellScript::GetTriggeringSpell()
     return m_spell->m_triggeredByAuraSpell;
 }
 
+bool SpellScript::IsSpellCrit(Unit* target) const
+{
+    for (auto itr : m_spell->m_UniqueTargetInfo)
+    {
+        if (itr.targetGUID == target->GetGUID())
+            return itr.crit;
+    }
+
+    return false;
+}
+
 void SpellScript::FinishCast(SpellCastResult result)
 {
     m_spell->SendCastResult(result);

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -372,6 +372,7 @@ class TC_GAME_API SpellScript : public _SpellScript
         Unit* GetOriginalCaster();
         SpellInfo const* GetSpellInfo();
         SpellValue const* GetSpellValue();
+        void SetSpellValue(SpellValueMod mod, int32 value);
         SpellEffectInfo const* GetEffectInfo(SpellEffIndex) const;
 
         // methods useable after spell is prepared
@@ -455,7 +456,7 @@ class TC_GAME_API SpellScript : public _SpellScript
 
         // Returns SpellInfo from the spell that triggered the current one
         SpellInfo const* GetTriggeringSpell();
-		
+
         bool IsSpellCrit(Unit* target) const;
 
         // finishes spellcast prematurely with selected error message

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -455,6 +455,8 @@ class TC_GAME_API SpellScript : public _SpellScript
 
         // Returns SpellInfo from the spell that triggered the current one
         SpellInfo const* GetTriggeringSpell();
+		
+        bool IsSpellCrit(Unit* target) const;
 
         // finishes spellcast prematurely with selected error message
         void FinishCast(SpellCastResult result);


### PR DESCRIPTION
**Changes proposed:**
-  Set the next spell crit/noncrit for a specific target
-  Set Spellvalues over SpellScript
-  Possibility to set Crit over SpellValue

**Target branch(es):** 6.x

**Tests performed:** (Does it build, tested in-game, etc)
Tested with Demon hunter spell Chaos Strike.
Chaos Strike should have a shared crit roll for main and off hand and it worked.
If Main hand crits, off hand will too.. if main hand doesn't crit, the off hand won't too

**Known issues and TODO list:**
- [ ] 
- [ ] 
