### PR TITLE
Fix typo in IsRaidQuest

### DIFF
--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -360,7 +360,7 @@ bool Quest::IsAutoComplete() const
 
 bool Quest::IsRaidQuest(Difficulty difficulty) const
 {
-    switch (Type)
+    switch (QuestInfoID)
     {
         case QUEST_INFO_RAID:
             return true;


### PR DESCRIPTION
**Changes proposed:**

-  Fix a Typo in IsRaidQuest, wrongly using Type instead of QuestInfoID

**Target branch(es):**

- [x] master

**Issues addressed:** None

**Tests performed:** (Does it build, tested in-game, etc.)
None