### PR TITLE
Core/Scripts: Implemented right Snobold Vassal behavior on Gormok fight.

### DIFF
--- a/sql/updates/world/3.3.5/9955_22_52_world.sql
+++ b/sql/updates/world/3.3.5/9955_22_52_world.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_gormok_ride_player','spell_gormok_jump_to_hand','spell_gormok_snobolled');
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
-(66245,'spell_gormok_ride_player'), 
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(66245,'spell_gormok_ride_player'),
 (66342,'spell_gormok_jump_to_hand'),
 (66406,'spell_gormok_snobolled');

--- a/sql/updates/world/3.3.5/9955_22_52_world.sql
+++ b/sql/updates/world/3.3.5/9955_22_52_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_gormok_ride_player','spell_gormok_jump_to_hand','spell_gormok_snobolled');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(66245,'spell_gormok_ride_player'), 
+(66342,'spell_gormok_jump_to_hand'),
+(66406,'spell_gormok_snobolled');

--- a/sql/updates/world/3.3.5/9955_22_52_world.sql
+++ b/sql/updates/world/3.3.5/9955_22_52_world.sql
@@ -3,3 +3,18 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (66245,'spell_gormok_ride_player'),
 (66342,'spell_gormok_jump_to_hand'),
 (66406,'spell_gormok_snobolled');
