### PR TITLE
[3.3.5] Core/Pet: Fix pet action bar loosing autocast settings (#16211)

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1520,7 +1520,7 @@ bool Pet::removeSpell(uint32 spell_id, bool learn_prev, bool clear_ab)
     }
 
     // if remove last rank or non-ranked then update action bar at server and client if need
-    if (m_charmInfo->RemoveSpellFromActionBar(spell_id) && !learn_prev && clear_ab)
+    if (clear_ab && !learn_prev && m_charmInfo->RemoveSpellFromActionBar(spell_id))
     {
         if (!m_loading)
             GetOwner()->PetSpellInitialize(); // need update action bar for last removed rank


### PR DESCRIPTION
reverts one line of 6c21ddd9b98d372cb802c9abf034e2aa3ecc70b9
Target branch:  3.3.5
Issues addressed: Closes #16211
Tests performed: build succeeded and tested/verified in game (me and Eronox)