### PR TITLE
[3.3.5] Addon channel GM command protocol

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -16,7 +16,6 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <boost/algorithm/string/replace.hpp>
 #include "Chat.h"
 #include "AccountMgr.h"
 #include "CellImpl.h"
@@ -34,6 +33,7 @@
 #include "Realm.h"
 #include "ScriptMgr.h"
 #include "World.h"
+#include <boost/algorithm/string/replace.hpp>
 
 ChatCommand::ChatCommand(char const* name, uint32 permission, bool allowConsole, pHandler handler, std::string help, std::vector<ChatCommand> childCommands /*= std::vector<ChatCommand>()*/)
     : Name(ASSERT_NOTNULL(name)), Permission(permission), AllowConsole(allowConsole), Handler(handler), Help(std::move(help)), ChildCommands(std::move(childCommands))

--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -16,6 +16,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <boost/algorithm/string/replace.hpp>
 #include "Chat.h"
 #include "AccountMgr.h"
 #include "CellImpl.h"
@@ -347,6 +348,7 @@ bool ChatHandler::ExecuteCommandInTable(std::vector<ChatCommand> const& table, c
                 SendSysMessage(table[i].Help.c_str());
             else
                 SendSysMessage(LANG_CMD_SYNTAX);
+            SetSentErrorMessage(true);
         }
 
         return true;
@@ -410,41 +412,39 @@ bool ChatHandler::SetDataForCommandInTable(std::vector<ChatCommand>& table, char
     return false;
 }
 
+bool ChatHandler::_ParseCommands(char const* text)
+{
+    if (ExecuteCommandInTable(getCommandTable(), text, text))
+        return true;
+    
+    // Pretend commands don't exist for regular players
+    if (m_session && !m_session->HasPermission(rbac::RBAC_PERM_COMMANDS_NOTIFY_COMMAND_NOT_FOUND_ERROR))
+        return false;
+
+    // Send error message for GMs
+    SendSysMessage(LANG_NO_CMD);
+    SetSentErrorMessage(true);
+    return true;
+}
+
 bool ChatHandler::ParseCommands(char const* text)
 {
     ASSERT(text);
     ASSERT(*text);
 
-    std::string fullcmd = text;
-
     /// chat case (.command or !command format)
-    if (m_session)
-    {
-        if (text[0] != '!' && text[0] != '.')
-            return false;
-    }
+    if (text[0] != '!' && text[0] != '.')
+        return false;
 
     /// ignore single . and ! in line
-    if (strlen(text) < 2)
+    if (!text[1])
         return false;
-    // original `text` can't be used. It content destroyed in command code processing.
 
     /// ignore messages staring from many dots.
-    if ((text[0] == '.' && text[1] == '.') || (text[0] == '!' && text[1] == '!'))
+    if (text[1] == '!' || text[1] == '.')
         return false;
 
-    /// skip first . or ! (in console allowed use command with . and ! and without its)
-    if (text[0] == '!' || text[0] == '.')
-        ++text;
-
-    if (!ExecuteCommandInTable(getCommandTable(), text, fullcmd))
-    {
-        if (m_session && !m_session->HasPermission(rbac::RBAC_PERM_COMMANDS_NOTIFY_COMMAND_NOT_FOUND_ERROR))
-            return false;
-
-        SendSysMessage(LANG_NO_CMD);
-    }
-    return true;
+    return _ParseCommands(text+1);
 }
 
 bool ChatHandler::isValidChatMessage(char const* message)
@@ -1232,6 +1232,16 @@ void CliHandler::SendSysMessage(const char *str, bool /*escapeCharacters*/)
     m_print(m_callbackArg, "\r\n");
 }
 
