### PR TITLE
Changed error message when loading outdated Vmap file

### DIFF
--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
-* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
-*
-* This program is free software; you can redistribute it and/or modify it
-* under the terms of the GNU General Public License as published by the
-* Free Software Foundation; either version 2 of the License, or (at your
-* option) any later version.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-* more details.
-*
-* You should have received a copy of the GNU General Public License along
-* with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef _IVMAPMANAGER_H
 #define _IVMAPMANAGER_H
@@ -38,63 +38,63 @@ namespace VMAP
         VMAP_LOAD_RESULT_IGNORED
     };
 
-#define VMAP_INVALID_HEIGHT       -100000.0f            // for check
-#define VMAP_INVALID_HEIGHT_VALUE -200000.0f            // real assigned value in unknown height case
+    #define VMAP_INVALID_HEIGHT       -100000.0f            // for check
+    #define VMAP_INVALID_HEIGHT_VALUE -200000.0f            // real assigned value in unknown height case
 
     //===========================================================
     class TC_COMMON_API IVMapManager
     {
-    private:
-        bool iEnableLineOfSightCalc;
-        bool iEnableHeightCalc;
+        private:
+            bool iEnableLineOfSightCalc;
+            bool iEnableHeightCalc;
 
-    public:
-        IVMapManager() : iEnableLineOfSightCalc(true), iEnableHeightCalc(true) { }
+        public:
+            IVMapManager() : iEnableLineOfSightCalc(true), iEnableHeightCalc(true) { }
 
-        virtual ~IVMapManager(void) { }
+            virtual ~IVMapManager(void) { }
 
-        virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
+            virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
-        ///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
-        virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
+			///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
+            virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;	
 
-        virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
-        virtual void unloadMap(unsigned int pMapId) = 0;
+            virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
+            virtual void unloadMap(unsigned int pMapId) = 0;
 
-        virtual bool isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2) = 0;
-        virtual float getHeight(unsigned int pMapId, float x, float y, float z, float maxSearchDist) = 0;
-        /**
-        test if we hit an object. return true if we hit one. rx, ry, rz will hold the hit position or the dest position, if no intersection was found
-        return a position, that is pReduceDist closer to the origin
-        */
-        virtual bool getObjectHitPos(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float &ry, float& rz, float pModifyDist) = 0;
-        /**
-        send debug commands
-        */
-        virtual bool processCommand(char *pCommand) = 0;
+            virtual bool isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2) = 0;
+            virtual float getHeight(unsigned int pMapId, float x, float y, float z, float maxSearchDist) = 0;
+            /**
+            test if we hit an object. return true if we hit one. rx, ry, rz will hold the hit position or the dest position, if no intersection was found
+            return a position, that is pReduceDist closer to the origin
+            */
+            virtual bool getObjectHitPos(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float &ry, float& rz, float pModifyDist) = 0;
+            /**
+            send debug commands
+            */
+            virtual bool processCommand(char *pCommand)= 0;
 
-        /**
-        Enable/disable LOS calculation
-        It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
-        */
-        void setEnableLineOfSightCalc(bool pVal) { iEnableLineOfSightCalc = pVal; }
-        /**
-        Enable/disable model height calculation
-        It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
-        */
-        void setEnableHeightCalc(bool pVal) { iEnableHeightCalc = pVal; }
+            /**
+            Enable/disable LOS calculation
+            It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
+            */
+            void setEnableLineOfSightCalc(bool pVal) { iEnableLineOfSightCalc = pVal; }
+            /**
+            Enable/disable model height calculation
+            It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
+            */
+            void setEnableHeightCalc(bool pVal) { iEnableHeightCalc = pVal; }
 
-        bool isLineOfSightCalcEnabled() const { return(iEnableLineOfSightCalc); }
-        bool isHeightCalcEnabled() const { return(iEnableHeightCalc); }
-        bool isMapLoadingEnabled() const { return(iEnableLineOfSightCalc || iEnableHeightCalc); }
+            bool isLineOfSightCalcEnabled() const { return(iEnableLineOfSightCalc); }
+            bool isHeightCalcEnabled() const { return(iEnableHeightCalc); }
+            bool isMapLoadingEnabled() const { return(iEnableLineOfSightCalc || iEnableHeightCalc  ); }
 
-        virtual std::string getDirFileName(unsigned int pMapId, int x, int y) const = 0;
-        /**
-        Query world model area info.
-        \param z gets adjusted to the ground height for which this are info is valid
-        */
-        virtual bool getAreaInfo(unsigned int pMapId, float x, float y, float &z, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const = 0;
-        virtual bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 ReqLiquidType, float &level, float &floor, uint32 &type) const = 0;
+            virtual std::string getDirFileName(unsigned int pMapId, int x, int y) const =0;
+            /**
+            Query world model area info.
+            \param z gets adjusted to the ground height for which this are info is valid
+            */
+            virtual bool getAreaInfo(unsigned int pMapId, float x, float y, float &z, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const=0;
+            virtual bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 ReqLiquidType, float &level, float &floor, uint32 &type) const=0;
     };
 
 }

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -56,6 +56,7 @@ namespace VMAP
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
             virtual bool existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
+			virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -38,6 +38,14 @@ namespace VMAP
         VMAP_LOAD_RESULT_IGNORED
     };
 
+    enum VMAP_CHECK_RESULT
+    {
+        VMAP_CHECK_RESULT_SUCCESS,
+        VMAP_CHECK_RESULT_FILENOTFOUND,
+        VMAP_CHECK_RESULT_VERSIONMISMATCH,
+        VMAP_CHECK_RESULT_UNKNOWN
+    };
+
     #define VMAP_INVALID_HEIGHT       -100000.0f            // for check
     #define VMAP_INVALID_HEIGHT_VALUE -200000.0f            // real assigned value in unknown height case
 

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -55,8 +55,8 @@ namespace VMAP
 
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
-			///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
-            virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;	
+            ///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
+            virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -1,20 +1,20 @@
 /*
- * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef _IVMAPMANAGER_H
 #define _IVMAPMANAGER_H
@@ -38,63 +38,63 @@ namespace VMAP
         VMAP_LOAD_RESULT_IGNORED
     };
 
-    #define VMAP_INVALID_HEIGHT       -100000.0f            // for check
-    #define VMAP_INVALID_HEIGHT_VALUE -200000.0f            // real assigned value in unknown height case
+#define VMAP_INVALID_HEIGHT       -100000.0f            // for check
+#define VMAP_INVALID_HEIGHT_VALUE -200000.0f            // real assigned value in unknown height case
 
     //===========================================================
     class TC_COMMON_API IVMapManager
     {
-        private:
-            bool iEnableLineOfSightCalc;
-            bool iEnableHeightCalc;
+    private:
+        bool iEnableLineOfSightCalc;
+        bool iEnableHeightCalc;
 
-        public:
-            IVMapManager() : iEnableLineOfSightCalc(true), iEnableHeightCalc(true) { }
+    public:
+        IVMapManager() : iEnableLineOfSightCalc(true), iEnableHeightCalc(true) { }
 
-            virtual ~IVMapManager(void) { }
+        virtual ~IVMapManager(void) { }
 
-            virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
+        virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
-			///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
-            virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;	
+        ///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
+        virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
-            virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
-            virtual void unloadMap(unsigned int pMapId) = 0;
+        virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
+        virtual void unloadMap(unsigned int pMapId) = 0;
 
-            virtual bool isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2) = 0;
-            virtual float getHeight(unsigned int pMapId, float x, float y, float z, float maxSearchDist) = 0;
-            /**
-            test if we hit an object. return true if we hit one. rx, ry, rz will hold the hit position or the dest position, if no intersection was found
-            return a position, that is pReduceDist closer to the origin
-            */
-            virtual bool getObjectHitPos(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float &ry, float& rz, float pModifyDist) = 0;
-            /**
-            send debug commands
-            */
-            virtual bool processCommand(char *pCommand)= 0;
+        virtual bool isInLineOfSight(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2) = 0;
+        virtual float getHeight(unsigned int pMapId, float x, float y, float z, float maxSearchDist) = 0;
+        /**
+        test if we hit an object. return true if we hit one. rx, ry, rz will hold the hit position or the dest position, if no intersection was found
+        return a position, that is pReduceDist closer to the origin
+        */
+        virtual bool getObjectHitPos(unsigned int pMapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float &ry, float& rz, float pModifyDist) = 0;
+        /**
+        send debug commands
+        */
+        virtual bool processCommand(char *pCommand) = 0;
 
-            /**
-            Enable/disable LOS calculation
-            It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
-            */
-            void setEnableLineOfSightCalc(bool pVal) { iEnableLineOfSightCalc = pVal; }
-            /**
-            Enable/disable model height calculation
-            It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
-            */
-            void setEnableHeightCalc(bool pVal) { iEnableHeightCalc = pVal; }
+        /**
+        Enable/disable LOS calculation
+        It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
+        */
+        void setEnableLineOfSightCalc(bool pVal) { iEnableLineOfSightCalc = pVal; }
+        /**
+        Enable/disable model height calculation
+        It is enabled by default. If it is enabled in mid game the maps have to loaded manualy
+        */
+        void setEnableHeightCalc(bool pVal) { iEnableHeightCalc = pVal; }
 
