### PR TITLE
Core/Spells: Improved Stormstrike proc

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3093,6 +3093,15 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->ProcChance = 0;
     });
 
+    // Improved Stormstrike
+    ApplySpellFix({ 
+        51521, // (Rank 1)
+        51522  // (Rank 2)
+    }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ProcFlags = PROC_FLAG_KILL | PROC_FLAG_DONE_SPELL_MELEE_DMG_CLASS;
+    });
+
     // Maelstrom Weapon
     ApplySpellFix({
         51528, // (Rank 1)


### PR DESCRIPTION
**Changes proposed:**
-  [Improved Stormstrike](https://dbwotlk.com/?spell=51522) doesn't restore mana on creature kill (works on hit).
-  PR fixes this behaviour by applying spell fix.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Tests performed:** builds, works in game.
