### PR TITLE
[3.3.5] assorted quest fixes

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world_335.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world_335.sql
@@ -1,0 +1,138 @@
+-- The boar hunter requires 12 kills, not 8
+UPDATE `quest_template` SET `RequiredNpcOrGoCount1` = 12 where `ID` = 183;
+
+-- The Troll Cave requires 14 kills, not 10.
+UPDATE `quest_template` SET `RequiredNpcOrGoCount1` = 14 where `ID` = 182;
+
+-- All Tunnel Rats should be able to drop ears, not just 1 out of 6 types.
+DELETE FROM `creature_loot_template` WHERE `Entry` in (1172,1174,1175,1176,1177) and `item` = 3110;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`) VALUES
+(1172, 3110, 38),
+(1174, 3110, 80),
+(1175, 3110, 80),
+(1176, 3110, 38),
+(1177, 3110, 80);
+
+-- Quest Westbrook Garrison Needs Help! has The Jasperlode Mine as prequest
+DELETE FROM `quest_template_addon` WHERE `ID` = 239;
+INSERT INTO `quest_template_addon` (`ID`, `PrevQuestID`) VALUES (239, 76);
+
+-- The Everstill Bridge has The Lost Tools as prequest
+DELETE FROM `quest_template_addon` WHERE `ID` = 89;
+INSERT INTO `quest_template_addon` (`ID`, `PrevQuestID`) VALUES (89, 125);
+
+-- Flesh Eating Worm and Rotting Worm adjustment
+UPDATE `creature_template` SET `DamageModifier` = 0.5, `Scale`=0.4 WHERE `Entry` = 2462;
+UPDATE `creature_template` SET `DamageModifier` = 0.5, `Scale`=0.4 WHERE `Entry` = 10925;
+
+-- Kurzen Jungle Fighter also drops Jungle Remedy
+DELETE FROM `creature_loot_template` WHERE `Entry` = 937 AND `Item` = 2633;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`) VALUES (937,2633,33);
+
+-- Kurzen's Mystery follows Bad Medicine, not Colonel Kurzen
+UPDATE `quest_template_addon` SET `PrevQuestId` = 204 WHERE `ID` = 207;
+
+-- Blue Pearls only drop from Vile Reef,STV giant clams game objects.
+DELETE FROM `gameobject_loot_template` WHERE `Item` = 4611 and `Entry` IN (2954, 2959);
+DELETE FROM   `creature_loot_template` WHERE `Item` = 4611 and `Entry` IN (871, 873, 875, 877, 879, 2744);
+DELETE FROM      `spell_loot_template` WHERE `Item` = 4611 and `Entry` IN (58168, 58172);
+
+-- Spirits of the Stonemaul Hold follows The Essence of Enmity
+UPDATE `quest_template_addon` SET `PrevQuestId` = 11161 WHERE `ID` = 11159;
+
+-- Bungle in the jungle follows March of the Silithid (alliance: 4493, horde:4494), which follow Rise of the Silithid (alliance: 162, horde: 32)
+DELETE FROM `quest_template_addon` WHERE `ID` IN (4493,4494);
+INSERT INTO `quest_template_addon` (`ID`, `PrevQuestID`, `NextQuestID`, `ExclusiveGroup`) VALUES 
+(4493, 162, 4496, 4493),
+(4494,  32, 4496, 4493);
+
+
+-- Salve via hunting first time quest for alliance was not rewarding money or xp
+UPDATE `quest_template` SET RewardXPDifficulty = 4, RewardBonusMoney = 3600 WHERE ID = 4103;
+-- Salve via hunting repeatable quest for horde WAS!
+UPDATE `quest_template` SET RewardXPDifficulty = 0, RewardBonusMoney = 0 WHERE ID = 5887;
+
+
+-- Atal'ai Artifacts (and 1 mithril deposit) are underground
+UPDATE `gameobject` SET `position_z`=-15.29  WHERE `guid`=30371;
+UPDATE `gameobject` SET `position_z`= 14.5   WHERE `guid`=30374;
+UPDATE `gameobject` SET `position_z`= 31.63  WHERE `guid`=30380;
+UPDATE `gameobject` SET `position_z`=-16.75  WHERE `guid`=30381;
+UPDATE `gameobject` SET `position_z`= 19.57  WHERE `guid`=30383;
+UPDATE `gameobject` SET `position_z`= 10.58  WHERE `guid`=30541;
+UPDATE `gameobject` SET `position_z`=-19     WHERE `guid`=30542;
+UPDATE `gameobject` SET `position_z`=-16.9   WHERE `guid`=30543;
+UPDATE `gameobject` SET `position_z`= 20.2   WHERE `guid`=30546;
+UPDATE `gameobject` SET `position_z`=-2.2    WHERE `guid`=30547;
+UPDATE `gameobject` SET `position_z`= 10.5   WHERE `guid`=30550;
+UPDATE `gameobject` SET `position_z`=-11.9   WHERE `guid`=30551;
+UPDATE `gameobject` SET `position_z`= 10.91  WHERE `guid`=30554;
+UPDATE `gameobject` SET `position_z`=-3.56   WHERE `guid`=30556;
+UPDATE `gameobject` SET `position_z`= 18.70  WHERE `guid`=30558;
+UPDATE `gameobject` SET `position_z`= 19.1   WHERE `guid`=30559;
+UPDATE `gameobject` SET `position_z`= 18.66  WHERE `guid`=30561;
+UPDATE `gameobject` SET `position_z`=-19     WHERE `guid`=30643;
+UPDATE `gameobject` SET `position_z`=-6      WHERE `guid`=30646;
+UPDATE `gameobject` SET `position_z`=-10.4   WHERE `guid`=30375;
+UPDATE `gameobject` SET `position_z`=-8.5    WHERE `guid`=30378;
+UPDATE `gameobject` SET `position_z`= 19     WHERE `guid`=31029;
+
+-- Atal'ai Artifact twin spawn
+DELETE FROM `gameobject` WHERE `guid`=30593;
+DELETE FROM `gameobject` WHERE `guid`=30594;
+DELETE FROM `gameobject` WHERE `guid`=30587;
+
+-- Trouble in Winterspring! is a breadcrumb quest, not prequest.
+UPDATE `quest_template_addon` SET `PrevQuestID` = 0 WHERE `ID` = 5082;
+
+-- Raising the drop rate of Thick Yeti Fur
+UPDATE `creature_loot_template` SET `Chance` = 71 WHERE `Entry` = 7457 AND `Item` = 12366;
+UPDATE `creature_loot_template` SET `Chance` = 41 WHERE `Entry` = 7458 AND `Item` = 12366;
+UPDATE `creature_loot_template` SET `Chance` = 43 WHERE `Entry` = 7459 AND `Item` = 12366;
+UPDATE `creature_loot_template` SET `Chance` = 45 WHERE `Entry` = 7460 AND `Item` = 12366;
+
+-- Raising the drop rate on Forked Mudrock Tongues
+UPDATE `creature_loot_template` SET `Chance` = 40 WHERE `Entry` = 4397 AND `Item` = 5883;
+
+-- Crimson Crysal Shard is a guaranteed drop
+UPDATE `creature_loot_template` SET `Chance` = 100 WHERE `Entry` = 19188 AND `Item` = 29476;
+
+-- Diaphanous wing droprate
+UPDATE `creature_loot_template` SET `Chance` = 40 WHERE `Item` = 24372 AND `Entry` IN (18132, 18133, 20197, 20198, 18283);
+
+-- Greater and Young Sporebat also drop eyes.
+DELETE FROM `creature_loot_template` WHERE `Entry` IN (20387, 18129) AND `Item` = 24426;
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Chance`) VALUES
+(18129,24426,20),
+(20387,24426,20);
+
+-- Escaping the Tomb was missing its goal
+UPDATE `quest_template` SET `AreaDescription` = 'Escort Akuno' WHERE `ID` = 10887;
+
+-- Redone Slain Sha'tar Vindicator
+DELETE FROM `creature` WHERE `id` = 21859;
+INSERT INTO `creature`
+(`id`,`map`,`zoneId`,`areaId`,`spawnMask`,`phaseMask`,`modelid`,`equipment_id`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`currentwaypoint`,`curhealth`,`curmana`,`MovementType`,`npcflag`,`unit_flags`,`dynamicflags`) VALUES
+(21859,530,0,0,1,1,0,1,-3736,   5333.73,-12.50,2.1171,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3750.4, 5301.33,-17.10,3.6650,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3649.6, 5322.93,-18.15,5.3430,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3779.2, 5225.73,-22.75,2.7725,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3714.4, 5214.93,-21.00,4.2144,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3750.4, 5171.73,-22.15,2.0036,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3764.8, 5128.53,-22.30,3.0938,150,0,0,6986,0,0,0,0,0),
+(21859,530,0,0,1,1,0,1,-3750.4, 5085.33,-18.40,0.6098,150,0,0,6986,0,0,0,0,0);
+
+-- Redone Slain Auchenai Warrior
+DELETE FROM `creature` WHERE `id` = 21846;
+INSERT INTO `creature` (`id`,`map`,`zoneId`,`areaId`,`spawnMask`,`phaseMask`,`modelid`,`equipment_id`,`position_x`,`position_y`,`position_z`,`orientation`,`spawntimesecs`,`spawndist`,`currentwaypoint`,`curhealth`,`curmana`,`MovementType`,`npcflag`,`unit_flags`,`dynamicflags`) VALUES
+(21846,530,0,0,1,1,0,1,-3714.4, 5290.53,-18.75,3.3858,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3714.4, 5225.73,-22.60,4.8247,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3692.8, 5344.53,-13.85,4.8579,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3642.4, 5290.53,-21.35,1.1159,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3750.4, 5268.93,-15.30,0.4874,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3772,   5214.93,-22.70,2.7571,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3736,   5160.93,-22.25,2.7343,150,0,0,6986,0,0,0,0,0),
+(21846,530,0,0,1,1,0,1,-3764.8, 5106.93,-19.80,0.6078,150,0,0,6986,0,0,0,0,0);
+
+-- Drop chance howling wind
+UPDATE `creature_loot_template` SET `Chance` = 20 WHERE `Item` = 24504 AND `Entry` IN (17158,17159,17160);


### PR DESCRIPTION
**The boar hunter**: needs 12 kills not 8.
http://wow.gamepedia.com/Quest:The_Boar_Hunter

**The Troll Cave**: needs 14 kills, not 10.
http://wow.gamepedia.com/Quest:The_Troll_Cave

**Tunnel Rat**:
Currently only 1 type drop ears, when all 6 should.
Some mobs have 4/5 drop rate.
http://www.wowhead.com/quest=416/rat-catching#comments:id=74106:reply=305815
Drop rate inside the cave is way higher.
http://www.wowhead.com/item=3110/tunnel-rat-ear#comments:id=353270

**Westbrook garrison needs help!** has The Jasperlode Mine as prequest.
http://www.wowhead.com/quest=239/westbrook-garrison-needs-help#comments:id=161626

**The Everstill Bridge** has The Lost Tools as prequest.
http://www.wowhead.com/quest=89/the-everstill-bridge#comments:id=246622

**Flesh Eating Worm and Rotting Worm**:
These are the worms that spawn when a Rotted One in Duskwood and Rotting Cadaver in Western Plaguelands respectively dies.
http://wow.gamepedia.com/File:Flesh_Eating_Worm.jpg
I reduced the size based on the image from 2008, sorta got it right.
I reduced their damage to be 50% based on http://www.wowhead.com/npc=10925/rotting-worm#comments:id=245916.

**Kurzen Jungle Fighter**: These should also drop Jungle Remedy.
http://www.wowhead.com/item=2633/jungle-remedy#comments:id=163587

**Kurzen's Mystery** has Bad Medicine as prequest, not Colonel Kurzen.
http://www.wowhead.com/quest=207/kurzens-mystery#comments:id=98747
http://wow.gamepedia.com/Stranglethorn_Vale_quests (search for Rebel Camp)

**Blue Pearls**: These only drop from the Giant Clam objects in the vile reef.
Not Giant Clam objects in other zones, clam items or murlocs.

**Forked Mudrock Tongue** droprate:
http://www.wowhead.com/quest=1204/mudrock-soup-and-bugs
http://www.wowhead.com/item=5883/forked-mudrock-tongue#dropped-by
Currently 25%, making it 40%.
From the comments some complain it's terrible, some say it's 100% and great.
I'm getting the suspicion it depends on the type of Mudrock. In the database there's 5 different Mudrocks, but as of patch 2.3, 4 turtle types were removed in favour of 1.
http://www.wowhead.com/npc=4396/mudrock-tortoise#comments
http://www.wowhead.com/npc=4398/mudrock-burrower#comments
http://www.wowhead.com/npc=4399/mudrock-borer#comments
http://www.wowhead.com/npc=4400/mudrock-snapjaw#comments

**Spirits of the Stonemaul Hold** has Essence of Enmity as prequest.
http://wow.gamepedia.com/Quest:Spirits_of_Stonemaul_Hold

**Bungle in the Jungle** follows March of the Silithid (alliance: 4493, horde:4494), which follow Rise of the Silithid (alliance: 162, horde: 32).
http://wow.gamepedia.com/Quest:Bungle_in_the_Jungle

**Salve Via Hunting** alliance first time quest was not rewarding xp or money, however horde version repeatable was.

**Atal'Ai Artifacts**
I could hardly find any of these, turns out most of them were underground, so I moved them up a little.
Found 21 artifacts and 1 mithril deposit underground and 3 double spawned artifacts that are deleted.
Run around with Find Treasure to see what I mean.

**Trouble in Winterspring!**: This is a breadcrumb quest, not a prequest.
http://www.wowhead.com/quest=6603/trouble-in-winterspring#comments:id=931604

**Thick Yeti Fur** droprate:
Increasing drop rates across the board.
http://www.wowhead.com/quest=3783/deprecated-are-we-there-yeti#comments:id=1043214
It varies between the types, and seems it was buffed at the end of wotlk.
http://www.wowhead.com/npc=7457/
http://www.wowhead.com/npc=7458/
http://www.wowhead.com/npc=7459/
http://www.wowhead.com/npc=7460/

**Crimson Crystal Shard**: Should be guaranteed over 5 kills, setting it to 100%

**Diaphanous wing** droprate: made uniform over all insects.
Reading through the comments, the wowhead droprate seems incorrect and skewed based on kills outside the quest, Captured Firefly farmers to blame, perhaps.
http://www.wowhead.com/item=24372/diaphanous-wing
http://www.wowhead.com/quest=9790/diaphanous-wings
http://www.wowhead.com/quest=9769/theres-no-explanation-for-fashion

**Greater and Young Sporebat**: now drop eyes, was added around 2.3 or so.
http://www.wowhead.com/item=24426/sporebat-eye

**Escaping the Tomb**: was missing its goal

**Slain Sha'tar Vindicator**: Redone to be more and faster respawn.
**Slain Auchenai Warrior**: Redone to be more and faster respawn.

**Howling wind**: dropratemade uniform for all wind elementals, wowhead stats skewed by farmers.
http://www.wowhead.com/item=24504/howling-wind#comments:id=990330
