### PR TITLE
Core/Unit: guardians will enter combat when reaching target

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5547,7 +5547,7 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     //if (GetTypeId() == TYPEID_UNIT)
     //    ToCreature()->SetCombatStartPosition(GetPositionX(), GetPositionY(), GetPositionZ());
 
-    if (creature && !IsPet())
+    if (creature && !IsControlledByPlayer())
     {
         EngageWithTarget(victim); // ensure that anything we're attacking has threat
 


### PR DESCRIPTION
**Changes proposed:**

- Fix issue when Guardians (Temp Pets) put their target in combat before reaching that target

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #19485


**Tests performed:** Built and Tested in-game

**Note: Please, others Devs dont merge it. Treeston or ccrs will merge when others prs (related) be merged**
Related to: #19930 and #19818