### PR TITLE
Core/Database: Prepared statement parameter preallocation

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.h
+++ b/src/server/database/Database/DatabaseWorkerPool.h
@@ -255,7 +255,7 @@ class DatabaseWorkerPool
         //! This object is not tied to the prepared statement on the MySQL context yet until execution.
         PreparedStatement* GetPreparedStatement(PreparedStatementIndex index)
         {
-            return new PreparedStatement(index);
+            return new PreparedStatement(index, _preparedStatementSize[index]);
         }
 
         //! Apply escape string'ing for current collation. (utf8)
@@ -294,6 +294,7 @@ class DatabaseWorkerPool
         std::unique_ptr<ProducerConsumerQueue<SQLOperation*>> _queue;
         std::array<std::vector<std::unique_ptr<T>>, IDX_SIZE> _connections;
         std::unique_ptr<MySQLConnectionInfo> _connectionInfo;
+        std::vector<uint8> _preparedStatementSize;
         uint8 _async_threads, _synch_threads;
 };
 

--- a/src/server/database/Database/MySQLConnection.h
+++ b/src/server/database/Database/MySQLConnection.h
@@ -35,17 +35,6 @@ enum ConnectionFlags
     CONNECTION_BOTH = CONNECTION_ASYNC | CONNECTION_SYNCH
 };
 
-struct PreparedStatementInfo
-{
-    PreparedStatementInfo(std::string const& queryString, ConnectionFlags connFlags) :
-        Query(queryString), Flags(connFlags) { }
-
-    std::string const Query;
-    ConnectionFlags const Flags; // sync/async
-};
-
-typedef std::unordered_map<uint32 /*index*/, PreparedStatementInfo> PreparedStatementContainer;
-
 struct TC_DATABASE_API MySQLConnectionInfo
 {
     explicit MySQLConnectionInfo(std::string const& infoString)
@@ -125,8 +114,9 @@ class TC_DATABASE_API MySQLConnection
         virtual void DoPrepareStatements() = 0;
 
     protected:
-        std::vector<std::unique_ptr<MySQLPreparedStatement>> m_stmts; //! PreparedStatements storage
-        PreparedStatementContainer           m_queries;       //! Query storage
+        typedef std::vector<std::unique_ptr<MySQLPreparedStatement>> PreparedStatementContainer;
+
+        PreparedStatementContainer           m_stmts;         //! PreparedStatements storage
         bool                                 m_reconnecting;  //! Are we reconnecting?
         bool                                 m_prepareError;  //! Was there any error while preparing statements?
 

--- a/src/server/database/Database/PreparedStatement.cpp
+++ b/src/server/database/Database/PreparedStatement.cpp
@@ -183,8 +183,8 @@ void PreparedStatement::setNull(const uint8 index)
     statement_data[index].type = TYPE_NULL;
 }
 
