### PR TITLE
[CORE] FOR_SCRIPTS shouldn't return

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -955,11 +955,9 @@ private:
 
 // Utility macros for looping over scripts.
 #define FOR_SCRIPTS(T, C, E) \
-    if (SCR_REG_LST(T).empty()) \
-        return; \
-    \
-    for (SCR_REG_ITR(T) C = SCR_REG_LST(T).begin(); \
-        C != SCR_REG_LST(T).end(); ++C)
+    if (!SCR_REG_LST(T).empty()) \
+        for (SCR_REG_ITR(T) C = SCR_REG_LST(T).begin(); \
+            C != SCR_REG_LST(T).end(); ++C)
 
 #define FOR_SCRIPTS_RET(T, C, E, R) \
     if (SCR_REG_LST(T).empty()) \


### PR DESCRIPTION
**Changes proposed:**

FOR_SCRIPTS, insteadof FOR_SCRIPTS_RET, shouldn't return
otherwise methods such as void ScriptMgr::OnPlayerEnterMap(Map* map, Player* player) could end prematurely

**Target branch(es):**

- 3.3.5 (but should be applied in master too)

**Issues addressed:** No specific issue but if you put a FOREACH_SCRIPT  macro, with no registered methods inside, before another piece of code it won't be processed.

**Tests performed:** Tested placing 2 FOREACH_SCRIPT in same function where the first FOREACH_SCRIPT has no register methods in its list. 
The second one is not called.

