### PR TITLE
Creature/Movement: Enable swimming creatures to chase targets in 3d space

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -166,7 +166,7 @@ bool TargetedMovementGeneratorMedium<T, D>::DoUpdate(T* owner, uint32 time_diff)
                 transport->CalculatePassengerPosition(dest.x, dest.y, dest.z);
 
         // First check distance
-        if (owner->GetTypeId() == TYPEID_UNIT && owner->ToCreature()->CanFly())
+        if (owner->GetTypeId() == TYPEID_UNIT && (owner->ToCreature()->CanFly() || owner->ToCreature()->CanSwim()))
             targetMoved = !i_target->IsWithinDist3d(dest.x, dest.y, dest.z, allowed_dist);
         else
             targetMoved = !i_target->IsWithinDist2d(dest.x, dest.y, allowed_dist);


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  Enable swimming creatures to chase targets in 3d space

**Target branch(es):** 3.3.5/master

**Issues addressed:** Closes #11060

**Tests performed:** Builds, works great in game

**Description:** Swimming creatures are currently unable to detect if targets are in range or not if they change their Z position, as they only calculate distance in 2d space.
This PR enables swimming creatures to calculate distance to target in 3d space, just like flying creatures does.