### PR TITLE
Core/Achievements: fix statistics related to epic/legendary items looted and received

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -1920,12 +1920,30 @@ bool AchievementMgr::RequirementsSatisfied(AchievementCriteriaEntry const* achie
                 return false;
             break;
         case ACHIEVEMENT_CRITERIA_TYPE_LOOT_EPIC_ITEM:
+        {
+            // Only Epic items should count
+            if (!miscValue1)
+                return false;
+            ItemTemplate const* proto = sObjectMgr->GetItemTemplate(miscValue1);
+            if (!proto || proto->Quality != ITEM_QUALITY_EPIC)
+                return false;
+            break;
+        }
         case ACHIEVEMENT_CRITERIA_TYPE_RECEIVE_EPIC_ITEM:
         {
+            // Epic and Legendary items share the same criteria, so we need to differentiate
             if (!miscValue1)
                 return false;
             ItemTemplate const* proto = sObjectMgr->GetItemTemplate(miscValue1);
             if (!proto || proto->Quality < ITEM_QUALITY_EPIC)
+                return false;
+
+            // Skip if criteria is "Legendary items obtained" and item is Epic
+            if (achievementCriteria->ID == 6141 && proto->Quality == ITEM_QUALITY_EPIC)
+                return false;
+
+            // Skip if criteria is "Epic items obtained" and item is Legendary
+            if (achievementCriteria->ID == 6142 && proto->Quality == ITEM_QUALITY_LEGENDARY)
                 return false;
             break;
         }


### PR DESCRIPTION
**Changes proposed:** I'll be the first to say that this is not really a good way to handle it. I'm looking for feedback and suggestions on a way to improve it.

So, statistics that keep track of looted and obtained epic and legendary items use the same achievement criteria. It means that both will increase at the same pace even when not supposed to.

Example: loot one legendary item, notice that the epic items obtained statistic increases too.

**Target branch(es):** 3.3.5

**Tests performed:** tested and working.

**Known issues and TODO list:**
- [ ] Throw the hack out the window
