### PR TITLE
Core/Scripts: Fixed Crash in SnoboldVassal Script

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -417,8 +417,9 @@ class npc_snobold_vassal : public CreatureScript
                     switch (eventId)
                     {
                         case EVENT_FIRE_BOMB:
-                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, -me->GetVehicleBase()->GetCombatReach(), true))
-                                me->CastSpell(target, SPELL_FIRE_BOMB);
+                            if (me->GetVehicleBase())
+                                if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, -me->GetVehicleBase()->GetCombatReach(), true))
+                                    me->CastSpell(target, SPELL_FIRE_BOMB);
                             _events.Repeat(Seconds(20));
                             break;
                         case EVENT_HEAD_CRACK:


### PR DESCRIPTION
**Changes proposed:**
-  Fixed an edge case when the event `EVENT_FIRE_BOMB` (4) is executed without a vehicle.

**Target branch(es):** 3.3.5
**Issues addressed:** Closes: #18122

**Tests performed:** Built and tested in game.
