### PR TITLE
Core/Spells: Fix Scatter Shot issue on moving players

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -33,10 +33,14 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* unit)
     if (!unit->IsAlive())
         return;
 
+    // send to clients the order to immobilize the unit and make it face a random direction.
     Movement::MoveSplineInit init(unit);
     init.MoveTo(i_x, i_y, i_z, false, true);
+    init.SetFacing(frand(0.0f, 2*(float)M_PI));
+    init.SetWalk(true);
     init.Launch();
 
+    unit->ClearUnitState(UNIT_STATE_MOVING);
     unit->AddUnitState(UNIT_STATE_CONFUSED_MOVE);
 }
 

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -33,11 +33,9 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* unit)
     if (!unit->IsAlive())
         return;
 
-    unit->ClearUnitState(UNIT_STATE_MOVING);
     Movement::MoveSplineInit init(unit);
     init.MoveTo(i_x, i_y, i_z, false, true);
     init.Launch();
-    unit->UpdatePosition(unit->GetPosition(), true);
 
     unit->AddUnitState(UNIT_STATE_CONFUSED_MOVE);
 }

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -36,7 +36,7 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* unit)
     // send to clients the order to immobilize the unit and make it face a random direction.
     Movement::MoveSplineInit init(unit);
     init.MoveTo(i_x, i_y, i_z, false, true);
-    init.SetFacing(frand(0.0f, 2*(float)M_PI));
+    init.SetFacing(frand(0.0f, 2 * static_cast<float>(M_PI)));
     init.SetWalk(true);
     init.Launch();
 

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -30,10 +30,15 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* unit)
     unit->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED);
     unit->GetPosition(i_x, i_y, i_z);
 
-    if (!unit->IsAlive() || unit->IsStopped())
+    if (!unit->IsAlive())
         return;
 
-    unit->StopMoving();
+    unit->ClearUnitState(UNIT_STATE_MOVING);
+    Movement::MoveSplineInit init(unit);
+    init.MoveTo(i_x, i_y, i_z, false, true);
+    init.Launch();
+    unit->UpdatePosition(unit->GetPosition(), true);
+
     unit->AddUnitState(UNIT_STATE_CONFUSED_MOVE);
 }
 


### PR DESCRIPTION
From https://github.com/TrinityCore/TrinityCore/issues/15952#issuecomment-263414400:

> First, I noticed that the target was not stopped right there, as soon as the spell lands, if the target is a player. By sniffing the communication between the client and TC while testing (something that more developers should do, it really helps debugging), i realized that the server wasn't sending the packet to make the player stop. By logging some key methods, I managed the trace the problem. First, @robinsch's change is needed because `unit->IsStopped()` returns true on moving players for some reason. Second, the call to `unit->StopMoving()` does nothing if the condition movespline->Finalized() is verified, which is usually the case for players.

**Changes proposed:**
-  Bypassing `unit->StopMoving()` in `ConfusedMovementGenerator<T>::DoInitialize` for now because it does nothing if the condition `movespline->Finalized()` is verified, which is usually the case for players.

**Target branch(es):**

- [X] 3.3.5

**Issues addressed:** Closes #  https://github.com/TrinityCore/TrinityCore/issues/15952


**Tests performed:** Tested IG. Works against moving players.


**Known issues and TODO list:**

This is a quick and dirty solution. A solution involving a cleaner method needs to be found before this can get merged.