-MySQLPreparedStatement::MySQLPreparedStatement(MYSQL_STMT* stmt, std::string const& queryString) :
-m_stmt(nullptr), m_Mstmt(stmt), m_bind(nullptr), m_queryString(queryString)
+MySQLPreparedStatement::MySQLPreparedStatement(MYSQL_STMT* stmt, std::string queryString) :
+m_stmt(nullptr), m_Mstmt(stmt), m_bind(nullptr), m_queryString(std::move(queryString))
 {
     /// Initialize variable parameters
     m_paramCount = mysql_stmt_param_count(stmt);

--- a/src/server/database/Database/PreparedStatement.cpp
+++ b/src/server/database/Database/PreparedStatement.cpp
@@ -19,15 +19,15 @@
 #include "MySQLConnection.h"
 #include "Log.h"
 
-PreparedStatement::PreparedStatement(uint32 index) :
-m_stmt(NULL),
-m_index(index) { }
+PreparedStatement::PreparedStatement(uint32 index, uint8 capacity) :
+m_stmt(nullptr), m_index(index), statement_data(capacity) { }
 
 PreparedStatement::~PreparedStatement() { }
 
-void PreparedStatement::BindParameters()
+void PreparedStatement::BindParameters(MySQLPreparedStatement* stmt)
 {
-    ASSERT (m_stmt);
+    ASSERT(stmt);
+    m_stmt = stmt;
 
     uint8 i = 0;
     for (; i < statement_data.size(); i++)
@@ -35,51 +35,51 @@ void PreparedStatement::BindParameters()
         switch (statement_data[i].type)
         {
             case TYPE_BOOL:
-                m_stmt->setBool(i, statement_data[i].data.boolean);
+                stmt->setBool(i, statement_data[i].data.boolean);
                 break;
             case TYPE_UI8:
-                m_stmt->setUInt8(i, statement_data[i].data.ui8);
+                stmt->setUInt8(i, statement_data[i].data.ui8);
                 break;
             case TYPE_UI16:
-                m_stmt->setUInt16(i, statement_data[i].data.ui16);
+                stmt->setUInt16(i, statement_data[i].data.ui16);
                 break;
             case TYPE_UI32:
-                m_stmt->setUInt32(i, statement_data[i].data.ui32);
+                stmt->setUInt32(i, statement_data[i].data.ui32);
                 break;
             case TYPE_I8:
-                m_stmt->setInt8(i, statement_data[i].data.i8);
+                stmt->setInt8(i, statement_data[i].data.i8);
                 break;
             case TYPE_I16:
-                m_stmt->setInt16(i, statement_data[i].data.i16);
+                stmt->setInt16(i, statement_data[i].data.i16);
                 break;
             case TYPE_I32:
-                m_stmt->setInt32(i, statement_data[i].data.i32);
+                stmt->setInt32(i, statement_data[i].data.i32);
                 break;
             case TYPE_UI64:
-                m_stmt->setUInt64(i, statement_data[i].data.ui64);
+                stmt->setUInt64(i, statement_data[i].data.ui64);
                 break;
             case TYPE_I64:
-                m_stmt->setInt64(i, statement_data[i].data.i64);
+                stmt->setInt64(i, statement_data[i].data.i64);
                 break;
             case TYPE_FLOAT:
-                m_stmt->setFloat(i, statement_data[i].data.f);
+                stmt->setFloat(i, statement_data[i].data.f);
                 break;
             case TYPE_DOUBLE:
-                m_stmt->setDouble(i, statement_data[i].data.d);
+                stmt->setDouble(i, statement_data[i].data.d);
                 break;
             case TYPE_STRING:
-                m_stmt->setBinary(i, statement_data[i].binary, true);
+                stmt->setBinary(i, statement_data[i].binary, true);
                 break;
             case TYPE_BINARY:
-                m_stmt->setBinary(i, statement_data[i].binary, false);
+                stmt->setBinary(i, statement_data[i].binary, false);
                 break;
             case TYPE_NULL:
-                m_stmt->setNull(i);
+                stmt->setNull(i);
                 break;
         }
     }
     #ifdef _DEBUG
-    if (i < m_stmt->m_paramCount)
+    if (i < stmt->m_paramCount)
         TC_LOG_WARN("sql.sql", "[WARNING]: BindParameters() for statement %u did not bind all allocated parameters", m_index);
     #endif
 }
