### PR TITLE
Core/Chat: Fixed call of CreatureAI::ReceiveEmote

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -656,7 +656,7 @@ void WorldSession::HandleTextEmoteOpcode(WorldPackets::Chat::CTextEmote& packet)
     // Send scripted event call
     if (unit)
         if (Creature* creature = unit->ToCreature())
-            creature->AI()->ReceiveEmote(_player, packet.SoundIndex);
+            creature->AI()->ReceiveEmote(_player, packet.EmoteID);
 }
 
 void WorldSession::HandleChatIgnoredOpcode(WorldPackets::Chat::ChatReportIgnored& chatReportIgnored)


### PR DESCRIPTION
**Changes proposed:**

CreatureAI::ReceiveEmote expects the EmoteID instead of the SoundIndex. This will fix creature scripts like npc_chicken_cluck

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
It builds.
Tested quest http://www.wowhead.com/quest=3861/cluck
