### PR TITLE
Core/Spells: Fixed Hand of Freedom while CC

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2812,6 +2812,13 @@ void SpellInfo::_LoadImmunityInfo()
                 break;
             case 49039: // Lichborne, don't allow normal stuns
                 break;
+            case 1044: // Hand of Freedom
+                _allowedMechanicMask |=
+                    (1 << MECHANIC_STUN) |
+                    (1 << MECHANIC_FREEZE) |
+                    (1 << MECHANIC_SAPPED) |
+                    (1 << MECHANIC_SLEEP);
+                break;
             default:
                 _allowedMechanicMask |= (1 << MECHANIC_STUN);
                 break;


### PR DESCRIPTION
**Changes proposed:**

-  Allow Hand of Freedom be cast while CC
- Restore behavior of 625ca6ec1ca524f7435b34408470c9a04b675566 for this spell

**Target branch(es):** 3.3.5


**Issues addressed:** Closes #7206


**Tests performed:** Builded and tested in game