### PR TITLE
Core/Vmaps: Stop M2s from occluding for spellcast LoS

### DIFF
--- a/src/common/Collision/BoundingIntervalHierarchy.h
+++ b/src/common/Collision/BoundingIntervalHierarchy.h
@@ -24,6 +24,7 @@
 #include "G3D/AABox.h"
 
 #include "Define.h"
+#include "ObjectIgnoreDefinitions.h"
 
 #include <stdexcept>
 #include <vector>

--- a/src/common/Collision/DynamicTree.cpp
+++ b/src/common/Collision/DynamicTree.cpp
@@ -151,7 +151,7 @@ struct DynamicTreeIntersectionCallback
     DynamicTreeIntersectionCallback(uint32 phasemask) : did_hit(false), phase_mask(phasemask) { }
     bool operator()(const G3D::Ray& r, const GameObjectModel& obj, float& distance)
     {
-        did_hit = obj.intersectRay(r, distance, true, phase_mask);
+        did_hit = obj.intersectRay(r, distance, true, phase_mask, ObjectIgnoreFlags::IGNORE_NONE);
         return did_hit;
     }
     bool didHit() const { return did_hit;}
@@ -168,7 +168,7 @@ struct DynamicTreeIntersectionCallback_WithLogger
     bool operator()(const G3D::Ray& r, const GameObjectModel& obj, float& distance)
     {
         TC_LOG_DEBUG("maps", "testing intersection with %s", obj.name.c_str());
-        bool hit = obj.intersectRay(r, distance, true, phase_mask);
+        bool hit = obj.intersectRay(r, distance, true, phase_mask, ObjectIgnoreFlags::IGNORE_NONE);
         if (hit)
         {
             did_hit = true;

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include "Define.h"
+#include "ObjectIgnoreDefinitions.h"
 
 //===========================================================
 
@@ -60,7 +61,7 @@ namespace VMAP
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;
 
-            virtual bool isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2) = 0;
+            virtual bool isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2, ObjectIgnoreFlags ignoreFlags) = 0;
             virtual float getHeight(unsigned int pMapId, float x, float y, float z, float maxSearchDist) = 0;
             /**
             test if we hit an object. return true if we hit one. rx, ry, rz will hold the hit position or the dest position, if no intersection was found

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -28,7 +28,6 @@
 #include "Log.h"
 #include "VMapDefinitions.h"
 #include "Errors.h"
-#include "ObjectIgnoreDefinitions.h"
 
 using G3D::Vector3;
 

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -163,7 +163,6 @@ namespace VMAP
         }
     }
 
-    //SPELL LOS CALLSTACK
     bool VMapManager2::isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2, ObjectIgnoreFlags ignoreFlags)
     {
         if (!isLineOfSightCalcEnabled() || IsVMAPDisabledForPtr(mapId, VMAP_DISABLE_LOS))

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include "Define.h"
 #include "IVMapManager.h"
-#include "ObjectIgnoreDefinitions.h"
 
 //===========================================================
 

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include "Define.h"
 #include "IVMapManager.h"
+#include "ObjectIgnoreDefinitions.h"
 
 //===========================================================
 
@@ -107,7 +108,7 @@ namespace VMAP
             void unloadMap(unsigned int mapId, int x, int y) override;
             void unloadMap(unsigned int mapId) override;
 
-            bool isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2) override ;
+            bool isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2, ObjectIgnoreFlags ignoreFlags) override ;
             /**
             fill the hit pos and return true, if an object was hit
             */
@@ -119,7 +120,7 @@ namespace VMAP
             bool getAreaInfo(unsigned int pMapId, float x, float y, float& z, uint32& flags, int32& adtId, int32& rootId, int32& groupId) const override;
             bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 reqLiquidType, float& level, float& floor, uint32& type) const override;
 
-            WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename);
+            WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename, uint32 flags = 0);
             void releaseModelInstance(const std::string& filename);
 
             // what's the use of this? o.O

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -23,6 +23,7 @@
 #include "Log.h"
 #include "Errors.h"
 #include "Metric.h"
+#include "ObjectIgnoreDefinitions.h"
 
 #include <string>
 #include <sstream>
@@ -33,14 +34,14 @@ using G3D::Vector3;
 
 namespace VMAP
 {
-
+    //SPELL LOS CALLSTACK
     class MapRayCallback
     {
         public:
-            MapRayCallback(ModelInstance* val): prims(val), hit(false) { }
+            MapRayCallback(ModelInstance* val, ObjectIgnoreFlags ignoreFlags): prims(val), hit(false), flags(ignoreFlags) { }
             bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit=true)
             {
-                bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit);
+                bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit, flags);
                 if (result)
                     hit = true;
                 return result;
