### PR TITLE
Core/Movement: Using player position extrapolation to smooth range checks

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1293,6 +1293,9 @@ class TC_GAME_API Unit : public WorldObject
         bool IsWithinMeleeRange(Unit const* obj) const;
         float GetMeleeRange(Unit const* target) const;
         void GetRandomContactPoint(const Unit* target, float &x, float &y, float &z, float distance2dMin, float distance2dMax) const;
+        float GetCurrentSpeed() const;
+        Position GetCurrentPosition() const;
+        float GetCurrentMovementOrientation() const;
         uint32 m_extraAttacks;
         bool m_canDualWield;
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5815,12 +5815,13 @@ SpellCastResult Spell::CheckRange(bool strict)
     maxRange *= maxRange;
 
     Unit* target = m_targets.GetUnitTarget();
+    Position projectedPosition = m_caster->GetCurrentPosition();
     if (target && target != m_caster)
     {
-        if (m_caster->GetExactDistSq(target) > maxRange)
+        if (projectedPosition.GetExactDistSq(target) > maxRange)
             return SPELL_FAILED_OUT_OF_RANGE;
 
-        if (minRange > 0.0f && m_caster->GetExactDistSq(target) < minRange)
+        if (minRange > 0.0f && projectedPosition.GetExactDistSq(target) < minRange)
             return SPELL_FAILED_OUT_OF_RANGE;
 
         if (m_caster->GetTypeId() == TYPEID_PLAYER &&
@@ -5830,9 +5831,9 @@ SpellCastResult Spell::CheckRange(bool strict)
 
     if (m_targets.HasDst() && !m_targets.HasTraj())
     {
-        if (m_caster->GetExactDistSq(m_targets.GetDstPos()) > maxRange)
+        if (projectedPosition.GetExactDistSq(m_targets.GetDstPos()) > maxRange)
             return !(_triggeredCastFlags & TRIGGERED_DONT_REPORT_CAST_ERROR) ? SPELL_FAILED_OUT_OF_RANGE : SPELL_FAILED_DONT_REPORT;
-        if (minRange > 0.0f && m_caster->GetExactDistSq(m_targets.GetDstPos()) < minRange)
+        if (minRange > 0.0f && projectedPosition.GetExactDistSq(m_targets.GetDstPos()) < minRange)
             return !(_triggeredCastFlags & TRIGGERED_DONT_REPORT_CAST_ERROR) ? SPELL_FAILED_OUT_OF_RANGE : SPELL_FAILED_DONT_REPORT;
     }
 


### PR DESCRIPTION
**Changes proposed:**
When a player moves, the client only send the current position of the player at the beginning and at the end of the movement and every 0.5s in between. This is not enough if we require high precision of the player position, during range checking for example. 

However, to counter that limitation, we can extrapolate the player position using his last known position + his speed and direction. This is what I have implemented.

**Target branch(es):** 3.3.5. Probably useful for the other branches.

**Issues addressed:** For now, the solution greatly mitigate the problem described here: https://github.com/TrinityCore/TrinityCore/issues/17539#issuecomment-242581530. At term, I'm hoping it completely fixes it. Also, the extrapolation of the player movement could probably be useful to other parts of the game, like spell hit checking which will improve the player experience.

**Tests performed:** tested IG.

**Known issues and TODO list:**
- So far, I've implemented the 2D side. 3D support isn't done yet.
- The solution can have a 1 to 5% inaccuracy because of lag and request processing time. I'm hoping to fix that by working on the time synchronization done between the client and the server (cf [this relevant read](http://www.mine-control.com/zack/timesync/timesync.html)).
