### PR TITLE
Core/ObjectAccessor: optimize FindPlayerByName

### DIFF
--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -81,17 +81,27 @@ HashMapHolder<Player>::MapType const& ObjectAccessor::GetPlayers()
 template class TC_GAME_API HashMapHolder<Player>;
 template class TC_GAME_API HashMapHolder<Transport>;
 
-void PlayerNameMapHolder::Insert(Player* p)
+namespace PlayerNameMapHolder
+{
+typedef std::unordered_map<std::string, Player*> MapType;
+
+MapType& GetContainer()
+{
+    static MapType _objectMap;
+    return _objectMap;
+}
+
+void Insert(Player* p)
 {
     GetContainer()[p->GetName()] = p;
 }
 
-void PlayerNameMapHolder::Remove(Player* p)
+void Remove(Player* p)
 {
     GetContainer().erase(p->GetName());
 }
 
-Player* PlayerNameMapHolder::Find(std::string const& name)
+Player* Find(std::string const& name)
 {
     std::string charName(name);
     if (!normalizePlayerName(charName))
@@ -100,12 +110,7 @@ Player* PlayerNameMapHolder::Find(std::string const& name)
     typename MapType::iterator itr = GetContainer().find(charName);
     return (itr != GetContainer().end()) ? itr->second : nullptr;
 }
-
-PlayerNameMapHolder::MapType& PlayerNameMapHolder::GetContainer()
-{
-    static MapType _objectMap;
-    return _objectMap;
-}
+} // namespace PlayerNameMapHolder
 
 WorldObject* ObjectAccessor::GetWorldObject(WorldObject const& p, ObjectGuid const& guid)
 {

--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -101,7 +101,7 @@ Player* PlayerNameMapHolder::Find(std::string const& name)
     return (itr != GetContainer().end()) ? itr->second : nullptr;
 }
 
-auto PlayerNameMapHolder::GetContainer() -> MapType&
+PlayerNameMapHolder::MapType& PlayerNameMapHolder::GetContainer()
 {
     static MapType _objectMap;
     return _objectMap;

--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -102,7 +102,7 @@ Player* Find(std::string const& name)
     if (!normalizePlayerName(charName))
         return nullptr;
 
-    typename MapType::iterator itr = PlayerNameMap.find(charName);
+    auto itr = PlayerNameMap.find(charName);
     return (itr != PlayerNameMap.end()) ? itr->second : nullptr;
 }
 } // namespace PlayerNameMapHolder

--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -83,15 +83,11 @@ template class TC_GAME_API HashMapHolder<Transport>;
 
 void PlayerNameMapHolder::Insert(Player* p)
 {
-    boost::unique_lock<boost::shared_mutex> lock(*GetLock());
-
     GetContainer()[p->GetName()] = p;
 }
 
 void PlayerNameMapHolder::Remove(Player* p)
 {
-    boost::unique_lock<boost::shared_mutex> lock(*GetLock());
-
     GetContainer().erase(p->GetName());
 }
 
@@ -101,24 +97,14 @@ Player* PlayerNameMapHolder::Find(std::string const& name)
     if (!normalizePlayerName(charName))
         return nullptr;
 
-    {
-        boost::shared_lock<boost::shared_mutex> lock(*GetLock());
-
-        typename MapType::iterator itr = GetContainer().find(charName);
-        return (itr != GetContainer().end()) ? itr->second : nullptr;
-    }
+    typename MapType::iterator itr = GetContainer().find(charName);
+    return (itr != GetContainer().end()) ? itr->second : nullptr;
 }
 
 auto PlayerNameMapHolder::GetContainer() -> MapType&
 {
     static MapType _objectMap;
     return _objectMap;
-}
-
-boost::shared_mutex* PlayerNameMapHolder::GetLock()
-{
-    static boost::shared_mutex _lock;
-    return &_lock;
 }
 
 WorldObject* ObjectAccessor::GetWorldObject(WorldObject const& p, ObjectGuid const& guid)

--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -84,21 +84,16 @@ template class TC_GAME_API HashMapHolder<Transport>;
 namespace PlayerNameMapHolder
 {
 typedef std::unordered_map<std::string, Player*> MapType;
-
-MapType& GetContainer()
-{
-    static MapType _objectMap;
-    return _objectMap;
-}
+static MapType PlayerNameMap;
 
 void Insert(Player* p)
 {
-    GetContainer()[p->GetName()] = p;
+    PlayerNameMap[p->GetName()] = p;
 }
 
 void Remove(Player* p)
 {
-    GetContainer().erase(p->GetName());
+    PlayerNameMap.erase(p->GetName());
 }
 
 Player* Find(std::string const& name)
@@ -107,8 +102,8 @@ Player* Find(std::string const& name)
     if (!normalizePlayerName(charName))
         return nullptr;
 
-    typename MapType::iterator itr = GetContainer().find(charName);
-    return (itr != GetContainer().end()) ? itr->second : nullptr;
+    typename MapType::iterator itr = PlayerNameMap.find(charName);
+    return (itr != PlayerNameMap.end()) ? itr->second : nullptr;
 }
 } // namespace PlayerNameMapHolder
 