+bool CliHandler::ParseCommands(char const* str)
+{
+    if (!str[0])
+        return false;
+    // Console allows using commands both with and without leading indicator
+    if (str[0] == '.' || str[0] == '!')
+        ++str;
+    return _ParseCommands(str);
+}
+
 std::string CliHandler::GetNameLink() const
 {
     return GetTrinityString(LANG_CONSOLE_COMMAND);
@@ -1294,4 +1304,103 @@ LocaleConstant CliHandler::GetSessionDbcLocale() const
 int CliHandler::GetSessionDbLocaleIndex() const
 {
     return sObjectMgr->GetDBCLocaleIndex();
+}
+
+bool AddonCliHandler::ParseCommands(char const* str)
+{
+    if (memcmp(str, "TrinityCore\t", 12))
+        return false;
+    char opcode = str[12];
+    if (!opcode) // str[12] is opcode
+        return false;
+    if (!str[13] || !str[14] || !str[15] || !str[16]) // str[13] through str[16] is 4-character command counter
+        return false;
+    echo = str+13;
+    
+    switch (opcode)
+    {
+        case 'p': // p Ping
+            SendAck();
+            return true;
+        case 'h': // h Issue human-readable command
+        case 'i': // i Issue command
+            if (!str[17])
+                return false;
+            humanReadable = (opcode == 'h');
+            if (_ParseCommands(str + 17)) // actual command starts at str[17]
+            {
+                if (!hadAck)
+                    SendAck();
+                if (HasSentErrorMessage())
+                    SendFailed();
+                else
+                    SendOK();
+            }
+            else
+            {
+                SendSysMessage(LANG_NO_CMD);
+                SendFailed();
+            }
+            return true;
+        default:
+            return false;
+    }
+}
+
+void AddonCliHandler::Send(std::string const& msg)
+{
+    WorldPacket data;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_ADDON, GetSession()->GetPlayer(), GetSession()->GetPlayer(), msg);
+    GetSession()->SendPacket(&data);
+}
+
+void AddonCliHandler::SendAck() // a Command acknowledged, no body
+{
+    ASSERT(echo);
+    char ack[18] = "TrinityCore\ta";
+    memcpy(ack+13, echo, 4);
+    ack[17] = '\0';
+    Send(ack);
+    hadAck = true;
+}
+
+void AddonCliHandler::SendOK() // o Command OK, no body
+{
+    ASSERT(echo);
+    char ok[18] = "TrinityCore\to";
+    memcpy(ok+13, echo, 4);
+    ok[17] = '\0';
+    Send(ok);
+}
+
+void AddonCliHandler::SendFailed() // f Command failed, no body
+{
+    ASSERT(echo);
+    char fail[18] = "TrinityCore\tf";
+    memcpy(fail + 13, echo, 4);
+    fail[17] = '\0';
+    Send(fail);
+}
+
+// m Command message, message in body
+void AddonCliHandler::SendSysMessage(char const* str, bool escapeCharacters)
+{
+    ASSERT(echo);
+    if (!hadAck)
+        SendAck();
+
+    std::string msg = "TrinityCore\tm";
+    msg.append(echo, 4);
+    std::string body(str);
+    if (escapeCharacters)
+        boost::replace_all(body, "|", "||");
+    size_t pos, lastpos;
+    for (lastpos = 0, pos = body.find('\n', lastpos); pos != std::string::npos; lastpos = pos + 1, pos = body.find('\n', lastpos))
+    {
+        std::string line(msg);
+        line.append(body, lastpos, pos - lastpos);
+        Send(line);
+    }
+    msg.append(body, lastpos, pos - lastpos);
+    Send(msg);
 }

--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -1306,7 +1306,7 @@ int CliHandler::GetSessionDbLocaleIndex() const
     return sObjectMgr->GetDBCLocaleIndex();
 }
 
-bool AddonCliHandler::ParseCommands(char const* str)
+bool AddonChannelCommandHandler::ParseCommands(char const* str)
 {
     if (memcmp(str, "TrinityCore\t", 12))
         return false;
@@ -1347,14 +1347,14 @@ bool AddonCliHandler::ParseCommands(char const* str)
     }
 }
 
-void AddonCliHandler::Send(std::string const& msg)
+void AddonChannelCommandHandler::Send(std::string const& msg)
 {
     WorldPacket data;
     ChatHandler::BuildChatPacket(data, CHAT_MSG_WHISPER, LANG_ADDON, GetSession()->GetPlayer(), GetSession()->GetPlayer(), msg);
     GetSession()->SendPacket(&data);
 }
 
-void AddonCliHandler::SendAck() // a Command acknowledged, no body
+void AddonChannelCommandHandler::SendAck() // a Command acknowledged, no body
 {
     ASSERT(echo);
     char ack[18] = "TrinityCore\ta";
@@ -1364,7 +1364,7 @@ void AddonCliHandler::SendAck() // a Command acknowledged, no body
     hadAck = true;
 }
 
-void AddonCliHandler::SendOK() // o Command OK, no body
+void AddonChannelCommandHandler::SendOK() // o Command OK, no body
 {
     ASSERT(echo);
     char ok[18] = "TrinityCore\to";
@@ -1373,7 +1373,7 @@ void AddonCliHandler::SendOK() // o Command OK, no body
     Send(ok);
 }
 
-void AddonCliHandler::SendFailed() // f Command failed, no body
+void AddonChannelCommandHandler::SendFailed() // f Command failed, no body
 {
     ASSERT(echo);
     char fail[18] = "TrinityCore\tf";
@@ -1383,7 +1383,7 @@ void AddonCliHandler::SendFailed() // f Command failed, no body
 }
 
 // m Command message, message in body