@@ -87,108 +87,84 @@ void PreparedStatement::BindParameters()
 //- Bind to buffer
 void PreparedStatement::setBool(const uint8 index, const bool value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.boolean = value;
     statement_data[index].type = TYPE_BOOL;
 }
 
 void PreparedStatement::setUInt8(const uint8 index, const uint8 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.ui8 = value;
     statement_data[index].type = TYPE_UI8;
 }
 
 void PreparedStatement::setUInt16(const uint8 index, const uint16 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.ui16 = value;
     statement_data[index].type = TYPE_UI16;
 }
 
 void PreparedStatement::setUInt32(const uint8 index, const uint32 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.ui32 = value;
     statement_data[index].type = TYPE_UI32;
 }
 
 void PreparedStatement::setUInt64(const uint8 index, const uint64 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.ui64 = value;
     statement_data[index].type = TYPE_UI64;
 }
 
 void PreparedStatement::setInt8(const uint8 index, const int8 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.i8 = value;
     statement_data[index].type = TYPE_I8;
 }
 
 void PreparedStatement::setInt16(const uint8 index, const int16 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.i16 = value;
     statement_data[index].type = TYPE_I16;
 }
 
 void PreparedStatement::setInt32(const uint8 index, const int32 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.i32 = value;
     statement_data[index].type = TYPE_I32;
 }
 
 void PreparedStatement::setInt64(const uint8 index, const int64 value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.i64 = value;
     statement_data[index].type = TYPE_I64;
 }
 
 void PreparedStatement::setFloat(const uint8 index, const float value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.f = value;
     statement_data[index].type = TYPE_FLOAT;
 }
 
 void PreparedStatement::setDouble(const uint8 index, const double value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].data.d = value;
     statement_data[index].type = TYPE_DOUBLE;
 }
 
 void PreparedStatement::setString(const uint8 index, const std::string& value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].binary.resize(value.length() + 1);
     memcpy(statement_data[index].binary.data(), value.c_str(), value.length() + 1);
     statement_data[index].type = TYPE_STRING;
@@ -196,18 +172,14 @@ void PreparedStatement::setString(const uint8 index, const std::string& value)
 
 void PreparedStatement::setBinary(const uint8 index, const std::vector<uint8>& value)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index + 1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].binary = value;
     statement_data[index].type = TYPE_BINARY;
 }
 
 void PreparedStatement::setNull(const uint8 index)
 {
-    if (index >= statement_data.size())
-        statement_data.resize(index+1);
-
+    ASSERT(index < statement_data.size());
     statement_data[index].type = TYPE_NULL;
 }
 
@@ -258,13 +230,12 @@ static bool ParamenterIndexAssertFail(uint32 stmtIndex, uint8 index, uint32 para
 }
 
 //- Bind on mysql level
-bool MySQLPreparedStatement::CheckValidIndex(uint8 index)
+void MySQLPreparedStatement::AssertValidIndex(uint8 index)
 {
     ASSERT(index < m_paramCount || ParamenterIndexAssertFail(m_stmt->m_index, index, m_paramCount));
 
     if (m_paramsSet[index])
-        TC_LOG_WARN("sql.sql", "[WARNING] Prepared Statement (id: %u) trying to bind value on already bound index (%u).", m_stmt->m_index, index);
-    return true;
+        TC_LOG_ERROR("sql.sql", "[ERROR] Prepared Statement (id: %u) trying to bind value on already bound index (%u).", m_stmt->m_index, index);
 }
 
 void MySQLPreparedStatement::setBool(const uint8 index, const bool value)
@@ -274,7 +245,7 @@ void MySQLPreparedStatement::setBool(const uint8 index, const bool value)
 
 void MySQLPreparedStatement::setUInt8(const uint8 index, const uint8 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_TINY, &value, sizeof(uint8), true);
@@ -282,7 +253,7 @@ void MySQLPreparedStatement::setUInt8(const uint8 index, const uint8 value)
 
 void MySQLPreparedStatement::setUInt16(const uint8 index, const uint16 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_SHORT, &value, sizeof(uint16), true);
@@ -290,7 +261,7 @@ void MySQLPreparedStatement::setUInt16(const uint8 index, const uint16 value)
 
 void MySQLPreparedStatement::setUInt32(const uint8 index, const uint32 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_LONG, &value, sizeof(uint32), true);
@@ -298,7 +269,7 @@ void MySQLPreparedStatement::setUInt32(const uint8 index, const uint32 value)
 
 void MySQLPreparedStatement::setUInt64(const uint8 index, const uint64 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_LONGLONG, &value, sizeof(uint64), true);
@@ -306,7 +277,7 @@ void MySQLPreparedStatement::setUInt64(const uint8 index, const uint64 value)
 
 void MySQLPreparedStatement::setInt8(const uint8 index, const int8 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_TINY, &value, sizeof(int8), false);
