### PR TITLE
Implement a general way to store selection data for gossip and fix trainer exploit

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -207,7 +207,7 @@ void PlayerMenu::ClearMenus()
 void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID)
 {
     _selectionData.Reset();
-    _selectionData.senderGuid = objectGUID;
+    _selectionData.SenderGuid = objectGUID;
 
     WorldPackets::NPC::GossipMessage packet;
     packet.GossipGUID = objectGUID;

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -33,7 +33,6 @@ GossipMenu::GossipMenu()
 {
     _menuId = 0;
     _locale = DEFAULT_LOCALE;
-    _senderGUID.Clear();
 }
 
 GossipMenu::~GossipMenu()
@@ -207,7 +206,8 @@ void PlayerMenu::ClearMenus()
 
 void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID)
 {
-    _gossipMenu.SetSenderGUID(objectGUID);
+    _selectionData.Reset();
+    _selectionData.senderGuid = objectGUID;
 
     WorldPackets::NPC::GossipMessage packet;
     packet.GossipGUID = objectGUID;
@@ -269,7 +269,7 @@ void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID)
 
 void PlayerMenu::SendCloseGossip()
 {
-    _gossipMenu.SetSenderGUID(ObjectGuid::Empty);
+    _selectionData.Reset();
 
     WorldPackets::NPC::GossipComplete packet;
     _session->SendPacket(packet.Write());

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -206,8 +206,8 @@ void PlayerMenu::ClearMenus()
 
 void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID)
 {
-    _selectionData.Reset();
-    _selectionData.SenderGuid = objectGUID;
+    _interactionData.Reset();
+    _interactionData.SourceGuid = objectGUID;
 
     WorldPackets::NPC::GossipMessage packet;
     packet.GossipGUID = objectGUID;
@@ -269,7 +269,7 @@ void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID)
 
 void PlayerMenu::SendCloseGossip()
 {
-    _selectionData.Reset();
+    _interactionData.Reset();
 
     WorldPackets::NPC::GossipComplete packet;
     _session->SendPacket(packet.Write());

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -241,7 +241,7 @@ class InteractionData
 
         void Reset()
         {
-            SourceGuid = ObjectGuid::Empty;
+            SourceGuid.Clear();
             TrainerId = 0;
         }
 

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -234,18 +234,18 @@ class TC_GAME_API QuestMenu
         QuestMenuItemList _questMenuItems;
 };
 
-class SelectionData
+class InteractionData
 {
     public:
-        SelectionData() { Reset(); }
+        InteractionData() { Reset(); }
 
         void Reset()
         {
-            SenderGuid = ObjectGuid::Empty;
+            SourceGuid = ObjectGuid::Empty;
             TrainerId = 0;
         }
 
-        ObjectGuid SenderGuid;
+        ObjectGuid SourceGuid;
         uint32 TrainerId;
 };
 
@@ -257,7 +257,7 @@ class TC_GAME_API PlayerMenu
 
         GossipMenu& GetGossipMenu() { return _gossipMenu; }
         QuestMenu& GetQuestMenu() { return _questMenu; }
-        SelectionData& GetSelectionData() { return _selectionData; }
+        InteractionData& GetInteractionData() { return _interactionData; }
 
         bool Empty() const { return _gossipMenu.Empty() && _questMenu.Empty(); }
 
@@ -289,6 +289,6 @@ class TC_GAME_API PlayerMenu
         GossipMenu _gossipMenu;
         QuestMenu  _questMenu;
         WorldSession* _session;
