### PR TITLE
[WIP] Core/Player: Titan's Grip should only allow dual wielding 2H Axes, Maces and Swords

### DIFF
--- a/src/server/game/Entities/Item/ItemTemplate.cpp
+++ b/src/server/game/Entities/Item/ItemTemplate.cpp
@@ -129,6 +129,34 @@ uint32 ItemTemplate::GetSkill() const
     }
 }
 
+bool ItemTemplate::IsWeaponOfSubClass(ItemSubclassWeapon subClass) const
+{
+    if (Class != ITEM_CLASS_WEAPON)
+        return false;
+
+    return SubClass == subClass;
+}
+
+bool ItemTemplate::IsWeaponOfSubClass(std::initializer_list<ItemSubclassWeapon> subClasses) const
+{
+    if (Class != ITEM_CLASS_WEAPON)
+        return false;
+
+    for (const auto& subClass : subClasses)
+        if (IsWeaponOfSubClass(subClass))
+            return true;
+
+    return false;
+}
+
+bool ItemTemplate::CanBeDualWieldedWithTitansGrip() const
+{
+    return IsWeaponOfSubClass({
+        ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_AXE2,
+        ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_SWORD2,
+        ITEM_SUBCLASS_WEAPON_MACE, ITEM_SUBCLASS_WEAPON_MACE2 });
+}
+
 void ItemTemplate::_LoadTotalAP()
 {
     int32 totalAP = 0;

--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -713,6 +713,10 @@ struct ItemTemplate
     bool IsArmorVellum() const { return Class == ITEM_CLASS_TRADE_GOODS && SubClass == ITEM_SUBCLASS_ARMOR_ENCHANTMENT; }
     bool IsConjuredConsumable() const { return Class == ITEM_CLASS_CONSUMABLE && (Flags & ITEM_FLAG_CONJURED); }
 
+    bool IsWeaponOfSubClass(ItemSubclassWeapon subClass) const;
+    bool IsWeaponOfSubClass(std::initializer_list<ItemSubclassWeapon> subClasses) const;
+    bool CanBeDualWieldedWithTitansGrip() const;
+
     void InitializeQueryData();
     WorldPacket BuildQueryData(LocaleConstant loc) const;
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11324,7 +11324,7 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16 &dest, Item* pItem, bool
             {
                 if (eslot == EQUIPMENT_SLOT_OFFHAND)
                 {
-                    if (!CanTitanGrip())
+                    if (!CanTitanGrip() || pProto->SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE)
                         return EQUIP_ERR_ITEM_CANT_BE_EQUIPPED;
                 }
                 else if (eslot != EQUIPMENT_SLOT_MAINHAND)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Disallow equipping fishing pole in offhand

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #20972


**Tests performed:**
- [x] Builds
- [x] Tested in-game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
