### PR TITLE
Crash: update pet phases

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5856,7 +5856,7 @@ void Spell::EffectUpdatePlayerPhase(SpellEffIndex /*effIndex*/)
     if (effectHandleMode != SPELL_EFFECT_HANDLE_HIT_TARGET)
         return;
 
-    if (!unitTarget || unitTarget->GetTypeId() != TYPEID_PLAYER)
+    if (!unitTarget || (unitTarget->GetTypeId() != TYPEID_PLAYER && !unitTarget->IsPet()))
         return;
 
     unitTarget->UpdateAreaAndZonePhase();


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  fixed crash when trying to update players phase with pet summoned. Pets must have phases updated too

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested in-game, server does not crash anymore
