### PR TITLE
Clean up locale functionality to proper add the case of enGB.

### DIFF
--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -18,8 +18,9 @@
 
 #include "Common.h"
 
-char const* localeNames[TOTAL_LOCALES] =
+char const* localeNames[TOTAL_LOCALES+1] =
 {
+  "enGB",
   "enUS",
   "koKR",
   "frFR",
@@ -36,10 +37,13 @@ char const* localeNames[TOTAL_LOCALES] =
 
 LocaleConstant GetLocaleByName(const std::string& name)
 {
-    for (uint32 i = 0; i < TOTAL_LOCALES; ++i)
-        if (name == localeNames[i])
-            return LocaleConstant(i);
+	//enGB case 
+	if (name == localeNames[0]) return LOCALE_enGB;
 
-    return LOCALE_enUS;                                     // including enGB case
+    for (uint32 i = 0; i =< TOTAL_LOCALES; ++i)
+        if (name == localeNames[i])
+            return LocaleConstant(i-1); //because of enGB there is a 1 shift
+
+    return LOCALE_ERROR;                                     
 }
 

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -115,6 +115,9 @@ enum AccountTypes
 
 enum LocaleConstant
 {
+	LOCALE_ERROR = -1,
+
+	LOCALE_enGB = 0,
     LOCALE_enUS = 0,
     LOCALE_koKR = 1,
     LOCALE_frFR = 2,
@@ -128,7 +131,7 @@ enum LocaleConstant
     LOCALE_ptBR = 10,
     LOCALE_itIT = 11,
 
-    TOTAL_LOCALES
+    TOTAL_LOCALES = 12
 };
 
 const uint8 OLD_TOTAL_LOCALES = 9; /// @todo convert in simple system

--- a/src/server/bnetserver/Server/Session.cpp
+++ b/src/server/bnetserver/Server/Session.cpp
@@ -224,7 +224,7 @@ uint32 Battlenet::Session::HandleLogon(authentication::v1::LogonRequest const* l
         return ERROR_BAD_PLATFORM;
     }
 
-    if (GetLocaleByName(logonRequest->locale()) == LOCALE_enUS && logonRequest->locale() != "enUS")
+    if (GetLocaleByName(logonRequest->locale()) == LOCALE_ERROR)
     {
         TC_LOG_DEBUG("session", "[Battlenet::LogonRequest] %s attempted to log in with unsupported locale (using %s)!", GetClientInfo().c_str(), logonRequest->locale().c_str());
         return ERROR_BAD_LOCALE;


### PR DESCRIPTION
**Changes proposed:**
-  Clean up locale functionality to proper add the case of enGB.
-  Eliminate an ugly locale check for enGB that would block specific clients from logging in.
-  Add error state to the GetLocaleByName so it does not return enUS in case of error ( it was a hack before ).

**Target branch(es):** 6.x

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc) Yes. A test for enGB locale client should be done.

**Known issues and TODO list:**
- [ ] Test a client connection with enGB locale.