-        SelectionData _selectionData;
+        InteractionData _interactionData;
 };
 #endif

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -237,7 +237,7 @@ class TC_GAME_API QuestMenu
 class SelectionData
 {
     public:
-        SelectionData() { Reset(); };
+        SelectionData() { Reset(); }
 
         void Reset()
         {

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -241,12 +241,12 @@ class SelectionData
 
         void Reset()
         {
-            senderGuid = ObjectGuid::Empty;
-            trainerId = 0;
+            SenderGuid = ObjectGuid::Empty;
+            TrainerId = 0;
         }
 
-        ObjectGuid senderGuid;
-        uint32 trainerId;
+        ObjectGuid SenderGuid;
+        uint32 TrainerId;
 };
 
 class TC_GAME_API PlayerMenu

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -172,8 +172,6 @@ class TC_GAME_API GossipMenu
 
         void SetMenuId(uint32 menu_id) { _menuId = menu_id; }
         uint32 GetMenuId() const { return _menuId; }
-        void SetSenderGUID(ObjectGuid guid) { _senderGUID = guid; }
-        ObjectGuid GetSenderGUID() const { return _senderGUID; }
         void SetLocale(LocaleConstant locale) { _locale = locale; }
         LocaleConstant GetLocale() const { return _locale; }
 
@@ -216,7 +214,6 @@ class TC_GAME_API GossipMenu
         GossipMenuItemContainer _menuItems;
         GossipMenuItemDataContainer _menuItemData;
         uint32 _menuId;
-        ObjectGuid _senderGUID;
         LocaleConstant _locale;
 };
 
@@ -237,6 +234,22 @@ class TC_GAME_API QuestMenu
         QuestMenuItemList _questMenuItems;
 };
 
+struct TC_GAME_API SelectionData
+{
+    SelectionData() { Reset(); };
+
+    void Reset()
+    {
+        senderGuid = ObjectGuid::Empty;
+        trainerId = 0;
+        menuId = 0;
+    }
+
+    ObjectGuid senderGuid;
+    uint32 trainerId;
+    uint32 menuId;
+};
+
 class TC_GAME_API PlayerMenu
 {
     public:
@@ -245,6 +258,7 @@ class TC_GAME_API PlayerMenu
 
         GossipMenu& GetGossipMenu() { return _gossipMenu; }
         QuestMenu& GetQuestMenu() { return _questMenu; }
+        SelectionData& GetSelectionData() { return _selectionData; }
 
         bool Empty() const { return _gossipMenu.Empty() && _questMenu.Empty(); }
 
@@ -276,5 +290,6 @@ class TC_GAME_API PlayerMenu
         GossipMenu _gossipMenu;
         QuestMenu  _questMenu;
         WorldSession* _session;
+        SelectionData _selectionData;
 };
 #endif

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -234,7 +234,7 @@ class TC_GAME_API QuestMenu
         QuestMenuItemList _questMenuItems;
 };
 
-class TC_GAME_API SelectionData
+class SelectionData
 {
     public:
         SelectionData() { Reset(); };

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -234,20 +234,19 @@ class TC_GAME_API QuestMenu
         QuestMenuItemList _questMenuItems;
 };
 
-struct TC_GAME_API SelectionData
+class TC_GAME_API SelectionData
 {
-    SelectionData() { Reset(); };
+    public:
+        SelectionData() { Reset(); };
 
-    void Reset()
-    {
-        senderGuid = ObjectGuid::Empty;
-        trainerId = 0;
-        menuId = 0;
-    }
+        void Reset()
+        {
+            senderGuid = ObjectGuid::Empty;
+            trainerId = 0;
+        }
 
-    ObjectGuid senderGuid;
-    uint32 trainerId;
-    uint32 menuId;
+        ObjectGuid senderGuid;
+        uint32 trainerId;
 };
 
 class TC_GAME_API PlayerMenu

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2337,8 +2337,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         SceneMgr& GetSceneMgr() { return m_sceneMgr; }
         RestMgr& GetRestMgr() const { return *_restMgr; }
 
-        uint32 GetCurrentTrainerId() const { return _currentTrainerId; }
-        void SetCurrentTrainerId(uint32 trainerId) { _currentTrainerId = trainerId; }
     protected:
         // Gamemaster whisper whitelist
         GuidList WhisperList;