@@ -49,6 +50,7 @@ namespace VMAP
     protected:
         ModelInstance* prims;
         bool hit;
+        ObjectIgnoreFlags flags;
     };
 
     class AreaInfoCallback
@@ -142,19 +144,19 @@ namespace VMAP
     If intersection is found within pMaxDist, sets pMaxDist to intersection distance and returns true.
     Else, pMaxDist is not modified and returns false;
     */
-
-    bool StaticMapTree::getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit) const
+    //SPELL LOS CALLSTACK
+    bool StaticMapTree::getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const
     {
         float distance = pMaxDist;
-        MapRayCallback intersectionCallBack(iTreeValues);
+        MapRayCallback intersectionCallBack(iTreeValues, ignoreFlags);
         iTree.intersectRay(pRay, intersectionCallBack, distance, pStopAtFirstHit);
         if (intersectionCallBack.didHit())
             pMaxDist = distance;
         return intersectionCallBack.didHit();
     }
     //=========================================================
-
-    bool StaticMapTree::isInLineOfSight(const Vector3& pos1, const Vector3& pos2) const
+    //SPELL LOS CALLSTACk
+    bool StaticMapTree::isInLineOfSight(const Vector3& pos1, const Vector3& pos2, ObjectIgnoreFlags ignoreFlag) const
     {
         float maxDist = (pos2 - pos1).magnitude();
         // return false if distance is over max float, in case of cheater teleporting to the end of the universe
@@ -168,7 +170,7 @@ namespace VMAP
             return true;
         // direction with length of 1
         G3D::Ray ray = G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1)/maxDist);
-        if (getIntersectionTime(ray, maxDist, true))
+        if (getIntersectionTime(ray, maxDist, true, ignoreFlag))
             return false;
 
         return true;
@@ -194,7 +196,7 @@ namespace VMAP
         Vector3 dir = (pPos2 - pPos1)/maxDist;              // direction with length of 1
         G3D::Ray ray(pPos1, dir);
         float dist = maxDist;
