### PR TITLE
[3.3.5] Scripts/ScarletMonastery: Mograine and Whitemane boss fight improvements

### DIFF
--- a/sql/updates/world/3.3.5/2017_10_02_99_world_335_mograine_and_whitemane.sql
+++ b/sql/updates/world/3.3.5/2017_10_02_99_world_335_mograine_and_whitemane.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_text` SET `Text`="Mograine has fallen? You shall pay for this treachery!", `BroadcastTextID`=0 WHERE `CreatureID`=3977 AND `GroupID`=0;

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
@@ -96,6 +96,7 @@ public:
         bool _bHasDied;
         bool _bHeal;
         bool _bFakeDeath;
+        bool _canCallForHelp;
 
         void Reset() override
         {
@@ -120,8 +121,7 @@ public:
         {
             Talk(SAY_MO_AGGRO);
             DoCast(me, SPELL_RETRIBUTIONAURA);
-
-            me->CallForHelp(VISIBLE_RANGE);
+            _canCallForHelp = true;
         }
 
         void KilledUnit(Unit* /*victim*/) override
@@ -129,7 +129,7 @@ public:
             Talk(SAY_MO_KILL);
         }
 
-        void DamageTaken(Unit* /*doneBy*/, uint32 &damage) override
+        void DamageTaken(Unit* attacker, uint32 &damage) override
         {
             if (damage < me->GetHealth() || _bHasDied || _bFakeDeath)
                 return;
@@ -140,6 +140,7 @@ public:
                 instance->SetBossState(DATA_MOGRAINE_AND_WHITE_EVENT, IN_PROGRESS);
 
                 Whitemane->GetMotionMaster()->MovePoint(1, 1163.113370f, 1398.856812f, 32.527786f);
+                Whitemane->GetAI()->AttackStart(attacker);
 
                 me->GetMotionMaster()->MovementExpired();
                 me->GetMotionMaster()->MoveIdle();
@@ -197,6 +198,12 @@ public:
 
                     _bHeal = true;
                 }
+            }
+
+            if (_canCallForHelp)
+            {
+                me->CallForHelp(VISIBLE_RANGE);
+                _canCallForHelp = false;
             }
 
             //This if-check to make sure mograine does not attack while fake death

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/instance_scarlet_monastery.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/instance_scarlet_monastery.cpp
@@ -22,12 +22,6 @@
 #include "Map.h"
 #include "scarlet_monastery.h"
 
-DoorData const doorData[] =
-{
-    { GO_HIGH_INQUISITORS_DOOR, DATA_MOGRAINE_AND_WHITE_EVENT, DOOR_TYPE_ROOM },
-    { 0,                        0,                             DOOR_TYPE_ROOM } // END
-};
-
 class instance_scarlet_monastery : public InstanceMapScript
 {
     public:
@@ -39,7 +33,6 @@ class instance_scarlet_monastery : public InstanceMapScript
             {
                 SetHeaders(DataHeader);
                 SetBossNumber(EncounterCount);
-                LoadDoorData(doorData);
 
                 HorsemanAdds.clear();
             }
@@ -52,6 +45,9 @@ class instance_scarlet_monastery : public InstanceMapScript
                 {
                     case GO_PUMPKIN_SHRINE:
                         PumpkinShrineGUID = go->GetGUID();
+                        break;
+                    case GO_HIGH_INQUISITORS_DOOR:
+                        HighInquisitorsDoorGUID = go->GetGUID();
                         break;
                     default:
                         break;
@@ -117,6 +113,10 @@ class instance_scarlet_monastery : public InstanceMapScript
                             HandleGameObject(PumpkinShrineGUID, false);
                         }
                         break;
+                    case DATA_MOGRAINE_AND_WHITE_EVENT:
+                        if (state == DONE || state == IN_PROGRESS)
+                            HandleGameObject(HighInquisitorsDoorGUID, true);
+                        break;
                     default:
                         break;
                 }
@@ -146,6 +146,7 @@ class instance_scarlet_monastery : public InstanceMapScript
             ObjectGuid MograineGUID;
             ObjectGuid WhitemaneGUID;
             ObjectGuid VorrelGUID;
+            ObjectGuid HighInquisitorsDoorGUID;
 
             GuidSet HorsemanAdds;
         };


### PR DESCRIPTION
**Changes proposed:**

- Fix call for help when boss is aggroed (this fails when called in EnterCombat, so moved it to UpdateAI).
- Correctly handle the door to High Inquisitor Whitemane so that it opens only when supposed to.
- Fix wrong creature text for High Inquisitor Whitemane (was rehauled after WotLK, so the broadcast_text entry is not valid for WotLK).
- Whitemane should attack the player that killed Mograine first.

Closes #15793.

**Target branch(es):**

- [x] 3.3.5

**Tests performed:** works fine.