-void AddonCliHandler::SendSysMessage(char const* str, bool escapeCharacters)
+void AddonChannelCommandHandler::SendSysMessage(char const* str, bool escapeCharacters)
 {
     ASSERT(echo);
     if (!hadAck)

--- a/src/server/game/Chat/Chat.h
+++ b/src/server/game/Chat/Chat.h
@@ -106,13 +106,13 @@ class TC_GAME_API ChatHandler
 
         // function with different implementation for chat/console
         virtual bool isAvailable(ChatCommand const& cmd) const;
+        virtual bool IsHumanReadable() const { return true; }
         virtual bool HasPermission(uint32 permission) const;
         virtual std::string GetNameLink() const;
         virtual bool needReportToTarget(Player* chr) const;
         virtual LocaleConstant GetSessionDbcLocale() const;
         virtual int GetSessionDbLocaleIndex() const;
 
-        bool IsHumanReadable() const { return humanReadable; }
         bool HasLowerSecurity(Player* target, ObjectGuid guid, bool strong = false);
         bool HasLowerSecurityAccount(WorldSession* target, uint32 account, bool strong = false);
 
@@ -154,7 +154,6 @@ class TC_GAME_API ChatHandler
         static bool SetDataForCommandInTable(std::vector<ChatCommand>& table, char const* text, uint32 permission, std::string const& help, std::string const& fullcommand);
         bool ExecuteCommandInTable(std::vector<ChatCommand> const& table, char const* text, std::string const& fullcmd);
         bool ShowHelpForSubCommands(std::vector<ChatCommand> const& table, char const* cmd, char const* subcmd);
-        bool humanReadable = true;
 
     private:
         WorldSession* m_session;                           // != nullptr for chat command call and nullptr for CLI command
@@ -185,13 +184,14 @@ class TC_GAME_API CliHandler : public ChatHandler
         Print* m_print;
 };
 
-class TC_GAME_API AddonCliHandler : public ChatHandler
+class TC_GAME_API AddonChannelCommandHandler : public ChatHandler
 {
     public:
         using ChatHandler::ChatHandler;
         bool ParseCommands(char const* str) override;
         void SendSysMessage(char const* str, bool escapeCharacters) override;
         using ChatHandler::SendSysMessage;
+        bool IsHumanReadable() const override { return humanReadable; }
 
     private:
         void Send(std::string const& msg);
@@ -201,6 +201,7 @@ class TC_GAME_API AddonCliHandler : public ChatHandler
 
         char const* echo = nullptr;
         bool hadAck = false;
+        bool humanReadable = false;
 };
 
 #endif

--- a/src/server/game/Chat/Chat.h
+++ b/src/server/game/Chat/Chat.h
@@ -93,7 +93,8 @@ class TC_GAME_API ChatHandler
             return Trinity::StringFormat(GetTrinityString(entry), std::forward<Args>(args)...);
         }
 
-        bool ParseCommands(char const* text);
+        bool _ParseCommands(char const* text);
+        virtual bool ParseCommands(char const* text);
 
         static std::vector<ChatCommand> const& getCommandTable();
         static void invalidateCommandTable();
@@ -111,6 +112,7 @@ class TC_GAME_API ChatHandler
         virtual LocaleConstant GetSessionDbcLocale() const;
         virtual int GetSessionDbLocaleIndex() const;
 
+        bool IsHumanReadable() const { return humanReadable; }
         bool HasLowerSecurity(Player* target, ObjectGuid guid, bool strong = false);
         bool HasLowerSecurityAccount(WorldSession* target, uint32 account, bool strong = false);
 
@@ -152,6 +154,7 @@ class TC_GAME_API ChatHandler
         static bool SetDataForCommandInTable(std::vector<ChatCommand>& table, char const* text, uint32 permission, std::string const& help, std::string const& fullcommand);
         bool ExecuteCommandInTable(std::vector<ChatCommand> const& table, char const* text, std::string const& fullcmd);
         bool ShowHelpForSubCommands(std::vector<ChatCommand> const& table, char const* cmd, char const* subcmd);
+        bool humanReadable = true;
 
     private:
         WorldSession* m_session;                           // != nullptr for chat command call and nullptr for CLI command
@@ -171,6 +174,7 @@ class TC_GAME_API CliHandler : public ChatHandler
         bool isAvailable(ChatCommand const& cmd) const override;
         bool HasPermission(uint32 /*permission*/) const override { return true; }
         void SendSysMessage(const char *str, bool escapeCharacters) override;
+        bool ParseCommands(char const* str) override;
         std::string GetNameLink() const override;
         bool needReportToTarget(Player* chr) const override;
         LocaleConstant GetSessionDbcLocale() const override;
