### PR TITLE
[3.3.5] AHBot Characters

### DIFF
--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -157,7 +157,7 @@ void AuctionHouseMgr::SendAuctionWonMail(AuctionEntry* auction, SQLTransaction& 
     }
 
     // receiver exist
-    if ((bidder || bidderAccId) && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
+    if ((bidder || bidderAccId) && !sAuctionBotConfig->IsBotChar(auction->bidder))
     {
         // set owner to bidder (to prevent delete item with sender char deleting)
         // owner in `data` will set at mail receive and item extracting
@@ -190,7 +190,7 @@ void AuctionHouseMgr::SendAuctionSalePendingMail(AuctionEntry* auction, SQLTrans
     Player* owner = ObjectAccessor::FindConnectedPlayer(owner_guid);
     uint32 owner_accId = sObjectMgr->GetPlayerAccountIdByGUID(owner_guid);
     // owner exist (online or offline)
-    if ((owner || owner_accId) && !sAuctionBotConfig->GetIsBotChar(auction->owner))
+    if ((owner || owner_accId) && !sAuctionBotConfig->IsBotChar(auction->owner))
         MailDraft(auction->BuildAuctionMailSubject(AUCTION_SALE_PENDING), AuctionEntry::BuildAuctionMailBody(auction->bidder, auction->bid, auction->buyout, auction->deposit, auction->GetAuctionCut()))
             .SendMailTo(trans, MailReceiver(owner, auction->owner), auction, MAIL_CHECK_MASK_COPIED);
 }
@@ -202,7 +202,7 @@ void AuctionHouseMgr::SendAuctionSuccessfulMail(AuctionEntry* auction, SQLTransa
     Player* owner = ObjectAccessor::FindConnectedPlayer(owner_guid);
     uint32 owner_accId = sObjectMgr->GetPlayerAccountIdByGUID(owner_guid);
     // owner exist
-    if ((owner || owner_accId) && !sAuctionBotConfig->GetIsBotChar(auction->owner))
+    if ((owner || owner_accId) && !sAuctionBotConfig->IsBotChar(auction->owner))
     {
         uint32 profit = auction->bid + auction->deposit - auction->GetAuctionCut();
 
@@ -233,7 +233,7 @@ void AuctionHouseMgr::SendAuctionExpiredMail(AuctionEntry* auction, SQLTransacti
     Player* owner = ObjectAccessor::FindConnectedPlayer(owner_guid);
     uint32 owner_accId = sObjectMgr->GetPlayerAccountIdByGUID(owner_guid);
     // owner exist
-    if ((owner || owner_accId) && !sAuctionBotConfig->GetIsBotChar(auction->owner))
+    if ((owner || owner_accId) && !sAuctionBotConfig->IsBotChar(auction->owner))
     {
         if (owner)
             owner->GetSession()->SendAuctionOwnerNotification(auction);
@@ -260,7 +260,7 @@ void AuctionHouseMgr::SendAuctionOutbiddedMail(AuctionEntry* auction, uint32 new
         oldBidder_accId = sObjectMgr->GetPlayerAccountIdByGUID(oldBidder_guid);
 
     // old bidder exist
-    if ((oldBidder || oldBidder_accId) && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
+    if ((oldBidder || oldBidder_accId) && !sAuctionBotConfig->IsBotChar(auction->bidder))
     {
         if (oldBidder && newBidder)
             oldBidder->GetSession()->SendAuctionBidderNotification(auction->GetHouseId(), auction->Id, newBidder->GetGUID(), newPrice, auction->GetAuctionOutBid(), auction->itemEntry);
@@ -282,7 +282,7 @@ void AuctionHouseMgr::SendAuctionCancelledToBidderMail(AuctionEntry* auction, SQ
         bidder_accId = sObjectMgr->GetPlayerAccountIdByGUID(bidder_guid);
 
     // bidder exist
-    if ((bidder || bidder_accId) && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
+    if ((bidder || bidder_accId) && !sAuctionBotConfig->IsBotChar(auction->bidder))
         MailDraft(auction->BuildAuctionMailSubject(AUCTION_CANCELLED_TO_BIDDER), AuctionEntry::BuildAuctionMailBody(auction->owner, auction->bid, auction->buyout, auction->deposit, 0))
             .AddMoney(auction->bid)
             .SendMailTo(trans, MailReceiver(bidder, auction->bidder), auction, MAIL_CHECK_MASK_COPIED);

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -27,6 +27,7 @@
 #include "ScriptMgr.h"
 #include "AccountMgr.h"
 #include "AuctionHouseMgr.h"
+#include "AuctionHouseBot.h"
 #include "Item.h"
 #include "Language.h"
 #include "Log.h"
@@ -156,7 +157,7 @@ void AuctionHouseMgr::SendAuctionWonMail(AuctionEntry* auction, SQLTransaction& 
     }
 
     // receiver exist
-    if (bidder || bidderAccId)
+    if ((bidder || bidderAccId) && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
     {
         // set owner to bidder (to prevent delete item with sender char deleting)
         // owner in `data` will set at mail receive and item extracting
@@ -189,7 +190,7 @@ void AuctionHouseMgr::SendAuctionSalePendingMail(AuctionEntry* auction, SQLTrans
     Player* owner = ObjectAccessor::FindConnectedPlayer(owner_guid);
     uint32 owner_accId = sObjectMgr->GetPlayerAccountIdByGUID(owner_guid);
     // owner exist (online or offline)
-    if (owner || owner_accId)
+    if ((owner || owner_accId) && !sAuctionBotConfig->GetIsBotChar(auction->owner))
         MailDraft(auction->BuildAuctionMailSubject(AUCTION_SALE_PENDING), AuctionEntry::BuildAuctionMailBody(auction->bidder, auction->bid, auction->buyout, auction->deposit, auction->GetAuctionCut()))
             .SendMailTo(trans, MailReceiver(owner, auction->owner), auction, MAIL_CHECK_MASK_COPIED);
 }
@@ -201,7 +202,7 @@ void AuctionHouseMgr::SendAuctionSuccessfulMail(AuctionEntry* auction, SQLTransa
     Player* owner = ObjectAccessor::FindConnectedPlayer(owner_guid);
     uint32 owner_accId = sObjectMgr->GetPlayerAccountIdByGUID(owner_guid);
     // owner exist
-    if (owner || owner_accId)
+    if ((owner || owner_accId) && !sAuctionBotConfig->GetIsBotChar(auction->owner))
     {
         uint32 profit = auction->bid + auction->deposit - auction->GetAuctionCut();
 
@@ -232,7 +233,7 @@ void AuctionHouseMgr::SendAuctionExpiredMail(AuctionEntry* auction, SQLTransacti
     Player* owner = ObjectAccessor::FindConnectedPlayer(owner_guid);
     uint32 owner_accId = sObjectMgr->GetPlayerAccountIdByGUID(owner_guid);
     // owner exist
-    if (owner || owner_accId)
+    if ((owner || owner_accId) && !sAuctionBotConfig->GetIsBotChar(auction->owner))
     {
         if (owner)
             owner->GetSession()->SendAuctionOwnerNotification(auction);
@@ -259,7 +260,7 @@ void AuctionHouseMgr::SendAuctionOutbiddedMail(AuctionEntry* auction, uint32 new
         oldBidder_accId = sObjectMgr->GetPlayerAccountIdByGUID(oldBidder_guid);
 
     // old bidder exist
-    if (oldBidder || oldBidder_accId)
+    if ((oldBidder || oldBidder_accId) && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
     {
         if (oldBidder && newBidder)
             oldBidder->GetSession()->SendAuctionBidderNotification(auction->GetHouseId(), auction->Id, newBidder->GetGUID(), newPrice, auction->GetAuctionOutBid(), auction->itemEntry);
@@ -281,7 +282,7 @@ void AuctionHouseMgr::SendAuctionCancelledToBidderMail(AuctionEntry* auction, SQ
         bidder_accId = sObjectMgr->GetPlayerAccountIdByGUID(bidder_guid);
 
     // bidder exist
-    if (bidder || bidder_accId)
+    if ((bidder || bidder_accId) && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
         MailDraft(auction->BuildAuctionMailSubject(AUCTION_CANCELLED_TO_BIDDER), AuctionEntry::BuildAuctionMailBody(auction->owner, auction->bid, auction->buyout, auction->deposit, 0))
             .AddMoney(auction->bid)
             .SendMailTo(trans, MailReceiver(bidder, auction->bidder), auction, MAIL_CHECK_MASK_COPIED);

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -19,6 +19,7 @@
 #include "Item.h"
 #include "World.h"
 #include "Config.h"
+#include "AccountMgr.h"
 #include "AuctionHouseMgr.h"
 #include "AuctionHouseBot.h"
 #include "AuctionHouseBotBuyer.h"
@@ -55,6 +56,36 @@ bool AuctionBotConfig::Initialize()
 
     _itemsPerCycleBoost = GetConfig(CONFIG_AHBOT_ITEMS_PER_CYCLE_BOOST);
     _itemsPerCycleNormal = GetConfig(CONFIG_AHBOT_ITEMS_PER_CYCLE_NORMAL);
+
+    if (GetConfig(CONFIG_AHBOT_ACCOUNT_ID))
+    {
+        // check character count
+        uint32 charcount = AccountMgr::GetCharactersCount(GetConfig(CONFIG_AHBOT_ACCOUNT_ID));
+        if (charcount)
+        {
+            // find account guids associated with ahbot account
+            PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARS_BY_ACCOUNT_ID);
+            stmt->setUInt32(0, GetConfig(CONFIG_AHBOT_ACCOUNT_ID));
+            PreparedQueryResult result = CharacterDatabase.Query(stmt);
+            
+            for (uint32 charno = 0; charno < result->GetRowCount(); charno++)
+            {
+                _AHBotCharacters.push_back((*result)[0].GetUInt32());
+                result->NextRow();
+            }
+
+            TC_LOG_DEBUG("ahbot", "AuctionHouseBot found %i characters", charcount);
+        }
+        else
+        {
+            _AHBotCharacters.push_back(uint32(0));
+            TC_LOG_WARN("ahbot", "AuctionHouseBot Account ID has no associated characters.");
+        }
+    }
+    else
+    {
+        _AHBotCharacters.push_back(uint32(0));
+    }
 
     return true;
 }
@@ -111,6 +142,8 @@ void AuctionBotConfig::SetConfig(AuctionBotConfigFloatValues index, char const* 
 //Get AuctionHousebot configuration file
 void AuctionBotConfig::GetConfigFromFile()
 {
+	SetConfig(CONFIG_AHBOT_ACCOUNT_ID, "AuctionHouseBot.Account", 0);
+
     SetConfigMax(CONFIG_AHBOT_ALLIANCE_ITEM_AMOUNT_RATIO, "AuctionHouseBot.Alliance.Items.Amount.Ratio", 100, 10000);
     SetConfigMax(CONFIG_AHBOT_HORDE_ITEM_AMOUNT_RATIO, "AuctionHouseBot.Horde.Items.Amount.Ratio", 100, 10000);
     SetConfigMax(CONFIG_AHBOT_NEUTRAL_ITEM_AMOUNT_RATIO, "AuctionHouseBot.Neutral.Items.Amount.Ratio", 100, 10000);
@@ -272,6 +305,31 @@ char const* AuctionBotConfig::GetHouseTypeName(AuctionHouseType houseType)
     return names[houseType];
 }
 
+// Picks a random character from the list of AHBot chars
+uint32 AuctionBotConfig::GetRandChar() const
+{
+    return _AHBotCharacters[urand(0, _AHBotCharacters.size() - 1)];
+}
+
+// Picks a random AHBot character, but excludes a specific one. This is used
+// to have another character than the auction owner place bids
+uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
+{
+    // avoid freezing if only one ahbot char (which defeats the purpose but oh well)
+    if (_AHBotCharacters.size() == 1) return GetRandChar();
+
+    uint32 result;
+    do {
+        result = GetRandChar();
+    } while (result == exclude);
+    return result;
+}
+
+bool AuctionBotConfig::GetIsBotChar(uint32 characterID) const
+{
+    return !characterID || find(_AHBotCharacters.begin(), _AHBotCharacters.end(), characterID) != _AHBotCharacters.end();
+}
+
 uint32 AuctionBotConfig::GetConfigItemAmountRatio(AuctionHouseType houseType) const
 {
     switch (houseType)
@@ -408,7 +466,7 @@ void AuctionHouseBot::PrepareStatusInfos(AuctionHouseBotStatusInfo& statusInfo)
             if (Item* item = sAuctionMgr->GetAItem(auctionEntry->itemGUIDLow))
             {
                 ItemTemplate const* prototype = item->GetTemplate();
-                if (!auctionEntry->owner)                         // Add only ahbot items
+                if (!auctionEntry->owner || sAuctionBotConfig->GetIsBotChar(auctionEntry->owner)) // Add only ahbot items
                 {
                     if (prototype->Quality < MAX_AUCTION_QUALITY)
                         ++statusInfo[i].QualityInfo[prototype->Quality];
@@ -426,7 +484,7 @@ void AuctionHouseBot::Rebuild(bool all)
     {
         AuctionHouseObject* auctionHouse = sAuctionMgr->GetAuctionsMap(AuctionHouseType(i));
         for (AuctionHouseObject::AuctionEntryMap::const_iterator itr = auctionHouse->GetAuctionsBegin(); itr != auctionHouse->GetAuctionsEnd(); ++itr)
-            if (!itr->second->owner)                        // ahbot auction
+            if (!itr->second->owner || sAuctionBotConfig->GetIsBotChar(itr->second->owner)) // ahbot auction
                 if (all || itr->second->bid == 0)           // expire now auction if no bid or forced
                     itr->second->expire_time = sWorld->GetGameTime();
     }

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -316,7 +316,7 @@ uint32 AuctionBotConfig::GetRandChar() const
 uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
 {
     // avoid freezing if only one ahbot char (which defeats the purpose but oh well)
-    if (_AHBotCharacters.size() == 1) return GetRandChar();
+    if (_AHBotCharacters.size() == 1) return _AHBotCharacters[0];
 
     uint32 result;
     do

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -319,9 +319,12 @@ uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
     if (_AHBotCharacters.size() == 1) return GetRandChar();
 
     uint32 result;
-    do {
+    do
+    {
         result = GetRandChar();
-    } while (result == exclude);
+    }
+    while (result == exclude);
+    
     return result;
 }
 

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -316,7 +316,8 @@ uint32 AuctionBotConfig::GetRandChar() const
 uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
 {
     // avoid freezing if only one ahbot char (which defeats the purpose but oh well)
-    if (_AHBotCharacters.size() == 1) return _AHBotCharacters[0];
+    if (_AHBotCharacters.size() == 1)
+        return _AHBotCharacters[0];
 
     uint32 result;
     do

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -331,7 +331,7 @@ uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
 
 bool AuctionBotConfig::GetIsBotChar(uint32 characterID) const
 {
-    return !characterID || find(_AHBotCharacters.begin(), _AHBotCharacters.end(), characterID) != _AHBotCharacters.end();
+    return !characterID || std::find(_AHBotCharacters.begin(), _AHBotCharacters.end(), characterID) != _AHBotCharacters.end();
 }
 
 uint32 AuctionBotConfig::GetConfigItemAmountRatio(AuctionHouseType houseType) const

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -329,7 +329,7 @@ uint32 AuctionBotConfig::GetRandCharExclude(uint32 exclude) const
     return result;
 }
 
-bool AuctionBotConfig::GetIsBotChar(uint32 characterID) const
+bool AuctionBotConfig::IsBotChar(uint32 characterID) const
 {
     return !characterID || std::find(_AHBotCharacters.begin(), _AHBotCharacters.end(), characterID) != _AHBotCharacters.end();
 }
@@ -470,7 +470,7 @@ void AuctionHouseBot::PrepareStatusInfos(AuctionHouseBotStatusInfo& statusInfo)
             if (Item* item = sAuctionMgr->GetAItem(auctionEntry->itemGUIDLow))
             {
                 ItemTemplate const* prototype = item->GetTemplate();
-                if (!auctionEntry->owner || sAuctionBotConfig->GetIsBotChar(auctionEntry->owner)) // Add only ahbot items
+                if (!auctionEntry->owner || sAuctionBotConfig->IsBotChar(auctionEntry->owner)) // Add only ahbot items
                 {
                     if (prototype->Quality < MAX_AUCTION_QUALITY)
                         ++statusInfo[i].QualityInfo[prototype->Quality];
@@ -488,7 +488,7 @@ void AuctionHouseBot::Rebuild(bool all)
     {
         AuctionHouseObject* auctionHouse = sAuctionMgr->GetAuctionsMap(AuctionHouseType(i));
         for (AuctionHouseObject::AuctionEntryMap::const_iterator itr = auctionHouse->GetAuctionsBegin(); itr != auctionHouse->GetAuctionsEnd(); ++itr)
-            if (!itr->second->owner || sAuctionBotConfig->GetIsBotChar(itr->second->owner)) // ahbot auction
+            if (!itr->second->owner || sAuctionBotConfig->IsBotChar(itr->second->owner)) // ahbot auction
                 if (all || itr->second->bid == 0)           // expire now auction if no bid or forced
                     itr->second->expire_time = sWorld->GetGameTime();
     }

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -142,7 +142,7 @@ void AuctionBotConfig::SetConfig(AuctionBotConfigFloatValues index, char const* 
 //Get AuctionHousebot configuration file
 void AuctionBotConfig::GetConfigFromFile()
 {
-	SetConfig(CONFIG_AHBOT_ACCOUNT_ID, "AuctionHouseBot.Account", 0);
+    SetConfig(CONFIG_AHBOT_ACCOUNT_ID, "AuctionHouseBot.Account", 0);
 
     SetConfigMax(CONFIG_AHBOT_ALLIANCE_ITEM_AMOUNT_RATIO, "AuctionHouseBot.Alliance.Items.Amount.Ratio", 100, 10000);
     SetConfigMax(CONFIG_AHBOT_HORDE_ITEM_AMOUNT_RATIO, "AuctionHouseBot.Horde.Items.Amount.Ratio", 100, 10000);

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.h
@@ -152,6 +152,7 @@ enum AuctionBotConfigUInt32Values
     CONFIG_AHBOT_CLASS_RANDOMSTACKRATIO_KEY,
     CONFIG_AHBOT_CLASS_RANDOMSTACKRATIO_MISC,
     CONFIG_AHBOT_CLASS_RANDOMSTACKRATIO_GLYPH,
+    CONFIG_AHBOT_ACCOUNT_ID,
     CONFIG_UINT32_AHBOT_UINT32_COUNT
 };
 
@@ -224,6 +225,9 @@ public:
 
     uint32 GetItemPerCycleBoost() const { return _itemsPerCycleBoost; }
     uint32 GetItemPerCycleNormal() const { return _itemsPerCycleNormal; }
+    uint32 GetRandChar() const;
+    uint32 GetRandCharExclude(uint32 exclude) const;
+    bool GetIsBotChar(uint32 characterID) const;
     void Reload() { GetConfigFromFile(); }
 
     static char const* GetHouseTypeName(AuctionHouseType houseType);
@@ -231,6 +235,7 @@ public:
 private:
     std::string _AHBotIncludes;
     std::string _AHBotExcludes;
+    std::vector<uint32> _AHBotCharacters;
     uint32 _itemsPerCycleBoost;
     uint32 _itemsPerCycleNormal;
 

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.h
@@ -227,7 +227,7 @@ public:
     uint32 GetItemPerCycleNormal() const { return _itemsPerCycleNormal; }
     uint32 GetRandChar() const;
     uint32 GetRandCharExclude(uint32 exclude) const;
-    bool GetIsBotChar(uint32 characterID) const;
+    bool IsBotChar(uint32 characterID) const;
     void Reload() { GetConfigFromFile(); }
 
     static char const* GetHouseTypeName(AuctionHouseType houseType);

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotBuyer.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotBuyer.cpp
@@ -103,7 +103,7 @@ uint32 AuctionBotBuyer::GetItemInformation(BuyerConfiguration& config)
     {
         AuctionEntry* entry = itr->second;
 
-        if (!entry->owner)
+        if (!entry->owner || sAuctionBotConfig->GetIsBotChar(entry->owner))
             continue; // Skip auctions owned by AHBot
 
         Item* item = sAuctionMgr->GetAItem(entry->itemGUIDLow);
@@ -218,7 +218,7 @@ bool AuctionBotBuyer::RollBidChance(const BuyerItemInfo* ahInfo, const Item* ite
     }
 
     // If a player has bidded on item, have fifth of normal chance
-    if (auction->bidder)
+    if (auction->bidder && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
         chance = chance / 5.f;
 
     // Add config weigh in for quality
@@ -391,11 +391,11 @@ void AuctionBotBuyer::BuyEntry(AuctionEntry* auction, AuctionHouseObject* auctio
     SQLTransaction trans = CharacterDatabase.BeginTransaction();
 
     // Send mail to previous bidder if any
-    if (auction->bidder)
+    if (auction->bidder && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
         sAuctionMgr->SendAuctionOutbiddedMail(auction, auction->buyout, NULL, trans);
 
     // Set bot as bidder and set new bid amount
-    auction->bidder = 0;
+    auction->bidder = sAuctionBotConfig->GetRandCharExclude(auction->owner);
     auction->bid = auction->buyout;
 
     // Mails must be under transaction control too to prevent data loss
@@ -422,11 +422,11 @@ void AuctionBotBuyer::PlaceBidToEntry(AuctionEntry* auction, uint32 bidPrice)
     SQLTransaction trans = CharacterDatabase.BeginTransaction();
 
     // Send mail to previous bidder if any
-    if (auction->bidder)
+    if (auction->bidder && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
         sAuctionMgr->SendAuctionOutbiddedMail(auction, bidPrice, NULL, trans);
 
     // Set bot as bidder and set new bid amount
-    auction->bidder = 0;
+    auction->bidder = sAuctionBotConfig->GetRandCharExclude(auction->owner);
     auction->bid = bidPrice;
 
     // Update auction to DB

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotBuyer.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotBuyer.cpp
@@ -103,7 +103,7 @@ uint32 AuctionBotBuyer::GetItemInformation(BuyerConfiguration& config)
     {
         AuctionEntry* entry = itr->second;
 
-        if (!entry->owner || sAuctionBotConfig->GetIsBotChar(entry->owner))
+        if (!entry->owner || sAuctionBotConfig->IsBotChar(entry->owner))
             continue; // Skip auctions owned by AHBot
 
         Item* item = sAuctionMgr->GetAItem(entry->itemGUIDLow);
@@ -218,7 +218,7 @@ bool AuctionBotBuyer::RollBidChance(const BuyerItemInfo* ahInfo, const Item* ite
     }
 
     // If a player has bidded on item, have fifth of normal chance
-    if (auction->bidder && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
+    if (auction->bidder && !sAuctionBotConfig->IsBotChar(auction->bidder))
         chance = chance / 5.f;
 
     // Add config weigh in for quality
@@ -391,7 +391,7 @@ void AuctionBotBuyer::BuyEntry(AuctionEntry* auction, AuctionHouseObject* auctio
     SQLTransaction trans = CharacterDatabase.BeginTransaction();
 
     // Send mail to previous bidder if any
-    if (auction->bidder && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
+    if (auction->bidder && !sAuctionBotConfig->IsBotChar(auction->bidder))
         sAuctionMgr->SendAuctionOutbiddedMail(auction, auction->buyout, NULL, trans);
 
     // Set bot as bidder and set new bid amount
@@ -422,7 +422,7 @@ void AuctionBotBuyer::PlaceBidToEntry(AuctionEntry* auction, uint32 bidPrice)
     SQLTransaction trans = CharacterDatabase.BeginTransaction();
 
     // Send mail to previous bidder if any
-    if (auction->bidder && !sAuctionBotConfig->GetIsBotChar(auction->bidder))
+    if (auction->bidder && !sAuctionBotConfig->IsBotChar(auction->bidder))
         sAuctionMgr->SendAuctionOutbiddedMail(auction, bidPrice, NULL, trans);
 
     // Set bot as bidder and set new bid amount

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
@@ -640,7 +640,7 @@ uint32 AuctionBotSeller::SetStat(SellerConfiguration& config)
         {
             ItemTemplate const* prototype = item->GetTemplate();
             if (prototype)
-                if (!auctionEntry->owner || sAuctionBotConfig->GetIsBotChar(auctionEntry->owner)) // Add only ahbot items
+                if (!auctionEntry->owner || sAuctionBotConfig->IsBotChar(auctionEntry->owner)) // Add only ahbot items
                     ++itemsSaved[prototype->Quality][prototype->Class];
         }
     }

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
@@ -640,7 +640,7 @@ uint32 AuctionBotSeller::SetStat(SellerConfiguration& config)
         {
             ItemTemplate const* prototype = item->GetTemplate();
             if (prototype)
-                if (!auctionEntry->owner)                         // Add only ahbot items
+                if (!auctionEntry->owner || sAuctionBotConfig->GetIsBotChar(auctionEntry->owner)) // Add only ahbot items
                     ++itemsSaved[prototype->Quality][prototype->Class];
         }
     }
@@ -1019,7 +1019,7 @@ void AuctionBotSeller::AddNewAuctions(SellerConfiguration& config)
 
         AuctionEntry* auctionEntry = new AuctionEntry();
         auctionEntry->Id = sObjectMgr->GenerateAuctionID();
-        auctionEntry->owner = 0;
+        auctionEntry->owner = sAuctionBotConfig->GetRandChar();
         auctionEntry->itemGUIDLow = item->GetGUID().GetCounter();
         auctionEntry->itemEntry = item->GetEntry();
         auctionEntry->startbid = bidPrice;

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3061,6 +3061,15 @@ PreventRenameCharacterOnCustomization = 0
 ###################################################################################################
 # AUCTION HOUSE BOT SETTINGS
 #
+#    AuctionHouseBot.Account
+#       Description: Account ID for AHBot characters. If non-zero, all auctions and bids associated
+#                    with the AHBot will randomly be assigned one of this account's characters.
+#       Default:     0
+#
+
+AuctionHouseBot.Account = 0
+
+#
 #    AuctionHouseBot.Update.Interval
 #       Description: Interval in seconds for AHBot to get updated
 #       Default:     20


### PR DESCRIPTION
**Changes proposed:**
- This PR implements auction house bot characters. The idea is that you create a dummy account and add some characters to it (they only need to be there for the name) and whenever the ahbot creates or bids on an auction, it will pick one of those characters as the owner/bidder. The reason for this is that I think it adds a tiny bit of life to the AH, instead of having your auctions being bought up by an empty string.
- I added a setting in the worldconfig that specifies the account ID that belongs to the AHbot. On server startup, it will load all associated character IDs. Note: If the account ID is zero, old behaviour is preserved.
- The bot characters will never receive auction-related mail (see my changes to AuctionHouseMgr.cpp) so they will not clutter up the item / mail tables just because they're 'real' characters.

**Target branch(es):** 3.3.5

**Tests performed:** Built and tested (release, x64) locally for several days, works fine. I have _not_ tested with ahbot disabled or account ID set to zero, though the code should work with this also.
