### PR TITLE
[WIP] Core/Movement: Targeted MoveGen Improvements

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -132,7 +132,9 @@ void TargetedMovementGenerator<T, D>::SetTargetLocation(T* owner, bool updateDes
             if (GetTarget()->IsWithinDistInMap(owner, CONTACT_DISTANCE))
                 return;
 
-            GetTarget()->GetContactPoint(owner, x, y, z);
+            x = GetTarget()->GetPositionX();
+            y = GetTarget()->GetPositionY();
+            z = GetTarget()->GetPositionZ();
         }
         else
         {
@@ -167,6 +169,16 @@ void TargetedMovementGenerator<T, D>::SetTargetLocation(T* owner, bool updateDes
     bool forceDest = (owner->GetTypeId() == TYPEID_UNIT && owner->ToCreature()->IsPet() && owner->HasUnitState(UNIT_STATE_FOLLOW));
 
     bool result = _path->CalculatePath(x, y, z, forceDest);
+
+    float distFromTarget;
+    if(!_offset)
+        distFromTarget = owner->GetCombatReach() + GetTarget()->GetCombatReach() + CONTACT_DISTANCE;
+    else if(owner->IsPet() && GetTarget()->GetTypeId() == TYPEID_PLAYER) // special case for offset != 0 and pets. cf above
+        distFromTarget = 1.0f + GetTarget()->GetCombatReach() + _offset;
+    else
+        distFromTarget = owner->GetCombatReach() + GetTarget()->GetCombatReach() + _offset;
+
+    _path->ReducePathLenghtByDist(distFromTarget, GetTarget()->ToUnit());
     if (!result || (_path->GetPathType() & PATHFIND_NOPATH))
     {
         // can't reach target

--- a/src/server/game/Movement/PathGenerator.h
+++ b/src/server/game/Movement/PathGenerator.h
@@ -74,7 +74,12 @@ class TC_GAME_API PathGenerator
 
         PathType GetPathType() const { return _type; }
 
-        void ReducePathLenghtByDist(float dist); // path must be already built
+        /*
+        Reduce the total length of the path by removing excess waypoints and cuting at the right distance
+        while making sure that the last point is in LoS with the target. If by the first cut, the new last point
+        isn't in LoS with the target, the cutted length will be smaller than "dist".
+        */
+        void ReducePathLenghtByDist(float dist, Unit* target); // path must be already built
 
     private:
 
@@ -133,6 +138,10 @@ class TC_GAME_API PathGenerator
         dtStatus FindSmoothPath(float const* startPos, float const* endPos,
                               dtPolyRef const* polyPath, uint32 polyPathSize,
                               float* smoothPath, int* smoothPathSize, uint32 smoothPathMaxSize);
+
+        bool IsValidFinalPoint(const G3D::Vector3 finalPoint, Unit* target, float dist) const;
+        uint32 SearchForFirstValidPoint(int startAtIndex, Unit* target, float dist) const;
+        void CutAtFirstValidPoint(int startAtIndex, Unit* target, float dist);
 };
 
 #endif

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5318,7 +5318,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                     else if (m_preGeneratedPath->IsInvalidDestinationZ(target)) // Check position z, if in a straight line
                             return SPELL_FAILED_NOPATH;
 
-                    m_preGeneratedPath->ReducePathLenghtByDist(objSize); // move back
+                    m_preGeneratedPath->ReducePathLenghtByDist(objSize, target); // move back
                 }
                 break;
             }


### PR DESCRIPTION
# Work in progress PR
## **Planned changes:**

Major changes:
- Changing how the way the destination point of each NPC path is determined. Up until now, each time a creature had to move, first a destination point was computed. And only then a path leading to that point was generated. Now it's the other way around. The destination point is actually deduced from the path itself. We first generate a path to the target's location and then remove from the path a certain length: the distance at which the npc should stand.

In the only commit yet, this is already implemented but only for MoveChase. Also, ReducePathLenghtByDist needs to be improved in order to make sure that after that method call, the last point of the path is always in LoS of the target & at the right distance.

Minor changes:
-  From sniff analysis, I found that the standard distance at which NPCs stand after chasing another unit is 'Chaser->CombatReach + Target->CombatReach' instead of 'Chaser->CombatReach + Target->CombatReach + 0.5'.
- From sniff analysis, I believe pets follow their masters at a 3 constant yard distance.
-  Planning to remove the third parameter of MoveChase (the angle).

**Target branch(es):** 3.3.5

**Issues addressed:** Seems to at least 
fix #16549
fix #9206 
fix #16647

**Tests performed:** WIP. Build and tested IG for what I have so far.

  