### PR TITLE
Core/Reputation: Aldor & Scryer guards should attack and be attackable when hostile

### DIFF
--- a/src/server/game/Reputation/ReputationMgr.cpp
+++ b/src/server/game/Reputation/ReputationMgr.cpp
@@ -463,8 +463,8 @@ void ReputationMgr::SetAtWar(RepListID repListID, bool on)
 
 void ReputationMgr::SetAtWar(FactionState* faction, bool atWar) const
 {
-    // not allow declare war to own faction
-    if (atWar && (faction->Flags & FACTION_FLAG_PEACE_FORCED))
+    // Do not allow to declare war to our own faction. But allow for rival factions (eg Aldor vs Scryer).
+    if (atWar && (faction->Flags & FACTION_FLAG_PEACE_FORCED) && !(faction->Flags & FACTION_FLAG_RIVAL))
         return;
 
     // already set


### PR DESCRIPTION
(These guards that cast a spell "exile" on you teleporting you out of Shattrath)

**Changes proposed:**
Allow to set at war for factions flagged as "rival" (only Aldor & Scryer in 335 I think)

**Target branch(es):** 3.3.5/master
- [x] 3.3.5

