### PR TITLE
Add additional faction check before completing an achievement

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -452,6 +452,10 @@ void PlayerAchievementMgr::CompletedAchievement(AchievementEntry const* achievem
     if (_owner->IsGameMaster())
         return;
 
+    if ((achievement->Faction == ACHIEVEMENT_FACTION_HORDE    && referencePlayer->GetTeam() != HORDE) ||
+        (achievement->Faction == ACHIEVEMENT_FACTION_ALLIANCE && referencePlayer->GetTeam() != ALLIANCE))
+        return;
+
     if (achievement->Flags & ACHIEVEMENT_FLAG_COUNTER || HasAchieved(achievement->ID))
         return;
 


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  Add additional faction check before completing an achievement.

Some faction specific achievements use the same criteria for both factions.
The core only checks the faction when deciding which critera should be updated. When the criteria tree is complete it gives the corresponding achievement without an additional faction check. So you get both the Horde and Alliance achievement.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master


**Tests performed:** (Does it build, tested in-game, etc.)
Tested in-game with achievements 2536/2537 (Mountain o' Mounts)
