### PR TITLE
Core/Gameobject: Fix greeting (Questgiver-)Gameobjects

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2240,8 +2240,9 @@ void GameObject::BuildValuesUpdate(uint8 updateType, ByteBuffer* data, Player* t
                 switch (GetGoType())
                 {
                     case GAMEOBJECT_TYPE_QUESTGIVER:
-                        if (ActivateToQuest(target))
-                            dynFlags |= GO_DYNFLAG_LO_ACTIVATE;
+                        // Interaction should only be possible if GO has gossip or is active for quest
+                        if (!ActivateToQuest(target) && !GetGOInfo()->questgiver.gossipID)
+                            dynFlags |= GO_DYNFLAG_LO_NO_INTERACT; // This flag will disable interaction, not setting GO_DYNFLAG_LO_ACTIVATE will not!
                         break;
                     case GAMEOBJECT_TYPE_CHEST:
                     case GAMEOBJECT_TYPE_GOOBER:


### PR DESCRIPTION
**Changes proposed:**

_Is:_ If a questgiver-GO has no text assigned and a player is not on or eligible for a quest with that GO, a default message will be issued (Greetings, $N)

_Should be:_ In such cases the player should not be able to interact with that GO

**Target branch(es):** 3.3.5

**Tests performed:** Thoroughly tested, did not recheck sniffs
