### PR TITLE
Core/Battlegrounds: disable health regen for battleground vehicles

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1526,6 +1526,9 @@ Creature* Battleground::AddCreature(uint32 entry, uint32 type, float x, float y,
     if (respawntime)
         creature->SetRespawnDelay(respawntime);
 
+    if (creature->IsVehicle())
+        creature->setRegeneratingHealth(false);
+
     return creature;
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  Disable health regeneration for battlegrounds vehicles

**Target branch(es):** 3.3.5/master
- [x] 3.3.5

**Issues addressed:** Partially fixes #950


**Tests performed:** Built and tested in **Strand of the Ancients** with the Demolishers