-            bool isLineOfSightCalcEnabled() const { return(iEnableLineOfSightCalc); }
-            bool isHeightCalcEnabled() const { return(iEnableHeightCalc); }
-            bool isMapLoadingEnabled() const { return(iEnableLineOfSightCalc || iEnableHeightCalc  ); }
+        bool isLineOfSightCalcEnabled() const { return(iEnableLineOfSightCalc); }
+        bool isHeightCalcEnabled() const { return(iEnableHeightCalc); }
+        bool isMapLoadingEnabled() const { return(iEnableLineOfSightCalc || iEnableHeightCalc); }
 
-            virtual std::string getDirFileName(unsigned int pMapId, int x, int y) const =0;
-            /**
-            Query world model area info.
-            \param z gets adjusted to the ground height for which this are info is valid
-            */
-            virtual bool getAreaInfo(unsigned int pMapId, float x, float y, float &z, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const=0;
-            virtual bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 ReqLiquidType, float &level, float &floor, uint32 &type) const=0;
+        virtual std::string getDirFileName(unsigned int pMapId, int x, int y) const = 0;
+        /**
+        Query world model area info.
+        \param z gets adjusted to the ground height for which this are info is valid
+        */
+        virtual bool getAreaInfo(unsigned int pMapId, float x, float y, float &z, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const = 0;
+        virtual bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 ReqLiquidType, float &level, float &floor, uint32 &type) const = 0;
     };
 
 }

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -56,7 +56,7 @@ namespace VMAP
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
             virtual bool existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
-			virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
+            virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -56,7 +56,7 @@ namespace VMAP
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
             virtual bool existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
-			virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
+	    virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -55,8 +55,9 @@ namespace VMAP
 
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
-            virtual bool existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
-			virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
+			///Changed from Bool to Int, in order to be able to use the same method with a little bit more of error descriptor.
+            virtual int existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
+			
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/IVMapManager.h
+++ b/src/common/Collision/Management/IVMapManager.h
@@ -56,7 +56,7 @@ namespace VMAP
             virtual int loadMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
 
             virtual bool existsMap(const char* pBasePath, unsigned int pMapId, int x, int y) = 0;
-	    virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
+			virtual bool isPathAccessibleForMap(const char* pBasePath, unsigned int pMapId) = 0;
 
             virtual void unloadMap(unsigned int pMapId, int x, int y) = 0;
             virtual void unloadMap(unsigned int pMapId) = 0;

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -332,7 +332,6 @@ namespace VMAP
 		if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
 			basePath.push_back('/');
 		std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
-		bool success = true;
 		FILE* rf = fopen(fullname.c_str(), "rb");
 		if (!rf)
 			return false;

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -321,25 +321,16 @@ namespace VMAP
         }
     }
 
-    bool VMapManager2::existsMap(const char* basePath, unsigned int mapId, int x, int y)
+	/* return 0 = All Good
+	*  return 1 = File not found
+	*  return 2 = Version Mismatch
+	*  return 3 = File corruption or something else
+	*/
+    int VMapManager2::existsMap(const char* basePath, unsigned int mapId, int x, int y)
     {
+		
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);
     }
-
-	bool VMapManager2::isPathAccessibleForMap(const char* _basePath, unsigned int mapID)
-	{
-		std::string basePath = std::string(_basePath);
-		if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
-			basePath.push_back('/');
-		std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
-		bool success = true;
-		FILE* rf = fopen(fullname.c_str(), "rb");
-		if (!rf)
-			return false;
-
-		fclose(rf);
-		return true;
-	}
 
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)
     {

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -321,13 +321,13 @@ namespace VMAP
         }
     }
 
-	/* return 0 = All Good
-	*  return 1 = File not found
-	*  return 2 = Version Mismatch
-	*  return 3 = File corruption or something else
-	*/
+    /* return 0 = All Good
+    *  return 1 = File not found
+    *  return 2 = Version Mismatch
+    *  return 3 = File corruption or something else
+    */
     int VMapManager2::existsMap(const char* basePath, unsigned int mapId, int x, int y)
-    {	
+    {
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);
     }
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include <iostream>
 #include <iomanip>
@@ -116,7 +116,7 @@ namespace VMAP
                 instanceTree = iInstanceMapTrees.insert(InstanceTreeMap::value_type(mapId, nullptr)).first;
             else
                 ASSERT(false, "Invalid mapId %u tile [%u, %u] passed to VMapManager2 after startup in thread unsafe environment",
-                mapId, tileX, tileY);
+                    mapId, tileX, tileY);
         }
 
         if (!instanceTree->second)
@@ -321,13 +321,13 @@ namespace VMAP
         }
     }
 
-	/* return 0 = All Good
-	*  return 1 = File not found
-	*  return 2 = Version Mismatch
-	*  return 3 = File corruption or something else
-	*/
+    /* return 0 = All Good
+    *  return 1 = File not found
+    *  return 2 = Version Mismatch
+    *  return 3 = File corruption or something else
+    */
     int VMapManager2::existsMap(const char* basePath, unsigned int mapId, int x, int y)
-    {	
+    {
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);
     }
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
-* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
-*
-* This program is free software; you can redistribute it and/or modify it
-* under the terms of the GNU General Public License as published by the
-* Free Software Foundation; either version 2 of the License, or (at your
-* option) any later version.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-* more details.
-*
-* You should have received a copy of the GNU General Public License along
-* with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <iostream>
 #include <iomanip>
@@ -116,7 +116,7 @@ namespace VMAP
                 instanceTree = iInstanceMapTrees.insert(InstanceTreeMap::value_type(mapId, nullptr)).first;
             else
                 ASSERT(false, "Invalid mapId %u tile [%u, %u] passed to VMapManager2 after startup in thread unsafe environment",
-                    mapId, tileX, tileY);
+                mapId, tileX, tileY);
         }
 
         if (!instanceTree->second)
@@ -321,13 +321,13 @@ namespace VMAP
         }
     }
 
-    /* return 0 = All Good
-    *  return 1 = File not found
-    *  return 2 = Version Mismatch
-    *  return 3 = File corruption or something else
-    */
+	/* return 0 = All Good
+	*  return 1 = File not found
+	*  return 2 = Version Mismatch
+	*  return 3 = File corruption or something else
+	*/
     int VMapManager2::existsMap(const char* basePath, unsigned int mapId, int x, int y)
-    {
+    {	
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);
     }
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -326,6 +326,21 @@ namespace VMAP
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);
     }
 
+	bool VMapManager2::isPathAccessibleForMap(const char* _basePath, unsigned int mapID)
+	{
+		std::string basePath = std::string(_basePath);
+		if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
+			basePath.push_back('/');
+		std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
+		bool success = true;
+		FILE* rf = fopen(fullname.c_str(), "rb");
+		if (!rf)
+			return false;
+
+		fclose(rf);
+		return true;
+	}
+
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)
     {
         instanceMapTree = iInstanceMapTrees;

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -328,16 +328,16 @@ namespace VMAP
 
 	bool VMapManager2::isPathAccessibleForMap(const char* _basePath, unsigned int mapID)
 	{
-		std::string basePath = std::string(_basePath);
-		if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
-			basePath.push_back('/');
-		std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
-		FILE* rf = fopen(fullname.c_str(), "rb");
-		if (!rf)
-			return false;
-
-		fclose(rf);
-		return true;
+        std::string basePath = std::string(_basePath);
+        if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
+        basePath.push_back('/');
+        std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
+        FILE* rf = fopen(fullname.c_str(), "rb");
+        if (!rf)
+            return false;
+ 
+        fclose(rf);
+        return true;
 	}
 
     void VMapManager2::getInstanceMapTree(InstanceTreeMap &instanceMapTree)

--- a/src/common/Collision/Management/VMapManager2.cpp
+++ b/src/common/Collision/Management/VMapManager2.cpp
@@ -321,11 +321,6 @@ namespace VMAP
         }
     }
 
-    /* return 0 = All Good
-    *  return 1 = File not found
-    *  return 2 = Version Mismatch
-    *  return 3 = File corruption or something else
-    */
     int VMapManager2::existsMap(const char* basePath, unsigned int mapId, int x, int y)
     {
         return StaticMapTree::CanLoadMap(std::string(basePath), mapId, x, y);

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -129,7 +129,7 @@ namespace VMAP
             }
             virtual bool existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
-			virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID) override;
+            virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID) override;
 
             void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -129,6 +129,8 @@ namespace VMAP
             }
             virtual bool existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
+			virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID);
+
             void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 
             typedef uint32(*GetLiquidFlagsFn)(uint32 liquidType);

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -129,7 +129,7 @@ namespace VMAP
             }
             virtual bool existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
-			virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID);
+			virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID) override;
 
             void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
-* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
-*
-* This program is free software; you can redistribute it and/or modify it
-* under the terms of the GNU General Public License as published by the
-* Free Software Foundation; either version 2 of the License, or (at your
-* option) any later version.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-* more details.
-*
-* You should have received a copy of the GNU General Public License along
-* with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef _VMAPMANAGER2_H
 #define _VMAPMANAGER2_H
