### PR TITLE
Core/Movement: Fix Scatter Shot issue on moving players - cleaner approach 

### DIFF
--- a/src/server/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/server/game/AI/PlayerAI/PlayerAI.cpp
@@ -1300,7 +1300,7 @@ void SimpleCharmedPlayerAI::UpdateAI(const uint32 diff)
             _forceFacing = true;
         }
 
-        if (me->IsStopped() && !me->HasUnitState(UNIT_STATE_CANNOT_TURN))
+        if (!me->HasUnitState(UNIT_STATE_MOVING) && !me->HasUnitState(UNIT_STATE_CANNOT_TURN))
         {
             float targetAngle = me->GetAngle(target);
             if (_forceFacing || fabs(me->GetOrientation() - targetAngle) > 0.4f)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -504,6 +504,10 @@ void Unit::UpdateSplineMovement(uint32 t_diff)
 
 void Unit::UpdateSplinePosition()
 {
+    // this method could be called on players. players usually do not have a movespline initialized. the following condition is therefore needed.
+    if (!movespline->Initialized())
+        return;
+
     static uint32 const positionUpdateDelay = 400;
 
     m_movesplineTimer.Reset(positionUpdateDelay);
@@ -11056,13 +11060,15 @@ void Unit::StopMoving()
     ClearUnitState(UNIT_STATE_MOVING);
 
     // not need send any packets if not in world or not moving
-    if (!IsInWorld() || movespline->Finalized())
+    if (!IsInWorld() || !isMoving())
         return;
 
     // Update position now since Stop does not start a new movement that can be updated later
-    UpdateSplinePosition();
+    if(!movespline->Finalized())
+        UpdateSplinePosition();
     Movement::MoveSplineInit init(this);
     init.Stop();
+    RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
 }
 
 void Unit::SendMovementFlagUpdate(bool self /* = false */)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11055,12 +11055,12 @@ void Unit::SendPetAIReaction(ObjectGuid guid)
 
 ///----------End of Pet responses methods----------
 
-void Unit::StopMoving()
+void Unit::StopMoving(bool force /* = false */)
 {
     ClearUnitState(UNIT_STATE_MOVING);
 
     // not need send any packets if not in world or not moving
-    if (!IsInWorld() || !isMoving())
+    if ( !force && (!IsInWorld() || !isMoving()) )
         return;
 
     // Update position now since Stop does not start a new movement that can be updated later

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13851,7 +13851,7 @@ void Unit::SetInFront(WorldObject const* target)
 
 void Unit::SetFacingTo(float ori, bool force)
 {
-    if (!force && !IsStopped())
+    if (!force && isMoving())
         return;
 
     Movement::MoveSplineInit init(this);
@@ -13865,7 +13865,7 @@ void Unit::SetFacingTo(float ori, bool force)
 void Unit::SetFacingToObject(WorldObject const* object, bool force)
 {
     // do not face when already moving
-    if (!force && !IsStopped())
+    if (!force && isMoving())
         return;
 
     /// @todo figure out under what conditions creature will move towards object instead of facing it where it currently is.

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2087,7 +2087,6 @@ class TC_GAME_API Unit : public WorldObject
         MotionMaster* GetMotionMaster() { return i_motionMaster; }
         const MotionMaster* GetMotionMaster() const { return i_motionMaster; }
 
-        bool IsStopped() const { return !(HasUnitState(UNIT_STATE_MOVING)); }
         void StopMoving();
 
         void AddUnitMovementFlag(uint32 f) { m_movementInfo.flags |= f; }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2087,7 +2087,7 @@ class TC_GAME_API Unit : public WorldObject
         MotionMaster* GetMotionMaster() { return i_motionMaster; }
         const MotionMaster* GetMotionMaster() const { return i_motionMaster; }
 
-        void StopMoving();
+        void StopMoving(bool force = false);
 
         void AddUnitMovementFlag(uint32 f) { m_movementInfo.flags |= f; }
         void RemoveUnitMovementFlag(uint32 f) { m_movementInfo.flags &= ~f; }

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -30,7 +30,7 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* unit)
     unit->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED);
     unit->GetPosition(i_x, i_y, i_z);
 
-    if (!unit->IsAlive() || unit->IsStopped())
+    if (!unit->IsAlive() || !unit->isMoving())
         return;
 
     unit->StopMoving();
@@ -42,7 +42,7 @@ void ConfusedMovementGenerator<T>::DoReset(T* unit)
 {
     i_nextMoveTime.Reset(0);
 
-    if (!unit->IsAlive() || unit->IsStopped())
+    if (!unit->IsAlive() || !unit->isMoving())
         return;
 
     unit->StopMoving();

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -30,10 +30,11 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* unit)
     unit->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED);
     unit->GetPosition(i_x, i_y, i_z);
 
-    if (!unit->IsAlive() || !unit->isMoving())
+    if (!unit->IsAlive())
         return;
 
-    unit->StopMoving();
+    unit->SetFacingTo(frand(0.0f, 2 * static_cast<float>(M_PI)), true);
+    unit->ClearUnitState(UNIT_STATE_MOVING);
     unit->AddUnitState(UNIT_STATE_CONFUSED_MOVE);
 }
 
