### PR TITLE
Core/Movement: Rewrite confused movement

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -60,7 +60,7 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* unit, uint32 diff)
     if (unit->HasUnitState(UNIT_STATE_NOT_MOVE))
         return true;
  
-    // Move.
+    // Ready to move.
     _move(unit);
 
     return true;
@@ -85,7 +85,7 @@ void ConfusedMovementGenerator<T>::_move(T* unit)
     path.SetPathLengthLimit(10.0f);
     bool result = path.CalculatePath(pos.m_positionX, pos.m_positionY, pos.m_positionZ);
     if (!result || (path.GetPathType() & PATHFIND_NOPATH))
-        return true; // Return without setting timer, generate another path on next update.
+        return; // Return without setting timer, generate another path on next update.
 
     // Add "currently moving" flag.
     unit->AddUnitState(UNIT_STATE_CONFUSED_MOVE);

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.h
@@ -35,6 +35,8 @@ class ConfusedMovementGenerator : public MovementGeneratorMedium< T, ConfusedMov
 
         MovementGeneratorType GetMovementGeneratorType() const override { return CONFUSED_MOTION_TYPE; }
     private:
+        void _move(T*);
+
         TimeTracker i_nextMoveTime;
         float i_x, i_y, i_z;
 };


### PR DESCRIPTION
Based on `15595_2012-08-22_22-02-32_looking_for_dungeon_delete_item_set.pkt`.

I gathered waypoints and made a nice graph/map of a few confusion effects:
https://www.desmos.com/calculator/cipr26agwb

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Unit will now make 5 moves and not 2 (during confusion that lasts 4 seconds).
    - New waypoint calculated right after 800ms, no wait time.
- Distance from original point seems to be more or less rounded value.
- Less unnecessary IF statements and indentation.

**Target branch(es):** 3.3.5/master

- 3.3.5 (probably?)
- master ✔️

**Issues addressed:** Closes #  (insert issue tracker number)

**Tests performed:** (Does it build, tested in-game, etc.)
* Build: ✔️
* Tests:
    * Confusion (41397) cast on enemy creatures nearby ✔️
    * Confusion (170349) cast on self ✔️

**Known issues and TODO list:** (add/remove lines as needed)
* None.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
