### PR TITLE
[DB/Game_Tele] Added Legion Teleport Points

### DIFF
--- a/sql/updates/world/master/2016_12_11_00_world.sql
+++ b/sql/updates/world/master/2016_12_11_00_world.sql
@@ -1,0 +1,20 @@
+--
+/* Dalaran, Krasus' Landing [Legion] */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1575, -828.835, 4371.91, 738.636, 1.88158, 1220, 'DalaranCity');
+/* Mardum, The Shattered Abyss [Demon Hunter Start Zone] */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1576, 1182.7, 3282.56, 69.99, 0.08, 1481, 'Mardum');
+/* Azsuna, The Ruined Sanctum */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1577, -218.95, 5600.9, 61.1105, 3.32418, 1220, 'Azsuna');
+/* Azsuna, Eye of Azshara */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1583, -3400, 4827.46, 27.829, 3.56, 1220, 'EyeAzshara');
+/* Val'Sharah, Bradensbrook */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1578, 2795.81, 7279.47, 21.6704, 4.75753, 1220, 'Val\'Sharah');
+/* Highmountain, Nesingwary's Retreat*/
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1579, 4492.69, 4836.35, 661.706, 1.37009, 1220, 'Highmountain');
+/* Stormheim, Stormtorn Foothills*/
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1580, 3854.78, 2020.04, 242.638, 3.2904, 1220, 'Stormheim');
+/* Suramar, Shal'Aran Sanctuary */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1581, 1708.83, 4637.75, 124.004, 5.25153, 1220, 'Suramar');
+/* BrokenShore */
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES (1582, -1306.66, 1741.4, 7.32331, 0.0914592, 1220, 'BrokenShore');
+--


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

Add .tele commands to:
-  Dalaran, Krasus' Landing [Legion] 
-  Mardum, The Shattered Abyss [Demon Hunter Start Zone]
-  Azsuna, The Ruined Sanctum
-  Azsuna, Eye of Azshara
-  Val'Sharah, Bradensbrook
-  Highmountain, Nesingwary's Retreat
-  Stormheim, Stormtorn Foothills
-  Suramar, Shal'Aran Sanctuary
-  BrokenShore

**Target branch(es):** master

**Issues addressed:** Closes #  (insert issue tracker number)
#18450 

**Tests performed:** (Does it build, tested in-game, etc.)
Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Missing game_tele for Legion Teleports 
