### PR TITLE
Core/GameObject: GAMEOBJECT_TYPE_GOOBER not casting spells

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -660,19 +660,6 @@ void GameObject::Update(uint32 diff)
             //if Gameobject should cast spell, then this, but some GOs (type = 10) should be destroyed
             if (GetGoType() == GAMEOBJECT_TYPE_GOOBER)
             {
-                uint32 spellId = GetGOInfo()->goober.spell;
-
-                if (spellId)
-                {
-                    for (GuidSet::const_iterator it = m_unique_users.begin(); it != m_unique_users.end(); ++it)
-                        // m_unique_users can contain only player GUIDs
-                        if (Player* owner = ObjectAccessor::GetPlayer(*this, *it))
-                            owner->CastSpell(owner, spellId, false);
-
-                    m_unique_users.clear();
-                    m_usetimes = 0;
-                }
-
                 SetGoState(GO_STATE_READY);
 
                 //any return here in case battleground traps
@@ -1263,6 +1250,10 @@ void GameObject::SwitchDoorOrButton(bool activate, bool alternative /* = false *
 
 void GameObject::Use(Unit* user)
 {
+    // we cannot use go with not selectable flags
+    if (HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE))
+        return;
+
     // by default spell caster is user
     Unit* spellCaster = user;
     uint32 spellId = 0;
@@ -1405,6 +1396,10 @@ void GameObject::Use(Unit* user)
         {
             GameObjectTemplate const* info = GetGOInfo();
 
+            // Goober cannot be used with this flag, skip
+            if (HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE))
+                return;
+
             if (Player* player = user->ToPlayer())
             {
                 if (info->goober.pageID)                    // show page...
@@ -1448,20 +1443,23 @@ void GameObject::Use(Unit* user)
             if (uint32 trapEntry = info->goober.linkedTrap)
                 TriggeringLinkedGameObject(trapEntry, user);
 
-            SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
-            SetLootState(GO_ACTIVATED, user);
+            if (info->GetAutoCloseTime())
+            {
+                SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
+                SetLootState(GO_ACTIVATED, user);
+                if (!info->goober.customAnim)
+                    SetGoState(GO_STATE_ACTIVE);
+            }
 
             // this appear to be ok, however others exist in addition to this that should have custom (ex: 190510, 188692, 187389)
             if (info->goober.customAnim)
                 SendCustomAnim(GetGoAnimProgress());
-            else
-                SetGoState(GO_STATE_ACTIVE);
 
             m_cooldownTime = time(NULL) + info->GetAutoCloseTime();
 
             // cast this spell later if provided
             spellId = info->goober.spell;
-            spellCaster = nullptr;
+            spellCaster = user;
 
             break;
         }


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:** **Description:** Every gameobject with type 10 (GAMEOBJECT_TYPE_GOOBER) with spell id in data10 field should cast a spell when you click on it.

**Current behaviour:** The spell isn't cast

**Expected behaviour:** The gameobject should cast its spell

**Steps to reproduce the problem:**

1. Just find any gameobject in game with type 10 and data10 field different from 0 (you can run this query to find them): `SELECT * FROM gameobject_template WHERE TYPE = 10 AND data10 > 0;`
2. Right click on it and you will see that the object doesn't cast the spell (for some gameobject you can only open it)

https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Entities/GameObject/GameObject.cpp#L1464 : `spellCaster = nullptr;`

Why is the spellCaster set to nullptr?

https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Entities/GameObject/GameObject.cpp#L1887-L1890
```c++
    if (spellCaster)
        spellCaster->CastSpell(user, spellInfo, triggered);
    else
CastSpell(user, spellId);
```

I tried adding comment to `spellCaster = nullptr;` and it works and it also works if you change the line 
`CastSpell(user, spellId);` to `user->CastSpell(user, spellId);`

**Target branch(es):** master

**Issues addressed:** Closes #18752

**Tests performed:** Tested in game and it works with no crashes.

**Known issues and TODO list:**
Nothing (I think), please check if something is missing.