### PR TITLE
Core/Channel: Added prefix to function to allow addon communication through the channel addon opcode

### DIFF
--- a/src/server/game/Chat/Channels/Channel.cpp
+++ b/src/server/game/Chat/Channels/Channel.cpp
@@ -695,7 +695,7 @@ void Channel::Announce(Player const* player)
     UpdateChannelInDB();
 }
 
-void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang) const
+void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang, std::string const& prefix) const
 {
     if (what.empty())
         return;
@@ -727,10 +727,10 @@ void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang) 
 
         WorldPackets::Chat::Chat* packet = new WorldPackets::Chat::Chat();
         if (Player* player = ObjectAccessor::FindConnectedPlayer(guid))
-            packet->Initialize(CHAT_MSG_CHANNEL, Language(lang), player, player, what, 0, GetName(localeIdx));
+            packet->Initialize(CHAT_MSG_CHANNEL, Language(lang), player, player, what, 0, GetName(localeIdx), DEFAULT_LOCALE, prefix);
         else
         {
-            packet->Initialize(CHAT_MSG_CHANNEL, Language(lang), nullptr, nullptr, what, 0, GetName(localeIdx));
+            packet->Initialize(CHAT_MSG_CHANNEL, Language(lang), nullptr, nullptr, what, 0, GetName(localeIdx), DEFAULT_LOCALE, prefix);
             packet->SenderGUID = guid;
             packet->TargetGUID = guid;
         }

--- a/src/server/game/Chat/Channels/Channel.cpp
+++ b/src/server/game/Chat/Channels/Channel.cpp
@@ -704,6 +704,11 @@ void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang, 
     if (sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_CHANNEL))
         lang = LANG_UNIVERSAL;
 
+    Player* player = ObjectAccessor::FindConnectedPlayer(guid);
+
+    if (!player->GetSession()->IsAddonRegistered(prefix))
+        return;
+
     if (!IsOn(guid))
     {
         NotMemberAppend appender;
@@ -726,7 +731,7 @@ void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang, 
         LocaleConstant localeIdx = sWorld->GetAvailableDbcLocale(locale);
 
         WorldPackets::Chat::Chat* packet = new WorldPackets::Chat::Chat();
-        if (Player* player = ObjectAccessor::FindConnectedPlayer(guid))
+        if (player)
             packet->Initialize(CHAT_MSG_CHANNEL, Language(lang), player, player, what, 0, GetName(localeIdx), DEFAULT_LOCALE, prefix);
         else
         {

--- a/src/server/game/Chat/Channels/Channel.cpp
+++ b/src/server/game/Chat/Channels/Channel.cpp
@@ -695,7 +695,7 @@ void Channel::Announce(Player const* player)
     UpdateChannelInDB();
 }
 
-void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang, std::string const& prefix) const
+void Channel::Say(ObjectGuid const& guid, std::string const& what, uint32 lang, std::string const& prefix /*= ""*/) const
 {
     if (what.empty())
         return;

--- a/src/server/game/Chat/Channels/Channel.h
+++ b/src/server/game/Chat/Channels/Channel.h
@@ -220,7 +220,7 @@ class TC_GAME_API Channel
         void UnsilenceAll(Player const* player, std::string const& name);
         void List(Player const* player);
         void Announce(Player const* player);
-        void Say(ObjectGuid const& guid, std::string const& what, uint32 lang) const;
+        void Say(ObjectGuid const& guid, std::string const& what, uint32 lang, std::string const& prefix) const;
         void DeclineInvite(Player const* player);
         void Invite(Player const* player, std::string const& newp);
         void JoinNotify(Player const* player);

--- a/src/server/game/Chat/Channels/Channel.h
+++ b/src/server/game/Chat/Channels/Channel.h
@@ -220,7 +220,7 @@ class TC_GAME_API Channel
         void UnsilenceAll(Player const* player, std::string const& name);
         void List(Player const* player);
         void Announce(Player const* player);
-        void Say(ObjectGuid const& guid, std::string const& what, uint32 lang, std::string const& prefix) const;
+        void Say(ObjectGuid const& guid, std::string const& what, uint32 lang, std::string const& prefix = "") const;
         void DeclineInvite(Player const* player);
         void Invite(Player const* player, std::string const& newp);
         void JoinNotify(Player const* player);

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -384,7 +384,7 @@ void WorldSession::HandleChatMessage(ChatMsg type, uint32 lang, std::string msg,
             if (Channel* chn = ChannelMgr::GetChannelForPlayerByNamePart(target, sender))
             {
                 sScriptMgr->OnPlayerChat(sender, type, lang, msg, chn);
-                chn->Say(sender->GetGUID(), msg.c_str(), lang);
+                chn->Say(sender->GetGUID(), msg.c_str(), lang, nullptr);
             }
             break;
         }
@@ -510,7 +510,7 @@ void WorldSession::HandleChatAddonMessage(ChatMsg type, std::string prefix, std:
         case CHAT_MSG_CHANNEL:
         {
             if (Channel* chn = ChannelMgr::GetChannelForPlayerByNamePart(target, sender))
-                chn->Say(sender->GetGUID(), text.c_str(), uint32(LANG_ADDON));
+                chn->Say(sender->GetGUID(), text.c_str(), uint32(LANG_ADDON), prefix);
             break;
         }
         default:

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -384,7 +384,7 @@ void WorldSession::HandleChatMessage(ChatMsg type, uint32 lang, std::string msg,
             if (Channel* chn = ChannelMgr::GetChannelForPlayerByNamePart(target, sender))
             {
                 sScriptMgr->OnPlayerChat(sender, type, lang, msg, chn);
-                chn->Say(sender->GetGUID(), msg.c_str(), lang, nullptr);
+                chn->Say(sender->GetGUID(), msg.c_str(), lang, "");
             }
             break;
         }

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -384,7 +384,7 @@ void WorldSession::HandleChatMessage(ChatMsg type, uint32 lang, std::string msg,
             if (Channel* chn = ChannelMgr::GetChannelForPlayerByNamePart(target, sender))
             {
                 sScriptMgr->OnPlayerChat(sender, type, lang, msg, chn);
-                chn->Say(sender->GetGUID(), msg.c_str(), lang, "");
+                chn->Say(sender->GetGUID(), msg.c_str(), lang);
             }
             break;
         }


### PR DESCRIPTION
**Changes proposed:**
-  Added 'prefix' to the 'Say' command in Channel to allow addon communication, referencing issue: https://github.com/TrinityCore/TrinityCore/issues/19490

**Target branch(es):** 3.3.5/master
- [x] master

**Issues addressed:**
https://github.com/TrinityCore/TrinityCore/issues/19490

**Tests performed:** (Does it build, tested in-game, etc.)
- [x] Builds, also tested it and addons now receive a message back from the channel opcode.

**Known issues and TODO list:** (add/remove lines as needed)
- The addons that use the MSP (Mary Sue Protocol) still don't communicate to other players clients correctly, it doesn't send anything back to the clients, only requests.