### PR TITLE
Core/Spells: Fixed spell Health Funnel and Improved Health Funnel

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5945,6 +5945,16 @@ void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const
         if (funnelDamage > healInfo.GetEffectiveHeal() && healInfo.GetEffectiveHeal())
             funnelDamage = healInfo.GetEffectiveHeal();
 
+        //Handle with Improved Health Funnel
+        if (caster->GetTypeId() == TYPEID_PLAYER)
+            caster->ToPlayer()->ApplySpellMod(GetSpellInfo()->Id, SPELLMOD_COST, funnelDamage);
+
+        if (caster->GetHealth() <= funnelDamage)
+        {
+            GetBase()->Remove();
+            return;
+        }
+
         uint32 funnelAbsorb = 0;
         caster->DealDamageMods(caster, funnelDamage, &funnelAbsorb);
         caster->SendSpellNonMeleeDamageLog(caster, GetId(), funnelDamage, GetSpellInfo()->GetSchoolMask(), funnelAbsorb, 0, false, 0, false);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -348,7 +348,7 @@ m_casterLevel(caster ? caster->getLevel() : m_spellInfo->SpellLevel), m_procChar
 m_isRemoved(false), m_isSingleTarget(false), m_isUsingCharges(false), m_dropEvent(nullptr),
 m_procCooldown(std::chrono::steady_clock::time_point::min())
 {
-    if (m_spellInfo->ManaPerSecond || m_spellInfo->ManaPerSecondPerLevel)
+    if ((m_spellInfo->ManaPerSecond || m_spellInfo->ManaPerSecondPerLevel) && !m_spellInfo->HasAttribute(SPELL_ATTR2_HEALTH_FUNNEL))
         m_timeCla = 1 * IN_MILLISECONDS;
 
     m_maxDuration = CalcMaxDuration(caster);
@@ -767,7 +767,7 @@ void Aura::RefreshDuration(bool withMods)
     else
         SetDuration(GetMaxDuration());
 
-    if (m_spellInfo->ManaPerSecond || m_spellInfo->ManaPerSecondPerLevel)
+    if ((m_spellInfo->ManaPerSecond || m_spellInfo->ManaPerSecondPerLevel) && !m_spellInfo->HasAttribute(SPELL_ATTR2_HEALTH_FUNNEL))
         m_timeCla = 1 * IN_MILLISECONDS;
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  Fixed spell Health Funnel consuming 3 times more health that should.
-  Fixed reduce of health using Health Funnel when warlock has Improved Health Funnel talent.

**Issue:**

Current script remove warlock health in 2 points.
Here: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Spells/Auras/SpellAuraEffects.cpp#L5941
And Here: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Spells/Auras/SpellAuras.cpp#L706
The second point, is called 2 times: First call is caused by Warlock Aura. The second is caused by Pet Aura.
And current script, dont check any ```SPELLMOD_COST```, so reduce cost part of Improved Health Funnel not work.

**Target branch(es):** 3.3.5

**Issues addressed:** has no open issues.

**Tests performed:** Builded and tested in game
