### PR TITLE
Core/Spells: mark Arcane Missiles triggered spell as negative.

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3391,7 +3391,7 @@ bool SpellInfo::_IsPositiveEffect(uint8 effIndex, bool deep) const
             if (SpellIconID == 45)
                 return true;
             // Arcane Missiles
-            if (SpellFamilyFlags[0] == 0x00000800)
+            if (SpellFamilyFlags[0] == 0x00000800 || SpellFamilyFlags[0] == 0x00200000)
                 return false;
             break;
         case SPELLFAMILY_PRIEST:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  mark Arcane Missile triggered spell effect as negative like this commmit for trigger spell: 2b9f807fd94db40568baa3d780ba7c218cccdd69

**Target branch(es):**

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes: #18259


**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
