### PR TITLE
Core/Scripts: minor fixes in boss_the_lich_king

### DIFF
--- a/sql/updates/world/3.3.5/2017_03_24_00_world.sql
+++ b/sql/updates/world/3.3.5/2017_03_24_00_world.sql
@@ -1,6 +1,6 @@
 -- Correct speed for Wicked Spirits and Spirit Bombs
 UPDATE `creature_template` SET `speed_walk`=1.2, `speed_run`=0.428571 WHERE `entry` IN(39189,39190,39287,39288,39289);
-UPDATE `creature_template` SET `InhabitType`=4, `HoverHeight`=4 WHERE `entry` IN (36609,39120,39121,39122);
+UPDATE `creature_template` SET `InhabitType`=4, `HoverHeight`=4 WHERE `entry` IN(36609,39120,39121,39122);
 
 DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_the_lich_king_harvest_souls_teleport';
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,5 +1,6 @@
 -- Correct speed for Wicked Spirits and Spirit Bombs
 UPDATE `creature_template` SET `speed_walk`=1.2, `speed_run`=0.428571 WHERE `entry` IN(39189,39190,39287,39288,39289);
+UPDATE `creature_template` SET `InhabitType`=4, `HoverHeight`=4 WHERE `entry` IN (36609,39120,39121,39122);
 
 DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_the_lich_king_harvest_souls_teleport';
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,13 @@
+-- Correct speed for Wicked Spirits and Spirit Bombs
+UPDATE `creature_template` SET `speed_walk`=1.2, `speed_run`=0.428571 WHERE `entry` IN(39189,39190,39287,39288,39289);
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_the_lich_king_harvest_souls_teleport';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(73655,'spell_the_lich_king_harvest_souls_teleport');
+
+DELETE FROM `spell_custom_attr` WHERE `entry` IN(69409,73797,73798,73799);
+INSERT INTO `spell_custom_attr` (`entry`,`attributes`) VALUES
+(69409,32768),
+(73797,32768),
+(73798,32768),
+(73799,32768);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3576,7 +3576,7 @@ void SpellMgr::LoadSpellInfoCorrections()
                 spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // 10yd
                 break;
             case 74282: // Shadow Trap (searcher)
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_3_YARDS); // 3yd
+                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_5_YARDS); // 5yd
                 break;
             case 72595: // Restore Soul
             case 73650: // Restore Soul
@@ -3615,11 +3615,13 @@ void SpellMgr::LoadSpellInfoCorrections()
                 spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_50000_YARDS); // 50000yd
                 break;
             case 71809: // Jump
-                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(3); // 20yd
-                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS); // 25yd
+                spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(5); // 40yd
+                spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_10_YARDS); // 10yd
+                spellInfo->Effects[EFFECT_0].MiscValue = 190;
                 break;
             case 72405: // Broken Frostmourne
-                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_200_YARDS); // 200yd
+                spellInfo->Effects[EFFECT_1].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_20_YARDS); // 20yd
+                spellInfo->AttributesEx |= SPELL_ATTR1_NO_THREAT;
                 break;
             // ENDOF ICECROWN CITADEL SPELLS
             //

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -1218,7 +1218,7 @@ class npc_tirion_fordring_tft : public CreatureScript
                 if (spell->Id == SPELL_ICE_LOCK)
                     me->SetFacingTo(3.085098f);
                 else if (spell->Id == SPELL_BROKEN_FROSTMOURNE_KNOCK)
-                    SetEquipmentSlots(true);    // remove glow on ashbringer
+                    me->LoadEquipment(1); // remove glow on ashbringer
             }
 
             void sGossipSelect(Player* /*player*/, uint32 menuId, uint32 gossipListId) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -219,6 +219,7 @@ enum Events
     EVENT_GRAB_PLAYER,
     EVENT_MOVE_TO_DROP_POS,
     EVENT_LIFE_SIPHON, // heroic only
+    EVENT_MOVE_TO_CENTER, // heroic only
     EVENT_START_ATTACK,
     EVENT_SUMMON_RAGING_SPIRIT_2,
     EVENT_QUAKE_2,
@@ -317,6 +318,7 @@ enum MovePoints
     POINT_OUTRO_JUMP        = 11,
     POINT_LK_OUTRO_2        = 12,
     POINT_GROUND            = 13,
+    POINT_SIPHON            = 14,
     POINT_CHARGE            = 1003, // globally used number for charge spell effects
 };
 
@@ -1506,19 +1508,18 @@ class npc_valkyr_shadowguard : public CreatureScript
 
                 if (me->HealthBelowPctDamaged(50, damage))
                 {
-                    _events.Reset();
                     DoCastAOE(SPELL_EJECT_ALL_PASSENGERS);
-                    me->GetMotionMaster()->MoveTargetedHome();
-                    me->ClearUnitState(UNIT_STATE_EVADE);
+                    ScheduleHeroicEvents();
                 }
             }
 
