### PR TITLE
Core/Quest: Delete only required amount of items unless item is quest

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14885,7 +14885,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
         {
-            if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
+            if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1 && itemTemplate->Flags & ITEM_PROTO_FLAG_MULTI_DROP))
                 DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
             else 
                 DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
@@ -14895,7 +14895,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
         {
-            if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1))
+            if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1 && itemTemplate->Flags & ITEM_PROTO_FLAG_MULTI_DROP))
                 DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
             else
                 DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14885,7 +14885,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
         {
-            if (quest->RequiredItemCount[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1 && itemTemplate->Flags & ITEM_PROTO_FLAG_MULTI_DROP))
+            if (quest->RequiredItemCount[i] > 0 && ((itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1) && itemTemplate->Flags & ITEM_PROTO_FLAG_MULTI_DROP))
                 DestroyItemCount(quest->RequiredItemId[i], 9999, true, true);
             else 
                 DestroyItemCount(quest->RequiredItemId[i], quest->RequiredItemCount[i], true, true);
@@ -14895,7 +14895,7 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
     {
         if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->ItemDrop[i]))
         {
-            if (quest->ItemDropQuantity[i] > 0 && (itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1 && itemTemplate->Flags & ITEM_PROTO_FLAG_MULTI_DROP))
+            if (quest->ItemDropQuantity[i] > 0 && ((itemTemplate->Bonding == BIND_QUEST_ITEM || itemTemplate->Bonding == BIND_QUEST_ITEM1) && itemTemplate->Flags & ITEM_PROTO_FLAG_MULTI_DROP))
                 DestroyItemCount(quest->ItemDrop[i], 9999, true, true);
             else
                 DestroyItemCount(quest->ItemDrop[i], quest->ItemDropQuantity[i], true, true);


### PR DESCRIPTION
**Changes proposed:**
-  Only delete all quest bound items on turn in if they can not be used on another quest

**Target branch(es):** 3.3.5/6.x

**Issues addressed:** Closes # 17758

**Tests performed:** (Does it build, tested in-game, etc)
- Builds

**Known issues and TODO list:**
- [ ]  Need to check if there are any quests that would require all quest bound, multi-drop items to NOT be deleted
- [ ] Need to check if there are any quests the would require all quest bound, but NOT multi-drop items to be deleted.

``` SQL
SELECT `entry`, `name` from `item_template` WHERE `bonding`=4 AND Flags & 0x800; // Use this list to check the first issue
SELECT `entry`, `name` from `item_template` WHERE `bonding`=4 AND Flags &~ 0x800; // Use this query to check the second issue
```
