### PR TITLE
Core/Battlegrounds: Fix lag caused by arena points distribution

### DIFF
--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -899,6 +899,10 @@ void ArenaTeam::SaveToDB()
 
     for (MemberList::const_iterator itr = Members.begin(); itr != Members.end(); ++itr)
     {
+        // Save the effort and go
+        if (itr->WeekGames == 0)
+            continue;
+
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ARENA_TEAM_MEMBER);
         stmt->setUInt16(0, itr->PersonalRating);
         stmt->setUInt16(1, itr->WeekGames);
@@ -919,8 +923,12 @@ void ArenaTeam::SaveToDB()
     CharacterDatabase.CommitTransaction(trans);
 }
 
-void ArenaTeam::FinishWeek()
+bool ArenaTeam::FinishWeek()
 {
+    // No need to go further than this
+    if (Stats.WeekGames == 0)
+        return false;
+
     // Reset team stats
     Stats.WeekGames = 0;
     Stats.WeekWins = 0;
@@ -931,6 +939,8 @@ void ArenaTeam::FinishWeek()
         itr->WeekGames = 0;
         itr->WeekWins = 0;
     }
+
+    return true;
 }
 
 bool ArenaTeam::IsFighting() const

--- a/src/server/game/Battlegrounds/ArenaTeam.h
+++ b/src/server/game/Battlegrounds/ArenaTeam.h
@@ -180,7 +180,7 @@ class TC_GAME_API ArenaTeam
 
         void UpdateArenaPointsHelper(std::map<uint32, uint32> & PlayerPoints);
 
-        void FinishWeek();
+        bool FinishWeek(); // returns true if arena team played this week
         void FinishGame(int32 mod);
 
     protected:

--- a/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
@@ -186,8 +186,9 @@ void ArenaTeamMgr::DistributeArenaPoints()
     {
         if (ArenaTeam* at = titr->second)
         {
-            at->FinishWeek();
-            at->SaveToDB();
+            if (at->FinishWeek())
+                at->SaveToDB();
+            
             at->NotifyStatsChanged();
         }
     }


### PR DESCRIPTION
Distribution of arena points caused worldserver lag spikes.
Arena teams list contained 4900 items. (ie the table contains 4927 arena teams)
The prepared statements contained large amount of queries and blocked the thread.
This seemed to be working out well when there are plenty inactive teams.