-            void JustReachedHome() override
+            void ScheduleHeroicEvents()
             {
-                // schedule siphon life event (heroic only)
                 DoZoneInCombat();
                 _events.Reset();
+                _events.ScheduleEvent(EVENT_MOVE_TO_CENTER, 1);
                 _events.ScheduleEvent(EVENT_LIFE_SIPHON, 2000);
+                me->ClearUnitState(UNIT_STATE_EVADE);
             }
 
             void AttackStart(Unit* /*target*/) override
@@ -1535,7 +1536,7 @@ class npc_valkyr_shadowguard : public CreatureScript
                     case POINT_DROP_PLAYER:
                         DoCastAOE(SPELL_EJECT_ALL_PASSENGERS);
                         if (IsHeroic())
-                            me->GetMotionMaster()->MoveTargetedHome();
+                            ScheduleHeroicEvents();
                         else
                             me->DespawnOrUnsummon(1000);
                         break;
@@ -1600,6 +1601,13 @@ class npc_valkyr_shadowguard : public CreatureScript
                                 DoCast(target, SPELL_LIFE_SIPHON);
                             _events.ScheduleEvent(EVENT_LIFE_SIPHON, 2500);
                             break;
+                        case EVENT_MOVE_TO_CENTER:
+                        {
+                            Position pos = me->GetRandomPoint(CenterPosition, 4.0f);
+                            pos.m_positionZ = me->GetHomePosition().m_positionZ;
+                            me->GetMotionMaster()->MovePoint(POINT_SIPHON, pos);
+                            break;
+                        }
                         default:
                             break;
                     }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -192,77 +192,79 @@ enum Events
 {
     // The Lich King
     // intro events
-    EVENT_INTRO_MOVE_1              = 1,
-    EVENT_INTRO_MOVE_2              = 2,
-    EVENT_INTRO_MOVE_3              = 3,
-    EVENT_INTRO_TALK_1              = 4,
-    EVENT_EMOTE_CAST_SHOUT          = 5,
-    EVENT_INTRO_EMOTE_1             = 6,
-    EVENT_INTRO_CHARGE              = 7,
-    EVENT_INTRO_CAST_FREEZE         = 8,
-    EVENT_FINISH_INTRO              = 9,
+    EVENT_INTRO_MOVE_1 = 1,
+    EVENT_INTRO_MOVE_2,
+    EVENT_INTRO_MOVE_3,
+    EVENT_INTRO_TALK_1,
+    EVENT_EMOTE_CAST_SHOUT,
+    EVENT_INTRO_EMOTE_1,
+    EVENT_INTRO_CHARGE,
+    EVENT_INTRO_CAST_FREEZE,
+    EVENT_FINISH_INTRO,
 
     // combat events
-    EVENT_SUMMON_SHAMBLING_HORROR   = 10,
-    EVENT_SUMMON_DRUDGE_GHOUL       = 11,
-    EVENT_INFEST                    = 12,
-    EVENT_NECROTIC_PLAGUE           = 13,
-    EVENT_SHADOW_TRAP               = 14,   // heroic only
-    EVENT_SOUL_REAPER               = 15,
-    EVENT_DEFILE                    = 16,
-    EVENT_HARVEST_SOUL              = 17,   // normal mode only
-    EVENT_PAIN_AND_SUFFERING        = 18,
-    EVENT_SUMMON_ICE_SPHERE         = 19,
-    EVENT_SUMMON_RAGING_SPIRIT      = 20,
-    EVENT_QUAKE                     = 21,
-    EVENT_SUMMON_VALKYR             = 22,
-    EVENT_GRAB_PLAYER               = 23,
-    EVENT_MOVE_TO_DROP_POS          = 24,
-    EVENT_LIFE_SIPHON               = 25,   // heroic only
-    EVENT_START_ATTACK              = 26,
-    EVENT_QUAKE_2                   = 27,
-    EVENT_VILE_SPIRITS              = 28,
-    EVENT_HARVEST_SOULS             = 29,   // heroic only
-    EVENT_BERSERK                   = 30,
-    EVENT_SOUL_RIP                  = 31,
-    EVENT_DESTROY_SOUL              = 32,
-    EVENT_FROSTMOURNE_TALK_1        = 33,
-    EVENT_FROSTMOURNE_TALK_2        = 34,
-    EVENT_FROSTMOURNE_TALK_3        = 35,
-    EVENT_TELEPORT_BACK             = 36,
-    EVENT_FROSTMOURNE_HEROIC        = 37,
-    EVENT_OUTRO_TALK_1              = 38,
-    EVENT_OUTRO_TALK_2              = 39,
-    EVENT_OUTRO_EMOTE_TALK          = 40,
-    EVENT_OUTRO_TALK_3              = 41,
-    EVENT_OUTRO_MOVE_CENTER         = 42,
-    EVENT_OUTRO_TALK_4              = 43,
-    EVENT_OUTRO_RAISE_DEAD          = 44,
-    EVENT_OUTRO_TALK_5              = 45,
-    EVENT_OUTRO_BLESS               = 46,
-    EVENT_OUTRO_REMOVE_ICE          = 47,
-    EVENT_OUTRO_MOVE_1              = 48,
-    EVENT_OUTRO_JUMP                = 49,
-    EVENT_OUTRO_TALK_6              = 50,
-    EVENT_OUTRO_KNOCK_BACK          = 51,
-    EVENT_OUTRO_SOUL_BARRAGE        = 52,
-    EVENT_OUTRO_SUMMON_TERENAS      = 53,
-    EVENT_OUTRO_TERENAS_TALK_1      = 54,
-    EVENT_OUTRO_TERENAS_TALK_2      = 55,
-    EVENT_OUTRO_TALK_7              = 56,
-    EVENT_OUTRO_TALK_8              = 57,
+    EVENT_SUMMON_SHAMBLING_HORROR,
+    EVENT_SUMMON_DRUDGE_GHOUL,
+    EVENT_INFEST,
+    EVENT_NECROTIC_PLAGUE,
+    EVENT_SHADOW_TRAP, // heroic only
+    EVENT_SOUL_REAPER,
+    EVENT_DEFILE,
+    EVENT_HARVEST_SOUL, // normal mode only
+    EVENT_PAIN_AND_SUFFERING,
+    EVENT_SUMMON_ICE_SPHERE,
+    EVENT_SUMMON_RAGING_SPIRIT,
+    EVENT_QUAKE,
+    EVENT_SUMMON_VALKYR,
+    EVENT_GRAB_PLAYER,
+    EVENT_MOVE_TO_DROP_POS,
+    EVENT_LIFE_SIPHON, // heroic only
+    EVENT_START_ATTACK,
+    EVENT_SUMMON_RAGING_SPIRIT_2,
+    EVENT_QUAKE_2,
+    EVENT_VILE_SPIRITS,
+    EVENT_HARVEST_SOULS, // heroic only
+    EVENT_BERSERK,
+    EVENT_SOUL_RIP,
+    EVENT_DESTROY_SOUL,
+    EVENT_FROSTMOURNE_TALK_1,
+    EVENT_FROSTMOURNE_TALK_2,
+    EVENT_FROSTMOURNE_TALK_3,
+    EVENT_TELEPORT_BACK,
+    EVENT_FROSTMOURNE_HEROIC,
+    EVENT_OUTRO_TALK_1,
+    EVENT_OUTRO_TALK_2,
+    EVENT_OUTRO_EMOTE_TALK,
+    EVENT_OUTRO_TALK_3,
+    EVENT_OUTRO_MOVE_CENTER,
+    EVENT_OUTRO_TALK_4,
+    EVENT_OUTRO_RAISE_DEAD,
+    EVENT_OUTRO_TALK_5,
+    EVENT_OUTRO_BLESS,
+    EVENT_OUTRO_REMOVE_ICE,
+    EVENT_OUTRO_MOVE_1,
+    EVENT_OUTRO_JUMP,
+    EVENT_OUTRO_TALK_6,
+    EVENT_OUTRO_KNOCK_BACK,
+    EVENT_OUTRO_SOUL_BARRAGE,
+    EVENT_OUTRO_SUMMON_TERENAS,
+    EVENT_OUTRO_TERENAS_TALK_1,
+    EVENT_OUTRO_TERENAS_TALK_2,
+    EVENT_OUTRO_TALK_7,
+    EVENT_OUTRO_TALK_8,
 
     // Shambling Horror
-    EVENT_SHOCKWAVE                 = 58,
-    EVENT_ENRAGE                    = 59,
+    EVENT_SHOCKWAVE,
+    EVENT_ENRAGE,
 
     // Raging Spirit
-    EVENT_SOUL_SHRIEK               = 60,
+    EVENT_SOUL_SHRIEK,
+    EVENT_SET_AGRESSIVE,
 
     // Strangulate Vehicle (Harvest Soul)
-    EVENT_TELEPORT                  = 61,
-    EVENT_MOVE_TO_LICH_KING         = 62,
-    EVENT_DESPAWN_SELF              = 63,
+    EVENT_TELEPORT,
+    EVENT_MOVE_TO_LICH_KING,
+    EVENT_DESPAWN_SELF
 };
 
 enum EventGroups
