### PR TITLE
Core/Movement: Use time synchronisation to better interpret client timestamps

### DIFF
--- a/src/common/Utilities/Timer.h
+++ b/src/common/Utilities/Timer.h
@@ -22,13 +22,20 @@
 #include "Define.h"
 #include <chrono>
 
-inline uint32 getMSTime()
+inline std::chrono::steady_clock::time_point GetApplicationStartTime()
 {
     using namespace std::chrono;
 
     static const steady_clock::time_point ApplicationStartTime = steady_clock::now();
 
-    return uint32(duration_cast<milliseconds>(steady_clock::now() - ApplicationStartTime).count());
+    return ApplicationStartTime;
+}
+
+inline uint32 getMSTime()
+{
+    using namespace std::chrono;
+
+    return uint32(duration_cast<milliseconds>(steady_clock::now() - GetApplicationStartTime()).count());
 }
 
 inline uint32 getMSTimeDiff(uint32 oldMSTime, uint32 newMSTime)
@@ -38,6 +45,14 @@ inline uint32 getMSTimeDiff(uint32 oldMSTime, uint32 newMSTime)
         return (0xFFFFFFFF - oldMSTime) + newMSTime;
     else
         return newMSTime - oldMSTime;
+}
+
+inline uint32 getMSTimeDiff(uint32 oldMSTime, std::chrono::steady_clock::time_point newTime)
+{
+    using namespace std::chrono;
+
+    uint32 newMSTime = uint32(duration_cast<milliseconds>(newTime - GetApplicationStartTime()).count());
+    return getMSTimeDiff(oldMSTime, newMSTime);
 }
 
 inline uint32 GetMSTimeDiffToNow(uint32 oldMSTime)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -380,11 +380,6 @@ Player::Player(WorldSession* session): Unit(true)
 
     m_ChampioningFaction = 0;
 
-    m_timeSyncCounter = 0;
-    m_timeSyncTimer = 0;
-    m_timeSyncClockDelta = 0;
-    m_timeSyncServer = 0;
-
     for (uint8 i = 0; i < MAX_POWERS; ++i)
         m_powerFraction[i] = 0;
 
@@ -1231,14 +1226,6 @@ void Player::Update(uint32 p_time)
         }
         else
             m_zoneUpdateTimer -= p_time;
-    }
-
-    if (m_timeSyncTimer > 0)
-    {
-        if (p_time >= m_timeSyncTimer)
-            SendTimeSync();
-        else
-            m_timeSyncTimer -= p_time;
     }
 
     if (IsAlive())
@@ -22517,8 +22504,8 @@ void Player::SendInitialPacketsAfterAddToMap()
     GetZoneAndAreaId(newzone, newarea);
     UpdateZone(newzone, newarea);                            // also call SendInitWorldStates();
 
-    ResetTimeSync();
-    SendTimeSync();
+    GetSession()->ResetTimeSync();
+    GetSession()->SendTimeSync();
 
     CastSpell(this, 836, true);                             // LOGINEFFECT
 
@@ -25955,25 +25942,6 @@ void Player::LoadActions(PreparedQueryResult result)
         _LoadActions(result);
 
     SendActionButtons(1);
-}
-
-void Player::ResetTimeSync()
-{
-    m_timeSyncCounter = 0;
-    m_timeSyncTimer = 0;
-    m_timeSyncClockDelta = 0;
-    m_timeSyncServer = GameTime::GetGameTimeMS(); // todo: maybe should use a queue for this because we could have more than one time sync request pending at the same time ? To be checked by looking at sniff
-}
-
-void Player::SendTimeSync()
-{
-    WorldPacket data(SMSG_TIME_SYNC_REQ, 4);
-    data << uint32(m_timeSyncCounter++);
-    SendDirectMessage(&data);
-
-    // Schedule next sync in 10 sec
-    m_timeSyncTimer = 10000;
-    m_timeSyncServer = GameTime::GetGameTimeMS();
 }
 
 void Player::SetReputation(uint32 factionentry, uint32 value)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -382,7 +382,7 @@ Player::Player(WorldSession* session): Unit(true)
 
     m_timeSyncCounter = 0;
     m_timeSyncTimer = 0;
-    m_timeSyncClient = 0;
+    m_timeSyncClockDelta = 0;
     m_timeSyncServer = 0;
 
     for (uint8 i = 0; i < MAX_POWERS; ++i)
@@ -25961,8 +25961,8 @@ void Player::ResetTimeSync()
 {
     m_timeSyncCounter = 0;
     m_timeSyncTimer = 0;
-    m_timeSyncClient = 0;
-    m_timeSyncServer = GameTime::GetGameTimeMS();
+    m_timeSyncClockDelta = 0;
+    m_timeSyncServer = GameTime::GetGameTimeMS(); // todo: maybe should use a queue for this because we could have more than one time sync request pending at the same time ? To be checked by looking at sniff
 }
 
 void Player::SendTimeSync()

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2462,7 +2462,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         uint32 m_timeSyncCounter;
         uint32 m_timeSyncTimer;
