### PR TITLE
Core/World: properly re-initialize daily quest reset time when resetting daily quests.

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2103,7 +2103,7 @@ void World::Update(uint32 diff)
     if (m_gameTime > m_NextDailyQuestReset)
     {
         ResetDailyQuests();
-        m_NextDailyQuestReset += DAY;
+        InitDailyQuestResetTime();
     }
 
     /// Handle weekly quests reset time

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2103,7 +2103,7 @@ void World::Update(uint32 diff)
     if (m_gameTime > m_NextDailyQuestReset)
     {
         ResetDailyQuests();
-        InitDailyQuestResetTime();
+        InitDailyQuestResetTime(false);
     }
 
     /// Handle weekly quests reset time
@@ -2934,18 +2934,19 @@ void World::InitWeeklyQuestResetTime()
     m_NextWeeklyQuestReset = wstime < curtime ? curtime : time_t(wstime);
 }
 
-void World::InitDailyQuestResetTime()
+void World::InitDailyQuestResetTime(bool loading)
 {
-    time_t mostRecentQuestTime;
+    time_t mostRecentQuestTime = 0;
 
-    QueryResult result = CharacterDatabase.Query("SELECT MAX(time) FROM character_queststatus_daily");
-    if (result)
+    if (loading)
     {
-        Field* fields = result->Fetch();
-        mostRecentQuestTime = time_t(fields[0].GetUInt32());
+        QueryResult result = CharacterDatabase.Query("SELECT MAX(time) FROM character_queststatus_daily");
+        if (result)
+        {
+            Field* fields = result->Fetch();
+            mostRecentQuestTime = time_t(fields[0].GetUInt32());
+        }
     }
-    else
-        mostRecentQuestTime = 0;
 
     // client built-in time for reset is 6:00 AM
     // FIX ME: client not show day start time

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -783,7 +783,7 @@ class TC_GAME_API World
         // callback for UpdateRealmCharacters
         void _UpdateRealmCharCount(PreparedQueryResult resultCharCount);
 
-        void InitDailyQuestResetTime();
+        void InitDailyQuestResetTime(bool loading = true);
         void InitWeeklyQuestResetTime();
         void InitMonthlyQuestResetTime();
         void InitRandomBGResetTime();


### PR DESCRIPTION
**Changes proposed:**

Right now, the server adds one day to the daily quest reset timer after it has been processed.

This assumes that the timer is always set to the proper daily reset time (6:00 AM). However, this is not always the case.
If the server is shut down before the reset time and restarted after the reset time, the timer is set to the time the last daily quest has been completed, which can be at any hour of the day.

Examples: if a daily quest is completed at 5:00 AM, and the server is shut down to be restarted at 7:00 AM, the timer would be equal to 5:00 AM. Adding one day to that means the next reset will not be at 6:00 AM as it's supposed to be.

**Target branch(es):** 3.3.5

**Tests performed:** tested and working.

**Known issues and TODO list:**
- [x] I'm not a hundred percent sure that it's "safe" for it to execute a SELECT query in `InitDailyQuestResetTime()` right after the DELETE in `ResetDailyQuests()`. Should it skip the SELECT if the server is not loading? Looking for advice here.