@@ -329,12 +331,14 @@ enum EncounterActions
     ACTION_SUMMON_TERENAS       = 6,
     ACTION_FINISH_OUTRO         = 7,
     ACTION_TELEPORT_BACK        = 8,
+    ACTION_DISABLE_RAGING       = 9
 };
 
 enum MiscData
 {
     LIGHT_SNOWSTORM             = 2490,
     LIGHT_SOULSTORM             = 2508,
+    LIGHT_FOG                   = 2509,
 
     MUSIC_FROZEN_THRONE         = 17457,
     MUSIC_SPECIAL               = 17458,    // Summon Shambling Horror, Remorseless Winter, Quake, Summon Val'kyr Periodic, Harvest Soul, Vile Spirits
@@ -515,17 +519,7 @@ class boss_the_lich_king : public CreatureScript
                 _vileSpiritExplosions = 0;
             }
 
-            void InitializeAI() override
-            {
-                SetupEncounter();
-            }
-
-            void JustRespawned() override
-            {
-                SetupEncounter();
-            }
-
-            void SetupEncounter()
+            void Reset() override
             {
                 _Reset();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
@@ -540,9 +534,10 @@ class boss_the_lich_king : public CreatureScript
                 me->VisitNearbyGridObject(333.0f, worker);
 
                 // Reset any light override
-                me->GetMap()->SetZoneOverrideLight(AREA_THE_FROZEN_THRONE, 0, 5000);
+                me->GetMap()->SetZoneOverrideLight(AREA_ICECROWN_CITADEL, 0, 5000);
 
-                me->SummonCreature(NPC_HIGHLORD_TIRION_FORDRING_LK, TirionSpawn, TEMPSUMMON_MANUAL_DESPAWN);
+                if (!ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_HIGHLORD_TIRION_FORDRING)))
+                    me->SummonCreature(NPC_HIGHLORD_TIRION_FORDRING_LK, TirionSpawn, TEMPSUMMON_MANUAL_DESPAWN);
             }
 
             void JustDied(Unit* /*killer*/) override
