### PR TITLE
Core/Maps: Correct some GetHeight functions

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2558,7 +2558,7 @@ float WorldObject::GetFloorZ() const
 {
     if (!IsInWorld())
         return m_staticFloorZ;
-    return std::max<float>(m_staticFloorZ, GetMap()->GetGameObjectFloor(GetPhaseMask(), GetPositionX(), GetPositionY(), GetPositionZ()));
+    return std::max<float>(m_staticFloorZ, GetMap()->GetHeight(GetPositionX(), GetPositionY(), GetPositionZ()));
 }
 
 template TC_GAME_API void WorldObject::GetGameObjectListWithEntryInGrid(std::list<GameObject*>&, uint32, float) const;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2558,7 +2558,7 @@ float WorldObject::GetFloorZ() const
 {
     if (!IsInWorld())
         return m_staticFloorZ;
-    return std::max<float>(m_staticFloorZ, GetMap()->GetHeight(GetPositionX(), GetPositionY(), GetPositionZ()));
+    return std::max<float>(m_staticFloorZ, GetMap()->GetGameObjectFloor(GetPhaseMask(), GetPositionX(), GetPositionY(), GetPositionZ()));
 }
 
 template TC_GAME_API void WorldObject::GetGameObjectListWithEntryInGrid(std::list<GameObject*>&, uint32, float) const;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2331,15 +2331,15 @@ float Map::GetWaterOrGroundLevel(uint32 phasemask, float x, float y, float z, fl
         LiquidData liquid_status;
 
         ZLiquidStatus res = GetLiquidStatus(x, y, ground_z, MAP_ALL_LIQUIDS, &liquid_status);
-		switch (res)
-		{
-			case LIQUID_MAP_ABOVE_WATER:
-				return std::max<float>(liquid_status.level, ground_z);
-			case LIQUID_MAP_NO_WATER:
-				return ground_z;
-			default:
-				return liquid_status.level;
-		}
+        switch (res)
+        {
+	        case LIQUID_MAP_ABOVE_WATER:
+		        return std::max<float>(liquid_status.level, ground_z);
+	        case LIQUID_MAP_NO_WATER:
+		        return ground_z;
+	        default:
+		        return liquid_status.level;
+        }
     }
 
     return VMAP_INVALID_HEIGHT_VALUE;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2333,12 +2333,12 @@ float Map::GetWaterOrGroundLevel(uint32 phasemask, float x, float y, float z, fl
         ZLiquidStatus res = GetLiquidStatus(x, y, ground_z, MAP_ALL_LIQUIDS, &liquid_status);
         switch (res)
         {
-	        case LIQUID_MAP_ABOVE_WATER:
-		        return std::max<float>(liquid_status.level, ground_z);
-	        case LIQUID_MAP_NO_WATER:
-		        return ground_z;
-	        default:
-		        return liquid_status.level;
+            case LIQUID_MAP_ABOVE_WATER:
+                return std::max<float>(liquid_status.level, ground_z);
+            case LIQUID_MAP_NO_WATER:
+                return ground_z;
+            default:
+                return liquid_status.level;
         }
     }
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2331,7 +2331,15 @@ float Map::GetWaterOrGroundLevel(uint32 phasemask, float x, float y, float z, fl
         LiquidData liquid_status;
 
         ZLiquidStatus res = GetLiquidStatus(x, y, ground_z, MAP_ALL_LIQUIDS, &liquid_status);
-        return res ? liquid_status.level : ground_z;
+		switch (res)
+		{
+			case LIQUID_MAP_ABOVE_WATER:
+				return std::max<float>(liquid_status.level, ground_z);
+			case LIQUID_MAP_NO_WATER:
+				return ground_z;
+			default:
+				return liquid_status.level;
+		}
     }
 
     return VMAP_INVALID_HEIGHT_VALUE;
@@ -2727,7 +2735,7 @@ bool Map::getObjectHitPos(uint32 phasemask, float x1, float y1, float z1, float 
 
 float Map::GetHeight(uint32 phasemask, float x, float y, float z, bool vmap/*=true*/, float maxSearchDist/*=DEFAULT_HEIGHT_SEARCH*/) const
 {
-    return std::max<float>(GetHeight(x, y, z, vmap, maxSearchDist), _dynamicTree.getHeight(x, y, z, maxSearchDist, phasemask));
+    return std::max<float>(GetHeight(x, y, z, vmap, maxSearchDist), GetGameObjectFloor(phasemask, x, y, z, maxSearchDist));
 }
 
 bool Map::IsInWater(float x, float y, float pZ, LiquidData* data) const

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -526,7 +526,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         bool ContainsGameObjectModel(const GameObjectModel& model) const { return _dynamicTree.contains(model);}
         float GetGameObjectFloor(uint32 phasemask, float x, float y, float z, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const
         {
-            return _dynamicTree.getHeight(x, y, z, phasemask, maxSearchDist);
+            return _dynamicTree.getHeight(x, y, z, maxSearchDist, phasemask);
         }
         bool getObjectHitPos(uint32 phasemask, float x1, float y1, float z1, float x2, float y2, float z2, float& rx, float &ry, float& rz, float modifyDist);
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Return ground_z instead of liquid level when above water, only if ground_z > liquid level

**Target branch(es):** Both

- 3.3.5
- master

**Issues addressed:** Not a 100% fix for #15798 follow up


**Tests performed:** (Does it build, tested in-game, etc.)
Tested in game

**Known issues and TODO list:** (add/remove lines as needed)

- I made this in the Test map really quick: https://puu.sh/wekrI/70683bbd24.png
As you can see wrong floorZ is present on the red marker while the blue one is correct
- A real example: https://puu.sh/wekvj/71fd07ac29.png Should be +- 394 for floorZ

- Also, I am not sure about the changes in object.cpp

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