@@ -314,7 +285,7 @@ void MySQLPreparedStatement::setInt8(const uint8 index, const int8 value)
 
 void MySQLPreparedStatement::setInt16(const uint8 index, const int16 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_SHORT, &value, sizeof(int16), false);
@@ -322,7 +293,7 @@ void MySQLPreparedStatement::setInt16(const uint8 index, const int16 value)
 
 void MySQLPreparedStatement::setInt32(const uint8 index, const int32 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_LONG, &value, sizeof(int32), false);
@@ -330,7 +301,7 @@ void MySQLPreparedStatement::setInt32(const uint8 index, const int32 value)
 
 void MySQLPreparedStatement::setInt64(const uint8 index, const int64 value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_LONGLONG, &value, sizeof(int64), false);
@@ -338,7 +309,7 @@ void MySQLPreparedStatement::setInt64(const uint8 index, const int64 value)
 
 void MySQLPreparedStatement::setFloat(const uint8 index, const float value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_FLOAT, &value, sizeof(float), (value > 0.0f));
@@ -346,7 +317,7 @@ void MySQLPreparedStatement::setFloat(const uint8 index, const float value)
 
 void MySQLPreparedStatement::setDouble(const uint8 index, const double value)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     setValue(param, MYSQL_TYPE_DOUBLE, &value, sizeof(double), (value > 0.0f));
@@ -354,7 +325,7 @@ void MySQLPreparedStatement::setDouble(const uint8 index, const double value)
 
 void MySQLPreparedStatement::setBinary(const uint8 index, const std::vector<uint8>& value, bool isString)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     uint32 len = uint32(value.size());
