### PR TITLE
Game/AI: Implement ContactDistance for ACTION_MOVE_TO_POS

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1523,10 +1523,11 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
             else
             {
-                Position Pos = target->GetPosition();
-                Pos.m_positionZ = target->GetPositionZ();
-                target->MovePosition(Pos, e.action.MoveToPos.ContactDistance, me->GetAngle(target));
-                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, Pos, e.action.MoveToPos.disablePathfinding == 0);
+                float x, y, z;
+                target->GetPosition(x, y, z);
+                if (e.action.MoveToPos.ContactDistance > 0)
+                    target->GetContactPoint(me, x, y, z, e.action.MoveToPos.ContactDistance);
+                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, x, y, z, e.action.MoveToPos.disablePathfinding == 0);
             }
             break;
         }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1523,13 +1523,10 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
             else
             {
-                float x, y, z;
-                x = target->GetPositionX();
-                y = target->GetPositionY();
-                z = target->GetPositionZ();
-                target->GetContactPoint(me, x, y, z, e.action.MoveToPos.ContactDistance);
-                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, x, y, z, e.action.MoveToPos.disablePathfinding == 0);
-
+                Position Pos = target->GetPosition();
+                Pos.m_positionZ = target->GetPositionZ();
+                target->MovePosition(Pos, e.action.MoveToPos.ContactDistance, me->GetAngle(target));
+                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, Pos, e.action.MoveToPos.disablePathfinding == 0);
             }
             break;
         }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1522,7 +1522,15 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, dest.x, dest.y, dest.z, e.action.MoveToPos.disablePathfinding == 0);
             }
             else
-                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), e.action.MoveToPos.disablePathfinding == 0);
+            {
+                float x, y, z;
+                x = target->GetPositionX();
+                y = target->GetPositionY();
+                z = target->GetPositionZ();
+                target->GetContactPoint(me, x, y, z, e.action.MoveToPos.ContactDistance);
+                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, x, y, z, e.action.MoveToPos.disablePathfinding == 0);
+
+            }
             break;
         }
         case SMART_ACTION_RESPAWN_TARGET:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -502,7 +502,7 @@ enum SMART_ACTION
     SMART_ACTION_SET_ORIENTATION                    = 66,     //
     SMART_ACTION_CREATE_TIMED_EVENT                 = 67,     // id, InitialMin, InitialMax, RepeatMin(only if it repeats), RepeatMax(only if it repeats), chance
     SMART_ACTION_PLAYMOVIE                          = 68,     // entry
-    SMART_ACTION_MOVE_TO_POS                        = 69,     // PointId, transport, disablePathfinding
+    SMART_ACTION_MOVE_TO_POS                        = 69,     // PointId, transport, disablePathfinding, ContactDistance
     SMART_ACTION_RESPAWN_TARGET                     = 70,     //
     SMART_ACTION_EQUIP                              = 71,     // entry, slotmask slot1, slot2, slot3   , only slots with mask set will be sent to client, bits are 1, 2, 4, leaving mask 0 is defaulted to mask 7 (send all), slots1-3 are only used if no entry is set
     SMART_ACTION_CLOSE_GOSSIP                       = 72,     // none
@@ -973,6 +973,7 @@ struct SmartAction
             uint32 pointId;
             uint32 transport;
             uint32 disablePathfinding;
+            uint32 ContactDistance;
         } MoveToPos;
 
         struct


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  Add ContactDistance for ACTION_MOVE_TO_POS
-  This pr should make the script for https://github.com/TrinityCore/TrinityCore/pull/18702 more simple.
-  As you can see in https://github.com/TrinityCore/TrinityCore/pull/18702, the Peons should walk to the closest Wood Pile. However if we use ACTION_MOVE_TO_POS with targettype TARGET_CLOSEST_GAMEOBJECT, the peon will walk directly ON TOP of the gameobject. Blizzlike he should walk IN FRONT of the pile with a contactdistance from around 1 till 2 yards. With this PR we can add contactdistance to the ACTION_MOVE_TO_POS if a worldobject (gameobject, player, npc..) is used a targettype. 
-  This fix will not change the behaviour for TARGET_POSITION (intended)

Some screen for this:

![GitHub Logo](http://i.imgur.com/jAQJm84.png)

**Target branch(es):** 3.3.5/master

- [X] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
- make script for https://github.com/TrinityCore/TrinityCore/pull/18702 more simple

**Tests performed:** (Does it build, tested in-game, etc.)
 yes and yes

**Known issues and TODO list:** (add/remove lines as needed)

- [x] One tiny problem. I hope the coredevs know the reason for it. If we use ACTION_MOVE_TO_POS with contactdistance = 0, the unit should actually walk INSIDE the target. But currently it alsways walks only 1 yard in front of the target. Dunno what causes that issue

I tested the script with this SAI (only customscript)

```sql
-- William Saldean SAI
SET @ENTRY := 33996;
UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`=@ENTRY;
DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
(@ENTRY,0,0,0,1,0,100,1,6000,6000,0,0,69,1,0,0,0,0,0,19,2118,100,0,0,0,0,0,"William Saldean - Out of Combat - Move To Closest Creature 'Abigail Shiel' (No Repeat)"),
(@ENTRY,0,1,0,34,0,100,0,0,1,0,0,51,0,0,0,0,0,0,1,0,0,0,0,0,0,0,"William Saldean - On Reached Point 1 - Kill Target");
```

[//]: # (**DEPRECATION NOTICE** Instead of creating new PRs to the (old) 6.x branch, make sure the target branch is **master** instead of 6.x.)
[//]: # (**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request (if not enabled already).)
[//]: # (**NOTE** If this PR __only__ contains SQL files, open a new issue instead and post or link the SQL there.)
[//]: # (**SUGGESTION** When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.)
