### PR TITLE
Correct Nav type for WMO objects

### DIFF
--- a/src/common/Collision/Maps/MapDefines.h
+++ b/src/common/Collision/Maps/MapDefines.h
@@ -5,7 +5,7 @@
 #include "DetourNavMesh.h"
 
 const uint32 MMAP_MAGIC = 0x4d4d4150; // 'MMAP'
-#define MMAP_VERSION 5
+#define MMAP_VERSION 6
 
 struct MmapTileHeader
 {

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -26,7 +26,7 @@
 #include <limits.h>
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
-#define MMAP_VERSION 5
+#define MMAP_VERSION 6
 
 struct MmapTileHeader
 {

--- a/src/tools/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/mmaps_generator/TerrainBuilder.cpp
@@ -710,7 +710,7 @@ namespace MMAP
                         uint8 type = NAV_EMPTY;
 
                         // convert liquid type to NavTerrain
-                        switch (liquid->GetType())
+                        switch (liquid->GetType() & 3)
                         {
                         case 0:
                         case 1:


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  MMaps will have proper Nav type for WMO objects. Problem was that WMO objects using specific liquid type https://github.com/TrinityCore/TrinityCore/blob/62e97c45518a522fe938921449e8cebb750f0d58/src/tools/vmap4_extractor/wmo.cpp#L438-L451
- Maybe some other issue related to liquid for mmaps

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:**
Closes #9753
Closes #17461 

**Tests performed:** (Does it build, tested in-game, etc.)
Tested in place give by https://github.com/TrinityCore/TrinityCore/issues/9753#issuecomment-93093561 and now NPC spawned there was moving in the water instead go to the roof (without this change it was like he said in the comment).

**Additional info:**
MMaps need to be regenerated.