@@ -554,6 +549,8 @@ class boss_the_lich_king : public CreatureScript
                 me->GetMotionMaster()->MoveFall();
                 if (Creature* frostmourne = me->FindNearestCreature(NPC_FROSTMOURNE_TRIGGER, 50.0f))
                     frostmourne->DespawnOrUnsummon();
+                me->GetMap()->SetZoneOverrideLight(AREA_ICECROWN_CITADEL, LIGHT_FOG, 5000);
+                me->GetMap()->SetZoneWeather(AREA_ICECROWN_CITADEL, WEATHER_STATE_FOG, 0.0f);
             }
 
             void EnterCombat(Unit* target) override
@@ -566,6 +563,7 @@ class boss_the_lich_king : public CreatureScript
                 }
 
                 me->setActive(true);
+                me->SetCombatPulseDelay(5);
                 DoZoneInCombat();
 
                 events.SetPhase(PHASE_ONE);
@@ -608,7 +606,7 @@ class boss_the_lich_king : public CreatureScript
                     case ACTION_START_ENCOUNTER:
                         instance->SetBossState(DATA_THE_LICH_KING, IN_PROGRESS);
                         Talk(SAY_LK_INTRO_1);
-                        me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_FROZEN_THRONE);
+                        me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_FROZEN_THRONE);
                         // schedule talks
                         me->SetStandState(UNIT_STAND_STATE_STAND);
                         events.ScheduleEvent(EVENT_INTRO_MOVE_1, 4000);
@@ -617,10 +615,10 @@ class boss_the_lich_king : public CreatureScript
                         events.ScheduleEvent(EVENT_START_ATTACK, 5000);
                         break;
                     case ACTION_PLAY_MUSIC:
-                        me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_FINAL);
+                        me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_FINAL);
                         break;
                     case ACTION_RESTORE_LIGHT:
-                        me->GetMap()->SetZoneOverrideLight(AREA_THE_FROZEN_THRONE, 0, 5000);
+                        me->GetMap()->SetZoneOverrideLight(AREA_ICECROWN_CITADEL, 0, 5000);
                         break;
                     case ACTION_BREAK_FROSTMOURNE:
                         me->CastSpell((Unit*)NULL, SPELL_SUMMON_BROKEN_FROSTMOURNE, TRIGGERED_IGNORE_CAST_IN_PROGRESS);
@@ -682,6 +680,7 @@ class boss_the_lich_king : public CreatureScript
                     events.SetPhase(PHASE_TRANSITION);
                     me->SetReactState(REACT_PASSIVE);
                     me->AttackStop();
+                    me->InterruptNonMeleeSpells(true);
                     me->GetMotionMaster()->MovePoint(POINT_CENTER_1, CenterPosition);
                     return;
                 }
@@ -691,6 +690,7 @@ class boss_the_lich_king : public CreatureScript
                     events.SetPhase(PHASE_TRANSITION);
                     me->SetReactState(REACT_PASSIVE);
                     me->AttackStop();
+                    me->InterruptNonMeleeSpells(true);
                     me->GetMotionMaster()->MovePoint(POINT_CENTER_2, CenterPosition);
                     return;
                 }
@@ -702,7 +702,7 @@ class boss_the_lich_king : public CreatureScript
                     events.Reset();
                     events.SetPhase(PHASE_OUTRO);
                     summons.DespawnAll();
-                    me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_FURY_OF_FROSTMOURNE);
+                    me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_FURY_OF_FROSTMOURNE);
                     me->InterruptNonMeleeSpells(true);
                     me->CastSpell((Unit*)NULL, SPELL_FURY_OF_FROSTMOURNE, TRIGGERED_NONE);
                     me->SetWalk(true);
