### PR TITLE
Core/Instance: Change the max visibility distance

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -1943,15 +1943,15 @@ Visibility.GroupMode = 1
 #    Visibility.Distance.BGArenas
 #        Description: Visibility distance to see other players or gameobjects.
 #                     Visibility on continents on retail ~90 yards. In BG/Arenas ~533.
-#                     For instances default ~170.
+#                     For instances default ~400.
 #                     Max limited by grid size: 533.33333
 #                     Min limit is max aggro radius (45) * Rate.Creature.Aggro
 #        Default:     90  - (Visibility.Distance.Continents)
-#                     170 - (Visibility.Distance.Instances)
+#                     400 - (Visibility.Distance.Instances)
 #                     533 - (Visibility.Distance.BGArenas)
 
 Visibility.Distance.Continents = 90
-Visibility.Distance.Instances = 170
+Visibility.Distance.Instances = 400
 Visibility.Distance.BGArenas = 533
 
 #


### PR DESCRIPTION
**Changes proposed:**

-  On retail, you can see Razorscale flying around when you use Ulduar Teleporter(Colossal Forge). Distance between teleporter and razorscale is approximately 400y.
-  On retail, you can see XT002 in Ulduar Teleporter (Colossal Forge). Distance between teleporter and XT002 is approximately 400y.

So the present value is very short and break razorscale encounter.

**Target branch(es):** 3.3.5


**Issues addressed:** Has no open issues, but will improve Razorscale fight (PR soon)


**Tests performed:** Builded and tested in game
