### PR TITLE
Core/Player: increase ActivateTaxiPathTo() distance check

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21113,7 +21113,7 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
         return false;
     }
 
-	// check node starting pos data set case if provided
+    // check node starting pos data set case if provided
     if (node->x != 0.0f || node->y != 0.0f || node->z != 0.0f)
     {
         if (node->map_id != GetMapId() || !IsInDist(node->x, node->y, node->z, 6 * INTERACTION_DISTANCE))
@@ -21122,7 +21122,6 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
             return false;
         }
     }
-
     // node must have pos if taxi master case (npc != NULL)
     else if (npc)
     {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21116,11 +21116,8 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
     // check node starting pos data set case if provided
     if (node->x != 0.0f || node->y != 0.0f || node->z != 0.0f)
     {
-        if (node->map_id != GetMapId() || !IsInDist(node->x, node->y, node->z, 2 * INTERACTION_DISTANCE))
-        {
-            GetSession()->SendActivateTaxiReply(ERR_TAXITOOFARAWAY);
-            return false;
-        }
+        GetSession()->SendActivateTaxiReply(ERR_TAXITOOFARAWAY);
+        return false;
     }
     // node must have pos if taxi master case (npc != NULL)
     else if (npc)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21113,14 +21113,8 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
         return false;
     }
 
-    // check node starting pos data set case if provided
-    if (node->x != 0.0f || node->y != 0.0f || node->z != 0.0f)
-    {
-        GetSession()->SendActivateTaxiReply(ERR_TAXITOOFARAWAY);
-        return false;
-    }
     // node must have pos if taxi master case (npc != NULL)
-    else if (npc)
+    if (npc)
     {
         GetSession()->SendActivateTaxiReply(ERR_TAXIUNSPECIFIEDSERVERERROR);
         return false;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21113,8 +21113,18 @@ bool Player::ActivateTaxiPathTo(std::vector<uint32> const& nodes, Creature* npc 
         return false;
     }
 
+	// check node starting pos data set case if provided
+    if (node->x != 0.0f || node->y != 0.0f || node->z != 0.0f)
+    {
+        if (node->map_id != GetMapId() || !IsInDist(node->x, node->y, node->z, 6 * INTERACTION_DISTANCE))
+        {
+            GetSession()->SendActivateTaxiReply(ERR_TAXITOOFARAWAY);
+            return false;
+        }
+    }
+
     // node must have pos if taxi master case (npc != NULL)
-    if (npc)
+    else if (npc)
     {
         GetSession()->SendActivateTaxiReply(ERR_TAXIUNSPECIFIEDSERVERERROR);
         return false;


### PR DESCRIPTION
**Changes proposed:**
Remove the distance check from ActiveTaxiPathTo()
*Should* Fix the failure to activate taxi paths for at least one quest (#18615)
Not sure if this is better than increasing the distance. Feedback please?

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)
#15398
#18615

**Tests performed:** (Does it build, tested in-game, etc.)
None. Feedback please?

**Known issues and TODO list:** (add/remove lines as needed)
None