### PR TITLE
Fix quest "Rescue the survivors" in Draenei starting zone.

### DIFF
--- a/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
@@ -51,7 +51,6 @@ enum draeneiSurvivor
     SAY_THANK_FOR_HEAL     = 0,
     SAY_ASK_FOR_HELP       = 1,
     SPELL_IRRIDATION       = 35046,
-    SPELL_GIFT_OF_THE_NAARU = 59544,
     SPELL_STUNNED          = 28630,
     EVENT_CAN_ASK_FOR_HELP = 1,
     EVENT_THANK_PLAYER     = 2,
@@ -110,7 +109,7 @@ public:
 
         void SpellHit(Unit* caster, const SpellInfo* spell) override
         {
-            if (spell->Id == SPELL_GIFT_OF_THE_NAARU && !_tappedBySpell)
+            if (spell->SpellFamilyFlags[2] & 0x80000000 && !_tappedBySpell)
             {
                 _events.Reset();
                 _tappedBySpell = true;

--- a/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
@@ -110,7 +110,7 @@ public:
 
         void SpellHit(Unit* caster, const SpellInfo* spell) override
         {
-            if (spell->Id == SPELL_GIFT_OF_THE_NAARU)
+            if (spell->Id == SPELL_GIFT_OF_THE_NAARU && !_tappedBySpell)
             {
                 _events.Reset();
                 _tappedBySpell = true;

--- a/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
@@ -51,6 +51,7 @@ enum draeneiSurvivor
     SAY_THANK_FOR_HEAL     = 0,
     SAY_ASK_FOR_HELP       = 1,
     SPELL_IRRIDATION       = 35046,
+    SPELL_GIFT_OF_THE_NAARU = 59544,
     SPELL_STUNNED          = 28630,
     EVENT_CAN_ASK_FOR_HELP = 1,
     EVENT_THANK_PLAYER     = 2,
@@ -109,7 +110,7 @@ public:
 
         void SpellHit(Unit* caster, const SpellInfo* spell) override
         {
-            if (spell->SpellFamilyFlags[2] & 0x080000000 && !_tappedBySpell)
+            if (spell->Id == SPELL_GIFT_OF_THE_NAARU)
             {
                 _events.Reset();
                 _tappedBySpell = true;


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Restrict quest "Rescue the survivor" to spell Gift of the Naaru.


**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)
closes #20240

**Tests performed:** (Does it build, tested in-game, etc.)
Compiled, tested in game.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
