### PR TITLE
Core/Object: Fix LoS issue

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1261,7 +1261,7 @@ Position WorldObject::GetHitSpherePointFor(Position const& dest) const
 {
     G3D::Vector3 vThis(GetPositionX(), GetPositionY(), GetPositionZ());
     G3D::Vector3 vObj(dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ());
-    G3D::Vector3 contactPoint = vThis + (vObj - vThis).directionOrZero() * GetObjectSize();
+    G3D::Vector3 contactPoint = vThis + (vObj - vThis).directionOrZero() * std::min(dest.GetExactDist(GetPosition()), GetObjectSize());
 
     return Position(contactPoint.x, contactPoint.y, contactPoint.z, GetAngle(contactPoint.x, contactPoint.y));
 }


### PR DESCRIPTION
**Changes proposed:**
- Limit the ObjectSize radius calculation so that we do not check for the point behind the caster when caster is in ObjectSize of target. (see https://github.com/TrinityCore/TrinityCore/pull/15807#issuecomment-268077802)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes https://github.com/TrinityCore/TrinityCore/pull/15807#issuecomment-268077802


**Tests performed:** 
- Builds
- Tested in game

Any feedback is welcome :)