### PR TITLE
Core/AI: fix EscortAI functionality for summoned creatures

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -123,8 +123,6 @@ void EscortAI::JustDied(Unit* /*killer*/)
 
 void EscortAI::JustAppeared()
 {
-    _escortState = STATE_ESCORT_NONE;
-
     if (!IsCombatMovementAllowed())
         SetCombatMovement(true);
 
@@ -134,7 +132,11 @@ void EscortAI::JustAppeared()
     if (me->GetFaction() != me->GetCreatureTemplate()->faction)
         me->RestoreFaction();
 
-    Reset();
+    if (!me->IsSummon())
+    {
+        _escortState = STATE_ESCORT_NONE;
+        Reset();
+    }
 }
 
 void EscortAI::ReturnToLastPoint()


### PR DESCRIPTION
**Changes proposed:**

The underlying issue is the way JustAppeared() is called.

The current flow for summoned creatures (and any other creature under the new dynamic spawns system) is the following:

1. Constructor
2. Script initialization (including Reset())
3. First AI tick calls JustAppeared() (which in turn calls Reset() again)

This causes scripts to reset, do their initialization and then reset again.

This only really affects summoned creatures, since they use dynamic spawn system by default. All other ~~EventAI~~ EscortAI cases can be disabled.

I'd have commented on #20310 to seek opinions, but it's locked. So, opinions here!

**Target branch(es):**

- [x] 3.3.5
- [ ] master

**Issues addressed:** updates (and probably closes, more testing needed) #20310.

**Tests performed:** works fine.