@@ -754,8 +754,8 @@ class boss_the_lich_king : public CreatureScript
                     {
                         summon->CastSpell((Unit*)NULL, SPELL_BROKEN_FROSTMOURNE, true);
 
-                        me->GetMap()->SetZoneOverrideLight(AREA_THE_FROZEN_THRONE, LIGHT_SOULSTORM, 10000);
-                        me->GetMap()->SetZoneWeather(AREA_THE_FROZEN_THRONE, WEATHER_STATE_BLACKSNOW, 0.5f);
+                        me->GetMap()->SetZoneOverrideLight(AREA_ICECROWN_CITADEL, LIGHT_SOULSTORM, 10000);
+                        me->GetMap()->SetZoneWeather(AREA_ICECROWN_CITADEL, WEATHER_STATE_BLACKSNOW, 0.5f);
 
                         events.ScheduleEvent(EVENT_OUTRO_SOUL_BARRAGE, 5000, 0, PHASE_OUTRO);
                         return;
@@ -809,8 +809,8 @@ class boss_the_lich_king : public CreatureScript
             {
                 if (spell->Id == REMORSELESS_WINTER_1 || spell->Id == REMORSELESS_WINTER_2)
                 {
-                    me->GetMap()->SetZoneOverrideLight(AREA_THE_FROZEN_THRONE, LIGHT_SNOWSTORM, 5000);
-                    me->GetMap()->SetZoneWeather(AREA_THE_FROZEN_THRONE, WEATHER_STATE_LIGHT_SNOW, 0.5f);
+                    me->GetMap()->SetZoneOverrideLight(AREA_ICECROWN_CITADEL, LIGHT_SNOWSTORM, 5000);
+                    me->GetMap()->SetZoneWeather(AREA_ICECROWN_CITADEL, WEATHER_STATE_LIGHT_SNOW, 0.5f);
                 }
             }
 
@@ -836,13 +836,14 @@ class boss_the_lich_king : public CreatureScript
                     case POINT_CENTER_1:
                         me->SetFacingTo(0.0f, true);
                         Talk(SAY_LK_REMORSELESS_WINTER);
-                        me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                        me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                         DoCast(me, SPELL_REMORSELESS_WINTER_1);
+                        summons.DespawnEntry(NPC_SHADOW_TRAP);
                         events.DelayEvents(62500, EVENT_GROUP_BERSERK); // delay berserk timer, its not ticking during phase transitions
                         events.ScheduleEvent(EVENT_QUAKE, 62500, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_PAIN_AND_SUFFERING, 4000, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_SUMMON_ICE_SPHERE, 8000, 0, PHASE_TRANSITION);
-                        events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, 3000, 0, PHASE_TRANSITION);
+                        events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, 6000, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_SUMMON_VALKYR, 78000, 0, PHASE_TWO);
                         events.ScheduleEvent(EVENT_INFEST, 70000, 0, PHASE_TWO);
                         events.ScheduleEvent(EVENT_DEFILE, 97000, 0, PHASE_TWO);
@@ -851,14 +852,14 @@ class boss_the_lich_king : public CreatureScript
                     case POINT_CENTER_2:
                         me->SetFacingTo(0.0f, true);
                         Talk(SAY_LK_REMORSELESS_WINTER);
-                        me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                        me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                         DoCast(me, SPELL_REMORSELESS_WINTER_2);
                         summons.DespawnEntry(NPC_VALKYR_SHADOWGUARD);
                         events.DelayEvents(62500, EVENT_GROUP_BERSERK); // delay berserk timer, its not ticking during phase transitions
                         events.ScheduleEvent(EVENT_QUAKE_2, 62500, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_PAIN_AND_SUFFERING, 6000, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_SUMMON_ICE_SPHERE, 8000, 0, PHASE_TRANSITION);
-                        events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, 5000, 0, PHASE_TRANSITION);
+                        events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT_2, 5000, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_DEFILE, 95500, 0, PHASE_THREE);
                         events.ScheduleEvent(EVENT_SOUL_REAPER, 99500, 0, PHASE_THREE);
                         events.ScheduleEvent(EVENT_VILE_SPIRITS, 79500, EVENT_GROUP_VILE_SPIRITS, PHASE_THREE);
@@ -934,10 +935,11 @@ class boss_the_lich_king : public CreatureScript
                             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
                             me->SetReactState(REACT_AGGRESSIVE);
                             events.SetPhase(PHASE_ONE);
+                            DoZoneInCombat();
                             break;
                         case EVENT_SUMMON_SHAMBLING_HORROR:
                             DoCast(me, SPELL_SUMMON_SHAMBLING_HORROR);
-                            me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                            me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             events.ScheduleEvent(EVENT_SUMMON_SHAMBLING_HORROR, 60000, 0, PHASE_ONE);
                             break;
                         case EVENT_SUMMON_DRUDGE_GHOUL:
@@ -993,24 +995,29 @@ class boss_the_lich_king : public CreatureScript
                                 me->CastSpell(target, SPELL_RAGING_SPIRIT, TRIGGERED_NONE);
                             events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, urand(22000, 23000), 0, PHASE_TRANSITION);
                             break;
+                        case EVENT_SUMMON_RAGING_SPIRIT_2:
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0.0f, true))
+                                me->CastSpell(target, SPELL_RAGING_SPIRIT, TRIGGERED_NONE);
+                            events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, 18000, 0, PHASE_TRANSITION);
+                            break;
                         case EVENT_QUAKE:
                             events.SetPhase(PHASE_TWO);
                             me->ClearUnitState(UNIT_STATE_CASTING);  // clear state to ensure check in DoCastAOE passes
                             DoCastAOE(SPELL_QUAKE);
