### PR TITLE
Core/VMaps: Fix LoS in Strand of the Ancients

### DIFF
--- a/src/common/Collision/VMapDefinitions.h
+++ b/src/common/Collision/VMapDefinitions.h
@@ -25,8 +25,8 @@
 
 namespace VMAP
 {
-    const char VMAP_MAGIC[] = "VMAP_4.4";
-    const char RAW_VMAP_MAGIC[] = "VMAP044";                // used in extracted vmap files with raw data
+    const char VMAP_MAGIC[] = "VMAP_4.5";
+    const char RAW_VMAP_MAGIC[] = "VMAP045";                // used in extracted vmap files with raw data
     const char GAMEOBJECT_MODELS[] = "GameObjectModels.dtree";
 
     // defined in TileAssembler.cpp currently...

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -109,7 +109,7 @@ struct MapLoadInfo
 
 //static const char * szWorkDirMaps = ".\\Maps";
 const char* szWorkDirWmo = "./Buildings";
-const char* szRawVMAPMagic = "VMAP044";
+const char* szRawVMAPMagic = "VMAP045";
 
 #define CASC_LOCALES_COUNT 17
 char const* CascLocaleNames[CASC_LOCALES_COUNT] =

--- a/src/tools/vmap4_extractor/wmo.h
+++ b/src/tools/vmap4_extractor/wmo.h
@@ -28,13 +28,17 @@
 #include "cascfile.h"
 
 // MOPY flags
-#define WMO_MATERIAL_NOCAMCOLLIDE    0x01
-#define WMO_MATERIAL_DETAIL          0x02
-#define WMO_MATERIAL_NO_COLLISION    0x04
-#define WMO_MATERIAL_HINT            0x08
-#define WMO_MATERIAL_RENDER          0x10
-#define WMO_MATERIAL_COLLIDE_HIT     0x20
-#define WMO_MATERIAL_WALL_SURFACE    0x40
+enum MopyFlags
+{
+    WMO_MATERIAL_UNK01          = 0x01,
+    WMO_MATERIAL_NOCAMCOLLIDE   = 0x02,
+    WMO_MATERIAL_DETAIL         = 0x04,
+    WMO_MATERIAL_COLLISION      = 0x08,
+    WMO_MATERIAL_HINT           = 0x10,
+    WMO_MATERIAL_RENDER         = 0x20,
+    WMO_MATERIAL_WALL_SURFACE   = 0x40, // Guessed
+    WMO_MATERIAL_COLLIDE_HIT    = 0x80
+};
 
 class WMOInstance;
 class WMOManager;
@@ -132,7 +136,7 @@ public:
     int doodadset;
     Vec3D pos;
     Vec3D pos2, pos3, rot;
-    uint32 indx, id, d2, d3;
+    uint32 indx, id;
 
     WMOInstance(CASCFile&f , char const* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile);
 };


### PR DESCRIPTION
Core/Collision: Fixed MOPY chunk flags enum.
Also avoid loading destructible WMOs into vmaps.
VMap re-extraction is required.

(cherry picked from commit https://github.com/TrinityCore/TrinityCore/commit/c35793941b3aae9b54dce92389aa528d40050754)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add changes from https://github.com/TrinityCore/TrinityCore/commit/c35793941b3aae9b54dce92389aa528d40050754 to master branch (thanks @Warpten for the fix :))

**Target branch(es):**

- master

**Issues addressed:** Closes #15798

**Tests performed:** (Does it build, tested in-game, etc.)
- Builds
- Didn't test in game (IIRC there is a crash in SotA, could already have been fixed)
- Checked with recast demo instead (https://puu.sh/wcoYd/23be8bd3ef.png)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
