### PR TITLE
Core/Player: Add config option for IsGroupVisibleFor()

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2626,6 +2626,7 @@ bool Player::IsGroupVisibleFor(Player const* p) const
         default: return IsInSameGroupWith(p);
         case 1:  return IsInSameRaidWith(p);
         case 2:  return GetTeam() == p->GetTeam();
+        case 3:  return nullptr;
     }
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2626,7 +2626,7 @@ bool Player::IsGroupVisibleFor(Player const* p) const
         default: return IsInSameGroupWith(p);
         case 1:  return IsInSameRaidWith(p);
         case 2:  return GetTeam() == p->GetTeam();
-        case 3:  return nullptr;
+        case 3:  return false;
     }
 }
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -1914,6 +1914,7 @@ GM.ForceShutdownThreshold = 30
 #        Default:     1 - (Raid)
 #                     0 - (Party)
 #                     2 - (Faction)
+#                     3 - (None)
 
 Visibility.GroupMode = 1
 


### PR DESCRIPTION
**Changes proposed:**

-  Add a new configurable option for IsGroupVisibleFor() in worldserver.conf for stealthed players to remain invisible, even while in the same group. Because why not?

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [?] master

**Issues addressed:** Closes #  (insert issue tracker number)
None

**Tests performed:** (Does it build, tested in-game, etc.)
Builds and works, looks fine.

**Known issues and TODO list:** (add/remove lines as needed)
None
