### PR TITLE
Strip QUEST_FLAGS_AUTO_ACCEPT from quest details sent to client ignoring auto-accepts

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -409,7 +409,7 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
     data << questDetails;
     data << questObjectives;
     data << uint8(activateAccept ? 1 : 0);                  // CGQuestInfo::m_autoLaunched
-    data << uint32(quest->GetFlags());                      // 3.3.3 questFlags
+    data << uint32(quest->GetFlags() & (sWorld->getBoolConfig(CONFIG_QUEST_IGNORE_AUTO_ACCEPT) ? ~QUEST_FLAGS_AUTO_ACCEPT : ~0)); // 3.3.3 questFlags
     data << uint32(quest->GetSuggestedPlayers());
     data << uint8(0);                                       // CGQuestInfo::m_startQuestCheat
 


### PR DESCRIPTION

**Changes proposed:**

-  If `Quests.IgnoreAutoAccept` is set to True (1) in `worldserver.conf`, then strip the `QUEST_FLAGS_AUTO_ACCEPT` flag from output when giving quest details to the client.

This PR is an ***alternative*** to #18523. @Shauren pointed out in #17403 that addressing the problem in the post-processing phase of quest loading would introduce client cache issues.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #17403

**Tests performed:**

Built and tested in-game.

* Tested the behavior of an auto-accept quest chosen via gossip option with `Quests.IgnoreAutoAccept` enabled.
  * "Rattling the Rattlecages" (ID 3901) was accepted without issue when the Accept button was pressed.
  * This test leads me to think that the flag stripping is only necessary in `PlayerMenu::SendQuestGiverQuestDetails`. Other locations within `GossipDef.cpp` don't seem to need to be changed to check for this configuration option.
