### PR TITLE
Core/Auth: Use QueryCallbackProcessor insted boost::optional.

### DIFF
--- a/src/server/authserver/Server/AuthSession.h
+++ b/src/server/authserver/Server/AuthSession.h
@@ -23,7 +23,7 @@
 #include "ByteBuffer.h"
 #include "Socket.h"
 #include "BigNumber.h"
-#include "QueryCallback.h"
+#include "QueryCallbackProcessor.h"
 #include <memory>
 #include <boost/asio/ip/tcp.hpp>
 
@@ -102,7 +102,7 @@ private:
     uint16 _build;
     uint8 _expversion;
 
-    Optional<QueryCallback> _queryCallback;
+    QueryCallbackProcessor _queryProcessor;
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
Fixes build for boost 1.55.0

[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  Failure to use boost::optional because it not support move semantic on 1.55.0
- Add IsEmpty() method to QueryCallbackProcessor