@@ -2690,8 +2688,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         void _InitHonorLevelOnLoadFromDB(uint32 /*honor*/, uint32 /*honorLevel*/, uint32 /*prestigeLevel*/);
         std::unique_ptr<RestMgr> _restMgr;
-
-        uint32 _currentTrainerId;
 };
 
 TC_GAME_API void AddItemsSetItem(Player* player, Item* item);

--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -20,6 +20,7 @@
 #include "BattlenetAccountMgr.h"
 #include "DatabaseEnv.h"
 #include "DB2Stores.h"
+#include "GossipDef.h"
 #include "Guild.h"
 #include "GuildMgr.h"
 #include "Item.h"
@@ -382,9 +383,8 @@ void WorldSession::HandleMailDelete(WorldPackets::Mail::MailDelete& packet)
 
 void WorldSession::HandleMailReturnToSender(WorldPackets::Mail::MailReturnToSender& packet)
 {
-    //TODO: find a proper way to replace this check. Idea: Save Guid form MailGetList until CMSG_CLOSE_INTERACTION is sent
-    /*if (!CanOpenMailBox(mailbox))
-        return;*/
+    if (!CanOpenMailBox(_player->PlayerTalkClass->GetInteractionData().SourceGuid))
+        return;
 
     Player* player = _player;
     Mail* m = player->GetMail(packet.MailID);
@@ -592,6 +592,8 @@ void WorldSession::HandleGetMailList(WorldPackets::Mail::MailGetList& packet)
         ++response.TotalNumRecords;
     }
 
+    player->PlayerTalkClass->GetInteractionData().Reset();
+    player->PlayerTalkClass->GetInteractionData().SourceGuid = packet.Mailbox;
     SendPacket(response.Write());
 
     // recalculate m_nextMailDelivereTime and unReadMails

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1169,7 +1169,7 @@ void WorldSession::HandlePvpPrestigeRankUp(WorldPackets::Misc::PvpPrestigeRankUp
         _player->Prestige();
 }
 
-void WorldSession::HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& packet)
+void WorldSession::HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& /*packet*/)
 {
     _player->PlayerTalkClass->GetInteractionData().Reset();
 }

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1168,3 +1168,8 @@ void WorldSession::HandlePvpPrestigeRankUp(WorldPackets::Misc::PvpPrestigeRankUp
     if (_player->CanPrestige())
         _player->Prestige();
 }
+
+void WorldSession::HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& packet)
+{
+    _player->PlayerTalkClass->GetInteractionData().Reset();
+}

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -113,9 +113,9 @@ void WorldSession::SendTrainerList(ObjectGuid guid, uint32 trainerId)
         return;
     }
 
-    _player->PlayerTalkClass->GetSelectionData().Reset();
-    _player->PlayerTalkClass->GetSelectionData().SenderGuid = guid;
-    _player->PlayerTalkClass->GetSelectionData().TrainerId = trainerId;
+    _player->PlayerTalkClass->GetInteractionData().Reset();
+    _player->PlayerTalkClass->GetInteractionData().SourceGuid = guid;
+    _player->PlayerTalkClass->GetInteractionData().TrainerId = trainerId;
     trainer->SendSpells(unit, _player, GetSessionDbLocaleIndex());
 }
 
@@ -134,10 +134,10 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPackets::NPC::TrainerBuySpel
     if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))
         GetPlayer()->RemoveAurasByType(SPELL_AURA_FEIGN_DEATH);
 
-    if (_player->PlayerTalkClass->GetSelectionData().SenderGuid != packet.TrainerGUID)
+    if (_player->PlayerTalkClass->GetInteractionData().SourceGuid != packet.TrainerGUID)
         return;
 
