### PR TITLE
Scripts/Spells: Hunter spell Exhilaration

### DIFF
--- a/sql/updates/world/master/2017_99_99_99._world.sql
+++ b/sql/updates/world/master/2017_99_99_99._world.sql
@@ -1,4 +1,3 @@
-
 -- Exhilaration
 DELETE FROM `spell_script_names` where `ScriptName`='spell_hun_exhilaration';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) 

--- a/sql/updates/world/master/2017_99_99_99._world.sql
+++ b/sql/updates/world/master/2017_99_99_99._world.sql
@@ -1,0 +1,5 @@
+
+-- Exhilaration
+DELETE FROM `spell_script_names` where `ScriptName`='spell_hun_exhilaration';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) 
+VALUES(109304,'spell_hun_exhilaration');

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -286,8 +286,7 @@ class spell_hun_exhilaration : public SpellScriptLoader
             void HandleOnHit()
             {
                 if (GetCaster()->HasAura(SPELL_HUNTER_EXHILARATION_R2))
-                    if (Unit* pet = GetCaster()->GetGuardianPet())
-                        GetCaster()->CastSpell(pet, SPELL_HUNTER_EXHILARATION_PET, true);
+                    GetCaster()->CastSpell((Unit*)0, SPELL_HUNTER_EXHILARATION_PET, true);
             }
 
             void Register() override

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -37,6 +37,7 @@ enum HunterSpells
     SPELL_HUNTER_CHIMERA_SHOT_HEAL                  = 53353,
     SPELL_HUNTER_EXHILARATION                       = 109304,
     SPELL_HUNTER_EXHILARATION_PET                   = 128594,
+    SPELL_HUNTER_EXHILARATION_R2                    = 231546,
     SPELL_HUNTER_FIRE                               = 82926,
     SPELL_HUNTER_GENERIC_ENERGIZE_FOCUS             = 91954,
     SPELL_HUNTER_IMPROVED_MEND_PET                  = 24406,
@@ -261,6 +262,43 @@ class spell_hun_disengage : public SpellScriptLoader
         SpellScript* GetSpellScript() const override
         {
             return new spell_hun_disengage_SpellScript();
+        }
+};
+
+// 109304 - Exhilaration
+class spell_hun_exhilaration : public SpellScriptLoader
+{
+    public:
+        spell_hun_exhilaration() : SpellScriptLoader("spell_hun_exhilaration") { }
+
+        class spell_hun_exhilaration_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_hun_exhilaration_SpellScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                return ValidateSpellInfo
+                ({
+                    SPELL_HUNTER_EXHILARATION_R2
+                });
+            }
+
+            void HandleOnHit()
+            {
+                if (GetCaster()->HasAura(SPELL_HUNTER_EXHILARATION_R2))
+                    if (Unit* pet = GetCaster()->GetGuardianPet())
+                        GetCaster()->CastSpell(pet, SPELL_HUNTER_EXHILARATION_PET, true);
+            }
+
+            void Register() override
+            {
+                OnHit += SpellHitFn(spell_hun_exhilaration_SpellScript::HandleOnHit);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_hun_exhilaration_SpellScript();
         }
 };
 
@@ -1026,6 +1064,7 @@ void AddSC_hunter_spell_scripts()
     new spell_hun_chimera_shot();
     new spell_hun_cobra_shot();
     new spell_hun_disengage();
+    new spell_hun_exhilaration();
     new spell_hun_hunting_party();
     new spell_hun_improved_mend_pet();
     new spell_hun_last_stand_pet();

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -286,7 +286,7 @@ class spell_hun_exhilaration : public SpellScriptLoader
             void HandleOnHit()
             {
                 if (GetCaster()->HasAura(SPELL_HUNTER_EXHILARATION_R2))
-                    GetCaster()->CastSpell((Unit*)0, SPELL_HUNTER_EXHILARATION_PET, true);
+                    GetCaster()->CastSpell((Unit*)nullptr, SPELL_HUNTER_EXHILARATION_PET, true);
             }
 
             void Register() override


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Simple fix for Exhilaration spell http://www.wowhead.com/spell=109304/exhilaration
with Exhilaration (Rank 2) http://www.wowhead.com/spell=231546/exhilaration

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** 
Closes #19605

**Tests performed:** 
Tested in-game on the following scenarios:
- Without Rank 2 the spell only heals the hunter.
- Tested with Rank 2 spell heals both hunter and pet.
- The spell does not glitch if pet is dead or despawned.

**Known issues and TODO list:**
None as far as I know.