### PR TITLE
Core/Scripts: Professor Putricide - Fixed Tear Gas spell sometimes dont casted in phase transitions

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -340,6 +340,9 @@ class boss_professor_putricide : public CreatureScript
 
             void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
             {
+                if (me->HasUnitState(UNIT_STATE_CASTING))
+                    return;
+
                 switch (_phase)
                 {
                     case PHASE_COMBAT_1:


### PR DESCRIPTION
**Changes proposed:**

-  If change phase event is called when Professor Putricide is casting, Tear Gas cast will not happen. So... just a check if PP is casting  solve this issue :)


**Target branch(es):** 3.3.5

**Issues addressed:** Closes #7972 and Replace: #18325

**Tests performed:** Builded and tested in game