-    if (_player->PlayerTalkClass->GetSelectionData().TrainerId != uint32(packet.TrainerID))
+    if (_player->PlayerTalkClass->GetInteractionData().TrainerId != uint32(packet.TrainerID))
         return;
 
     Trainer::Trainer const* trainer = sObjectMgr->GetTrainer(packet.TrainerID);
@@ -195,7 +195,7 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPackets::NPC::GossipSelec
         return;
 
     // Prevent cheating on C++ scripted menus
-    if (_player->PlayerTalkClass->GetSelectionData().SenderGuid != packet.GossipUnit)
+    if (_player->PlayerTalkClass->GetInteractionData().SourceGuid != packet.GossipUnit)
         return;
 
     Creature* unit = nullptr;

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -114,8 +114,8 @@ void WorldSession::SendTrainerList(ObjectGuid guid, uint32 trainerId)
     }
 
     _player->PlayerTalkClass->GetSelectionData().Reset();
-    _player->PlayerTalkClass->GetSelectionData().senderGuid = guid;
-    _player->PlayerTalkClass->GetSelectionData().trainerId = trainerId;
+    _player->PlayerTalkClass->GetSelectionData().SenderGuid = guid;
+    _player->PlayerTalkClass->GetSelectionData().TrainerId = trainerId;
     trainer->SendSpells(unit, _player, GetSessionDbLocaleIndex());
 }
 
@@ -134,10 +134,10 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPackets::NPC::TrainerBuySpel
     if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))
         GetPlayer()->RemoveAurasByType(SPELL_AURA_FEIGN_DEATH);
 
-    if (_player->PlayerTalkClass->GetSelectionData().senderGuid != packet.TrainerGUID)
+    if (_player->PlayerTalkClass->GetSelectionData().SenderGuid != packet.TrainerGUID)
         return;
 
-    if (_player->PlayerTalkClass->GetSelectionData().trainerId != uint32(packet.TrainerID))
+    if (_player->PlayerTalkClass->GetSelectionData().TrainerId != uint32(packet.TrainerID))
         return;
 
     Trainer::Trainer const* trainer = sObjectMgr->GetTrainer(packet.TrainerID);
@@ -195,7 +195,7 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPackets::NPC::GossipSelec
         return;
 
     // Prevent cheating on C++ scripted menus
-    if (_player->PlayerTalkClass->GetSelectionData().senderGuid != packet.GossipUnit)
+    if (_player->PlayerTalkClass->GetSelectionData().SenderGuid != packet.GossipUnit)
         return;
 
     Creature* unit = nullptr;

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -113,7 +113,9 @@ void WorldSession::SendTrainerList(ObjectGuid guid, uint32 trainerId)
         return;
     }
 
-    _player->SetCurrentTrainerId(trainerId);
+    _player->PlayerTalkClass->GetSelectionData().Reset();
+    _player->PlayerTalkClass->GetSelectionData().senderGuid = guid;
+    _player->PlayerTalkClass->GetSelectionData().trainerId = trainerId;
     trainer->SendSpells(unit, _player, GetSessionDbLocaleIndex());
 }
 
@@ -132,7 +134,10 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPackets::NPC::TrainerBuySpel
     if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))
         GetPlayer()->RemoveAurasByType(SPELL_AURA_FEIGN_DEATH);
 
-    if (_player->GetCurrentTrainerId() != uint32(packet.TrainerID))
+    if (_player->PlayerTalkClass->GetSelectionData().senderGuid != packet.TrainerGUID)
+        return;
+
+    if (_player->PlayerTalkClass->GetSelectionData().trainerId != uint32(packet.TrainerID))
         return;
 
     Trainer::Trainer const* trainer = sObjectMgr->GetTrainer(packet.TrainerID);
@@ -190,7 +195,7 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPackets::NPC::GossipSelec
         return;
 
     // Prevent cheating on C++ scripted menus
-    if (_player->PlayerTalkClass->GetGossipMenu().GetSenderGUID() != packet.GossipUnit)
+    if (_player->PlayerTalkClass->GetSelectionData().senderGuid != packet.GossipUnit)
         return;
 
     Creature* unit = nullptr;

