### PR TITLE
Core/Spells: change to the way the spell effect SPELL_EFFECT_JUMP work

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1024,12 +1024,9 @@ void Spell::EffectJump(SpellEffIndex effIndex)
     if (!unitTarget)
         return;
 
-    float x, y, z;
-    unitTarget->GetContactPoint(m_caster, x, y, z, CONTACT_DISTANCE);
-
     float speedXY, speedZ;
-    CalculateJumpSpeeds(effIndex, m_caster->GetExactDist2d(x, y), speedXY, speedZ);
-    m_caster->GetMotionMaster()->MoveJump(x, y, z, 0.0f, speedXY, speedZ, EVENT_JUMP, false);
+    CalculateJumpSpeeds(effIndex, m_caster->GetExactDist2d(unitTarget), speedXY, speedZ);
+    m_caster->GetMotionMaster()->MoveJump(*unitTarget, speedXY, speedZ, EVENT_JUMP, false);
 }
 
 void Spell::EffectJumpDest(SpellEffIndex effIndex)


### PR DESCRIPTION
**Changes proposed:**
- The spell effect 41 (SPELL_EFFECT_JUMP) moves the caster at the exact target's position instead of moving it to the closest "contact point" with the target.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes https://github.com/TrinityCore/TrinityCore/issues/17265#issuecomment-292783050


**Tests performed:** Tested IG. Appears to work well.

**Left to do:**
What is left is verify through sniffs analysis that this change is indeed retail like. I observed 3 spells with that spell effects (56729, 70122 and 52631). The 3 of them seems to follow the new logic.