### PR TITLE
Core/Spells Make credit for quests "The Grand Melee" and "Among the Champions" a triggered cast

### DIFF
--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -2524,7 +2524,7 @@ class spell_q13665_q13790_bested_trigger : public SpellScriptLoader
             void HandleScript(SpellEffIndex /*effIndex*/)
             {
                 Unit* target = GetHitUnit()->GetCharmerOrOwnerOrSelf();
-                target->CastSpell(target, uint32(GetEffectValue()));
+                target->CastSpell(target, uint32(GetEffectValue()), true);
             }
 
             void Register() override


### PR DESCRIPTION
**Changes proposed:**
-  Core/Spells Make credit for quests "The Grand Melee" and "Among the Champions" a triggered cast
- Fix a problem where the credit wasn't casted due to CGD

**Target branch(es):** 3.3.5/6.x

**Issues addressed:** Closes #15534

**Tests performed:** Built and tested
