### PR TITLE
[3.3.5] Core/Pet: Fix PetSpellMap <-> DB sync

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1307,7 +1307,6 @@ bool Pet::addSpell(uint32 spellId, ActiveStates active /*= ACT_DECIDE*/, PetSpel
     {
         if (itr->second.state == PETSPELL_REMOVED)
         {
-            m_spells.erase(itr);
             state = PETSPELL_CHANGED;
         }
         else if (state == PETSPELL_UNCHANGED && itr->second.state != PETSPELL_UNCHANGED)

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1306,23 +1306,22 @@ bool Pet::addSpell(uint32 spellId, ActiveStates active /*= ACT_DECIDE*/, PetSpel
     if (itr != m_spells.end())
     {
         if (itr->second.state == PETSPELL_REMOVED)
-        {
             state = PETSPELL_CHANGED;
-        }
-        else if (state == PETSPELL_UNCHANGED && itr->second.state != PETSPELL_UNCHANGED)
-        {
-            // can be in case spell loading but learned at some previous spell loading
-            itr->second.state = PETSPELL_UNCHANGED;
-
-            if (active == ACT_ENABLED)
-                ToggleAutocast(spellInfo, true);
-            else if (active == ACT_DISABLED)
-                ToggleAutocast(spellInfo, false);
-
-            return false;
-        }
         else
+        {
+            if (state == PETSPELL_UNCHANGED && itr->second.state != PETSPELL_UNCHANGED)
+            {
+                // can be in case spell loading but learned at some previous spell loading
+                itr->second.state = PETSPELL_UNCHANGED;
+
+                if (active == ACT_ENABLED)
+                    ToggleAutocast(spellInfo, true);
+                else if (active == ACT_DISABLED)
+                    ToggleAutocast(spellInfo, false);
+            }
+
             return false;
+        }
     }
 
     PetSpell newspell;


### PR DESCRIPTION
``PetSpellMap`` entries with ``state == PETSPELL_REMOVED`` must not be erased before DB sync. 
* Target branch: 3.3.5
* Issues addressed: Finally closes #16211
* Tests performed:
  * build success
  * tested/verified in game
  * DB ``characters.pet_spells`` checked
  * previous spell ranks are now correctly removed from DB

The previous patch was only a partial fix for the issue and didn't actually address the root cause, which is ``PetSpellMap`` and ``characters.pet_spell``are getting out of sync. The current fix only helps with (ranked non-talent) spells that are toggled on the pet action bar, because those are also written to ``characters.character_pet``.
Ranked non-talent spells that are not on the pet action bar, but put on auto via the pet spell book only are not correctly remembered without this second fix.