### PR TITLE
Handle Quests.IgnoreAutoAccept in the post-processing phase of quest …

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4711,6 +4711,10 @@ void ObjectMgr::LoadQuests()
             qinfo->SetSpecialFlag(QUEST_SPECIAL_FLAGS_TIMED);
         if (qinfo->RequiredPlayerKills)
             qinfo->SetSpecialFlag(QUEST_SPECIAL_FLAGS_PLAYER_KILL);
+
+        // If forcing manual quest acceptance through config, then remove auto-accept flag
+        if (qinfo->Flags & QUEST_FLAGS_AUTO_ACCEPT && sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_ACCEPT))
+            qinfo->Flags &= ~QUEST_FLAGS_AUTO_ACCEPT;
     }
 
     // check QUEST_SPECIAL_FLAGS_EXPLORATION_OR_EVENT for spell with SPELL_EFFECT_QUEST_COMPLETE

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -256,7 +256,7 @@ uint32 Quest::GetRewMoneyMaxLevel() const
 
 bool Quest::IsAutoAccept() const
 {
-    return !sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_ACCEPT) && HasFlag(QUEST_FLAGS_AUTO_ACCEPT);
+    return HasFlag(QUEST_FLAGS_AUTO_ACCEPT);
 }
 
 bool Quest::IsAutoComplete() const


### PR DESCRIPTION
**Changes proposed:**

- During post-processing in `ObjectMgr::LoadQuests` when quests are loaded from the database, remove the `QUEST_FLAGS_AUTO_ACCEPT` flag if we are dealing with an auto-accept quest and `Quests.IgnoreAutoAccept` is set to True (1) in `worldserver.conf`
-  Change `Quest::IsAutoAccept` to only check the `Quest` object's flag, as the post-processing addition should make the configuration check here redundant.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #17403

**Tests performed:** (Does it build, tested in-game, etc.)

Built and tested in game.

- When `Quests.IgnoreAutoAccept` is set to ***0***, the quest is accepted the moment that the dialog comes up, which is consistent with how things were before this PR. I don't think that this is entirely Blizzlike, but that's a hiccup for another issue.
- When `Quests.IgnoreAutoAccept` is set to ***1***, the quest now appears in the quest log after the "Accept" button is pressed. Previously, the quest dialog would disappear but no quest would be accepted.