@@ -102,7 +103,7 @@ void ConfusedMovementGenerator<Player>::DoFinalize(Player* unit)
 {
     unit->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED);
     unit->ClearUnitState(UNIT_STATE_CONFUSED | UNIT_STATE_CONFUSED_MOVE);
-    unit->StopMoving();
+    unit->StopMoving(true);
 }
 
 template<>
@@ -110,6 +111,7 @@ void ConfusedMovementGenerator<Creature>::DoFinalize(Creature* unit)
 {
     unit->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED);
     unit->ClearUnitState(UNIT_STATE_CONFUSED | UNIT_STATE_CONFUSED_MOVE);
+    unit->StopMoving(true);
     if (unit->GetVictim())
         unit->SetTarget(unit->EnsureVictim()->GetGUID());
 }

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
@@ -31,13 +31,13 @@ void IdleMovementGenerator::Initialize(Unit* owner)
 
 void IdleMovementGenerator::Reset(Unit* owner)
 {
-    if (!owner->IsStopped())
+    if (owner->isMoving())
         owner->StopMoving();
 }
 
 void RotateMovementGenerator::Initialize(Unit* owner)
 {
-    if (!owner->IsStopped())
+    if (owner->isMoving())
         owner->StopMoving();
 
     if (owner->GetVictim())

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -30,7 +30,7 @@
 template<class T>
 void PointMovementGenerator<T>::DoInitialize(T* unit)
 {
-    if (!unit->IsStopped())
+    if (unit->isMoving())
         unit->StopMoving();
 
     unit->AddUnitState(UNIT_STATE_ROAMING|UNIT_STATE_ROAMING_MOVE);
@@ -95,7 +95,7 @@ void PointMovementGenerator<T>::DoFinalize(T* unit)
 template<class T>
 void PointMovementGenerator<T>::DoReset(T* unit)
 {
-    if (!unit->IsStopped())
+    if (unit->isMoving())
         unit->StopMoving();
 
     unit->AddUnitState(UNIT_STATE_ROAMING|UNIT_STATE_ROAMING_MOVE);

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -151,7 +151,7 @@ bool TargetedMovementGeneratorMedium<T, D>::DoUpdate(T* owner, uint32 time_diff)
     // prevent movement while casting spells with cast time or channel time
     if (owner->IsMovementPreventedByCasting())
     {
-        if (!owner->IsStopped())
+        if (owner->isMoving())
             owner->StopMoving();
         return true;
     }

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -212,7 +212,7 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* creature, uint32 di
         if (!creature->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) || !creature->GetTransGUID())
             creature->SetHomePosition(creature->GetPosition());
 
-        if (creature->IsStopped())
+        if (!creature->HasUnitState(UNIT_STATE_MOVING))
             Stop(sWorld->getIntConfig(CONFIG_CREATURE_STOP_FOR_PLAYER));
         else if (creature->movespline->Finalized())
         {

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -65,7 +65,7 @@ namespace Movement
         // there is a big chance that current position is unknown if current state is not finalized, need compute it
         // this also allows CalculatePath spline position and update map position in much greater intervals
         // Don't compute for transport movement if the unit is in a motion between two transports
-        if (!move_spline.Finalized() && move_spline.onTransport == transport)
+        if (move_spline.Initialized() && !move_spline.Finalized() && move_spline.onTransport == transport)
             real_position = move_spline.ComputePosition();
         else
         {
@@ -135,12 +135,12 @@ namespace Movement
         MoveSpline& move_spline = *unit->movespline;
 
         // No need to stop if we are not moving
-        if (move_spline.Finalized())
+        if (!unit->isMoving())
             return;
 
         bool transport = unit->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && unit->GetTransGUID();
         Location loc;
-        if (move_spline.onTransport == transport)
+        if (move_spline.Initialized() && !move_spline.Finalized() && move_spline.onTransport == transport)
             loc = move_spline.ComputePosition();
         else
         {


### PR DESCRIPTION
Cleaner approach to https://github.com/TrinityCore/TrinityCore/pull/18336

The first commit is sufficient as a fix on its own (and as you can see, it does not actually touch the Confused MoveGen code). In the second commit I try to make Confused MoveGen more retail like but it's minor changes.

The general idea of the fix is that the methods Unit::IsStopped() and Unit::StopMoving() should now work properly on player-moved units, which was not the case until now.

The PR is ready to be reviewed and potentially merged. However, the changes here have much broader implications than in the first PR, so extensive testing is needed.

**Target branch(es):**

- [X] 3.3.5

**Issues addressed:** Closes #  https://github.com/TrinityCore/TrinityCore/issues/15952

**Tests performed:** Tested IG. Works against moving players.

**Known issues and TODO list:** Nothing that I'm aware of.