### PR TITLE
Core/Unit: Fixed friendly NPC's inherit GM auras

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12849,9 +12849,22 @@ bool Unit::IsInRaidWith(Unit const* unit) const
 
     if (u1->GetTypeId() == TYPEID_PLAYER && u2->GetTypeId() == TYPEID_PLAYER)
         return u1->ToPlayer()->IsInSameRaidWith(u2->ToPlayer());
-    else if ((u2->GetTypeId() == TYPEID_PLAYER && u1->GetTypeId() == TYPEID_UNIT && u1->ToCreature()->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_TREAT_AS_RAID_UNIT) ||
-            (u1->GetTypeId() == TYPEID_PLAYER && u2->GetTypeId() == TYPEID_UNIT && u2->ToCreature()->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_TREAT_AS_RAID_UNIT))
-        return true;
+
+    if (u2->GetTypeId() == TYPEID_PLAYER && u1->GetTypeId() == TYPEID_UNIT)
+    {
+        if (u1->ToCreature()->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_TREAT_AS_RAID_UNIT)
+            return true;
+        else
+            return false;
+    }
+
+    if (u1->GetTypeId() == TYPEID_PLAYER && u2->GetTypeId() == TYPEID_UNIT)
+    {
+        if (u2->ToCreature()->GetCreatureTemplate()->type_flags & CREATURE_TYPE_FLAG_TREAT_AS_RAID_UNIT)
+            return true;
+        else
+            return false;
+    }
 
     // else u1->GetTypeId() == u2->GetTypeId() == TYPEID_UNIT
     return u1->getFaction() == u2->getFaction();


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**
- Unit is considered 'in raid with' player only if CreatureTemplate type flag 'CREATURE_TYPE_FLAG_TREAT_AS_RAID_UNIT' is set.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Issues addressed:** #19077

**Tests performed:** (Does it build, tested in-game, etc.)
- [x] Builds
- [x] Tested in game