### PR TITLE
Core/Spells: fix PvP Taunt (ref. #18877)

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2295,6 +2295,10 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
                 m_caster->ToCreature()->LowerPlayerDamageReq(target->damage);
         }
     }
+	else if (missInfo == SPELL_MISS_IMMUNE2)
+	{
+		m_caster->CombatStart(ObjectAccessor::GetUnit(*m_caster, target->targetGUID)); // Initiate combat with target, despite target being immune
+	}
 
     bool enablePvP = false; // need to check PvP state before spell effects, but act on it afterwards
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2295,10 +2295,10 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
                 m_caster->ToCreature()->LowerPlayerDamageReq(target->damage);
         }
     }
-	else if (missInfo == SPELL_MISS_IMMUNE2)
-	{
-		m_caster->CombatStart(ObjectAccessor::GetUnit(*m_caster, target->targetGUID)); // Initiate combat with target, despite target being immune
-	}
+    else if (missInfo == SPELL_MISS_IMMUNE2)
+    {
+        m_caster->CombatStart(ObjectAccessor::GetUnit(*m_caster, target->targetGUID)); // Initiate combat with target, despite target being immune
+    }
 
     bool enablePvP = false; // need to check PvP state before spell effects, but act on it afterwards
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Core/Spell: Caster enters combat with target even when target is immune.

**Target branch(es):** 3.3.5

- [x] 3.3.5

**Issues addressed:** Closes #18877


**Tests performed:** 
- Casting warrior taunt outside of combat in a PvP duel - Caster enters combat with target.
- Casting warrior taunt  while in combat in a PvP duel - Caster remain in combat with target (extended time).

**Known issues and TODO list:**


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
