### PR TITLE
Scripts/NPC: Minigob Manabonk update

### DIFF
--- a/src/server/scripts/Northrend/zone_dalaran.cpp
+++ b/src/server/scripts/Northrend/zone_dalaran.cpp
@@ -135,14 +135,18 @@ enum MinigobData
 {
     ZONE_DALARAN            = 4395,
 
-    SPELL_MANABONKED        = 61834,
+    SPELL_MANABONKED        = 61839,
     SPELL_TELEPORT_VISUAL   = 51347,
     SPELL_IMPROVED_BLINK    = 61995,
 
     EVENT_SELECT_TARGET     = 1,
-    EVENT_BLINK             = 2,
-    EVENT_DESPAWN_VISUAL    = 3,
-    EVENT_DESPAWN           = 4,
+    EVENT_LAUGH_1           = 2,
+    EVENT_WANDER            = 3,
+    EVENT_PAUSE             = 4,
+    EVENT_CAST              = 5,
+    EVENT_LAUGH_2           = 6,
+    EVENT_BLINK             = 7,
+    EVENT_DESPAWN           = 8,
 
     MAIL_MINIGOB_ENTRY      = 264,
     MAIL_DELIVER_DELAY_MIN  = 5*MINUTE,
@@ -163,26 +167,29 @@ class npc_minigob_manabonk : public CreatureScript
 
             void Reset() override
             {
+                playerGuid = ObjectGuid();
                 me->SetVisible(false);
-                events.ScheduleEvent(EVENT_SELECT_TARGET, IN_MILLISECONDS);
+                events.ScheduleEvent(EVENT_SELECT_TARGET, Seconds(1));
             }
 
-            Player* SelectTargetInDalaran()
+            void GetPlayersInDalaran(std::vector<Player*>& playerList) const
             {
-                std::vector<Player*> PlayerInDalaranList;
-
                 Map::PlayerList const& players = me->GetMap()->GetPlayers();
                 for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
                     if (Player* player = itr->GetSource()->ToPlayer())
                         if (player->GetZoneId() == ZONE_DALARAN && !player->IsFlying() && !player->IsMounted() && !player->IsGameMaster())
-                            PlayerInDalaranList.push_back(player);
+                            playerList.push_back(player);
+            }
 
+            static Player* SelectTargetInDalaran(std::vector<Player*>& PlayerInDalaranList)
+            {
                 if (PlayerInDalaranList.empty())
                     return nullptr;
+
                 return Trinity::Containers::SelectRandomContainerElement(PlayerInDalaranList);
             }
 
-            void SendMailToPlayer(Player* player)
+            void SendMailToPlayer(Player* player) const
             {
                 SQLTransaction trans = CharacterDatabase.BeginTransaction();
                 int16 deliverDelay = irand(MAIL_DELIVER_DELAY_MIN, MAIL_DELIVER_DELAY_MAX);
@@ -199,30 +206,61 @@ class npc_minigob_manabonk : public CreatureScript
                     switch (eventId)
                     {
                         case EVENT_SELECT_TARGET:
+                        {
+                            std::vector<Player*> PlayerInDalaranList;
+                            GetPlayersInDalaran(PlayerInDalaranList);
+
+                            // Increases chance of event based on player count in Dalaran (100 players or more = 100% else player count%)
+                            if (PlayerInDalaranList.empty() || urand(1, 100) > PlayerInDalaranList.size())
+                                me->AddObjectToRemoveList();
+
                             me->SetVisible(true);
-                            DoCast(me, SPELL_TELEPORT_VISUAL);
-                            if (Player* player = SelectTargetInDalaran())
+                            DoCastSelf(SPELL_TELEPORT_VISUAL);
+                            if (Player* player = SelectTargetInDalaran(PlayerInDalaranList))
                             {
-                                me->NearTeleportTo(player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), 0.0f);
+                                playerGuid = player->GetGUID();
+                                Position pos = player->GetPosition();
+                                float dist = frand(10.0f, 30.0f);
+                                float angle = frand(0.0f, 1.0f) * M_PI * 2.0f;
+                                player->MovePositionToFirstCollision(pos, dist, angle);
+                                me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation());
+                            }
+                            events.ScheduleEvent(EVENT_LAUGH_1, Seconds(2));
+                            break;
+                        }
+                        case EVENT_LAUGH_1:
+                            me->HandleEmoteCommand(EMOTE_ONESHOT_LAUGH_NO_SHEATHE);
+                            events.ScheduleEvent(EVENT_WANDER, Seconds(3));
+                            break;
+                        case EVENT_WANDER:
+                            me->GetMotionMaster()->MoveRandom(8);
+                            events.ScheduleEvent(EVENT_PAUSE, Minutes(1));
+                            break;
+                        case EVENT_PAUSE:
+                            me->GetMotionMaster()->MoveIdle();
+                            events.ScheduleEvent(EVENT_CAST, Seconds(2));
+                            break;
+                        case EVENT_CAST:
+                            if (Player* player = me->GetMap()->GetPlayer(playerGuid))
+                            {
                                 DoCast(player, SPELL_MANABONKED);
                                 SendMailToPlayer(player);
                             }
-                            events.ScheduleEvent(EVENT_BLINK, 3*IN_MILLISECONDS);
+                            else
+                                me->AddObjectToRemoveList();
+
+                            events.ScheduleEvent(EVENT_LAUGH_2, Seconds(8));
+                            break;
+                        case EVENT_LAUGH_2:
+                            me->HandleEmoteCommand(EMOTE_ONESHOT_LAUGH_NO_SHEATHE);
+                            events.ScheduleEvent(EVENT_BLINK, Seconds(3));
                             break;
                         case EVENT_BLINK:
-                        {
-                            DoCast(me, SPELL_IMPROVED_BLINK);
-                            Position pos = me->GetRandomNearPosition(frand(15, 40));
-                            me->GetMotionMaster()->MovePoint(0, pos.m_positionX, pos.m_positionY, pos.m_positionZ);
-                            events.ScheduleEvent(EVENT_DESPAWN, 3 * IN_MILLISECONDS);
-                            events.ScheduleEvent(EVENT_DESPAWN_VISUAL, 2.5*IN_MILLISECONDS);
-                            break;
-                        }
-                        case EVENT_DESPAWN_VISUAL:
-                            DoCast(me, SPELL_TELEPORT_VISUAL);
+                            DoCastSelf(SPELL_IMPROVED_BLINK);
+                            events.ScheduleEvent(EVENT_DESPAWN, Seconds(4));
                             break;
                         case EVENT_DESPAWN:
-                            me->DespawnOrUnsummon();
+                            me->AddObjectToRemoveList();
                             break;
                         default:
                             break;
@@ -231,6 +269,8 @@ class npc_minigob_manabonk : public CreatureScript
             }
 
         private:
