### PR TITLE
Avoid float zero division

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26779,6 +26779,8 @@ float Player::GetAverageItemLevel() const
         ++count;
     }
 
+    if (count == 0)
+        return 0;
     return ((float)sum) / count;
 }
 


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

- when count is 0, dont divide by it and directly return 0 in getaverageitemlevel
- normally division by 0 would result in inf, nan or -inf. We dont want any of these most likely. The average should be 0 when no items were equipped for example.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)
