### PR TITLE
Core/Totem: Remove aura due to spell glyph of stoneclaw shield

### DIFF
--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -123,6 +123,10 @@ void Totem::UnSummon(uint32 msTime)
     if (GetEntry() == SENTRY_TOTEM_ENTRY)
         GetOwner()->RemoveAurasDueToSpell(SENTRY_TOTEM_SPELLID);
 
+    // Remove Glyph of Stoneclaw shield
+    if (GetEntry() == STONECLAW_TOTEM_ENTRY)
+        GetOwner()->RemoveAurasDueToSpell(55277);
+
     //remove aura all party members too
     if (Player* owner = GetOwner()->ToPlayer())
     {

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -31,6 +31,7 @@ enum TotemType
 #define SENTRY_TOTEM_SPELLID  6495
 
 #define SENTRY_TOTEM_ENTRY    3968
+#define STONECLAW_TOTEM_ENTRY 3579
 
 class TC_GAME_API Totem : public Minion
 {


### PR DESCRIPTION
**Changes proposed:**
When the stoneclaw totem is destroyed it also should destroy glyph of stoneclaw shield
- When the stoneclaw totem is destroyed it destroy glyph of stoneclaw shield

**Target branch(es):** 3.3.5/master

**Issues addressed:**

**Tests performed:** (Does it build, tested in-game, etc)

**Known issues and ToDo list:**