-        uint32 m_timeSyncClient;
+        int64 m_timeSyncClockDelta;
         uint32 m_timeSyncServer;
 
         InstanceTimeMap _instanceResetTimes;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2315,9 +2315,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         ItemDurationList m_itemDuration;
         GuidUnorderedSet m_itemSoulboundTradeable;
 
-        void ResetTimeSync();
-        void SendTimeSync();
-
         std::unique_ptr<ResurrectionData> _resurrectionData;
 
         WorldSession* m_session;
@@ -2459,11 +2456,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         ReputationMgr*  m_reputationMgr;
 
         uint32 m_ChampioningFaction;
-
-        uint32 m_timeSyncCounter;
-        uint32 m_timeSyncTimer;
-        int64 m_timeSyncClockDelta;
-        uint32 m_timeSyncServer;
 
         InstanceTimeMap _instanceResetTimes;
         uint32 _pendingBindId;

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1239,7 +1239,7 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     // we are going to make 2 assumptions:
     // 1) we assume that the request processing time equals 0.
     // 2) we assume that the packet took as much time to travel from server to client than it took to travel from client to server.
-    uint32 roundTripDuration = getMSTimeDiff(serverTimeAtSent, getMSTime());
+    uint32 roundTripDuration = getMSTimeDiff(serverTimeAtSent, GameTime::GetGameTimeMS());
     uint32 lagDelay = roundTripDuration / 2;
 
     /*

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1229,7 +1229,7 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     uint32 counter, clientTimestamp;
     recvData >> counter >> clientTimestamp;
 
-    if (counter != _player->m_timeSyncCounter - 1)
+    if (counter != m_timeSyncCounter - 1)
     {
         TC_LOG_DEBUG("network", "Wrong time sync counter from player %s (cheater?)", _player->GetName().c_str());
         // todo: send a new one?
@@ -1237,8 +1237,11 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     }
 
     // time it took for the request to travel to the client, for the client to process it and reply and for response to travel back to the server.
-    uint32 roundTripDuration = getMSTimeDiff(_player->m_timeSyncServer, getMSTime());
-    uint32 lagDelay = roundTripDuration / 2; // we assume that the request processing time equals 0.
+    // we are going to make 2 assumptions:
+    // 1) we assume that the request processing time equals 0.
+    // 2) we assume that the packet took as much time to travel from server to client than it took to travel from client to server.
+    uint32 roundTripDuration = getMSTimeDiff(m_timeSyncServer, getMSTime());
+    uint32 lagDelay = roundTripDuration / 2;
 
     /*
     clockDelta = serverTime - clientTime

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1239,7 +1239,7 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     // we are going to make 2 assumptions:
     // 1) we assume that the request processing time equals 0.
     // 2) we assume that the packet took as much time to travel from server to client than it took to travel from client to server.
-    uint32 roundTripDuration = getMSTimeDiff(serverTimeAtSent, GameTime::GetGameTimeMS());
+    uint32 roundTripDuration = getMSTimeDiff(serverTimeAtSent, recvData.GetReceivedTime());
     uint32 lagDelay = roundTripDuration / 2;
 
     /*

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1255,10 +1255,6 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     int64 clockDelta = (int64)(serverTimeAtSent + lagDelay) - (int64)clientTimestamp;
     timeSyncClockDeltaQueue.push_back(std::pair<int64, uint32>(clockDelta, roundTripDuration));
     ComputeNewClockDelta();
-
-    TC_LOG_ERROR("custom", "CMSG_TIME_SYNC_RESP. counter %u clientTimestamp %u serverTimeAtSent %u", counter, clientTimestamp, serverTimeAtSent);
-    TC_LOG_ERROR("custom", "CMSG_TIME_SYNC_RESP. roundTripDuration %u", roundTripDuration);
-    TC_LOG_ERROR("custom", "CMSG_TIME_SYNC_RESP. new delta: %i for player  %s", timeSyncClockDelta, _player->GetName().c_str());
 }
 
 void WorldSession::HandleResetInstancesOpcode(WorldPacket& /*recvData*/)

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1250,7 +1250,12 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     using the following relation:
     serverTime = clockDelta + clientTime
     */
-    _player->m_timeSyncClockDelta = (int64) (_player->m_timeSyncServer + lagDelay) - (int64) clientTimestamp;
+    int64 clockDelta = (int64)(m_timeSyncServer + lagDelay) - (int64)clientTimestamp;
+    timeSyncClockDeltaQueue.push_back(std::pair<int64, uint32>(clockDelta, roundTripDuration));
+    ComputeNewClockDelta();
+
+    TC_LOG_ERROR("custom", "CMSG_TIME_SYNC_RESP. roundTripDuration %u", roundTripDuration);
+    TC_LOG_ERROR("custom", "CMSG_TIME_SYNC_RESP. new delta: %i for player  %s", timeSyncClockDelta, _player->GetName().c_str());
 }
 
 void WorldSession::HandleResetInstancesOpcode(WorldPacket& /*recvData*/)

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -363,7 +363,7 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
     /* process position-change */
     WorldPacket data(opcode, recvData.size());
     int64 movementTime = (int64) movementInfo.time + timeSyncClockDelta;
