### PR TITLE
Tools/VMAPs: Fix extractor crash when some .mpq files does not exist

### DIFF
--- a/src/tools/vmap4_extractor/mpq_libmpq.cpp
+++ b/src/tools/vmap4_extractor/mpq_libmpq.cpp
@@ -19,6 +19,7 @@
 #include "mpq_libmpq04.h"
 #include <deque>
 #include <cstdio>
+#include <algorithm>
 
 ArchiveSet gOpenArchives;
 
@@ -50,6 +51,11 @@ MPQArchive::MPQArchive(const char* filename)
         return;
     }
     gOpenArchives.push_front(this);
+}
+
+bool MPQArchive::isOpened() const
+{
+    return std::find(gOpenArchives.begin(), gOpenArchives.end(), this) != gOpenArchives.end();
 }
 
 void MPQArchive::close()

--- a/src/tools/vmap4_extractor/mpq_libmpq04.h
+++ b/src/tools/vmap4_extractor/mpq_libmpq04.h
@@ -34,7 +34,7 @@ public:
     mpq_archive_s *mpq_a;
 
     MPQArchive(const char* filename);
-    ~MPQArchive() { close(); }
+    ~MPQArchive() { if (isOpened()) close(); }
 
     void GetFileListTo(std::vector<std::string>& filelist) {
         uint32_t filenum;
@@ -66,6 +66,7 @@ public:
 
 private:
     void close();
+    bool isOpened() const;
 };
 typedef std::deque<MPQArchive*> ArchiveSet;
 
@@ -95,13 +96,8 @@ public:
 
 inline void flipcc(char *fcc)
 {
-    char t;
-    t=fcc[0];
-    fcc[0]=fcc[3];
-    fcc[3]=t;
-    t=fcc[1];
-    fcc[1]=fcc[2];
-    fcc[2]=t;
+    std::swap(fcc[0], fcc[3]);
+    std::swap(fcc[1], fcc[2]);
 }
 
 #endif


### PR DESCRIPTION
**Changes proposed:**

Fix extractor crash when some .mpq files does not exist

How to reproduce: Delete Data/common.MPQ and run vmap4_extractor.exe

**Target branch(es):** 3.3.5/master

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc.)

**Known issues and TODO list:**
- [ ] 
- [ ] 

**DEPRECATION NOTICE** When creating new PRs to the (old) 6.x branch, make sure the target branch is **master** instead of 6.x.
**NOTE** Enable the setting "Allow edits from maintainers." when creating your pull request.  
**NOTE** If this PR **only** contains SQL files, create an issue instead.  
**NOTE** Squashing commits is not required.  
**SUGGESTION** When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
