### PR TITLE
[WIP] [3.3.5] Pet hit rating inheritance

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.h
+++ b/src/server/game/Entities/Creature/TemporarySummon.h
@@ -85,6 +85,11 @@ class TC_GAME_API Guardian : public Minion
         void UpdateAttackPowerAndDamage(bool ranged = false) override;
         void UpdateDamagePhysical(WeaponAttackType attType) override;
 
+        void UpdateMeleeHitChances();
+        void UpdateSpellHitChances();
+        void UpdateExpertise(WeaponAttackType attack);
+
+
         int32 GetBonusDamage() const { return m_bonusSpellDamage; }
         float GetBonusStatFromOwner(Stats stat) const { return m_statFromOwner[stat]; }
         void SetBonusDamage(int32 damage);

--- a/src/server/game/Entities/Creature/TemporarySummon.h
+++ b/src/server/game/Entities/Creature/TemporarySummon.h
@@ -87,8 +87,7 @@ class TC_GAME_API Guardian : public Minion
 
         void UpdateMeleeHitChances();
         void UpdateSpellHitChances();
-        void UpdateExpertise(WeaponAttackType attack);
-
+        void UpdateExpertise();
 
         int32 GetBonusDamage() const { return m_bonusSpellDamage; }
         float GetBonusStatFromOwner(Stats stat) const { return m_statFromOwner[stat]; }

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1515,6 +1515,7 @@ void Guardian::UpdateSpellHitChances()
 
 void Guardian::UpdateExpertise()
 {
+    /*
     Unit* owner = GetOwner();
     if (owner && owner->GetTypeId() == TYPEID_PLAYER)
     {
@@ -1526,8 +1527,8 @@ void Guardian::UpdateExpertise()
         // Increase hit spell from spell hit ratings
         Expertise += powner->GetRatingBonusValue(CR_HIT_SPELL);
 
-        SetUInt32Value(PLAYER_EXPERTISE, expertise);
-    }
+        SetUInt32Value(PLAYER_EXPERTISE, Expertise);
+    }*/
 }
 
 void Guardian::SetBonusDamage(int32 damage)

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1221,6 +1221,10 @@ bool Guardian::UpdateAllStats()
         UpdateMaxPower(Powers(i));
 
     UpdateAllResistances();
+    UpdateMeleeHitChances();
+    UpdateSpellHitChances();
+    UpdateExpertise();
+
 
     return true;
 }
@@ -1483,16 +1487,16 @@ void Guardian::UpdateDamagePhysical(WeaponAttackType attType)
     SetStatFloatValue(UNIT_FIELD_MAXDAMAGE, maxdamage);
 }
 
-
 void Guardian::UpdateMeleeHitChances()
 {
     Unit* owner = GetOwner();
     if (owner && owner->GetTypeId() == TYPEID_PLAYER)
     {
+        Player* powner = owner->ToPlayer();
         // Increase hit from SPELL_AURA_MOD_SPELL_HIT_CHANCE
-        m_modMeleeHitChance = (float)owner->GetTotalAuraModifier(SPELL_AURA_MOD_HIT_CHANCE);    
+        m_modMeleeHitChance = (float)powner->GetTotalAuraModifier(SPELL_AURA_MOD_HIT_CHANCE);    
         // Increase hit spell from spell hit ratings
-        m_modMeleeHitChance += owner->GetRatingBonusValue(CR_HIT_MELEE);
+        m_modMeleeHitChance += powner->GetRatingBonusValue(CR_HIT_MELEE);
     }
 }
 
@@ -1501,10 +1505,11 @@ void Guardian::UpdateSpellHitChances()
     Unit* owner = GetOwner();
     if (owner && owner->GetTypeId() == TYPEID_PLAYER)
     {
+        Player* powner = owner->ToPlayer();
         // Increase hit from SPELL_AURA_MOD_SPELL_HIT_CHANCE
-        m_modSpellHitChance = (float)owner->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
+        m_modSpellHitChance = (float)powner->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
         // Increase hit spell from spell hit ratings
-        m_modSpellHitChance += owner->GetRatingBonusValue(CR_HIT_SPELL);
+        m_modSpellHitChance += powner->GetRatingBonusValue(CR_HIT_SPELL);
     }
 }
 
