### PR TITLE
Core/SAI: don't call OnReset right after a creature using SAI is summoned, and fix WaypointReached usage outside of escorts

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -235,7 +235,6 @@ class TC_GAME_API SmartAI : public CreatureAI
 
         uint32 mDespawnTime;
         uint32 mDespawnState;
-        bool mJustReset;
 
         // Vehicle conditions
         bool mHasConditions;


### PR DESCRIPTION
**Changes proposed:**

The waypoint change is related to #20684.

About the OnReset change: when JustAppeared() is called by a summoned creature, it also resets invoker and on-going scripts that have been called via SMART_EVENT_JUST_SUMMONED and similar.

This change makes it so spawned creatures don't reset at their fist update tick (they're new creatures, they've already reset - no need to do so again).

Also cleaned up JustAppeared and JustReachedHome a bit, and removed a now useless bool.

**Target branch(es):**

- [x] 3.3.5
- [x] master

**Issues addressed:** closes #20771, updates #20310.

**Tests performed:** works fine.