### PR TITLE
Get all tiles in beginning and calulate proper total tile count

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -54,7 +54,7 @@ namespace MMAP
 {
     MapBuilder::MapBuilder(float maxWalkableAngle, bool skipLiquid,
         bool skipContinents, bool skipJunkMaps, bool skipBattlegrounds,
-        bool debugOutput, bool bigBaseUnit, char const* offMeshFilePath) :
+        bool debugOutput, bool bigBaseUnit, int mapid, char const* offMeshFilePath) :
         m_terrainBuilder     (nullptr),
         m_debugOutput        (debugOutput),
         m_offMeshFilePath    (offMeshFilePath),
@@ -63,6 +63,7 @@ namespace MMAP
         m_skipBattlegrounds  (skipBattlegrounds),
         m_maxWalkableAngle   (maxWalkableAngle),
         m_bigBaseUnit        (bigBaseUnit),
+        m_mapid              (mapid),
         m_totalTiles         (0u),
         m_totalTilesProcessed(0u),
         m_rcContext          (nullptr),
@@ -152,10 +153,29 @@ namespace MMAP
                 if (tiles->insert(tileID).second)
                     count++;
             }
+
+            // make sure we process maps which don't have tiles
+            if (tiles->empty())
+            {
+                // convert coord bounds to grid bounds
+                uint32 minX, minY, maxX, maxY;
+                getGridBounds(mapID, minX, minY, maxX, maxY);
+
+                // add all tiles within bounds to tile list.
+                for (uint32 i = minX; i <= maxX; ++i)
+                    for (uint32 j = minY; j <= maxY; ++j)
+                        if (tiles->insert(StaticMapTree::packTileID(i, j)).second)
+                            count++;
+            }
         }
         printf("found %u.\n\n", count);
 
-        m_totalTiles.store(count, std::memory_order_relaxed);
+        // Calculate tiles to process in total
+        for (TileList::iterator it = m_tiles.begin(); it != m_tiles.end(); ++it)
+        {
+            if (!shouldSkipMap(it->m_mapId))
+                m_totalTiles += it->m_tiles->size();
+        }
     }
 
     /**************************************************************************/
@@ -374,25 +394,7 @@ namespace MMAP
     /**************************************************************************/
     void MapBuilder::buildMap(uint32 mapID)
     {
-#ifndef __APPLE__
-        //printf("[Thread %u] Building map %03u:\n", uint32(ACE_Thread::self()), mapID);
-#endif
-
         std::set<uint32>* tiles = getTileList(mapID);
-
-        // make sure we process maps which don't have tiles
-        if (!tiles->size())
-        {
-            // convert coord bounds to grid bounds
-            uint32 minX, minY, maxX, maxY;
-            getGridBounds(mapID, minX, minY, maxX, maxY);
-
-            // add all tiles within bounds to tile list.
-            for (uint32 i = minX; i <= maxX; ++i)
-                for (uint32 j = minY; j <= maxY; ++j)
-                    if (tiles->insert(StaticMapTree::packTileID(i, j)).second)
-                        ++m_totalTiles;
-        }
 
         if (!tiles->empty())
         {
@@ -415,11 +417,9 @@ namespace MMAP
                 // unpack tile coords
                 StaticMapTree::unpackTileID((*it), tileX, tileY);
 
+                if (!shouldSkipTile(mapID, tileX, tileY))
+                    buildTile(mapID, tileX, tileY, navMesh);
                 ++m_totalTilesProcessed;
-                if (shouldSkipTile(mapID, tileX, tileY))
-                    continue;
-
-                buildTile(mapID, tileX, tileY, navMesh);
             }
 
             dtFreeNavMesh(navMesh);
@@ -908,6 +908,9 @@ namespace MMAP
     /**************************************************************************/
     bool MapBuilder::shouldSkipMap(uint32 mapID)
     {
+        if (m_mapid >= 0)
+            return m_mapid != mapID;
+
         if (m_skipContinents)
             switch (mapID)
             {

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -909,7 +909,7 @@ namespace MMAP
     bool MapBuilder::shouldSkipMap(uint32 mapID)
     {
         if (m_mapid >= 0)
-            return m_mapid != mapID;
+            return static_cast<uint32>(m_mapid) != mapID;
 
         if (m_skipContinents)
             switch (mapID)

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -81,6 +81,7 @@ namespace MMAP
                 bool skipBattlegrounds   = false,
                 bool debugOutput         = false,
                 bool bigBaseUnit         = false,
+                int mapid                = -1,
                 char const* offMeshFilePath = nullptr);
 
             ~MapBuilder();
@@ -138,6 +139,8 @@ namespace MMAP
 
             float m_maxWalkableAngle;
             bool m_bigBaseUnit;
+
+            int32 m_mapid;
 
             std::atomic<uint32> m_totalTiles;
             std::atomic<uint32> m_totalTilesProcessed;

--- a/src/tools/mmaps_generator/PathGenerator.cpp
+++ b/src/tools/mmaps_generator/PathGenerator.cpp
@@ -282,7 +282,7 @@ int main(int argc, char** argv)
         return silent ? -3 : finish("Press ENTER to close...", -3);
 
     MapBuilder builder(maxAngle, skipLiquid, skipContinents, skipJunkMaps,
-                       skipBattlegrounds, debugOutput, bigBaseUnit, offMeshInputPath);
+                       skipBattlegrounds, debugOutput, bigBaseUnit, mapnum, offMeshInputPath);
 
     uint32 start = getMSTime();
     if (file)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Add the mapid restriction from commandline parameters to the MapBuilder::shouldSkipMap function to allow calculating proper tile count for both single map and all maps processing
- Remove an old print that was commented out
- Move all tile discovering to the part that discovers tiles
- Now that all tiles are discovered at the beginning and we have access to shouldSkipMap in it's entirety we now calculate the actual tile count to be processed per map. The tile count only reflects the amount of tiles to build for a single or all maps however and is not and should not be used for single file or tile processing configurations. See https://github.com/TrinityCore/TrinityCore/blob/07593f6c3488666423093c2c32514a0a378da942/src/tools/mmaps_generator/PathGenerator.cpp#L288-L295
- Move `++m_totalTilesProcessed;` to be after the map tile processing in MapBuilder::buildMap so we dont reach 100% prematurely (and since there is no print we actually never see 100% printed). I felt that having 100% print before we are there and upping the count of a tile being processed before it is processed to be illogical

Example log output
[mmaps_output.txt](https://github.com/TrinityCore/TrinityCore/files/1133867/mmaps_output.txt)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)
- Closes https://github.com/TrinityCore/TrinityCore/issues/18832

**Tests performed:** (Does it build, tested in-game, etc.)
- checked that percentage only grows and doesnt shift back and forth between two values
- checked that percentage does reach 99% on both a single map and all maps run
- Built mmaps with old and new extractor and took md5 hashes of the mmap file contents to verify that the output was not changed. Also compared the folder sizes which matched
- Verified moving tile discovering to single threaded part is not spending noticeable amount of time

**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
