### PR TITLE
Core/Instance: Fix GetInstanceSave sometimes checking the wrong map

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -18587,7 +18587,7 @@ InstanceSave* Player::GetInstanceSave(uint32 mapid, bool raid)
     InstanceSave* pSave = pBind ? pBind->save : NULL;
     if (!pBind || !pBind->perm)
         if (Group* group = GetGroup())
-            if (InstanceGroupBind* groupBind = group->GetBoundInstance(this))
+            if (InstanceGroupBind* groupBind = group->GetBoundInstance(GetDifficulty(raid), mapid))
                 pSave = groupBind->save;
 
     return pSave;


### PR DESCRIPTION
**Changes proposed:**
-  Always check the correct map ID in GetInstanceSave. If the player was in a group, it would check for a save on the players current map instead of the requested mapID

**Target branch(es):** 3.3.5/6.x

**Tests performed:** Builds, works correctly ingame
