### PR TITLE
Core/SmartAI: allow SMART_TARGET_OWNER_OR_SUMMONER to target a temporary summon's summoner, too

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2757,7 +2757,7 @@ ObjectList* SmartScript::GetTargets(SmartScriptHolder const& e, Unit* invoker /*
             {
                 ObjectGuid charmerOrOwnerGuid = me->GetCharmerOrOwnerGUID();
 
-                if (TempSummon* tempSummon = me->ToTempSummon())
+                if (!charmerOrOwnerGuid && TempSummon* tempSummon = me->ToTempSummon())
                     if (Unit* summoner = tempSummon->GetSummoner())
                         charmerOrOwnerGuid = summoner->GetGUID();
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2757,6 +2757,10 @@ ObjectList* SmartScript::GetTargets(SmartScriptHolder const& e, Unit* invoker /*
             {
                 ObjectGuid charmerOrOwnerGuid = me->GetCharmerOrOwnerGUID();
 
+                if (TempSummon* tempSummon = me->ToTempSummon())
+                    if (Unit* summoner = tempSummon->GetSummoner())
+                        charmerOrOwnerGuid = summoner->GetGUID();
+
                 if (!charmerOrOwnerGuid)
                     charmerOrOwnerGuid = me->GetCreatorGUID();
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2757,9 +2757,10 @@ ObjectList* SmartScript::GetTargets(SmartScriptHolder const& e, Unit* invoker /*
             {
                 ObjectGuid charmerOrOwnerGuid = me->GetCharmerOrOwnerGUID();
 
-                if (!charmerOrOwnerGuid && TempSummon* tempSummon = me->ToTempSummon())
-                    if (Unit* summoner = tempSummon->GetSummoner())
-                        charmerOrOwnerGuid = summoner->GetGUID();
+                if (!charmerOrOwnerGuid)
+                    if (TempSummon* tempSummon = me->ToTempSummon())
+                        if (Unit* summoner = tempSummon->GetSummoner())
+                            charmerOrOwnerGuid = summoner->GetGUID();
 
                 if (!charmerOrOwnerGuid)
                     charmerOrOwnerGuid = me->GetCreatorGUID();


### PR DESCRIPTION
**Changes proposed:** this allows SMART_TARGET_OWNER_OR_SUMMONER to target the player using a quest item to summon said creature (for example, the one involved in [this quest](http://www.wowhead.com/quest=11281)).

**Target branch(es):** 3.3.5

**Tests performed:** tested and working.
