### PR TITLE
Core/Player: Fixed Battleground double kill exploit

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -17164,7 +17164,6 @@ bool Player::LoadFromDB(ObjectGuid guid, SQLQueryHolder *holder)
 
             //join player to battleground group
             currentBg->EventPlayerLoggedIn(this);
-            currentBg->AddOrSetPlayerToCorrectBgGroup(this, m_bgData.bgTeam);
 
             SetInviteForBattlegroundQueueType(bgQueueTypeId, currentBg->GetInstanceID());
         }


### PR DESCRIPTION
**Changes proposed:**

-  Remove AddOrSetPlayerToCorrectBgGroup call, that make player join again in bg group
Fix by: Sirikfoll

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #20616


**Tests performed:** Builded and tested in game