### PR TITLE
Fix non-PCH build after e86a2c439aa2a032ce338d974dae1e5311bcb18f

### DIFF
--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -23,6 +23,7 @@
 #include "Util.h"
 #include "Object.h"
 #include "SpellAuraDefines.h"
+#include <algorithm>
 
 class Unit;
 class Player;


### PR DESCRIPTION
**Changes proposed:**

-  Add include to fix non-PCH build (std::find_if is in `<algorithm>`)
-  
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
 - built
