### PR TITLE
Core/SAI: remove double calls to SMART_EVENT_RESPAWN for creatures and gameobjects

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -552,6 +552,7 @@ void SmartAI::JustAppeared()
         me->RestoreFaction();
     mJustReset = true;
     JustReachedHome();
+    GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
     mFollowGuid.Clear(); // do not reset follower on Reset(), we need it after combat evade
     mFollowDist = 0;
     mFollowAngle = 0;
@@ -694,10 +695,7 @@ void SmartAI::InitializeAI()
     GetScript()->OnInitialize(me);
 
     if (!me->isDead())
-    {
         GetScript()->OnReset();
-        GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
-    }
 }
 
 void SmartAI::OnCharmed(bool apply)
@@ -926,15 +924,14 @@ void SmartGameObjectAI::UpdateAI(uint32 diff)
 void SmartGameObjectAI::InitializeAI()
 {
     GetScript()->OnInitialize(me);
-
-    // do not call respawn event if go is not spawned
-    if (me->isSpawned())
-        GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
     //Reset();
 }
 
 void SmartGameObjectAI::Reset()
 {
+    // call respawn event on reset
+    GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
+
     GetScript()->OnReset();
 }
 

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -552,7 +552,6 @@ void SmartAI::JustAppeared()
         me->RestoreFaction();
     mJustReset = true;
     JustReachedHome();
-    GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
     mFollowGuid.Clear(); // do not reset follower on Reset(), we need it after combat evade
     mFollowDist = 0;
     mFollowAngle = 0;
@@ -936,9 +935,6 @@ void SmartGameObjectAI::InitializeAI()
 
 void SmartGameObjectAI::Reset()
 {
-    // call respawn event on reset
-    GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
-
     GetScript()->OnReset();
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  SMART_EVENT_RESPAWN is already called in the respective InitializeAI() methods for both creatures and gameobjects. The other existing calls are wrongly executed on reset. Since there's already SMART_EVENT_RESET, this double script call is confusing and harmful for scripts that must execute only at respawn.

**Target branch(es):**

- [x] 3.3.5

**Issues addressed:** I think I saw an issue related to this somewhere... but can't find it now.

**Tests performed:** works fine.