### PR TITLE
Core/Spells: Spells with Attribute SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY should dispel snare auras.

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2877,13 +2877,7 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
                 target->ApplySpellImmune(Id, IMMUNITY_MECHANIC, i, apply);
 
         if (apply && HasAttribute(SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY))
-        {
-            // exception for purely snare mechanic (eg. hands of freedom)!
-            if (mechanicImmunity == (1 << MECHANIC_SNARE))
-                target->RemoveMovementImpairingAuras(false);
-            else
-                target->RemoveAurasWithMechanic(mechanicImmunity, AURA_REMOVE_BY_DEFAULT, Id);
-        }
+            target->RemoveAurasWithMechanic(mechanicImmunity, AURA_REMOVE_BY_DEFAULT, Id);
     }
 
     if (uint32 dispelImmunity = immuneInfo->DispelImmune)


### PR DESCRIPTION
**Changes proposed:**

- Proof: https://youtu.be/ZR0E2gzp0Bo?t=413

Condition added by xinef1 here: https://github.com/TrinityCore/TrinityCore/commit/93746e8c4a79c8256cd4896533315683f143508c

**Target branch(es):** 3.3.5

**Tests performed:** Built and tested in-game.