-                            me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                            me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             Talk(SAY_LK_QUAKE);
                             break;
                         case EVENT_QUAKE_2:
                             events.SetPhase(PHASE_THREE);
                             me->ClearUnitState(UNIT_STATE_CASTING);  // clear state to ensure check in DoCastAOE passes
                             DoCastAOE(SPELL_QUAKE);
-                            me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                            me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             Talk(SAY_LK_QUAKE);
                             break;
                         case EVENT_SUMMON_VALKYR:
-                            me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                            me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             Talk(SAY_LK_SUMMON_VALKYR);
-                            DoCastAOE(SUMMON_VALKYR);
+                            DoCastAOE(SUMMON_VALKYR, true);
                             events.ScheduleEvent(EVENT_SUMMON_VALKYR, urand(45000, 50000), 0, PHASE_TWO);
                             break;
                         case EVENT_START_ATTACK:
@@ -1019,7 +1026,7 @@ class boss_the_lich_king : public CreatureScript
                                 events.SetPhase(PHASE_THREE);
                             break;
                         case EVENT_VILE_SPIRITS:
-                            me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_SPECIAL);
+                            me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             DoCastAOE(SPELL_VILE_SPIRITS);
                             events.ScheduleEvent(EVENT_VILE_SPIRITS, urand(35000, 40000), EVENT_GROUP_VILE_SPIRITS, PHASE_THREE);
                             break;
@@ -1035,6 +1042,25 @@ class boss_the_lich_king : public CreatureScript
                             events.RescheduleEvent(EVENT_SOUL_REAPER, urand(57000, 62000), 0, PHASE_THREE);
                             events.ScheduleEvent(EVENT_START_ATTACK, 49000);
                             events.ScheduleEvent(EVENT_FROSTMOURNE_HEROIC, 6500);
+                            for (ObjectGuid guid : summons)
+                            {
+                                if (Creature* summon = ObjectAccessor::GetCreature(*me, guid))
+                                {
+                                    if (summon->GetEntry() == NPC_VILE_SPIRIT)
+                                    {
+                                        summon->m_Events.KillAllEvents(true);
+                                        summon->m_Events.AddEvent(new VileSpiritActivateEvent(summon), summon->m_Events.CalculateTime(56500));
+                                        summon->SetReactState(REACT_PASSIVE);
+                                        summon->CombatStop(true);
+                                        summon->RemoveAurasDueToSpell(SPELL_VILE_SPIRIT_MOVE_SEARCH);
+                                        summon->RemoveAurasDueToSpell(SPELL_VILE_SPIRIT_DAMAGE_SEARCH);
+                                        summon->GetMotionMaster()->MoveTargetedHome();
+                                        summon->GetMotionMaster()->MoveRandom(10.0f);
+                                    }
+                                    else if (summon->GetEntry() == NPC_RAGING_SPIRIT)
+                                        summon->AI()->DoAction(ACTION_DISABLE_RAGING);
+                                }
+                            }
                             break;
                         case EVENT_FROSTMOURNE_HEROIC:
                             if (TempSummon* terenas = me->GetMap()->SummonCreature(NPC_TERENAS_MENETHIL_FROSTMOURNE_H, TerenasSpawnHeroic, NULL, 50000))
@@ -1049,18 +1075,6 @@ class boss_the_lich_king : public CreatureScript
                                     spawner->CastSpell(spawner, SPELL_SUMMON_SPIRIT_BOMB_1, true);  // summons bombs randomly
                                     spawner->CastSpell(spawner, SPELL_SUMMON_SPIRIT_BOMB_2, true);  // summons bombs on players
                                     spawner->m_Events.AddEvent(new TriggerWickedSpirit(spawner), spawner->m_Events.CalculateTime(3000));
-                                }
-
-                                for (SummonList::iterator i = summons.begin(); i != summons.end(); ++i)
-                                {
-                                    Creature* summon = ObjectAccessor::GetCreature(*me, *i);
-                                    if (summon && summon->GetEntry() == NPC_VILE_SPIRIT)
-                                    {
-                                        summon->m_Events.KillAllEvents(true);
-                                        summon->m_Events.AddEvent(new VileSpiritActivateEvent(summon), summon->m_Events.CalculateTime(50000));
-                                        summon->GetMotionMaster()->MoveRandom(10.0f);
-                                        summon->SetReactState(REACT_PASSIVE);
-                                    }
                                 }
                             }
                             break;
@@ -1090,7 +1104,7 @@ class boss_the_lich_king : public CreatureScript
                         case EVENT_OUTRO_RAISE_DEAD:
                             DoCastAOE(SPELL_RAISE_DEAD);
                             me->ClearUnitState(UNIT_STATE_CASTING);
-                            me->GetMap()->SetZoneMusic(AREA_THE_FROZEN_THRONE, MUSIC_FINAL);
+                            me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_FINAL);
                             break;
                         case EVENT_OUTRO_TALK_5:
                             Talk(SAY_LK_OUTRO_5);
