### PR TITLE
Core/AI: implemented AI hook for interrupting spells

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -157,6 +157,9 @@ class TC_GAME_API CreatureAI : public UnitAI
 
         void OnCharmed(bool apply) override;
 
+        // Called when a spell cast gets interrupted
+        virtual void OnSpellCastInterrupt(SpellInfo const* /*spell*/) { }
+
         // Called at reaching home after evade
         virtual void JustReachedHome() { }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2932,6 +2932,9 @@ void Unit::InterruptSpell(CurrentSpellTypes spellType, bool withDelayed, bool wi
         if (spell->getState() != SPELL_STATE_FINISHED)
             spell->cancel();
 
+        if (GetTypeId() == TYPEID_UNIT && IsAIEnabled)
+            ToCreature()->AI()->OnSpellCastInterrupt(spell->GetSpellInfo());
+
         m_currentSpells[spellType] = NULL;
         spell->SetReferencedFromCurrent(false);
     }


### PR DESCRIPTION
**Changes proposed:**

-  implement an AI hook that gets called when a creature's spell cast gets interrupted. Needed for Cataclysm+ boss implementations. Maybe 3.3.5 as well.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame with some scripts, works as intended.

**Known issues and TODO list:**
