### PR TITLE
[3.3.5] Implement Pet combo point system

### DIFF
--- a/src/server/game/Entities/Pet/Pet.h
+++ b/src/server/game/Entities/Pet/Pet.h
@@ -141,6 +141,15 @@ class TC_GAME_API Pet : public Guardian
         void SetAuraUpdateMaskForRaid(uint8 slot) { m_auraRaidUpdateMask |= (uint64(1) << slot); }
         void ResetAuraUpdateMaskForRaid() { m_auraRaidUpdateMask = 0; }
 
+        void SendComboPoints() const;
+        void AddComboPoints(Unit* target, uint8 count);
+        void AddComboPoints(uint8 count) { AddComboPoints(nullptr, count); }
+        void ClearComboPoints();
+        uint8 GetComboPoints() const { return m_comboPoints; }
+        uint8 GetComboPoints(ObjectGuid const& guid) const { return (guid && guid != m_comboTarget) ? 0 : m_comboPoints; }
+        uint8 GetComboPoints(Unit* target) const { return target ? GetComboPoints(target->GetGUID()) : GetComboPoints(); }
+        ObjectGuid GetComboTarget() const { return m_comboTarget; }
+
         DeclinedName const* GetDeclinedNames() const { return m_declinedname; }
 
         bool    m_removed;                                  // prevent overwrite pet state in DB at next Pet::Update if pet already removed(saved)
@@ -148,12 +157,14 @@ class TC_GAME_API Pet : public Guardian
         Player* GetOwner() const;
 
     protected:
-        uint32  m_happinessTimer;
+        uint32 m_happinessTimer;
         PetType m_petType;
-        int32   m_duration;                                 // time until unsummon (used mostly for summoned guardians and not used for controlled pets)
-        uint64  m_auraRaidUpdateMask;
-        bool    m_loading;
-        uint32  m_focusRegenTimer;
+        int32 m_duration; // time until unsummon (used mostly for summoned guardians and not used for controlled pets)
+        uint64 m_auraRaidUpdateMask;
+        bool m_loading;
+        uint32 m_focusRegenTimer;
+        uint8 m_comboPoints; // only used for Wolverine Bite talent (max 1 CP)
+        ObjectGuid m_comboTarget;
 
         DeclinedName *m_declinedname;
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1508,6 +1508,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void SetSelection(ObjectGuid guid) { SetGuidValue(UNIT_FIELD_TARGET, guid); }
 
         uint8 GetComboPoints() const { return m_comboPoints; }
+        uint8 GetComboPoints(ObjectGuid const& guid) const { return (guid && guid != m_comboTarget) ? 0 : m_comboPoints; }
+        uint8 GetComboPoints(Unit* target) const { return target ? GetComboPoints(target->GetGUID()) : GetComboPoints(); }
         ObjectGuid GetComboTarget() const { return m_comboTarget; }
 
         void AddComboPoints(Unit* target, int8 count, Spell* spell = nullptr);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3980,13 +3980,13 @@ void Spell::EffectAddComboPoints(SpellEffIndex /*effIndex*/)
     if (!unitTarget)
         return;
 
-    if (!m_caster->m_playerMovingMe)
-        return;
-
     if (damage <= 0)
         return;
 
-    m_caster->m_playerMovingMe->AddComboPoints(unitTarget, damage, this);
+    if (Player* player = m_caster->GetPlayerMovingMe())
+        player->AddComboPoints(unitTarget, damage, this);
+    else if (Pet* pet = m_caster->ToPet())
+        pet->AddComboPoints(unitTarget, damage);
 }
 
 void Spell::EffectDuel(SpellEffIndex effIndex)

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -445,10 +445,10 @@ int32 SpellEffectInfo::CalcValue(Unit const* caster, int32 const* bp, Unit const
     if (caster)
     {
         // bonus amount from combo points
-        if (caster->m_playerMovingMe)
-            if (uint8 comboPoints = caster->m_playerMovingMe->GetComboPoints())
+        if (Player* player = caster->GetPlayerMovingMe())
+            if (uint8 comboPoints = player->GetComboPoints())
                 if (float comboDamage = PointsPerComboPoint)
-                    value += comboDamage* comboPoints;
+                    value += comboDamage * comboPoints;
 
         value = caster->ApplyEffectModifiers(_spellInfo, _effIndex, value);
 


### PR DESCRIPTION
* Implement Pet combo point system
* Implement a hack to add combo points and make Wolverine Bite useful (fixes #752).
* Fix an issue where players could use client hacks to use combo points on a different target from the one they're applied to.