-    if (movementTime < 0 || movementTime > 0xFFFFFFFF)
+    if (timeSyncClockDelta == 0 || movementTime < 0 || movementTime > 0xFFFFFFFF)
     {
         TC_LOG_WARN("misc", "The computed movement time using clockDelta is erronous. Using fallback instead");
         movementInfo.time = GameTime::GetGameTimeMS();

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -362,13 +362,16 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
 
     /* process position-change */
     WorldPacket data(opcode, recvData.size());
-    int64 movementTime = (int64) movementInfo.time + plrMover->m_timeSyncClockDelta + 500u; // time of the event on the server clock + 500ms (for the anti-jitter buffer).
+    int64 movementTime = (int64) movementInfo.time + timeSyncClockDelta;
     if (movementTime < 0 || movementTime > 0xFFFFFFFF)
     {
         TC_LOG_WARN("misc", "The computed movement time using clockDelta is erronous. Using fallback instead");
-        movementTime = GameTime::GetGameTimeMS();
+        movementInfo.time = GameTime::GetGameTimeMS();
     }
-    movementInfo.time = (uint32) movementTime;
+    else
+    {
+        movementInfo.time = (uint32)movementTime;
+    }
 
     movementInfo.guid = mover->GetGUID();
     WriteMovementInfo(&data, &movementInfo);

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -709,7 +709,7 @@ void WorldSession::ComputeNewClockDelta()
     if (sampleSizeAfterFiltering != 0)
     {
         int64 meanClockDelta = static_cast<int64>(std::round(mean(clockDeltasAfterFiltering)));
-        if (std::fabs(meanClockDelta - _timeSyncClockDelta) > 25)
+        if (std::abs(meanClockDelta - _timeSyncClockDelta) > 25)
             _timeSyncClockDelta = meanClockDelta;
     }
     else if (_timeSyncClockDelta == 0)

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -700,7 +700,7 @@ void WorldSession::ComputeNewClockDelta()
     uint32 sampleSizeAfterFiltering = 0;
     for (auto pair : _timeSyncClockDeltaQueue)
     {
-        if (std::fabs(pair.second - latencyMedian) <= latencyStandardDeviation) {
+        if (pair.second < latencyStandardDeviation + latencyMedian) {
             clockDeltasAfterFiltering(pair.first);
             sampleSizeAfterFiltering++;
         }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -753,11 +753,8 @@ void Map::Update(uint32 t_diff)
         {
             //player->Update(t_diff);
             WorldSession* session = player->GetSession();
-
             MapSessionFilter updater(session);
             session->Update(t_diff, updater);
-
-            session->UpdateForPlayersOnMap(t_diff);
         }
     }
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -753,8 +753,11 @@ void Map::Update(uint32 t_diff)
         {
             //player->Update(t_diff);
             WorldSession* session = player->GetSession();
+
             MapSessionFilter updater(session);
             session->Update(t_diff, updater);
+
+            session->UpdateForPlayersOnMap(t_diff);
         }
     }
 

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -1042,7 +1042,7 @@ void OpcodeTable::Initialize()
     /*0x38E*/ DEFINE_HANDLER(MSG_PARTY_ASSIGNMENT,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandlePartyAssignmentOpcode     );
     /*0x38F*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_OFFER_PETITION_ERROR,      STATUS_NEVER);
     /*0x390*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_TIME_SYNC_REQ,             STATUS_NEVER);
-    /*0x391*/ DEFINE_HANDLER(CMSG_TIME_SYNC_RESP,                          STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::HandleTimeSyncResp              );
+    /*0x391*/ DEFINE_HANDLER(CMSG_TIME_SYNC_RESP,                          STATUS_LOGGEDIN, PROCESS_THREADSAFE,   &WorldSession::HandleTimeSyncResp              );
     /*0x392*/ DEFINE_HANDLER(CMSG_SEND_LOCAL_EVENT,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     /*0x393*/ DEFINE_HANDLER(CMSG_SEND_GENERAL_TRIGGER,                    STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     /*0x394*/ DEFINE_HANDLER(CMSG_SEND_COMBAT_TRIGGER,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -1042,7 +1042,7 @@ void OpcodeTable::Initialize()
     /*0x38E*/ DEFINE_HANDLER(MSG_PARTY_ASSIGNMENT,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandlePartyAssignmentOpcode     );
     /*0x38F*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_OFFER_PETITION_ERROR,      STATUS_NEVER);
     /*0x390*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_TIME_SYNC_REQ,             STATUS_NEVER);
-    /*0x391*/ DEFINE_HANDLER(CMSG_TIME_SYNC_RESP,                          STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::HandleTimeSyncResp              );
+    /*0x391*/ DEFINE_HANDLER(CMSG_TIME_SYNC_RESP,                          STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::Handle_EarlyProccess            );
     /*0x392*/ DEFINE_HANDLER(CMSG_SEND_LOCAL_EVENT,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     /*0x393*/ DEFINE_HANDLER(CMSG_SEND_GENERAL_TRIGGER,                    STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     /*0x394*/ DEFINE_HANDLER(CMSG_SEND_COMBAT_TRIGGER,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -1042,7 +1042,7 @@ void OpcodeTable::Initialize()
     /*0x38E*/ DEFINE_HANDLER(MSG_PARTY_ASSIGNMENT,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandlePartyAssignmentOpcode     );
     /*0x38F*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_OFFER_PETITION_ERROR,      STATUS_NEVER);
     /*0x390*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_TIME_SYNC_REQ,             STATUS_NEVER);
-    /*0x391*/ DEFINE_HANDLER(CMSG_TIME_SYNC_RESP,                          STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::Handle_EarlyProccess            );
+    /*0x391*/ DEFINE_HANDLER(CMSG_TIME_SYNC_RESP,                          STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::HandleTimeSyncResp              );
     /*0x392*/ DEFINE_HANDLER(CMSG_SEND_LOCAL_EVENT,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     /*0x393*/ DEFINE_HANDLER(CMSG_SEND_GENERAL_TRIGGER,                    STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     /*0x394*/ DEFINE_HANDLER(CMSG_SEND_COMBAT_TRIGGER,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );

--- a/src/server/game/Server/WorldPacket.h
+++ b/src/server/game/Server/WorldPacket.h
@@ -22,6 +22,7 @@
 #include "Common.h"
 #include "Opcodes.h"
 #include "ByteBuffer.h"
+#include <chrono>
 
 class WorldPacket : public ByteBuffer
 {

--- a/src/server/game/Server/WorldPacket.h
+++ b/src/server/game/Server/WorldPacket.h
@@ -38,7 +38,7 @@ class WorldPacket : public ByteBuffer
         {
         }
 
-        WorldPacket(WorldPacket&& packet, uint32  recvdTime) : ByteBuffer(std::move(packet)), m_opcode(packet.m_opcode), m_recvdTime(recvdTime)
+        WorldPacket(WorldPacket&& packet, std::chrono::steady_clock::time_point receivedTime) : ByteBuffer(std::move(packet)), m_opcode(packet.m_opcode), m_receivedTime(receivedTime)
         {
         }
 
@@ -80,11 +80,11 @@ class WorldPacket : public ByteBuffer
         uint16 GetOpcode() const { return m_opcode; }
         void SetOpcode(uint16 opcode) { m_opcode = opcode; }
 
-        uint32 GetReceivedTime() const { return m_recvdTime; }
+        std::chrono::steady_clock::time_point GetReceivedTime() const { return m_receivedTime; }
 
     protected:
         uint16 m_opcode;
-        uint32 m_recvdTime; // only set for a specific set of opcodes, for performance reasons.
+        std::chrono::steady_clock::time_point m_receivedTime; // only set for a specific set of opcodes, for performance reasons.
 };
 
 #endif

--- a/src/server/game/Server/WorldPacket.h
+++ b/src/server/game/Server/WorldPacket.h
@@ -38,6 +38,10 @@ class WorldPacket : public ByteBuffer
         {
         }
 
+        WorldPacket(WorldPacket&& packet, uint32  recvdTime) : ByteBuffer(std::move(packet)), m_opcode(packet.m_opcode), m_recvdTime(recvdTime)
+        {
+        }
+
         WorldPacket(WorldPacket const& right) : ByteBuffer(right), m_opcode(right.m_opcode)
         {
         }
@@ -76,8 +80,11 @@ class WorldPacket : public ByteBuffer
         uint16 GetOpcode() const { return m_opcode; }
         void SetOpcode(uint16 opcode) { m_opcode = opcode; }
 
+        uint32 GetReceivedTime() const { return m_recvdTime; }
+
     protected:
         uint16 m_opcode;
+        uint32 m_recvdTime; // only set for a specific set of opcodes, for performance reasons.
 };
 
 #endif

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -132,7 +132,7 @@ WorldSession::WorldSession(uint32 id, std::string&& name, std::shared_ptr<WorldS
     expireTime(60000), // 1 min after socket loss, session is deleted
     forceExit(false),
     m_currentBankerGUID(),
-    _timeSyncClockDeltaQueue(boost::circular_buffer<std::pair<int64, uint32>>(6)),
+    _timeSyncClockDeltaQueue(6),
     _timeSyncClockDelta(0),
     _pendingTimeSyncRequests()
 {

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -284,40 +284,27 @@ void WorldSession::ComputeNewClockDelta()
     for (auto pair : timeSyncClockDeltaQueue)
         acc(pair.second);
 
-    TC_LOG_ERROR("custom", "-------------------------------------------");
-    TC_LOG_ERROR("custom", "queue content BEFORE");
-    for (std::pair<int64, uint32> pair : timeSyncClockDeltaQueue)
-        TC_LOG_ERROR("custom", "%i / %u", pair.first, pair.second);
-
-    TC_LOG_ERROR("custom", "mean: %f", mean(acc));
-    TC_LOG_ERROR("custom", "median: %f", median(acc));
-    TC_LOG_ERROR("custom", "variance: %f", variance(acc));
-    TC_LOG_ERROR("custom", "std deviation: %f", sqrt(variance(acc)));
-
     uint32 latencyMedian = static_cast<uint32>(std::round(median(acc)));
     uint32 latencyStandardDeviation = static_cast<uint32>(std::round(sqrt(variance(acc))));
+
     accumulator_set<int64, features<tag::mean> > clockDeltasAfterFiltering;
-    TC_LOG_ERROR("custom", "queue content AFTER");
     uint32 sampleSizeAfterFiltering = 0;
     for (auto pair : timeSyncClockDeltaQueue)
     {
         if (std::fabs(pair.second - latencyMedian) <= latencyStandardDeviation) {
             clockDeltasAfterFiltering(pair.first);
             sampleSizeAfterFiltering++;
-            TC_LOG_ERROR("custom", "%i / %u", pair.first, pair.second);
         }
     }
 
     if (sampleSizeAfterFiltering != 0)
     {
         int64 meanClockDelta = static_cast<int64>(std::round(mean(clockDeltasAfterFiltering)));
-        TC_LOG_ERROR("custom", "meanClockDelta: %i", meanClockDelta);
         if (std::fabs(meanClockDelta - timeSyncClockDelta) > 50)
             timeSyncClockDelta = meanClockDelta;
     }
     else if (timeSyncClockDelta == 0)
     {
-        TC_LOG_ERROR("custom", "using fallback clockDelta");
         std::pair<int64, uint32> back = timeSyncClockDeltaQueue.back();
         timeSyncClockDelta = back.first;
     }

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -280,7 +280,6 @@ void WorldSession::ComputeNewClockDelta()
 
     accumulator_set<uint32, features<tag::mean, tag::median, tag::variance(lazy)> > acc;
 
-    // timeSyncClockDeltaQueue: <clockDelta,latency>
     for (auto pair : timeSyncClockDeltaQueue)
         acc(pair.second);
 

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -278,13 +278,13 @@ void WorldSession::ComputeNewClockDelta()
 {
     using namespace boost::accumulators;
 
-    accumulator_set<uint32, features<tag::mean, tag::median, tag::variance(lazy)> > acc;
+    accumulator_set<uint32, features<tag::mean, tag::median, tag::variance(lazy)> > latencyAccumulator;
 
     for (auto pair : timeSyncClockDeltaQueue)
-        acc(pair.second);
+        latencyAccumulator(pair.second);
 
-    uint32 latencyMedian = static_cast<uint32>(std::round(median(acc)));
-    uint32 latencyStandardDeviation = static_cast<uint32>(std::round(sqrt(variance(acc))));
+    uint32 latencyMedian = static_cast<uint32>(std::round(median(latencyAccumulator)));
+    uint32 latencyStandardDeviation = static_cast<uint32>(std::round(sqrt(variance(latencyAccumulator))));
 
     accumulator_set<int64, features<tag::mean> > clockDeltasAfterFiltering;
     uint32 sampleSizeAfterFiltering = 0;
@@ -307,7 +307,6 @@ void WorldSession::ComputeNewClockDelta()
         std::pair<int64, uint32> back = timeSyncClockDeltaQueue.back();
         timeSyncClockDelta = back.first;
     }
-
 }
 
 /// Update the WorldSession (triggered by World update)

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -125,7 +125,6 @@ WorldSession::WorldSession(uint32 id, std::string&& name, std::shared_ptr<WorldS
     m_sessionDbcLocale(sWorld->GetAvailableDbcLocale(locale)),
     m_sessionDbLocaleIndex(locale),
     m_latency(0),
-    m_clientTimeDelay(0),
     m_TutorialsChanged(TUTORIALS_FLAG_NONE),
     recruiterId(recruiter),
     isRecruiter(isARecruiter),

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -299,7 +299,7 @@ void WorldSession::ComputeNewClockDelta()
     if (sampleSizeAfterFiltering != 0)
     {
         int64 meanClockDelta = static_cast<int64>(std::round(mean(clockDeltasAfterFiltering)));
-        if (std::fabs(meanClockDelta - timeSyncClockDelta) > 50)
+        if (std::fabs(meanClockDelta - timeSyncClockDelta) > 25)
             timeSyncClockDelta = meanClockDelta;
     }
     else if (timeSyncClockDelta == 0)
@@ -1620,7 +1620,7 @@ void WorldSession::SendTimeSync()
 
     pendingTimeSyncRequests[m_timeSyncNextCounter] = GameTime::GetGameTimeMS();
 
-    // Schedule next sync in 10 sec
-    m_timeSyncTimer = 10000;
+    // Schedule next sync in 10 sec (except for the 2 first packets, which are spaced by only 5s)
+    m_timeSyncTimer = m_timeSyncNextCounter == 0 ? 5000 : 10000;
     m_timeSyncNextCounter++;
 }

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -405,7 +405,7 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
     if (m_Socket && m_Socket->IsOpen() && _warden)
         _warden->Update();
 
-    if (!updater.ProcessLogout()) // <=> updater is of type MapSessionFilter
+    if (!updater.ProcessUnsafe()) // <=> updater is of type MapSessionFilter
     {
         // Send time sync packet every 10s.
         if (_timeSyncTimer > 0)
@@ -421,7 +421,7 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
 
     //check if we are safe to proceed with logout
     //logout procedure should happen only in World::UpdateSessions() method!!!
-    if (updater.ProcessLogout())
+    if (updater.ProcessUnsafe())
     {
         ///- If necessary, log the player out
         if (ShouldLogOut(currentTime) && !m_playerLoading)

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -132,14 +132,14 @@ WorldSession::WorldSession(uint32 id, std::string&& name, std::shared_ptr<WorldS
     expireTime(60000), // 1 min after socket loss, session is deleted
     forceExit(false),
     m_currentBankerGUID(),
-    timeSyncClockDeltaQueue(boost::circular_buffer<std::pair<int64, uint32>>(6)),
-    timeSyncClockDelta(0),
-    pendingTimeSyncRequests()
+    _timeSyncClockDeltaQueue(boost::circular_buffer<std::pair<int64, uint32>>(6)),
+    _timeSyncClockDelta(0),
+    _pendingTimeSyncRequests()
 {
     memset(m_Tutorials, 0, sizeof(m_Tutorials));
 
-    m_timeSyncNextCounter = 0;
-    m_timeSyncTimer = 0;
+    _timeSyncNextCounter = 0;
+    _timeSyncTimer = 0;
 
     if (sock)
     {
@@ -438,12 +438,12 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
 bool WorldSession::UpdateForPlayersOnMap(uint32 diff)
 {
     // Send time sync packet every 10s.
-    if (m_timeSyncTimer > 0)
+    if (_timeSyncTimer > 0)
     {
-        if (diff >= m_timeSyncTimer)
+        if (diff >= _timeSyncTimer)
             SendTimeSync();
         else
-            m_timeSyncTimer -= diff;
+            _timeSyncTimer -= diff;
     }
 
     return true;
@@ -1570,19 +1570,19 @@ WorldSession::DosProtection::DosProtection(WorldSession* s) : Session(s), _polic
 
 void WorldSession::ResetTimeSync()
 {
-    m_timeSyncNextCounter = 0;
-    pendingTimeSyncRequests.clear();
+    _timeSyncNextCounter = 0;
+    _pendingTimeSyncRequests.clear();
 }
 
 void WorldSession::SendTimeSync()
 {
     WorldPacket data(SMSG_TIME_SYNC_REQ, 4);
-    data << uint32(m_timeSyncNextCounter);
+    data << uint32(_timeSyncNextCounter);
     SendPacket(&data);
 
-    pendingTimeSyncRequests[m_timeSyncNextCounter] = GameTime::GetGameTimeMS();
+    _pendingTimeSyncRequests[_timeSyncNextCounter] = GameTime::GetGameTimeMS();
 
     // Schedule next sync in 10 sec (except for the 2 first packets, which are spaced by only 5s)
-    m_timeSyncTimer = m_timeSyncNextCounter == 0 ? 5000 : 10000;
-    m_timeSyncNextCounter++;
+    _timeSyncTimer = _timeSyncNextCounter == 0 ? 5000 : 10000;
+    _timeSyncNextCounter++;
 }

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1580,7 +1580,7 @@ void WorldSession::SendTimeSync()
     data << uint32(_timeSyncNextCounter);
     SendPacket(&data);
 
-    _pendingTimeSyncRequests[_timeSyncNextCounter] = GameTime::GetGameTimeMS();
+    _pendingTimeSyncRequests[_timeSyncNextCounter] = getMSTime();
 
     // Schedule next sync in 10 sec (except for the 2 first packets, which are spaced by only 5s)
     _timeSyncTimer = _timeSyncNextCounter == 0 ? 5000 : 10000;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -458,17 +458,6 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
     if (m_Socket && m_Socket->IsOpen() && _warden)
         _warden->Update();
 
-    if (_player && _player->IsInWorld())
-    {
-        if (m_timeSyncTimer > 0)
-        {
-            if (diff >= m_timeSyncTimer)
-                SendTimeSync();
-            else
-                m_timeSyncTimer -= diff;
-        }
-    }
-
     ProcessQueryCallbacks();
 
     //check if we are safe to proceed with logout
@@ -494,6 +483,20 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
 
         if (!m_Socket)
             return false;                                       //Will remove this session from the world session map
+    }
+
+    return true;
+}
+
+bool WorldSession::UpdateForPlayersOnMap(uint32 diff)
+{
+    // Send time sync packet every 10s.
+    if (m_timeSyncTimer > 0)
+    {
+        if (diff >= m_timeSyncTimer)
+            SendTimeSync();
+        else
+            m_timeSyncTimer -= diff;
     }
 
     return true;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -405,6 +405,18 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
     if (m_Socket && m_Socket->IsOpen() && _warden)
         _warden->Update();
 
+    if (!updater.ProcessLogout()) // <=> updater is of type MapSessionFilter
+    {
+        // Send time sync packet every 10s.
+        if (_timeSyncTimer > 0)
+        {
+            if (diff >= _timeSyncTimer)
+                SendTimeSync();
+            else
+                _timeSyncTimer -= diff;
+        }
+    }
+
     ProcessQueryCallbacks();
 
     //check if we are safe to proceed with logout
@@ -430,20 +442,6 @@ bool WorldSession::Update(uint32 diff, PacketFilter& updater)
 
         if (!m_Socket)
             return false;                                       //Will remove this session from the world session map
-    }
-
-    return true;
-}
-
-bool WorldSession::UpdateForPlayersOnMap(uint32 diff)
-{
-    // Send time sync packet every 10s.
-    if (_timeSyncTimer > 0)
-    {
-        if (diff >= _timeSyncTimer)
-            SendTimeSync();
-        else
-            _timeSyncTimer -= diff;
     }
 
     return true;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -349,7 +349,6 @@ class TC_GAME_API WorldSession
 
         void QueuePacket(WorldPacket* new_packet);
         bool Update(uint32 diff, PacketFilter& updater);
-        bool UpdateForPlayersOnMap(uint32 diff);
 
         /// Handle the authentication waiting queue (to be completed)
         void SendAuthWaitQue(uint32 position);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -174,7 +174,7 @@ public:
     virtual ~PacketFilter() { }
 
     virtual bool Process(WorldPacket* /*packet*/) { return true; }
-    virtual bool ProcessLogout() const { return true; }
+    virtual bool ProcessUnsafe() const { return true; }
 
 protected:
     WorldSession* const m_pSession;
@@ -192,7 +192,7 @@ public:
 
     virtual bool Process(WorldPacket* packet) override;
     //in Map::Update() we do not process player logout!
-    virtual bool ProcessLogout() const override { return false; }
+    virtual bool ProcessUnsafe() const override { return false; }
 };
 
 //class used to filer only thread-unsafe packets from queue

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -438,7 +438,6 @@ class TC_GAME_API WorldSession
 
         uint32 GetLatency() const { return m_latency; }
         void SetLatency(uint32 latency) { m_latency = latency; }
-        void ResetClientTimeDelay() { m_clientTimeDelay = 0; }
 
         std::atomic<time_t> m_timeOutTime;
 
@@ -1066,7 +1065,6 @@ class TC_GAME_API WorldSession
         LocaleConstant m_sessionDbcLocale;
         LocaleConstant m_sessionDbLocaleIndex;
         std::atomic<uint32> m_latency;
-        std::atomic<uint32> m_clientTimeDelay;
         AccountData m_accountData[NUM_ACCOUNT_DATA_TYPES];
         uint32 m_Tutorials[MAX_ACCOUNT_TUTORIAL_VALUES];
         uint8  m_TutorialsChanged;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -1083,13 +1083,13 @@ class TC_GAME_API WorldSession
         bool forceExit;
         ObjectGuid m_currentBankerGUID;
 
-        boost::circular_buffer<std::pair<int64, uint32>> timeSyncClockDeltaQueue; // first member: clockDelta. Second member: latency of the packet exchange that was used to compute that clockDelta.
-        int64 timeSyncClockDelta;
+        boost::circular_buffer<std::pair<int64, uint32>> _timeSyncClockDeltaQueue; // first member: clockDelta. Second member: latency of the packet exchange that was used to compute that clockDelta.
+        int64 _timeSyncClockDelta;
         void ComputeNewClockDelta();
 
-        std::map<uint32, uint32> pendingTimeSyncRequests; // key: counter. value: server time when packet with that counter was sent.
-        uint32 m_timeSyncNextCounter;
-        uint32 m_timeSyncTimer;
+        std::map<uint32, uint32> _pendingTimeSyncRequests; // key: counter. value: server time when packet with that counter was sent.
+        uint32 _timeSyncNextCounter;
+        uint32 _timeSyncTimer;
 
 
         WorldSession(WorldSession const& right) = delete;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -1086,9 +1086,9 @@ class TC_GAME_API WorldSession
         int64 timeSyncClockDelta;
         void ComputeNewClockDelta();
 
-        uint32 m_timeSyncCounter;
+        std::map<uint32, uint32> pendingTimeSyncRequests; // key: counter. value: server time when packet with that counter was sent.
+        uint32 m_timeSyncNextCounter;
         uint32 m_timeSyncTimer;
-        uint32 m_timeSyncServer;
 
 
         WorldSession(WorldSession const& right) = delete;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -348,6 +348,7 @@ class TC_GAME_API WorldSession
 
         void QueuePacket(WorldPacket* new_packet);
         bool Update(uint32 diff, PacketFilter& updater);
+        bool UpdateForPlayersOnMap(uint32 diff);
 
         /// Handle the authentication waiting queue (to be completed)
         void SendAuthWaitQue(uint32 position);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -32,6 +32,7 @@
 #include "SharedDefines.h"
 #include <string>
 #include <unordered_map>
+#include <boost/circular_buffer.hpp>
 
 class BigNumber;
 class Creature;
@@ -1076,6 +1077,10 @@ class TC_GAME_API WorldSession
         uint32 expireTime;
         bool forceExit;
         ObjectGuid m_currentBankerGUID;
+
+        boost::circular_buffer<std::pair<int64, uint32>> timeSyncClockDeltaQueue;
+        int64 timeSyncClockDelta;
+        void ComputeNewClockDelta();
 
         WorldSession(WorldSession const& right) = delete;
         WorldSession& operator=(WorldSession const& right) = delete;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -31,6 +31,7 @@
 #include "QueryCallbackProcessor.h"
 #include "SharedDefines.h"
 #include <string>
+#include <map>
 #include <unordered_map>
 #include <boost/circular_buffer.hpp>
 

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -450,6 +450,10 @@ class TC_GAME_API WorldSession
         uint32 GetRecruiterId() const { return recruiterId; }
         bool IsARecruiter() const { return isRecruiter; }
 
+        // Time Synchronisation
+        void ResetTimeSync();
+        void SendTimeSync();
+
     public:                                                 // opcodes handlers
 
         void Handle_NULL(WorldPacket& recvPacket);          // not used
@@ -1081,6 +1085,11 @@ class TC_GAME_API WorldSession
         boost::circular_buffer<std::pair<int64, uint32>> timeSyncClockDeltaQueue;
         int64 timeSyncClockDelta;
         void ComputeNewClockDelta();
+
+        uint32 m_timeSyncCounter;
+        uint32 m_timeSyncTimer;
+        uint32 m_timeSyncServer;
+
 
         WorldSession(WorldSession const& right) = delete;
         WorldSession& operator=(WorldSession const& right) = delete;

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -1083,7 +1083,7 @@ class TC_GAME_API WorldSession
         bool forceExit;
         ObjectGuid m_currentBankerGUID;
 
-        boost::circular_buffer<std::pair<int64, uint32>> timeSyncClockDeltaQueue;
+        boost::circular_buffer<std::pair<int64, uint32>> timeSyncClockDeltaQueue; // first member: clockDelta. Second member: latency of the packet exchange that was used to compute that clockDelta.
         int64 timeSyncClockDelta;
         void ComputeNewClockDelta();
 

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -360,6 +360,13 @@ WorldSocket::ReadDataHandlerResult WorldSocket::ReadDataHandler()
             if (_worldSession)
                 _worldSession->ResetTimeOutTime(true);
             break;
+
+        case CMSG_TIME_SYNC_RESP:
+            sessionGuard.lock(); // is this necessary?
+            LogOpcodeText(opcode, sessionGuard);
+            _worldSession->HandleTimeSyncResp(packet);
+            break;
+
         default:
         {
             sessionGuard.lock();
@@ -674,10 +681,7 @@ bool WorldSocket::HandlePing(WorldPacket& recvPacket)
         std::lock_guard<std::mutex> sessionGuard(_worldSessionLock);
 
         if (_worldSession)
-        {
             _worldSession->SetLatency(latency);
-            _worldSession->ResetClientTimeDelay();
-        }
         else
         {
             TC_LOG_ERROR("network", "WorldSocket::HandlePing: peer sent CMSG_PING, but is not authenticated or got recently kicked, address = %s", GetRemoteIpAddress().to_string().c_str());

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -365,7 +365,7 @@ WorldSocket::ReadDataHandlerResult WorldSocket::ReadDataHandler()
             // todo: handle this packet in the same way of CMSG_TIME_SYNC_RESP
 
         case CMSG_TIME_SYNC_RESP:
-            packetToQueue = new WorldPacket(std::move(packet), getMSTime());
+            packetToQueue = new WorldPacket(std::move(packet), std::chrono::steady_clock::now());
             break;
 
         default:


### PR DESCRIPTION
**Changes proposed:**
- Implement [Simple Network Time Protocol](https://tools.ietf.org/html/rfc4330) (SNTP) using the `SMSG_TIME_SYNC_REQUEST `/  `CMSG_TIME_SYNC_RESPONSE` exchange. No need to read however the RFC. The mechanism is quite simple and it is explained in the code. This packet exchange initiated by the server provides to the server the following information: the difference between its own clock and the clock of the client. With that clock delta, the server can precisely interpret timestamps sent by the client.
- On top of SNTP, I implemented the approach described [HERE](https://web.archive.org/web/20180430214420/http://www.mine-control.com/zack/timesync/timesync.html). That approach is necessary to use on top of SNTP because plain SNTP is designed to work on UDP, not TCP. The fact that TCP can resend dropped packets without any warning requires extra care.
- Using the server newly found information, which is the clock delta, we can now interpret the only timestamps sent by the client to the server: The movement timestamps. Now, when movement events occur on the client, we can precisely know their time on server clock (such as the player has started to move forward, for example). And send these movement timestamps on server clock to the observing nearby players. This change should improve the visual perseption of the other players on screen.

**Target branch(es):** 3.3.5

**Issues addressed:** should improve the visual perseption of the other players on screen. Should help with https://github.com/TrinityCore/TrinityCore/issues/19271.

**Tests performed:** Build and tested IG with artificial latency and packet drop on my machine. Larger scale testing should be performed

**Known issues and TODO list:**
Nothing that I'm aware of.