--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -95,13 +95,18 @@ void PlayerNameMapHolder::Remove(Player* p)
     GetContainer().erase(p->GetName());
 }
 
-// note that input string shall be normalized by the caller
 Player* PlayerNameMapHolder::Find(std::string const& name)
 {
-    boost::shared_lock<boost::shared_mutex> lock(*GetLock());
+    std::string charName(name);
+    if (!normalizePlayerName(charName))
+        return nullptr;
 
-    typename MapType::iterator itr = GetContainer().find(name);
-    return (itr != GetContainer().end()) ? itr->second : nullptr;
+    {
+        boost::shared_lock<boost::shared_mutex> lock(*GetLock());
+
+        typename MapType::iterator itr = GetContainer().find(charName);
+        return (itr != GetContainer().end()) ? itr->second : nullptr;
+    }
 }
 
 auto PlayerNameMapHolder::GetContainer() -> MapType&
@@ -252,11 +257,7 @@ Player* ObjectAccessor::FindConnectedPlayer(ObjectGuid const& guid)
 
 Player* ObjectAccessor::FindPlayerByName(std::string const& name)
 {
-    std::string nameStr = name;
-    if (!normalizePlayerName(nameStr))
-        return nullptr;
-
-    Player* player = PlayerNameMapHolder::Find(nameStr);
+    Player* player = PlayerNameMapHolder::Find(name);
     if (!player || !player->IsInWorld())
         return nullptr;
 
@@ -265,11 +266,7 @@ Player* ObjectAccessor::FindPlayerByName(std::string const& name)
 
 Player* ObjectAccessor::FindConnectedPlayerByName(std::string const& name)
 {
-    std::string nameStr = name;
-    if (!normalizePlayerName(nameStr))
-        return nullptr;
-
-    return PlayerNameMapHolder::Find(nameStr);
+    return PlayerNameMapHolder::Find(name);
 }
 
 void ObjectAccessor::SaveAllPlayers()

--- a/src/server/game/Globals/ObjectAccessor.h
+++ b/src/server/game/Globals/ObjectAccessor.h
@@ -81,8 +81,6 @@ public:
     static Player* Find(std::string const& name);
 
     static MapType& GetContainer();
-
-    static boost::shared_mutex* GetLock();
 };
 
 namespace ObjectAccessor

--- a/src/server/game/Globals/ObjectAccessor.h
+++ b/src/server/game/Globals/ObjectAccessor.h
@@ -65,24 +65,6 @@ public:
     static boost::shared_mutex* GetLock();
 };
 
-class TC_GAME_API PlayerNameMapHolder
-{
-    //Non instanceable only static
-    PlayerNameMapHolder() { }
-
-public:
-
-    typedef std::unordered_map<std::string, Player*> MapType;
-
-    static void Insert(Player* p);
-
-    static void Remove(Player* p);
-
-    static Player* Find(std::string const& name);
-
-    static MapType& GetContainer();
-};
-
 namespace ObjectAccessor
 {
     // these functions return objects only if in map of specified object

--- a/src/server/game/Globals/ObjectAccessor.h
+++ b/src/server/game/Globals/ObjectAccessor.h
@@ -72,7 +72,7 @@ class TC_GAME_API PlayerNameMapHolder
 
 public:
 
-    typedef std::map<std::string, Player*> MapType;
+    typedef std::unordered_map<std::string, Player*> MapType;
 
     static void Insert(Player* p);
 

--- a/src/server/game/Globals/ObjectAccessor.h
+++ b/src/server/game/Globals/ObjectAccessor.h
@@ -65,6 +65,26 @@ public:
     static boost::shared_mutex* GetLock();
 };
 
+class TC_GAME_API PlayerNameMapHolder
+{
+    //Non instanceable only static
+    PlayerNameMapHolder() { }
+
+public:
+
+    typedef std::map<std::string, Player*> MapType;
+
+    static void Insert(Player* p);
+
+    static void Remove(Player* p);
+
+    static Player* Find(std::string const& name);
+
+    static MapType& GetContainer();
+
+    static boost::shared_mutex* GetLock();
+};
+
 namespace ObjectAccessor
 {
     // these functions return objects only if in map of specified object
@@ -104,6 +124,12 @@ namespace ObjectAccessor
     {
         HashMapHolder<T>::Remove(object);
     }
+
+    template<>
+    void AddObject(Player* player);
+
+    template<>
+    void RemoveObject(Player* player);
 
     TC_GAME_API void SaveAllPlayers();
 };


### PR DESCRIPTION
**Changes proposed:**
-  Adds a template specialization for ObjectAccessor::Add/RemoveObject(Player*)
- Saves the (normalized) names in a map, so instead of iterating every player we can do a simple lookup on this new map.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc) Builds ok
