### PR TITLE
Core/Config: Add configurable scaling to in-game (server) time

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22572,7 +22572,7 @@ void Player::SendInitialPacketsBeforeAddToMap()
 
     data.Initialize(SMSG_LOGIN_SETTIMESPEED, 4 + 4 + 4);
     data.AppendPackedTime(GameTime::GetGameTime());
-    data << float(0.01666667f);                             // game speed
+    data << float(0.01666667f * sWorld->getFloatConfig(CONFIG_GAMETIME_SCALE));                          // game speed
     data << uint32(0);                                      // added in 3.1.2
     GetSession()->SendPacket(&data);
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1043,6 +1043,8 @@ void World::LoadConfigSettings(bool reload)
     m_bool_configs[CONFIG_DEATH_BONES_BG_OR_ARENA]        = sConfigMgr->GetBoolDefault("Death.Bones.BattlegroundOrArena", true);
 
     m_bool_configs[CONFIG_DIE_COMMAND_MODE] = sConfigMgr->GetBoolDefault("Die.Command.Mode", true);
+		
+	m_float_configs[CONFIG_GAMETIME_SCALE] = sConfigMgr->GetFloatDefault("Gametime.Scale", 1.0f);
 
     m_float_configs[CONFIG_THREAT_RADIUS] = sConfigMgr->GetFloatDefault("ThreatRadius", 60.0f);
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -2318,6 +2318,13 @@ Death.Bones.BattlegroundOrArena = 1
 Die.Command.Mode = 1
 
 #
+#    Gametime.Scale
+#        Description: Sets the scale of the in-game day/night cycle.
+#        Default:     1
+
+Gametime.Scale = 1
+
+#
 ###################################################################################################
 
 ###################################################################################################


### PR DESCRIPTION
**Changes proposed:**

-  Adds a float config option to scale up (or down) the in game time. Default value in the config is set at 1, and is multiplied by the default game speed.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
n/a

**Tests performed:** (Does it build, tested in-game, etc.)
Builds, tested in game with various values (100, 1000) and it works fine.

**Known issues and TODO list:** (add/remove lines as needed)
none