### PR TITLE
Core/SpellAuras: Do not save Channeled auras

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -947,6 +947,9 @@ bool Aura::CanBeSaved() const
     if (IsPassive())
         return false;
 
+    if (GetSpellInfo()->IsChanneled())
+        return false;
+
     // Check if aura is single target, not only spell info
     if (GetCasterGUID() != GetOwner()->GetGUID())
         if (GetSpellInfo()->IsSingleTarget() || IsSingleTarget())


### PR DESCRIPTION
**Changes proposed:**
-  Do not save channeled auras into character_aura

Up for discussion, is this correct?

Quick repro steps:
.event start 1
.go ob 51040
Click on the Ribbon Pole
Logout
Log back and note the aura is stuck

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #19934