### PR TITLE
Core/Phases: Fix SetInPhase not honoring zone phase

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1462,36 +1462,21 @@ bool ConditionMgr::addToSpellImplicitTargetConditions(Condition* cond) const
 
 bool ConditionMgr::addToPhases(Condition* cond) const
 {
-    if (!cond->SourceEntry)
-    {
-        bool found = false;
-        PhaseInfo& p = sObjectMgr->GetAreaAndZonePhasesForLoading();
-        for (auto phaseItr = p.begin(); phaseItr != p.end(); ++phaseItr)
-        {
-            for (PhaseInfoStruct& phase : phaseItr->second)
-            {
-                if (phase.Id == cond->SourceGroup)
-                {
-                    phase.Conditions.push_back(cond);
-                    found = true;
-                }
-            }
-        }
-
-        if (found)
-            return true;
-    }
-    else if (std::vector<PhaseInfoStruct>* phases = sObjectMgr->GetPhasesForAreaOrZoneForLoading(cond->SourceEntry))
+    bool found = false;
+    if (std::vector<PhaseInfoStruct>* phases = sObjectMgr->GetAreaAndZonePhasesForLoading(cond->SourceGroup))
     {
         for (PhaseInfoStruct& phase : *phases)
         {
-            if (phase.Id == cond->SourceGroup)
+            if (!cond->SourceEntry || cond->SourceEntry == phase.AreaOrZone)
             {
                 phase.Conditions.push_back(cond);
-                return true;
+                found = true;
             }
         }
     }
+
+    if (found)
+        return true;
 
     TC_LOG_ERROR("sql.sql", "%s Area %u does not have phase %u.", cond->ToString().c_str(), cond->SourceGroup, cond->SourceEntry);
     return false;

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1467,7 +1467,7 @@ bool ConditionMgr::addToPhases(Condition* cond) const
     {
         for (PhaseInfoStruct& phase : *phases)
         {
-            if (!cond->SourceEntry || cond->SourceEntry == phase.AreaOrZone)
+            if (!cond->SourceEntry || cond->SourceEntry == int32(phase.AreaOrZone))
             {
                 phase.Conditions.push_back(cond);
                 found = true;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -3028,11 +3028,13 @@ bool WorldObject::SetInPhase(uint32 id, bool update, bool apply)
         {
             // if area phase passes the condition we should not remove it (ie: if remove called from aura remove)
             // this however breaks the .mod phase command, you wont be able to remove any area based phases with it
-            if (std::vector<PhaseInfoStruct> const* phases = sObjectMgr->GetPhasesForArea(GetAreaId()))
-                for (PhaseInfoStruct const& phase : *phases)
-                    if (id == phase.Id)
-                        if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
-                            return false;
+            PhaseInfo const& phases = sObjectMgr->GetAreaAndZonePhases();
+            for (PhaseInfo::const_iterator itr = phases.begin(); itr != phases.end(); ++itr)
+                if (itr->first == GetAreaId() || itr->first == GetZoneId())
+                    for (PhaseInfoStruct const& phase : itr->second)
+                        if (id == phase.Id)
+                            if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
+                                return false;
 
             if (!HasInPhaseList(id)) // do not run the updates if we are not in this phase
                 return false;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2950,10 +2950,9 @@ void WorldObject::UpdateAreaAndZonePhase()
     PhaseInfo const& phases = sObjectMgr->GetAreaAndZonePhases();
     for (PhaseInfo::const_iterator itr = phases.begin(); itr != phases.end(); ++itr)
     {
-        uint32 areaOrZoneId = itr->first;
         for (PhaseInfoStruct const& phase : itr->second)
         {
-            if (areaOrZoneId == GetAreaId() || areaOrZoneId == GetZoneId())
+            if (phase.AreaOrZone == GetAreaId() || phase.AreaOrZone == GetZoneId())
             {
                 if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
                 {
@@ -3028,13 +3027,11 @@ bool WorldObject::SetInPhase(uint32 id, bool update, bool apply)
         {
             // if area phase passes the condition we should not remove it (ie: if remove called from aura remove)
             // this however breaks the .mod phase command, you wont be able to remove any area based phases with it
-            PhaseInfo const& phases = sObjectMgr->GetAreaAndZonePhases();
-            for (PhaseInfo::const_iterator itr = phases.begin(); itr != phases.end(); ++itr)
-                if (itr->first == GetAreaId() || itr->first == GetZoneId())
-                    for (PhaseInfoStruct const& phase : itr->second)
-                        if (id == phase.Id)
-                            if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
-                                return false;
+            std::vector<PhaseInfoStruct> const* phases = sObjectMgr->GetAreaAndZonePhasesById(id);
+            for (PhaseInfoStruct const& phase : *phases)
+                if (GetAreaId() == phase.AreaOrZone || GetZoneId() == phase.AreaOrZone)
+                    if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
+                        return false;
 
             if (!HasInPhaseList(id)) // do not run the updates if we are not in this phase
                 return false;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -3027,11 +3027,11 @@ bool WorldObject::SetInPhase(uint32 id, bool update, bool apply)
         {
             // if area phase passes the condition we should not remove it (ie: if remove called from aura remove)
             // this however breaks the .mod phase command, you wont be able to remove any area based phases with it
-            std::vector<PhaseInfoStruct> const* phases = sObjectMgr->GetAreaAndZonePhasesById(id);
-            for (PhaseInfoStruct const& phase : *phases)
-                if (GetAreaId() == phase.AreaOrZone || GetZoneId() == phase.AreaOrZone)
-                    if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
-                        return false;
+            if (std::vector<PhaseInfoStruct> const* phases = sObjectMgr->GetAreaAndZonePhasesById(id))
+                for (PhaseInfoStruct const& phase : *phases)
+                    if (GetAreaId() == phase.AreaOrZone || GetZoneId() == phase.AreaOrZone)
+                        if (sConditionMgr->IsObjectMeetToConditions(this, phase.Conditions))
+                            return false;
 
             if (!HasInPhaseList(id)) // do not run the updates if we are not in this phase
                 return false;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16005,7 +16005,7 @@ void Player::SendQuestUpdate(uint32 questId)
     }
 
     UpdateForQuestWorldObjects();
-    SendUpdatePhasing();
+    UpdateAreaAndZonePhase();
 }
 
 QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16005,7 +16005,7 @@ void Player::SendQuestUpdate(uint32 questId)
     }
 
     UpdateForQuestWorldObjects();
-    UpdateAreaAndZonePhase();
+    SendUpdatePhasing();
 }
 
 QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -9521,9 +9521,9 @@ void ObjectMgr::LoadAreaPhases()
         Field* fields = result->Fetch();
 
         PhaseInfoStruct phase;
-        uint32 area = fields[0].GetUInt32();
+        phase.AreaOrZone = fields[0].GetUInt32();
         phase.Id = fields[1].GetUInt32();
-        _phases[area].push_back(phase);
+        _phases[phase.Id].push_back(phase);
 
         ++count;
     } while (result->NextRow());

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1437,9 +1437,9 @@ class TC_GAME_API ObjectMgr
             auto itr = _terrainWorldMapStore.find(terrainId);
             return itr != _terrainWorldMapStore.end() ? &itr->second : nullptr;
         }
-        std::vector<PhaseInfoStruct> const* GetPhasesForArea(uint32 area) const
+        std::vector<PhaseInfoStruct> const* GetPhasesForAreaOrZone(uint32 areaOrZone) const
         {
-            auto itr = _phases.find(area);
+            auto itr = _phases.find(areaOrZone);
             return itr != _phases.end() ? &itr->second : nullptr;
         }
         TerrainPhaseInfo const& GetDefaultTerrainSwapStore() const { return _terrainMapDefaultStore; }

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -820,6 +820,7 @@ typedef std::unordered_map<uint64, DungeonEncounterList> DungeonEncounterContain
 struct PhaseInfoStruct
 {
     uint32 Id;
+    uint32 AreaOrZone;
     ConditionContainer Conditions;
 };
 
@@ -1437,20 +1438,19 @@ class TC_GAME_API ObjectMgr
             auto itr = _terrainWorldMapStore.find(terrainId);
             return itr != _terrainWorldMapStore.end() ? &itr->second : nullptr;
         }
-        std::vector<PhaseInfoStruct> const* GetPhasesForAreaOrZone(uint32 areaOrZone) const
+        std::vector<PhaseInfoStruct> const* GetAreaAndZonePhasesById(uint32 id) const
         {
-            auto itr = _phases.find(areaOrZone);
+            auto itr = _phases.find(id);
             return itr != _phases.end() ? &itr->second : nullptr;
         }
         TerrainPhaseInfo const& GetDefaultTerrainSwapStore() const { return _terrainMapDefaultStore; }
         PhaseInfo const& GetAreaAndZonePhases() const { return _phases; }
         // condition loading helpers
-        std::vector<PhaseInfoStruct>* GetPhasesForAreaOrZoneForLoading(uint32 areaOrZone)
+        std::vector<PhaseInfoStruct>* GetAreaAndZonePhasesForLoading(uint32 id)
         {
-            auto itr = _phases.find(areaOrZone);
+            auto itr = _phases.find(id);
             return itr != _phases.end() ? &itr->second : nullptr;
         }
-        PhaseInfo& GetAreaAndZonePhasesForLoading() { return _phases; }
 
         // for wintergrasp only
         GraveYardContainer GraveYardStore;


### PR DESCRIPTION
**Changes proposed:**
- Fix SetInPhase not honoring zone phases, only area
- Update area and zone phases on quest update

**Target branch(es):**
- [x] master

**Tests performed:**
- Compiled
- Tested in-game