### PR TITLE
Linear time RandomResize

### DIFF
--- a/src/common/Utilities/Containers.h
+++ b/src/common/Utilities/Containers.h
@@ -55,7 +55,6 @@ namespace Trinity
 
         // resizes <container> to have at most <requestedSize> elements
         // if it has more than <requestedSize> elements, the elements to keep are selected randomly
-        // note: after calling this method, the elements remaining in <container> will not necessarily have the same order as they did before the call
         template<class C>
         void RandomResize(C& container, std::size_t requestedSize)
         {

--- a/src/common/Utilities/Containers.h
+++ b/src/common/Utilities/Containers.h
@@ -53,17 +53,30 @@ namespace Trinity
             return size;
         }
 
+        // resizes <container> to have at most <requestedSize> elements
+        // if it has more than <requestedSize> elements, the elements to keep are selected randomly
+        // note: after calling this method, the elements remaining in <container> will not necessarily have the same order as they did before the call
         template<class C>
         void RandomResize(C& container, std::size_t requestedSize)
         {
-            uint32 currentSize = uint32(Size(container));
-            while (currentSize > requestedSize)
+            static_assert(std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<decltype(std::begin(container))>::iterator_category>::value, "Invalid container passed to Trinity::Containers::RandomResize");
+            if (Size(container) <= requestedSize)
+                return;
+            auto keepIt = std::begin(container), curIt = std::begin(container);
+            uint32 elementsToKeep = requestedSize, elementsToProcess = Size(container);
+            while (elementsToProcess)
             {
-                auto itr = std::begin(container);
-                std::advance(itr, urand(0, currentSize - 1));
-                container.erase(itr);
-                --currentSize;
+                // this element has chance (elementsToKeep / elementsToProcess) of being kept
+                if (urand(1, elementsToProcess) <= elementsToKeep)
+                {
+                    *keepIt = std::move(*curIt);
+                    ++keepIt;
+                    --elementsToKeep;
+                }
+                ++curIt;
+                --elementsToProcess;
             }
+            container.erase(keepIt, std::end(container));
         }
 
         template<class C, class Predicate>

--- a/src/common/Utilities/Containers.h
+++ b/src/common/Utilities/Containers.h
@@ -59,7 +59,7 @@ namespace Trinity
         template<class C>
         void RandomResize(C& container, std::size_t requestedSize)
         {
-            static_assert(std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<decltype(std::begin(container))>::iterator_category>::value, "Invalid container passed to Trinity::Containers::RandomResize");
+            static_assert(std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<typename C::iterator>::iterator_category>::value, "Invalid container passed to Trinity::Containers::RandomResize");
             if (Size(container) <= requestedSize)
                 return;
             auto keepIt = std::begin(container), curIt = std::begin(container);


### PR DESCRIPTION
The current `RandomResize` implementation uses `O(n)` calls to `std::advance` and `O(n)` calls to `std::erase`. This means that for `std::vector` (`std::erase` in linear time) and `std::list` (`std::advance` in linear time) it takes quadratic time in the worst case.

This PR proposes an improved implementation of `RandomResize` which cuts asymptotic performance to `O(n)` for all containers.

Runtime breakdown (resizing from size `n` to size `k`):
* Exactly `k` calls to `std::move` (each call takes `ϴ(1)`)
* `<= n` calls to `urand` (each call takes `ϴ(1)`)
* `<= n+k` increments of `container::iterator` (each call takes `ϴ(1)`)
* A single `container.erase` call that erases `(n-k)` elements (takes `O(n-k) = O(n)`)

-> Overall runtime is `O(n)`.