+
+            ObjectGuid playerGuid;
             EventMap events;
     };
 


### PR DESCRIPTION
**Changes proposed:**

This was primarily a correction to the constant respawn issue Minigob Manabonk sometimes gains since dynamic spawns.

However, while I was here I checked against the only video I could find, and a couple of sniffs from retail and produced something not perfect, but matching much closer to retail manabonk.

 - Despawn and stay despawned!
 - Adjusted actions to match the only video of event I could find and
   based on sniff data from 3.3.5, 12340 build.
 - Chance for event to occur is drastically reduced based on Dalaran
   population. 1-99, the population of Dalaran is the chance. 100+ means
   the event is assured.**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master (may be valid, is he in new Dalaran?)

**Issues addressed:** Closes #  (insert issue tracker number)

Minigob manabonk would continuously spawn (this wasn't reported as an issue yet)
Event now follows sniffed event more closely.

Event now has a much lower chance to occur, based on the Dalaran population.

**Tests performed:** (Does it build, tested in-game, etc.)

Run the event several times, tested logging out during event, triggering event with no players etc.

**Known issues and TODO list:** (add/remove lines as needed)

Not really a known issue, but the reason I'm making this a PR rather than just merging is because I want a bit of feedback.

First off, I store the target player as owner, simply to make it easier to pull target player back later in the event. Now, I could store it in the class. But it feels like there's no harm doing this, but I'm 50/50 as to whether it's more hacky to store in class and ensure it's cleared correctly, or store in summon as I am now. So, I'm asking for opinions on this case.

Second I think he fires far too often, on an empty server. I was on a very empty realm during cata/mop and I could often sit entirely alone in Dalaran and yet never got manabonked. Whereas during wrath on a busy server it happened twice. Go figure. Anyway, I figured he should have a greater chance of appearing, the more players that are in Dalaran. How it works is that if the number of players in Dalaran are 100 or more, then it will always summon and he'll pick a random player as is normal. If there are 1-99 players, he will have a more likely chance to appear, the more players there are. So for 1 player, it's 1 in 100. For 2, it's 2 in 100 (or 1 in 50) and so on..

So again, want to see if people agree on this rationing of manabonking.

Finally some review of the event itself, to see if people agree with how it runs (you will need to start/stop the event MANY times if you're alone in Dalaran to test it).

