### PR TITLE
Scripts/Commands: Add failure state for quest remove

### DIFF
--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -128,27 +128,26 @@ public:
             return false;
         }
 
-        // remove all quest entries for 'entry' from quest log
-        for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
-        {
-            uint32 logQuest = player->GetQuestSlotQuestId(slot);
-            if (logQuest == entry)
-            {
-                player->SetQuestSlot(slot, 0);
-
-                // we ignore unequippable quest items in this case, its' still be equipped
-                player->TakeQuestSourceItem(logQuest, false);
-
-                if (quest->HasFlag(QUEST_FLAGS_FLAGS_PVP))
-                {
-                    player->pvpInfo.IsHostile = player->pvpInfo.IsInHostileArea || player->HasPvPForcingQuest();
-                    player->UpdatePvPState();
-                }
-            }
-        }
-        
         if (player->GetQuestStatus(entry) != QUEST_STATUS_NONE)
         {
+            // remove all quest entries for 'entry' from quest log
+            for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
+            {
+                uint32 logQuest = player->GetQuestSlotQuestId(slot);
+                if (logQuest == entry)
+                {
+                    player->SetQuestSlot(slot, 0);
+
+                    // we ignore unequippable quest items in this case, its' still be equipped
+                    player->TakeQuestSourceItem(logQuest, false);
+
+                    if (quest->HasFlag(QUEST_FLAGS_FLAGS_PVP))
+                    {
+                        player->pvpInfo.IsHostile = player->pvpInfo.IsInHostileArea || player->HasPvPForcingQuest();
+                        player->UpdatePvPState();
+                    }
+                }
+            }
             player->RemoveActiveQuest(entry, false);
             player->RemoveRewardedQuest(entry);
 

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -147,7 +147,7 @@ public:
             }
         }
         
-        if(player->GetQuestStatus(entry) != QUEST_STATUS_NONE /* || player->IsActiveQuest(entry) ? */ )
+        if (player->GetQuestStatus(entry) != QUEST_STATUS_NONE /* || player->IsActiveQuest(entry) ? */ )
         {
             player->RemoveActiveQuest(entry, false);
             player->RemoveRewardedQuest(entry);
@@ -157,7 +157,8 @@ public:
             handler->SendSysMessage(LANG_COMMAND_QUEST_REMOVED);
             return true;
         }
-        else {
+        else
+        {
             handler->SendSysMessage(LANG_COMMAND_QUEST_NOTFOUND);
             handler->SetSentErrorMessage(true);
             return false;

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -147,7 +147,8 @@ public:
             }
         }
         
-        if(player->GetQuestStatus(entry) != QUEST_STATUS_NONE /* || player->IsActiveQuest(entry) ? */ ) {
+        if(player->GetQuestStatus(entry) != QUEST_STATUS_NONE /* || player->IsActiveQuest(entry) ? */ )
+        {
             player->RemoveActiveQuest(entry, false);
             player->RemoveRewardedQuest(entry);
 
@@ -155,7 +156,8 @@ public:
 
             handler->SendSysMessage(LANG_COMMAND_QUEST_REMOVED);
             return true;
-        } else {
+        }
+        else {
             handler->SendSysMessage(LANG_COMMAND_QUEST_NOTFOUND);
             handler->SetSentErrorMessage(true);
             return false;

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -147,7 +147,7 @@ public:
             }
         }
         
-        if (player->GetQuestStatus(entry) != QUEST_STATUS_NONE /* || player->IsActiveQuest(entry) ? */ )
+        if (player->GetQuestStatus(entry) != QUEST_STATUS_NONE)
         {
             player->RemoveActiveQuest(entry, false);
             player->RemoveRewardedQuest(entry);

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -146,14 +146,21 @@ public:
                 }
             }
         }
+        
+        if(player->GetQuestStatus(entry) != QUEST_STATUS_NONE /* || player->IsActiveQuest(entry) ? */ ) {
+            player->RemoveActiveQuest(entry, false);
+            player->RemoveRewardedQuest(entry);
 
-        player->RemoveActiveQuest(entry, false);
-        player->RemoveRewardedQuest(entry);
+            sScriptMgr->OnQuestStatusChange(player, entry);
 
-        sScriptMgr->OnQuestStatusChange(player, entry);
-
-        handler->SendSysMessage(LANG_COMMAND_QUEST_REMOVED);
-        return true;
+            handler->SendSysMessage(LANG_COMMAND_QUEST_REMOVED);
+            return true;
+        } else {
+            handler->SendSysMessage(LANG_COMMAND_QUEST_NOTFOUND);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+        
     }
 
     static bool HandleQuestComplete(ChatHandler* handler, char const* args)

--- a/src/server/scripts/Commands/cs_quest.cpp
+++ b/src/server/scripts/Commands/cs_quest.cpp
@@ -163,7 +163,6 @@ public:
             handler->SetSentErrorMessage(true);
             return false;
         }
-        
     }
 
     static bool HandleQuestComplete(ChatHandler* handler, char const* args)


### PR DESCRIPTION
**Changes proposed:**

-  Add more verbose messaging to the `.quest remove` command. This could be useful for debugging; there's another issue that I _think_ this command might have but I can't tell without better output.

**Target branch(es):**
3.3.5. It's probably relevant for master too, but I branched off of 3.3.5 so I see no problem starting here. :)

**Tests performed:**
It builds, which is a good start since I don't really know much about C++. The logic checks out to me, but I haven't been able to test it yet due to cost constraints on my end.

**Questions:**

- Should there be a separate, unique message for this failure state rather than reusing `LANG_COMMAND_QUEST_NOTFOUND`?
- If so, what should it say?
- If not, should the conditions be moved up to line 124, which already outputs `LANG_COMMAND_QUEST_NOTFOUND`, instead of here?