### PR TITLE
Scripts/Spells - Fix Enrage proc

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -34,6 +34,7 @@
 enum WarriorSpells
 {
     SPELL_WARRIOR_BLADESTORM_PERIODIC_WHIRLWIND     = 50622,
+    SPELL_WARRIOR_BLOODTHIRST                       = 23881,
     SPELL_WARRIOR_BLOODTHIRST_HEAL                  = 117313,
     SPELL_WARRIOR_CHARGE                            = 34846,
     SPELL_WARRIOR_CHARGE_EFFECT                     = 218104,
@@ -263,6 +264,30 @@ class spell_warr_concussion_blow : public SpellScriptLoader
         {
             return new spell_warr_concussion_blow_SpellScript();
         }
+};
+
+// 184361 Enrage
+class spell_warr_enrage : public AuraScript
+{
+    PrepareAuraScript(spell_warr_enrage);
+
+    bool CheckProc(ProcEventInfo& procInfo)
+    {
+        if (procInfo.GetActor()->GetTypeId() != TYPEID_PLAYER)
+            return false;
+
+        if (!(procInfo.GetHitMask() & PROC_HIT_CRITICAL))
+            return false;
+
+        if (procInfo.GetSpellInfo()->Id != SPELL_WARRIOR_BLOODTHIRST)
+            return false;
+        return true;
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_warr_enrage::CheckProc);
+    }
 };
 
 // 5308 - Execute
@@ -1368,6 +1393,7 @@ void AddSC_warrior_spell_scripts()
     new spell_warr_charge_drop_fire_periodic();
     new spell_warr_charge_effect();
     new spell_warr_concussion_blow();
+    RegisterAuraScript(spell_warr_enrage);
     new spell_warr_execute();
     new spell_warr_heroic_leap();
     new spell_warr_heroic_leap_jump();


### PR DESCRIPTION
**Changes proposed:**

-  Fix the proc of the warriors enrage spell. It can be triggered by Bloodthirst critical strikes, Rampage and if player has Outburst talent by Berserker Rage too.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** Closes #19799


**Tests performed:** (Does it build, tested in-game, etc.)
Tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Bloodthirst critical strikes
- [ ] Rampage
- [ ] Berserker rage (if the player has Outburst talent)

SQL stuff
DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warr_enrage';
INSERT INTO `spell_script_names` VALUES (184361, 'spell_warr_enrage');