### PR TITLE
Core/Entities: add extra use of UPDATETYPE_CREATE_OBJECT2

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -55,7 +55,7 @@ Object::Object() : m_PackGUID(sizeof(uint64)+1)
     _fieldNotifyFlags   = UF_FLAG_DYNAMIC;
 
     m_inWorld           = false;
-    m_isNewObject      = false;
+    m_isNewObject       = false;
     m_objectUpdated     = false;
 }
 

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -55,6 +55,7 @@ Object::Object() : m_PackGUID(sizeof(uint64)+1)
     _fieldNotifyFlags   = UF_FLAG_DYNAMIC;
 
     m_inWorld           = false;
+    m_isNewObject      = false;
     m_objectUpdated     = false;
 }
 
@@ -169,6 +170,34 @@ void Object::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) c
     /** lower flag1 **/
     if (target == this)                                      // building packet for yourself
         flags |= UPDATEFLAG_SELF;
+
+    if (m_isNewObject)
+    {
+        switch (GetGUID().GetHigh())
+        {
+            case HighGuid::Player:
+            case HighGuid::Pet:
+            case HighGuid::Corpse:
+            case HighGuid::DynamicObject:
+                updateType = UPDATETYPE_CREATE_OBJECT2;
+                break;
+            case HighGuid::Unit:
+            case HighGuid::Vehicle:
+            {
+                if (ToUnit()->IsSummon())
+                    updateType = UPDATETYPE_CREATE_OBJECT2;
+                break;
+            }
+            case HighGuid::GameObject:
+            {
+                if (ToGameObject()->GetOwnerGUID().IsPlayer())
+                    updateType = UPDATETYPE_CREATE_OBJECT2;
+                break;
+            }
+            default:
+                break;
+        }
+    }
 
     if (flags & UPDATEFLAG_STATIONARY_POSITION)
     {

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -137,6 +137,7 @@ class TC_GAME_API Object
 
         virtual bool hasQuest(uint32 /* quest_id */) const { return false; }
         virtual bool hasInvolvedQuest(uint32 /* quest_id */) const { return false; }
+        void SetIsNewObject(bool enable) { m_isNewObject = enable; }
         virtual void BuildUpdate(UpdateDataMapType&) { }
         void BuildFieldsUpdate(Player*, UpdateDataMapType &) const;
 
@@ -203,6 +204,7 @@ class TC_GAME_API Object
 
     private:
         bool m_inWorld;
+        bool m_isNewObject;
 
         PackedGuid m_PackGUID;
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -646,9 +646,9 @@ bool Map::AddToMap(T* obj)
 
     //something, such as vehicle, needs to be update immediately
     //also, trigger needs to cast spell, if not update, cannot see visual
-    obj->SetItsNewObject(true);
+    obj->SetIsNewObject(true);
     obj->UpdateObjectVisibilityOnCreate();
-    obj->SetItsNewObject(false);
+    obj->SetIsNewObject(false);
     return true;
 }
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -646,7 +646,9 @@ bool Map::AddToMap(T* obj)
 
     //something, such as vehicle, needs to be update immediately
     //also, trigger needs to cast spell, if not update, cannot see visual
+    obj->SetItsNewObject(true);
     obj->UpdateObjectVisibilityOnCreate();
+    obj->SetItsNewObject(false);
     return true;
 }
 


### PR DESCRIPTION
Mixup of commits TrinityCore@533517b and  cmangos/mangos-wotlk@89c2c8a

**Changes proposed:**

Use UPDATETYPE_CREATE_OBJECT2 for newly created objects of type:
-  Player, Pet, Corpse, DynamicObject
-  Summoned Units and Vehicles
-  Summoned GameObject wich has player as summoner

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master
