### PR TITLE
Core/Spells: Rewrite mod energy by pct aura effect

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4043,17 +4043,18 @@ void AuraEffect::HandleAuraModIncreaseEnergyPercent(AuraApplication const* aurAp
     float pct = float(GetAmount());
 
     // Calculate the change.
-    int32 change = target->GetMaxPower(powerType);
-    ApplyPct(change, apply ? pct : (100 - 100 / (1 + pct / 100))); // On removal (!apply) GetMaxPower is already increased by pct.
+    float change = target->GetMaxPower(powerType);
+    ApplyPercentModFloatVar(amount, pct, apply);
+    change -= target->GetMaxPower(powerType);
 
     if (!apply) // We reduce power before removal of aura effect.
-        target->ModifyPower(powerType, -change);
+        target->ModifyPower(powerType, int32(change));
 
     // The actual aura effect for max power.
     target->HandleStatModifier(unitMod, TOTAL_PCT, pct, apply);
 
     if (apply) // We increase power after application of aura effect.
-        target->ModifyPower(powerType, change);
+        target->ModifyPower(powerType, int32(change));
 }
 
 void AuraEffect::HandleAuraModIncreaseHealthPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4040,21 +4040,14 @@ void AuraEffect::HandleAuraModIncreaseEnergyPercent(AuraApplication const* aurAp
     Powers powerType = Powers(GetMiscValue());
     UnitMods unitMod = UnitMods(UNIT_MOD_POWER_START + powerType);
 
-    float pct = float(GetAmount());
+    int32 oldPower = target->GetPower(powerType);
+    int32 oldMaxPower = target->GetMaxPower(powerType);
 
-    // Calculate the change.
-    float change = target->GetMaxPower(powerType);
-    ApplyPercentModFloatVar(change, pct, apply);
-    change -= target->GetMaxPower(powerType);
+    target->HandleStatModifier(unitMod, TOTAL_PCT, float(GetAmount()), apply);
 
-    if (!apply) // We reduce power before removal of aura effect.
-        target->ModifyPower(powerType, int32(change));
-
-    // The actual aura effect for max power.
-    target->HandleStatModifier(unitMod, TOTAL_PCT, pct, apply);
-
-    if (apply) // We increase power after application of aura effect.
-        target->ModifyPower(powerType, int32(change));
+    int32 change = target->GetMaxPower(powerType) - oldMaxPower;
+    change = (oldPower + change) - target->GetPower(powerType);
+    target->ModifyPower(powerType, change);
 }
 
 void AuraEffect::HandleAuraModIncreaseHealthPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4044,7 +4044,7 @@ void AuraEffect::HandleAuraModIncreaseEnergyPercent(AuraApplication const* aurAp
 
     // Calculate the change.
     float change = target->GetMaxPower(powerType);
-    ApplyPercentModFloatVar(amount, pct, apply);
+    ApplyPercentModFloatVar(change, pct, apply);
     change -= target->GetMaxPower(powerType);
 
     if (!apply) // We reduce power before removal of aura effect.


### PR DESCRIPTION
Separated from: Core/Entities: Creature powers #20981.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Correct amount of mana reduced when current max power is already increased by pct (formula in line no. 4047).

**Target branch(es):** 3.3.5/master
- 3.3.5 ✔️
- master ✔️

**Tests performed:** (Does it build, tested in-game, etc.)
Build OK.
- [ ] I don't have 3.3.5 to test https://wow.gamepedia.com/Hymn_of_Hope. 
- [x] On 7.x there are only small values, but it works.

**Known issues and TODO list:** (add/remove lines as needed)
- None.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->