### PR TITLE
Core/ObjectMgr: Remove ABORT() when faction template does not exist in DB

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -870,8 +870,8 @@ void ObjectMgr::CheckCreatureTemplate(CreatureTemplate const* cInfo)
     FactionTemplateEntry const* factionTemplate = sFactionTemplateStore.LookupEntry(cInfo->faction);
     if (!factionTemplate)
     {
-        TC_LOG_FATAL("sql.sql", "Creature (Entry: %u) has non-existing faction template (%u). This can lead to crashes, aborting.", cInfo->Entry, cInfo->faction);
-        ABORT();
+        TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has non-existing faction template (%u). This can lead to crashes, set to faction 35.", cInfo->Entry, cInfo->faction);
+        factionTemplate = sFactionTemplateStore.LookupEntry(35);
     }
 
     // used later for scale

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -871,8 +871,7 @@ void ObjectMgr::CheckCreatureTemplate(CreatureTemplate const* cInfo)
     if (!factionTemplate)
     {
         TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has non-existing faction template (%u). This can lead to crashes, set to faction 35.", cInfo->Entry, cInfo->faction);
-        factionTemplate = sFactionTemplateStore.LookupEntry(35);
-        ASSERT(factionTemplate);
+        factionTemplate = sFactionTemplateStore.AssertEntry(35);
     }
 
     // used later for scale

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -872,6 +872,7 @@ void ObjectMgr::CheckCreatureTemplate(CreatureTemplate const* cInfo)
     {
         TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has non-existing faction template (%u). This can lead to crashes, set to faction 35.", cInfo->Entry, cInfo->faction);
         factionTemplate = sFactionTemplateStore.LookupEntry(35);
+        ASSERT(factionTemplate);
     }
 
     // used later for scale


### PR DESCRIPTION
Set to 35 if it can't find the template

Closes #20625