### PR TITLE
[3.3.5] Core/Chat: make Player commands behave like retail + configurable

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -396,7 +396,9 @@ bool ChatHandler::ParseCommands(char const* text)
     ASSERT(*text);
 
     std::string fullcmd = text;
-
+         
+    if (m_session && AccountMgr::IsPlayerAccount(m_session->GetSecurity()) && !sWorld->getBoolConfig(CONFIG_ALLOW_PLAYER_COMMANDS))
+        return false;
     /// chat case (.command or !command format)
     if (m_session)
     {

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -603,6 +603,7 @@ void World::LoadConfigSettings(bool reload)
     m_int_configs[CONFIG_TICKET_LEVEL_REQ] = sConfigMgr->GetIntDefault("LevelReq.Ticket", 1);
     m_int_configs[CONFIG_AUCTION_LEVEL_REQ] = sConfigMgr->GetIntDefault("LevelReq.Auction", 1);
     m_int_configs[CONFIG_MAIL_LEVEL_REQ] = sConfigMgr->GetIntDefault("LevelReq.Mail", 1);
+    m_bool_configs[CONFIG_ALLOW_PLAYER_COMMANDS] = sConfigMgr->GetBoolDefault("AllowPlayerCommands", 1);
     m_bool_configs[CONFIG_PRESERVE_CUSTOM_CHANNELS] = sConfigMgr->GetBoolDefault("PreserveCustomChannels", false);
     m_int_configs[CONFIG_PRESERVE_CUSTOM_CHANNEL_DURATION] = sConfigMgr->GetIntDefault("PreserveCustomChannelDuration", 14);
     m_bool_configs[CONFIG_GRID_UNLOAD] = sConfigMgr->GetBoolDefault("GridUnload", true);

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3004,6 +3004,14 @@ LevelReq.Auction = 1
 LevelReq.Mail = 1
 
 #
+#    AllowPlayerCommands
+#        Description: Allow players to use commands.
+#        Default:     0 - (Disabled)
+#                     1 - (Enabled)
+
+AllowPlayerCommands = 0
+
+#
 #     PlayerDump.DisallowPaths
 #        Description: Disallow using paths in PlayerDump output files
 #        Default:     1


### PR DESCRIPTION
**Changes proposed:**
Allows to disable or enable player commands just like in retail.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:**
Fixes issue with players able to type in commands making it not blizzlike standards. 

**Tests performed:** Builds and has been tested in-game. 

**Known issues and TODO list:** None.