### PR TITLE
Tools/mmaps_generator: Add percentageDone to console

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -146,28 +146,8 @@ namespace MMAP
         }
         printf("found %u.\n\n", count);
 
-        // DEBUG code, this does the same as L115 through L147 above
-
-        // I'm counting tiles of every map with some portion of code taken
-        // from lines inside of buildMap() and buildNavMesh() wich are the real 
-        // process of building tile files, and buildng navmesh, first of all 
-        // this methods get how many tiles has each mapId in order to process data
-
-        // Surprisingly m_totalTiles matches how many tiles are found at L147
-
-        printf("\n\n Comienza la parte de codigo para saber el total de tiles\n\n");
-        std::set<uint32>* tiles;
-
-        for (TileList::iterator it = m_tiles.begin(); it != m_tiles.end(); ++it)
-        {
-            uint32 mapId = it->m_mapId;
-            tiles = getTileList(mapId);
-
-            m_totalTiles += tiles->size();
-            printf("Tiles para el mapa %u en total %zu.\n\n", mapId, tiles->size());
-        }
-
-        printf("Tiles en total %u.\n\n", m_totalTiles);
+        // percentageDone - total tiles to process
+        m_totalTiles = count;
     }
 
     /**************************************************************************/
@@ -440,6 +420,7 @@ namespace MMAP
     /**************************************************************************/
     void MapBuilder::buildTile(uint32 mapID, uint32 tileX, uint32 tileY, dtNavMesh* navMesh)
     {
+        // percentageDone - added, now it will show addional reference percentage done of the overall process
         printf("%u%% [Map %03i] Building tile [%02u,%02u]\n", percentageDone(m_totalTiles, m_totalTilesBuilt), mapID, tileX, tileY);
 
         MeshData meshData;
@@ -475,9 +456,8 @@ namespace MMAP
         // build navmesh tile
         buildMoveMapTile(mapID, tileX, tileY, meshData, bmin, bmax, navMesh);
 
-        // increment tiles done for percentageDone
+        // percentageDone - increment tiles built
         m_totalTilesBuilt++;
-        printf("m_totalTilesBuilt = %u\n", m_totalTilesBuilt);
     }
 
     /**************************************************************************/

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -60,6 +60,9 @@ namespace MMAP
 
         m_rcContext = new rcContext(false);
 
+        m_totalTiles = 0;
+        m_totalTilesDone = 0;
+
         discoverTiles();
     }
 
@@ -142,6 +145,8 @@ namespace MMAP
             }
         }
         printf("found %u.\n\n", count);
+
+        m_totalTiles = count;
     }
 
     /**************************************************************************/
@@ -414,7 +419,7 @@ namespace MMAP
     /**************************************************************************/
     void MapBuilder::buildTile(uint32 mapID, uint32 tileX, uint32 tileY, dtNavMesh* navMesh)
     {
-        printf("[Map %03i] Building tile [%02u,%02u]\n", mapID, tileX, tileY);
+        printf("%u%% [Map %03i] Building tile [%02u,%02u]\n", percentageDone(m_totalTiles, m_totalTilesDone), mapID, tileX, tileY);
 
         MeshData meshData;
 
@@ -851,6 +856,7 @@ namespace MMAP
 
             // now that tile is written to disk, we can unload it
             navMesh->removeTile(tileRef, NULL, NULL);
+            m_totalTilesDone++;
         }
         while (0);
 
@@ -1003,6 +1009,15 @@ namespace MMAP
             return false;
 
         return true;
+    }
+
+    /**************************************************************************/
+    uint32 MapBuilder::percentageDone(uint32 totalTiles, uint32 totalTilesDone)
+    {
+        if (totalTiles)
+            return totalTilesDone * 100 / totalTiles;
+
+        return 0;
     }
 
 }

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -60,6 +60,7 @@ namespace MMAP
 
         m_rcContext = new rcContext(false);
 