--- a/src/server/game/Server/Packets/MiscPackets.cpp
+++ b/src/server/game/Server/Packets/MiscPackets.cpp
@@ -662,3 +662,8 @@ void WorldPackets::Misc::MountSetFavorite::Read()
     _worldPacket >> MountSpellID;
     IsFavorite = _worldPacket.ReadBit();
 }
+
+void WorldPackets::Misc::CloseInteraction::Read()
+{
+    _worldPacket >> SourceGuid;
+}

--- a/src/server/game/Server/Packets/MiscPackets.h
+++ b/src/server/game/Server/Packets/MiscPackets.h
@@ -874,6 +874,16 @@ namespace WorldPackets
 
             void Read() override { }
         };
+
+        class CloseInteraction final : public ClientPacket
+        {
+        public:
+            CloseInteraction(WorldPacket&& packet) : ClientPacket(CMSG_CLOSE_INTERACTION, std::move(packet)) { }
+
+            void Read() override;
+
+            ObjectGuid SourceGuid;
+        };
     }
 }
 

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -323,7 +323,7 @@ void OpcodeTable::Initialize()
     DEFINE_HANDLER(CMSG_CLEAR_RAID_MARKER,                                  STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleClearRaidMarker);
     DEFINE_HANDLER(CMSG_CLEAR_TRADE_ITEM,                                   STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleClearTradeItemOpcode);
     DEFINE_HANDLER(CMSG_CLIENT_PORT_GRAVEYARD,                              STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandlePortGraveyard);
-    DEFINE_HANDLER(CMSG_CLOSE_INTERACTION,                                  STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL);
+    DEFINE_HANDLER(CMSG_CLOSE_INTERACTION,                                  STATUS_UNHANDLED, PROCESS_THREADSAFE,   &WorldSession::HandleCloseInteraction);
     DEFINE_HANDLER(CMSG_COLLECTION_ITEM_SET_FAVORITE,                       STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleCollectionItemSetFavorite);
     DEFINE_HANDLER(CMSG_COMMENTATOR_ENABLE,                                 STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     DEFINE_HANDLER(CMSG_COMMENTATOR_ENTER_INSTANCE,                         STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -466,6 +466,7 @@ namespace WorldPackets
         class SetTaxiBenchmarkMode;
         class MountSetFavorite;
         class PvpPrestigeRankUp;
+        class CloseInteraction;
     }
 
     namespace Movement
@@ -1644,6 +1645,7 @@ class TC_GAME_API WorldSession
         void HandleObjectUpdateFailedOpcode(WorldPackets::Misc::ObjectUpdateFailed& objectUpdateFailed);
         void HandleObjectUpdateRescuedOpcode(WorldPackets::Misc::ObjectUpdateRescued& objectUpdateRescued);
         void HandleRequestCategoryCooldowns(WorldPackets::Spells::RequestCategoryCooldowns& requestCategoryCooldowns);
+        void HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& packet);
 
         // Toys
         void HandleAddToy(WorldPackets::Toy::AddToy& packet);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Make a single place to store sender guid and related information for gossip actions - now sending a new gossip menu erases trainerid for example
- Fix trainer exploit by checking that trainer guid is same when sending trainer menu and when learning spells
- Use the sender guid storage to store mailbox guid to check later interaction with the mailbox
- Implement CloseInteraction packet that will call reset for the interaction data.

**Target branch(es):** 3.3.5/master

- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)

Closes https://github.com/TrinityCore/TrinityCore/issues/20080

**Tests performed:** (Does it build, tested in-game, etc.)

Compiles.
Gossip at stormwind city guard works.

**Known issues and TODO list:** (add/remove lines as needed)

- [x] After implement https://github.com/TrinityCore/TrinityCore/pull/20085#discussion_r130220802


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
