### PR TITLE
Pet/DK: Make Risen Ghoul and Bloodworms no longer suicidal

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_BLOODWORMS.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_BLOODWORMS.sql
@@ -1,0 +1,2 @@
+-- add AI to bloodworms to make them not stupid and suicidal
+UPDATE `creature_template` SET `ScriptName`='npc_pet_dk_guardian', `AIName`='' WHERE `entry` IN (26125,28017);

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -43,21 +43,10 @@ class npc_pet_dk_ebon_gargoyle : public CreatureScript
 
         struct npc_pet_dk_ebon_gargoyleAI : CasterAI
         {
-            npc_pet_dk_ebon_gargoyleAI(Creature* creature) : CasterAI(creature)
-            {
-                Initialize();
-            }
-
-            void Initialize()
-            {
-                // Not needed to be despawned now
-                _despawnTimer = 0;
-            }
+            npc_pet_dk_ebon_gargoyleAI(Creature* creature) : CasterAI(creature) { }
 
             void InitializeAI() override
             {
-                Initialize();
-
                 CasterAI::InitializeAI();
                 ObjectGuid ownerGuid = me->GetOwnerGUID();
                 if (!ownerGuid)
@@ -112,25 +101,8 @@ class npc_pet_dk_ebon_gargoyle : public CreatureScript
                 me->GetMotionMaster()->MovePoint(0, x, y, z);
 
                 // Despawn as soon as possible
-                _despawnTimer = 4 * IN_MILLISECONDS;
+                me->DespawnOrUnsummon(Seconds(4));
             }
-
-            void UpdateAI(uint32 diff) override
-            {
-                if (_despawnTimer > 0)
-                {
-                    if (_despawnTimer > diff)
-                        _despawnTimer -= diff;
-                    else
-                        me->DespawnOrUnsummon();
-                    return;
-                }
-
-                CasterAI::UpdateAI(diff);
-            }
-
-        private:
-           uint32 _despawnTimer;
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -139,7 +111,34 @@ class npc_pet_dk_ebon_gargoyle : public CreatureScript
         }
 };
 
+class npc_pet_dk_guardian : public CreatureScript
+{
+    public:
+        npc_pet_dk_guardian() : CreatureScript("npc_pet_dk_guardian") { }
+
+        struct npc_pet_dk_guardianAI : public AggressorAI
+        {
+            npc_pet_dk_guardianAI(Creature* creature) : AggressorAI(creature) { }
+
+            bool CanAIAttack(Unit const* target) const override
+            {
+                if (!target)
+                    return false;
+                Unit* owner = me->GetOwner();
+                if (owner && !target->IsInCombatWith(owner))
+                    return false;
+                return AggressorAI::CanAIAttack(target);
+            }
+        };
+
+        CreatureAI* GetAI(Creature* creature) const override
+        {
+            return new npc_pet_dk_guardianAI(creature);
+        }
+};
+
 void AddSC_deathknight_pet_scripts()
 {
     new npc_pet_dk_ebon_gargoyle();
+    new npc_pet_dk_guardian();
 }


### PR DESCRIPTION
Pretty much as the title says. No more rambo pets.

Current behavior: Ghouls and Bloodworms will aggress any nearby creature, including creatures that aren't currently in combat with the owner. They will even sometimes decide to do so right after being summoned.

New behavior: Ghouls and Bloodworms will never attack a target that isn't already in combat with the DK the guardians are owned by.