@@ -1161,7 +1175,6 @@ class npc_tirion_fordring_tft : public CreatureScript
                 _events.Reset();
                 if (_instance->GetBossState(DATA_THE_LICH_KING) == DONE)
                     me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                me->LoadEquipment(1);
             }
 
             void MovementInform(uint32 type, uint32 id) override
@@ -1373,7 +1386,9 @@ class npc_raging_spirit : public CreatureScript
 
             void Reset() override
             {
+                me->SetReactState(REACT_PASSIVE);
                 _events.Reset();
+                _events.ScheduleEvent(EVENT_SET_AGRESSIVE, 2000);
                 _events.ScheduleEvent(EVENT_SOUL_SHRIEK, urand(12000, 15000));
                 DoCast(me, SPELL_PLAGUE_AVOIDANCE, true);
                 DoCast(me, SPELL_RAGING_SPIRIT_VISUAL, true);
@@ -1381,6 +1396,19 @@ class npc_raging_spirit : public CreatureScript
                     if (Unit* summoner = summon->GetSummoner())
                         summoner->CastSpell(me, SPELL_RAGING_SPIRIT_VISUAL_CLONE, true);
                 DoCast(me, SPELL_BOSS_HITTIN_YA, true);
+            }
+
+            void DoAction(int32 action) override
+            {
+                if (action == ACTION_DISABLE_RAGING)
+                {
+                    _events.Reset();
+                    _events.SetPhase(PHASE_FROSTMOURNE);
+                    _events.ScheduleEvent(EVENT_SET_AGRESSIVE, 52000);
+                    me->SetReactState(REACT_PASSIVE);
+                    me->AttackStop();
+                    me->InterruptNonMeleeSpells(true);
+                }
             }
 
             void IsSummonedBy(Unit* /*summoner*/) override
@@ -1400,7 +1428,7 @@ class npc_raging_spirit : public CreatureScript
 
             void UpdateAI(uint32 diff) override
             {
-                if (!UpdateVictim())
+                if (!_events.IsInPhase(PHASE_FROSTMOURNE) && !UpdateVictim())
                     return;
 
                 _events.Update(diff);
@@ -1415,6 +1443,14 @@ class npc_raging_spirit : public CreatureScript
                         case EVENT_SOUL_SHRIEK:
                             DoCastAOE(SPELL_SOUL_SHRIEK);
                             _events.ScheduleEvent(EVENT_SOUL_SHRIEK, urand(12000, 15000));
+                            break;
+                        case EVENT_SET_AGRESSIVE:
+                            me->SetReactState(REACT_AGGRESSIVE);
+                            if (_events.IsInPhase(PHASE_FROSTMOURNE))
+                            {
+                                _events.SetPhase(PHASE_THREE);
+                                _events.ScheduleEvent(EVENT_SOUL_SHRIEK, urand(12000, 15000));
+                            }
                             break;
                         default:
                             break;
@@ -1498,7 +1534,7 @@ class npc_valkyr_shadowguard : public CreatureScript
                 {
                     case POINT_DROP_PLAYER:
                         DoCastAOE(SPELL_EJECT_ALL_PASSENGERS);
-                        me->DespawnOrUnsummon(1000);
+                        IsHeroic() ? me->GetMotionMaster()->MoveTargetedHome() : me->DespawnOrUnsummon(1000);
                         break;
                     case POINT_CHARGE:
                         if (Player* target = ObjectAccessor::GetPlayer(*me, _grabbedPlayer))
@@ -1623,6 +1659,7 @@ class npc_strangulate_vehicle : public CreatureScript
 
                 if (Creature* lichKing = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING)))
                     lichKing->AI()->SummonedCreatureDespawn(me);
+                me->DespawnOrUnsummon();
             }
 
             void UpdateAI(uint32 diff) override
@@ -2117,7 +2154,7 @@ class spell_the_lich_king_necrotic_plague_jump : public SpellScriptLoader
             }
 
         private:
-            void SelectTarget(std::list<Unit*>& targets)
+            void SelectTarget(std::list<WorldObject*>& targets)
             {
                 targets.sort(Trinity::ObjectDistanceOrderPred(GetCaster()));
                 if (targets.size() < 2)
@@ -2140,6 +2177,7 @@ class spell_the_lich_king_necrotic_plague_jump : public SpellScriptLoader
 
             void Register() override
             {
+                OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_the_lich_king_necrotic_plague_SpellScript::SelectTarget, EFFECT_0, TARGET_UNIT_SRC_AREA_ENTRY);
                 BeforeHit += SpellHitFn(spell_the_lich_king_necrotic_plague_SpellScript::CheckAura);
                 OnHit += SpellHitFn(spell_the_lich_king_necrotic_plague_SpellScript::AddMissingStack);
             }
