### PR TITLE
Core/Creature: implement base support for sparring between creatures

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2790,6 +2790,27 @@ Unit* Creature::SelectNearestHostileUnitInAggroRange(bool useLOS) const
     return target;
 }
 
+CreatureSparring const* Creature::GetSparringData(uint32 attackerEntry, uint32 victimEntry) const
+{
+    return sObjectMgr->GetCreatureSparringInfo(attackerEntry, victimEntry);
+}
+
+bool Creature::CanSparWith(Creature* victim) const
+{
+    if (GetSparringData(GetEntry(), victim->GetEntry()))
+        return true;
+
+    return false;
+}
+
+float Creature::GetSparringHealthLimitPctFor(Creature* victim) const
+{
+    if (CreatureSparring const* sparrData = GetSparringData(GetEntry(), victim->GetEntry()))
+        return sparrData->GetHealthLimitPct();
+
+    return 0.0f;
+}
+
 void Creature::UpdateMovementFlags()
 {
     // Do not update movement flags if creature is controlled by a player (charm/vehicle)

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -226,6 +226,10 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         Player* SelectNearestPlayer(float distance = 0) const;
         Unit* SelectNearestHostileUnitInAggroRange(bool useLOS = false) const;
 
+        CreatureSparring const* GetSparringData(uint32 attackerEntry, uint32 victimEntry) const;
+        bool CanSparWith(Creature* victim) const;
+        float GetSparringHealthLimitPctFor(Creature* victim) const;
+
         void DoFleeToGetAssistance();
         void CallForHelp(float fRadius);
         void CallAssistance();

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -561,6 +561,17 @@ struct CreatureAddon
     std::vector<uint32> auras;
 };
 
