### PR TITLE
Script/Quest: improvements for Let Them Eat Crow.

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,13 @@
+--
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` IN (13, 17) AND `SourceEntry` IN (42767, 42788);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 2, 42788, 0, 0, 31, 0, 3, 23943, 0, 0, 0, 0, "", "Spell 'Feed Plaguehound' targets NPC 'Hungry Plaguehound'"),
+(17, 0, 42788, 0, 0, 29, 0, 23943, 10, 0, 0, 0, 0, "", "Spell 'Feed Plaguehound' requires NPC 'Hungry Plaguehound' within 10 yards"),
+(13, 1, 42767, 0, 0, 31, 0, 3, 23945, 0, 0, 0, 0, "", "Spell 'Sic'em' targets NPC 'Fjord Crow'");
+
+UPDATE `creature_template` SET `spell1`=42767 WHERE `entry`=23943;
+
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=23945;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=23945;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(23945, 0, 0, 0, 8, 0, 100, 0, 42767, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, "Fjord Crow - On Spellhit 'Sic'em' - Attack Invoker");

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2185,7 +2185,7 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
     if (!entry)
         return;
 
-    SummonPropertiesEntry const* properties = sSummonPropertiesStore.LookupEntry(m_spellInfo->Effects[effIndex].MiscValueB);
+    SummonPropertiesEntry* properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(m_spellInfo->Effects[effIndex].MiscValueB));
     if (!properties)
     {
         TC_LOG_ERROR("spells", "EffectSummonType: Unhandled summon type %u.", m_spellInfo->Effects[effIndex].MiscValueB);
@@ -2230,6 +2230,15 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
         default:
             numSummons = 1;
             break;
+    }
+
+    // Some creatures must be summoned as pets, yet have a different category or type set in SummonProperties.dbc.
+    // Until a generic way is found to handle them, replace the existing values.
+    switch (properties->Id)
+    {
+    case 628: // Hungry Plaguehound
+        properties->Category = SUMMON_CATEGORY_PET;
+        break;
     }
 
     switch (properties->Category)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2185,7 +2185,7 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
     if (!entry)
         return;
 
-    SummonPropertiesEntry* properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(m_spellInfo->Effects[effIndex].MiscValueB));
+    SummonPropertiesEntry const* properties = sSummonPropertiesStore.LookupEntry(m_spellInfo->Effects[effIndex].MiscValueB);
     if (!properties)
     {
         TC_LOG_ERROR("spells", "EffectSummonType: Unhandled summon type %u.", m_spellInfo->Effects[effIndex].MiscValueB);
@@ -2230,15 +2230,6 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
         default:
             numSummons = 1;
             break;
-    }
-
-    // Some creatures must be summoned as pets, yet have a different category or type set in SummonProperties.dbc.
-    // Until a generic way is found to handle them, replace the existing values.
-    switch (properties->Id)
-    {
-    case 628: // Hungry Plaguehound
-        properties->Category = SUMMON_CATEGORY_PET;
-        break;
     }
 
     switch (properties->Category)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3375,6 +3375,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 29726: // Test Ribbon Pole Channel
                 spellInfo->InterruptFlags &= ~AURA_INTERRUPT_FLAG_CAST;
                 break;
+            case 42767: // Sic'em
+                spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_NEARBY_ENTRY);
+                break;
             // VIOLET HOLD SPELLS
             //
             case 54258: // Water Globule (Ichoron)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3825,6 +3825,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         properties->Type = SUMMON_TYPE_TOTEM;
     if (SummonPropertiesEntry* properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(647))) // 52893
         properties->Type = SUMMON_TYPE_TOTEM;
+    if (SummonPropertiesEntry* properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(628))) // Hungry Plaguehound
+        properties->Category = SUMMON_CATEGORY_PET;
 
     TC_LOG_INFO("server.loading", ">> Loaded SpellInfo corrections in %u ms", GetMSTimeDiffToNow(oldMSTime));
 }


### PR DESCRIPTION
**Changes proposed:**
- Improve the quest [Let Them Eat Crow](http://www.wowhead.com/quest=11227/let-them-eat-crow) by summoning the Hungry Plaguehound as pet, with the Sic'em spell useable to aggro Fjord Crows.

I can't find any pattern in SummonProperties.dbc to give this poor npc a pet bar, hence why I change the summon type in SpellEffects.cpp.
This can also be used for other creatures that should be summoned as pets yet don't have the pet category/type already set.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #16737

**Tests performed:** tested and working.
