### PR TITLE
Core/Movement: Properly clear UNIT_STATE_MOVING when reaching chase target

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -216,6 +216,7 @@ bool TargetedMovementGeneratorMedium<T, D>::DoUpdate(T* owner, uint32 time_diff)
 template<class T>
 void ChaseMovementGenerator<T>::_reachTarget(T* owner)
 {
+    _clearUnitStateMove(owner);
     if (owner->IsWithinMeleeRange(this->i_target.getTarget()))
         owner->Attack(this->i_target.getTarget(), true);
     if (owner->GetTypeId() == TYPEID_UNIT)


### PR DESCRIPTION
Very small change to fix a persistent bug where UNIT_STATE_MOVING remains set when a mob reaches melee range and starts attacking.

Making a PR for this because I'm not 100% familiar with movement code, would love input from @Shauren and others on whether this is correct.
