### PR TITLE
Core/SAI: allow to pause/resume waypoint for non-escorting NPCs

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -128,9 +128,6 @@ bool SmartAI::LoadPath(uint32 entry)
 
 void SmartAI::PausePath(uint32 delay, bool forced)
 {
-    if (!HasEscortState(SMART_ESCORT_ESCORTING))
-        return;
-
     if (HasEscortState(SMART_ESCORT_PAUSED))
     {
         TC_LOG_ERROR("misc", "SmartAI::PausePath: Creature entry %u wanted to pause waypoint (current waypoint: %u) movement while already paused, ignoring.", me->GetEntry(), _currentWaypointNode);
@@ -155,9 +152,6 @@ void SmartAI::PausePath(uint32 delay, bool forced)
 
 void SmartAI::StopPath(uint32 DespawnTime, uint32 quest, bool fail)
 {
-    if (!HasEscortState(SMART_ESCORT_ESCORTING))
-        return;
-
     if (quest)
         mEscortQuestID = quest;
 
@@ -269,9 +263,6 @@ void SmartAI::ReturnToLastOOCPos()
 
 void SmartAI::UpdatePath(const uint32 diff)
 {
-    if (!HasEscortState(SMART_ESCORT_ESCORTING))
-        return;
-
     if (_escortInvokerCheckTimer < diff)
     {
         if (!IsEscortInvokerInRange())


### PR DESCRIPTION
**Changes proposed:**

Some SAI actions related to waypoints (SMART_ACTION_WP_PAUSE and SMART_ACTION_WP_STOP) wrongly check for SMART_ESCORT_ESCORTING. But NPCs that aren't involved in escort quests should be able to benefit from those actions too.

This change fixes many non-trivial waypoint SAI scripts that use SAI's waypoint scripting functions.

[Example of such a creature](http://www.wowhead.com/npc=18146).

**Target branch(es):**

- [x] 3.3.5
- [x] master (unsure)

**Issues addressed:** updates #20310 (only the ones related to SAI). 

**Tests performed:** works fine.