### PR TITLE
Enhance quest status hook

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14832,6 +14832,8 @@ void Player::AddQuest(Quest const* quest, Object* questGiver)
         // add to Quest Tracker
         CharacterDatabase.Execute(stmt);
     }
+
+    sScriptMgr->OnQuestStatusChange(this, quest_id);
 }
 
 void Player::CompleteQuest(uint32 quest_id)
@@ -15074,6 +15076,8 @@ void Player::RewardQuest(Quest const* quest, uint32 reward, Object* questGiver, 
 
     //lets remove flag for delayed teleports
     SetCanDelayTeleport(false);
+
+    sScriptMgr->OnQuestStatusChange(this, quest_id);
 }
 
 void Player::FailQuest(uint32 questId)
@@ -15734,7 +15738,7 @@ void Player::SetQuestStatus(uint32 questId, QuestStatus status, bool update /*= 
     if (update)
         SendQuestUpdate();
 
-    sScriptMgr->OnQuestStatusChange(this, questId, status);
+    sScriptMgr->OnQuestStatusChange(this, questId);
 }
 
 void Player::RemoveActiveQuest(uint32 questId, bool update /*= true*/)

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -442,6 +442,8 @@ void WorldSession::HandleQuestLogRemoveQuest(WorldPacket& recvData)
                 // add to Quest Tracker
                 CharacterDatabase.Execute(stmt);
             }
+
+            sScriptMgr->OnQuestStatusChange(_player, questId);
         }
 
         _player->SetQuestSlot(slot, 0);

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2106,9 +2106,9 @@ void ScriptMgr::OnPlayerUpdateZone(Player* player, uint32 newZone, uint32 newAre
     FOREACH_SCRIPT(PlayerScript)->OnUpdateZone(player, newZone, newArea);
 }
 
-void ScriptMgr::OnQuestStatusChange(Player* player, uint32 questId, QuestStatus status)
+void ScriptMgr::OnQuestStatusChange(Player* player, uint32 questId)
 {
-    FOREACH_SCRIPT(PlayerScript)->OnQuestStatusChange(player, questId, status);
+    FOREACH_SCRIPT(PlayerScript)->OnQuestStatusChange(player, questId);
 }
 
 // Account

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -735,7 +735,7 @@ class TC_GAME_API PlayerScript : public UnitScript
         virtual void OnMapChanged(Player* /*player*/) { }
 
         // Called after a player's quest status has been changed
-        virtual void OnQuestStatusChange(Player* /*player*/, uint32 /*questId*/, QuestStatus /*status*/) { }
+        virtual void OnQuestStatusChange(Player* /*player*/, uint32 /*questId*/) { }
 };
 
 class TC_GAME_API AccountScript : public ScriptObject
@@ -1064,7 +1064,7 @@ class TC_GAME_API ScriptMgr
         void OnPlayerSave(Player* player);
         void OnPlayerBindToInstance(Player* player, Difficulty difficulty, uint32 mapid, bool permanent, uint8 extendState);
         void OnPlayerUpdateZone(Player* player, uint32 newZone, uint32 newArea);
-        void OnQuestStatusChange(Player* player, uint32 questId, QuestStatus status);
+        void OnQuestStatusChange(Player* player, uint32 questId);
 
     public: /* AccountScript */
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4823,6 +4823,8 @@ void Spell::EffectQuestClear(SpellEffIndex effIndex)
 
     player->RemoveActiveQuest(quest_id, false);
     player->RemoveRewardedQuest(quest_id);
+
+    sScriptMgr->OnQuestStatusChange(player, quest_id);
 }
 
 void Spell::EffectSendTaxi(SpellEffIndex effIndex)

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -143,6 +143,8 @@ public:
         player->RemoveActiveQuest(entry, false);
         player->RemoveRewardedQuest(entry);
 
+        sScriptMgr->OnQuestStatusChange(player, entry);
+
         handler->SendSysMessage(LANG_COMMAND_QUEST_REMOVED);
         return true;
     }


### PR DESCRIPTION
**Changes proposed:**
- One thing to note is that there already exists hooks for quest accept and quest reward(end of quest). However those hooks are for CreatureScript and GameObjectScript and this hook is for PlayerScript
- This PR enhances quest status hook by making it catch more, if not all quest status changes. For example quest add, fail, remove
- Before this hook only tracked when the quest status was changed through quest status method, which is not the only thing that changes quest statuses - as you can see by looking at `Player::GetQuestStatus` function contents.
- Unfortunately this changes the API to not pass the quest status through hook parameters, but if needed you can get it with `player->GetQuestStatus(questid)`, fortunately TC doesnt use the hook.

**Target branch(es):** 3.3.5/6.x

**Issues addressed:** https://community.trinitycore.org/topic/12843-c-quest-status-problem/

**Tests performed:**
- Does build
- Tested in game that the start and end as well as status changes like quest objective completion of a couple of quests were catched (first two/three draenei and human start quests)
- There seemed to be no duplicate catches
- Only tested on 3.3.5 branch

**Known issues and TODO list:**
- [ ] Need more testing
