### PR TITLE
Core/SAI: Reimplement EVENT_FRIENDLY_HEALTH_PCT

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3155,40 +3155,20 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             if (!me || !me->IsEngaged())
                 return;
 
-            ObjectVector targets;
-            switch (e.GetTargetType())
+            // Get any friendly creature missing health within 30 yard radius
+            Unit* target = DoSelectLowestHpFriendly(30.0f, 1);
+            if (!target || !target->IsInCombat())
             {
-                case SMART_TARGET_CREATURE_RANGE:
-                case SMART_TARGET_CREATURE_GUID:
-                case SMART_TARGET_CREATURE_DISTANCE:
-                case SMART_TARGET_CLOSEST_CREATURE:
-                case SMART_TARGET_CLOSEST_PLAYER:
-                case SMART_TARGET_PLAYER_RANGE:
-                case SMART_TARGET_PLAYER_DISTANCE:
-                    GetTargets(targets, e);
-                    break;
-                default:
-                    return;
+                // if there are at least two same npcs, they will perform the same action immediately even if this is useless...
+                RecalcTimer(e, 1000, 3000);
+                return;
             }
 
-            Unit* unitTarget = nullptr;
-            for (WorldObject* target : targets)
-            {
-                if (IsUnit(target) && me->IsFriendlyTo(target->ToUnit()) && target->ToUnit()->IsAlive() && target->ToUnit()->IsInCombat())
-                {
-                    uint32 healthPct = uint32(target->ToUnit()->GetHealthPct());
-                    if (healthPct > e.event.friendlyHealthPct.maxHpPct || healthPct < e.event.friendlyHealthPct.minHpPct)
-                        continue;
-
-                    unitTarget = target->ToUnit();
-                    break;
-                }
-            }
-
-            if (!unitTarget)
+            uint32 perc = (uint32)target->GetHealthPct();
+            if (perc > e.event.friendlyHealthPct.maxHpPct || perc < e.event.friendlyHealthPct.minHpPct)
                 return;
 
-            ProcessTimedAction(e, e.event.friendlyHealthPct.repeatMin, e.event.friendlyHealthPct.repeatMax, unitTarget);
+            ProcessTimedAction(e, e.event.friendlyHealthPct.repeatMin, e.event.friendlyHealthPct.repeatMax, target);
             break;
         }
         case SMART_EVENT_DISTANCE_CREATURE:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -868,21 +868,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                     TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u has pct value above 100, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
                     return false;
                 }
-
-                switch (e.GetTargetType())
-                {
-                    case SMART_TARGET_CREATURE_RANGE:
-                    case SMART_TARGET_CREATURE_GUID:
-                    case SMART_TARGET_CREATURE_DISTANCE:
-                    case SMART_TARGET_CLOSEST_CREATURE:
-                    case SMART_TARGET_CLOSEST_PLAYER:
-                    case SMART_TARGET_PLAYER_RANGE:
-                    case SMART_TARGET_PLAYER_DISTANCE:
-                        break;
-                    default:
-                        TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u uses invalid target_type %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.GetTargetType());
-                        return false;
-                }
                 break;
             case SMART_EVENT_DISTANCE_CREATURE:
                 if (e.event.distance.guid == 0 && e.event.distance.entry == 0)


### PR DESCRIPTION

**Changes proposed:**

EVENT_FRIENDLY_HEALTH_PCT is fundamentally broken, as any ACTION that uses a target will not work with it. It attempts to implement an action into an event, which doesn't work.

This change will reimplement it to be consistent with other events (like EVENT_FRIENDLY_HEALTH) and will allow the use of TARGET_ACTION_INVOKER, which is also consistent with other events.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #20536

**Tests performed:**

Builds on current 3.3.5 branch and tested with an NPC, works as expected.

**Known issues and TODO list:** (add/remove lines as needed)

A hard coded range is necessary as we only have four fields for an event - two are for the per cent range and two for the repeat timer.

All current SAI using this event is broken anway, but to fix it, all it needs is the target type changed to TARGET_ACTION_INVOKER, as the reimplementation is otherwise compatible with existing fields.