### PR TITLE
Core/ScriptReloadMgr: Fixed scripts hot swapping on OS X

### DIFF
--- a/cmake/macros/ConfigureScripts.cmake
+++ b/cmake/macros/ConfigureScripts.cmake
@@ -85,10 +85,12 @@ function(IsDynamicLinkingRequired variable)
   set(${variable} ${IS_REQUIRED} PARENT_SCOPE)
 endfunction()
 
-# Stores the native variable name 
+# Stores the native variable name
 function(GetNativeSharedLibraryName module variable)
   if(WIN32)
     set(${variable} "${module}.dll" PARENT_SCOPE)
+  elseif(APPLE)
+    set(${variable} "lib${module}.dylib" PARENT_SCOPE)
   else()
     set(${variable} "lib${module}.so" PARENT_SCOPE)
   endif()

--- a/src/server/game/Scripting/ScriptReloadMgr.cpp
+++ b/src/server/game/Scripting/ScriptReloadMgr.cpp
@@ -67,6 +67,9 @@ namespace fs = boost::filesystem;
 #ifdef _WIN32
     #include <windows.h>
     #define HOTSWAP_PLATFORM_REQUIRES_CACHING
+#elif __APPLE__
+    #include <dlfcn.h>
+    #define HOTSWAP_PLATFORM_REQUIRES_CACHING
 #else // Posix
     #include <dlfcn.h>
     // #define HOTSWAP_PLATFORM_REQUIRES_CACHING
@@ -87,11 +90,13 @@ static char const* GetSharedLibraryPrefix()
 #endif
 }
 
-// Returns "dll" on Windows and "so" on posix.
+// Returns "dll" on Windows, "dylib" on OS X, and "so" on posix.
 static char const* GetSharedLibraryExtension()
 {
 #ifdef _WIN32
     return "dll";
+#elif __APPLE__
+    return "dylib";
 #else // Posix
     return "so";
 #endif
@@ -112,7 +117,7 @@ static fs::path GetDirectoryOfExecutable()
     if (path.is_absolute())
         return path.parent_path();
     else
-        return fs::absolute(path).parent_path();
+        return fs::canonical(fs::absolute(path)).parent_path();
 }
 
 class SharedLibraryUnloader


### PR DESCRIPTION
**Changes proposed:**
-  Added appropriate dynamic linking include, and shared library extension for OS X
-  Canonicalized world server executable path in ScriptReloadMgr::GetDirectoryOfExecutable()

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**
- [x] Builds
- [x] Tested in-game

**Known issues and TODO list:**
