### PR TITLE
Core/VMaps: Fix LoS in Strand of the Ancients

### DIFF
--- a/src/common/Collision/VMapDefinitions.h
+++ b/src/common/Collision/VMapDefinitions.h
@@ -25,8 +25,8 @@
 
 namespace VMAP
 {
-    const char VMAP_MAGIC[] = "VMAP_4.2";
-    const char RAW_VMAP_MAGIC[] = "VMAP042";                // used in extracted vmap files with raw data
+    const char VMAP_MAGIC[] = "VMAP_4.3";
+    const char RAW_VMAP_MAGIC[] = "VMAP043";                // used in extracted vmap files with raw data
     const char GAMEOBJECT_MODELS[] = "GameObjectModels.dtree";
 
     // defined in TileAssembler.cpp currently...

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -68,7 +68,7 @@ bool preciseVectorData = false;
 
 //static const char * szWorkDirMaps = ".\\Maps";
 const char* szWorkDirWmo = "./Buildings";
-const char* szRawVMAPMagic = "VMAP042";
+const char* szRawVMAPMagic = "VMAP043";
 
 // Local testing functions
 

--- a/src/tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/vmap4_extractor/wmo.cpp
@@ -349,11 +349,12 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
         {
             // Skip no collision triangles
             bool isRenderFace = (MOPY[2 * i] & WMO_MATERIAL_RENDER) && !(MOPY[2 * i] & WMO_MATERIAL_DETAIL);
-            bool isDetail = (MOPY[2 * i] & WMO_MATERIAL_DETAIL);
-            bool isCollision = (MOPY[2 * i] & WMO_MATERIAL_COLLISION);
+            bool isDetail = (MOPY[2 * i] & WMO_MATERIAL_DETAIL) != 0;
+            bool isCollision = (MOPY[2 * i] & WMO_MATERIAL_COLLISION) != 0;
 
             if (!isRenderFace && !isDetail && !isCollision)
                 continue;
+
             // Use this triangle
             for (int j=0; j<3; ++j)
             {

--- a/src/tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/vmap4_extractor/wmo.cpp
@@ -348,8 +348,11 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
         for (int i=0; i<nTriangles; ++i)
         {
             // Skip no collision triangles
-            if (MOPY[2*i]&WMO_MATERIAL_NO_COLLISION ||
-              !(MOPY[2*i]&(WMO_MATERIAL_HINT|WMO_MATERIAL_COLLIDE_HIT)) )
+            bool isRenderFace = (MOPY[2 * i] & WMO_MATERIAL_RENDER) && !(MOPY[2 * i] & WMO_MATERIAL_DETAIL);
+            bool isDetail = (MOPY[2 * i] & WMO_MATERIAL_DETAIL);
+            bool isCollision = (MOPY[2 * i] & WMO_MATERIAL_COLLISION);
+
+            if (!(isRenderFace || isDetail || isCollision))
                 continue;
             // Use this triangle
             for (int j=0; j<3; ++j)
@@ -482,7 +485,7 @@ WMOGroup::~WMOGroup()
 }
 
 WMOInstance::WMOInstance(MPQFile& f, char const* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile)
-    : currx(0), curry(0), wmo(NULL), doodadset(0), pos(), indx(0), id(0), d2(0), d3(0)
+    : currx(0), curry(0), wmo(NULL), doodadset(0), pos(), indx(0), id(0)
 {
     float ff[3];
     f.read(&id, 4);
@@ -491,14 +494,24 @@ WMOInstance::WMOInstance(MPQFile& f, char const* WmoInstName, uint32 mapID, uint
     f.read(ff,12);
     rot = Vec3D(ff[0],ff[1],ff[2]);
     f.read(ff,12);
-    pos2 = Vec3D(ff[0],ff[1],ff[2]);
+    pos2 = Vec3D(ff[0],ff[1],ff[2]); // bounding box corners
     f.read(ff,12);
-    pos3 = Vec3D(ff[0],ff[1],ff[2]);
-    f.read(&d2,4);
+    pos3 = Vec3D(ff[0],ff[1],ff[2]); // bounding box corners
+
+    uint16 fflags;
+    f.read(&fflags, 2);
+
+    uint16 doodadSet;
+    f.read(&doodadSet, 2);
 
     uint16 trash,adtId;
     f.read(&adtId,2);
     f.read(&trash,2);
+
+    // destructible wmo, do not dump. we can handle the vmap for these
+    // in dynamic tree (gameobject vmaps)
+    if (fflags & 0x01)
+        return;
 
     //-----------add_in _dir_file----------------
 

--- a/src/tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/vmap4_extractor/wmo.cpp
@@ -352,7 +352,7 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
             bool isDetail = (MOPY[2 * i] & WMO_MATERIAL_DETAIL);
             bool isCollision = (MOPY[2 * i] & WMO_MATERIAL_COLLISION);
 
-            if (!(isRenderFace || isDetail || isCollision))
+            if (!isRenderFace && !isDetail && !isCollision)
                 continue;
             // Use this triangle
             for (int j=0; j<3; ++j)
@@ -510,7 +510,7 @@ WMOInstance::WMOInstance(MPQFile& f, char const* WmoInstName, uint32 mapID, uint
 
     // destructible wmo, do not dump. we can handle the vmap for these
     // in dynamic tree (gameobject vmaps)
-    if (fflags & 0x01)
+    if ((fflags & 0x01) != 0)
         return;
 
     //-----------add_in _dir_file----------------

--- a/src/tools/vmap4_extractor/wmo.h
+++ b/src/tools/vmap4_extractor/wmo.h
@@ -27,15 +27,17 @@
 #include "loadlib/loadlib.h"
 
 // MOPY flags
-#define WMO_MATERIAL_UNK01           0x01
-#define WMO_MATERIAL_NOCAMCOLLIDE    0x02
-#define WMO_MATERIAL_DETAIL          0x04
-#define WMO_MATERIAL_COLLISION       0x08
-#define WMO_MATERIAL_HINT            0x10
-#define WMO_MATERIAL_RENDER          0x20
-#define WMO_MATERIAL_WALL_SURFACE    0x40 // Guessed
-#define WMO_MATERIAL_COLLIDE_HIT     0x80
-
+enum MopyFlags
+{
+    WMO_MATERIAL_UNK01          = 0x01,
+    WMO_MATERIAL_NOCAMCOLLIDE   = 0x02,
+    WMO_MATERIAL_DETAIL         = 0x04,
+    WMO_MATERIAL_COLLISION      = 0x08,
+    WMO_MATERIAL_HINT           = 0x10,
+    WMO_MATERIAL_RENDER         = 0x20,
+    WMO_MATERIAL_WALL_SURFACE   = 0x40, // Guessed
+    WMO_MATERIAL_COLLIDE_HIT    = 0x80
+};
 
 class WMOInstance;
 class WMOManager;

--- a/src/tools/vmap4_extractor/wmo.h
+++ b/src/tools/vmap4_extractor/wmo.h
@@ -27,13 +27,15 @@
 #include "loadlib/loadlib.h"
 
 // MOPY flags
-#define WMO_MATERIAL_NOCAMCOLLIDE    0x01
-#define WMO_MATERIAL_DETAIL          0x02
-#define WMO_MATERIAL_NO_COLLISION    0x04
-#define WMO_MATERIAL_HINT            0x08
-#define WMO_MATERIAL_RENDER          0x10
-#define WMO_MATERIAL_COLLIDE_HIT     0x20
-#define WMO_MATERIAL_WALL_SURFACE    0x40
+#define WMO_MATERIAL_UNK01           0x01
+#define WMO_MATERIAL_NOCAMCOLLIDE    0x02
+#define WMO_MATERIAL_DETAIL          0x04
+#define WMO_MATERIAL_COLLISION       0x08
+#define WMO_MATERIAL_HINT            0x10
+#define WMO_MATERIAL_RENDER          0x20
+#define WMO_MATERIAL_WALL_SURFACE    0x40 // Guessed
+#define WMO_MATERIAL_COLLIDE_HIT     0x80
+
 
 class WMOInstance;
 class WMOManager;
@@ -128,7 +130,7 @@ public:
     int doodadset;
     Vec3D pos;
     Vec3D pos2, pos3, rot;
-    uint32 indx, id, d2, d3;
+    uint32 indx, id;
 
     WMOInstance(MPQFile&f , char const* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile);
 


### PR DESCRIPTION

Fixed LoS issues in some places like SotA.
Re extracting VMaps is required.
Thanks @Warpten for the patch.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't dump destructible wmo's
-  Better check to skip no collision triangles 

**Target branch(es):** Both.

- 3.3.5
- master

**Issues addressed:** Closes #15798


**Tests performed:** 
- Builds
- Tested in game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
