### PR TITLE
Fix evade issues when a projectile hits the target as it's evading

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5790,6 +5790,11 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (GetTypeId() == TYPEID_PLAYER && IsMounted())
         return false;
 
+    Creature* creature = ToCreature();
+    // creatures cannot attack while evading
+    if (creature && creature->IsInEvadeMode())
+        return false;
+
     if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
         return false;
 
@@ -5854,7 +5859,7 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     //if (GetTypeId() == TYPEID_UNIT)
     //    ToCreature()->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ());
 
-    if (GetTypeId() == TYPEID_UNIT && !IsPet())
+    if (creature && !IsPet())
     {
         // should not let player enter combat by right clicking target - doesn't helps
         AddThreat(victim, 0.0f);
@@ -5862,8 +5867,8 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
         if (victim->GetTypeId() == TYPEID_PLAYER)
             victim->SetInCombatWith(this);
 
-        ToCreature()->SendAIReaction(AI_REACTION_HOSTILE);
-        ToCreature()->CallAssistance();
+        creature->SendAIReaction(AI_REACTION_HOSTILE);
+        creature->CallAssistance();
 
         // Remove emote state - will be restored on creature reset
         SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
@@ -5878,7 +5883,7 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
 
     // Let the pet know we've started attacking someting. Handles melee attacks only
     // Spells such as auto-shot and others handled in WorldSession::HandleCastSpellOpcode
-    if (this->GetTypeId() == TYPEID_PLAYER)
+    if (GetTypeId() == TYPEID_PLAYER)
     {
         Pet* playerPet = this->ToPlayer()->GetPet();
 


### PR DESCRIPTION
Creatures should no longer get stuck in evade mode following a target if a spell hits the creature just as it's entering evade mode.
Fixes and closes #4943. Finally.

Reliable repro on f2b0819:
* Level 1 Human Warlock with Imp pet
* Begin Imp autocast on a Diseased Young Wolf
* Just as the first Imp Firebolt is about to finish casting, start casting your own shadow bolt
* If done correctly, your Shadow Bolt will impact just before the Imp's second Firebolt.
* The Shadow Bolt will trigger bug #19768, giving a reliable evade state.
* The Firebolt will then hit before the home motion finishes, causing ::AttackStart to trigger MoveChase.

Fix details:
* I correct this behavior by checking evade state for creatures in Unit::Attack, and rejecting the attack command if the creature is evading.
  * This causes AttackStart to properly abort and not trigger the movechase.

[Before](https://gfycat.com/ShallowBeautifulAsiansmallclawedotter) / [After](https://gfycat.com/EnlightenedGraveCock)