@@ -1513,18 +1518,17 @@ void Guardian::UpdateExpertise()
     Unit* owner = GetOwner();
     if (owner && owner->GetTypeId() == TYPEID_PLAYER)
     {
+        Player* powner = owner->ToPlayer();
         // For others recalculate it from:
         float Expertise = 0.0f;
         // Increase hit from SPELL_AURA_MOD_SPELL_HIT_CHANCE
-        Expertise += owner->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
+        Expertise += powner->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
         // Increase hit spell from spell hit ratings
-        Expertise += owner->GetRatingBonusValue(CR_HIT_SPELL);
+        Expertise += powner->GetRatingBonusValue(CR_HIT_SPELL);
 
         SetUInt32Value(PLAYER_EXPERTISE, expertise);
     }
 }
-
-
 
 void Guardian::SetBonusDamage(int32 damage)
 {

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -1483,6 +1483,49 @@ void Guardian::UpdateDamagePhysical(WeaponAttackType attType)
     SetStatFloatValue(UNIT_FIELD_MAXDAMAGE, maxdamage);
 }
 
+
+void Guardian::UpdateMeleeHitChances()
+{
+    Unit* owner = GetOwner();
+    if (owner && owner->GetTypeId() == TYPEID_PLAYER)
+    {
+        // Increase hit from SPELL_AURA_MOD_SPELL_HIT_CHANCE
+        m_modMeleeHitChance = (float)owner->GetTotalAuraModifier(SPELL_AURA_MOD_HIT_CHANCE);    
+        // Increase hit spell from spell hit ratings
+        m_modMeleeHitChance += owner->GetRatingBonusValue(CR_HIT_MELEE);
+    }
+}
+
+void Guardian::UpdateSpellHitChances()
+{
+    Unit* owner = GetOwner();
+    if (owner && owner->GetTypeId() == TYPEID_PLAYER)
+    {
+        // Increase hit from SPELL_AURA_MOD_SPELL_HIT_CHANCE
+        m_modSpellHitChance = (float)owner->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
+        // Increase hit spell from spell hit ratings
+        m_modSpellHitChance += owner->GetRatingBonusValue(CR_HIT_SPELL);
+    }
+}
+
+void Guardian::UpdateExpertise()
+{
+    Unit* owner = GetOwner();
+    if (owner && owner->GetTypeId() == TYPEID_PLAYER)
+    {
+        // For others recalculate it from:
+        float Expertise = 0.0f;
+        // Increase hit from SPELL_AURA_MOD_SPELL_HIT_CHANCE
+        Expertise += owner->GetTotalAuraModifier(SPELL_AURA_MOD_SPELL_HIT_CHANCE);
+        // Increase hit spell from spell hit ratings
+        Expertise += owner->GetRatingBonusValue(CR_HIT_SPELL);
+
+        SetUInt32Value(PLAYER_EXPERTISE, expertise);
+    }
+}
+
+
+
 void Guardian::SetBonusDamage(int32 damage)
 {
     m_bonusSpellDamage = damage;


### PR DESCRIPTION
**Changes proposed:**
Warlock (and hunter) pets do not inherit hit from their owners.
This used to be done through scaling auras, but these seem to have been deprecated in favour of the StatSystem (right?)
Only, StatSystem includes everything for pets but combat ratings, so here's a fix for hit.

This fix feels kinda "tacked on", any thoughts on this @ariel-? you wrote most of the StatSystem, right?

**Target branch(es):**
- [x] 3.3.5

**Issues addressed:** Closes probably many that I don't remember...

**Tests performed:**
Tested for Felhunter, was using Instructor Razuvious on 25 man as my dummy.

Here is the current situation, hit rating was 368 (14.03%)
![0](https://user-images.githubusercontent.com/1158801/31735873-6abf0bc6-b443-11e7-8dbb-736114fb2318.png)
This PR at 145 hit rating (5.53%), with 3/3 suppression.
![1](https://user-images.githubusercontent.com/1158801/31735875-6c7e15e2-b443-11e7-8135-bd7f018d5bd8.png)
This PR at 368 (14.03%), with 3/3 suppression.
![2](https://user-images.githubusercontent.com/1158801/31735879-6e0f0aec-b443-11e7-8fea-b5f5c02c3f7d.png)