### PR TITLE
Core/SAI: implement SMART_ACTION_EXIT_VEHICLE and fix orientation in _ExitVehicle().

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2210,6 +2210,26 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             }
             break;
         }
+        case SMART_ACTION_EXIT_VEHICLE:
+        {
+            if (e.GetTargetType() == SMART_TARGET_POSITION)
+            {
+                Position _exitPosition = { e.target.x, e.target.y, e.target.z, e.target.o };
+                if (Creature* creature = GetBaseObject()->ToCreature())
+                    creature->_ExitVehicle(&_exitPosition);
+            }
+            else
+            {
+                for (WorldObject* const target : targets)
+                {
+                    if (Player* player = target->ToPlayer())
+                        player->_ExitVehicle();
+                    else if (Creature* creature = target->ToCreature())
+                        creature->_ExitVehicle();
+                }
+            }
+            break;
+        }
         default:
             TC_LOG_ERROR("sql.sql", "SmartScript::ProcessAction: Entry %d SourceType %u, Event %u, Unhandled Action type %u", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1501,6 +1501,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_REMOVE_ALL_GAMEOBJECTS:
         case SMART_ACTION_SPAWN_SPAWNGROUP:
         case SMART_ACTION_DESPAWN_SPAWNGROUP:
+        case SMART_ACTION_EXIT_VEHICLE:
             break;
         default:
             TC_LOG_ERROR("sql.sql", "SmartAIMgr: Not handled action_type(%u), event_type(%u), Entry %d SourceType %u Event %u, skipped.", e.GetActionType(), e.GetEventType(), e.entryOrGuid, e.GetScriptType(), e.event_id);

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -462,7 +462,7 @@ enum SMART_ACTION
     SMART_ACTION_THREAT_SINGLE_PCT                  = 13,     // Threat%
     SMART_ACTION_THREAT_ALL_PCT                     = 14,     // Threat%
     SMART_ACTION_CALL_AREAEXPLOREDOREVENTHAPPENS    = 15,     // QuestID
-    SMART_ACTION_UNUSED_16                          = 16,     // UNUSED
+    SMART_ACTION_EXIT_VEHICLE                       = 16,     //
     SMART_ACTION_SET_EMOTE_STATE                    = 17,     // emoteID
     SMART_ACTION_SET_UNIT_FLAG                      = 18,     // Flags (may be more than one field OR'd together), Target
     SMART_ACTION_REMOVE_UNIT_FLAG                   = 19,     // Flags (may be more than one field OR'd together), Target

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13831,7 +13831,7 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         init.SetFall();
 
     init.MoveTo(pos.GetPositionX(), pos.GetPositionY(), height, false);
-    init.SetFacing(GetOrientation());
+    init.SetFacing(pos.GetOrientation());
     init.SetTransportExit();
     init.Launch();
 


### PR DESCRIPTION
**Changes proposed:**

-  Implement SMART_ACTION_EXIT_VEHICLE, allowing to choose the exit position for passenger by using SMART_TARGET_POSITION, or choose which entity should eject vehicle, using other target types.

This is needed for cases where the only vehicle aura applied is [Ride Vehicle Hardcoded](http://www.wowhead.com/spell=46598) (unapplying it doesn't dismount entity) and where the exit position is not default (example: [this quest](https://youtu.be/eGsEu1rPcOU?t=38).

- Fix orientation used in _ExitVehicle(). Previously it was using the original vehicle's orientation instead of the one set in the Position parameter.

**Target branch(es):**

- [x] 3.3.5

**Tests performed:** works fine.