### PR TITLE
warlock pet base damage

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -795,6 +795,11 @@ bool Pet::CreateBaseAtTamed(CreatureTemplate const* cinfo, Map* map)
     return true;
 }
 
+static float interpolate_base_damage (float level, float max_level, float min_level, float max_damage, float min_damage, float power) {
+    float ic = pow((level - min_level) / (max_level - min_level), power);
+    return max_damage * ic + min_damage * (1.0f-ic);
+}
+
 /// @todo Move stat mods code to pet passive auras
 bool Guardian::InitStatsForLevel(uint8 petlevel)
 {
@@ -898,9 +903,30 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
 
             SetBonusDamage(val * 0.15f);
 
-            SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, float(petlevel - (petlevel / 4)));
-            SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, float(petlevel + (petlevel / 4)));
-
+            float base_damage = petlevel;
+            switch (GetEntry())
+            {
+                case 416: // NPC_IMP
+                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 1.0f, 381.5f, 5.0f, 3.0f);
+                    break;
+                case 1860: //NPC_VOIDWALKER
+                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 10.0f, 342.64f, 10.57f, 3.0f);
+                    break;
+                case 1863: //NPC_SUCCUBUS
+                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 20.0f, 461,14f, 24.86f, 2.5f);
+                    break;
+                case 417: // NPC_FELHUNTER
+                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 30.0f, 312.6f, 23.07f, 2.0f);
+                    break;
+                case 17252: // NPC_FELGUARD
+                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 50.0f, 412.0f, 131.0f, 1.0f);
+                    break;
+                default:
+                    break;
+            }
+            SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, base_damage * 0.80f);
+            SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, base_damage * 1.20f);
+            
             //SetModifierValue(UNIT_MOD_ATTACK_POWER, BASE_VALUE, float(cinfo->attackpower));
             break;
         }

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -913,7 +913,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
                     base_damage = interpolate_base_damage ( petlevel, 80.0f, 10.0f, 342.64f, 10.57f, 3.0f);
                     break;
                 case 1863: //NPC_SUCCUBUS
-                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 20.0f, 461,14f, 24.86f, 2.5f);
+                    base_damage = interpolate_base_damage ( petlevel, 80.0f, 20.0f, 461.14f, 24.86f, 2.5f);
                     break;
                 case 417: // NPC_FELHUNTER
                     base_damage = interpolate_base_damage ( petlevel, 80.0f, 30.0f, 312.6f, 23.07f, 2.0f);


### PR DESCRIPTION
suggested fix to the warlock pet base damage, tired of posting this issue on 4 different servers.

references:
[1] simcraft
https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/simulationcraft/simc-335-1-win32.zip
[2] old wowwiki
http://wowwiki.wikia.com/wiki/Felguard_(warlock_minion)?oldid=2409171
http://wowwiki.wikia.com/wiki/Felhunter?oldid=2714647
http://wowwiki.wikia.com/wiki/Succubus_(warlock_minion)?oldid=2408937
http://wowwiki.wikia.com/wiki/Voidwalker_(warlock_minion)?oldid=2353207
http://wowwiki.wikia.com/wiki/Imp_(warlock_minion)?oldid=2410392
[3] voidwalker tanking
https://www.youtube.com/watch?v=SWqecvALz6Q
https://www.youtube.com/watch?v=WO-E2craHms
[4] my work files
https://www.mediafire.com/folder/rbt5u2yu1w232a9,7mt04maidc7u0uu,gv97znicm4y5sb5,rv7jsd0d32gc7sc,990y8fgqhk5vgcc,je7y4dfqg574cug,quft16relsflk6f,ur88x7lih6d56x1/shared
[5] image set for discussion
http://imgur.com/a/vf4uQ

Please start by taking a look at the image set[5].
The first image is a plot of all the wowwiki datapoints, with stock trinity and sunwells felguard for comparison.
There are many datapoints that are missing, if anyone have any sources to fill in let me know asap, but there's reason to suspect Blizzard reduced the damage at lvl 60 and 70 for balancing reason back in the day. Other than that it seems to be more or less smooth curves.

Dalaran-wow and ToD (rip) solved this issue by linear scaling; https://github.com/dalaranwow/dalaran-wow/issues/3237.
This works for lvl 80, but all pets become massively overpowered at lower levels, as is seen in later images.
Second image in the set is the general formula I suggest, it's interpolation with a power factor.

The rest of the image series is comparing the wowwiki datapoints (purple), to linear scales (green), the suggested interpolation (orange, note the power variable for each pet) and trinity (black) for each pet.

Target branch(es): 3.3.5/master
- [x] 3.3.5
- [x] master