@@ -376,7 +347,7 @@ void MySQLPreparedStatement::setBinary(const uint8 index, const std::vector<uint
 
 void MySQLPreparedStatement::setNull(const uint8 index)
 {
-    CheckValidIndex(index);
+    AssertValidIndex(index);
     m_paramsSet[index] = true;
     MYSQL_BIND* param = &m_bind[index];
     param->buffer_type = MYSQL_TYPE_NULL;

--- a/src/server/database/Database/PreparedStatement.cpp
+++ b/src/server/database/Database/PreparedStatement.cpp
@@ -183,10 +183,8 @@ void PreparedStatement::setNull(const uint8 index)
     statement_data[index].type = TYPE_NULL;
 }
 
-MySQLPreparedStatement::MySQLPreparedStatement(MYSQL_STMT* stmt) :
-m_stmt(NULL),
-m_Mstmt(stmt),
-m_bind(NULL)
+MySQLPreparedStatement::MySQLPreparedStatement(MYSQL_STMT* stmt, std::string const& queryString) :
+m_stmt(nullptr), m_Mstmt(stmt), m_bind(nullptr), m_queryString(queryString)
 {
     /// Initialize variable parameters
     m_paramCount = mysql_stmt_param_count(stmt);
@@ -372,9 +370,9 @@ void MySQLPreparedStatement::setValue(MYSQL_BIND* param, enum_field_types type, 
     memcpy(param->buffer, value, len);
 }
 
-std::string MySQLPreparedStatement::getQueryString(std::string const& sqlPattern) const
+std::string MySQLPreparedStatement::getQueryString() const
 {
-    std::string queryString = sqlPattern;
+    std::string queryString(m_queryString);
 
     size_t pos = 0;
     for (uint32 i = 0; i < m_stmt->statement_data.size(); i++)

--- a/src/server/database/Database/PreparedStatement.h
+++ b/src/server/database/Database/PreparedStatement.h
@@ -119,7 +119,7 @@ class TC_DATABASE_API MySQLPreparedStatement
     friend class PreparedStatement;
 
     public:
-        MySQLPreparedStatement(MYSQL_STMT* stmt);
+        MySQLPreparedStatement(MYSQL_STMT* stmt, std::string const& queryString);
         ~MySQLPreparedStatement();
 
         void setBool(const uint8 index, const bool value);
@@ -144,7 +144,7 @@ class TC_DATABASE_API MySQLPreparedStatement
         PreparedStatement* m_stmt;
         void ClearParameters();
         void AssertValidIndex(uint8 index);
-        std::string getQueryString(std::string const& sqlPattern) const;
+        std::string getQueryString() const;
 
     private:
         void setValue(MYSQL_BIND* param, enum_field_types type, const void* value, uint32 len, bool isUnsigned);
@@ -154,6 +154,7 @@ class TC_DATABASE_API MySQLPreparedStatement
         uint32 m_paramCount;
         std::vector<bool> m_paramsSet;
         MYSQL_BIND* m_bind;
+        std::string const m_queryString;
 
         MySQLPreparedStatement(MySQLPreparedStatement const& right) = delete;
         MySQLPreparedStatement& operator=(MySQLPreparedStatement const& right) = delete;

--- a/src/server/database/Database/PreparedStatement.h
+++ b/src/server/database/Database/PreparedStatement.h
@@ -119,7 +119,7 @@ class TC_DATABASE_API MySQLPreparedStatement
     friend class PreparedStatement;
 
     public:
-        MySQLPreparedStatement(MYSQL_STMT* stmt, std::string const& queryString);
+        MySQLPreparedStatement(MYSQL_STMT* stmt, std::string queryString);
         ~MySQLPreparedStatement();
 
         void setBool(const uint8 index, const bool value);

--- a/src/server/database/Database/PreparedStatement.h
+++ b/src/server/database/Database/PreparedStatement.h
@@ -78,7 +78,7 @@ class TC_DATABASE_API PreparedStatement
     friend class MySQLConnection;
 
     public:
-        explicit PreparedStatement(uint32 index);
+        PreparedStatement(uint32 index, uint8 capacity);
         ~PreparedStatement();
 
         void setBool(const uint8 index, const bool value);
@@ -97,12 +97,14 @@ class TC_DATABASE_API PreparedStatement
         void setNull(const uint8 index);
 
     protected:
-        void BindParameters();
+        void BindParameters(MySQLPreparedStatement* stmt);
 
     protected:
         MySQLPreparedStatement* m_stmt;
         uint32 m_index;
-        std::vector<PreparedStatementData> statement_data;    //- Buffer of parameters, not tied to MySQL in any way yet
+
+        //- Buffer of parameters, not tied to MySQL in any way yet
+        std::vector<PreparedStatementData> statement_data;
 
         PreparedStatement(PreparedStatement const& right) = delete;
         PreparedStatement& operator=(PreparedStatement const& right) = delete;
@@ -134,12 +136,14 @@ class TC_DATABASE_API MySQLPreparedStatement
         void setBinary(const uint8 index, const std::vector<uint8>& value, bool isString);
         void setNull(const uint8 index);
 
+        uint32 GetParameterCount() const { return m_paramCount; }
+
     protected:
         MYSQL_STMT* GetSTMT() { return m_Mstmt; }
         MYSQL_BIND* GetBind() { return m_bind; }
         PreparedStatement* m_stmt;
         void ClearParameters();
-        bool CheckValidIndex(uint8 index);
+        void AssertValidIndex(uint8 index);
         std::string getQueryString(std::string const& sqlPattern) const;
 
     private:


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  Rename CheckValidIndex -> AssertValidIndex
-  Cached prepared size on the worker pool as it's shared among all connections (original implementation cached this info on every connection, so there were multiple instances, needlessly wasting memory)
 - Removed cached query data map, only was used for logging and sql query is now saved on the MySQLPreparedStatement proper
- Cached size is now passed on to constructor, added assertions to check out of range parameter indices

Based on https://github.com/Naios/TrinityCore/commit/7d13a6c6a3e95bf97ad41278176d7a54e86c9921

**Target branch(es):** 3.3.5

**Issues addressed:** Ref #14274


**Tests performed:** Builds and works as intended
