### PR TITLE
Core/Scripts: More fixes in boss Lich King

### DIFF
--- a/sql/updates/world/3.3.5/2017_08_17_00_world.sql
+++ b/sql/updates/world/3.3.5/2017_08_17_00_world.sql
@@ -1,1 +1,2 @@
+-- Vile Spirit + (1),(2),(3) / Wicked Spirit + (1),(2),(3)
 UPDATE `creature_template` SET `InhabitType`=4 WHERE `entry` IN (39190,39287,39288,39289,37799,39284,39285,39286);

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `InhabitType`=4 WHERE `entry` IN (39190,39287,39288,39289,37799,39284,39285,39286);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4655,9 +4655,13 @@ void Spell::EffectChargeDest(SpellEffIndex /*effIndex*/)
     if (m_targets.HasDst())
     {
         Position pos = destTarget->GetPosition();
-        float angle = m_caster->GetRelativeAngle(pos.GetPositionX(), pos.GetPositionY());
-        float dist = m_caster->GetDistance(pos);
-        pos = m_caster->GetFirstCollisionPosition(dist, angle);
+
+        if (!m_caster->IsWithinLOS(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ()))
+        {
+            float angle = m_caster->GetRelativeAngle(pos.GetPositionX(), pos.GetPositionY());
+            float dist = m_caster->GetDistance(pos);
+            pos = m_caster->GetFirstCollisionPosition(dist, angle);
+        }
 
         m_caster->GetMotionMaster()->MoveCharge(pos.m_positionX, pos.m_positionY, pos.m_positionZ);
     }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -268,7 +268,10 @@ enum Events
     // Strangulate Vehicle (Harvest Soul)
     EVENT_TELEPORT,
     EVENT_MOVE_TO_LICH_KING,
-    EVENT_DESPAWN_SELF
+    EVENT_DESPAWN_SELF,
+
+    //Spirit Bomb
+    EVENT_BOMB_EXPLOSION
 };
 
 enum EventGroups
@@ -1057,7 +1060,6 @@ class boss_the_lich_king : public CreatureScript
                                         summon->RemoveAurasDueToSpell(SPELL_VILE_SPIRIT_MOVE_SEARCH);
                                         summon->RemoveAurasDueToSpell(SPELL_VILE_SPIRIT_DAMAGE_SEARCH);
                                         summon->GetMotionMaster()->MoveTargetedHome();
-                                        summon->GetMotionMaster()->MoveRandom(10.0f);
                                     }
                                     else if (summon->GetEntry() == NPC_RAGING_SPIRIT)
                                         summon->AI()->DoAction(ACTION_DISABLE_RAGING);
@@ -1074,6 +1076,7 @@ class boss_the_lich_king : public CreatureScript
                                 {
                                     triggers.sort(Trinity::ObjectDistanceOrderPred(terenas, true));
                                     Creature* spawner = triggers.front();
+                                    spawner->setActive(true);
                                     spawner->CastSpell(spawner, SPELL_SUMMON_SPIRIT_BOMB_1, true);  // summons bombs randomly
                                     spawner->CastSpell(spawner, SPELL_SUMMON_SPIRIT_BOMB_2, true);  // summons bombs on players
                                     spawner->m_Events.AddEvent(new TriggerWickedSpirit(spawner), spawner->m_Events.CalculateTime(3000));
@@ -1974,20 +1977,29 @@ class npc_spirit_bomb : public CreatureScript
                 if (type != POINT_MOTION_TYPE || point != POINT_GROUND)
                     return;
 
-                me->RemoveAllAuras();
-                DoCastAOE(SPELL_EXPLOSION);
-                me->DespawnOrUnsummon(1000);
+                _events.ScheduleEvent(EVENT_BOMB_EXPLOSION, 3000);
             }
 
             void AttackStart(Unit* /*victim*/) override
             {
             }
 
-            void UpdateAI(uint32 /*diff*/) override
+            void UpdateAI(uint32 diff) override
             {
                 UpdateVictim();
-                // no melee attacks
+
+                _events.Update(diff);
+
+                if (_events.ExecuteEvent() == EVENT_BOMB_EXPLOSION)
+                {
+                    me->RemoveAllAuras();
+                    DoCastAOE(SPELL_EXPLOSION);
+                    me->DespawnOrUnsummon(1000);
+                }
             }
+
+        private:
+            EventMap _events;
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -2509,8 +2521,9 @@ class spell_the_lich_king_summon_into_air : public SpellScriptLoader
                 // spirit bombs get higher
                 if (GetSpellInfo()->Effects[effIndex].MiscValue == NPC_SPIRIT_BOMB)
                 {
-                    dest->RelocateOffset(offset);
-                    GetHitDest()->RelocateOffset(offset);
+                    static Position const offsetExtra = { 0.0f, 0.0f, 5.0f, 0.0f };
+                    dest->RelocateOffset(offsetExtra);
+                    GetHitDest()->RelocateOffset(offsetExtra);
                 }
             }
 


### PR DESCRIPTION
**Changes proposed:**
- Fix Valkyr charge spell, they will no longer ignore Z position and become unreachable.
- Correct height of Spirit Bomb and added the 3 seconds delay on his explosion.
- Set the Trigger inside frostmourne room as active, to avoid problems with reseting the room, e.g: Spirit Bombs not despawning and Wicked Spirits stuck in evade.
- Use correct InhabitType for Wicked and Vile Spirits, this avoid a situation where they could spawn falling.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [x] master

**Issues addressed:** Updates #7266

**Tests performed:** Built and tested during boss fight, with 2 players