### PR TITLE
Change offset behavior of UnitAI::SelectTarget(List)

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -171,54 +171,7 @@ class TC_GAME_API UnitAI
                 return nullptr;
 
             std::list<Unit*> targetList;
-            if (targetType == SELECT_TARGET_MAXDISTANCE || targetType == SELECT_TARGET_MINDISTANCE)
-            {
-                for (ThreatReference const* ref : mgr.GetUnsortedThreatList())
-                {
-                    if (ref->IsOffline())
-                        continue;
-
-                    targetList.push_back(ref->GetVictim());
-                }
-            }
-            else
-            {
-                Unit* currentVictim = mgr.GetCurrentVictim();
-                if (currentVictim)
-                    targetList.push_back(currentVictim);
-
-                for (ThreatReference const* ref : mgr.GetSortedThreatList())
-                {
-                    if (ref->IsOffline())
-                        continue;
-
-                    Unit* thisTarget = ref->GetVictim();
-                    if (thisTarget != currentVictim)
-                        targetList.push_back(thisTarget);
-                }
-            }
-
-            // filter by predicate
-            targetList.remove_if([&predicate](Unit* target) { return !predicate(target); });
-
-            // shortcut: the list certainly isn't gonna get any larger after this point
-            if (targetList.size() <= offset)
-                return nullptr;
-
-            // right now, list is unsorted for DISTANCE types - re-sort by MAXDISTANCE
-            if (targetType == SELECT_TARGET_MAXDISTANCE || targetType == SELECT_TARGET_MINDISTANCE)
-                SortByDistance(targetList, targetType == SELECT_TARGET_MINDISTANCE);
-
-            // then reverse the sorting for MIN sortings
-            if (targetType == SELECT_TARGET_MINTHREAT)
-                targetList.reverse();
-
-            // now pop the first <offset> elements
-            while (offset)
-            {
-                targetList.pop_front();
-                --offset;
-            }
+            SelectTargetList(targetList, mgr.GetThreatListSize(), targetType, offset, predicate);
 
             // maybe nothing fulfills the predicate
             if (targetList.empty())
@@ -287,9 +240,6 @@ class TC_GAME_API UnitAI
                 }
             }
 
-            // filter by predicate
-            targetList.remove_if([&predicate](Unit* target) { return !predicate(target); });
-
             // shortcut: the list isn't gonna get any larger
             if (targetList.size() <= offset)
             {
@@ -311,6 +261,9 @@ class TC_GAME_API UnitAI
                 targetList.pop_front();
                 --offset;
             }
+
+            // then finally filter by predicate
+            targetList.remove_if([&predicate](Unit* target) { return !predicate(target); });
 
             if (targetList.size() <= num)
                 return;


### PR DESCRIPTION
Current behavior:
* Ignore the first `offset` units in `targetType` order that match `predicate`.

Proposed behavior:
* Ignore the first `offset` units in `targetType` order, regardless of whether they match `predicate`.

**Example:**
`Unit* target = SelectTarget(SELECT_TARGET_TOPAGGRO, 1, 10.0f, true);`
**Expected (New):** Selects the highest threat non-tank in 10yd.
**Current:** Selects the highest threat non-tank within 10yd, unless the tank is not within 10yd, then selects the second highest threat non-tank within 10yd.

Also includes some major code deduplication (changing `SelectTarget` to call `SelectTargetList` to handle filtering and sorting).