### PR TITLE
Fixed SCRIPT_COMMAND_TALK description, comment was still matching the old behavior

### DIFF
--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -101,7 +101,7 @@ struct TempSummonData
 // DB scripting commands
 enum ScriptCommands
 {
-    SCRIPT_COMMAND_TALK                  = 0,                // source/target = Creature, target = any, datalong = talk type (0=say, 1=whisper, 2=yell, 3=emote text, 4=boss emote text), datalong2 & 1 = player talk (instead of creature), dataint = string_id
+    SCRIPT_COMMAND_TALK                  = 0,                // source/target = Creature, target = any, datalong = talk type (see ChatType enum), datalong2 & 1 = player talk (instead of creature), dataint = string_id
     SCRIPT_COMMAND_EMOTE                 = 1,                // source/target = Creature, datalong = emote id, datalong2 = 0: set emote state; > 0: play emote state
     SCRIPT_COMMAND_FIELD_SET             = 2,                // source/target = Creature, datalong = field id, datalog2 = value
     SCRIPT_COMMAND_MOVE_TO               = 3,                // source/target = Creature, datalong2 = time to reach, x/y/z = destination

--- a/src/server/game/Maps/MapScripts.cpp
+++ b/src/server/game/Maps/MapScripts.cpp
@@ -671,7 +671,7 @@ void Map::ScriptsProcess()
 
                 Unit* uSource = nullptr;
                 Unit* uTarget = nullptr;
-                // source/target cast spell at target/source (script->datalong2: 0: s->t 1: s->s 2: t->t 3: t->s
+                // source/target cast spell at target/source (script->datalong2: 0: s->t 1: s->s 2: t->t 3: t->s)
                 switch (step.script->CastSpell.Flags)
                 {
                     case SF_CASTSPELL_SOURCE_TO_TARGET: // source -> target


### PR DESCRIPTION
**Changes proposed:**

Changing a comment only. Talk.ChatType is using ChatType enum instead of old values specific to scripts.
See SCRIPT_COMMAND_TALK handler https://github.com/TrinityCore/TrinityCore/blob/e7ec5bead14dd78c2447c4840558e20214293b23/src/server/game/Maps/MapScripts.cpp#L371-L420

**Target branch(es):** 3.3.5/master