+// `creature_sparring_template` table
+struct CreatureSparring
+{
+    CreatureSparring(uint32 _victimEntry, float _healthLimitPct) : victimEntry(_victimEntry), healthLimitPct(_healthLimitPct) { }
+
+    uint32 victimEntry;
+    float healthLimitPct;
+
+    float GetHealthLimitPct() const { return healthLimitPct; }
+};
+
 // Vendors
 struct VendorItem
 {

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -629,6 +629,58 @@ void ObjectMgr::LoadCreatureTemplateAddons()
     TC_LOG_INFO("server.loading", ">> Loaded %u creature template addons in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
 }
 
+void ObjectMgr::LoadCreatureSparringTemplate()
+{
+    uint32 oldMSTime = getMSTime();
+
+    //                                               0              1             2
+    QueryResult result = WorldDatabase.Query("SELECT AttackerEntry, VictimEntry, HealthLimitPct FROM creature_sparring_template");
+
+    if (!result)
+    {
+        TC_LOG_INFO("server.loading", ">> Loaded 0 creature template sparring definitions. DB table `creature_sparring_template` is empty.");
+        return;
+    }
+
+    uint32 count = 0;
+    do
+    {
+        Field* fields = result->Fetch();
+
+        uint32 entry = fields[0].GetUInt32();
+        uint32 victim = fields[1].GetUInt32();
+        float healthPct = fields[2].GetFloat();
+
+        if (!sObjectMgr->GetCreatureTemplate(entry))
+        {
+            TC_LOG_ERROR("sql.sql", "Creature template (Entry: %u) does not exist but has a record in `creature_sparring_template`", entry);
+            continue;
+        }
+
+        if (!sObjectMgr->GetCreatureTemplate(victim))
+        {
+            TC_LOG_ERROR("sql.sql", "Creature template (Entry: %u) does not exist but has a record in `creature_sparring_template`", entry);
+            continue;
+        }
+
+        if (healthPct > 100.0f)
+        {
+            TC_LOG_ERROR("sql.sql", "Sparring entry (Entry: %u, Victim: %u) exceeds the health percentage limit. Setting to 100.", entry, victim);
+            healthPct = 100.0f;
+        }
+
+        if (healthPct <= 0.0f)
+        {
+            TC_LOG_ERROR("sql.sql", "Sparring entry (Entry: %u, Victim: %u) has a negative or too small health percentage. Setting to 0.1.", entry, victim);
+            healthPct = 0.1f;
+        }
+
+        _creatureSparringTemplateStore[entry].emplace_back(CreatureSparring(victim, healthPct));
+    } while (result->NextRow());
+
+    TC_LOG_INFO("server.loading", ">> Loaded %u creature sparring templates in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
+}
+
 void ObjectMgr::LoadCreatureScalingData()
 {
     uint32 oldMSTime = getMSTime();

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -479,6 +479,8 @@ struct TrinityString
 typedef std::map<ObjectGuid, ObjectGuid> LinkedRespawnContainer;
 typedef std::unordered_map<uint32, CreatureTemplate> CreatureTemplateContainer;
 typedef std::unordered_map<uint32, CreatureAddon> CreatureTemplateAddonContainer;
+typedef std::vector<CreatureSparring> CreatureSparringList;
+typedef std::unordered_map<uint32, CreatureSparringList> CreatureSparringTemplateMap;
 typedef std::unordered_map<ObjectGuid::LowType, CreatureData> CreatureDataContainer;
 typedef std::unordered_map<ObjectGuid::LowType, CreatureAddon> CreatureAddonContainer;
 typedef std::unordered_map<uint16, CreatureBaseStats> CreatureBaseStatsContainer;
@@ -1170,6 +1172,7 @@ class TC_GAME_API ObjectMgr
         void LoadCreatureLocales();
         void LoadCreatureTemplates();
         void LoadCreatureTemplateAddons();
+        void LoadCreatureSparringTemplate();
         void LoadCreatureTemplate(Field* fields);
         void LoadCreatureScalingData();
         void CheckCreatureTemplate(CreatureTemplate const* cInfo);
@@ -1415,6 +1418,19 @@ class TC_GAME_API ObjectMgr
         }
         GameObjectData& NewGOData(ObjectGuid::LowType guid) { return _gameObjectDataStore[guid]; }
         void DeleteGOData(ObjectGuid::LowType guid);
+
+        CreatureSparring const* GetCreatureSparringInfo(uint32 attackerEntry, uint32 victimEntry) const
+        {
+            auto itr = _creatureSparringTemplateStore.find(attackerEntry);
+            if (itr == _creatureSparringTemplateStore.end())
+                return nullptr;
+
+            for (CreatureSparring const& sparring : itr->second)
+                if (sparring.victimEntry == victimEntry)
+                    return &sparring;
+
+            return nullptr;
+        }
 
         TrinityString const* GetTrinityString(uint32 entry) const
         {
@@ -1716,6 +1732,7 @@ class TC_GAME_API ObjectMgr
         CreatureTemplateContainer _creatureTemplateStore;
         CreatureModelContainer _creatureModelStore;
         CreatureAddonContainer _creatureAddonStore;
+        CreatureSparringTemplateMap _creatureSparringTemplateStore;
         GameObjectAddonContainer _gameObjectAddonStore;
         GameObjectQuestItemMap _gameObjectQuestItemStore;
         CreatureQuestItemMap _creatureQuestItemStore;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2531,6 +2531,13 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
 
             caster->DealSpellDamage(&damageInfo, true);
 
+            // Sparring Checks
+            if (Creature* me = caster->ToCreature())
+                if (Creature* target = damageInfo.target->ToCreature())
+                    if (me->CanSparWith(target))
+                        if (target->GetHealthPct() <= me->GetSparringHealthLimitPctFor(target))
+                            damageInfo.damage = 0;
+
             // Send log damage message to client
             caster->SendSpellNonMeleeDamageLog(&damageInfo);
         }

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1756,6 +1756,9 @@ void World::SetInitialWorldSettings()
     TC_LOG_INFO("server.loading", "Loading Creature Quest Items...");
     sObjectMgr->LoadCreatureQuestItems();
 
+    TC_LOG_INFO("server.loading", "Loading Creature Sparring Data...");
+    sObjectMgr->LoadCreatureSparringTemplate();
+
     TC_LOG_INFO("server.loading", "Loading Creature Linked Respawn...");
     sObjectMgr->LoadLinkedRespawn();                             // must be after LoadCreatures(), LoadGameObjects()
 


### PR DESCRIPTION
*note: this system basicly blocks any damage once the defined health limit in the table has been reached.

AttackerEntry is the entry of the creature that deals damage while the VictimEntry is the creature that gets damaged. HealthLimitPct defines the health percentage at which the attacker entry cannot deal damage anymore. This handled by nullifying all damage. This allows us to define individual health limits for different entries.

Thanks to r00ty-TC for helping me with the unorderedMap part.

**Changes proposed:**

-  implemented database side defineable limits for damage in combat between creatures to prevent them killing each other without having to use c++ scripts every time

**Target branch(es):** master

- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame, works so far

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] DoT's are still reducing the health clientside. While the health stays correct serverside, the client still thinks that health is being lost.

  