### PR TITLE
Core/AI: only call JustAppeared for entities that are using the old respawn system

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -748,7 +748,10 @@ void SmartAI::InitializeAI()
     GetScript()->OnInitialize(me);
 
     if (!me->isDead())
+    {
         GetScript()->OnReset();
+        GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
+    }
 }
 
 void SmartAI::OnCharmed(bool apply)
@@ -977,6 +980,9 @@ void SmartGameObjectAI::UpdateAI(uint32 diff)
 void SmartGameObjectAI::InitializeAI()
 {
     GetScript()->OnInitialize(me);
+
+    if (me->isSpawned())
+        GetScript()->ProcessEventsFor(SMART_EVENT_RESPAWN);
     //Reset();
 }
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -616,10 +616,15 @@ void Creature::Update(uint32 diff)
 {
     if (IsAIEnabled && m_triggerJustAppeared && m_deathState == ALIVE)
     {
-        if (m_respawnCompatibilityMode && m_vehicleKit)
-            m_vehicleKit->Reset();
+        if (m_respawnCompatibilityMode)
+        {
+            if (m_vehicleKit)
+                m_vehicleKit->Reset();
+
+            AI()->JustAppeared();
+        }
+
         m_triggerJustAppeared = false;
-        AI()->JustAppeared();
     }
 
     UpdateMovementFlags();


### PR DESCRIPTION
**Changes proposed:**

This hopefully fixes everything that's wrong with ~~the world~~ AI not behaving like it should.

JustAppeared was meant only for re-used entities (old respawn system). So allow it to be called only by those entities.

**Target branch(es):**

- [x] 3.3.5
- [ ] master

**Issues addressed:** updates #20310.

**Tests performed:** works fine.