### PR TITLE
Fix exploit for learning spells that the player should not get

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23361,11 +23361,9 @@ bool Player::IsSpellFitByClassAndRace(uint32 spell_id) const
     {
         if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell_id))
         {
-            if (ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(getClass()))
-            {
-                if (spellInfo->SpellFamilyName == classEntry->spellfamily)
-                    return false;
-            }
+            ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(getClass());
+            if (spellInfo->SpellFamilyName == classEntry->spellfamily)
+                return false;
         }
         return true;
     }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23358,7 +23358,17 @@ bool Player::IsSpellFitByClassAndRace(uint32 spell_id) const
 
     SkillLineAbilityMapBounds bounds = sSpellMgr->GetSkillLineAbilityMapBounds(spell_id);
     if (bounds.first == bounds.second)
+    {
+        if (const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spell_id))
+        {
+            if (ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(getClass()))
+            {
+                if (spellInfo->SpellFamilyName == classEntry->spellfamily)
+                    return false;
+            }
+        }
         return true;
+    }
 
     for (SkillLineAbilityMap::const_iterator _spell_idx = bounds.first; _spell_idx != bounds.second; ++_spell_idx)
     {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23359,7 +23359,7 @@ bool Player::IsSpellFitByClassAndRace(uint32 spell_id) const
     SkillLineAbilityMapBounds bounds = sSpellMgr->GetSkillLineAbilityMapBounds(spell_id);
     if (bounds.first == bounds.second)
     {
-        if (const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spell_id))
+        if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spell_id))
         {
             if (ChrClassesEntry const* classEntry = sChrClassesStore.LookupEntry(getClass()))
             {

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -8234,7 +8234,7 @@ void ObjectMgr::AddSpellToTrainer(uint32 entry, uint32 spell, uint32 spellCost, 
 
     if (GetTalentSpellCost(spell))
     {
-        TC_LOG_ERROR("sql.sql", "Table `npc_trainer` contains an entry (Entry: %u) for a non-existing spell (Spell: %u) which is a talent, ignoring", entry, spell);
+        TC_LOG_ERROR("sql.sql", "Table `npc_trainer` contains an entry (Entry: %u) for a spell (Spell: %u) which is a talent, ignoring", entry, spell);
         return;
     }
 


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

- First off I would like to note that I don't know what GetSkillLineAbilityMapBounds contains exactly and if there is a better / more correct way to do this. The base issue is that there are class spells which should not be learned by any class and the suggested code rules them out. The suggested code cannot be used on all spells most likely, only the ones a class trainer can teach. 
- Add a check to race&class check. The check will now return false if the spell is a class specific spell (spell family matches class) and it is not in skill line ability store.
- Fix an error message that claimed a spell was nonexistent even if the spell exists, but it is a talent

The spells this new check filters out do not appear on client training list even if sent to the client. They show up in general tab if learned. They should not be learnable. They can be learned through .learn all my class command before this PR and through hacks by altering the spell being learned at a trainer.

List of bad spells from linked issue:
1785, 1786, 1787, 6783, 8649, 8650, 9913, 11197, 11198, 26866, 48669, 49913, 49914, 49915, 49916, 51426, 51427, 51428, 51429, 53720

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master - possibly, same spells are not in DB

**Issues addressed:** Closes #  (insert issue tracker number)
Closes https://github.com/TrinityCore/TrinityCore/issues/14790

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested only on 3.3.5
- Compiles
- Set up debugging to log all spells that the modification returns false for, logged in with each class, leveled to 80, performed .learn all my class, added some money to the player, went to a class trainer and learned all spells he had to offer. In the end only the same list of spells was being blocked as mentioned in the issue linked above.
- I also tried to check if some (but not all) profession trainers had spells blocked by this unintentionally, but I did not notice any on First Aid, Leatherworking, Cooking

**Known issues and TODO list:** (add/remove lines as needed)
- [ ] This modification does not alert that there are bad spells in trainer table, just silently ignores them and does not let player learn them due to red status.
- [ ] This modification does not remove the bad spells from DB, I'm unsure if the DB data in npc_trainer is blizzlike or not. It could be, even if these spells are not learnable (they are ignored by client).
