### PR TITLE
Fix typo in VMap BIH generation

### DIFF
--- a/src/common/Collision/BoundingIntervalHierarchy.cpp
+++ b/src/common/Collision/BoundingIntervalHierarchy.cpp
@@ -152,13 +152,13 @@ void BIH::subdivide(int left, int right, std::vector<uint32> &tempTree, buildDat
         else if (left > right)
         {
             // all right
+            right = rightOrig;
             if (prevAxis == axis && G3D::fuzzyEq(prevSplit, split)) {
                 // we are stuck here - create a leaf
                 stats.updateLeaf(depth, rightOrig - left + 1);
                 createNode(tempTree, nodeIndex, left, rightOrig);
                 return;
             }
-            right = rightOrig;
             if (clipR >= split) {
                 // keep looping on right half
                 gridBox.lo[axis] = split;

--- a/src/common/Collision/BoundingIntervalHierarchy.cpp
+++ b/src/common/Collision/BoundingIntervalHierarchy.cpp
@@ -155,8 +155,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32> &tempTree, buildDat
             right = rightOrig;
             if (prevAxis == axis && G3D::fuzzyEq(prevSplit, split)) {
                 // we are stuck here - create a leaf
-                stats.updateLeaf(depth, rightOrig - left + 1);
-                createNode(tempTree, nodeIndex, left, rightOrig);
+                stats.updateLeaf(depth, right - left + 1);
+                createNode(tempTree, nodeIndex, left, right);
                 return;
             }
             if (clipR >= split) {

--- a/src/common/Collision/BoundingIntervalHierarchy.cpp
+++ b/src/common/Collision/BoundingIntervalHierarchy.cpp
@@ -43,8 +43,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32> &tempTree, buildDat
     if ((right - left + 1) <= dat.maxPrims || depth >= MAX_STACK_SIZE)
     {
         // write leaf node
-        stats.updateLeaf(depth, right - left + 1);
-        createNode(tempTree, nodeIndex, left, right);
+        stats.updateLeaf(depth, rightOrig - left + 1);
+        createNode(tempTree, nodeIndex, left, rightOrig);
         return;
     }
     // calculate extents

--- a/src/common/Collision/BoundingIntervalHierarchy.cpp
+++ b/src/common/Collision/BoundingIntervalHierarchy.cpp
@@ -43,8 +43,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32> &tempTree, buildDat
     if ((right - left + 1) <= dat.maxPrims || depth >= MAX_STACK_SIZE)
     {
         // write leaf node
-        stats.updateLeaf(depth, rightOrig - left + 1);
-        createNode(tempTree, nodeIndex, left, rightOrig);
+        stats.updateLeaf(depth, right - left + 1);
+        createNode(tempTree, nodeIndex, left, right);
         return;
     }
     // calculate extents
@@ -154,8 +154,8 @@ void BIH::subdivide(int left, int right, std::vector<uint32> &tempTree, buildDat
             // all right
             if (prevAxis == axis && G3D::fuzzyEq(prevSplit, split)) {
                 // we are stuck here - create a leaf
-                stats.updateLeaf(depth, right - left + 1);
-                createNode(tempTree, nodeIndex, left, right);
+                stats.updateLeaf(depth, rightOrig - left + 1);
+                createNode(tempTree, nodeIndex, left, rightOrig);
                 return;
             }
             right = rightOrig;


### PR DESCRIPTION
Description: typo in Vmap BoundingIntervalHierarchy generation
Due to this typo, some objects could be left out during BIH generation and thus never checked for intersection. This breaks height and LoS calculations in some areas.

cmangos/mangos-classic#215

File name & path in TC: https://github.com/TrinityCore/TrinityCore/blob/master/src/common/Collision/BoundingIntervalHierarchy.cpp

Current behaviour: Height and LoS calculation breaks in some areas.

Expected behaviour: LoS and Height calculation should not break, NPCs should behave normally.

Steps to reproduce the problem:
The occurrence of this bug can be seen in "Md_Mushroomcave.wmo". It can be found in several locations, for example (-6140, -2960, 400), map 0. In some parts of the cave mobs will either fall through the ground or fly up into the sky when chasing the player. LoS is not obstructed there as well.

Branch(es): 3.3.5 and master