### PR TITLE
Fixed less and less objects from pools being spawned the longer the server is running

### DIFF
--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -153,34 +153,6 @@ bool PoolGroup<T>::CheckPool() const
     return true;
 }
 
-template <class T>
-PoolObject* PoolGroup<T>::RollOne(ActivePoolData& spawns, uint32 triggerFrom)
-{
-    if (!ExplicitlyChanced.empty())
-    {
-        float roll = (float)rand_chance();
-
-        for (uint32 i = 0; i < ExplicitlyChanced.size(); ++i)
-        {
-            roll -= ExplicitlyChanced[i].chance;
-            // Triggering object is marked as spawned at this time and can be also rolled (respawn case)
-            // so this need explicit check for this case
-            if (roll < 0 && (ExplicitlyChanced[i].guid == triggerFrom || !spawns.IsActiveObject<T>(ExplicitlyChanced[i].guid)))
-               return &ExplicitlyChanced[i];
-        }
-    }
-    if (!EqualChanced.empty())
-    {
-        uint32 index = urand(0, EqualChanced.size()-1);
-        // Triggering object is marked as spawned at this time and can be also rolled (respawn case)
-        // so this need explicit check for this case
-        if (EqualChanced[index].guid == triggerFrom || !spawns.IsActiveObject<T>(EqualChanced[index].guid))
-           return &EqualChanced[index];
-    }
-
-    return nullptr;
-}
-
 // Main method to despawn a creature or gameobject in a pool
 // If no guid is passed, the pool is just removed (event end case)
 // If guid is filled, cache will be used and no removal will occur, it just fill the cache
@@ -340,7 +312,6 @@ void PoolGroup<Pool>::RemoveOneRelation(uint32 child_pool_id)
 template <class T>
 void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom)
 {
-    uint32 lastDespawned = 0;
     int count = limit - spawns.GetActiveObjectCount(poolId);
 
     // If triggered from some object respawn this object is still marked as spawned
@@ -349,32 +320,70 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
     if (triggerFrom)
         ++count;
 
-    // This will try to spawn the rest of pool, not guaranteed
-    for (int i = 0; i < count; ++i)
+    if (count > 0)
     {
-        PoolObject* obj = RollOne(spawns, triggerFrom);
-        if (!obj)
-            continue;
-        if (obj->guid == lastDespawned)
-            continue;
+        PoolObjectList rolledObjects;
+        rolledObjects.reserve(count);
 
-        if (obj->guid == triggerFrom)
+        // roll objects to be spawned
+        if (!ExplicitlyChanced.empty())
         {
-            ReSpawn1Object(obj);
-            triggerFrom = 0;
-            continue;
+            while (count && ExplicitlyChanced.size() > rolledObjects.size())
+            {
+                --count;
+                float roll = (float)rand_chance();
+
+                for (auto obj : ExplicitlyChanced)
+                {
+                    roll -= obj.chance;
+                    // Triggering object is marked as spawned at this time and can be also rolled (respawn case)
+                    // so this need explicit check for this case
+                    if (roll < 0 && (obj.guid == triggerFrom || !spawns.IsActiveObject<T>(obj.guid)))
+                    {
+                        rolledObjects.push_back(obj);
+                        break;
+                    }
+                }
+            }
         }
-        spawns.ActivateObject<T>(obj->guid, poolId);
-        Spawn1Object(obj);
-
-        if (triggerFrom)
+        else if (!EqualChanced.empty())
         {
-            // One spawn one despawn no count increase
-            DespawnObject(spawns, triggerFrom);
-            lastDespawned = triggerFrom;
-            triggerFrom = 0;
+            rolledObjects = EqualChanced;
+
+            for (auto itr = rolledObjects.begin(); itr != rolledObjects.end();)
+            {
+                // remove most of the active objects so there is higher chance inactive ones are spawned
+                if (spawns.IsActiveObject<T>(itr->guid) && urand(1, 4) != 1)
+                    itr = rolledObjects.erase(itr);
+                else
+                    ++itr;
+            }
+
+            Trinity::Containers::RandomResize(rolledObjects, count);
+        }
+
+        // try to spawn rolled objects
+        for (auto obj : rolledObjects)
+        {
+            if (spawns.IsActiveObject<T>(obj.guid))
+                continue;
+
+            if (obj.guid == triggerFrom)
+            {
+                ReSpawn1Object(&obj);
+                triggerFrom = 0;
+            }
+            else
+            {
+                spawns.ActivateObject<T>(obj.guid, poolId);
+                Spawn1Object(&obj);
+            }
         }
     }
+
+    // One spawn one despawn no count increase
+    if (triggerFrom)
+        DespawnObject(spawns, triggerFrom);
 }
 
 // Method that is actualy doing the spawn job on 1 creature

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -333,7 +333,7 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
                 --count;
                 float roll = (float)rand_chance();
 
-                for (auto obj : ExplicitlyChanced)
+                for (PoolObject& obj : ExplicitlyChanced)
                 {
                     roll -= obj.chance;
                     // Triggering object is marked as spawned at this time and can be also rolled (respawn case)
@@ -363,7 +363,7 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
         }
 
         // try to spawn rolled objects
-        for (auto obj : rolledObjects)
+        for (PoolObject& obj : rolledObjects)
         {
             if (spawns.IsActiveObject<T>(obj.guid))
                 continue;

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -77,7 +77,6 @@ class TC_GAME_API PoolGroup
         bool isEmpty() const { return ExplicitlyChanced.empty() && EqualChanced.empty(); }
         void AddEntry(PoolObject& poolitem, uint32 maxentries);
         bool CheckPool() const;
-        PoolObject* RollOne(ActivePoolData& spawns, uint32 triggerFrom);
         void DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType guid=0);
         void Despawn1Object(ObjectGuid::LowType guid);
         void SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom);


### PR DESCRIPTION
**Changes proposed:**

- Problem with old implementation is that it doesn't check already spawned objects when choosing new ones to spawn and it can choose the same one incorrectly multiple times.
- Rewritten it so that it now takes into account if object is already spawned (still not 100% chance)

**Target branch(es):**

- [x] 3.3.5
- [x] master ? (not sure)

**Issues addressed:** Closes #11141, maybe #19257


**Tests performed:**
- running on live server


**Known issues and TODO list:**

- [ ] I don't have any idea how it worked on retail, but figured out that possibility of choosing only some objects was added on purpose, so I kinda reimplemented it (PoolMgr.cpp:356, subject to changes)
- [ ] Obviously with this implementation it happens more frequently that for example 3 veins are spawned on top of one another (titanium, rich saronite, saronite), but I don't think this is up to pool system implementation to fix.
- [ ] Too long title ^_^