@@ -179,6 +183,24 @@ class TC_GAME_API CliHandler : public ChatHandler
     private:
         void* m_callbackArg;
         Print* m_print;
+};
+
+class TC_GAME_API AddonCliHandler : public ChatHandler
+{
+    public:
+        using ChatHandler::ChatHandler;
+        bool ParseCommands(char const* str) override;
+        void SendSysMessage(char const* str, bool escapeCharacters) override;
+        using ChatHandler::SendSysMessage;
+
+    private:
+        void Send(std::string const& msg);
+        void SendAck();
+        void SendOK();
+        void SendFailed();
+
+        char const* echo = nullptr;
+        bool hadAck = false;
 };
 
 #endif

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -218,7 +218,7 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
 
         if (lang == LANG_ADDON)
         {
-            if (AddonCliHandler(this).ParseCommands(msg.c_str()))
+            if (AddonChannelCommandHandler(this).ParseCommands(msg.c_str()))
                 return;
         }
         if (lang != LANG_ADDON)

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -126,7 +126,7 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
     // LANG_ADDON should not be changed nor be affected by flood control
     else
     {
-        // send in universal language if player in .gmon mode (ignore spell effects)
+        // send in universal language if player in .gm on mode (ignore spell effects)
         if (sender->IsGameMaster())
             lang = LANG_UNIVERSAL;
         else
@@ -216,11 +216,15 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
         if (msg.empty())
             return;
 
-        if (ChatHandler(this).ParseCommands(msg.c_str()))
-            return;
-
+        if (lang == LANG_ADDON)
+        {
+            if (AddonCliHandler(this).ParseCommands(msg.c_str()))
+                return;
+        }
         if (lang != LANG_ADDON)
         {
+            if (ChatHandler(this).ParseCommands(msg.c_str()))
+                return;
             // Strip invisible characters for non-addon messages
             if (sWorld->getBoolConfig(CONFIG_CHAT_FAKE_MESSAGE_PREVENTING))
                 stripLineInvisibleChars(msg);

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -132,7 +132,10 @@ public:
     // Display the 'Message of the day' for the realm
     static bool HandleServerMotdCommand(ChatHandler* handler, char const* /*args*/)
     {
-        handler->PSendSysMessage(LANG_MOTD_CURRENT, Motd::GetMotd());
+        if (handler->IsHumanReadable())
+            handler->PSendSysMessage(LANG_MOTD_CURRENT, Motd::GetMotd());
+        else
+            handler->SendSysMessage(Motd::GetMotd());
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -132,10 +132,7 @@ public:
     // Display the 'Message of the day' for the realm
     static bool HandleServerMotdCommand(ChatHandler* handler, char const* /*args*/)
     {
-        if (handler->IsHumanReadable())
-            handler->PSendSysMessage(LANG_MOTD_CURRENT, Motd::GetMotd());
-        else
-            handler->SendSysMessage(Motd::GetMotd());
+        handler->PSendSysMessage(LANG_MOTD_CURRENT, Motd::GetMotd());
         return true;
     }
 


### PR DESCRIPTION
Little-known fact for most of you: I write addons.
Pet peeve: Integrating with TC GM commands sucks major balls.

Thus, fixing that.

This PR implements a well-formed protocol for addons to communicate with the server, outlined below:

* All communication happens over the addon channel (`LANG_ADDON` in terms of the core, `CHAT_MSG_ADDON`/`SendAddonMessage` for the client). The prefix used for all messages is `TrinityCore` (in client terms - in core terms, every message starts with `TrinityCore\t`).
* In each message, the first character is the opcode. The following four characters are a unique identifier for the invocation in question, and will be echoed back by the server in every message related to that invocation. Following is the message body, if any.
* The following opcodes are supported:
  * Client to server:
    * `p` - Ping request. The core will always respond by ACKing with the passed identifier. No body.
    * `i` or `h` - Command invocation. The message body is the command text without prefix.
      `i` requests machine-readable output, `h` requests human-readable.
  * Server to client:
    * `a` - ACK. The first message sent in response to any invocation (before any output). No body.
    * `m` - Message. Sent once per line of output the server generates. Body = output line.
    * `o` - OK. Indicates that the command finished processing with no errors. No body.
    * `f` - Failed. Indicates that command processing is done, but there was an error. No body.

Expected overhead is minimal, and this integrates seamlessly with existing command scripts (no changes necessary).

PS: There's also a client-side addon library that exposes this protocol in a developer-friendly way over at [Treeston/LibTrinityCore-1.0](https://github.com/Treeston/LibTrinityCore-1.0).