### PR TITLE
Changed error message when loading outdated Vmap file

### DIFF
--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -56,6 +56,7 @@ namespace VMAP
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
             virtual bool existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
+			virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -326,6 +326,21 @@ namespace VMAP
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);
     }
 
+	bool VMapManager2::isPathAccessibleForMap(const char* _basePath, unsigned int mapID)
+	{
+		std::string basePath = std::string(_basePath);
+		if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
+			basePath.push_back('/');
+		std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
+		bool success = true;
+		FILE* rf = fopen(fullname.c_str(), "rb");
+		if (!rf)
+			return false;
+
+		fclose(rf);
+		return true;
+	}
+
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)
     {
         instanceMapTree = iInstanceMapTrees;

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -129,6 +129,8 @@ namespace VMAP
             }
             virtual bool existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
+			virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID);
+
             void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 
             typedef uint32(*GetLiquidFlagsFn)(uint32 liquidType);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -102,24 +102,33 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
     return ret;
 }
 
-bool Map::ExistVMap(uint32 mapid, int gx, int gy)
+bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
-    if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
-    {
-        if (vmgr->isMapLoadingEnabled())
-        {
-            bool exists = vmgr->existsMap((sWorld->GetDataPath()+ "vmaps").c_str(),  mapid, gx, gy);
-            if (!exists)
-            {
-                std::string name = vmgr->getDirFileName(mapid, gx, gy);
-                TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath()+"vmaps/"+name).c_str());
-                TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath()+"vmaps/").c_str());
-                return false;
-            }
-        }
-    }
+	if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
+	{
+		if (vmgr->isMapLoadingEnabled())
+		{
+			bool exists = vmgr->isPathAccessibleForMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid);
+			if (!exists)
+			{
+				std::string name = vmgr->getDirFileName(mapid, gx, gy);
+				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
+				return false;
+			}
 
-    return true;
+
+			bool couldLoad = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy); //TODO: This method should be renamed to 'canLoadMap' because, it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
+			if (!couldLoad)
+			{
+				std::string name = vmgr->getDirFileName(mapid, gx, gy);
+				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "This may be due a mismatch version, lack of permissions or a corrupted file. Try re-extracting the maps again.");
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 void Map::LoadMMap(int gx, int gy)


### PR DESCRIPTION
Added a more descriptive message in case the Vmap file fails to load due
being outdated or if it is infact on in the folder.

[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  When a Vmap file cant be loaded because of incompatibility, it should say it, instead of saying that the file does not exist, otherwise you may think it is a filesystem /permission problems.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** #18853


**Tests performed:** (Does it build, tested in-game, etc.)
Builds, no in-game modifications done. Works as expected.

**Known issues and TODO list:** (add/remove lines as needed)

***Function names should be corrected:***
- [Game->Maps->Map.cpp, line 105] Function should be renamed from ExistVMap to CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded! 
- [Game->Maps->Map.cpp, line 121] This method should be renamed to 'canLoadMap'. it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
