### PR TITLE
Core/VMaps: Fix no collision triangles

### DIFF
--- a/src/common/Collision/VMapDefinitions.h
+++ b/src/common/Collision/VMapDefinitions.h
@@ -25,8 +25,8 @@
 
 namespace VMAP
 {
-    const char VMAP_MAGIC[] = "VMAP_4.3";
-    const char RAW_VMAP_MAGIC[] = "VMAP043";                // used in extracted vmap files with raw data
+    const char VMAP_MAGIC[] = "VMAP_4.4";
+    const char RAW_VMAP_MAGIC[] = "VMAP044";                // used in extracted vmap files with raw data
     const char GAMEOBJECT_MODELS[] = "GameObjectModels.dtree";
 
     // defined in TileAssembler.cpp currently...

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -65,7 +65,7 @@ bool preciseVectorData = false;
 
 //static const char * szWorkDirMaps = ".\\Maps";
 char const* szWorkDirWmo = "./Buildings";
-char const* szRawVMAPMagic = "VMAP043";
+char const* szRawVMAPMagic = "VMAP044";
 
 // Local testing functions
 

--- a/src/tools/vmap4_extractor/wmo.cpp
+++ b/src/tools/vmap4_extractor/wmo.cpp
@@ -349,10 +349,8 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE *output, WMORoot *rootWMO, bool precise
         {
             // Skip no collision triangles
             bool isRenderFace = (MOPY[2 * i] & WMO_MATERIAL_RENDER) && !(MOPY[2 * i] & WMO_MATERIAL_DETAIL);
-            bool isDetail = (MOPY[2 * i] & WMO_MATERIAL_DETAIL) != 0;
-            bool isCollision = (MOPY[2 * i] & WMO_MATERIAL_COLLISION) != 0;
-
-            if (!isRenderFace && !isDetail && !isCollision)
+            bool isCollision = MOPY[2 * i] & WMO_MATERIAL_COLLISION || isRenderFace;
+            if (!isCollision)
                 continue;
 
             // Use this triangle


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix collision check when generating vmaps

**Target branch(es):** 3.3.5/master

- 3.3.5
- master

**Issues addressed:** Closes https://github.com/TrinityCore/TrinityCore/issues/19865


**Tests performed:** (Does it build, tested in-game, etc.)
- Builds
- Tested in game

**Notes:**
- Reextracting vmaps



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