@@ -53,15 +53,15 @@ namespace VMAP
 
     class TC_COMMON_API ManagedModel
     {
-    public:
-        ManagedModel() : iModel(nullptr), iRefCount(0) { }
-        void setModel(WorldModel* model) { iModel = model; }
-        WorldModel* getModel() { return iModel; }
-        void incRefCount() { ++iRefCount; }
-        int decRefCount() { return --iRefCount; }
-    protected:
-        WorldModel* iModel;
-        int iRefCount;
+        public:
+            ManagedModel() : iModel(nullptr), iRefCount(0) { }
+            void setModel(WorldModel* model) { iModel = model; }
+            WorldModel* getModel() { return iModel; }
+            void incRefCount() { ++iRefCount; }
+            int decRefCount() { return --iRefCount; }
+        protected:
+            WorldModel* iModel;
+            int iRefCount;
     };
 
     typedef std::unordered_map<uint32, StaticMapTree*> InstanceTreeMap;
@@ -69,73 +69,73 @@ namespace VMAP
 
     enum DisableTypes
     {
-        VMAP_DISABLE_AREAFLAG = 0x1,
-        VMAP_DISABLE_HEIGHT = 0x2,
-        VMAP_DISABLE_LOS = 0x4,
-        VMAP_DISABLE_LIQUIDSTATUS = 0x8
+        VMAP_DISABLE_AREAFLAG       = 0x1,
+        VMAP_DISABLE_HEIGHT         = 0x2,
+        VMAP_DISABLE_LOS            = 0x4,
+        VMAP_DISABLE_LIQUIDSTATUS   = 0x8
     };
 
     class TC_COMMON_API VMapManager2 : public IVMapManager
     {
-    protected:
-        // Tree to check collision
-        ModelFileMap iLoadedModelFiles;
-        InstanceTreeMap iInstanceMapTrees;
-        bool thread_safe_environment;
-        // Mutex for iLoadedModelFiles
-        std::mutex LoadedModelFilesLock;
+        protected:
+            // Tree to check collision
+            ModelFileMap iLoadedModelFiles;
+            InstanceTreeMap iInstanceMapTrees;
+            bool thread_safe_environment;
+            // Mutex for iLoadedModelFiles
+            std::mutex LoadedModelFilesLock;
 
-        bool _loadMap(uint32 mapId, const std::string& basePath, uint32 tileX, uint32 tileY);
-        /* void _unloadMap(uint32 pMapId, uint32 x, uint32 y); */
+            bool _loadMap(uint32 mapId, const std::string& basePath, uint32 tileX, uint32 tileY);
+            /* void _unloadMap(uint32 pMapId, uint32 x, uint32 y); */
 
-        static uint32 GetLiquidFlagsDummy(uint32) { return 0; }
-        static bool IsVMAPDisabledForDummy(uint32 /*entry*/, uint8 /*flags*/) { return false; }
+            static uint32 GetLiquidFlagsDummy(uint32) { return 0; }
+            static bool IsVMAPDisabledForDummy(uint32 /*entry*/, uint8 /*flags*/) { return false; }
 
-        InstanceTreeMap::const_iterator GetMapTree(uint32 mapId) const;
+            InstanceTreeMap::const_iterator GetMapTree(uint32 mapId) const;
 
-    public:
-        // public for debug
-        G3D::Vector3 convertPositionToInternalRep(float x, float y, float z) const;
-        static std::string getMapFileName(unsigned int mapId);
+        public:
+            // public for debug
+            G3D::Vector3 convertPositionToInternalRep(float x, float y, float z) const;
+            static std::string getMapFileName(unsigned int mapId);
 
-        VMapManager2();
-        ~VMapManager2(void);
+            VMapManager2();
+            ~VMapManager2(void);
 
-        void InitializeThreadUnsafe(const std::vector<uint32>& mapIds);
-        int loadMap(const char* pBasePath, unsigned int mapId, int x, int y) override;
+            void InitializeThreadUnsafe(const std::vector<uint32>& mapIds);
+            int loadMap(const char* pBasePath, unsigned int mapId, int x, int y) override;
 
-        void unloadMap(unsigned int mapId, int x, int y) override;
-        void unloadMap(unsigned int mapId) override;
+            void unloadMap(unsigned int mapId, int x, int y) override;
+            void unloadMap(unsigned int mapId) override;
 
-        bool isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2) override;
-        /**
-        fill the hit pos and return true, if an object was hit
-        */
-        bool getObjectHitPos(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float& ry, float& rz, float modifyDist) override;
-        float getHeight(unsigned int mapId, float x, float y, float z, float maxSearchDist) override;
+            bool isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2) override ;
+            /**
+            fill the hit pos and return true, if an object was hit
+            */
+            bool getObjectHitPos(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float& ry, float& rz, float modifyDist) override;
+            float getHeight(unsigned int mapId, float x, float y, float z, float maxSearchDist) override;
 
-        bool processCommand(char* /*command*/) override { return false; } // for debug and extensions
+            bool processCommand(char* /*command*/) override { return false; } // for debug and extensions
 
-        bool getAreaInfo(unsigned int pMapId, float x, float y, float& z, uint32& flags, int32& adtId, int32& rootId, int32& groupId) const override;
-        bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 reqLiquidType, float& level, float& floor, uint32& type) const override;
+            bool getAreaInfo(unsigned int pMapId, float x, float y, float& z, uint32& flags, int32& adtId, int32& rootId, int32& groupId) const override;
+            bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 reqLiquidType, float& level, float& floor, uint32& type) const override;
 
-        WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename);
-        void releaseModelInstance(const std::string& filename);
+            WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename);
+            void releaseModelInstance(const std::string& filename);
 
-        // what's the use of this? o.O
-        virtual std::string getDirFileName(unsigned int mapId, int /*x*/, int /*y*/) const override
-        {
-            return getMapFileName(mapId);
-        }
-        virtual int existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
+            // what's the use of this? o.O
+            virtual std::string getDirFileName(unsigned int mapId, int /*x*/, int /*y*/) const override
+            {
+                return getMapFileName(mapId);
+            }
+            virtual int existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
-        void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
+            void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 
-        typedef uint32(*GetLiquidFlagsFn)(uint32 liquidType);
-        GetLiquidFlagsFn GetLiquidFlagsPtr;
+            typedef uint32(*GetLiquidFlagsFn)(uint32 liquidType);
+            GetLiquidFlagsFn GetLiquidFlagsPtr;
 
-        typedef bool(*IsVMAPDisabledForFn)(uint32 entry, uint8 flags);
-        IsVMAPDisabledForFn IsVMAPDisabledForPtr;
+            typedef bool(*IsVMAPDisabledForFn)(uint32 entry, uint8 flags);
+            IsVMAPDisabledForFn IsVMAPDisabledForPtr;
     };
 }
 

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -1,20 +1,20 @@
 /*
- * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef _VMAPMANAGER2_H
 #define _VMAPMANAGER2_H
@@ -53,15 +53,15 @@ namespace VMAP
 
     class TC_COMMON_API ManagedModel
     {
-        public:
-            ManagedModel() : iModel(nullptr), iRefCount(0) { }
-            void setModel(WorldModel* model) { iModel = model; }
-            WorldModel* getModel() { return iModel; }
-            void incRefCount() { ++iRefCount; }
-            int decRefCount() { return --iRefCount; }
-        protected:
-            WorldModel* iModel;
-            int iRefCount;
+    public:
+        ManagedModel() : iModel(nullptr), iRefCount(0) { }
+        void setModel(WorldModel* model) { iModel = model; }
+        WorldModel* getModel() { return iModel; }
+        void incRefCount() { ++iRefCount; }
+        int decRefCount() { return --iRefCount; }
+    protected:
+        WorldModel* iModel;
+        int iRefCount;
     };
 
     typedef std::unordered_map<uint32, StaticMapTree*> InstanceTreeMap;
@@ -69,73 +69,73 @@ namespace VMAP
 
     enum DisableTypes
     {
-        VMAP_DISABLE_AREAFLAG       = 0x1,
-        VMAP_DISABLE_HEIGHT         = 0x2,
-        VMAP_DISABLE_LOS            = 0x4,
-        VMAP_DISABLE_LIQUIDSTATUS   = 0x8
+        VMAP_DISABLE_AREAFLAG = 0x1,
+        VMAP_DISABLE_HEIGHT = 0x2,
+        VMAP_DISABLE_LOS = 0x4,
+        VMAP_DISABLE_LIQUIDSTATUS = 0x8
     };
 
     class TC_COMMON_API VMapManager2 : public IVMapManager
     {
-        protected:
-            // Tree to check collision
-            ModelFileMap iLoadedModelFiles;
-            InstanceTreeMap iInstanceMapTrees;
-            bool thread_safe_environment;
-            // Mutex for iLoadedModelFiles
-            std::mutex LoadedModelFilesLock;
+    protected:
+        // Tree to check collision
+        ModelFileMap iLoadedModelFiles;
+        InstanceTreeMap iInstanceMapTrees;
+        bool thread_safe_environment;
+        // Mutex for iLoadedModelFiles
+        std::mutex LoadedModelFilesLock;
 
-            bool _loadMap(uint32 mapId, const std::string& basePath, uint32 tileX, uint32 tileY);
-            /* void _unloadMap(uint32 pMapId, uint32 x, uint32 y); */
+        bool _loadMap(uint32 mapId, const std::string& basePath, uint32 tileX, uint32 tileY);
+        /* void _unloadMap(uint32 pMapId, uint32 x, uint32 y); */
 
-            static uint32 GetLiquidFlagsDummy(uint32) { return 0; }
-            static bool IsVMAPDisabledForDummy(uint32 /*entry*/, uint8 /*flags*/) { return false; }
+        static uint32 GetLiquidFlagsDummy(uint32) { return 0; }
+        static bool IsVMAPDisabledForDummy(uint32 /*entry*/, uint8 /*flags*/) { return false; }
 
