### PR TITLE
Core/Misc: do not kick GameMasters from instances

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21589,7 +21589,7 @@ uint32 Player::GetMaxPersonalArenaRatingRequirement(uint32 minarenaslot) const
 void Player::UpdateHomebindTime(uint32 time)
 {
     // GMs never get homebind timer online
-    if (m_InstanceValid || IsGameMaster())
+    if (m_InstanceValid || CanBeGameMaster())
     {
         if (m_HomebindTimer)                                 // instance valid, but timer not reset
         {

--- a/src/server/game/Maps/MapInstanced.cpp
+++ b/src/server/game/Maps/MapInstanced.cpp
@@ -153,7 +153,11 @@ Map* MapInstanced::CreateInstanceForPlayer(const uint32 mapId, Player* player, u
             if (loginInstanceId) // if the player has a saved instance id on login, we either use this instance or relocate him out (return null)
             {
                 map = FindInstanceMap(loginInstanceId);
-                return (map && map->GetId() == GetId()) ? map : nullptr; // is this check necessary? or does MapInstanced only find instances of itself?
+                if (map && map->GetId() == GetId()) // is this check necessary? or does MapInstanced only find instances of itself?
+                    return map;
+
+                if (!player->CanBeGameMaster())
+                    return nullptr;
             }
 
             InstanceGroupBind* groupBind = nullptr;

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -146,7 +146,7 @@ Map::EnterState MapManager::PlayerCannotEnter(uint32 mapid, Player* player, bool
         return Map::CANNOT_ENTER_DIFFICULTY_UNAVAILABLE;
 
     //Bypass checks for GMs
-    if (player->IsGameMaster())
+    if (player->CanBeGameMaster())
         return Map::CAN_ENTER;
 
     char const* mapName = entry->name[player->GetSession()->GetSessionDbcLocale()];


### PR DESCRIPTION
**Changes proposed:**

-  Even when GameMaster mode is deactivated, do not remove the GM from the instance (happens after a server shutdown/restart)
-  Always allow GMs to enter raid instances without GM mode active and/or raid group

**Target branch(es):** 3.3.5/master
- [x] 3.3.5

**Issues addressed:** Closes #18228

**Tests performed:** Built and tested with a GM character