### PR TITLE
Game/Mapscripts: Implement SCRIPT_COMMAND_MOVEMENT

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -109,6 +109,7 @@ std::string GetScriptCommandName(ScriptCommands command)
         case SCRIPT_COMMAND_MODEL: res = "SCRIPT_COMMAND_MODEL"; break;
         case SCRIPT_COMMAND_CLOSE_GOSSIP: res = "SCRIPT_COMMAND_CLOSE_GOSSIP"; break;
         case SCRIPT_COMMAND_PLAYMOVIE: res = "SCRIPT_COMMAND_PLAYMOVIE"; break;
+        case SCRIPT_COMMAND_MOVEMENT: res = "SCRIPT_COMMAND_MOVEMENT"; break;
         default:
         {
             char sz[32];

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -114,7 +114,8 @@ enum ScriptCommands
     SCRIPT_COMMAND_EQUIP                 = 31,               // soucre = Creature, datalong = equipment id
     SCRIPT_COMMAND_MODEL                 = 32,               // source = Creature, datalong = model id
     SCRIPT_COMMAND_CLOSE_GOSSIP          = 33,               // source = Player
-    SCRIPT_COMMAND_PLAYMOVIE             = 34                // source = Player, datalong = movie id
+    SCRIPT_COMMAND_PLAYMOVIE             = 34,               // source = Player, datalong = movie id
+    SCRIPT_COMMAND_MOVEMENT              = 35                // soucre = Creature, datalong = MovementType, datalong2 = MovementDistance (spawndist f.ex.), dataint = pathid
 };
 
 // Benchmarked: Faster than std::unordered_map (insert/find)
@@ -363,6 +364,13 @@ struct ScriptInfo
         {
             uint32 MovieID;         // datalong
         } PlayMovie;
+
+        struct                       // SCRIPT_COMMAND_MOVEMENT (35)
+        {
+            uint32 MovementType;     // datalong
+            uint32 MovementDistance; // datalong2
+            int32  Path;             // dataint
+        } Movement;
     };
 
     std::string GetDebugInfo() const;

--- a/src/server/game/Maps/MapScripts.cpp
+++ b/src/server/game/Maps/MapScripts.cpp
@@ -872,6 +872,28 @@ void Map::ScriptsProcess()
                     player->SendMovieStart(step.script->PlayMovie.MovieID);
                 break;
 
+            case SCRIPT_COMMAND_MOVEMENT:
+                // Source must be Creature.                
+                if (Creature* cSource = _GetScriptCreature(source, true, step.script))
+                {
+                    if (!cSource->IsAlive())
+                        return;
+
+                    cSource->GetMotionMaster()->MovementExpired();
+                    cSource->GetMotionMaster()->MoveIdle();
+
+                    switch (step.script->Movement.MovementType)
+                    {
+                        case RANDOM_MOTION_TYPE:
+                            cSource->GetMotionMaster()->MoveRandom((float)step.script->Movement.MovementDistance);
+                            break;
+                        case WAYPOINT_MOTION_TYPE:
+                            cSource->GetMotionMaster()->MovePath(step.script->Movement.Path, false);
+                            break;
+                    }
+                }
+                break;
+
             default:
                 TC_LOG_ERROR("scripts", "Unknown script command %s.", step.script->GetDebugInfo().c_str());
                 break;


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  We can now use randommovement and waypoint movement for a creature

Examplescript:

```sql
SET @MAXGUID := 919; 
SET @SCRIPTID := 8014900; 
DELETE FROM `waypoint_scripts` WHERE `id` IN (@SCRIPTID+0);
INSERT INTO `waypoint_scripts` (`id`, `delay`, `command`, `datalong`, `datalong2`, `dataint`, `x`, `y`, `z`, `o`, `guid`) VALUES 
(@SCRIPTID+0, 1, 35, 1, 5, 0, 0, 0, 0, 0, (@MAXGUID := @MAXGUID + 1)),
(@SCRIPTID+0, 15, 35, 2, 0, 801490, 0, 0, 0, 0, (@MAXGUID := @MAXGUID + 1));

SET @NPC := 80149;
SET @PATH := @NPC * 10;
UPDATE `creature` SET `spawndist`=0,`MovementType`=2 WHERE `guid`=@NPC;
DELETE FROM `creature_addon` WHERE `guid`=@NPC;
INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
DELETE FROM `waypoint_data` WHERE `id`=@PATH;
INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`, `orientation`, `delay`, `move_type`, `action`) VALUES
(@PATH, 1, -9008.89, -320.603, 75.8279, 2.8812, 1000, 1, 0),                                                               
(@PATH, 2, -8981.22, -335.138, 73.3474, 5.82645, 0, 1, 0),                                                               
(@PATH, 3, -8946.51, -338.891, 71.1134, 5.82409, 0, 1, 0),                                                               
(@PATH, 4, -8912.77, -352.085, 72.5823, 5.88143, 0, 1, 0),                                                               
(@PATH, 5, -8881.49, -355.84, 73.1462, 6.17595, 0, 1, 0),                                                               
(@PATH, 6, -8910.65, -346.602, 71.1023, 2.81837, 0, 0, 0),                                                               
(@PATH, 7, -8883.13, -352.739, 72.9499, 2.75397, 0, 0, 0),                                                               
(@PATH, 8, -8911.38, -347.166, 71.3269, 2.95582, 0, 0, 0),                                                               
(@PATH, 9, -8947.63, -337.566, 70.9275, 2.87728, 0, 0, 0),                                                               
(@PATH, 10, -9008.89, -320.603, 75.8279, 2.8812, 20000, 0, @SCRIPTID);

UPDATE `waypoint_data` SET `action_chance`=100 WHERE `action` IN (@SCRIPTID);
```

So the creature will be able to move the path 801490, then after reaching the last point it will change to randommovement for 14 seconds and loads the old path 801490 after that again. We can now also load different paths. This fix is a small mini version of https://github.com/TrinityCore/TrinityCore/issues/18873. After the system in https://github.com/TrinityCore/TrinityCore/issues/18873 was implemented correctly we can drop mapscripts.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [X] master

**Tests performed:** (Does it build, tested in-game, etc.)
yes and yes

<!---
**DEPRECATION NOTICE** Instead of creating new PRs to the (old) 6.x branch, make sure the target branch is **master** instead of 6.x.
**NOTE** Enable the setting "[√] Allow edits from maintainers." when creating your pull request (if not enabled already).
**NOTE** If this PR __only__ contains SQL files, open a new issue instead and post or link the SQL there.
**SUGGESTION** When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
-->