-            InstanceTreeMap::const_iterator GetMapTree(uint32 mapId) const;
+        InstanceTreeMap::const_iterator GetMapTree(uint32 mapId) const;
 
-        public:
-            // public for debug
-            G3D::Vector3 convertPositionToInternalRep(float x, float y, float z) const;
-            static std::string getMapFileName(unsigned int mapId);
+    public:
+        // public for debug
+        G3D::Vector3 convertPositionToInternalRep(float x, float y, float z) const;
+        static std::string getMapFileName(unsigned int mapId);
 
-            VMapManager2();
-            ~VMapManager2(void);
+        VMapManager2();
+        ~VMapManager2(void);
 
-            void InitializeThreadUnsafe(const std::vector<uint32>& mapIds);
-            int loadMap(const char* pBasePath, unsigned int mapId, int x, int y) override;
+        void InitializeThreadUnsafe(const std::vector<uint32>& mapIds);
+        int loadMap(const char* pBasePath, unsigned int mapId, int x, int y) override;
 
-            void unloadMap(unsigned int mapId, int x, int y) override;
-            void unloadMap(unsigned int mapId) override;
+        void unloadMap(unsigned int mapId, int x, int y) override;
+        void unloadMap(unsigned int mapId) override;
 
-            bool isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2) override ;
-            /**
-            fill the hit pos and return true, if an object was hit
-            */
-            bool getObjectHitPos(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float& ry, float& rz, float modifyDist) override;
-            float getHeight(unsigned int mapId, float x, float y, float z, float maxSearchDist) override;
+        bool isInLineOfSight(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2) override;
+        /**
+        fill the hit pos and return true, if an object was hit
+        */
+        bool getObjectHitPos(unsigned int mapId, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float& ry, float& rz, float modifyDist) override;
+        float getHeight(unsigned int mapId, float x, float y, float z, float maxSearchDist) override;
 
-            bool processCommand(char* /*command*/) override { return false; } // for debug and extensions
+        bool processCommand(char* /*command*/) override { return false; } // for debug and extensions
 
-            bool getAreaInfo(unsigned int pMapId, float x, float y, float& z, uint32& flags, int32& adtId, int32& rootId, int32& groupId) const override;
-            bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 reqLiquidType, float& level, float& floor, uint32& type) const override;
+        bool getAreaInfo(unsigned int pMapId, float x, float y, float& z, uint32& flags, int32& adtId, int32& rootId, int32& groupId) const override;
+        bool GetLiquidLevel(uint32 pMapId, float x, float y, float z, uint8 reqLiquidType, float& level, float& floor, uint32& type) const override;
 
-            WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename);
-            void releaseModelInstance(const std::string& filename);
+        WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename);
+        void releaseModelInstance(const std::string& filename);
 
-            // what's the use of this? o.O
-            virtual std::string getDirFileName(unsigned int mapId, int /*x*/, int /*y*/) const override
-            {
-                return getMapFileName(mapId);
-            }
-            virtual int existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
+        // what's the use of this? o.O
+        virtual std::string getDirFileName(unsigned int mapId, int /*x*/, int /*y*/) const override
+        {
+            return getMapFileName(mapId);
+        }
+        virtual int existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
-            void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
+        void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 
-            typedef uint32(*GetLiquidFlagsFn)(uint32 liquidType);
-            GetLiquidFlagsFn GetLiquidFlagsPtr;
+        typedef uint32(*GetLiquidFlagsFn)(uint32 liquidType);
+        GetLiquidFlagsFn GetLiquidFlagsPtr;
 
-            typedef bool(*IsVMAPDisabledForFn)(uint32 entry, uint8 flags);
-            IsVMAPDisabledForFn IsVMAPDisabledForPtr;
+        typedef bool(*IsVMAPDisabledForFn)(uint32 entry, uint8 flags);
+        IsVMAPDisabledForFn IsVMAPDisabledForPtr;
     };
 }
 

--- a/src/common/Collision/Management/VMapManager2.h
+++ b/src/common/Collision/Management/VMapManager2.h
@@ -127,9 +127,7 @@ namespace VMAP
             {
                 return getMapFileName(mapId);
             }
-            virtual bool existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
-
-			virtual bool isPathAccessibleForMap(const char * _basePath, unsigned int mapID) override;
+            virtual int existsMap(const char* basePath, unsigned int mapId, int x, int y) override;
 
             void getInstanceMapTree(InstanceTreeMap &instanceMapTree);
 

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -238,35 +238,41 @@ namespace VMAP
     }
 
     //=========================================================
-
-    bool StaticMapTree::CanLoadMap(const std::string &vmapPath, uint32 mapID, uint32 tileX, uint32 tileY)
+	/* return 0 = All Good
+	*  return 1 = File not found
+	*  return 2 = Version Mismatch 
+	*  return 3 = File corruption or something else
+	*/
+    int StaticMapTree::CanLoadMap(const std::string &vmapPath, uint32 mapID, uint32 tileX, uint32 tileY)
     {
         std::string basePath = vmapPath;
         if (basePath.length() > 0 && basePath[basePath.length()-1] != '/' && basePath[basePath.length()-1] != '\\')
             basePath.push_back('/');
         std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
-        bool success = true;
+
+        int success = 0; //All Good
+
         FILE* rf = fopen(fullname.c_str(), "rb");
         if (!rf)
-            return false;
-        /// @todo check magic number when implemented...
+            return 1; //File not found
+
         char tiled;
         char chunk[8];
         if (!readChunk(rf, chunk, VMAP_MAGIC, 8) || fread(&tiled, sizeof(char), 1, rf) != 1)
         {
             fclose(rf);
-            return false;
+            return 2; //Version Mismatch 
         }
         if (tiled)
         {
             std::string tilefile = basePath + getTileFileName(mapID, tileX, tileY);
             FILE* tf = fopen(tilefile.c_str(), "rb");
             if (!tf)
-                success = false;
+                success = 3; //File corruption or something else
             else
             {
                 if (!readChunk(tf, chunk, VMAP_MAGIC, 8))
-                    success = false;
+                    success = 3; //File corruption or something else
                 fclose(tf);
             }
         }

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -250,34 +250,34 @@ namespace VMAP
             basePath.push_back('/');
         std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
 
-        int success = 0; //All Good
+        VMAP_CHECK_RESULT result = VMAP_CHECK_RESULT::VMAP_CHECK_RESULT_SUCCESS;
 
         FILE* rf = fopen(fullname.c_str(), "rb");
         if (!rf)
-            return 1; //File not found
+            return VMAP_CHECK_RESULT::VMAP_CHECK_RESULT_FILENOTFOUND;
 
         char tiled;
         char chunk[8];
         if (!readChunk(rf, chunk, VMAP_MAGIC, 8) || fread(&tiled, sizeof(char), 1, rf) != 1)
         {
             fclose(rf);
-            return 2; //Version Mismatch 
+            return VMAP_CHECK_RESULT::VMAP_CHECK_RESULT_VERSIONMISMATCH;
         }
         if (tiled)
         {
             std::string tilefile = basePath + getTileFileName(mapID, tileX, tileY);
             FILE* tf = fopen(tilefile.c_str(), "rb");
             if (!tf)
-                success = 3; //File corruption or something else
+                result = VMAP_CHECK_RESULT::VMAP_CHECK_RESULT_UNKNOWN;
             else
             {
                 if (!readChunk(tf, chunk, VMAP_MAGIC, 8))
-                    success = 3; //File corruption or something else
+                    result = VMAP_CHECK_RESULT::VMAP_CHECK_RESULT_UNKNOWN;
                 fclose(tf);
             }
         }
         fclose(rf);
-        return success;
+        return result;
     }
 
     //=========================================================

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -238,11 +238,6 @@ namespace VMAP
     }
 
     //=========================================================
-    /* return 0 = All Good
-    *  return 1 = File not found
-    *  return 2 = Version Mismatch 
-    *  return 3 = File corruption or something else
-    */
     int StaticMapTree::CanLoadMap(const std::string &vmapPath, uint32 mapID, uint32 tileX, uint32 tileY)
     {
         std::string basePath = vmapPath;

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
-* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
-*
-* This program is free software; you can redistribute it and/or modify it
-* under the terms of the GNU General Public License as published by the
-* Free Software Foundation; either version 2 of the License, or (at your
-* option) any later version.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-* more details.
-*
-* You should have received a copy of the GNU General Public License along
-* with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "MapTree.h"
 #include "ModelInstance.h"
@@ -36,15 +36,15 @@ namespace VMAP
 
     class MapRayCallback
     {
-    public:
-        MapRayCallback(ModelInstance* val) : prims(val), hit(false) { }
-        bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit = true)
-        {
-            bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit);
-            if (result)
-                hit = true;
-            return result;
-        }
+        public:
+            MapRayCallback(ModelInstance* val): prims(val), hit(false) { }
+            bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit=true)
+            {
+                bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit);
+                if (result)
+                    hit = true;
+                return result;
+            }
         bool didHit() { return hit; }
     protected:
         ModelInstance* prims;
