### PR TITLE
Core/Script: Fix Heigan runaway eruption event

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
@@ -123,7 +123,7 @@ public:
             events.ScheduleEvent(EVENT_DISRUPT, randtime(Seconds(15), Seconds(20)), 0, PHASE_FIGHT);
             events.ScheduleEvent(EVENT_FEVER, randtime(Seconds(10), Seconds(20)), 0, PHASE_FIGHT);
             events.ScheduleEvent(EVENT_DANCE, Minutes(1) + Seconds(30), 0, PHASE_FIGHT);
-            events.ScheduleEvent(EVENT_ERUPT, Seconds(15), 0, PHASE_FIGHT);
+            events.ScheduleEvent(EVENT_ERUPT, Seconds(15));
 
             _safetyDance = true;
 
@@ -172,7 +172,7 @@ public:
                         DoCast(SPELL_TELEPORT_SELF);
                         DoCastAOE(SPELL_PLAGUE_CLOUD);
                         events.ScheduleEvent(EVENT_DANCE_END, Seconds(45), 0, PHASE_DANCE);
-                        events.ScheduleEvent(EVENT_ERUPT, Seconds(10));
+                        events.RescheduleEvent(EVENT_ERUPT, Seconds(10));
                         break;
                     case EVENT_DANCE_END:
                         events.SetPhase(PHASE_FIGHT);
@@ -181,7 +181,7 @@ public:
                         events.ScheduleEvent(EVENT_DISRUPT, randtime(Seconds(10), Seconds(25)), 0, PHASE_FIGHT);
                         events.ScheduleEvent(EVENT_FEVER, randtime(Seconds(15), Seconds(20)), 0, PHASE_FIGHT);
                         events.ScheduleEvent(EVENT_DANCE, Minutes(1) + Seconds(30), 0, PHASE_FIGHT);
-                        events.ScheduleEvent(EVENT_ERUPT, Seconds(15), 0, PHASE_FIGHT);
+                        events.RescheduleEvent(EVENT_ERUPT, Seconds(15));
                         me->CastStop();
                         me->SetReactState(REACT_AGGRESSIVE);
                         DoZoneInCombat();


### PR DESCRIPTION
By scheduling the eruption event without cancelling the previously registered eruption events, Heigan's eruption (or dance) would overlap and cause a runaway scenario, where eruptions would not follow a proper timer.

By using Reschedule and not locking the Eruption event to the fighting phase, the dance now works as intended.

**Changes proposed:**

-  Replace multiple event schedules with re-scheduling and not locking to specific phase.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)

- None I could see

**Tests performed:** (Does it build, tested in-game, etc.)

- Builds, tested solo and with a raid