-        if (getIntersectionTime(ray, dist, false))
+        if (getIntersectionTime(ray, dist, false, ObjectIgnoreFlags::IGNORE_NONE))
         {
             pResultHitPos = pPos1 + dir * dist;
             if (pModifyDist < 0)
@@ -230,7 +232,7 @@ namespace VMAP
         Vector3 dir = Vector3(0, 0, -1);
         G3D::Ray ray(pPos, dir);   // direction with length of 1
         float maxDist = maxSearchDist;
-        if (getIntersectionTime(ray, maxDist, false))
+        if (getIntersectionTime(ray, maxDist, false, ObjectIgnoreFlags::IGNORE_NONE))
         {
             height = pPos.z - maxDist;
         }
@@ -306,7 +308,7 @@ namespace VMAP
 #endif
         if (!iIsTiled && ModelSpawn::readFromFile(rf, spawn))
         {
-            WorldModel* model = vm->acquireModelInstance(iBasePath, spawn.name);
+            WorldModel* model = vm->acquireModelInstance(iBasePath, spawn.name, spawn.flags);
             VMAP_DEBUG_LOG("maps", "StaticMapTree::InitMap() : loading %s", spawn.name.c_str());
             if (model)
             {
@@ -376,7 +378,7 @@ namespace VMAP
                 if (result)
                 {
                     // acquire model instance
-                    WorldModel* model = vm->acquireModelInstance(iBasePath, spawn.name);
+                    WorldModel* model = vm->acquireModelInstance(iBasePath, spawn.name, spawn.flags);
                     if (!model)
                         VMAP_ERROR_LOG("misc", "StaticMapTree::LoadMapTile() : could not acquire WorldModel pointer [%u, %u]", tileX, tileY);
 

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -23,7 +23,6 @@
 #include "Log.h"
 #include "Errors.h"
 #include "Metric.h"
-#include "ObjectIgnoreDefinitions.h"
 
 #include <string>
 #include <sstream>

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -34,7 +34,6 @@ using G3D::Vector3;
 
 namespace VMAP
 {
-    //SPELL LOS CALLSTACK
     class MapRayCallback
     {
         public:
@@ -144,7 +143,6 @@ namespace VMAP
     If intersection is found within pMaxDist, sets pMaxDist to intersection distance and returns true.
     Else, pMaxDist is not modified and returns false;
     */
-    //SPELL LOS CALLSTACK
     bool StaticMapTree::getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const
     {
         float distance = pMaxDist;
@@ -154,8 +152,8 @@ namespace VMAP
             pMaxDist = distance;
         return intersectionCallBack.didHit();
     }
+
     //=========================================================
-    //SPELL LOS CALLSTACk
     bool StaticMapTree::isInLineOfSight(const Vector3& pos1, const Vector3& pos2, ObjectIgnoreFlags ignoreFlag) const
     {
         float maxDist = (pos2 - pos1).magnitude();

--- a/src/common/Collision/Maps/MapTree.h
+++ b/src/common/Collision/Maps/MapTree.h
@@ -22,7 +22,6 @@
 #include "Define.h"
 #include "BoundingIntervalHierarchy.h"
 #include <unordered_map>
-#include "ObjectIgnoreDefinitions.h"
 
 namespace VMAP
 {

--- a/src/common/Collision/Maps/MapTree.h
+++ b/src/common/Collision/Maps/MapTree.h
@@ -22,6 +22,7 @@
 #include "Define.h"
 #include "BoundingIntervalHierarchy.h"
 #include <unordered_map>
+#include "ObjectIgnoreDefinitions.h"
 
 namespace VMAP
 {
@@ -57,7 +58,7 @@ namespace VMAP
             std::string iBasePath;
 
         private:
-            bool getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit) const;
+            bool getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const;
             //bool containsLoadedMapTile(unsigned int pTileIdent) const { return(iLoadedMapTiles.containsKey(pTileIdent)); }
         public:
             static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
@@ -68,7 +69,7 @@ namespace VMAP
             StaticMapTree(uint32 mapID, const std::string &basePath);
             ~StaticMapTree();
 
-            bool isInLineOfSight(const G3D::Vector3& pos1, const G3D::Vector3& pos2) const;
+            bool isInLineOfSight(const G3D::Vector3& pos1, const G3D::Vector3& pos2, ObjectIgnoreFlags ignoreFlags) const;
             bool getObjectHitPos(const G3D::Vector3& pos1, const G3D::Vector3& pos2, G3D::Vector3& pResultHitPos, float pModifyDist) const;
             float getHeight(const G3D::Vector3& pPos, float maxSearchDist) const;
             bool getAreaInfo(G3D::Vector3 &pos, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const;

--- a/src/common/Collision/Models/GameObjectModel.cpp
+++ b/src/common/Collision/Models/GameObjectModel.cpp
@@ -153,7 +153,7 @@ GameObjectModel* GameObjectModel::Create(std::unique_ptr<GameObjectModelOwnerBas
     return mdl;
 }
 
-bool GameObjectModel::intersectRay(const G3D::Ray& ray, float& MaxDist, bool StopAtFirstHit, uint32 ph_mask) const
+bool GameObjectModel::intersectRay(const G3D::Ray& ray, float& MaxDist, bool StopAtFirstHit, uint32 ph_mask, ObjectIgnoreFlags ignoreFlags) const
 {
     if (!(phasemask & ph_mask) || !owner->IsSpawned())
         return false;
@@ -166,7 +166,7 @@ bool GameObjectModel::intersectRay(const G3D::Ray& ray, float& MaxDist, bool Sto
     Vector3 p = iInvRot * (ray.origin() - iPos) * iInvScale;
     Ray modRay(p, iInvRot * ray.direction());
     float distance = MaxDist * iInvScale;
-    bool hit = iModel->IntersectRay(modRay, distance, StopAtFirstHit);
+    bool hit = iModel->IntersectRay(modRay, distance, StopAtFirstHit, ignoreFlags);
     if (hit)
     {
         distance *= iScale;

--- a/src/common/Collision/Models/GameObjectModel.h
+++ b/src/common/Collision/Models/GameObjectModel.h
@@ -25,6 +25,7 @@
 #include <G3D/Ray.h>
 
 #include "Define.h"
+#include "ObjectIgnoreDefinitions.h"
 #include <memory>
 
 namespace VMAP
@@ -65,7 +66,7 @@ public:
 
     bool isEnabled() const {return phasemask != 0;}
 
-    bool intersectRay(const G3D::Ray& Ray, float& MaxDist, bool StopAtFirstHit, uint32 ph_mask) const;
+    bool intersectRay(const G3D::Ray& Ray, float& MaxDist, bool StopAtFirstHit, uint32 ph_mask, ObjectIgnoreFlags ignoreFlags) const;
 
     static GameObjectModel* Create(std::unique_ptr<GameObjectModelOwnerBase> modelOwner, std::string const& dataPath);
 

--- a/src/common/Collision/Models/ModelInstance.cpp
+++ b/src/common/Collision/Models/ModelInstance.cpp
@@ -30,7 +30,7 @@ namespace VMAP
         iInvRot = G3D::Matrix3::fromEulerAnglesZYX(G3D::pif()*iRot.y/180.f, G3D::pif()*iRot.x/180.f, G3D::pif()*iRot.z/180.f).inverse();
         iInvScale = 1.f/iScale;
     }
-    //SPELL LOS CALLSTACK
+
     bool ModelInstance::intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const
     {
         if (!iModel)

--- a/src/common/Collision/Models/ModelInstance.cpp
+++ b/src/common/Collision/Models/ModelInstance.cpp
@@ -30,8 +30,8 @@ namespace VMAP
         iInvRot = G3D::Matrix3::fromEulerAnglesZYX(G3D::pif()*iRot.y/180.f, G3D::pif()*iRot.x/180.f, G3D::pif()*iRot.z/180.f).inverse();
         iInvScale = 1.f/iScale;
     }
-
-    bool ModelInstance::intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit) const
+    //SPELL LOS CALLSTACK
+    bool ModelInstance::intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const
     {
         if (!iModel)
         {
@@ -55,7 +55,7 @@ namespace VMAP
         Vector3 p = iInvRot * (pRay.origin() - iPos) * iInvScale;
         Ray modRay(p, iInvRot * pRay.direction());
         float distance = pMaxDist * iInvScale;
-        bool hit = iModel->IntersectRay(modRay, distance, pStopAtFirstHit);
+        bool hit = iModel->IntersectRay(modRay, distance, pStopAtFirstHit, ignoreFlags);
         if (hit)
         {
             distance *= iScale;

--- a/src/common/Collision/Models/ModelInstance.h
+++ b/src/common/Collision/Models/ModelInstance.h
@@ -25,6 +25,7 @@
 #include <G3D/Ray.h>
 
 #include "Define.h"
+#include "ObjectIgnoreDefinitions.h"
 
 namespace VMAP
 {
@@ -66,7 +67,7 @@ namespace VMAP
             ModelInstance(): iInvScale(0.0f), iModel(nullptr) { }
             ModelInstance(const ModelSpawn &spawn, WorldModel* model);
             void setUnloaded() { iModel = nullptr; }
-            bool intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit) const;
+            bool intersectRay(const G3D::Ray& pRay, float& pMaxDist, bool pStopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const;
             void intersectPoint(const G3D::Vector3& p, AreaInfo &info) const;
             bool GetLocationInfo(const G3D::Vector3& p, LocationInfo &info) const;
             bool GetLiquidLevel(const G3D::Vector3& p, LocationInfo &info, float &liqHeight) const;

--- a/src/common/Collision/Models/ObjectIgnoreDefinitions.h
+++ b/src/common/Collision/Models/ObjectIgnoreDefinitions.h
@@ -21,8 +21,8 @@
 
 enum ObjectIgnoreFlags
 {
-	IGNORE_NONE = 0x00,
-	IGNORE_M2 = 0x01
+    IGNORE_NONE = 0x00,
+    IGNORE_M2 = 0x01
 };
 
 

--- a/src/common/Collision/Models/ObjectIgnoreDefinitions.h
+++ b/src/common/Collision/Models/ObjectIgnoreDefinitions.h
@@ -1,0 +1,29 @@
+/*
+* Copyright (C) 2008-2016 TrinityCore <http://www.trinitycore.org/>
+* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _OBJECTIGNOREDEFINITIONS_H_
+#define _OBJECTIGNOREDEFINITIONS_H_
+
+enum ObjectIgnoreFlags
+{
+	IGNORE_NONE = 0x00,
+	IGNORE_M2 = 0x01
+};
+
+
+#endif

--- a/src/common/Collision/Models/WorldModel.cpp
+++ b/src/common/Collision/Models/WorldModel.cpp
@@ -443,9 +443,18 @@ namespace VMAP
         std::vector<GroupModel>::const_iterator models;
         bool hit;
     };
-
-    bool WorldModel::IntersectRay(const G3D::Ray &ray, float &distance, bool stopAtFirstHit) const
+    //SPELL LOS CALLSTACK
+    bool WorldModel::IntersectRay(const G3D::Ray &ray, float &distance, bool stopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const
     {
+        // If the caller asked us to ignore certain objects we should check flags
+        if (ignoreFlags & ObjectIgnoreFlags::IGNORE_M2)
+        {
+            // M2 models are not taken into account for LoS calculation if caller requested their ignoring.
+            if (Flags & MOD_M2)
+                return false;
+        }
+
+
         // small M2 workaround, maybe better make separate class with virtual intersection funcs
         // in any case, there's no need to use a bound tree if we only have one submodel
         if (groupModels.size() == 1)

--- a/src/common/Collision/Models/WorldModel.cpp
+++ b/src/common/Collision/Models/WorldModel.cpp
@@ -443,7 +443,7 @@ namespace VMAP
         std::vector<GroupModel>::const_iterator models;
         bool hit;
     };
-    //SPELL LOS CALLSTACK
+
     bool WorldModel::IntersectRay(const G3D::Ray &ray, float &distance, bool stopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const
     {
         // If the caller asked us to ignore certain objects we should check flags

--- a/src/common/Collision/Models/WorldModel.h
+++ b/src/common/Collision/Models/WorldModel.h
@@ -27,6 +27,14 @@
 
 #include "Define.h"
 
+//Redef from export library
+enum ModelFlags
+{
+    MOD_M2 = 1,
+    MOD_WORLDSPAWN = 1 << 1,
+    MOD_HAS_BOUND = 1 << 2
+};
+
 namespace VMAP
 {
     class TreeNode;
@@ -111,12 +119,13 @@ namespace VMAP
             //! pass group models to WorldModel and create BIH. Passed vector is swapped with old geometry!
             void setGroupModels(std::vector<GroupModel> &models);
             void setRootWmoID(uint32 id) { RootWMOID = id; }
-            bool IntersectRay(const G3D::Ray &ray, float &distance, bool stopAtFirstHit) const;
+            bool IntersectRay(const G3D::Ray &ray, float &distance, bool stopAtFirstHit, ObjectIgnoreFlags ignoreFlags) const;
             bool IntersectPoint(const G3D::Vector3 &p, const G3D::Vector3 &down, float &dist, AreaInfo &info) const;
             bool GetLocationInfo(const G3D::Vector3 &p, const G3D::Vector3 &down, float &dist, LocationInfo &info) const;
             bool writeFile(const std::string &filename);
             bool readFile(const std::string &filename);
             void getGroupModels(std::vector<GroupModel>& outGroupModels);
+            uint32 Flags;
         protected:
             uint32 RootWMOID;
             std::vector<GroupModel> groupModels;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -43,6 +43,7 @@
 #include "MovementPacketBuilder.h"
 #include "BattlefieldMgr.h"
 #include "Battleground.h"
+#include "ObjectIgnoreDefinitions.h"
 
 Object::Object() : m_PackGUID(sizeof(uint64)+1)
 {
@@ -1149,7 +1150,7 @@ bool WorldObject::_IsWithinDist(WorldObject const* obj, float dist2compare, bool
     return distsq < maxdist * maxdist;
 }
 
-bool WorldObject::IsWithinLOSInMap(const WorldObject* obj) const
+bool WorldObject::IsWithinLOSInMap(const WorldObject* obj, ObjectIgnoreFlags ignoreFlags) const
 {
     if (!IsInMap(obj))
         return false;
@@ -1160,7 +1161,7 @@ bool WorldObject::IsWithinLOSInMap(const WorldObject* obj) const
     else
         obj->GetHitSpherePointFor(GetPosition(), x, y, z);
 
-    return IsWithinLOS(x, y, z);
+    return IsWithinLOS(x, y, z, ignoreFlags);
 }
 
 float WorldObject::GetDistance(const WorldObject* obj) const
@@ -1237,7 +1238,8 @@ bool WorldObject::IsWithinDistInMap(WorldObject const* obj, float dist2compare, 
     return obj && IsInMap(obj) && InSamePhase(obj) && _IsWithinDist(obj, dist2compare, is3D);
 }
 
-bool WorldObject::IsWithinLOS(float ox, float oy, float oz) const
+//SPELL LOS CALLSTACK
+bool WorldObject::IsWithinLOS(float ox, float oy, float oz, ObjectIgnoreFlags ignoreFlags) const
 {
     /*float x, y, z;
     GetPosition(x, y, z);
@@ -1251,7 +1253,7 @@ bool WorldObject::IsWithinLOS(float ox, float oy, float oz) const
         else
             GetHitSpherePointFor({ ox, oy, oz }, x, y, z);
 
-        return GetMap()->isInLineOfSight(x, y, z + 2.0f, ox, oy, oz + 2.0f, GetPhaseMask());
+        return GetMap()->isInLineOfSight(x, y, z + 2.0f, ox, oy, oz + 2.0f, GetPhaseMask(), ignoreFlags);
     }
 
     return true;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1238,7 +1238,6 @@ bool WorldObject::IsWithinDistInMap(WorldObject const* obj, float dist2compare, 
     return obj && IsInMap(obj) && InSamePhase(obj) && _IsWithinDist(obj, dist2compare, is3D);
 }
 
-//SPELL LOS CALLSTACK
 bool WorldObject::IsWithinLOS(float ox, float oy, float oz, ObjectIgnoreFlags ignoreFlags) const
 {
     /*float x, y, z;

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -24,6 +24,7 @@
 #include "UpdateMask.h"
 #include "GridReference.h"
 #include "ObjectDefines.h"
+#include "ObjectIgnoreDefinitions.h"
 #include "Map.h"
 
 #include <set>
@@ -489,8 +490,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         // use only if you will sure about placing both object at same map
         bool IsWithinDist(WorldObject const* obj, float dist2compare, bool is3D = true) const;
         bool IsWithinDistInMap(WorldObject const* obj, float dist2compare, bool is3D = true) const;
-        bool IsWithinLOS(float x, float y, float z) const;
-        bool IsWithinLOSInMap(WorldObject const* obj) const;
+        bool IsWithinLOS(float x, float y, float z, ObjectIgnoreFlags ignoreFlags = ObjectIgnoreFlags::IGNORE_NONE) const;
+        bool IsWithinLOSInMap(WorldObject const* obj, ObjectIgnoreFlags ignoreFlags = ObjectIgnoreFlags::IGNORE_NONE) const;
         Position GetHitSpherePointFor(Position const& dest) const;
         void GetHitSpherePointFor(Position const& dest, float& x, float& y, float& z) const;
         bool GetDistanceOrder(WorldObject const* obj1, WorldObject const* obj2, bool is3D = true) const;

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -24,7 +24,6 @@
 #include "UpdateMask.h"
 #include "GridReference.h"
 #include "ObjectDefines.h"
-#include "ObjectIgnoreDefinitions.h"
 #include "Map.h"
 
 #include <set>

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -31,6 +31,7 @@
 #include "MapInstanced.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
+#include "ObjectIgnoreDefinitions.h"
 #include "Pet.h"
 #include "ScriptMgr.h"
 #include "Transport.h"
@@ -2593,9 +2594,10 @@ float Map::GetWaterLevel(float x, float y) const
         return 0;
 }
 
-bool Map::isInLineOfSight(float x1, float y1, float z1, float x2, float y2, float z2, uint32 phasemask) const
+//SPELL LOS CALLSTACK
+bool Map::isInLineOfSight(float x1, float y1, float z1, float x2, float y2, float z2, uint32 phasemask, ObjectIgnoreFlags ignoreFlags) const
 {
-    return VMAP::VMapFactory::createOrGetVMapManager()->isInLineOfSight(GetId(), x1, y1, z1, x2, y2, z2)
+    return VMAP::VMapFactory::createOrGetVMapManager()->isInLineOfSight(GetId(), x1, y1, z1, x2, y2, z2, ignoreFlags)
         && _dynamicTree.isInLineOfSight(x1, y1, z1, x2, y2, z2, phasemask);
 }
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2594,7 +2594,6 @@ float Map::GetWaterLevel(float x, float y) const
         return 0;
 }
 
-//SPELL LOS CALLSTACK
 bool Map::isInLineOfSight(float x1, float y1, float z1, float x2, float y2, float z2, uint32 phasemask, ObjectIgnoreFlags ignoreFlags) const
 {
     return VMAP::VMapFactory::createOrGetVMapManager()->isInLineOfSight(GetId(), x1, y1, z1, x2, y2, z2, ignoreFlags)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -31,7 +31,6 @@
 #include "MapInstanced.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
-#include "ObjectIgnoreDefinitions.h"
 #include "Pet.h"
 #include "ScriptMgr.h"
 #include "Transport.h"

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -31,6 +31,7 @@
 #include "DynamicTree.h"
 #include "GameObjectModel.h"
 #include "ObjectGuid.h"
+#include "ObjectIgnoreDefinitions.h"
 
 #include <bitset>
 #include <list>
@@ -496,7 +497,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
 
         float GetWaterOrGroundLevel(uint32 phasemask, float x, float y, float z, float* ground = NULL, bool swim = false) const;
         float GetHeight(uint32 phasemask, float x, float y, float z, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const;
-        bool isInLineOfSight(float x1, float y1, float z1, float x2, float y2, float z2, uint32 phasemask) const;
+        bool isInLineOfSight(float x1, float y1, float z1, float x2, float y2, float z2, uint32 phasemask, ObjectIgnoreFlags ignoreFlags) const;
         void Balance() { _dynamicTree.balance(); }
         void RemoveGameObjectModel(const GameObjectModel& model) { _dynamicTree.remove(model); }
         void InsertGameObjectModel(const GameObjectModel& model) { _dynamicTree.insert(model); }

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -31,7 +31,6 @@
 #include "DynamicTree.h"
 #include "GameObjectModel.h"
 #include "ObjectGuid.h"
-#include "ObjectIgnoreDefinitions.h"
 
 #include <bitset>
 #include <list>

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -55,7 +55,7 @@ void FleeingMovementGenerator<T>::_setTargetLocation(T* owner)
                                                                                 mypos.m_positionX,
                                                                                 mypos.m_positionY,
                                                                                 mypos.m_positionZ + 2.0f,
-                                                                                x, y, z + 2.0f);
+                                                                                x, y, z + 2.0f, ObjectIgnoreFlags::IGNORE_NONE);
     if (!isInLOS)
     {
         i_nextCheckTime.Reset(200);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -54,7 +54,6 @@
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
 #include "TradeData.h"
-#include "ObjectIgnoreDefinitions.h"
 
 extern pEffect SpellEffects[TOTAL_SPELL_EFFECTS];
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -54,6 +54,7 @@
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
 #include "TradeData.h"
+#include "ObjectIgnoreDefinitions.h"
 
 extern pEffect SpellEffects[TOTAL_SPELL_EFFECTS];
 
@@ -1915,7 +1916,7 @@ void Spell::SearchChainTargets(std::list<WorldObject*>& targets, uint32 chainTar
                 if (Unit* unit = (*itr)->ToUnit())
                 {
                     uint32 deficit = unit->GetMaxHealth() - unit->GetHealth();
-                    if ((deficit > maxHPDeficit || foundItr == tempTargets.end()) && target->IsWithinDist(unit, jumpRadius) && target->IsWithinLOSInMap(unit))
+                    if ((deficit > maxHPDeficit || foundItr == tempTargets.end()) && target->IsWithinDist(unit, jumpRadius) && target->IsWithinLOSInMap(unit, ObjectIgnoreFlags::IGNORE_M2))
                     {
                         foundItr = itr;
                         maxHPDeficit = deficit;
@@ -1930,10 +1931,10 @@ void Spell::SearchChainTargets(std::list<WorldObject*>& targets, uint32 chainTar
             {
                 if (foundItr == tempTargets.end())
                 {
-                    if ((!isBouncingFar || target->IsWithinDist(*itr, jumpRadius)) && target->IsWithinLOSInMap(*itr))
+                    if ((!isBouncingFar || target->IsWithinDist(*itr, jumpRadius)) && target->IsWithinLOSInMap(*itr, ObjectIgnoreFlags::IGNORE_M2))
                         foundItr = itr;
                 }
-                else if (target->GetDistanceOrder(*itr, *foundItr) && target->IsWithinLOSInMap(*itr))
+                else if (target->GetDistanceOrder(*itr, *foundItr) && target->IsWithinLOSInMap(*itr, ObjectIgnoreFlags::IGNORE_M2))
                     foundItr = itr;
             }
         }
@@ -5039,7 +5040,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                     if (DynamicObject* dynObj = m_caster->GetDynObject(m_triggeredByAuraSpell->Id))
                         losTarget = dynObj;
 
-                if (!m_spellInfo->HasAttribute(SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, m_spellInfo->Id, NULL, SPELL_DISABLE_LOS) && !target->IsWithinLOSInMap(losTarget))
+                if (!m_spellInfo->HasAttribute(SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, m_spellInfo->Id, NULL, SPELL_DISABLE_LOS) && !target->IsWithinLOSInMap(losTarget, ObjectIgnoreFlags::IGNORE_M2))
                     return SPELL_FAILED_LINE_OF_SIGHT;
             }
         }
@@ -5051,9 +5052,15 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
         float x, y, z;
         m_targets.GetDstPos()->GetPosition(x, y, z);
 
-        if (!m_spellInfo->HasAttribute(SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, m_spellInfo->Id, NULL, SPELL_DISABLE_LOS) && !m_caster->IsWithinLOS(x, y, z))
+        if (!m_spellInfo->HasAttribute(SPELL_ATTR2_CAN_TARGET_NOT_IN_LOS) && !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, m_spellInfo->Id, NULL, SPELL_DISABLE_LOS) && !m_caster->IsWithinLOS(x, y, z, ObjectIgnoreFlags::IGNORE_M2))
             return SPELL_FAILED_LINE_OF_SIGHT;
     }
+
+    // Check for line of sight for Grip spells
+    if (m_spellInfo->HasAttribute(SPELL_ATTR6_UNK28))
+        if (Unit* target = m_targets.GetUnitTarget())
+            if (!target->IsWithinLOSInMap(m_caster)) //If we have a target check full LoS
+                return SPELL_FAILED_LINE_OF_SIGHT;
 
     // check pet presence
     for (int j = 0; j < MAX_SPELL_EFFECTS; ++j)
@@ -5293,6 +5300,10 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                     if (!target)
                         return SPELL_FAILED_DONT_REPORT;
 
+                    // first we must check to see if the target is in LoS. A path can usually be built but LoS matters for charge spells
+                    if (!target->IsWithinLOSInMap(m_caster)) //Do full LoS/Path check. Don't exclude m2
+                        return SPELL_FAILED_LINE_OF_SIGHT;
+
                     float objSize = target->GetObjectSize();
                     float range = m_spellInfo->GetMaxRange(true, m_caster, this) * 1.5f + objSize; // can't be overly strict
 
@@ -5311,6 +5322,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                             return SPELL_FAILED_NOPATH;
                         else if (m_preGeneratedPath.IsInvalidDestinationZ(target)) // Check position z, if not in a straight line
                             return SPELL_FAILED_NOPATH;
+
                     }
                     else if (m_preGeneratedPath.IsInvalidDestinationZ(target)) // Check position z, if in a straight line
                             return SPELL_FAILED_NOPATH;
@@ -6785,7 +6797,7 @@ bool Spell::CheckEffectTarget(Unit const* target, uint32 eff, Position const* lo
         default:                                            // normal case
         {
             if (losPosition)
-                return target->IsWithinLOS(losPosition->GetPositionX(), losPosition->GetPositionY(), losPosition->GetPositionZ());
+                return target->IsWithinLOS(losPosition->GetPositionX(), losPosition->GetPositionY(), losPosition->GetPositionZ(), ObjectIgnoreFlags::IGNORE_M2);
             else
             {
                 // Get GO cast coordinates if original caster -> GO
@@ -6794,7 +6806,7 @@ bool Spell::CheckEffectTarget(Unit const* target, uint32 eff, Position const* lo
                     caster = m_caster->GetMap()->GetGameObject(m_originalCasterGUID);
                 if (!caster)
                     caster = m_caster;
-                if (target != m_caster && !target->IsWithinLOSInMap(caster))
+                if (target != m_caster && !target->IsWithinLOSInMap(caster, ObjectIgnoreFlags::IGNORE_M2))
                     return false;
             }
             break;


### PR DESCRIPTION
**Changes proposed:**

Thanks to Robinsch for his help.

-  Change LoS/Raycasting API to include optional flag that acts as layer mask.
-  Create flags that can mask out objects that reside on layers (WMO, M2 and etc)  
-  Fix the spell casting LoS to not account for M2 objects in the world based on  Subv's [2012 commit](https://github.com/TrinityCore/TrinityCore/commit/c53d722aa29ff3a39d881de7d6ef86b79deffe48) that was eventually reverted due to a pathfinding bug (a bug that is fixed in this version).

**Target branch(es):** 3.3.5

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)

This commit addresses the fact that M2 objects should not occlude targets when calculating LoS. However, M2s should be included for pathfinding. The tight coupling of the raycasting/intersection system and LoS and Pathfinding makes it difficult to produce a clean solution. Because there was no encapsulation for the concept of a Ray or RayTestInfo, that you may find in other physics systems, it was not possible to extend without an API change. This appears to essentially preform the role of the 2012 commit without breaking the pathfinding like it did before.

Closes #3495
Closes #5312

**Tests performed:** (Does it build, tested in-game, etc.)

Builds. Tested pathfinding and LoS. LoS ignores M2s. Pets and pathfinding still respect M2 placement. Runs on a public 3.3.5 server too. No crashes so far from this change. Behavior seems to be correct.

**Known issues and TODO list:** (add/remove lines as needed)

None that I know of.

P.S. I left the [2012 commit](https://github.com/TrinityCore/TrinityCore/commit/c53d722aa29ff3a39d881de7d6ef86b79deffe48) as is even though I think it should be cleaned up. It was merged so I figured it was good enough.
