### PR TITLE
Core/GameObject: also spawn trap for GAMEOBJECT_TYPE_BUTTON

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -495,6 +495,7 @@ struct GameObjectTemplate
     {
         switch (type)
         {
+            case GAMEOBJECT_TYPE_BUTTON:      return button.linkedTrap;
             case GAMEOBJECT_TYPE_CHEST:       return chest.linkedTrapId;
             case GAMEOBJECT_TYPE_SPELL_FOCUS: return spellFocus.linkedTrapId;
             case GAMEOBJECT_TYPE_GOOBER:      return goober.linkedTrapId;


### PR DESCRIPTION
**Changes proposed:**

Also spawn traps for GameObjects with type [`GAMEOBJECT_TYPE_BUTTON`](https://trinitycore.atlassian.net/wiki/display/tc/gameobject_template#gameobject_template-data0-23) (1)

Example of usage, [spell 47690 Summon Mole Machine Minion Summoner](http://www.wowhead.com/spell=47690/summon-mole-machine-minion-summoner) summons the [object 188508 Dark Iron Mole Machine (Minion Summoner)](http://wotlk.openwow.com/object=188508), that is a button and it's supposed to summon the trap 188509

P.S.: I don't know if there's any reason not to do this, I leave it to the experts ^^

**Target branch(es):** 3.3.5/6.x

**Tests performed:** Built and tested with [Gob 188508](http://wotlk.openwow.com/object=188508)
