### PR TITLE
Core/Pools: Fixed a bug in explicitly + equally chanced pools

### DIFF
--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -353,7 +353,7 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
 
             for (auto itr = rolledObjects.begin(); itr != rolledObjects.end();)
             {
-                if (spawns.IsActiveObject<T>(itr->guid))
+                if (itr->guid != triggerFrom && spawns.IsActiveObject<T>(itr->guid))
                     itr = rolledObjects.erase(itr);
                 else
                     ++itr;
@@ -365,9 +365,6 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
         // try to spawn rolled objects
         for (PoolObject& obj : rolledObjects)
         {
-            if (spawns.IsActiveObject<T>(obj.guid))
-                continue;
-
             if (obj.guid == triggerFrom)
             {
                 ReSpawn1Object(&obj);

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -346,14 +346,14 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
                 }
             }
         }
-        else if (!EqualChanced.empty())
+
+        if (!EqualChanced.empty() && rolledObjects.empty())
         {
             rolledObjects = EqualChanced;
 
             for (auto itr = rolledObjects.begin(); itr != rolledObjects.end();)
             {
-                // remove most of the active objects so there is higher chance inactive ones are spawned
-                if (spawns.IsActiveObject<T>(itr->guid) && urand(1, 4) != 1)
+                if (spawns.IsActiveObject<T>(itr->guid))
                     itr = rolledObjects.erase(itr);
                 else
                     ++itr;


### PR DESCRIPTION
Fixed a bug introduced in https://github.com/TrinityCore/TrinityCore/commit/de80cd2e0de470522a734e8e7a65e81b82bfc5fb (https://github.com/TrinityCore/TrinityCore/issues/21032).
@Killyana, can you please test it?
I can't do it right now, but I think this is simple enough fix to not need any extensive testing.