### PR TITLE
Optimizations for Zapcc compiler

### DIFF
--- a/src/server/scripts/EasternKingdoms/BaradinHold/baradin_hold.h
+++ b/src/server/scripts/EasternKingdoms/BaradinHold/baradin_hold.h
@@ -27,14 +27,14 @@
 
 uint32 const EncounterCount = 3;
 
-enum DataTypes
+enum BHDataTypesBH
 {
     DATA_ARGALOTH           = 0,
     DATA_OCCUTHAR           = 1,
     DATA_ALIZABAL           = 2
 };
 
-enum CreatureIds
+enum BHCreatureIdsBH
 {
     BOSS_ARGALOTH           = 47120,
     BOSS_OCCUTHAR           = 52363,
@@ -45,7 +45,7 @@ enum CreatureIds
     NPC_OCCUTHAR_EYE        = 52368
 };
 
-enum GameObjectIds
+enum BHGameObjectIds
 {
     GO_ARGALOTH_DOOR        = 207619,
     GO_OCCUTHAR_DOOR        = 208953,

--- a/src/server/scripts/EasternKingdoms/BaradinHold/baradin_hold.h
+++ b/src/server/scripts/EasternKingdoms/BaradinHold/baradin_hold.h
@@ -27,14 +27,14 @@
 
 uint32 const EncounterCount = 3;
 
-enum BHDataTypesBH
+enum BHDataTypes
 {
     DATA_ARGALOTH           = 0,
     DATA_OCCUTHAR           = 1,
     DATA_ALIZABAL           = 2
 };
 
-enum BHCreatureIdsBH
+enum BHCreatureIds
 {
     BOSS_ARGALOTH           = 47120,
     BOSS_OCCUTHAR           = 52363,

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockCaverns/blackrock_caverns.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockCaverns/blackrock_caverns.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount             = 5;
 
-enum DataTypes
+enum BRCDataTypes
 {
     // Encounter States // Boss GUIDs
     DATA_ROMOGG_BONECRUSHER             = 0,
@@ -36,7 +36,7 @@ enum DataTypes
     DATA_RAZ_THE_CRAZED                 = 5
 };
 
-enum CreatureIds
+enum BRCCreatureIds
 {
     NPC_TWILIGHT_FLAME_CALLER           = 39708,
     NPC_RAZ_THE_CRAZED                  = 39670,

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.h
@@ -21,14 +21,14 @@
 
 #define DataHeader "BRD"
 
-enum FactionIds
+enum BRDFactionIds
 {
     FACTION_NEUTRAL            = 734,
     FACTION_HOSTILE            = 754,
     FACTION_FRIEND             = 35
 };
 
-enum DataTypes
+enum BRDDataTypes
 {
     TYPE_RING_OF_LAW        = 1,
     TYPE_VAULT              = 2,

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
@@ -23,7 +23,7 @@ uint32 const EncounterCount         = 23;
 #define BRSScriptName "instance_blackrock_spire"
 #define DataHeader    "BRS"
 
-enum DataTypes
+enum BRSDataTypes
 {
     DATA_HIGHLORD_OMOKK             = 0,
     DATA_SHADOW_HUNTER_VOSHGAJIN    = 1,
@@ -51,7 +51,7 @@ enum DataTypes
     DATA_HALL_RUNE_7                = 22
 };
 
-enum CreaturesIds
+enum BRSCreaturesIds
 {
     NPC_HIGHLORD_OMOKK              = 9196,
     NPC_SHADOW_HUNTER_VOSHGAJIN     = 9236,
@@ -74,7 +74,7 @@ enum CreaturesIds
     NPC_LORD_VICTOR_NEFARIUS        = 10162
 };
 
-enum AdditionalData
+enum BRSAdditionalData
 {
     SPELL_SUMMON_ROOKERY_WHELP      = 15745,
     EVENT_UROK_DOOMHOWL             = 4845,
@@ -84,7 +84,7 @@ enum AdditionalData
     AREATRIGGER_BLACKROCK_STADIUM   = 2026
 };
 
-enum GameObjectsIds
+enum BRSGameObjectsIds
 {
     GO_WHELP_SPAWNER                = 175622, // trap spawned by go id 175124
     // Doors

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/blackwing_lair.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/blackwing_lair.h
@@ -39,7 +39,7 @@ enum BWLEncounter
     DATA_LORD_VICTOR_NEFARIUS   = 8
 };
 
-enum CreatureIds
+enum BWLCreatureIds
 {
     NPC_RAZORGORE               = 12435,
     NPC_BLACKWING_DRAGON        = 12422,
@@ -56,7 +56,7 @@ enum CreatureIds
     NPC_NEFARIAN                = 11583
 };
 
-enum GameObjectIds
+enum BWLGameObjectIds
 {
     GO_BLACK_DRAGON_EGG         = 177807,
     GO_PORTCULLIS               = 176965,

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/molten_core.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/molten_core.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "MC"
 
-enum Encounters
+enum MCEncounters
 {
     BOSS_LUCIFRON                   = 0,
     BOSS_MAGMADAR                   = 1,
@@ -36,7 +36,7 @@ enum Encounters
     MAX_ENCOUNTER,
 };
 
-enum Actions
+enum MCActions
 {
     ACTION_START_RAGNAROS       = 0,
     ACTION_START_RAGNAROS_ALT   = 1,
@@ -45,7 +45,7 @@ enum Actions
 Position const RagnarosTelePos   = {829.159f, -815.773f, -228.972f, 5.30500f};
 Position const RagnarosSummonPos = {838.510f, -829.840f, -232.000f, 2.00000f};
 
-enum Creatures
+enum MCCreatures
 {
     NPC_LUCIFRON                    = 12118,
     NPC_MAGMADAR                    = 11982,
@@ -61,12 +61,12 @@ enum Creatures
     NPC_FLAMEWAKER_ELITE            = 11664,
 };
 
-enum GameObjects
+enum MCGameObjects
 {
     GO_CACHE_OF_THE_FIRELORD        = 179703,
 };
 
-enum Data
+enum MCData
 {
     DATA_RAGNAROS_ADDS  = 0,
 };

--- a/src/server/scripts/EasternKingdoms/Deadmines/deadmines.h
+++ b/src/server/scripts/EasternKingdoms/Deadmines/deadmines.h
@@ -20,7 +20,7 @@
 
 #define DataHeader "DM"
 
-enum CannonState
+enum DMCannonState
 {
     CANNON_NOT_USED,
     CANNON_GUNPOWDER_USED,
@@ -29,18 +29,18 @@ enum CannonState
     EVENT_DONE
 };
 
-enum Data
+enum DMData
 {
     EVENT_STATE,
     EVENT_RHAHKZOR
 };
 
-enum Data64
+enum DMData64
 {
     DATA_SMITE_CHEST
 };
 
-enum GameObjects
+enum DMGameObjects
 {
     GO_FACTORY_DOOR                                        = 13965,
     GO_IRONCLAD_DOOR                                       = 16397,
@@ -48,4 +48,5 @@ enum GameObjects
     GO_DOOR_LEVER                                          = 101833,
     GO_MR_SMITE_CHEST                                      = 144111
 };
+
 #endif

--- a/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.h
+++ b/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.h
@@ -20,14 +20,14 @@
 
 #define DataHeader "GNO"
 
-enum GameObjectIds
+enum GNOGameObjectIds
 {
     GO_CAVE_IN_LEFT     = 146085,
     GO_CAVE_IN_RIGHT    = 146086,
     GO_RED_ROCKET       = 103820
 };
 
-enum CreatureIds
+enum GNOCreatureIds
 {
     NPC_BLASTMASTER_EMI_SHORTFUSE   = 7998,
     NPC_CAVERNDEEP_AMBUSHER         = 6207,
@@ -35,12 +35,12 @@ enum CreatureIds
     NPC_CHOMPER                     = 6215
 };
 
-enum Data
+enum GNOData
 {
     TYPE_EVENT = 1
 };
 
-enum Data64
+enum GNOData64
 {
     DATA_GO_CAVE_IN_LEFT,
     DATA_GO_CAVE_IN_RIGHT,

--- a/src/server/scripts/EasternKingdoms/Karazhan/karazhan.h
+++ b/src/server/scripts/EasternKingdoms/Karazhan/karazhan.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 12;
 
-enum DataTypes
+enum KZDataTypes
 {
     DATA_ATTUMEN                    = 0,
     DATA_MOROES                     = 1,
@@ -56,14 +56,14 @@ enum DataTypes
     DATA_GO_SIDE_ENTRANCE_DOOR      = 29
 };
 
-enum OperaEvents
+enum KZOperaEvents
 {
     EVENT_OZ                        = 1,
     EVENT_HOOD                      = 2,
     EVENT_RAJ                       = 3
 };
 
-enum MiscCreatures
+enum KZMiscCreatures
 {
     NPC_HYAKISS_THE_LURKER          = 16179,
     NPC_ROKAD_THE_RAVAGER           = 16181,
@@ -83,7 +83,7 @@ enum MiscCreatures
     NPC_KILREK                      = 17229
 };
 
-enum GameObjectIds
+enum KZGameObjectIds
 {
     GO_STAGE_CURTAIN                = 183932,
     GO_STAGE_DOOR_LEFT              = 184278,
@@ -99,7 +99,7 @@ enum GameObjectIds
     GO_DUST_COVERED_CHEST           = 185119
 };
 
-enum Misc
+enum KZMisc
 {
     OPTIONAL_BOSS_REQUIRED_DEATH_COUNT = 50
 };

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/magisters_terrace.h
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/magisters_terrace.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum MTDataTypes
 {
     DATA_SELIN,
     DATA_VEXALLUS,
@@ -38,7 +38,7 @@ enum DataTypes
     DATA_ESCAPE_ORB
 };
 
-enum CreatureIds
+enum MTCreatureIds
 {
     NPC_SELIN               = 24723,
     NPC_DELRISSA            = 24560,
@@ -47,7 +47,7 @@ enum CreatureIds
     NPC_HUMAN_KALECGOS      = 24848
 };
 
-enum GameObjectIds
+enum MTGameObjectIds
 {
     GO_VEXALLUS_DOOR        = 187896,
     GO_SELIN_DOOR           = 187979,
@@ -59,17 +59,17 @@ enum GameObjectIds
     GO_ESCAPE_ORB           = 188173
 };
 
-enum InstanceEventIds
+enum MTInstanceEventIds
 {
     EVENT_SPAWN_KALECGOS    = 16547
 };
 
-enum InstanceText
+enum MTInstanceText
 {
     SAY_KALECGOS_SPAWN      = 0
 };
 
-enum MovementData
+enum MTMovementData
 {
     PATH_KALECGOS_FLIGHT    = 248440
 };

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/scarlet_monastery.h
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/scarlet_monastery.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 10;
 
-enum DataTypes
+enum SMDataTypes
 {
     DATA_MOGRAINE_AND_WHITE_EVENT   = 1,
     DATA_MOGRAINE                   = 2,
@@ -43,7 +43,7 @@ enum DataTypes
     DATA_SCORN                      = 14
 };
 
-enum CreatureIds
+enum SMCreatureIds
 {
     NPC_MOGRAINE                    = 3976,
     NPC_WHITEMANE                   = 3977,
@@ -54,7 +54,7 @@ enum CreatureIds
     NPC_PUMPKIN                     = 23694
 };
 
-enum GameObjectIds
+enum SMGameObjectIds
 {
     GO_HIGH_INQUISITORS_DOOR        = 104600,
     GO_PUMPKIN_SHRINE               = 186267

--- a/src/server/scripts/EasternKingdoms/Scholomance/scholomance.h
+++ b/src/server/scripts/EasternKingdoms/Scholomance/scholomance.h
@@ -22,7 +22,7 @@
 
 uint32 const EncounterCount             = 8;
 
-enum DataTypes
+enum SCDataTypes
 {
     DATA_DOCTORTHEOLENKRASTINOV         = 0,
     DATA_INSTRUCTORMALICIA              = 1,
@@ -34,13 +34,13 @@ enum DataTypes
     DATA_KIRTONOS                       = 7
 };
 
-enum CreatureIds
+enum SCCreatureIds
 {
     NPC_DARKMASTER_GANDLING             = 1853,
     NPC_BONE_MINION                     = 16119
 };
 
-enum GameobjectIds
+enum SCGameobjectIds
 {
     GO_GATE_KIRTONOS                    = 175570,
     GO_GATE_GANDLING                    = 177374,

--- a/src/server/scripts/EasternKingdoms/ShadowfangKeep/shadowfang_keep.h
+++ b/src/server/scripts/EasternKingdoms/ShadowfangKeep/shadowfang_keep.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "SK"
 
-enum DataTypes
+enum SKDataTypes
 {
     TYPE_FREE_NPC               = 1,
     TYPE_RETHILGORE             = 2,

--- a/src/server/scripts/EasternKingdoms/Stratholme/stratholme.h
+++ b/src/server/scripts/EasternKingdoms/Stratholme/stratholme.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "STR"
 
-enum DataTypes
+enum STRDataTypes
 {
     TYPE_BARON_RUN                      = 1,
     TYPE_BARONESS                       = 2,
@@ -43,7 +43,7 @@ enum DataTypes
     TYPE_SH_AELMAR                      = 25
 };
 
-enum CreatureIds
+enum STRCreatureIds
 {
     NPC_CRYSTAL                         = 10415, // ziggurat crystal
     NPC_BARON                           = 10440, // ziggurat crystal
@@ -56,7 +56,7 @@ enum CreatureIds
     NPC_YSIDA                           = 16031,
 };
 
-enum GameobjectIds
+enum STRGameobjectIds
 {
     GO_DOOR_HALAZZI                     = 186303,
     GO_SERVICE_ENTRANCE                 = 175368,
@@ -71,12 +71,12 @@ enum GameobjectIds
     GO_PORT_ELDERS                      = 175377   // port at elders square
 };
 
-enum QuestIds
+enum STRQuestIds
 {
     QUEST_DEAD_MAN_PLEA                 = 8945
 };
 
-enum SpellIds
+enum STRSpellIds
 {
     SPELL_BARON_ULTIMATUM               = 27861
 };

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/sunwell_plateau.h
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/sunwell_plateau.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 6;
 
-enum DataTypes
+enum SWPDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_KALECGOS                            = 0,
@@ -53,7 +53,7 @@ enum DataTypes
     DATA_PLAYER_GUID
 };
 
-enum CreatureIds
+enum SWPCreatureIds
 {
     NPC_MURU                                 = 25741,
     NPC_ENTROPIUS                            = 25840,
@@ -100,7 +100,7 @@ enum CreatureIds
     NPC_BLACK_HOLE                           = 25855
 };
 
-enum GameObjectIds
+enum SWPGameObjectIds
 {
     GO_ORB_OF_THE_BLUE_DRAGONFLIGHT          = 188415,
     GO_FORCE_FIELD                           = 188421,

--- a/src/server/scripts/EasternKingdoms/Uldaman/uldaman.h
+++ b/src/server/scripts/EasternKingdoms/Uldaman/uldaman.h
@@ -23,7 +23,7 @@
 
 #define MAX_ENCOUNTER                   3
 
-enum DataTypes
+enum UDDataTypes
 {
     DATA_ALTAR_DOORS                    = 1,
     DATA_ANCIENT_DOOR                   = 2,
@@ -33,7 +33,7 @@ enum DataTypes
     DATA_IRONAYA_SEAL                   = 6,
 };
 
-enum GameObjectIds
+enum UDGameObjectIds
 {
     GO_ARCHAEDAS_TEMPLE_DOOR            = 141869,
     GO_ALTAR_OF_THE_KEEPER_TEMPLE_DOOR  = 124367,

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.h
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.h
@@ -22,7 +22,7 @@ uint32 const EncounterCount = 6;
 #define ZulAmanScriptName "instance_zulaman"
 #define DataHeader "ZA"
 
-enum DataTypes
+enum ZADataTypes
 {
     // BossState
     DATA_AKILZON                = 0,
@@ -42,7 +42,7 @@ enum DataTypes
     DATA_ZULAMAN_STATE
 };
 
-enum CreatureIds
+enum ZACreatureIds
 {
     NPC_AKILZON                 = 23574,
     NPC_NALORAKK                = 23576,
@@ -55,24 +55,24 @@ enum CreatureIds
     NPC_HEXLORD_TRIGGER         = 24363
 };
 
-enum GameObjectIds
+enum ZAGameObjectIds
 {
     GO_STRANGE_GONG             = 187359,
     GO_MASSIVE_GATE             = 186728,
 };
 
-enum ZulAmanEvents
+enum ZAEvents
 {
     EVENT_START_ZULAMAN         = 15897,
     EVENT_UPDATE_ZULAMAN_TIMER  = 1,
 };
 
-enum ZulAmanAction
+enum ZAAction
 {
     ACTION_START_ZULAMAN        = 1
 };
 
-enum ZulAmanWorldStates
+enum ZAWorldStates
 {
     WORLD_STATE_ZULAMAN_TIMER_ENABLED   = 3104,
     WORLD_STATE_ZULAMAN_TIMER           = 3106,

--- a/src/server/scripts/EasternKingdoms/ZulGurub/zulgurub.h
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/zulgurub.h
@@ -24,7 +24,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum ZGDataTypes
 {
     DATA_VENOXIS                    = 0,
     DATA_MANDOKIR                   = 1,
@@ -42,7 +42,7 @@ enum DataTypes
     DATA_JINDOR_TRIGGER,
 };
 
-enum CreatureIds
+enum ZGCreatureIds
 {
     NPC_VENOXIS                     = 52155,
     NPC_MANDOKIR                    = 52151,
@@ -66,7 +66,7 @@ enum CreatureIds
     NPC_SHADOW_OF_HAKKAR            = 52650
 };
 
-enum GameObjectIds
+enum ZGGameObjectIds
 {
     // High Priest Venoxis
     GO_VENOXIS_COIL                 = 208844,

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.h
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 3;
 
-enum Data64
+enum BFDData64
 {
     DATA_SHRINE1,
     DATA_SHRINE2,
@@ -35,7 +35,7 @@ enum Data64
     DATA_MAINDOOR,
 };
 
-enum Data
+enum BFDData
 {
     DATA_GELIHAST,
     DATA_KELRIS,
@@ -44,7 +44,7 @@ enum Data
     DATA_EVENT
 };
 
-enum CreatureIds
+enum BFDCreatureIds
 {
     NPC_TWILIGHT_LORD_KELRIS                               = 4832,
     NPC_LORGUS_JETT                                        = 12902,
@@ -57,7 +57,7 @@ enum CreatureIds
     NPC_MORRIDUNE                                          = 6729
 };
 
-enum GameObjectIds
+enum BFDGameObjectIds
 {
     GO_SHRINE_OF_GELIHAST                                  = 103015,
     GO_FIRE_OF_AKU_MAI_1                                   = 21118,

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal.h
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount     = 5;
 
-enum DataTypes
+enum HYDataTypes
 {
     DATA_ANETHERON              = 1,
     DATA_ANETHERONEVENT         = 2,
@@ -48,14 +48,14 @@ enum DataTypes
     DATA_CHANNEL_TARGET         = 21
 };
 
-enum WorldStateIds
+enum HYWorldStateIds
 {
     WORLD_STATE_WAVES           = 2842,
     WORLD_STATE_ENEMY           = 2453,
     WORLD_STATE_ENEMYCOUNT      = 2454
 };
 
-enum CreaturesIds
+enum HYCreaturesIds
 {
     // Trash Mobs summoned in waves
     NECROMANCER                 = 17899,
@@ -82,7 +82,7 @@ enum CreaturesIds
     NPC_CHANNEL_TARGET          = 22418
 };
 
-enum GameobjectIds
+enum HYGameobjectIds
 {
     GO_HORDE_ENCAMPMENT_PORTAL  = 182060,
     GO_NIGHT_ELF_VILLAGE_PORTAL = 182061,

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.h
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.h
@@ -22,7 +22,7 @@
 #define CoSScriptName "instance_culling_of_stratholme"
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum CSDataTypes
 {
     DATA_ARTHAS,
     DATA_MEATHOOK,
@@ -39,7 +39,7 @@ enum DataTypes
     DATA_INFINITE_COUNTER
 };
 
-enum CreatureIds
+enum CSCreatureIds
 {
     NPC_MEATHOOK         = 26529,
     NPC_SALRAMM          = 26530,
@@ -58,7 +58,7 @@ enum CreatureIds
     NPC_GUARDIAN_OF_TIME = 32281
 };
 
-enum GameObjectIds
+enum CSGameObjectIds
 {
     GO_SHKAF_GATE       = 188686,
     GO_MALGANIS_GATE_1  = 187711,
@@ -70,7 +70,7 @@ enum GameObjectIds
     GO_PLAGUED_CRATE    = 190095
 };
 
-enum WorldStatesCoT
+enum CSWorldStatesCoT
 {
     WORLDSTATE_SHOW_CRATES          = 3479,
     WORLDSTATE_CRATES_REVEALED      = 3480,
@@ -79,12 +79,12 @@ enum WorldStatesCoT
     WORLDSTATE_TIME_GUARDIAN_SHOW   = 3932
 };
 
-enum CrateSpells
+enum CSCrateSpells
 {
     SPELL_CRATES_CREDIT     = 58109
 };
 
-enum Texts
+enum CSTexts
 {
     SAY_CRATES_COMPLETED    = 0,
     // Chromie
@@ -95,7 +95,7 @@ enum Texts
     SAY_FAIL_EVENT          = 2 // On Infinite Corruptor event fail
 };
 
-enum InstanceEvents
+enum CSInstanceEvents
 {
     EVENT_INFINITE_TIMER    = 1
 };

--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.h
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "OH"
 
-enum DataTypes
+enum OHDataTypes
 {
     TYPE_BARREL_DIVERSION   = 1,
     TYPE_THRALL_EVENT       = 2,
@@ -36,7 +36,7 @@ enum DataTypes
 
 };
 
-enum WorldStateIds
+enum OHWorldStateIds
 {
     WORLD_STATE_OH              = 2436
 };

--- a/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/the_black_morass.h
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/the_black_morass.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount             = 2;
 
-enum DataTypes
+enum TBMDataTypes
 {
     TYPE_MEDIVH                         = 1,
     TYPE_RIFT                           = 2,
@@ -35,20 +35,20 @@ enum DataTypes
     DATA_SHIELD                         = 12
 };
 
-enum WorldStateIds
+enum TBMWorldStateIds
 {
     WORLD_STATE_BM                      = 2541,
     WORLD_STATE_BM_SHIELD               = 2540,
     WORLD_STATE_BM_RIFT                 = 2784
 };
 
-enum QuestIds
+enum TBMQuestIds
 {
     QUEST_OPENING_PORTAL                = 10297,
     QUEST_MASTER_TOUCH                  = 9836
 };
 
-enum CreatureIds
+enum TBMCreatureIds
 {
     NPC_MEDIVH                          = 15608,
     NPC_TIME_RIFT                       = 17838,

--- a/src/server/scripts/Kalimdor/Firelands/firelands.h
+++ b/src/server/scripts/Kalimdor/Firelands/firelands.h
@@ -26,7 +26,7 @@
 
 uint32 const EncounterCount = 7;
 
-enum DataTypes
+enum FLDataTypes
 {
     DATA_BETH_TILAC         = 0,
     DATA_LORD_RHYOLITH      = 1,
@@ -37,7 +37,7 @@ enum DataTypes
     DATA_RAGNAROS           = 6,
 };
 
-enum CreatureIds
+enum FLCreatureIds
 {
     NPC_BLAZING_MONSTROSITY_LEFT    = 53786,
     NPC_BLAZING_MONSTROSITY_RIGHT   = 53791,

--- a/src/server/scripts/Kalimdor/HallsOfOrigination/halls_of_origination.h
+++ b/src/server/scripts/Kalimdor/HallsOfOrigination/halls_of_origination.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 12;
 
-enum Data
+enum HOOData
 {
     // Bosses
     DATA_TEMPLE_GUARDIAN_ANHUUR,
@@ -52,7 +52,7 @@ enum Data
     DATA_ANRAPHET_GUID,
 };
 
-enum Creatures
+enum HOOCreatures
 {
     BOSS_TEMPLE_GUARDIAN_ANHUUR     = 39425,
     NPC_CAVE_IN_STALKER             = 40183,
@@ -76,7 +76,7 @@ enum Creatures
     NPC_OMEGA_STANCE                = 41194,
 };
 
-enum GameObjects
+enum HOOGameObjects
 {
     GO_ANHUURS_BRIDGE               = 206506,
     GO_DOODAD_ULDUM_ELEVATOR_COL01  = 207725,
@@ -99,14 +99,14 @@ enum GameObjects
     GO_DOODAD_ULDUM_LASERBEAMS_03   = 207665, // Matches GO_DOODAD_ULDUM_LIGHTMACHINE_03
 };
 
-enum Misc
+enum HOOMisc
 {
     AREA_TOMB_OF_THE_EARTHRAGER     = 4945,
     ACHIEV_VAULT_OF_LIGHTS_EVENT    = 24212, // Faster Than The Speed Of Light
     SPELL_VAULT_OF_LIGHTS_CREDIT    = 94067, // Not in DBC
 };
 
-enum GlobalActions
+enum HOOGlobalActions
 {
     ACTION_ANRAPHET_INTRO,
     ACTION_ELEMENTAL_DIED,

--- a/src/server/scripts/Kalimdor/OnyxiasLair/onyxias_lair.h
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/onyxias_lair.h
@@ -22,32 +22,32 @@
 
 uint32 const EncounterCount     = 1;
 
-enum DataTypes
+enum OLDataTypes
 {
     DATA_ONYXIA                 = 0,
 };
 
-enum Data32
+enum OLData32
 {
     DATA_ONYXIA_PHASE           = 0,
     DATA_SHE_DEEP_BREATH_MORE   = 1,
     DATA_MANY_WHELPS_COUNT      = 2
 };
 
-enum Data64
+enum OLData64
 {
     DATA_ONYXIA_GUID            = 0,
     DATA_FLOOR_ERUPTION_GUID    = 1
 };
 
-enum OnyxiaPhases
+enum OLOnyxiaPhases
 {
     PHASE_START                 = 1,
     PHASE_BREATH                = 2,
     PHASE_END                   = 3
 };
 
-enum CreatureIds
+enum OLCreatureIds
 {
     NPC_WHELP                   = 11262,
     NPC_LAIRGUARD               = 36561,
@@ -55,13 +55,13 @@ enum CreatureIds
     NPC_TRIGGER                 = 14495
 };
 
-enum GameObjectIds
+enum OLGameObjectIds
 {
     GO_WHELP_SPAWNER            = 176510,
     GO_WHELP_EGG                = 176511
 };
 
-enum AchievementData
+enum OLAchievementData
 {
     ACHIEV_CRITERIA_MANY_WHELPS_10_PLAYER                   = 12565, // Criteria for achievement 4403: Many Whelps! Handle It! (10 player) Hatch 50 eggs in 10s
     ACHIEV_CRITERIA_MANY_WHELPS_25_PLAYER                   = 12568, // Criteria for achievement 4406: Many Whelps! Handle It! (25 player) Hatch 50 eggs in 10s

--- a/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.h
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum RFDDataTypes
 {
     // Main Bosses
     DATA_TUTEN_KASH                        = 0,
@@ -36,7 +36,7 @@ enum DataTypes
     DATA_EXTINGUISHING_THE_IDOL            = 6
 };
 
-enum CreatureIds
+enum RFDCreatureIds
 {
     // Used in Tuten Kash summon event
     NPC_TOMB_FIEND                         = 7349,
@@ -50,7 +50,7 @@ enum CreatureIds
     NPC_PLAGUEMAW_THE_ROTTING              = 7356
 };
 
-enum GameObjectIds
+enum RFDGameObjectIds
 {
     // Used for Tuten Kash summon event
     GO_GONG                                = 148917,

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/ruins_of_ahnqiraj.h
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/ruins_of_ahnqiraj.h
@@ -20,7 +20,7 @@
 
 #define DataHeader "AQR"
 
-enum DataTypes
+enum AQRDataTypes
 {
     DATA_KURINNAXX          = 0,
     DATA_RAJAXX             = 1,
@@ -33,7 +33,7 @@ enum DataTypes
     DATA_PARALYZED          = 7
 };
 
-enum Creatures
+enum AQRCreatures
 {
     NPC_KURINAXX                = 15348,
     NPC_RAJAXX                  = 15341,
@@ -52,7 +52,7 @@ enum Creatures
     NPC_HORNET                  = 15934
 };
 
-enum GameObjects
+enum AQRGameObjectIds
 {
     GO_OSSIRIAN_CRYSTAL         = 180619
 };

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.h
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/temple_of_ahnqiraj.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "AQT"
 
-enum DataTypes
+enum AQTDataTypes
 {
     DATA_SKERAM             = 1,
     DATA_KRI                = 2,
@@ -39,7 +39,7 @@ enum DataTypes
     DATA_VISCIDUS           = 21
 };
 
-enum Creatures
+enum AQTCreatures
 {
     BOSS_EYE_OF_CTHUN       = 15589,
     NPC_CTHUN_PORTAL        = 15896,
@@ -61,5 +61,5 @@ enum Creatures
     NPC_VEKLOR              = 15276,
     NPC_VEKNILASH           = 15275
 };
-#endif
 
+#endif

--- a/src/server/scripts/Kalimdor/WailingCaverns/wailing_caverns.h
+++ b/src/server/scripts/Kalimdor/WailingCaverns/wailing_caverns.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "WC"
 
-enum DataTypes
+enum WCDataTypes
 {
     TYPE_LORD_COBRAHN         = 1,
     TYPE_LORD_PYTHAS          = 2,

--- a/src/server/scripts/Kalimdor/ZulFarrak/zulfarrak.h
+++ b/src/server/scripts/Kalimdor/ZulFarrak/zulfarrak.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "ZF"
 
-enum zfEntries
+enum ZFEntries
 {
     ENTRY_ZUM_RAH       = 7271,
     ENTRY_BLY           = 7604,
@@ -36,12 +36,12 @@ enum zfEntries
     EVENT_GAHZRILLA
 };
 
-enum DataTypes
+enum ZFDataTypes
 {
     DATA_ZUM_RAH = 0
 };
 
-enum zfPyramidPhases
+enum ZFPyramidPhases
 {
     PYRAMID_NOT_STARTED, //default
     PYRAMID_CAGES_OPEN, //happens in GO hello for cages

--- a/src/server/scripts/Maelstrom/Stonecore/stonecore.h
+++ b/src/server/scripts/Maelstrom/Stonecore/stonecore.h
@@ -21,7 +21,7 @@
 #define SCScriptName "instance_stonecore"
 #define DataHeader "SC"
 
-enum DataTypes
+enum SCDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_CORBORUS,
@@ -44,7 +44,7 @@ enum DataTypes
     DATA_STONECORE_TELEPORTER_2,
 };
 
-enum Misc
+enum SCMisc
 {
     ACTION_CORBORUS_INTRO,
     ACTION_SLABHIDE_INTRO,

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/ahnkahet.h
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/ahnkahet.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum AKDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_ELDER_NADOX                = 0,
@@ -44,7 +44,7 @@ enum DataTypes
     DATA_ALL_INITIAND_DEAD          = 13
 };
 
-enum CreatureIds
+enum AKCreatureIds
 {
     NPC_ELDER_NADOX                 = 29309,
     NPC_PRINCE_TALDARAM             = 29308,
@@ -72,7 +72,7 @@ enum CreatureIds
     NPC_TWISTED_VISAGE              = 30625
 };
 
-enum GameObjectIds
+enum AKGameObjectIds
 {
     GO_PRINCE_TALDARAM_GATE         = 192236,
     GO_PRINCE_TALDARAM_PLATFORM     = 193564,

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/azjol_nerub.h
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/azjol_nerub.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 3;
 
-enum DataTypes
+enum ANDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_KRIKTHIR_THE_GATEWATCHER   = 0,
@@ -36,7 +36,7 @@ enum DataTypes
     DATA_WATCHER_NARJIL             = 5
 };
 
-enum CreatureIds
+enum ANCreatureIds
 {
     NPC_KRIKTHIR                    = 28684,
     NPC_HADRONOX                    = 28921,
@@ -47,7 +47,7 @@ enum CreatureIds
     NPC_WATCHER_SILTHIK             = 28731
 };
 
-enum GameObjectIds
+enum ANGameObjectIds
 {
     GO_KRIKTHIR_DOOR                = 192395,
     GO_ANUBARAK_DOOR_1              = 192396,

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/obsidian_sanctum.h
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/obsidian_sanctum.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum OSDataTypes
 {
     DATA_SARTHARION             = 0,
     DATA_TENEBRON               = 1,
@@ -33,7 +33,7 @@ enum DataTypes
     TWILIGHT_ACHIEVEMENTS       = 5
 };
 
-enum CreaturesIds
+enum OSCreaturesIds
 {
     NPC_SARTHARION              = 28860,
     NPC_TENEBRON                = 30452,
@@ -41,7 +41,7 @@ enum CreaturesIds
     NPC_VESPERON                = 30449
 };
 
-enum GameObjectIds
+enum OSGameObjectIds
 {
     GO_TWILIGHT_PORTAL          = 193988
 };

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/ruby_sanctum.h
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/ruby_sanctum.h
@@ -25,7 +25,7 @@ uint32 const EncounterCount = 4;
 
 Position const HalionControllerSpawnPos = {3156.037f, 533.2656f, 72.97205f, 0.0f};
 
-enum DataTypes
+enum RSDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_BALTHARUS_THE_WARBORN              = 0,
@@ -51,14 +51,14 @@ enum DataTypes
     DATA_TWILIGHT_FLAME_RING                = 18,
 };
 
-enum SharedActions
+enum RSSharedActions
 {
     ACTION_INTRO_BALTHARUS                  = -3975101,
     ACTION_BALTHARUS_DEATH                  = -3975102,
     ACTION_INTRO_HALION                     = -4014601,
 };
 
-enum CreaturesIds
+enum RSCreaturesIds
 {
     // Baltharus the Warborn
     NPC_BALTHARUS_THE_WARBORN               = 39751,
@@ -99,7 +99,7 @@ enum CreaturesIds
     NPC_XERESTRASZA                         = 40429,
 };
 
-enum GameObjectsIds
+enum RSGameObjectsIds
 {
     GO_HALION_PORTAL_1                      = 202794,   // Unknown spell 75074, should be somehow be linked to 74807
     GO_HALION_PORTAL_2                      = 202795,   // Also spell 75074
@@ -114,14 +114,14 @@ enum GameObjectsIds
     GO_BURNING_TREE_4                       = 203037,
 };
 
-enum WorldStatesRS
+enum RSWorldStates
 {
     WORLDSTATE_CORPOREALITY_MATERIAL = 5049,
     WORLDSTATE_CORPOREALITY_TWILIGHT = 5050,
     WORLDSTATE_CORPOREALITY_TOGGLE   = 5051,
 };
 
-enum InstanceSpell
+enum RSInstanceSpell
 {
     SPELL_BERSERK                       = 26662,
 };

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/trial_of_the_champion.h
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/trial_of_the_champion.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "TC"
 
-enum Data
+enum TCData
 {
     BOSS_GRAND_CHAMPIONS,
     BOSS_ARGENT_CHALLENGE_E,
@@ -34,7 +34,7 @@ enum Data
     DATA_ARGENT_SOLDIER_DEFEATED
 };
 
-enum Data64
+enum TCData64
 {
     DATA_ANNOUNCER,
     DATA_MAIN_GATE,
@@ -48,7 +48,7 @@ enum Data64
     DATA_GRAND_CHAMPION_3
 };
 
-enum CreatureIds
+enum TCCreatureIds
 {
     // Horde Champions
     NPC_MOKRA                   = 35572,
@@ -80,7 +80,7 @@ enum CreatureIds
     NPC_ARELAS                  = 35005
 };
 
-enum GameObjects
+enum TCGameObjects
 {
     GO_MAIN_GATE                = 195647,
 
@@ -94,7 +94,7 @@ enum GameObjects
     GO_PALETRESS_LOOT_H            = 195324
 };
 
-enum Vehicles
+enum TCVehicles
 {
     //Grand Champions Alliance Vehicles
     VEHICLE_MARSHAL_JACOB_ALERIUS_MOUNT             = 35637,

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.h
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.h
@@ -7,7 +7,7 @@
 
 #define DataHeader "TCR"
 
-enum DataTypes
+enum TCRDataTypes
 {
     BOSS_BEASTS                 = 0,
     BOSS_JARAXXUS               = 1,
@@ -31,7 +31,7 @@ enum DataTypes
     DECREASE                    = 502,
 };
 
-enum SpellIds
+enum TCRSpellIds
 {
     SPELL_WILFRED_PORTAL        = 68424,
     SPELL_JARAXXUS_CHAINS       = 67924,
@@ -39,7 +39,7 @@ enum SpellIds
     SPELL_DESTROY_FLOOR_KNOCKUP = 68193,
 };
 
-enum MiscData
+enum TCRMiscData
 {
     DESPAWN_TIME                = 1200000
 };
@@ -145,7 +145,7 @@ const Position EndSpawnLoc[]=
     {644.6250f, 149.2743f, 140.6015f, 0}  // 2 - Portal to Dalaran
 };
 
-enum WorldStateIds
+enum TCRWorldStateIds
 {
     UPDATE_STATE_UI_SHOW            = 4390,
     UPDATE_STATE_UI_COUNT           = 4389
@@ -174,7 +174,7 @@ enum AnnouncerMessages
     MSG_ANUBARAK               = 724006
 };
 
-enum CreatureIds
+enum TCRCreatureIds
 {
     NPC_BARRENT                 = 34816,
     NPC_TIRION                  = 34996,
@@ -238,7 +238,7 @@ enum CreatureIds
     NPC_ANUBARAK                        = 34564
 };
 
-enum GameObjectIds
+enum TCRGameObjectIds
 {
     GO_CRUSADERS_CACHE_10       = 195631,
     GO_CRUSADERS_CACHE_25       = 195632,
@@ -264,7 +264,7 @@ enum GameObjectIds
     GO_PORTAL_TO_DALARAN        = 195682
 };
 
-enum AchievementData
+enum TCRAchievementData
 {
     // Northrend Beasts
     UPPER_BACK_PAIN_10_PLAYER               = 11779,

--- a/src/server/scripts/Northrend/DraktharonKeep/drak_tharon_keep.h
+++ b/src/server/scripts/Northrend/DraktharonKeep/drak_tharon_keep.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum DTKDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_TROLLGORE                      = 0,
@@ -50,7 +50,7 @@ enum DataTypes
     ACTION_CRYSTAL_HANDLER_DIED
 };
 
-enum CreatureIds
+enum DTKCreatureIds
 {
     NPC_TROLLGORE                       = 26630,
     NPC_NOVOS                           = 26631,
@@ -76,7 +76,7 @@ enum CreatureIds
     NPC_WORLD_TRIGGER                   = 22515
 };
 
-enum GameObjectIds
+enum DTKGameObjectIds
 {
     GO_NOVOS_CRYSTAL_1                  = 189299,
     GO_NOVOS_CRYSTAL_2                  = 189300,

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/forge_of_souls.h
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/forge_of_souls.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 2;
 
-enum Data
+enum FOSData
 {
     // Encounter states and GUIDs
     DATA_BRONJAHM                   = 0,
@@ -33,7 +33,7 @@ enum Data
     DATA_TEAM_IN_INSTANCE           = 2
 };
 
-enum Creatures
+enum FOSCreatures
 {
     NPC_BRONJAHM                    = 36497,
     NPC_DEVOURER                    = 36502,

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.h
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.h
@@ -29,7 +29,7 @@ uint32 const EncounterCount = 3;
  2 - The Lich King
 */
 
-enum DataTypes
+enum HORDataTypes
 {
     DATA_FALRIC                                 = 0,
     DATA_MARWYN                                 = 1,
@@ -55,7 +55,7 @@ enum DataTypes
     DATA_QUEL_DELAR_INVOKER                     = 17
 };
 
-enum CreatureIds
+enum HORCreatureIds
 {
     NPC_JAINA_INTRO                             = 37221,
     NPC_SYLVANAS_INTRO                          = 37223,
@@ -92,7 +92,7 @@ enum CreatureIds
     NPC_WORLD_TRIGGER                           = 22515
 };
 
-enum GameObjectIds
+enum HORGameObjectIds
 {
     GO_FROSTMOURNE                              = 202302,
     GO_ENTRANCE_DOOR                            = 201976,
@@ -115,14 +115,14 @@ enum GameObjectIds
     GO_THE_CAPTAIN_CHEST_HORDE_HEROIC           = 202337
 };
 
-enum Achievements
+enum HORAchievements
 {
     ACHIEV_NOT_RETREATING_EVENT                 = 22615,
     SPELL_ACHIEV_CHECK                          = 72830
 };
 
 // Common actions from Instance Script to Boss Script
-enum Actions
+enum HORActions
 {
     ACTION_ENTER_COMBAT                         = -668001,
     ACTION_START_PREFIGHT                       = -668002,
@@ -131,7 +131,7 @@ enum Actions
     ACTION_GUNSHIP_ARRIVAL_2                    = -668005
 };
 
-enum InstanceEvents
+enum HORInstanceEvents
 {
     EVENT_SPAWN_WAVES                           = 1,
     EVENT_NEXT_WAVE                             = 2,
@@ -141,14 +141,14 @@ enum InstanceEvents
     EVENT_QUEL_DELAR_SUMMON_UTHER               = 6
 };
 
-enum InstanceEventIds
+enum HORInstanceEventIds
 {
     EVENT_GUNSHIP_ARRIVAL                       = 22709,
     EVENT_GUNSHIP_ARRIVAL_2                     = 22714,
     EVENT_ICE_WALL_SUMMONED                     = 22795
 };
 
-enum InstanceSpells
+enum HORInstanceSpells
 {
     // Trash
     SPELL_WELL_OF_SOULS                         = 72630, // cast when spawn (become visible)
@@ -174,19 +174,19 @@ enum InstanceSpells
     SPELL_ESSENCE_OF_CAPTURED                   = 70720
 };
 
-enum InstanceQuests
+enum HORInstanceQuests
 {
     QUEST_HALLS_OF_REFLECTION_ALLIANCE          = 24480,
     QUEST_HALLS_OF_REFLECTION_HORDE             = 24561
 };
 
-enum InstanceWorldStates
+enum HORInstanceWorldStates
 {
     WORLD_STATE_HOR_WAVES_ENABLED               = 4884,
     WORLD_STATE_HOR_WAVE_COUNT                  = 4882
 };
 
-enum InstanceYells
+enum HORInstanceYells
 {
     SAY_CAPTAIN_FIRE                            = 0,
     SAY_CAPTAIN_FINAL                           = 1

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.h
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 3;
 
-enum DataTypes
+enum POSDataTypes
 {
     // Encounter states and GUIDs
     DATA_GARFROST           = 0,
@@ -39,7 +39,7 @@ enum DataTypes
     DATA_TEAM_IN_INSTANCE   = 8
 };
 
-enum CreatureIds
+enum POSCreatureIds
 {
     NPC_GARFROST                                = 36494,
     NPC_KRICK                                   = 36477,
@@ -89,7 +89,7 @@ enum CreatureIds
     NPC_ICY_BLAST                               = 36731
 };
 
-enum GameObjectIds
+enum POSGameObjectIds
 {
     GO_SARONITE_ROCK                            = 196485,
     GO_ICE_WALL                                 = 201885,

--- a/src/server/scripts/Northrend/Gundrak/gundrak.h
+++ b/src/server/scripts/Northrend/Gundrak/gundrak.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum GDDataTypes
 {
     // Encounter Ids // Encounter States // Boss GUIDs
     DATA_SLAD_RAN                    = 0,
@@ -49,7 +49,7 @@ enum DataTypes
     DATA_STATUE_ACTIVATE             = 15,
 };
 
-enum CreatureIds
+enum GDCreatureIds
 {
     NPC_SLAD_RAN                     = 29304,
     NPC_MOORABI                      = 29305,
@@ -60,7 +60,7 @@ enum CreatureIds
     NPC_ALTAR_TRIGGER                = 30298
 };
 
-enum GameObjectIds
+enum GDGameObjectIds
 {
     GO_SLAD_RAN_ALTAR                = 192518,
     GO_MOORABI_ALTAR                 = 192519,
@@ -78,14 +78,14 @@ enum GameObjectIds
     GO_COLLISION                     = 192633,
 };
 
-enum SpellIds
+enum GDSpellIds
 {
     SPELL_FIRE_BEAM_MAMMOTH          = 57068,
     SPELL_FIRE_BEAM_SNAKE            = 57071,
     SPELL_FIRE_BEAM_ELEMENTAL        = 57072
 };
 
-enum InstanceMisc
+enum GDInstanceMisc
 {
     TIMER_STATUE_ACTIVATION          = 3500
 };

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -35,7 +35,7 @@
 // * Blood Quickening             (DONE)
 // * Respite for a Tormented Soul
 
-enum Texts
+enum ICCTexts
 {
     // Highlord Tirion Fordring (at Light's Hammer)
     SAY_TIRION_INTRO_1              = 0,
@@ -100,7 +100,7 @@ enum Texts
     SAY_CROK_DEATH                  = 8,
 };
 
-enum Spells
+enum ICCSpells
 {
     // Rotting Frost Giant
     SPELL_DEATH_PLAGUE              = 72879,
@@ -175,7 +175,7 @@ enum Spells
 #define SPELL_MACHINE_GUN       (IsUndead ? SPELL_MACHINE_GUN_UNDEAD : SPELL_MACHINE_GUN_NORMAL)
 #define SPELL_ROCKET_LAUNCH     (IsUndead ? SPELL_ROCKET_LAUNCH_UNDEAD : SPELL_ROCKET_LAUNCH_NORMAL)
 
-enum EventTypes
+enum ICCEventTypes
 {
     // Highlord Tirion Fordring (at Light's Hammer)
     // The Lich King (at Light's Hammer)
@@ -257,12 +257,12 @@ enum EventTypes
     EVENT_SOUL_MISSILE                  = 55,
 };
 
-enum DataTypesICC
+enum ICCDataTypes
 {
     DATA_DAMNED_KILLS       = 1,
 };
 
-enum Actions
+enum ICCActions
 {
     // Sister Svalna
     ACTION_KILL_CAPTAIN         = 1,
@@ -272,7 +272,7 @@ enum Actions
     ACTION_RESET_EVENT          = 5,
 };
 
-enum EventIds
+enum ICCEventIds
 {
     EVENT_AWAKEN_WARD_1 = 22900,
     EVENT_AWAKEN_WARD_2 = 22907,
@@ -280,7 +280,7 @@ enum EventIds
     EVENT_AWAKEN_WARD_4 = 22909,
 };
 
-enum MovementPoints
+enum ICCMovementPoints
 {
     POINT_LAND  = 1,
 };

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
@@ -37,7 +37,7 @@ extern Position const TerenasSpawnHeroic;
 extern Position const SpiritWardenSpawn;
 
 // Shared spells used by more than one script
-enum SharedSpells
+enum ICSharedSpells
 {
     SPELL_BERSERK                       = 26662,
     SPELL_BERSERK2                      = 47008,
@@ -58,7 +58,7 @@ enum SharedSpells
     SPELL_SHADOWS_FATE                  = 71169
 };
 
-enum TeleporterSpells
+enum ICTeleporterSpells
 {
     LIGHT_S_HAMMER_TELEPORT         = 70781,
     ORATORY_OF_THE_DAMNED_TELEPORT  = 70856,
@@ -69,7 +69,7 @@ enum TeleporterSpells
     SINDRAGOSA_S_LAIR_TELEPORT      = 70861
 };
 
-enum DataTypes
+enum ICDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_LORD_MARROWGAR                = 0,
@@ -119,7 +119,7 @@ enum DataTypes
     DATA_BLOOD_QUEEN_LANA_THEL_COUNCIL = 42
 };
 
-enum CreaturesIds
+enum ICCreaturesIds
 {
     // At Light's Hammer
     NPC_HIGHLORD_TIRION_FORDRING_LH             = 37119,
@@ -322,7 +322,7 @@ enum CreaturesIds
     NPC_INVISIBLE_STALKER                       = 30298
 };
 
-enum GameObjectsIds
+enum ICGameObjectsIds
 {
     // ICC Teleporters
     GO_SCOURGE_TRANSPORTER_LICHKING         = 202223,
@@ -428,7 +428,7 @@ enum GameObjectsIds
     GO_LAVAMAN_PILLARS_UNCHAINED            = 202438
 };
 
-enum AchievementCriteriaIds
+enum ICAchievementCriteriaIds
 {
     // Lord Marrowgar
     CRITERIA_BONED_10N                  = 12775,
@@ -463,7 +463,7 @@ enum AchievementCriteriaIds
     CRITERIA_ONCE_BITTEN_TWICE_SHY_25V  = 13013
 };
 
-enum SharedActions
+enum ICSharedActions
 {
     // Icecrown Gunship Battle
     ACTION_ENEMY_GUNSHIP_TALK   = -369390,
@@ -495,7 +495,7 @@ enum SharedActions
     ACTION_FROSTMOURNE_INTRO    = -36823
 };
 
-enum WeekliesICC
+enum ICWeekliesICC
 {
     QUEST_DEPROGRAMMING_10                  = 24869,
     QUEST_DEPROGRAMMING_25                  = 24875,
@@ -509,7 +509,7 @@ enum WeekliesICC
     QUEST_RESPITE_FOR_A_TORNMENTED_SOUL_25  = 24880
 };
 
-enum WorldStatesICC
+enum ICWorldStatesICC
 {
     WORLDSTATE_SHOW_TIMER           = 4903,
     WORLDSTATE_EXECUTION_TIME       = 4904,
@@ -518,7 +518,7 @@ enum WorldStatesICC
     WORLDSTATE_ATTEMPTS_MAX         = 4942
 };
 
-enum AreaIds
+enum ICAreaIds
 {
     AREA_ICECROWN_CITADEL   = 4812,
     AREA_THE_FROZEN_THRONE  = 4859

--- a/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
@@ -74,7 +74,7 @@ enum Actions
 
 enum HorsemenData
 {
-    DATA_HORSEMEN_IS_TIMED_KILL = Data::DATA_HORSEMEN_CHECK_ACHIEVEMENT_CREDIT, // inherit from naxxramas.h - this needs to be the first entry to ensure that there are no conflicts
+    DATA_HORSEMEN_IS_TIMED_KILL = NAXData::DATA_HORSEMEN_CHECK_ACHIEVEMENT_CREDIT, // inherit from naxxramas.h - this needs to be the first entry to ensure that there are no conflicts
     DATA_MOVEMENT_FINISHED,
     DATA_DEATH_TIME
 };

--- a/src/server/scripts/Northrend/Naxxramas/naxxramas.h
+++ b/src/server/scripts/Northrend/Naxxramas/naxxramas.h
@@ -22,7 +22,7 @@
 
 uint32 const EncounterCount     = 15;
 
-enum Encounter
+enum NAXEncounter
 {
     BOSS_ANUBREKHAN,
     BOSS_FAERLINA,
@@ -41,7 +41,7 @@ enum Encounter
     BOSS_KELTHUZAD
 };
 
-enum Data
+enum NAXData
 {
     DATA_GOTHIK_GATE,
     DATA_HAD_ANUBREKHAN_GREET,
@@ -58,7 +58,7 @@ enum Data
     DATA_NAXX_PORTAL_MILITARY
 };
 
-enum Data64
+enum NAXData64
 {
     DATA_ANUBREKHAN,
     DATA_FAERLINA,
@@ -83,7 +83,7 @@ enum Data64
     DATA_LICH_KING
 };
 
-enum CreaturesIds
+enum NAXCreaturesIds
 {
     NPC_ANUBREKHAN              = 15956,
     NPC_FAERLINA                = 15953,
@@ -110,7 +110,7 @@ enum CreaturesIds
     NPC_OLD_WORLD_TRIGGER       = 15384
 };
 
-enum GameObjectsIds
+enum NAXGameObjectsIds
 {
     GO_HORSEMEN_CHEST_HERO      = 193426,
     GO_HORSEMEN_CHEST           = 181366,
@@ -160,7 +160,7 @@ enum GameObjectsIds
     GO_NAXX_PORTAL_MILITARY     = 181578
 };
 
-enum InstanceEvents
+enum NAXInstanceEvents
 {
     // Dialogue that happens after Gothik's death.
     EVENT_DIALOGUE_GOTHIK_KORTHAZZ = 1,
@@ -184,7 +184,7 @@ enum InstanceEvents
     EVENT_DIALOGUE_SAPPHIRON_KELTHUZAD4
 };
 
-enum InstanceTexts
+enum NAXInstanceTexts
 {
     // The Four Horsemen
     SAY_DIALOGUE_GOTHIK_HORSEMAN      = 5,

--- a/src/server/scripts/Northrend/Nexus/Nexus/nexus.h
+++ b/src/server/scripts/Northrend/Nexus/Nexus/nexus.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum NEXDataTypes
 {
     DATA_COMMANDER                    = 0,
     DATA_MAGUS_TELESTRA               = 1,
@@ -36,7 +36,7 @@ enum DataTypes
     TELESTRAS_CONTAINMET_SPHERE       = 7
 };
 
-enum CreatureIds
+enum NEXCreatureIds
 {
     NPC_ANOMALUS                      = 26763,
     NPC_KERISTRASZA                   = 26723,
@@ -56,7 +56,7 @@ enum CreatureIds
     NPC_COMMANDER_KOLURG              = 26798
 };
 
-enum GameObjectIds
+enum NEXGameObjectIds
 {
     GO_ANOMALUS_CONTAINMET_SPHERE     = 188527,
     GO_ORMOROKS_CONTAINMET_SPHERE     = 188528,

--- a/src/server/scripts/Northrend/Nexus/Oculus/oculus.h
+++ b/src/server/scripts/Northrend/Nexus/Oculus/oculus.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum OCDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_DRAKOS                 = 0,
@@ -34,7 +34,7 @@ enum DataTypes
     DATA_CONSTRUCTS             = 4
 };
 
-enum CreatureIds
+enum OCCreatureIds
 {
     NPC_DRAKOS                  = 27654,
     NPC_VAROS                   = 27447,
@@ -52,55 +52,55 @@ enum CreatureIds
     NPC_GREATER_WHELP           = 28276
 };
 
-enum GameObjectIds
+enum OCGameObjectIds
 {
     GO_DRAGON_CAGE_DOOR         = 193995,
     GO_EREGOS_CACHE_N           = 191349,
     GO_EREGOS_CACHE_H           = 193603
 };
 
-enum SpellEvents
+enum OCSpellEvents
 {
     EVENT_CALL_DRAGON           = 12229
 };
 
-enum CreatureActions
+enum OCCreatureActions
 {
     ACTION_CALL_DRAGON_EVENT    = 1
 };
 
-enum OculusWorldStates
+enum OCWorldStates
 {
     WORLD_STATE_CENTRIFUGE_CONSTRUCT_SHOW   = 3524,
     WORLD_STATE_CENTRIFUGE_CONSTRUCT_AMOUNT = 3486
 };
 
-enum OculusSpells
+enum OCSpells
 {
     SPELL_CENTRIFUGE_SHIELD     = 50053,
     SPELL_DEATH_SPELL           = 50415
 };
 
-enum InstanceTexts
+enum OCInstanceTexts
 {
     SAY_EREGOS_INTRO_TEXT = 0,
     SAY_VAROS_INTRO_TEXT  = 4
 };
 
-enum InstanceEvents
+enum OCInstanceEvents
 {
     EVENT_VAROS_INTRO = 1,
     EVENT_EREGOS_INTRO
 };
 
-enum ConstructKillState
+enum OCConstructKillState
 {
     KILL_NO_CONSTRUCT           = 0,
     KILL_ONE_CONSTRUCT          = 1,
     KILL_MORE_CONSTRUCT         = 2
 };
 
-enum Misc
+enum OCMisc
 {
     POINT_MOVE_OUT              = 1
 };

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/halls_of_lightning.h
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/halls_of_lightning.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum HOLDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_BJARNGRIM          = 0,
@@ -32,7 +32,7 @@ enum DataTypes
     DATA_LOKEN              = 3
 };
 
-enum CreaturesIds
+enum HOLCreaturesIds
 {
     NPC_BJARNGRIM           = 28586,
     NPC_VOLKHAN             = 28587,
@@ -40,7 +40,7 @@ enum CreaturesIds
     NPC_LOKEN               = 28923
 };
 
-enum GameObjectIds
+enum HOLGameObjectIds
 {
     GO_BJARNGRIM_DOOR       = 191416,
     GO_VOLKHAN_DOOR         = 191325,

--- a/src/server/scripts/Northrend/Ulduar/HallsOfStone/halls_of_stone.h
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfStone/halls_of_stone.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum HOSDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_KRYSTALLUS             = 0,
@@ -42,7 +42,7 @@ enum DataTypes
     DATA_GO_SKY_FLOOR           = 11
 };
 
-enum CreatureIds
+enum HOSCreatureIds
 {
     NPC_MAIDEN                  = 27975,
     NPC_KRYSTALLUS              = 27977,
@@ -53,7 +53,7 @@ enum CreatureIds
     NPC_BRANN                   = 28070
 };
 
-enum GameObjectIds
+enum HOSGameObjectIds
 {
     GO_ABEDNEUM                 = 191669,
     GO_MARNAK                   = 191670,

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/utgarde_keep.h
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/utgarde_keep.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 3;
 
-enum DataTypes
+enum UKDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_PRINCE_KELESETH    = 0,
@@ -39,7 +39,7 @@ enum DataTypes
     DATA_FORGE_3            = 7
 };
 
-enum CreatureIds
+enum UKCreatureIds
 {
     NPC_PRINCE_KELESETH     = 23953,
     NPC_SKARVALD            = 24200,
@@ -56,7 +56,7 @@ enum CreatureIds
     NPC_ANNHYLDE_THE_CALLER = 24068
 };
 
-enum GameObjectIds
+enum UKGameObjectIds
 {
     GO_BELLOW_1             = 186688,
     GO_BELLOW_2             = 186689,

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/utgarde_pinnacle.h
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/utgarde_pinnacle.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum UPDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_SVALA_SORROWGRAVE          = 0,
@@ -44,7 +44,7 @@ enum DataTypes
     DATA_GORTOK_PALEHOOF_SPHERE     = 12
 };
 
-enum CreatureIds
+enum UPCreatureIds
 {
     NPC_SVALA_SORROWGRAVE           = 26668,
     NPC_GORTOK_PALEHOOF             = 26687,
@@ -74,7 +74,7 @@ enum CreatureIds
     NPC_AVENGING_SPIRIT             = 27386
 };
 
-enum GameObjectIds
+enum UPGameObjectIds
 {
     GO_GORTOK_PALEHOOF_SPHERE       = 188593,
     GO_UTGARDE_MIRROR               = 191745,

--- a/src/server/scripts/Northrend/VaultOfArchavon/vault_of_archavon.h
+++ b/src/server/scripts/Northrend/VaultOfArchavon/vault_of_archavon.h
@@ -22,7 +22,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum Data
+enum VAData
 {
     DATA_ARCHAVON       = 0,
     DATA_EMALON         = 1,
@@ -30,7 +30,7 @@ enum Data
     DATA_TORAVON        = 3,
 };
 
-enum CreatureIds
+enum VACreatureIds
 {
     NPC_ARCHAVON        = 31125,
     NPC_EMALON          = 33993,
@@ -38,13 +38,13 @@ enum CreatureIds
     NPC_TORAVON         = 38433
 };
 
-enum AchievementCriteriaIds
+enum VAAchievementCriteriaIds
 {
     CRITERIA_EARTH_WIND_FIRE_10 = 12018,
     CRITERIA_EARTH_WIND_FIRE_25 = 12019,
 };
 
-enum AchievementSpells
+enum VAAchievementSpells
 {
     SPELL_EARTH_WIND_FIRE_ACHIEVEMENT_CHECK = 68308,
 };

--- a/src/server/scripts/Northrend/VioletHold/violet_hold.h
+++ b/src/server/scripts/Northrend/VioletHold/violet_hold.h
@@ -40,7 +40,7 @@ extern Position const PortalIntroPositions[];
  * 7 - Cyanigosa
  */
 
-enum Data
+enum VHData
 {
     // Main encounters
     DATA_1ST_BOSS       = 0,
@@ -83,7 +83,7 @@ enum Data
     DATA_HANDLE_CELLS
 };
 
-enum CreaturesIds
+enum VHCreaturesIds
 {
     NPC_TELEPORTATION_PORTAL                    = 30679,
     NPC_TELEPORTATION_PORTAL_ELITE              = 32174,
@@ -118,7 +118,7 @@ enum CreaturesIds
     NPC_DEFENSE_SYSTEM                          = 30837
 };
 
-enum GameObjectIds
+enum VHGameObjectIds
 {
     GO_MAIN_DOOR                                = 191723,
     GO_XEVOZZ_DOOR                              = 191556,
@@ -133,19 +133,19 @@ enum GameObjectIds
     GO_INTRO_ACTIVATION_CRYSTAL                 = 193615
 };
 
-enum WorldStateIds
+enum VHWorldStateIds
 {
     WORLD_STATE_VH_SHOW                         = 3816,
     WORLD_STATE_VH_PRISON_STATE                 = 3815,
     WORLD_STATE_VH_WAVE_COUNT                   = 3810,
 };
 
-enum Events
+enum VHEvents
 {
     EVENT_ACTIVATE_CRYSTAL                      = 20001
 };
 
-enum InstanceMisc
+enum VHInstanceMisc
 {
     ACTION_SINCLARI_OUTRO                       = 1,
     POINT_INTRO                                 = 1

--- a/src/server/scripts/Outland/Auchindoun/AuchenaiCrypts/auchenai_crypts.h
+++ b/src/server/scripts/Outland/Auchindoun/AuchenaiCrypts/auchenai_crypts.h
@@ -23,19 +23,11 @@
 
 uint32 const EncounterCount = 2;
 
-enum DataTypes
+enum ACDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_SHIRRAK_THE_DEAD_WATCHER   = 0,
     DATA_EXARCH_MALADAAR            = 1
-};
-
-enum CreatureIds
-{
-};
-
-enum GameObjectIds
-{
 };
 
 template<class AI>

--- a/src/server/scripts/Outland/Auchindoun/ManaTombs/mana_tombs.h
+++ b/src/server/scripts/Outland/Auchindoun/ManaTombs/mana_tombs.h
@@ -23,21 +23,13 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum MTDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_PANDEMONIUS            = 0,
     DATA_TAVAROK                = 1,
     DATA_NEXUSPRINCE_SHAFFAR    = 2,
     DATA_YOR                    = 3
-};
-
-enum CreatureIds
-{
-};
-
-enum GameObjectIds
-{
 };
 
 template<class AI>

--- a/src/server/scripts/Outland/Auchindoun/SethekkHalls/sethekk_halls.h
+++ b/src/server/scripts/Outland/Auchindoun/SethekkHalls/sethekk_halls.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount             = 3;
 
-enum DataTypes
+enum SHDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_DARKWEAVER_SYTH                = 0,
@@ -34,13 +34,13 @@ enum DataTypes
     DATA_TALON_KING_COFFER              = 3
 };
 
-enum CreatureIds
+enum SHCreatureIds
 {
     NPC_ANZU                            = 23035,
     NPC_BROOD_OF_ANZU                   = 23132
 };
 
-enum GameObjectIds
+enum SHGameObjectIds
 {
     GO_IKISS_DOOR                       = 177203,
     GO_TALON_KING_COFFER                = 187372

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/shadow_labyrinth.h
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/shadow_labyrinth.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum SLDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_AMBASSADOR_HELLMAW             = 0,
@@ -35,20 +35,20 @@ enum DataTypes
     DATA_FEL_OVERSEER                   = 4
 };
 
-enum CreatureIds
+enum SLCreatureIds
 {
     NPC_AMBASSADOR_HELLMAW              = 18731,
     NPC_GRANDMASTER_VORPIL              = 18732,
     NPC_FEL_OVERSEER                    = 18796
 };
 
-enum GameObjectIds
+enum SLGameObjectIds
 {
     GO_REFECTORY_DOOR                   = 183296, // door opened when blackheart the inciter dies
     GO_SCREAMING_HALL_DOOR              = 183295  // door opened when grandmaster vorpil dies
 };
 
-enum Misc
+enum SLMisc
 {
     ACTION_AMBASSADOR_HELLMAW_INTRO     = 1,
     ACTION_AMBASSADOR_HELLMAW_BANISH    = 2,

--- a/src/server/scripts/Outland/BlackTemple/black_temple.h
+++ b/src/server/scripts/Outland/BlackTemple/black_temple.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount         = 9;
 
-enum DataTypes
+enum BTDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_HIGH_WARLORD_NAJENTUS      = 0,
@@ -51,7 +51,7 @@ enum DataTypes
     DATA_GO_ILLIDAN_DOOR_L          = 18
 };
 
-enum CreatureIds
+enum BTCreatureIds
 {
     NPC_HIGH_WARLORD_NAJENTUS       = 22887,
     NPC_SUPREMUS                    = 22898,
@@ -71,7 +71,7 @@ enum CreatureIds
     NPC_SUPREMUS_VOLCANO            = 23085
 };
 
-enum GameObjectIds
+enum BTGameObjectIds
 {
     GO_NAJENTUS_GATE                = 185483,
     GO_NAJENTUS_SPINE               = 185584,

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/serpent_shrine.h
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/serpent_shrine.h
@@ -21,14 +21,14 @@
 
 #define DataHeader "SS"
 
-enum WaterEventState
+enum SSWaterEventState
 {
     WATERSTATE_NONE     = 0,
     WATERSTATE_FRENZY   = 1,
     WATERSTATE_SCALDING = 2
 };
 
-enum DataTypes
+enum SSDataTypes
 {
     DATA_CANSTARTPHASE3             = 1,
     DATA_CARIBDIS                   = 2,

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/steam_vault.h
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/steam_vault.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 3;
 
-enum DataTypes
+enum SVDataTypes
 {
     DATA_HYDROMANCER_THESPIA        = 0,
     DATA_MEKGINEER_STEAMRIGGER      = 1,
@@ -35,14 +35,14 @@ enum DataTypes
     DATA_ACCESS_PANEL_MEK           = 5
 };
 
-enum CreatureIds
+enum SVCreatureIds
 {
     NPC_HYDROMANCER_THESPIA         = 17797,
     NPC_MEKGINEER_STEAMRIGGER       = 17796,
     NPC_WARLORD_KALITHRESH          = 17798
 };
 
-enum GameObjectIds
+enum SVGameObjectIds
 {
     GO_MAIN_CHAMBERS_DOOR           = 183049,
     GO_ACCESS_PANEL_HYDRO           = 184125,

--- a/src/server/scripts/Outland/CoilfangReservoir/TheSlavePens/the_slave_pens.h
+++ b/src/server/scripts/Outland/CoilfangReservoir/TheSlavePens/the_slave_pens.h
@@ -23,7 +23,7 @@ uint32 const EncounterCount               = 3;
 #define SPScriptName "instance_the_slave_pens"
 #define DataHeader "SP"
 
-enum DataTypes
+enum SPDataTypes
 {
     DATA_MENNU_THE_BETRAYER               = 1,
     DATA_ROKMAR_THE_CRACKLER              = 2,
@@ -43,7 +43,7 @@ enum DataTypes
     DATA_LUMA_SKYMOTHER                   = 16
 };
 
-enum CreaturesIds
+enum SPCreaturesIds
 {
     NPC_AHUNE                            = 25740,
     NPC_FROZEN_CORE                      = 25865,
@@ -60,7 +60,7 @@ enum CreaturesIds
     NPC_WHISP_SOURCE_BUNNY               = 26121
 };
 
-enum GameObjectIds
+enum SPGameObjectIds
 {
     GO_ICE_SPEAR                         = 188077,
     GO_ICE_STONE                         = 187882

--- a/src/server/scripts/Outland/GruulsLair/gruuls_lair.h
+++ b/src/server/scripts/Outland/GruulsLair/gruuls_lair.h
@@ -23,14 +23,14 @@
 
 uint32 const EncounterCount = 2;
 
-enum DataTypes
+enum GLDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_MAULGAR                = 0,
     DATA_GRUUL                  = 1
 };
 
-enum CreatureIds
+enum GLCreatureIds
 {
     NPC_MAULGAR                 = 18831,
     NPC_KROSH_FIREHAND          = 18832,
@@ -39,7 +39,7 @@ enum CreatureIds
     NPC_BLINDEYE_THE_SEER       = 18836
 };
 
-enum GameObjectIds
+enum GLGameObjectIds
 {
     GO_MAULGAR_DOOR             = 184468,
     GO_GRUUL_DOOR               = 184662

--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/blood_furnace.h
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/blood_furnace.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 3;
 
-enum DataTypes
+enum BFDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_THE_MAKER              = 0,
@@ -43,7 +43,7 @@ enum DataTypes
     DATA_BROGGOK_LEVER          = 12
 };
 
-enum CreatureIds
+enum BFCreatureIds
 {
     NPC_THE_MAKER               = 17381,
     NPC_BROGGOK                 = 17380,
@@ -52,7 +52,7 @@ enum CreatureIds
     NPC_BROGGOK_POISON_CLOUD    = 17662
 };
 
-enum GameObjectIds
+enum BFGameObjectIds
 {
     GO_PRISON_DOOR_01           = 181766, // Final Exit Door
     GO_PRISON_DOOR_02           = 181811, // The Maker Front Door
@@ -73,7 +73,7 @@ enum GameObjectIds
     GO_BROGGOK_LEVER            = 181982
 };
 
-enum ActionIds
+enum BFActionIds
 {
     ACTION_ACTIVATE_BROGGOK     = 1,
     ACTION_RESET_BROGGOK        = 2,

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/hellfire_ramparts.h
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/hellfire_ramparts.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount       = 4;
 
-enum DataTypes
+enum HRDataTypes
 {
     DATA_WATCHKEEPER_GARGOLMAR    = 0,
     DATA_OMOR_THE_UNSCARRED       = 1,
@@ -31,7 +31,7 @@ enum DataTypes
     DATA_NAZAN                    = 3
 };
 
-enum CreatureIds
+enum HRCreatureIds
 {
     NPC_HELLFIRE_SENTRY           = 17517,
     NPC_VAZRUDEN_HERALD           = 17307,
@@ -40,7 +40,7 @@ enum CreatureIds
     NPC_LIQUID_FIRE               = 22515
 };
 
-enum GameobjectIds
+enum HRGameobjectIds
 {
     GO_FEL_IRON_CHEST_NORMAL      = 185168,
     GO_FEL_IRON_CHEST_HEROIC      = 185169

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
@@ -21,7 +21,7 @@
 
 #define DataHeader "ML"
 
-enum DataTypes
+enum MLDataTypes
 {
     DATA_MAGTHERIDON_EVENT         = 1,
     DATA_MAGTHERIDON               = 3,

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/shattered_halls.h
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/shattered_halls.h
@@ -24,7 +24,7 @@
 uint32 const EncounterCount          = 4;
 uint32 const VictimCount             = 3;
 
-enum DataTypes
+enum SHDataTypes
 {
     DATA_NETHEKURSE                  = 0,
     DATA_OMROGG                      = 1,
@@ -40,7 +40,7 @@ enum DataTypes
     DATA_THIRD_PRISONER
 };
 
-enum CreatureIds
+enum SHCreatureIds
 {
     NPC_GRAND_WARLOCK_NETHEKURSE     = 16807,
     NPC_KARGATH_BLADEFIST            = 16808,
@@ -62,19 +62,19 @@ enum CreatureIds
     NPC_HORDE_VICTIM_2               = 17297
 };
 
-enum GameobjectIds
+enum SHGameobjectIds
 {
     GO_GRAND_WARLOCK_CHAMBER_DOOR_1  = 182539,
     GO_GRAND_WARLOCK_CHAMBER_DOOR_2  = 182540
 };
 
-enum QuestIds
+enum SHQuestIds
 {
     QUEST_IMPRISONED_A               = 9524,
     QUEST_IMPRISONED_H               = 9525
 };
 
-enum InstanceSpells
+enum SHInstanceSpells
 {
     SPELL_KARGATH_EXECUTIONER_1      = 39288,
     SPELL_KARGATH_EXECUTIONER_2      = 39289,
@@ -83,7 +83,7 @@ enum InstanceSpells
     SPELL_REMOVE_KARGATH_EXECUTIONER = 39291
 };
 
-enum Actions
+enum SHActions
 {
     ACTION_EXECUTIONER_TAUNT = 1
 };

--- a/src/server/scripts/Outland/TempestKeep/Eye/the_eye.h
+++ b/src/server/scripts/Outland/TempestKeep/Eye/the_eye.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum TEDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_KAELTHAS                       = 0,
@@ -43,7 +43,7 @@ enum DataTypes
     DATA_TEMPEST_BRIDGE_WINDOW          = 11
 };
 
-enum CreatureIds
+enum TECreatureIds
 {
     NPC_SANGUINAR                       = 20060,
     NPC_CAPERNIAN                       = 20062,
@@ -54,7 +54,7 @@ enum CreatureIds
     NPC_ALAR                            = 19514
 };
 
-enum GameObjectIds
+enum TEGameObjectIds
 {
     GO_TEMPEST_BRIDDGE_WINDOW           = 184069,
     GO_KAEL_STATUE_RIGHT                = 184596,

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/mechanar.h
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/mechanar.h
@@ -22,7 +22,7 @@
 
 uint32 const EncounterCount             = 5;
 
-enum DataTypes
+enum MRDataTypes
 {
     DATA_GATEWATCHER_GYROKILL           = 0,
     DATA_GATEWATCHER_IRON_HAND          = 1,
@@ -31,7 +31,7 @@ enum DataTypes
     DATA_PATHALEON_THE_CALCULATOR       = 4
 };
 
-enum GameobjectIds
+enum MRGameobjectIds
 {
     GO_DOOR_MOARG_1                     = 184632,
     GO_DOOR_MOARG_2                     = 184322,

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.h
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 4;
 
-enum DataTypes
+enum AZDataTypes
 {
     // Encounter States/Boss GUIDs
     DATA_ZEREKETH                               = 0,
@@ -42,7 +42,7 @@ enum DataTypes
     DATA_WARDENS_SHIELD                         = 11
 };
 
-enum CreatureIds
+enum AZCreatureIds
 {
     NPC_DALLIAH                                 = 20885,
     NPC_SOCCOTHRATES                            = 20886,
@@ -50,7 +50,7 @@ enum CreatureIds
     NPC_ALPHA_POD_TARGET                        = 21436
 };
 
-enum GameObjectIds
+enum AZGameObjectIds
 {
     GO_CONTAINMENT_CORE_SECURITY_FIELD_ALPHA    = 184318, // door opened when Wrath-Scryer Soccothrates dies
     GO_CONTAINMENT_CORE_SECURITY_FIELD_BETA     = 184319, // door opened when Dalliah the Doomsayer dies

--- a/src/server/scripts/Outland/TempestKeep/botanica/the_botanica.h
+++ b/src/server/scripts/Outland/TempestKeep/botanica/the_botanica.h
@@ -23,7 +23,7 @@
 
 uint32 const EncounterCount = 5;
 
-enum DataTypes
+enum BCDataTypes
 {
     DATA_COMMANDER_SARANNIS             = 0,
     DATA_HIGH_BOTANIST_FREYWINN         = 1,
@@ -32,7 +32,7 @@ enum DataTypes
     DATA_WARP_SPLINTER                  = 4
 };
 
-enum CreatureIds
+enum BCCreatureIds
 {
     NPC_COMMANDER_SARANNIS              = 17976,
     NPC_HIGH_BOTANIST_FREYWINN          = 17975,


### PR DESCRIPTION
**Changes proposed:**

-  Scripts: Minimize duplicated enum names in header files
        This reduces the number of cache resets with the Zapcc compiler
        Standard followed is instance/raid TLA + DataTypes/CreaturesIds/etc

**Target branch(es):** 3.3.5/master

**Issues addressed:** N/A

**Tests performed:** Builds. Does not affect in-game.