### PR TITLE
Remove bad slot for mirror image packet

### DIFF
--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -539,7 +539,6 @@ void WorldSession::HandleMirrorImageDataRequest(WorldPackets::Spells::GetMirrorI
             EQUIPMENT_SLOT_HANDS,
             EQUIPMENT_SLOT_TABARD,
             EQUIPMENT_SLOT_BACK,
-            EQUIPMENT_SLOT_END
         };
 
         // Display items in visible slots


### PR DESCRIPTION
[//]: # (***************************)
[//]: # (** FILL IN THIS TEMPLATE **)
[//]: # (***************************)

**Changes proposed:**

-  Remove invalid equip slot from mirror image packet

In older code the END slot was used to indicate that the slot list ended:
https://github.com/TrinityCore/TrinityCore/blob/81d011170d48e7d4cce7892897d24528254615af/src/server/game/Handlers/SpellHandler.cpp#L643
But in new code since the loop is a range based for loop, it will loop through that END even though it should not. This will thus add data to the packet that should not possibly be there.

Additionally the container for the items is reserved to 11 elements. Pushing this 12th element forces an unnecessary grow of the container.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame and packet still works.
Compiles (travis)

**Known issues and TODO list:** (add/remove lines as needed)
