### PR TITLE
Core/Accounts: prevent existing account ban from being updated

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `trinity_string` WHERE `entry`=1188;
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES (1188, 'Ban exists');

--- a/src/server/game/Accounts/AccountMgr.cpp
+++ b/src/server/game/Accounts/AccountMgr.cpp
@@ -390,6 +390,20 @@ std::string AccountMgr::CalculateShaPassHash(std::string const& name, std::strin
     return ByteArrayToHexStr(sha.GetDigest(), sha.GetLength());
 }
 
+bool AccountMgr::IsBannedAccount(std::string const& name)
+{
+    PreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BANNED_BY_USERNAME);
+    stmt->setString(0, name);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    if (!result)
+    {
+        return false;
+    }
+        
+    return true;
+}
+
 bool AccountMgr::IsPlayerAccount(uint32 gmlevel)
 {
     return gmlevel == SEC_PLAYER;

--- a/src/server/game/Accounts/AccountMgr.h
+++ b/src/server/game/Accounts/AccountMgr.h
@@ -75,6 +75,7 @@ class TC_GAME_API AccountMgr
         static uint32 GetCharactersCount(uint32 accountId);
 
         static std::string CalculateShaPassHash(std::string const& name, std::string const& password);
+        static bool IsBannedAccount(std::string const& name);
         static bool IsPlayerAccount(uint32 gmlevel);
         static bool IsAdminAccount(uint32 gmlevel);
         static bool IsConsoleAccount(uint32 gmlevel);

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -999,7 +999,8 @@ enum TrinityStrings
     LANG_GROUP_NOT_IN_RAID_GROUP        = 1185,
     LANG_GROUP_ROLE_CHANGED             = 1186,
     LANG_LEADER_CANNOT_BE_ASSISTANT     = 1187,
-    // Room for more level 3              1188-1198 not used
+    LANG_BAN_EXISTS                     = 1188,             // ban exists
+    // Room for more level 3              1189-1198 not used
 
     // Debug commands
     LANG_DO_NOT_USE_6X_DEBUG_AREATRIGGER_LEFT = 1999,

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -3365,6 +3365,7 @@ enum BanMode
 /// Ban function return codes
 enum BanReturn
 {
+    BAN_EXISTS,
     BAN_SUCCESS,
     BAN_SYNTAX_ERROR,
     BAN_NOTFOUND

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2671,6 +2671,12 @@ BanReturn World::BanAccount(BanMode mode, std::string const& nameOrIP, uint32 du
     PreparedQueryResult resultAccounts = PreparedQueryResult(nullptr); //used for kicking
     PreparedStatement* stmt = nullptr;
 
+    // Prevent exploit with existing account ban
+    if (mode == BAN_ACCOUNT && AccountMgr::IsBannedAccount(nameOrIP))
+    {
+        return BAN_EXISTS;
+    }
+
     ///- Update the database with ban information
     switch (mode)
     {

--- a/src/server/scripts/Commands/cs_ban.cpp
+++ b/src/server/scripts/Commands/cs_ban.cpp
@@ -200,6 +200,9 @@ public:
 
         switch (sWorld->BanAccount(mode, nameOrIP, durationStr, reasonStr, author))
         {
+            case BAN_EXISTS:
+                handler->PSendSysMessage(LANG_BAN_EXISTS);
+                break;
             case BAN_SUCCESS:
                 if (atoi(durationStr) > 0)
                 {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Create new function in AccountMgr for determining whether account already have banned.
- Add an additional check in ban handler before updating data.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #7466

**Tests performed:** Builds, not in-game tested

**Known issues and TODO list:** (add/remove lines as needed)
- [x] Add corresponding message for existing ban in the DB.
- [ ] Allow the "author" and higher rank GM to update ban.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