@@ -53,36 +53,36 @@ namespace VMAP
 
     class AreaInfoCallback
     {
-    public:
-        AreaInfoCallback(ModelInstance* val) : prims(val) { }
-        void operator()(const Vector3& point, uint32 entry)
-        {
+        public:
+            AreaInfoCallback(ModelInstance* val): prims(val) { }
+            void operator()(const Vector3& point, uint32 entry)
+            {
 #ifdef VMAP_DEBUG
-            TC_LOG_DEBUG("maps", "AreaInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
+                TC_LOG_DEBUG("maps", "AreaInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
 #endif
-            prims[entry].intersectPoint(point, aInfo);
-        }
+                prims[entry].intersectPoint(point, aInfo);
+            }
 
-        ModelInstance* prims;
-        AreaInfo aInfo;
+            ModelInstance* prims;
+            AreaInfo aInfo;
     };
 
     class LocationInfoCallback
     {
-    public:
-        LocationInfoCallback(ModelInstance* val, LocationInfo &info) : prims(val), locInfo(info), result(false) { }
-        void operator()(const Vector3& point, uint32 entry)
-        {
+        public:
+            LocationInfoCallback(ModelInstance* val, LocationInfo &info): prims(val), locInfo(info), result(false) { }
+            void operator()(const Vector3& point, uint32 entry)
+            {
 #ifdef VMAP_DEBUG
-            TC_LOG_DEBUG("maps", "LocationInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
+                TC_LOG_DEBUG("maps", "LocationInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
 #endif
-            if (prims[entry].GetLocationInfo(point, locInfo))
-                result = true;
-        }
+                if (prims[entry].GetLocationInfo(point, locInfo))
+                    result = true;
+            }
 
-        ModelInstance* prims;
-        LocationInfo &locInfo;
-        bool result;
+            ModelInstance* prims;
+            LocationInfo &locInfo;
+            bool result;
     };
 
     //=========================================================
@@ -124,7 +124,7 @@ namespace VMAP
         iMapID(mapID), iIsTiled(false), iTreeValues(NULL),
         iNTreeValues(0), iBasePath(basePath)
     {
-        if (iBasePath.length() > 0 && iBasePath[iBasePath.length() - 1] != '/' && iBasePath[iBasePath.length() - 1] != '\\')
+        if (iBasePath.length() > 0 && iBasePath[iBasePath.length()-1] != '/' && iBasePath[iBasePath.length()-1] != '\\')
         {
             iBasePath.push_back('/');
         }
@@ -167,7 +167,7 @@ namespace VMAP
         if (maxDist < 1e-10f)
             return true;
         // direction with length of 1
-        G3D::Ray ray = G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1) / maxDist);
+        G3D::Ray ray = G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1)/maxDist);
         if (getIntersectionTime(ray, maxDist, true))
             return false;
 
@@ -181,7 +181,7 @@ namespace VMAP
 
     bool StaticMapTree::getObjectHitPos(const Vector3& pPos1, const Vector3& pPos2, Vector3& pResultHitPos, float pModifyDist) const
     {
-        bool result = false;
+        bool result=false;
         float maxDist = (pPos2 - pPos1).magnitude();
         // valid map coords should *never ever* produce float overflow, but this would produce NaNs too
         ASSERT(maxDist < std::numeric_limits<float>::max());
@@ -191,7 +191,7 @@ namespace VMAP
             pResultHitPos = pPos2;
             return false;
         }
-        Vector3 dir = (pPos2 - pPos1) / maxDist;              // direction with length of 1
+        Vector3 dir = (pPos2 - pPos1)/maxDist;              // direction with length of 1
         G3D::Ray ray(pPos1, dir);
         float dist = maxDist;
         if (getIntersectionTime(ray, dist, false))
@@ -238,15 +238,15 @@ namespace VMAP
     }
 
     //=========================================================
