### PR TITLE
Ability to add locales for quest reward text

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -5,4 +5,4 @@ CREATE TABLE `quest_offer_reward_locale` (
   `RewardText` text,
   `VerifiedBuild` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`ID`,`locale`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+)

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS `quest_offer_reward_locale`;
+CREATE TABLE `quest_offer_reward_locale` (
+  `ID` int(10) unsigned NOT NULL DEFAULT '0',
+  `locale` varchar(4) NOT NULL,
+  `RewardText` text,
+  `VerifiedBuild` smallint(6) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`,`locale`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -625,15 +625,15 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
         if (QuestTemplateLocale const* questTemplateLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
         {
             ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle, locale, questTitle);
-			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText, locale, portraitGiverText);
-			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName, locale, portraitGiverName);
-			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInText, locale, portraitTurnInText);
-			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInName, locale, portraitTurnInName);
+            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText, locale, portraitGiverText);
+            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName, locale, portraitGiverName);
+            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInText, locale, portraitTurnInText);
+            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInName, locale, portraitTurnInName);
         }
-
+        
         if (QuestOfferRewardLocale const* questOfferRewardLocale = sObjectMgr->GetQuestOfferRewardLocale(quest->GetQuestId()))
         {
-			ObjectMgr::GetLocaleString(questOfferRewardLocale->RewardText, locale, questOfferRewardText);
+            ObjectMgr::GetLocaleString(questOfferRewardLocale->RewardText, locale, questOfferRewardText);
         }
     }
 

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -622,19 +622,19 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     LocaleConstant locale = _session->GetSessionDbLocaleIndex();
     if (locale >= LOCALE_enUS)
     {
-		if (QuestTemplateLocale const* questTemplateLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
-		{
-			ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle, locale, questTitle);
+        if (QuestTemplateLocale const* questTemplateLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
+        {
+            ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle, locale, questTitle);
 			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText, locale, portraitGiverText);
 			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName, locale, portraitGiverName);
 			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInText, locale, portraitTurnInText);
 			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInName, locale, portraitTurnInName);
-		}
+        }
 
-		if (QuestOfferRewardLocale const* questOfferRewardLocale = sObjectMgr->GetQuestOfferRewardLocale(quest->GetQuestId()))
-		{
+        if (QuestOfferRewardLocale const* questOfferRewardLocale = sObjectMgr->GetQuestOfferRewardLocale(quest->GetQuestId()))
+        {
 			ObjectMgr::GetLocaleString(questOfferRewardLocale->RewardText, locale, questOfferRewardText);
-		}
+        }
     }
 
     if (sWorld->getBoolConfig(CONFIG_UI_QUESTLEVELS_IN_DIALOGS))

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -622,15 +622,19 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     LocaleConstant locale = _session->GetSessionDbLocaleIndex();
     if (locale >= LOCALE_enUS)
     {
-        if (QuestTemplateLocale const* questTemplateLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
-        {
-            ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle,           locale, questTitle);
-            ObjectMgr::GetLocaleString(questTemplateLocale->OfferRewardText,    locale, questOfferRewardText);
-            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText,  locale, portraitGiverText);
-            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName,  locale, portraitGiverName);
-            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInText, locale, portraitTurnInText);
-            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInName, locale, portraitTurnInName);
-        }
+		if (QuestTemplateLocale const* questTemplateLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
+		{
+			ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle, locale, questTitle);
+			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText, locale, portraitGiverText);
+			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName, locale, portraitGiverName);
+			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInText, locale, portraitTurnInText);
+			ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInName, locale, portraitTurnInName);
+		}
+
+		if (QuestOfferRewardLocale const* questOfferRewardLocale = sObjectMgr->GetQuestOfferRewardLocale(quest->GetQuestId()))
+		{
+			ObjectMgr::GetLocaleString(questOfferRewardLocale->RewardText, locale, questOfferRewardText);
+		}
     }
 
     if (sWorld->getBoolConfig(CONFIG_UI_QUESTLEVELS_IN_DIALOGS))

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -624,16 +624,16 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUI
     {
         if (QuestTemplateLocale const* questTemplateLocale = sObjectMgr->GetQuestLocale(quest->GetQuestId()))
         {
-            ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle, locale, questTitle);
-            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText, locale, portraitGiverText);
-            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName, locale, portraitGiverName);
+            ObjectMgr::GetLocaleString(questTemplateLocale->LogTitle,           locale, questTitle);
+            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverText,  locale, portraitGiverText);
+            ObjectMgr::GetLocaleString(questTemplateLocale->PortraitGiverName,  locale, portraitGiverName);
             ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInText, locale, portraitTurnInText);
             ObjectMgr::GetLocaleString(questTemplateLocale->PortraitTurnInName, locale, portraitTurnInName);
         }
         
         if (QuestOfferRewardLocale const* questOfferRewardLocale = sObjectMgr->GetQuestOfferRewardLocale(quest->GetQuestId()))
         {
-            ObjectMgr::GetLocaleString(questOfferRewardLocale->RewardText, locale, questOfferRewardText);
+            ObjectMgr::GetLocaleString(questOfferRewardLocale->RewardText,      locale, questOfferRewardText);
         }
     }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4749,7 +4749,7 @@ void ObjectMgr::LoadQuestTemplateLocale()
         AddLocaleString(questCompletionLog,     locale, data.QuestCompletionLog);
     } while (result->NextRow());
 
-    TC_LOG_INFO("server.loading", ">> Loaded %u Quest Tempalate locale strings in %u ms", uint32(_questTemplateLocaleStore.size()), GetMSTimeDiffToNow(oldMSTime));
+    TC_LOG_INFO("server.loading", ">> Loaded %u Quest Template locale strings in %u ms", uint32(_questTemplateLocaleStore.size()), GetMSTimeDiffToNow(oldMSTime));
 }
 
 void ObjectMgr::LoadQuestObjectivesLocale()
@@ -4781,6 +4781,36 @@ void ObjectMgr::LoadQuestObjectivesLocale()
     while (result->NextRow());
 
     TC_LOG_INFO("server.loading", ">> Loaded %u Quest Objectives locale strings in %u ms", uint32(_questObjectivesLocaleStore.size()), GetMSTimeDiffToNow(oldMSTime));
+}
+
+void ObjectMgr::LoadQuestOfferRewardLocale()
+{
+	uint32 oldMSTime = getMSTime();
+
+	_questOfferRewardLocaleStore.clear(); // need for reload case
+										 //                                               0     1          2
+	QueryResult result = WorldDatabase.Query("SELECT Id, locale, RewardText FROM quest_offer_reward_locale");
+	if (!result)
+		return;
+
+	do
+	{
+		Field* fields = result->Fetch();
+
+		uint32 id = fields[0].GetUInt32();
+		std::string localeName = fields[1].GetString();
+
+		std::string RewardText = fields[2].GetString();
+
+		QuestOfferRewardLocale& data = _questOfferRewardLocaleStore[id];
+		LocaleConstant locale = GetLocaleByName(localeName);
+		if (locale == LOCALE_enUS)
+			continue;
+
+		AddLocaleString(RewardText, locale, data.RewardText);
+	} while (result->NextRow());
+
+	TC_LOG_INFO("server.loading", ">> Loaded %u Quest Offer Reward locale strings in %u ms", uint32(_questOfferRewardLocaleStore.size()), GetMSTimeDiffToNow(oldMSTime));
 }
 
 void ObjectMgr::LoadScripts(ScriptsType type)

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4785,32 +4785,32 @@ void ObjectMgr::LoadQuestObjectivesLocale()
 
 void ObjectMgr::LoadQuestOfferRewardLocale()
 {
-	uint32 oldMSTime = getMSTime();
+    uint32 oldMSTime = getMSTime();
 
-	_questOfferRewardLocaleStore.clear(); // need for reload case
-										 //                                               0     1          2
-	QueryResult result = WorldDatabase.Query("SELECT Id, locale, RewardText FROM quest_offer_reward_locale");
-	if (!result)
+    _questOfferRewardLocaleStore.clear(); // need for reload case
+                                         //                                               0     1          2
+    QueryResult result = WorldDatabase.Query("SELECT Id, locale, RewardText FROM quest_offer_reward_locale");
+    if (!result)
         return;
 
-	do
-	{
-		Field* fields = result->Fetch();
+    do
+    {
+        Field* fields = result->Fetch();
 
-		uint32 id = fields[0].GetUInt32();
-		std::string localeName = fields[1].GetString();
+        uint32 id = fields[0].GetUInt32();
+        std::string localeName = fields[1].GetString();
 
-		std::string RewardText = fields[2].GetString();
+        std::string RewardText = fields[2].GetString();
 
-		QuestOfferRewardLocale& data = _questOfferRewardLocaleStore[id];
-		LocaleConstant locale = GetLocaleByName(localeName);
-		if (locale == LOCALE_enUS)
-			continue;
+        QuestOfferRewardLocale& data = _questOfferRewardLocaleStore[id];
+        LocaleConstant locale = GetLocaleByName(localeName);
+        if (locale == LOCALE_enUS)
+            continue;
 
-		AddLocaleString(RewardText, locale, data.RewardText);
-	} while (result->NextRow());
+        AddLocaleString(RewardText, locale, data.RewardText);
+    } while (result->NextRow());
 
-	TC_LOG_INFO("server.loading", ">> Loaded %u Quest Offer Reward locale strings in %u ms", uint32(_questOfferRewardLocaleStore.size()), GetMSTimeDiffToNow(oldMSTime));
+    TC_LOG_INFO("server.loading", ">> Loaded %u Quest Offer Reward locale strings in %u ms", uint32(_questOfferRewardLocaleStore.size()), GetMSTimeDiffToNow(oldMSTime));
 }
 
 void ObjectMgr::LoadScripts(ScriptsType type)

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4791,7 +4791,7 @@ void ObjectMgr::LoadQuestOfferRewardLocale()
 										 //                                               0     1          2
 	QueryResult result = WorldDatabase.Query("SELECT Id, locale, RewardText FROM quest_offer_reward_locale");
 	if (!result)
-		return;
+        return;
 
 	do
 	{

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -441,6 +441,7 @@ typedef std::unordered_map<uint32, CreatureLocale> CreatureLocaleContainer;
 typedef std::unordered_map<uint32, GameObjectLocale> GameObjectLocaleContainer;
 typedef std::unordered_map<uint32, QuestTemplateLocale> QuestTemplateLocaleContainer;
 typedef std::unordered_map<uint32, QuestObjectivesLocale> QuestObjectivesLocaleContainer;
+typedef std::unordered_map<uint32, QuestOfferRewardLocale> QuestOfferRewardLocaleContainer;
 typedef std::unordered_map<uint32, PageTextLocale> PageTextLocaleContainer;
 typedef std::unordered_map<uint32, GossipMenuItemsLocale> GossipMenuItemsLocaleContainer;
 typedef std::unordered_map<uint32, PointOfInterestLocale> PointOfInterestLocaleContainer;
@@ -1014,6 +1015,7 @@ class TC_GAME_API ObjectMgr
         void LoadItemScriptNames();
         void LoadQuestTemplateLocale();
         void LoadQuestObjectivesLocale();
+		void LoadQuestOfferRewardLocale();
         void LoadPageTextLocales();
         void LoadGossipMenuItemsLocales();
         void LoadPointOfInterestLocales();
@@ -1184,6 +1186,12 @@ class TC_GAME_API ObjectMgr
             if (itr == _questTemplateLocaleStore.end()) return nullptr;
             return &itr->second;
         }
+		QuestOfferRewardLocale const* GetQuestOfferRewardLocale(uint32 entry) const
+		{
+			QuestOfferRewardLocaleContainer::const_iterator itr = _questOfferRewardLocaleStore.find(entry);
+			if (itr == _questOfferRewardLocaleStore.end()) return nullptr;
+			return &itr->second;
+		}
         QuestObjectivesLocale const* GetQuestObjectivesLocale(uint32 entry) const
         {
             QuestObjectivesLocaleContainer::const_iterator itr = _questObjectivesLocaleStore.find(entry);
@@ -1537,6 +1545,7 @@ class TC_GAME_API ObjectMgr
         ItemTemplateContainer _itemTemplateStore;
         QuestTemplateLocaleContainer _questTemplateLocaleStore;
         QuestObjectivesLocaleContainer _questObjectivesLocaleStore;
+		QuestOfferRewardLocaleContainer _questOfferRewardLocaleStore;
         PageTextLocaleContainer _pageTextLocaleStore;
         GossipMenuItemsLocaleContainer _gossipMenuItemsLocaleStore;
         PointOfInterestLocaleContainer _pointOfInterestLocaleStore;

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1015,7 +1015,7 @@ class TC_GAME_API ObjectMgr
         void LoadItemScriptNames();
         void LoadQuestTemplateLocale();
         void LoadQuestObjectivesLocale();
-		void LoadQuestOfferRewardLocale();
+	void LoadQuestOfferRewardLocale();
         void LoadPageTextLocales();
         void LoadGossipMenuItemsLocales();
         void LoadPointOfInterestLocales();
@@ -1186,12 +1186,12 @@ class TC_GAME_API ObjectMgr
             if (itr == _questTemplateLocaleStore.end()) return nullptr;
             return &itr->second;
         }
-		QuestOfferRewardLocale const* GetQuestOfferRewardLocale(uint32 entry) const
-		{
-			QuestOfferRewardLocaleContainer::const_iterator itr = _questOfferRewardLocaleStore.find(entry);
-			if (itr == _questOfferRewardLocaleStore.end()) return nullptr;
-			return &itr->second;
-		}
+	QuestOfferRewardLocale const* GetQuestOfferRewardLocale(uint32 entry) const
+	{
+		QuestOfferRewardLocaleContainer::const_iterator itr = _questOfferRewardLocaleStore.find(entry);
+		if (itr == _questOfferRewardLocaleStore.end()) return nullptr;
+		return &itr->second;
+	}
         QuestObjectivesLocale const* GetQuestObjectivesLocale(uint32 entry) const
         {
             QuestObjectivesLocaleContainer::const_iterator itr = _questObjectivesLocaleStore.find(entry);
@@ -1545,7 +1545,7 @@ class TC_GAME_API ObjectMgr
         ItemTemplateContainer _itemTemplateStore;
         QuestTemplateLocaleContainer _questTemplateLocaleStore;
         QuestObjectivesLocaleContainer _questObjectivesLocaleStore;
-		QuestOfferRewardLocaleContainer _questOfferRewardLocaleStore;
+	QuestOfferRewardLocaleContainer _questOfferRewardLocaleStore;
         PageTextLocaleContainer _pageTextLocaleStore;
         GossipMenuItemsLocaleContainer _gossipMenuItemsLocaleStore;
         PointOfInterestLocaleContainer _pointOfInterestLocaleStore;

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1015,7 +1015,7 @@ class TC_GAME_API ObjectMgr
         void LoadItemScriptNames();
         void LoadQuestTemplateLocale();
         void LoadQuestObjectivesLocale();
-	void LoadQuestOfferRewardLocale();
+        void LoadQuestOfferRewardLocale();
         void LoadPageTextLocales();
         void LoadGossipMenuItemsLocales();
         void LoadPointOfInterestLocales();
@@ -1186,12 +1186,12 @@ class TC_GAME_API ObjectMgr
             if (itr == _questTemplateLocaleStore.end()) return nullptr;
             return &itr->second;
         }
-	QuestOfferRewardLocale const* GetQuestOfferRewardLocale(uint32 entry) const
-	{
-		QuestOfferRewardLocaleContainer::const_iterator itr = _questOfferRewardLocaleStore.find(entry);
-		if (itr == _questOfferRewardLocaleStore.end()) return nullptr;
-		return &itr->second;
-	}
+        QuestOfferRewardLocale const* GetQuestOfferRewardLocale(uint32 entry) const
+        {
+            QuestOfferRewardLocaleContainer::const_iterator itr = _questOfferRewardLocaleStore.find(entry);
+            if (itr == _questOfferRewardLocaleStore.end()) return nullptr;
+            return &itr->second;
+        }
         QuestObjectivesLocale const* GetQuestObjectivesLocale(uint32 entry) const
         {
             QuestObjectivesLocaleContainer::const_iterator itr = _questObjectivesLocaleStore.find(entry);
@@ -1545,7 +1545,7 @@ class TC_GAME_API ObjectMgr
         ItemTemplateContainer _itemTemplateStore;
         QuestTemplateLocaleContainer _questTemplateLocaleStore;
         QuestObjectivesLocaleContainer _questObjectivesLocaleStore;
-	QuestOfferRewardLocaleContainer _questOfferRewardLocaleStore;
+        QuestOfferRewardLocaleContainer _questOfferRewardLocaleStore;
         PageTextLocaleContainer _pageTextLocaleStore;
         GossipMenuItemsLocaleContainer _gossipMenuItemsLocaleStore;
         PointOfInterestLocaleContainer _pointOfInterestLocaleStore;

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -255,13 +255,17 @@ struct QuestTemplateLocale
     StringVector QuestCompletionLog;
 
     /// @todo: implemente this in new tables
-    StringVector OfferRewardText;
     StringVector RequestItemsText;
 };
 
 struct QuestObjectivesLocale
 {
     StringVector Description;
+};
+
+struct QuestOfferRewardLocale
+{
+	StringVector RewardText;
 };
 
 struct QuestObjective

--- a/src/server/game/Quests/QuestDef.h
+++ b/src/server/game/Quests/QuestDef.h
@@ -265,7 +265,7 @@ struct QuestObjectivesLocale
 
 struct QuestOfferRewardLocale
 {
-	StringVector RewardText;
+    StringVector RewardText;
 };
 
 struct QuestObjective

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1604,6 +1604,7 @@ void World::SetInitialWorldSettings()
     sObjectMgr->LoadCreatureLocales();
     sObjectMgr->LoadGameObjectLocales();
     sObjectMgr->LoadQuestTemplateLocale();
+	sObjectMgr->LoadQuestOfferRewardLocale();
     sObjectMgr->LoadQuestObjectivesLocale();
     sObjectMgr->LoadPageTextLocales();
     sObjectMgr->LoadGossipMenuItemsLocales();

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1604,7 +1604,7 @@ void World::SetInitialWorldSettings()
     sObjectMgr->LoadCreatureLocales();
     sObjectMgr->LoadGameObjectLocales();
     sObjectMgr->LoadQuestTemplateLocale();
-	sObjectMgr->LoadQuestOfferRewardLocale();
+    sObjectMgr->LoadQuestOfferRewardLocale();
     sObjectMgr->LoadQuestObjectivesLocale();
     sObjectMgr->LoadPageTextLocales();
     sObjectMgr->LoadGossipMenuItemsLocales();

--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -1059,10 +1059,10 @@ public:
         TC_LOG_INFO("misc", "Re-Loading Quest Locale ... ");
         sObjectMgr->LoadQuestTemplateLocale();
         sObjectMgr->LoadQuestObjectivesLocale();
-		sObjectMgr->LoadQuestOfferRewardLocale();
+        sObjectMgr->LoadQuestOfferRewardLocale();
         handler->SendGlobalGMSysMessage("DB table `quest_template_locale` reloaded.");
         handler->SendGlobalGMSysMessage("DB table `quest_objectives_locale` reloaded.");
-		handler->SendGlobalGMSysMessage("DB table `quest_offer_reward_locale` reloaded.");
+        handler->SendGlobalGMSysMessage("DB table `quest_offer_reward_locale` reloaded.");
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -1059,8 +1059,10 @@ public:
         TC_LOG_INFO("misc", "Re-Loading Quest Locale ... ");
         sObjectMgr->LoadQuestTemplateLocale();
         sObjectMgr->LoadQuestObjectivesLocale();
+		sObjectMgr->LoadQuestOfferRewardLocale();
         handler->SendGlobalGMSysMessage("DB table `quest_template_locale` reloaded.");
         handler->SendGlobalGMSysMessage("DB table `quest_objectives_locale` reloaded.");
+		handler->SendGlobalGMSysMessage("DB table `quest_offer_reward_locale` reloaded.");
         return true;
     }
 


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**
Adds a new table quest_offer_reward_locale for quest ending text

**Target branch(es):** 3.3.5/master
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
Does build and works ingame.

**Known issues and TODO list:** (add/remove lines as needed)
none