+        // percentageDone - Initializing
         m_totalTiles = 0;
         m_totalTilesBuilt = 0;
 

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -138,7 +138,7 @@ namespace MMAP
             float m_maxWalkableAngle;
             bool m_bigBaseUnit;
             uint32 m_totalTiles;
-            uint32 m_totalTilesDone;
+            std::atomic<uint32> m_totalTilesDone;
 
             // build performance - not really used for now
             rcContext* m_rcContext;

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -138,7 +138,7 @@ namespace MMAP
             float m_maxWalkableAngle;
             bool m_bigBaseUnit;
             uint32 m_totalTiles;
-            std::atomic<uint32> m_totalTilesDone;
+            std::atomic<uint32> m_totalTilesBuilt;
 
             // build performance - not really used for now
             rcContext* m_rcContext;

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -123,6 +123,7 @@ namespace MMAP
             bool shouldSkipMap(uint32 mapID);
             bool isTransportMap(uint32 mapID);
             bool shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY);
+            uint32 percentageDone(uint32 totalTiles, uint32 totalTilesDone);
 
             TerrainBuilder* m_terrainBuilder;
             TileList m_tiles;
@@ -136,6 +137,8 @@ namespace MMAP
 
             float m_maxWalkableAngle;
             bool m_bigBaseUnit;
+            uint32 m_totalTiles;
+            uint32 m_totalTilesDone;
 
             // build performance - not really used for now
             rcContext* m_rcContext;

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -137,6 +137,7 @@ namespace MMAP
 
             float m_maxWalkableAngle;
             bool m_bigBaseUnit;
+            // percentageDone - variables to calculate percentage
             uint32 m_totalTiles;
             std::atomic<uint32> m_totalTilesBuilt;
 

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -123,6 +123,7 @@ namespace MMAP
             bool shouldSkipMap(uint32 mapID);
             bool isTransportMap(uint32 mapID);
             bool shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY);
+            // percentageDone - method to calculate percentage
             uint32 percentageDone(uint32 totalTiles, uint32 totalTilesDone);
 
             TerrainBuilder* m_terrainBuilder;

--- a/src/tools/mmaps_generator/PathGenerator.cpp
+++ b/src/tools/mmaps_generator/PathGenerator.cpp
@@ -242,7 +242,7 @@ int finish(const char* message, int returnValue)
 
 int main(int argc, char** argv)
 {
-    int threads = 8, mapnum = -1;
+    int threads = 3, mapnum = -1;
     float maxAngle = 70.0f;
     int tileX = -1, tileY = -1;
     bool skipLiquid = false,

--- a/src/tools/mmaps_generator/PathGenerator.cpp
+++ b/src/tools/mmaps_generator/PathGenerator.cpp
@@ -242,7 +242,7 @@ int finish(const char* message, int returnValue)
 
 int main(int argc, char** argv)
 {
-    int threads = 3, mapnum = -1;
+    int threads = 8, mapnum = -1;
     float maxAngle = 70.0f;
     int tileX = -1, tileY = -1;
     bool skipLiquid = false,


### PR DESCRIPTION
**Changes proposed:**
-  We all know that mmaps extractor takes a lot of time, but never know when it will finish, at least never had an idea unless you did it before, this will help new people not to rush and be patient while console shows general percentage done of the task.
-  Add percentageDone method and two holders m_totalTiles, m_totalTilesBuilt for the purpose.
-  People will do something else while the machine is extracting mmaps instead posting help posts / download mmaps posts.

**Target branch(es):** 3.3.5/6.x

**Tests performed:** Built under Windows10, VS2015, Corei5, All Built for x64

<img width="660" alt="captura de pantalla 2016-08-17 04 24 01" src="https://cloud.githubusercontent.com/assets/527331/17731386/a55ba8f0-6432-11e6-8a0b-e45232853123.png">
<img width="659" alt="captura de pantalla 2016-08-17 04 24 08" src="https://cloud.githubusercontent.com/assets/527331/17731387/a5663ad6-6432-11e6-9c6c-92cff27a15ac.png">
