### PR TITLE
Core/Spell: do not send duplicate updates for auras

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22939,6 +22939,7 @@ void Player::SendAurasForTarget(Unit* target) const
     {
         AuraApplication * auraApp = itr->second;
         auraApp->BuildUpdatePacket(data, false);
+        auraApp->SetNeedClientUpdate(false);
     }
 
     GetSession()->SendPacket(&data);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -212,7 +212,7 @@ void AuraApplication::BuildUpdatePacket(ByteBuffer& data, bool remove) const
 
 void AuraApplication::ClientUpdate(bool remove)
 {
-    _needClientUpdate = false;
+    SetNeedClientUpdate(false);
 
     WorldPacket data(SMSG_AURA_UPDATE);
     data << GetTarget()->GetPackGUID();

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -76,7 +76,7 @@ class TC_GAME_API AuraApplication
         void SetRemoveMode(AuraRemoveMode mode) { _removeMode = mode; }
         AuraRemoveMode GetRemoveMode() const {return _removeMode;}
 
-        void SetNeedClientUpdate() { _needClientUpdate = true;}
+        void SetNeedClientUpdate(bool update = true) { _needClientUpdate = update; }
         bool IsNeedClientUpdate() const { return _needClientUpdate;}
         void BuildUpdatePacket(ByteBuffer& data, bool remove) const;
         void ClientUpdate(bool remove = false);


### PR DESCRIPTION
**Changes proposed:**

When the server sends SMSG_AURA_UPDATE_ALL, it also sends a SMSG_AURA_UPDATE for every affected aura. This results in duplicate updates (one from UPDATE_ALL and one from UPDATE).

Sniffs show that the server only sends SMSG_AURA_UPDATE_ALL.

**Target branch(es):** 3.3.5

**Tests performed:** tested and working.
