### PR TITLE
Use system supported threads instead of hardcoded amount for mmaps

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -190,9 +190,11 @@ namespace MMAP
         }
     }
 
-    void MapBuilder::buildAllMaps(int threads)
+    void MapBuilder::buildAllMaps(unsigned int threads)
     {
-        for (int i = 0; i < threads; ++i)
+        printf("Using %u threads to extract mmaps\n", threads);
+
+        for (unsigned int i = 0; i < threads; ++i)
         {
             _workerThreads.push_back(std::thread(&MapBuilder::WorkerThread, this));
         }

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -95,7 +95,7 @@ namespace MMAP
             void buildSingleTile(uint32 mapID, uint32 tileX, uint32 tileY);
 
             // builds list of maps, then builds all of mmap tiles (based on the skip settings)
-            void buildAllMaps(int threads);
+            void buildAllMaps(unsigned int threads);
 
             void WorkerThread();
 

--- a/src/tools/mmaps_generator/PathGenerator.cpp
+++ b/src/tools/mmaps_generator/PathGenerator.cpp
@@ -73,7 +73,7 @@ bool handleArgs(int argc, char** argv,
                bool &bigBaseUnit,
                char* &offMeshInputPath,
                char* &file,
-               int& threads)
+               unsigned int& threads)
 {
     char* param = NULL;
     for (int i = 1; i < argc; ++i)
@@ -95,8 +95,7 @@ bool handleArgs(int argc, char** argv,
             param = argv[++i];
             if (!param)
                 return false;
-            threads = atoi(param);
-            printf("Using %i threads to extract mmaps\n", threads);
+            threads = static_cast<unsigned int>(std::max(0, atoi(param)));
         }
         else if (strcmp(argv[i], "--file") == 0)
         {
@@ -244,7 +243,8 @@ int main(int argc, char** argv)
 {
     Trinity::Banner::Show("MMAP generator", [](char const* text) { printf("%s\n", text); }, nullptr);
 
-    int threads = 3, mapnum = -1;
+    unsigned int threads = std::thread::hardware_concurrency();
+    int mapnum = -1;
     float maxAngle = 70.0f;
     int tileX = -1, tileY = -1;
     bool skipLiquid = false,


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

- Use unsigned int for thread count
- Use std::thread::hardware_concurrency() to try estimate available threads instead of hardcoded 3 threads by default for mmap generation
- Print thread count always regardless of using --threads switch or not

Motivation:
Not everyone uses the extractor.bat in contrib, its not available for linux, not everyone uses the switches and people with 8 cores end up with 3 threads. Multiple people have been using the extractor directly and not have been aware of the thread switch and have had multiple cores.

With the changes we use c++11 functions to get the system supported thread count and use that to utilize all system cores.
According to http://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency it gives only a hint though and it is possible the count cannot be found. In these cases 0 is used, which means only single threaded processing instead of the hardcoded 3.
If wanted, there could be used std::max to define either 3 or the std::thread::hardware_concurrency() amount of threads if the switch is not used to make sure that when the amount cannot be deduced then at least 3 are used.

EDIT:
Tried to evaluate if 3 threads is alright or if having hugely more is beneficial. (for fun)

These times are for master branch with 3.4GHz processor. http://pastebin.com/WQtEz5qz
It seems that if the extracting already takes about an hour, then to speed up the process the extraction would need to be recoded (if possible) because the minimum time at the moment is how long the longest map processing takes and that is 1 hour. The measurement would suggest that the optimal core count is around 8-10. So in conclusion there is clear benefit to utilizing more cores even with the current code, dropping some 9 hours of processing to just one hour.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
Builds and tested extracting to see the print.
With default settings used 4 threads on 4 core system. Tested using --threads switch to change threads from -5  to 0 to 5 and results are 0, 0 and 5.

**Known issues and TODO list:** (add/remove lines as needed)
