### PR TITLE
Core/Unit: Remove incorrect check that dont allow units attack your vehicle/passenger

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11531,11 +11531,6 @@ bool Unit::_IsValidAttackTarget(Unit const* target, SpellInfo const* bySpell, Wo
         || (target->GetTypeId() == TYPEID_PLAYER && target->ToPlayer()->IsGameMaster()))
         return false;
 
-    // can't attack own vehicle or passenger
-    if (m_vehicle)
-        if (IsOnVehicle(target) || m_vehicle->GetBase()->IsOnVehicle(target))
-            return false;
-
     // can't attack invisible (ignore stealth for aoe spells) also if the area being looked at is from a spell use the dynamic object created instead of the casting unit. Ignore stealth if target is player and unit in combat with same player
     if ((!bySpell || !bySpell->HasAttribute(SPELL_ATTR6_CAN_TARGET_INVISIBLE)) && (obj ? !obj->CanSeeOrDetect(target, bySpell && bySpell->IsAffectingArea()) : !CanSeeOrDetect(target, (bySpell && bySpell->IsAffectingArea()) || (target->GetTypeId() == TYPEID_PLAYER && target->HasStealthAura() && target->IsInCombat() && IsInCombatWith(target)))))
         return false;


### PR DESCRIPTION
**Changes proposed:**
-  Remove incorrect check that dont allow units attack your vehicle/passenger, added in : https://github.com/TrinityCore/TrinityCore/commit/31e755c2910d26c1616c098a39b343101c398e96
  In Gormok Fight (Trial of The Crusader) and Flame Leviathan (Ulduar), units can attack your own vehicle/passenger

More info:

> Keader: Shauren: this is acceptable ? https://gist.github.com/Keader/066665dc402d3dfebe945ce244ca9315
> Keader: snobolds in gormok fight (trial of the crusader) needs attack player, and in this case, player is vehicle
> Shauren : that whole check is wrong
> Shauren: someone incorrectly assumed this would always be true
> Shauren: find out who added it any why
> Shauren: git blame
> Keader:  https://github.com/TrinityCore/TrinityCore/commit/31e755c2910d26c1616c098a39b343101c398e96#commitcomment-594991
> Shauren: remove.  
> 
> > Machiavell1 on 17 Sep 2011
> > This is not correct I think. During the Flame Leviathan encounter, players can be launched onto one of Flame Leviathan's seats, which is a vehicle as well. This secondary vehicle holds a turret and an empty seat for the players. The objective is that the player destroys the turret from that location. This check put in place above prevents this working correctly.
> > https://github.com/TrinityCore/TrinityCore/commit/31e755c2910d26c1616c098a39b343101c398e96#commitcomment-594991

**Issues addressed:** Updates #17934

**Target branch(es):** 3.3.5/6.x

**Tests performed:** Builded and working in game