-    /* return 0 = All Good
-    *  return 1 = File not found
-    *  return 2 = Version Mismatch
-    *  return 3 = File corruption or something else
-    */
+	/* return 0 = All Good
+	*  return 1 = File not found
+	*  return 2 = Version Mismatch 
+	*  return 3 = File corruption or something else
+	*/
     int StaticMapTree::CanLoadMap(const std::string &vmapPath, uint32 mapID, uint32 tileX, uint32 tileY)
     {
         std::string basePath = vmapPath;
-        if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
+        if (basePath.length() > 0 && basePath[basePath.length()-1] != '/' && basePath[basePath.length()-1] != '\\')
             basePath.push_back('/');
         std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
 
@@ -374,7 +374,7 @@ namespace VMAP
             uint32 numSpawns = 0;
             if (result && fread(&numSpawns, sizeof(uint32), 1, tf) != 1)
                 result = false;
-            for (uint32 i = 0; i<numSpawns && result; ++i)
+            for (uint32 i=0; i<numSpawns && result; ++i)
             {
                 // read model spawns
                 ModelSpawn spawn;
@@ -444,14 +444,14 @@ namespace VMAP
             FILE* tf = fopen(tilefile.c_str(), "rb");
             if (tf)
             {
-                bool result = true;
+                bool result=true;
                 char chunk[8];
                 if (!readChunk(tf, chunk, VMAP_MAGIC, 8))
                     result = false;
                 uint32 numSpawns;
                 if (fread(&numSpawns, sizeof(uint32), 1, tf) != 1)
                     result = false;
-                for (uint32 i = 0; i<numSpawns && result; ++i)
+                for (uint32 i=0; i<numSpawns && result; ++i)
                 {
                     // read model spawns
                     ModelSpawn spawn;
@@ -469,7 +469,7 @@ namespace VMAP
                         else
                         {
                             if (!iLoadedSpawns.count(referencedNode))
-                                VMAP_ERROR_LOG("misc", "StaticMapTree::UnloadMapTile() : trying to unload non-referenced model '%s' (ID:%u)", spawn.name.c_str(), spawn.ID);
+                            VMAP_ERROR_LOG("misc", "StaticMapTree::UnloadMapTile() : trying to unload non-referenced model '%s' (ID:%u)", spawn.name.c_str(), spawn.ID);
                             else if (--iLoadedSpawns[referencedNode] == 0)
                             {
                                 iTreeValues[referencedNode].setUnloaded();

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -238,11 +238,11 @@ namespace VMAP
     }
 
     //=========================================================
-	/* return 0 = All Good
-	*  return 1 = File not found
-	*  return 2 = Version Mismatch 
-	*  return 3 = File corruption or something else
-	*/
+    /* return 0 = All Good
+    *  return 1 = File not found
+    *  return 2 = Version Mismatch 
+    *  return 3 = File corruption or something else
+    */
     int StaticMapTree::CanLoadMap(const std::string &vmapPath, uint32 mapID, uint32 tileX, uint32 tileY)
     {
         std::string basePath = vmapPath;

--- a/src/common/Collision/Maps/MapTree.cpp
+++ b/src/common/Collision/Maps/MapTree.cpp
@@ -1,20 +1,20 @@
 /*
- * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include "MapTree.h"
 #include "ModelInstance.h"
@@ -36,15 +36,15 @@ namespace VMAP
 
     class MapRayCallback
     {
-        public:
-            MapRayCallback(ModelInstance* val): prims(val), hit(false) { }
-            bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit=true)
-            {
-                bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit);
-                if (result)
-                    hit = true;
-                return result;
-            }
+    public:
+        MapRayCallback(ModelInstance* val) : prims(val), hit(false) { }
+        bool operator()(const G3D::Ray& ray, uint32 entry, float& distance, bool pStopAtFirstHit = true)
+        {
+            bool result = prims[entry].intersectRay(ray, distance, pStopAtFirstHit);
+            if (result)
+                hit = true;
+            return result;
+        }
         bool didHit() { return hit; }
     protected:
         ModelInstance* prims;
@@ -53,36 +53,36 @@ namespace VMAP
 
     class AreaInfoCallback
     {
-        public:
-            AreaInfoCallback(ModelInstance* val): prims(val) { }
-            void operator()(const Vector3& point, uint32 entry)
-            {
+    public:
+        AreaInfoCallback(ModelInstance* val) : prims(val) { }
+        void operator()(const Vector3& point, uint32 entry)
+        {
 #ifdef VMAP_DEBUG
-                TC_LOG_DEBUG("maps", "AreaInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
+            TC_LOG_DEBUG("maps", "AreaInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
 #endif
-                prims[entry].intersectPoint(point, aInfo);
-            }
+            prims[entry].intersectPoint(point, aInfo);
+        }
 
-            ModelInstance* prims;
-            AreaInfo aInfo;
+        ModelInstance* prims;
+        AreaInfo aInfo;
     };
 
     class LocationInfoCallback
     {
-        public:
-            LocationInfoCallback(ModelInstance* val, LocationInfo &info): prims(val), locInfo(info), result(false) { }
-            void operator()(const Vector3& point, uint32 entry)
-            {
+    public:
+        LocationInfoCallback(ModelInstance* val, LocationInfo &info) : prims(val), locInfo(info), result(false) { }
+        void operator()(const Vector3& point, uint32 entry)
+        {
 #ifdef VMAP_DEBUG
-                TC_LOG_DEBUG("maps", "LocationInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
+            TC_LOG_DEBUG("maps", "LocationInfoCallback: trying to intersect '%s'", prims[entry].name.c_str());
 #endif
-                if (prims[entry].GetLocationInfo(point, locInfo))
-                    result = true;
-            }
+            if (prims[entry].GetLocationInfo(point, locInfo))
+                result = true;
+        }
 
-            ModelInstance* prims;
-            LocationInfo &locInfo;
-            bool result;
+        ModelInstance* prims;
+        LocationInfo &locInfo;
+        bool result;
     };
 
     //=========================================================
@@ -124,7 +124,7 @@ namespace VMAP
         iMapID(mapID), iIsTiled(false), iTreeValues(NULL),
         iNTreeValues(0), iBasePath(basePath)
     {
-        if (iBasePath.length() > 0 && iBasePath[iBasePath.length()-1] != '/' && iBasePath[iBasePath.length()-1] != '\\')
+        if (iBasePath.length() > 0 && iBasePath[iBasePath.length() - 1] != '/' && iBasePath[iBasePath.length() - 1] != '\\')
         {
             iBasePath.push_back('/');
         }
@@ -167,7 +167,7 @@ namespace VMAP
         if (maxDist < 1e-10f)
             return true;
         // direction with length of 1
-        G3D::Ray ray = G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1)/maxDist);
+        G3D::Ray ray = G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1) / maxDist);
         if (getIntersectionTime(ray, maxDist, true))
             return false;
 
@@ -181,7 +181,7 @@ namespace VMAP
 
     bool StaticMapTree::getObjectHitPos(const Vector3& pPos1, const Vector3& pPos2, Vector3& pResultHitPos, float pModifyDist) const
     {
-        bool result=false;
+        bool result = false;
         float maxDist = (pPos2 - pPos1).magnitude();
         // valid map coords should *never ever* produce float overflow, but this would produce NaNs too
         ASSERT(maxDist < std::numeric_limits<float>::max());
@@ -191,7 +191,7 @@ namespace VMAP
             pResultHitPos = pPos2;
             return false;
         }
-        Vector3 dir = (pPos2 - pPos1)/maxDist;              // direction with length of 1
+        Vector3 dir = (pPos2 - pPos1) / maxDist;              // direction with length of 1
         G3D::Ray ray(pPos1, dir);
         float dist = maxDist;
         if (getIntersectionTime(ray, dist, false))
@@ -238,15 +238,15 @@ namespace VMAP
     }
 
     //=========================================================
-	/* return 0 = All Good
-	*  return 1 = File not found
-	*  return 2 = Version Mismatch 
-	*  return 3 = File corruption or something else
-	*/
+    /* return 0 = All Good
+    *  return 1 = File not found
+    *  return 2 = Version Mismatch
+    *  return 3 = File corruption or something else
+    */
     int StaticMapTree::CanLoadMap(const std::string &vmapPath, uint32 mapID, uint32 tileX, uint32 tileY)
     {
         std::string basePath = vmapPath;
-        if (basePath.length() > 0 && basePath[basePath.length()-1] != '/' && basePath[basePath.length()-1] != '\\')
+        if (basePath.length() > 0 && basePath[basePath.length() - 1] != '/' && basePath[basePath.length() - 1] != '\\')
             basePath.push_back('/');
         std::string fullname = basePath + VMapManager2::getMapFileName(mapID);
 
@@ -374,7 +374,7 @@ namespace VMAP
             uint32 numSpawns = 0;
             if (result && fread(&numSpawns, sizeof(uint32), 1, tf) != 1)
                 result = false;
-            for (uint32 i=0; i<numSpawns && result; ++i)
+            for (uint32 i = 0; i<numSpawns && result; ++i)
             {
                 // read model spawns
                 ModelSpawn spawn;
@@ -444,14 +444,14 @@ namespace VMAP
             FILE* tf = fopen(tilefile.c_str(), "rb");
             if (tf)
             {
-                bool result=true;
+                bool result = true;
                 char chunk[8];
                 if (!readChunk(tf, chunk, VMAP_MAGIC, 8))
                     result = false;
                 uint32 numSpawns;
                 if (fread(&numSpawns, sizeof(uint32), 1, tf) != 1)
                     result = false;
-                for (uint32 i=0; i<numSpawns && result; ++i)
+                for (uint32 i = 0; i<numSpawns && result; ++i)
                 {
                     // read model spawns
                     ModelSpawn spawn;
@@ -469,7 +469,7 @@ namespace VMAP
                         else
                         {
                             if (!iLoadedSpawns.count(referencedNode))
-                            VMAP_ERROR_LOG("misc", "StaticMapTree::UnloadMapTile() : trying to unload non-referenced model '%s' (ID:%u)", spawn.name.c_str(), spawn.ID);
+                                VMAP_ERROR_LOG("misc", "StaticMapTree::UnloadMapTile() : trying to unload non-referenced model '%s' (ID:%u)", spawn.name.c_str(), spawn.ID);
                             else if (--iLoadedSpawns[referencedNode] == 0)
                             {
                                 iTreeValues[referencedNode].setUnloaded();

--- a/src/common/Collision/Maps/MapTree.h
+++ b/src/common/Collision/Maps/MapTree.h
@@ -1,20 +1,20 @@
 /*
- * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
- * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program. If not, see <http://www.gnu.org/licenses/>.
- */
+* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+*
+* This program is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the
+* Free Software Foundation; either version 2 of the License, or (at your
+* option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifndef _MAPTREE_H
 #define _MAPTREE_H
@@ -31,7 +31,7 @@ namespace VMAP
 
     struct TC_COMMON_API LocationInfo
     {
-        LocationInfo(): hitInstance(nullptr), hitModel(nullptr), ground_Z(-G3D::finf()) { }
+        LocationInfo() : hitInstance(nullptr), hitModel(nullptr), ground_Z(-G3D::finf()) { }
         const ModelInstance* hitInstance;
         const GroupModel* hitModel;
         float ground_Z;
@@ -41,55 +41,55 @@ namespace VMAP
     {
         typedef std::unordered_map<uint32, bool> loadedTileMap;
         typedef std::unordered_map<uint32, uint32> loadedSpawnMap;
-        private:
-            uint32 iMapID;
-            bool iIsTiled;
-            BIH iTree;
-            ModelInstance* iTreeValues; // the tree entries
-            uint32 iNTreeValues;
+    private:
+        uint32 iMapID;
+        bool iIsTiled;
+        BIH iTree;
+        ModelInstance* iTreeValues; // the tree entries
+        uint32 iNTreeValues;
 
-            // Store all the map tile idents that are loaded for that map
-            // some maps are not splitted into tiles and we have to make sure, not removing the map before all tiles are removed
-            // empty tiles have no tile file, hence map with bool instead of just a set (consistency check)
-            loadedTileMap iLoadedTiles;
-            // stores <tree_index, reference_count> to invalidate tree values, unload map, and to be able to report errors
-            loadedSpawnMap iLoadedSpawns;
-            std::string iBasePath;
+        // Store all the map tile idents that are loaded for that map
+        // some maps are not splitted into tiles and we have to make sure, not removing the map before all tiles are removed
+        // empty tiles have no tile file, hence map with bool instead of just a set (consistency check)
+        loadedTileMap iLoadedTiles;
+        // stores <tree_index, reference_count> to invalidate tree values, unload map, and to be able to report errors
+        loadedSpawnMap iLoadedSpawns;
+        std::string iBasePath;
 
-        private:
-            bool getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit) const;
-            //bool containsLoadedMapTile(unsigned int pTileIdent) const { return(iLoadedMapTiles.containsKey(pTileIdent)); }
-        public:
-            static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
-            static uint32 packTileID(uint32 tileX, uint32 tileY) { return tileX<<16 | tileY; }
-            static void unpackTileID(uint32 ID, uint32 &tileX, uint32 &tileY) { tileX = ID>>16; tileY = ID&0xFF; }
-            static int CanLoadMap(const std::string &basePath, uint32 mapID, uint32 tileX, uint32 tileY);
+    private:
+        bool getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit) const;
+        //bool containsLoadedMapTile(unsigned int pTileIdent) const { return(iLoadedMapTiles.containsKey(pTileIdent)); }
+    public:
+        static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
+        static uint32 packTileID(uint32 tileX, uint32 tileY) { return tileX << 16 | tileY; }
+        static void unpackTileID(uint32 ID, uint32 &tileX, uint32 &tileY) { tileX = ID >> 16; tileY = ID & 0xFF; }
+        static int CanLoadMap(const std::string &basePath, uint32 mapID, uint32 tileX, uint32 tileY);
 
-            StaticMapTree(uint32 mapID, const std::string &basePath);
-            ~StaticMapTree();
+        StaticMapTree(uint32 mapID, const std::string &basePath);
+        ~StaticMapTree();
 
-            bool isInLineOfSight(const G3D::Vector3& pos1, const G3D::Vector3& pos2) const;
-            bool getObjectHitPos(const G3D::Vector3& pos1, const G3D::Vector3& pos2, G3D::Vector3& pResultHitPos, float pModifyDist) const;
-            float getHeight(const G3D::Vector3& pPos, float maxSearchDist) const;
-            bool getAreaInfo(G3D::Vector3 &pos, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const;
-            bool GetLocationInfo(const G3D::Vector3 &pos, LocationInfo &info) const;
+        bool isInLineOfSight(const G3D::Vector3& pos1, const G3D::Vector3& pos2) const;
+        bool getObjectHitPos(const G3D::Vector3& pos1, const G3D::Vector3& pos2, G3D::Vector3& pResultHitPos, float pModifyDist) const;
+        float getHeight(const G3D::Vector3& pPos, float maxSearchDist) const;
+        bool getAreaInfo(G3D::Vector3 &pos, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const;
+        bool GetLocationInfo(const G3D::Vector3 &pos, LocationInfo &info) const;
 
-            bool InitMap(const std::string &fname, VMapManager2* vm);
-            void UnloadMap(VMapManager2* vm);
-            bool LoadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
-            void UnloadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
-            bool isTiled() const { return iIsTiled; }
-            uint32 numLoadedTiles() const { return uint32(iLoadedTiles.size()); }
-            void getModelInstances(ModelInstance* &models, uint32 &count);
+        bool InitMap(const std::string &fname, VMapManager2* vm);
+        void UnloadMap(VMapManager2* vm);
+        bool LoadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
+        void UnloadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
+        bool isTiled() const { return iIsTiled; }
+        uint32 numLoadedTiles() const { return uint32(iLoadedTiles.size()); }
+        void getModelInstances(ModelInstance* &models, uint32 &count);
 
-        private:
-            StaticMapTree(StaticMapTree const& right) = delete;
-            StaticMapTree& operator=(StaticMapTree const& right) = delete;
+    private:
+        StaticMapTree(StaticMapTree const& right) = delete;
+        StaticMapTree& operator=(StaticMapTree const& right) = delete;
     };
 
     struct TC_COMMON_API AreaInfo
     {
-        AreaInfo(): result(false), ground_Z(-G3D::finf()), flags(0), adtId(0),
+        AreaInfo() : result(false), ground_Z(-G3D::finf()), flags(0), adtId(0),
             rootId(0), groupId(0) { }
         bool result;
         float ground_Z;

--- a/src/common/Collision/Maps/MapTree.h
+++ b/src/common/Collision/Maps/MapTree.h
@@ -63,7 +63,7 @@ namespace VMAP
             static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
             static uint32 packTileID(uint32 tileX, uint32 tileY) { return tileX<<16 | tileY; }
             static void unpackTileID(uint32 ID, uint32 &tileX, uint32 &tileY) { tileX = ID>>16; tileY = ID&0xFF; }
-            static bool CanLoadMap(const std::string &basePath, uint32 mapID, uint32 tileX, uint32 tileY);
+            static int CanLoadMap(const std::string &basePath, uint32 mapID, uint32 tileX, uint32 tileY);
 
             StaticMapTree(uint32 mapID, const std::string &basePath);
             ~StaticMapTree();

--- a/src/common/Collision/Maps/MapTree.h
+++ b/src/common/Collision/Maps/MapTree.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
-* Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
-*
-* This program is free software; you can redistribute it and/or modify it
-* under the terms of the GNU General Public License as published by the
-* Free Software Foundation; either version 2 of the License, or (at your
-* option) any later version.
-*
-* This program is distributed in the hope that it will be useful, but WITHOUT
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-* more details.
-*
-* You should have received a copy of the GNU General Public License along
-* with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+ * Copyright (C) 2005-2010 MaNGOS <http://getmangos.com/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef _MAPTREE_H
 #define _MAPTREE_H
@@ -31,7 +31,7 @@ namespace VMAP
 
     struct TC_COMMON_API LocationInfo
     {
-        LocationInfo() : hitInstance(nullptr), hitModel(nullptr), ground_Z(-G3D::finf()) { }
+        LocationInfo(): hitInstance(nullptr), hitModel(nullptr), ground_Z(-G3D::finf()) { }
         const ModelInstance* hitInstance;
         const GroupModel* hitModel;
         float ground_Z;
@@ -41,55 +41,55 @@ namespace VMAP
     {
         typedef std::unordered_map<uint32, bool> loadedTileMap;
         typedef std::unordered_map<uint32, uint32> loadedSpawnMap;
-    private:
-        uint32 iMapID;
-        bool iIsTiled;
-        BIH iTree;
-        ModelInstance* iTreeValues; // the tree entries
-        uint32 iNTreeValues;
+        private:
+            uint32 iMapID;
+            bool iIsTiled;
+            BIH iTree;
+            ModelInstance* iTreeValues; // the tree entries
+            uint32 iNTreeValues;
 
-        // Store all the map tile idents that are loaded for that map
-        // some maps are not splitted into tiles and we have to make sure, not removing the map before all tiles are removed
-        // empty tiles have no tile file, hence map with bool instead of just a set (consistency check)
-        loadedTileMap iLoadedTiles;
-        // stores <tree_index, reference_count> to invalidate tree values, unload map, and to be able to report errors
-        loadedSpawnMap iLoadedSpawns;
-        std::string iBasePath;
+            // Store all the map tile idents that are loaded for that map
+            // some maps are not splitted into tiles and we have to make sure, not removing the map before all tiles are removed
+            // empty tiles have no tile file, hence map with bool instead of just a set (consistency check)
+            loadedTileMap iLoadedTiles;
+            // stores <tree_index, reference_count> to invalidate tree values, unload map, and to be able to report errors
+            loadedSpawnMap iLoadedSpawns;
+            std::string iBasePath;
 
-    private:
-        bool getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit) const;
-        //bool containsLoadedMapTile(unsigned int pTileIdent) const { return(iLoadedMapTiles.containsKey(pTileIdent)); }
-    public:
-        static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
-        static uint32 packTileID(uint32 tileX, uint32 tileY) { return tileX << 16 | tileY; }
-        static void unpackTileID(uint32 ID, uint32 &tileX, uint32 &tileY) { tileX = ID >> 16; tileY = ID & 0xFF; }
-        static int CanLoadMap(const std::string &basePath, uint32 mapID, uint32 tileX, uint32 tileY);
+        private:
+            bool getIntersectionTime(const G3D::Ray& pRay, float &pMaxDist, bool pStopAtFirstHit) const;
+            //bool containsLoadedMapTile(unsigned int pTileIdent) const { return(iLoadedMapTiles.containsKey(pTileIdent)); }
+        public:
+            static std::string getTileFileName(uint32 mapID, uint32 tileX, uint32 tileY);
+            static uint32 packTileID(uint32 tileX, uint32 tileY) { return tileX<<16 | tileY; }
+            static void unpackTileID(uint32 ID, uint32 &tileX, uint32 &tileY) { tileX = ID>>16; tileY = ID&0xFF; }
+            static int CanLoadMap(const std::string &basePath, uint32 mapID, uint32 tileX, uint32 tileY);
 
-        StaticMapTree(uint32 mapID, const std::string &basePath);
-        ~StaticMapTree();
+            StaticMapTree(uint32 mapID, const std::string &basePath);
+            ~StaticMapTree();
 
-        bool isInLineOfSight(const G3D::Vector3& pos1, const G3D::Vector3& pos2) const;
-        bool getObjectHitPos(const G3D::Vector3& pos1, const G3D::Vector3& pos2, G3D::Vector3& pResultHitPos, float pModifyDist) const;
-        float getHeight(const G3D::Vector3& pPos, float maxSearchDist) const;
-        bool getAreaInfo(G3D::Vector3 &pos, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const;
-        bool GetLocationInfo(const G3D::Vector3 &pos, LocationInfo &info) const;
+            bool isInLineOfSight(const G3D::Vector3& pos1, const G3D::Vector3& pos2) const;
+            bool getObjectHitPos(const G3D::Vector3& pos1, const G3D::Vector3& pos2, G3D::Vector3& pResultHitPos, float pModifyDist) const;
+            float getHeight(const G3D::Vector3& pPos, float maxSearchDist) const;
+            bool getAreaInfo(G3D::Vector3 &pos, uint32 &flags, int32 &adtId, int32 &rootId, int32 &groupId) const;
+            bool GetLocationInfo(const G3D::Vector3 &pos, LocationInfo &info) const;
 
-        bool InitMap(const std::string &fname, VMapManager2* vm);
-        void UnloadMap(VMapManager2* vm);
-        bool LoadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
-        void UnloadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
-        bool isTiled() const { return iIsTiled; }
-        uint32 numLoadedTiles() const { return uint32(iLoadedTiles.size()); }
-        void getModelInstances(ModelInstance* &models, uint32 &count);
+            bool InitMap(const std::string &fname, VMapManager2* vm);
+            void UnloadMap(VMapManager2* vm);
+            bool LoadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
+            void UnloadMapTile(uint32 tileX, uint32 tileY, VMapManager2* vm);
+            bool isTiled() const { return iIsTiled; }
+            uint32 numLoadedTiles() const { return uint32(iLoadedTiles.size()); }
+            void getModelInstances(ModelInstance* &models, uint32 &count);
 
-    private:
-        StaticMapTree(StaticMapTree const& right) = delete;
-        StaticMapTree& operator=(StaticMapTree const& right) = delete;
+        private:
+            StaticMapTree(StaticMapTree const& right) = delete;
+            StaticMapTree& operator=(StaticMapTree const& right) = delete;
     };
 
     struct TC_COMMON_API AreaInfo
     {
-        AreaInfo() : result(false), ground_Z(-G3D::finf()), flags(0), adtId(0),
+        AreaInfo(): result(false), ground_Z(-G3D::finf()), flags(0), adtId(0),
             rootId(0), groupId(0) { }
         bool result;
         float ground_Z;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -104,31 +104,31 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
 
 bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
-	if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
-	{
-		if (vmgr->isMapLoadingEnabled())
-		{
-			bool exists = vmgr->isPathAccessibleForMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid);
-			if (!exists)
-			{
-				std::string name = vmgr->getDirFileName(mapid, gx, gy);
-				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
-				return false;
-			}
-
-
-			bool couldLoad = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy); //TODO: This method should be renamed to 'canLoadMap' because, it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
-			if (!couldLoad)
-			{
-				std::string name = vmgr->getDirFileName(mapid, gx, gy);
-				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "This may be due a mismatch version, lack of permissions or a corrupted file. Try re-extracting the maps again.");
-				return false;
-			}
-		}
-	}
-	return true;
+    if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
+    {
+        if (vmgr->isMapLoadingEnabled())
+        {
+            bool exists = vmgr->isPathAccessibleForMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid);
+            if (!exists)
+            {
+                std::string name = vmgr->getDirFileName(mapid, gx, gy);
+                TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
+                return false;
+            }
+            
+            
+            bool couldLoad = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy); //TODO: This method should be renamed to 'canLoadMap' because, it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
+            if (!couldLoad)
+            {
+                std::string name = vmgr->getDirFileName(mapid, gx, gy);
+                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "This may be due a mismatch version, lack of permissions or a corrupted file. Try re-extracting the maps again.");
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 void Map::LoadMMap(int gx, int gy)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -102,24 +102,33 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
     return ret;
 }
 
-bool Map::ExistVMap(uint32 mapid, int gx, int gy)
+bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
-    if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
-    {
-        if (vmgr->isMapLoadingEnabled())
-        {
-            bool exists = vmgr->existsMap((sWorld->GetDataPath()+ "vmaps").c_str(),  mapid, gx, gy);
-            if (!exists)
-            {
-                std::string name = vmgr->getDirFileName(mapid, gx, gy);
-                TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath()+"vmaps/"+name).c_str());
-                TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath()+"vmaps/").c_str());
-                return false;
-            }
-        }
-    }
+	if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
+	{
+		if (vmgr->isMapLoadingEnabled())
+		{
+			bool exists = vmgr->isPathAccessibleForMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid);
+			if (!exists)
+			{
+				std::string name = vmgr->getDirFileName(mapid, gx, gy);
+				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
+				return false;
+			}
 
-    return true;
+
+			bool couldLoad = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy); //TODO: This method should be renamed to 'canLoadMap' because, it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
+			if (!couldLoad)
+			{
+				std::string name = vmgr->getDirFileName(mapid, gx, gy);
+				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "This may be due a mismatch version, lack of permissions or a corrupted file. Try re-extracting the maps again.");
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 void Map::LoadMMap(int gx, int gy)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -108,23 +108,26 @@ bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed Exist
 	{
 		if (vmgr->isMapLoadingEnabled())
 		{
-			bool exists = vmgr->isPathAccessibleForMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid);
-			if (!exists)
+			int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
+			std::string name = vmgr->getDirFileName(mapid, gx, gy);
+			switch (result)
 			{
-				std::string name = vmgr->getDirFileName(mapid, gx, gy);
+			case 1:
 				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
 				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
 				return false;
-			}
 
-
-			bool couldLoad = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy); //TODO: This method should be renamed to 'canLoadMap' because, it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
-			if (!couldLoad)
-			{
-				std::string name = vmgr->getDirFileName(mapid, gx, gy);
+			case 2:
 				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "This may be due a mismatch version, lack of permissions or a corrupted file. Try re-extracting the maps again.");
+				TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module."); 
 				return false;
+
+			case 3:
+				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "This could be caused by a corrupted file or not lack of permissions to access the file. Try re-extracting the maps again.");
+				return false;
+			default:
+				break;
 			}
 		}
 	}

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -104,34 +104,34 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
 
 bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
-    if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
-    {
-        if (vmgr->isMapLoadingEnabled())
-        {
-            int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
-            std::string name = vmgr->getDirFileName(mapid, gx, gy);
-            switch (result)
-            {
-            case 1:
-                TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-                TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
-                return false;
+	if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
+	{
+		if (vmgr->isMapLoadingEnabled())
+		{
+			int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
+			std::string name = vmgr->getDirFileName(mapid, gx, gy);
+			switch (result)
+			{
+			case 1:
+				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
+				return false;
 
-            case 2:
-                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-                TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module."); 
-                return false;
+			case 2:
+				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module."); 
+				return false;
 
-            case 3:
-                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-                TC_LOG_ERROR("maps", "This could be caused by a corrupted file or not lack of permissions to access the file. Try re-extracting the maps again.");
-                return false;
-            default:
-                break;
-            }
-        }
-    }
-    return true;
+			case 3:
+				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+				TC_LOG_ERROR("maps", "This could be caused by a corrupted file or not lack of permissions to access the file. Try re-extracting the maps again.");
+				return false;
+			default:
+				break;
+			}
+		}
+	}
+	return true;
 }
 
 void Map::LoadMMap(int gx, int gy)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -102,7 +102,7 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
     return ret;
 }
 
-bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
+bool Map::ExistVMap(uint32 mapid, int gx, int gy) // Note: Should be renamed from ExistVMap to CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
     if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
     {
@@ -110,24 +110,26 @@ bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed Exist
         {
             int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
             std::string name = vmgr->getDirFileName(mapid, gx, gy);
+
             switch (result)
             {
-            case 1:
+            case VMAP::VMAP_CHECK_RESULT_SUCCESS:
+                break;
+
+            case VMAP::VMAP_CHECK_RESULT_FILENOTFOUND:
                 TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
                 TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
                 return false;
 
-            case 2:
+            case VMAP::VMAP_CHECK_RESULT_VERSIONMISMATCH:
                 TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
                 TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module.");
                 return false;
 
-            case 3:
+            case VMAP::VMAP_CHECK_RESULT_UNKNOWN:
                 TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
                 TC_LOG_ERROR("maps", "This could be caused by a corrupted file or lack of permissions to access the file. Try re-extracting the maps again.");
                 return false;
-            default:
-                break;
             }
         }
     }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -104,34 +104,34 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
 
 bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
-	if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
-	{
-		if (vmgr->isMapLoadingEnabled())
-		{
-			int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
-			std::string name = vmgr->getDirFileName(mapid, gx, gy);
-			switch (result)
-			{
-			case 1:
-				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
-				return false;
+    if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
+    {
+        if (vmgr->isMapLoadingEnabled())
+        {
+            int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
+            std::string name = vmgr->getDirFileName(mapid, gx, gy);
+            switch (result)
+            {
+            case 1:
+                TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
+                return false;
 
-			case 2:
-				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module."); 
-				return false;
+            case 2:
+                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module.");
+                return false;
 
-			case 3:
-				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "This could be caused by a corrupted file or not lack of permissions to access the file. Try re-extracting the maps again.");
-				return false;
-			default:
-				break;
-			}
-		}
-	}
-	return true;
+            case 3:
+                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "This could be caused by a corrupted file or lack of permissions to access the file. Try re-extracting the maps again.");
+                return false;
+            default:
+                break;
+            }
+        }
+    }
+    return true;
 }
 
 void Map::LoadMMap(int gx, int gy)

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -104,34 +104,34 @@ bool Map::ExistMap(uint32 mapid, int gx, int gy)
 
 bool Map::ExistVMap(uint32 mapid, int gx, int gy) //TODO Should be renamed ExistVMap -> CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded!
 {
-	if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
-	{
-		if (vmgr->isMapLoadingEnabled())
-		{
-			int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
-			std::string name = vmgr->getDirFileName(mapid, gx, gy);
-			switch (result)
-			{
-			case 1:
-				TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
-				return false;
+    if (VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager())
+    {
+        if (vmgr->isMapLoadingEnabled())
+        {
+            int result = vmgr->existsMap((sWorld->GetDataPath() + "vmaps").c_str(), mapid, gx, gy);
+            std::string name = vmgr->getDirFileName(mapid, gx, gy);
+            switch (result)
+            {
+            case 1:
+                TC_LOG_ERROR("maps", "VMap file '%s' does not exist", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "Please place VMAP-files (*.vmtree and *.vmtile) in the vmap-directory (%s), or correct the DataDir setting in your worldserver.conf file.", (sWorld->GetDataPath() + "vmaps/").c_str());
+                return false;
 
-			case 2:
-				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module."); 
-				return false;
+            case 2:
+                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "This is because the version of the VMap file and the version of this module are different, please re-extract the maps with the tools compiled with this module."); 
+                return false;
 
-			case 3:
-				TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
-				TC_LOG_ERROR("maps", "This could be caused by a corrupted file or not lack of permissions to access the file. Try re-extracting the maps again.");
-				return false;
-			default:
-				break;
-			}
-		}
-	}
-	return true;
+            case 3:
+                TC_LOG_ERROR("maps", "VMap file '%s' couldn't be loaded", (sWorld->GetDataPath() + "vmaps/" + name).c_str());
+                TC_LOG_ERROR("maps", "This could be caused by a corrupted file or not lack of permissions to access the file. Try re-extracting the maps again.");
+                return false;
+            default:
+                break;
+            }
+        }
+    }
+    return true;
 }
 
 void Map::LoadMMap(int gx, int gy)


### PR DESCRIPTION
Added a more descriptive message in case the Vmap file fails to load due
being outdated or if it is infact on in the folder.

[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  When a Vmap file cant be loaded because of incompatibility, it should say it, instead of saying that the file does not exist, otherwise you may think it is a filesystem /permission problems.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #18431


**Tests performed:** (Does it build, tested in-game, etc.)
Builds, no in-game modifications done. Works as expected.

**Known issues and TODO list:** (add/remove lines as needed)

***Function names should be corrected:***
- [Game->Maps->Map.cpp, line 105] Function should be renamed from ExistVMap to CheckVMap or something else that implies that it not only checks if file exist but also if it can be loaded! 
- [Game->Maps->Map.cpp, line 121] This method should be renamed to 'canLoadMap'. it is not clear when it couldn't load because didn't exist or couldn't load because of file mismatch!
