### PR TITLE
Scripts/Northrend: fix event for quest A Suitable Test Subject

### DIFF
--- a/sql/updates/world/3.3.5/2017_09_28_99_world_bloodspore_ruination.sql
+++ b/sql/updates/world/3.3.5/2017_09_28_99_world_bloodspore_ruination.sql
@@ -1,5 +1,5 @@
 --
-DELETE FROM `spell_script_names` WHERE `spell_id`=45997;
+DELETE FROM `spell_script_names` WHERE `ScriptName`="spell_q11719_bloodspore_ruination_45997";
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (45997, "spell_q11719_bloodspore_ruination_45997");
 UPDATE `creature_template` SET `ScriptName`="npc_bloodmage_laurith" WHERE `entry`=25381;

--- a/sql/updates/world/3.3.5/2017_09_28_99_world_bloodspore_ruination.sql
+++ b/sql/updates/world/3.3.5/2017_09_28_99_world_bloodspore_ruination.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id`=45997;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(45997, "spell_q11719_bloodspore_ruination_45997");
+UPDATE `creature_template` SET `ScriptName`="npc_bloodmage_laurith" WHERE `entry`=25381;
+DELETE FROM `creature_text` WHERE `CreatureID`=25381;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(25381, 0, 0, "How positively awful! You were totally incapacitated? Weak? Hot flashes?", 15, 0, 100, 21, 0, 0, 24992, 0, "Bloodmage Laurith");

--- a/sql/updates/world/3.3.5/2017_10_29_00_world.sql
+++ b/sql/updates/world/3.3.5/2017_10_29_00_world.sql
@@ -1,8 +1,10 @@
---
+-- quest: A Suitable Test Subject (11719)
 DELETE FROM `spell_script_names` WHERE `ScriptName`="spell_q11719_bloodspore_ruination_45997";
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
 (45997, "spell_q11719_bloodspore_ruination_45997");
+
 UPDATE `creature_template` SET `ScriptName`="npc_bloodmage_laurith" WHERE `entry`=25381;
+
 DELETE FROM `creature_text` WHERE `CreatureID`=25381;
-INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+INSERT INTO `creature_text` (`CreatureID`,`GroupID`,`ID`,`Text`,`Type`,`Language`,`Probability`,`Emote`,`Duration`,`Sound`,`BroadcastTextId`,`TextRange`,`comment`) VALUES
 (25381, 0, 0, "How positively awful! You were totally incapacitated? Weak? Hot flashes?", 15, 0, 100, 21, 0, 0, 24992, 0, "Bloodmage Laurith");

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2384,6 +2384,103 @@ public:
     }
 };
 
+enum BloodsporeRuination
+{
+    NPC_BLOODMAGE_LAURITH = 25381,
+
+    EVENT_TALK = 1,
+    EVENT_RESET_ORIENTATION
+};
+
+class spell_q11719_bloodspore_ruination_45997 : public SpellScriptLoader
+{
+public:
+    spell_q11719_bloodspore_ruination_45997() : SpellScriptLoader("spell_q11719_bloodspore_ruination_45997") { }
+
+    class spell_q11719_bloodspore_ruination_45997_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_q11719_bloodspore_ruination_45997_SpellScript);
+
+        void HandleEffect(SpellEffIndex /*effIndex*/)
+        {
+            if (Unit* caster = GetCaster())
+                if (Creature* laurith = caster->FindNearestCreature(NPC_BLOODMAGE_LAURITH, 100.0f))
+                    laurith->AI()->SetGUID(caster->GetGUID());
+        }
+
+        void Register() override
+        {
+            OnEffectHit += SpellEffectFn(spell_q11719_bloodspore_ruination_45997_SpellScript::HandleEffect, EFFECT_1, SPELL_EFFECT_SEND_EVENT);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_q11719_bloodspore_ruination_45997_SpellScript();
+    }
+};
+
+class npc_bloodmage_laurith : public CreatureScript
+{
+public:
+    npc_bloodmage_laurith() : CreatureScript("npc_bloodmage_laurith") { }
+
+    struct npc_bloodmage_laurithAI : public ScriptedAI
+    {
+        npc_bloodmage_laurithAI(Creature* creature) : ScriptedAI(creature) { }
+
+        void Reset() override
+        {
+            _events.Reset();
+            _playerGUID.Clear();
+        }
+
+        void SetGUID(ObjectGuid guid, int32 /*action*/) override
+        {
+            _playerGUID = guid;
+
+            if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
+                me->SetFacingToObject(player);
+
+            _events.ScheduleEvent(EVENT_TALK, Seconds(1));
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            _events.Update(diff);
+
+            if (uint32 eventId = _events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_TALK:
+                        if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
+                            Talk(0, player);
+                        _events.ScheduleEvent(EVENT_RESET_ORIENTATION, Seconds(5));
+                        break;
+                    case EVENT_RESET_ORIENTATION:
+                        me->SetFacingTo(me->GetHomePosition().GetOrientation());
+                        break;
+                }
+            }
+
+            if (!UpdateVictim())
+                return;
+
+            DoMeleeAttackIfReady();
+        }
+
+        private:
+            EventMap _events;
+            ObjectGuid _playerGUID;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_bloodmage_laurithAI(creature);
+    }
+};
+
 void AddSC_borean_tundra()
 {
     new npc_sinkhole_kill_credit();
@@ -2409,4 +2506,6 @@ void AddSC_borean_tundra()
     new npc_warmage_coldarra();
     new npc_hidden_cultist();
     new spell_windsoul_totem_aura();
+    new spell_q11719_bloodspore_ruination_45997();
+    new npc_bloodmage_laurith();
 }

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2386,9 +2386,9 @@ public:
 
 enum BloodsporeRuination
 {
-    NPC_BLOODMAGE_LAURITH = 25381,
-    TALK_0 = 0,
-    EVENT_TALK = 1,
+    NPC_BLOODMAGE_LAURITH   = 25381,
+    SAY_BLOODMAGE_LAURITH   = 0,
+    EVENT_TALK              = 1,
     EVENT_RESET_ORIENTATION
 };
 
@@ -2464,7 +2464,7 @@ public:
                 {
                     case EVENT_TALK:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
-                            Talk(TALK_0, player);
+                            Talk(SAY_BLOODMAGE_LAURITH, player);
                         _playerGUID.Clear();
                         _events.ScheduleEvent(EVENT_RESET_ORIENTATION, Seconds(5));
                         break;

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2447,6 +2447,12 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
+            if (UpdateVictim())
+            {
+                DoMeleeAttackIfReady();
+                return;
+            }
+
             _events.Update(diff);
 
             if (uint32 eventId = _events.ExecuteEvent())
@@ -2463,11 +2469,6 @@ public:
                         break;
                 }
             }
-
-            if (!UpdateVictim())
-                return;
-
-            DoMeleeAttackIfReady();
         }
 
         private:

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2387,6 +2387,8 @@ public:
 enum BloodsporeRuination
 {
     NPC_BLOODMAGE_LAURITH = 25381,
+    
+    TALK_0 = 0,
 
     EVENT_TALK = 1,
     EVENT_RESET_ORIENTATION
@@ -2464,7 +2466,7 @@ public:
                 {
                     case EVENT_TALK:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
-                            Talk(0, player);
+                            Talk(TALK_0, player);
                         _playerGUID.Clear();
                         _events.ScheduleEvent(EVENT_RESET_ORIENTATION, Seconds(5));
                         break;

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2387,9 +2387,7 @@ public:
 enum BloodsporeRuination
 {
     NPC_BLOODMAGE_LAURITH = 25381,
-    
     TALK_0 = 0,
-
     EVENT_TALK = 1,
     EVENT_RESET_ORIENTATION
 };

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -2437,6 +2437,9 @@ public:
 
         void SetGUID(ObjectGuid guid, int32 /*action*/) override
         {
+            if (!_playerGUID.IsEmpty())
+                return;
+
             _playerGUID = guid;
 
             if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
@@ -2462,6 +2465,7 @@ public:
                     case EVENT_TALK:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
                             Talk(0, player);
+                        _playerGUID.Clear();
                         _events.ScheduleEvent(EVENT_RESET_ORIENTATION, Seconds(5));
                         break;
                     case EVENT_RESET_ORIENTATION:


### PR DESCRIPTION
**Changes proposed:**

When using the quest item for [this quest](http://www.wowhead.com/quest=11719), when the spell aura vanishes, the nearby questgiver should turn toward the player and whisper a line.

This is handled via spell event for [this spell](http://www.wowhead.com/spell=45997).

[Video here](https://www.youtube.com/watch?v=oH_CGGqolns).

**Target branch(es):**

- [x] 3.3.5
- [x] master

**Tests performed:** works fine.