### PR TITLE
Core/AH: Fix AuctionHouseBot BidPrice memory and default price issues

### DIFF
--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -295,7 +295,7 @@ void AuctionBotConfig::GetConfigFromFile()
     SetConfig(CONFIG_AHBOT_CLASS_RANDOMSTACKRATIO_GLYPH, "AuctionHouseBot.Class.RandomStackRatio.Glyph", 0);
 
     SetConfig(CONFIG_AHBOT_BIDPRICE_MIN, "AuctionHouseBot.BidPrice.Min", 0.6f);
-    SetConfig(CONFIG_AHBOT_BIDPRICE_MAX, "AuctionHouseBot.BidPrice.Max", 1.4f);
+    SetConfig(CONFIG_AHBOT_BIDPRICE_MAX, "AuctionHouseBot.BidPrice.Max", 0.9f);
 }
 
 char const* AuctionBotConfig::GetHouseTypeName(AuctionHouseType houseType)

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.h
@@ -193,9 +193,9 @@ enum AuctionBotConfigBoolValues
 enum AuctionBotConfigFloatValues
 {
     CONFIG_AHBOT_BUYER_CHANCE_FACTOR,
-    CONFIG_AHBOT_FLOAT_COUNT,
     CONFIG_AHBOT_BIDPRICE_MIN,
-    CONFIG_AHBOT_BIDPRICE_MAX
+    CONFIG_AHBOT_BIDPRICE_MAX,
+    CONFIG_AHBOT_FLOAT_COUNT
 };
 
 // All basic config data used by other AHBot classes for self-configure.

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3227,10 +3227,10 @@ AuctionHouseBot.BuyPrice.Seller = 1
 #    AuctionHouseBot.BidPrice.*
 #       Description: These values determine the range that the Bid Price will fall into, as a percentage of the Buy Price
 #       Default:     0.6 - (Min)
-#                    1.4 - (Max)
+#                    0.9 - (Max)
 
 AuctionHouseBot.BidPrice.Min = 0.6
-AuctionHouseBot.BidPrice.Max = 1.4
+AuctionHouseBot.BidPrice.Max = 0.9
 
 #
 #    AuctionHouseBot.Alliance.Price.Ratio


### PR DESCRIPTION
**Changes proposed:**
I discovered that my recently merged PR (which added config options for auction house bid prices) had a bug in it. I added my new config options to an enum and did not move `CONFIG_AHBOT_FLOAT_COUNT` to the last spot in the enum. This meant that my new config options were added to an array that was too small, and memory was getting clobbered.

Aokromes also altered my PR before merging it so that the default bid price minimum and maximum were higher. This resulted in the bid price maximum being too large, and auctions by default had a bid price that is higher than the buyout price. I assume this was not intentional, so I lowered that back down to 90% of buyout price as the default bid max.

**Target branch(es):**

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
No issue number. Just bug fixes.

**Tests performed:**
Builds, tested in game without config options (using defaults) and with config options.

**Known issues and TODO list:**

None that I know about (and hopefully this time none that I don't know about) 
