### PR TITLE
Core/Creature: Insert npcflag for Battle pet

### DIFF
--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -270,6 +270,7 @@ enum NPCFlags : uint64
     UNIT_NPC_FLAG_ARTIFACT_POWER_RESPEC = 0x0008000000,     // artifact powers reset
     UNIT_NPC_FLAG_TRANSMOGRIFIER        = 0x0010000000,     // transmogrification
     UNIT_NPC_FLAG_VAULTKEEPER           = 0x0020000000,     // void storage
+    UNIT_NPC_FLAG_BATTLE_PET_CAPTURABLE = 0x0040000000,     // critter capturable for battle pet
     UNIT_NPC_FLAG_BLACK_MARKET          = 0x0080000000,     // black market
     UNIT_NPC_FLAG_ITEM_UPGRADE_MASTER   = 0x0100000000,
     UNIT_NPC_FLAG_GARRISON_ARCHITECT    = 0x0200000000,

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -270,7 +270,7 @@ enum NPCFlags : uint64
     UNIT_NPC_FLAG_ARTIFACT_POWER_RESPEC = 0x0008000000,     // artifact powers reset
     UNIT_NPC_FLAG_TRANSMOGRIFIER        = 0x0010000000,     // transmogrification
     UNIT_NPC_FLAG_VAULTKEEPER           = 0x0020000000,     // void storage
-    UNIT_NPC_FLAG_BATTLE_PET_CAPTURABLE = 0x0040000000,     // critter capturable for battle pet
+    UNIT_NPC_FLAG_BATTLE_PET_CAPTURABLE = 0x0040000000,     // Pet that player can fight (Battle Pet)
     UNIT_NPC_FLAG_BLACK_MARKET          = 0x0080000000,     // black market
     UNIT_NPC_FLAG_ITEM_UPGRADE_MASTER   = 0x0100000000,
     UNIT_NPC_FLAG_GARRISON_ARCHITECT    = 0x0200000000,

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -270,7 +270,7 @@ enum NPCFlags : uint64
     UNIT_NPC_FLAG_ARTIFACT_POWER_RESPEC = 0x0008000000,     // artifact powers reset
     UNIT_NPC_FLAG_TRANSMOGRIFIER        = 0x0010000000,     // transmogrification
     UNIT_NPC_FLAG_VAULTKEEPER           = 0x0020000000,     // void storage
-    UNIT_NPC_FLAG_BATTLE_PET_CAPTURABLE = 0x0040000000,     // Pet that player can fight (Battle Pet)
+    UNIT_NPC_FLAG_WILD_BATTLE_PET       = 0x0040000000,     // Pet that player can fight (Battle Pet)
     UNIT_NPC_FLAG_BLACK_MARKET          = 0x0080000000,     // black market
     UNIT_NPC_FLAG_ITEM_UPGRADE_MASTER   = 0x0100000000,
     UNIT_NPC_FLAG_GARRISON_ARCHITECT    = 0x0200000000,


### PR DESCRIPTION
**Changes proposed:**

-  Little improvement of npcflag list by inserting the BattlePet npcflag

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
Build ok, no errors.
Tested and checked via db.
Npcflag= 1073741824 is used for all pets that players can capture for Battle Pet

Screenshots:
With npcflag -> https://dl.dropboxusercontent.com/s/nt8scoj7fy78qlm/With.jpg
Without npcflag -> https://dl.dropboxusercontent.com/s/tvx3zk51pgby3zf/Without.jpg

