### PR TITLE
Core/GameObject: Fixed GAMEOBJECT_TYPE_DOOR turning closed

### DIFF
--- a/src/server/scripts/Commands/cs_gobject.cpp
+++ b/src/server/scripts/Commands/cs_gobject.cpp
@@ -89,9 +89,11 @@ public:
             return false;
         }
 
+        uint32_t const autoCloseTime = object->GetGOInfo()->GetAutoCloseTime() ? 10000u : 0u;
+
         // Activate
         object->SetLootState(GO_READY);
-        object->UseDoorOrButton(10000, false, handler->GetSession()->GetPlayer());
+        object->UseDoorOrButton(autoCloseTime, false, handler->GetSession()->GetPlayer());
 
         handler->PSendSysMessage("Object activated!");
 


### PR DESCRIPTION
Core/GameObject: Fixed GAMEOBJECT_TYPE_DOOR turning closed after activation even tho 'data2=0'

**Changes proposed:**
-  Value of argument 'time_to_restore' is overwritten with auto close time ('data2'), if auto close time equals 0.

**Target branch(es):**
- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #19261

**Tests performed:**
- [x] Builds
- [x] Tested in-game