### PR TITLE
Core/Movement: Set CatmullRom only when flying when using MoveSmoothPath

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -465,6 +465,7 @@ void MotionMaster::MoveSmoothPath(uint32 pointId, Position const* pathPoints, si
     {
         init.SetFly();
         init.SetUncompressed();
+        init.SetSmooth();
     }
 
     Movement::PointsArray path;
@@ -474,7 +475,6 @@ void MotionMaster::MoveSmoothPath(uint32 pointId, Position const* pathPoints, si
         return G3D::Vector3(point.GetPositionX(), point.GetPositionY(), point.GetPositionZ());
     });
     init.MovebyPath(path);
-    init.SetSmooth();
     init.SetWalk(walk);
     init.Launch();
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Only enable CatmullRom when fly parameter in MoveSmoothPath is set to true

**Target branch(es):** master

- master

**Tests performed:** 
- Builds
- Tested in game

**Known issues and TODO list:**

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