@@ -2374,13 +2412,6 @@ class spell_the_lich_king_raging_spirit : public SpellScriptLoader
         {
             PrepareSpellScript(spell_the_lich_king_raging_spirit_SpellScript);
 
-            bool Validate(SpellInfo const* /*spell*/) override
-            {
-                if (!sSpellMgr->GetSpellInfo(SPELL_LIFE_SIPHON_HEAL))
-                    return false;
-                return true;
-            }
-
             void HandleScript(SpellEffIndex effIndex)
             {
                 PreventHitDefaultEffect(effIndex);
@@ -2539,7 +2570,7 @@ class spell_the_lich_king_valkyr_target_search : public SpellScriptLoader
         private:
             bool Validate(SpellInfo const* /*spell*/) override
             {
-                if (!sSpellMgr->GetSpellInfo(SPELL_ICE_BURST))
+                if (!sSpellMgr->GetSpellInfo(SPELL_CHARGE))
                     return false;
                 return true;
             }
@@ -3192,6 +3223,34 @@ class spell_the_lich_king_play_movie : public SpellScriptLoader
         }
 };
 
+class spell_the_lich_king_harvest_souls_teleport : public SpellScriptLoader
+{
+    public:
+        spell_the_lich_king_harvest_souls_teleport() : SpellScriptLoader("spell_the_lich_king_harvest_souls_teleport") { }
+
+        class spell_the_lich_king_harvest_souls_teleport_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_the_lich_king_harvest_souls_teleport_SpellScript);
+
+            void RelocateTransportOffset(SpellEffIndex /*effIndex*/)
+            {
+                float randCoordX = frand(-18.0f, 18.0f);
+                float randCoordY = frand(-18.0f, 18.0f);
+                GetHitDest()->RelocateOffset({ randCoordX, randCoordY, 0.0f, 0.0f });
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_the_lich_king_harvest_souls_teleport_SpellScript::RelocateTransportOffset, EFFECT_1, SPELL_EFFECT_TELEPORT_UNITS);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_the_lich_king_harvest_souls_teleport_SpellScript();
+        }
+};
+
 class achievement_been_waiting_long_time : public AchievementCriteriaScript
 {
     public:
@@ -3262,6 +3321,7 @@ void AddSC_boss_the_lich_king()
     new spell_the_lich_king_jump_remove_aura();
     new spell_trigger_spell_from_caster("spell_the_lich_king_mass_resurrection", SPELL_MASS_RESURRECTION_REAL);
     new spell_the_lich_king_play_movie();
+    new spell_the_lich_king_harvest_souls_teleport();
     new achievement_been_waiting_long_time();
     new achievement_neck_deep_in_vile();
 }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -1534,7 +1534,10 @@ class npc_valkyr_shadowguard : public CreatureScript
                 {
                     case POINT_DROP_PLAYER:
                         DoCastAOE(SPELL_EJECT_ALL_PASSENGERS);
-                        IsHeroic() ? me->GetMotionMaster()->MoveTargetedHome() : me->DespawnOrUnsummon(1000);
+                        if (IsHeroic())
+                            me->GetMotionMaster()->MoveTargetedHome();
+                        else
+                            me->DespawnOrUnsummon(1000);
                         break;
                     case POINT_CHARGE:
                         if (Player* target = ObjectAccessor::GetPlayer(*me, _grabbedPlayer))

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
@@ -317,6 +317,7 @@ enum CreaturesIds
     NPC_WORLD_TRIGGER_INFINITE_AOI              = 36171,
     NPC_SPIRIT_BOMB                             = 39189,
     NPC_FROSTMOURNE_TRIGGER                     = 38584,
+    NPC_SHADOW_TRAP                             = 39137,
 
     // Generic
     NPC_INVISIBLE_STALKER                       = 30298
@@ -520,8 +521,7 @@ enum WorldStatesICC
 
 enum AreaIds
 {
-    AREA_ICECROWN_CITADEL   = 4812,
-    AREA_THE_FROZEN_THRONE  = 4859
+    AREA_ICECROWN_CITADEL   = 4812
 };
 
 class spell_trigger_spell_from_caster : public SpellScriptLoader


### PR DESCRIPTION
**Changes proposed:**

-  Fix a bug where the boss wouldn't cast Remorseless Winter if he was casting any other spell
-  Despawn shadow traps at the end of phase one
-  Make boss agressive
-  Improve Vile Spirits and Raging Spirit behavior when frostmourne heroic phase begins(all become passiveVile Spirits return to Home and move random)
-  Fix Valkyr Shadowguard behavior in heroic mode, they should not despawn in this case
-  Add randomization to the Harvest Souls teleport
-  Fix speed from Wicked Spirits and Spirit Bombs
-  Fix Tirion Jump and Knockback(based on fix from SunwellCore)
-  Register OnObjectAreaTargetSelect in spell_the_lich_king_necrotic_plague_SpellScript
-  Change Shadow Trap radius to 5yards

Knockback exception in SpellEffects.cpp may be wrong, accepting ideas ^^

**Target branch(es):** 3.3.5/master
- [x] 3.3.5

**Issues addressed:** Closes #4427 closes #7091

**Tests performed:** Built and tested

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Tirion's knockback will depende on a change done in another PR, to allow knockback on bosses under certain conditions.