+
+DELETE FROM `disables` WHERE `sourceType`=0 AND `entry`=66636;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0, 66636, 64, 0, 0, 'Disable LoS for Spell Rising Anger');
+
+DELETE FROM `npc_spellclick_spells` WHERE `npc_entry`=34796;
+INSERT INTO `npc_spellclick_spells` (`npc_entry`, `spell_id`, `cast_flags`, `user_type`) VALUES
+(34796, 46598, 0, 0);
+
+DELETE FROM `vehicle_template_accessory` WHERE `entry`=34796 AND `accessory_entry`=34800;
+INSERT INTO `vehicle_template_accessory` (`entry`, `accessory_entry`, `seat_id`, `minion`, `description`, `summontype`, `summontimer`) VALUES
+(34796,34800,0,0,'Snobold Vassal', 5,0),
+(34796,34800,1,0,'Snobold Vassal', 5,0),
+(34796,34800,2,0,'Snobold Vassal', 5,0),
+(34796,34800,3,0,'Snobold Vassal', 5,0);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -309,7 +309,7 @@ class boss_gormok : public CreatureScript
 class SnobolledTargetSelector : public std::unary_function<Unit*, bool>
 {
 public:
-    SnobolledTargetSelector(Unit const* unit) { }
+    SnobolledTargetSelector(Unit const* /*unit*/) { }
 
     bool operator()(Unit* unit) const
     {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -78,6 +78,10 @@ enum BossSpells
     SPELL_HEAD_CRACK        = 66407,
     SPELL_JUMP_TO_HAND      = 66342,
     SPELL_RIDE_PLAYER       = 66245,
+    SPELL_VEHICLE_0         = 66270,
+    SPELL_VEHICLE_1         = 66273,
+    SPELL_VEHICLE_2         = 66274,
+    SPELL_VEHICLE_3         = 68260,
 
     //Acidmaw & Dreadscale Generic
     SPELL_SWEEP             = 66794,
@@ -165,6 +169,8 @@ enum GormokMisc
     PLAYER_VEHICLE_ID       = 444,
 };
 
+uint32 const SnoboldMountspells[4] = { SPELL_VEHICLE_0 , SPELL_VEHICLE_1, SPELL_VEHICLE_2, SPELL_VEHICLE_3 };
+
 class boss_gormok : public CreatureScript
 {
     public:
@@ -230,7 +236,7 @@ class boss_gormok : public CreatureScript
                 {
                     if (Creature* snobold = DoSpawnCreature(NPC_SNOBOLD_VASSAL, 0, 0, 0, 0, TEMPSUMMON_CORPSE_DESPAWN, 0))
                     {
-                        snobold->EnterVehicle(me, i);
+                        snobold->CastSpell(me, SnoboldMountspells[i], true);
                         snobold->AI()->DoAction(ACTION_ENABLE_FIRE_BOMB);
                         DoZoneInCombat(snobold);
                     }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -309,7 +309,7 @@ class boss_gormok : public CreatureScript
 class SnobolledTargetSelector : public std::unary_function<Unit*, bool>
 {
 public:
-    SnobolledTargetSelector(Unit const* unit) : _me(unit) { }
+    SnobolledTargetSelector(Unit const* unit) { }
 
     bool operator()(Unit* unit) const
     {
@@ -321,9 +321,6 @@ public:
 
         return true;
     }
-
-private:
-    Unit const* _me;
 };
 
 class SnoboldEvent : public BasicEvent

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -281,7 +281,7 @@ class boss_gormok : public CreatureScript
                                 {
                                     snobold->ExitVehicle();
                                     snobold->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
-                                    snobold->ToCreature()->AI()->DoAction(ACTION_DISABLE_FIRE_BOMB);
+                                    snobold->GetAI()->DoAction(ACTION_DISABLE_FIRE_BOMB);
                                     snobold->CastSpell(me, SPELL_JUMP_TO_HAND, true);
                                     break;
                                 }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -323,14 +323,13 @@ class npc_snobold_vassal : public CreatureScript
         {
             npc_snobold_vassalAI(Creature* creature) : ScriptedAI(creature), _instance(creature->GetInstanceScript()), _isActive(false)
             {
+                _targetGUID.Clear();
                 _instance->SetData(DATA_SNOBOLD_COUNT, INCREASE);
+                SetCombatMovement(false);
             }
 
             void Reset() override
             {
-                _targetGUID.Clear();
-                _isActive = false;
-                _events.Reset();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 me->SetInCombatWithZone();
                 _events.ScheduleEvent(EVENT_CHECK_MOUNT, Seconds(1));
@@ -382,7 +381,6 @@ class npc_snobold_vassal : public CreatureScript
                     return;
 
                 ScriptedAI::AttackStart(who);
-                SetCombatMovement(false);
             }
 
             void MountOnBoss()
@@ -1248,9 +1246,7 @@ public:
 
         void AfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
-            Unit* target = GetTarget();
-            target->RemoveAurasDueToSpell(SPELL_SNOBOLLED);
-            target->RemoveVehicleKit();
+            GetTarget()->RemoveVehicleKit();
         }
 
         void Register() override
@@ -1282,7 +1278,7 @@ public:
             return true;
         }
 
-        void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+        void OnPeriodic(AuraEffect const* /*aurEff*/)
         {
             if (!GetTarget()->HasAura(SPELL_RIDE_PLAYER))
                 Remove();
@@ -1290,7 +1286,7 @@ public:
 
         void Register() override
         {
-            OnEffectApply += AuraEffectApplyFn(spell_gormok_snobolled_AuraScript::OnApply, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY, AURA_EFFECT_HANDLE_REAL);
+            OnEffectPeriodic += AuraEffectPeriodicFn(spell_gormok_snobolled_AuraScript::OnPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
         }
     };
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -388,6 +388,7 @@ class npc_snobold_vassal : public CreatureScript
                 if (gormok && gormok->IsAlive())
                 {
                     me->AttackStop();
+                    _targetGUID.Clear();
                     _isActive = false;
                     _events.CancelEvent(EVENT_BATTER);
                     _events.CancelEvent(EVENT_HEAD_CRACK);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -323,7 +323,6 @@ class npc_snobold_vassal : public CreatureScript
         {
             npc_snobold_vassalAI(Creature* creature) : ScriptedAI(creature), _instance(creature->GetInstanceScript()), _isActive(false)
             {
-                _targetGUID.Clear();
                 _instance->SetData(DATA_SNOBOLD_COUNT, INCREASE);
                 SetCombatMovement(false);
             }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -319,7 +319,7 @@ public:
         if (_dist > 0.0f && !_me->IsWithinCombatRange(unit, _dist))
             return false;
 
-        if (!_me->IsWithinCombatRange(unit, -_dist))
+        else if (_dist < 0.0f && !_me->IsWithinCombatRange(unit, -_dist))
             return false;
 
         if (unit->HasAura(SPELL_RIDE_PLAYER) || unit->HasAura(SPELL_SNOBOLLED))
@@ -342,7 +342,6 @@ public:
     {
         if (_apply)
             _owner->CastSpell(_target, SPELL_SNOBOLLED, true);
-
         else
         {
             _target->RemoveAurasDueToSpell(SPELL_SNOBOLLED);
@@ -426,6 +425,7 @@ class npc_snobold_vassal : public CreatureScript
 
             void AttackStart(Unit* who) override
             {
+                //Snobold only melee attack players that is your vehicle
                 if (!_isActive || who->GetGUID() != _targetGUID)
                     return;
 
@@ -462,6 +462,7 @@ class npc_snobold_vassal : public CreatureScript
 
             void UpdateAI(uint32 diff) override
             {
+                //Always that Snobold has no vehicle, he should mount in boss/another player
                 if (!me->GetVehicleBase())
                     MountOnBoss();
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -309,17 +309,11 @@ class boss_gormok : public CreatureScript
 class SnobolledTargetSelector : public std::unary_function<Unit*, bool>
 {
 public:
-    SnobolledTargetSelector(Unit const* unit, float dist = 200.0f) : _me(unit), _dist(dist) { }
+    SnobolledTargetSelector(Unit const* unit) : _me(unit) { }
 
     bool operator()(Unit* unit) const
     {
         if (unit->GetTypeId() != TYPEID_PLAYER)
-            return false;
-
-        if (_dist > 0.0f && !_me->IsWithinCombatRange(unit, _dist))
-            return false;
-
-        else if (_dist < 0.0f && !_me->IsWithinCombatRange(unit, -_dist))
             return false;
 
         if (unit->HasAura(SPELL_RIDE_PLAYER) || unit->HasAura(SPELL_SNOBOLLED))
@@ -330,7 +324,6 @@ public:
 
 private:
     Unit const* _me;
-    float _dist;
 };
 
 class SnoboldEvent : public BasicEvent


### PR DESCRIPTION
**Changes proposed:**
-  Added std::chrono in events.
-  Implemented Snobold Vassal behavior, that Snobold should mount on player and attack him.
- Scripted spells : Jump To Hand, Ride Vehicle.
- Scripted spell: Snobolled. In this case, if player gets DC with Snobold on him, Snobolled aura stays on player after login and until player dies, will never get (be target of) another Snobold.
- Removed wrong DamageTaken function on Snobold. Players who are passengers of Snobold can attack Snobold (with spells like corruption, vampiric touch or any spell that don't need target facing)
- Removed wrong MovementInform function on Snobold. They only despawn if still on Gormok's back when Gormok dies and on "boss wipe" (Gormok forced despawn).
- Fixed spam erros in console.
- Codestyle improvements.
- Cleanups.
- Fixed cast of spell Fire Bomb

Thanks Sirikfoll (like always) for all help 🐰 

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #16895 and replaces #17158

**Tests performed:** Built and tested in-game.

**Known issues and ToDo list:**
- [x] #17932 must be merged before for Snobold works properly (without it, Snobold will not do melee attack)
