### PR TITLE
Core/Scripts: Fixed Gunship Mage cast interrupt

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -1721,10 +1721,7 @@ class npc_gunship_mage : public CreatureScript
                 me->SetReactState(REACT_PASSIVE);
             }
 
-            void EnterEvadeMode(EvadeReason why) override
-            {
-                ScriptedAI::EnterEvadeMode(why);
-            }
+            void EnterEvadeMode(EvadeReason /*why*/) override { }
 
             void MovementInform(uint32 type, uint32 pointId) override
             {


### PR DESCRIPTION
**Changes proposed:**
-  Remove EnterEvadeMode for Mage Gunship. When Gunship evades he despawn all creatures... so mage dont realy need EnterEvade. Without EnterEvadeMode, he will not stop the cast and encounter can progress normally.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #14912

**Tests performed:** Tested in game
