### PR TITLE
Core/Scripts Fix issue with Lady Deathwhisper's door

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -213,6 +213,7 @@ class boss_lady_deathwhisper : public CreatureScript
 
             void Reset() override
             {
+                _Reset();
                 Initialize();
                 _phase = PHASE_ONE;
                 DoCastSelf(SPELL_SHADOW_CHANNELING);


### PR DESCRIPTION
**Changes proposed:**

-  Add _Reset() call to Reset() hook, to properly open and close the door

**Target branch(es):** 3.3.5/master
- [x] 3.3.5

**Issues addressed:** Closes #18966

**Tests performed:** Built and tested