### PR TITLE
[3.3.5] Core/Quest: always send the specified RewardNextQuest regardless of eventual scripts

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -303,45 +303,44 @@ void WorldSession::HandleQuestgiverChooseRewardOpcode(WorldPacket& recvData)
                 case TYPEID_UNIT:
                 {
                     Creature* questgiver = object->ToCreature();
-                    if (!sScriptMgr->OnQuestReward(_player, questgiver, quest, reward))
+                    // Send next quest
+                    if (Quest const* nextQuest = _player->GetNextQuest(guid, quest))
                     {
-                        // Send next quest
-                        if (Quest const* nextQuest = _player->GetNextQuest(guid, quest))
+                        // Only send the quest to the player if the conditions are met
+                        if (_player->CanTakeQuest(nextQuest, false))
                         {
-                            // Only send the quest to the player if the conditions are met
-                            if (_player->CanTakeQuest(nextQuest, false))
-                            {
-                                if (nextQuest->IsAutoAccept() && _player->CanAddQuest(nextQuest, true))
-                                    _player->AddQuestAndCheckCompletion(nextQuest, object);
+                            if (nextQuest->IsAutoAccept() && _player->CanAddQuest(nextQuest, true))
+                                _player->AddQuestAndCheckCompletion(nextQuest, object);
 
-                                _player->PlayerTalkClass->SendQuestGiverQuestDetails(nextQuest, guid, true);
-                            }
+                            _player->PlayerTalkClass->SendQuestGiverQuestDetails(nextQuest, guid, true);
                         }
-
-                        questgiver->AI()->sQuestReward(_player, quest, reward);
                     }
+
+                    if (!sScriptMgr->OnQuestReward(_player, questgiver, quest, reward))
+                        questgiver->AI()->sQuestReward(_player, quest, reward);
+
                     break;
                 }
                 case TYPEID_GAMEOBJECT:
                 {
                     GameObject* questGiver = object->ToGameObject();
-                    if (!sScriptMgr->OnQuestReward(_player, questGiver, quest, reward))
+
+                    // Send next quest
+                    if (Quest const* nextQuest = _player->GetNextQuest(guid, quest))
                     {
-                        // Send next quest
-                        if (Quest const* nextQuest = _player->GetNextQuest(guid, quest))
+                        // Only send the quest to the player if the conditions are met
+                        if (_player->CanTakeQuest(nextQuest, false))
                         {
-                            // Only send the quest to the player if the conditions are met
-                            if (_player->CanTakeQuest(nextQuest, false))
-                            {
-                                if (nextQuest->IsAutoAccept() && _player->CanAddQuest(nextQuest, true))
-                                    _player->AddQuestAndCheckCompletion(nextQuest, object);
+                            if (nextQuest->IsAutoAccept() && _player->CanAddQuest(nextQuest, true))
+                                _player->AddQuestAndCheckCompletion(nextQuest, object);
 
-                                _player->PlayerTalkClass->SendQuestGiverQuestDetails(nextQuest, guid, true);
-                            }
+                            _player->PlayerTalkClass->SendQuestGiverQuestDetails(nextQuest, guid, true);
                         }
-
-                        questGiver->AI()->QuestReward(_player, quest, reward);
                     }
+
+                    if (!sScriptMgr->OnQuestReward(_player, questGiver, quest, reward))
+                        questGiver->AI()->QuestReward(_player, quest, reward);
+
                     break;
                 }
                 default:

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -318,13 +318,11 @@ void WorldSession::HandleQuestgiverChooseRewardOpcode(WorldPacket& recvData)
 
                     if (!sScriptMgr->OnQuestReward(_player, questgiver, quest, reward))
                         questgiver->AI()->sQuestReward(_player, quest, reward);
-
                     break;
                 }
                 case TYPEID_GAMEOBJECT:
                 {
                     GameObject* questGiver = object->ToGameObject();
-
                     // Send next quest
                     if (Quest const* nextQuest = _player->GetNextQuest(guid, quest))
                     {
@@ -340,7 +338,6 @@ void WorldSession::HandleQuestgiverChooseRewardOpcode(WorldPacket& recvData)
 
                     if (!sScriptMgr->OnQuestReward(_player, questGiver, quest, reward))
                         questGiver->AI()->QuestReward(_player, quest, reward);
-
                     break;
                 }
                 default:


### PR DESCRIPTION
**Suggested changes**:

Before this change, if the OnQuestReward() hook returned true, the quest window would get stuck because it was expecting a RewardNextQuest that the server would not send.

Easily noticeable with the quest [Envoy to the Horde](http://www.wowhead.com/quest=9812): the quest window will be stuck on quest reward, because Sylvanas has [a core script using that hook](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/EasternKingdoms/zone_undercity.cpp#L99) which returns true.

Since the purpose of RewardNextQuest is to show a quest straight after another quest is rewarded, it makes no sense to allow scripts to influence that behavior.

**Target branch(es)**: 3.3.5

**Issues addressed:** I could have sworn I saw an issue about this, but can't find it again.

**Tests performed**: builds and works just fine.