### PR TITLE
[3.3.5] Core/Movement: Pets go for the back unless being the victim

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -140,6 +140,7 @@ void TargetedMovementGenerator<T, D>::SetTargetLocation(T* owner, bool updateDes
             float size = owner->GetCombatReach();
 
             if (owner->IsPet())
+            {
                 if (GetTarget()->GetTypeId() == TYPEID_PLAYER)
                 {
                     distance = 1.0f;
@@ -149,6 +150,7 @@ void TargetedMovementGenerator<T, D>::SetTargetLocation(T* owner, bool updateDes
                     _angle = float(M_PI); // then pet goes for the back
                 else
                     _angle = 0.f; // else pet goes for the front
+            }
 
             if (GetTarget()->IsWithinDistInMap(owner, distance))
                 return;

--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -139,11 +139,16 @@ void TargetedMovementGenerator<T, D>::SetTargetLocation(T* owner, bool updateDes
             float distance = _offset + 1.0f;
             float size = owner->GetCombatReach();
 
-            if (owner->IsPet() && GetTarget()->GetTypeId() == TYPEID_PLAYER)
-            {
-                distance = 1.0f;
-                size = 1.0f;
-            }
+            if (owner->IsPet())
+                if (GetTarget()->GetTypeId() == TYPEID_PLAYER)
+                {
+                    distance = 1.0f;
+                    size = 1.0f;
+                }
+                else if (GetTarget()->GetVictim() != owner) // if pet is not the target's victim
+                    _angle = float(M_PI); // then pet goes for the back
+                else
+                    _angle = 0.f; // else pet goes for the front
 
             if (GetTarget()->IsWithinDistInMap(owner, distance))
                 return;


### PR DESCRIPTION
This restores the pet's original behavior to **not always** attack from the front and get cleaved down.
* Target branch: 3.3.5
* Issues addressed: Closes #19925 
* Tests performed:
  * build success
  * tested/verified in game

I was neither able to pinpoint the commit that broke it nor do I think I found the best place/way to fix it, but it's very effective and should make warlocks and hunters happy again.

Demo showing the new (restored) pet behavior: https://youtu.be/9p4CYmOOWaE