### PR TITLE
[3.3.5] Core/Spells: don't skip resisted damage calculations for binary spells cast by creatures

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1678,8 +1678,8 @@ uint32 Unit::CalcSpellResistedDamage(Unit* victim, uint32 damage, SpellSchoolMas
         if (spellInfo->HasAttribute(SPELL_ATTR4_IGNORE_RESISTANCES))
             return 0;
 
-        // Binary spells can't have damage part resisted
-        if (spellInfo->HasAttribute(SPELL_ATTR0_CU_BINARY_SPELL))
+        // Damage dealt by binary spells cast by players cannot be partially resisted
+        if (GetTypeId() == TYPEID_PLAYER && spellInfo->HasAttribute(SPELL_ATTR0_CU_BINARY_SPELL))
             return 0;
     }
 


### PR DESCRIPTION
**Changes proposed:**

Binary spells cast by NPCs should allow for the damage to be partially resisted via normal resistance calculations, as opposed to those cast by players.

Right now, it can only be fully resisted or not resisted at all.

One example for this behavior is [here](https://youtu.be/V-qgBmWcEjg?t=46): the Druid is partially resisting Frost Nova's damage.

Another example is [here](https://youtu.be/Qtk3JXUvjWQ?t=122): the Warrior resists most of Prophet Skeram's Earth Shock (a binary spell) damage due to high Nature Resistance.

**Target branch(es):** 3.3.5

**Tests performed:** builds and works just fine.