### PR TITLE
Core/Creature: Remove duplicate check for evade in Creature::CanAssistTo()

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2276,9 +2276,6 @@ void Creature::CallForHelp(float radius)
 
 bool Creature::CanAssistTo(Unit const* u, Unit const* enemy, bool checkfaction /*= true*/) const
 {
-    if (IsInEvadeMode())
-        return false;
-
     // is it true?
     if (!HasReactState(REACT_AGGRESSIVE))
         return false;


### PR DESCRIPTION
**Changes proposed:**

``IsInEvadeMode()`` is checked twice in succession for no obvious reason.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master
