### PR TITLE
Core/Transport: always update position of non-static passengers

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -201,6 +201,8 @@ void Transport::Update(uint32 diff)
     if (_positionChangeTimer.Passed())
     {
         _positionChangeTimer.Reset(positionUpdateDelay);
+        UpdatePassengerPositions(_passengers);
+
         if (IsMoving())
         {
             float t = CalculateSegmentPos(float(timer) * 0.001f);


### PR DESCRIPTION
**Changes proposed:**

Currently, the position of players inside transports is updated quite accurately when the transport is moving. However, this is not the case when the transport is not moving. Somehow, when the transport's waypoint movement is stopped, the player's position desyncs from the client.

The best way to check this is the quest [Mutiny on the Mercy](http://www.wowhead.com/quest=11527/mutiny-on-the-mercy). On the ship's lower levels, there are hostile mobs. When the player is standing still or the ship is moving, they can attack and be attacked by the player just fine. But if the ship is standing still and the player moves, the mobs will reset and evade, unable to reach the player.

This fix greatly improves the behavior in such cases. I'm not sure if it's the proper way™ to fix it, but it's a start if anyone knows enough about the transport system to look into it.

**Target branch(es):** 3.3.5

**Tests performed:** tested and working.
