### PR TITLE
Core/Entities: add Battle pets automatically into pet journal

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -21,6 +21,9 @@
 #include "Player.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
+#include "WorldSession.h"
+#include "BattlePetMgr.h"
+#include "DB2Stores.h"
 
 namespace Trainer
 {
@@ -86,6 +89,18 @@ namespace Trainer
             player->CastSpell(player, trainerSpell->SpellId, true);
         else
             player->LearnSpell(trainerSpell->SpellId, false);
+
+        uint32 BattlePetSpell = trainerSpell->SpellId;
+        for (BattlePetSpeciesEntry const* entry : sBattlePetSpeciesStore)
+        {
+            if (entry->SummonSpellID == BattlePetSpell)
+            {
+                BattlePetMgr* battlePetMgr = player->GetSession()->GetBattlePetMgr();
+                battlePetMgr->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
+                player->UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
+                break;
+            }
+        }
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -21,9 +21,6 @@
 #include "Player.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
-#include "WorldSession.h"
-#include "BattlePetMgr.h"
-#include "DB2Stores.h"
 
 namespace Trainer
 {
@@ -90,17 +87,6 @@ namespace Trainer
         else
             player->LearnSpell(trainerSpell->SpellId, false);
 
-        uint32 BattlePetSpell = trainerSpell->SpellId;
-        for (BattlePetSpeciesEntry const* entry : sBattlePetSpeciesStore)
-        {
-            if (entry->SummonSpellID == BattlePetSpell)
-            {
-                BattlePetMgr* battlePetMgr = player->GetSession()->GetBattlePetMgr();
-                battlePetMgr->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
-                player->UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
-                break;
-            }
-        }
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -86,7 +86,6 @@ namespace Trainer
             player->CastSpell(player, trainerSpell->SpellId, true);
         else
             player->LearnSpell(trainerSpell->SpellId, false);
-
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3149,13 +3149,17 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     if (sDB2Manager.GetMount(spellId))
         GetSession()->GetCollectionMgr()->AddMount(spellId, MOUNT_STATUS_NONE, false, IsInWorld() ? false : true);
 
+    // need to add Battle pets automatically into pet journal
     for (BattlePetSpeciesEntry const* entry : sBattlePetSpeciesStore)
     {
-        if (entry->SummonSpellID == spellId)
+        if (GetSession()->GetBattlePetMgr()->GetPetCount(entry->ID) == 0)
         {
-            GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
-            UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
-            break;
+            if (entry->SummonSpellID == spellId)
+            {
+                GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
+                UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
+                break;
+            }
         }
     }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3152,14 +3152,11 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     // need to add Battle pets automatically into pet journal
     for (BattlePetSpeciesEntry const* entry : sBattlePetSpeciesStore)
     {
-        if (GetSession()->GetBattlePetMgr()->GetPetCount(entry->ID) == 0)
+        if (entry->SummonSpellID == spellId && GetSession()->GetBattlePetMgr()->GetPetCount(entry->ID) == 0)
         {
-            if (entry->SummonSpellID == spellId)
-            {
-                GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
-                UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
-                break;
-            }
+            GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
+            UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
+            break;
         }
     }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3153,9 +3153,10 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     {
         if (entry->SummonSpellID == spellId)
         {
-            GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID)); 
+            GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
             break;
         }
+        break;
     }
 
     // return true (for send learn packet) only if spell active (in case ranked spells) and not replace old spell

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3149,6 +3149,15 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     if (sDB2Manager.GetMount(spellId))
         GetSession()->GetCollectionMgr()->AddMount(spellId, MOUNT_STATUS_NONE, false, IsInWorld() ? false : true);
 
+    for (BattlePetSpeciesEntry const* entry : sBattlePetSpeciesStore)
+    {
+        if (entry->SummonSpellID == spellId)
+        {
+            GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID)); 
+            break;
+        }
+    }
+
     // return true (for send learn packet) only if spell active (in case ranked spells) and not replace old spell
     return active && !disabled && !superceded_old;
 }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3154,9 +3154,9 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
         if (entry->SummonSpellID == spellId)
         {
             GetSession()->GetBattlePetMgr()->AddPet(entry->ID, entry->CreatureID, BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
+            UpdateCriteria(CRITERIA_TYPE_OWN_BATTLE_PET_COUNT);
             break;
         }
-        break;
     }
 
     // return true (for send learn packet) only if spell active (in case ranked spells) and not replace old spell


### PR DESCRIPTION
**Changes proposed:**

-  Added a check on spell type and automatic insert pets in the pet journal (same learn system from item)

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)
Not present (a sub fix for #20193)

**Tests performed:** (Does it build, tested in-game, etc.)
Build ok, no compile error.
System work as well and it has been tested with multiple characters.

**Known issues and TODO list:** (add/remove lines as needed)
- [ ] **Known issue**: Battle pets are not shareable with other characters. (Pets are present in the journal **BUT** they can be learned again from new charas).

**Note**
I created this fix with a "not_sniffed" trainerId only for test.
For and with this purpose, I will insert a test sql in comment.

PS: Don't be rude with me, I just started to fix and I need to learn a lot about this huge project. :)


Edit: add screenshots
https://dl.dropboxusercontent.com/s/j1m5pd9asnqi72d/Before%20learn.jpg -> Before learning pet from trainer
https://dl.dropboxusercontent.com/s/eanuydk37b6jokm/On%20trainer%20window.jpg -> On trainer window for learning
https://dl.dropbox.com/s/8eg4ex80xl87l0w/After%20learning.jpg -> After learning pet from trainer
https://dl.dropbox.com/s/rrs5d68gfzypc49/Check%20on%20journal.jpg -> Final check on pet journal