### PR TITLE
Build/Boost: update Boost API to match version 1.66

### DIFF
--- a/src/common/Logging/Log.cpp
+++ b/src/common/Logging/Log.cpp
@@ -30,7 +30,7 @@
 #include <chrono>
 #include <sstream>
 
-Log::Log() : AppenderId(0), lowestLogLevel(LOG_LEVEL_FATAL), _ioService(nullptr), _strand(nullptr)
+Log::Log() : AppenderId(0), lowestLogLevel(LOG_LEVEL_FATAL), _ioContext(nullptr), _strand(nullptr)
 {
     m_logsTimestamp = "_" + GetTimestampStr();
     RegisterAppender<AppenderConsole>();
@@ -228,11 +228,11 @@ void Log::write(std::unique_ptr<LogMessage>&& msg) const
 {
     Logger const* logger = GetLoggerByType(msg->type);
 
-    if (_ioService)
+    if (_ioContext)
     {
         auto logOperation = std::make_shared<LogOperation>(logger, std::move(msg));
 
-        _ioService->post(_strand->wrap([logOperation](){ logOperation->call(); }));
+        _ioContext->post(_strand->wrap([logOperation](){ logOperation->call(); }));
     }
     else
         logger->write(msg.get());
@@ -367,12 +367,12 @@ Log* Log::instance()
     return &instance;
 }
 
-void Log::Initialize(boost::asio::io_service* ioService)
+void Log::Initialize(boost::asio::io_context* ioContext)
 {
-    if (ioService)
+    if (ioContext)
     {
-        _ioService = ioService;
-        _strand = new Trinity::AsioStrand(*ioService);
+        _ioContext = ioContext;
+        _strand = new Trinity::AsioStrand(*ioContext);
     }
 
     LoadFromConfig();
@@ -382,7 +382,7 @@ void Log::SetSynchronous()
 {
     delete _strand;
     _strand = nullptr;
-    _ioService = nullptr;
+    _ioContext = nullptr;
 }
 
 void Log::LoadFromConfig()

--- a/src/common/Logging/Log.h
+++ b/src/common/Logging/Log.h
@@ -35,7 +35,7 @@ namespace boost
 {
     namespace asio
     {
-        class io_service;
+        class io_context;
     }
 }
 
@@ -62,7 +62,7 @@ class TC_COMMON_API Log
     public:
         static Log* instance();
 
-        void Initialize(boost::asio::io_service* ioService);
+        void Initialize(boost::asio::io_context* ioContext);
         void SetSynchronous();  // Not threadsafe - should only be called from main() after all threads are joined
         void LoadFromConfig();
         void Close();
@@ -122,7 +122,7 @@ class TC_COMMON_API Log
         std::string m_logsDir;
         std::string m_logsTimestamp;
 
-        boost::asio::io_service* _ioService;
+        boost::asio::io_context* _ioContext;
         Trinity::AsioStrand* _strand;
 };
 

--- a/src/common/Metric/Metric.cpp
+++ b/src/common/Metric/Metric.cpp
@@ -25,12 +25,12 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
-void Metric::Initialize(std::string const& realmName, boost::asio::io_service& ioService, std::function<void()> overallStatusLogger)
+void Metric::Initialize(std::string const& realmName, boost::asio::io_context& ioContext, std::function<void()> overallStatusLogger)
 {
     _dataStream = Trinity::make_unique<boost::asio::ip::tcp::iostream>();
     _realmName = FormatInfluxDBTagValue(realmName);
-    _batchTimer = Trinity::make_unique<boost::asio::deadline_timer>(ioService);
-    _overallStatusTimer = Trinity::make_unique<boost::asio::deadline_timer>(ioService);
+    _batchTimer = Trinity::make_unique<boost::asio::deadline_timer>(ioContext);
+    _overallStatusTimer = Trinity::make_unique<boost::asio::deadline_timer>(ioContext);
     _overallStatusLogger = overallStatusLogger;
     LoadFromConfigs();
 }
@@ -216,7 +216,7 @@ void Metric::ScheduleSend()
 void Metric::ForceSend()
 {
     // Send what's queued only if io_service is stopped (so only on shutdown)
-    if (_enabled && _batchTimer->get_io_service().stopped())
+    if (_enabled && _batchTimer->get_io_context().stopped())
         SendBatch();
 }
 

--- a/src/common/Metric/Metric.h
+++ b/src/common/Metric/Metric.h
@@ -31,7 +31,7 @@ namespace boost
 {
     namespace asio
     {
-        class io_service;
+        class io_context;
     }
 }
 
@@ -95,7 +95,7 @@ public:
     ~Metric();
     static Metric* instance();
 
-    void Initialize(std::string const& realmName, boost::asio::io_service& ioService, std::function<void()> overallStatusLogger);
+    void Initialize(std::string const& realmName, boost::asio::io_context& ioContext, std::function<void()> overallStatusLogger);
     void LoadFromConfigs();
     void Update();
 

--- a/src/common/Utilities/AsioHacksFwd.h
+++ b/src/common/Utilities/AsioHacksFwd.h
@@ -41,10 +41,10 @@ namespace boost
             template <typename InternetProtocol>
             class resolver_service;
 
-            template <typename InternetProtocol, typename ResolverService>
+            template <typename InternetProtocol>
             class basic_resolver;
 
-            typedef basic_resolver<tcp, resolver_service<tcp>> tcp_resolver;
+            typedef basic_resolver<tcp> tcp_resolver;
         }
 
         template <typename Time>
@@ -53,10 +53,10 @@ namespace boost
         template <typename TimeType, typename TimeTraits>
         class deadline_timer_service;
 
-        template <typename Time, typename TimeTraits, typename TimerService>
+        template <typename Time, typename TimeTraits>
         class basic_deadline_timer;
 
-        typedef basic_deadline_timer<posix_time::ptime, time_traits<posix_time::ptime>, deadline_timer_service<posix_time::ptime, time_traits<posix_time::ptime>>> deadline_timer;
+        typedef basic_deadline_timer<posix_time::ptime, time_traits<posix_time::ptime>> deadline_timer;
     }
 }
 

--- a/src/common/Utilities/AsioHacksImpl.h
+++ b/src/common/Utilities/AsioHacksImpl.h
@@ -18,14 +18,14 @@
 #ifndef AsioHacksImpl_h__
 #define AsioHacksImpl_h__
 
-#include <boost/asio/strand.hpp>
+#include <boost/asio/io_context_strand.hpp>
 
 namespace Trinity
 {
-    class AsioStrand : public boost::asio::io_service::strand
+    class AsioStrand : public boost::asio::io_context::strand
     {
     public:
-        AsioStrand(boost::asio::io_service& io_service) : boost::asio::io_service::strand(io_service) { }
+        AsioStrand(boost::asio::io_context& io_context) : boost::asio::io_context::strand(io_context) { }
     };
 }
 

--- a/src/server/bnetserver/Main.cpp
+++ b/src/server/bnetserver/Main.cpp
@@ -64,12 +64,12 @@ char serviceDescription[] = "TrinityCore Battle.net emulator authentication serv
 */
 int m_ServiceStatus = -1;
 
-void ServiceStatusWatcher(std::weak_ptr<boost::asio::deadline_timer> serviceStatusWatchTimerRef, std::weak_ptr<boost::asio::io_service> ioServiceRef, boost::system::error_code const& error);
+void ServiceStatusWatcher(std::weak_ptr<boost::asio::deadline_timer> serviceStatusWatchTimerRef, std::weak_ptr<boost::asio::io_context> ioContextRef, boost::system::error_code const& error);
 #endif
 
 bool StartDB();
 void StopDB();
-void SignalHandler(std::weak_ptr<boost::asio::io_service> ioServiceRef, boost::system::error_code const& error, int signalNumber);
+void SignalHandler(std::weak_ptr<boost::asio::io_context> ioContextRef, boost::system::error_code const& error, int signalNumber);
 void KeepDatabaseAliveHandler(std::weak_ptr<boost::asio::deadline_timer> dbPingTimerRef, int32 dbPingInterval, boost::system::error_code const& error);
 void BanExpiryHandler(std::weak_ptr<boost::asio::deadline_timer> banExpiryCheckTimerRef, int32 banExpiryCheckInterval, boost::system::error_code const& error);
 variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, std::string& configService);
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
 
     std::shared_ptr<void> dbHandle(nullptr, [](void*) { StopDB(); });
 
-    std::shared_ptr<boost::asio::io_service> ioService = std::make_shared<boost::asio::io_service>();
+    std::shared_ptr<boost::asio::io_context> ioContext = std::make_shared<boost::asio::io_context>();
 
     // Start the listening port (acceptor) for auth connections
     int32 bnport = sConfigMgr->GetIntDefault("BattlenetPort", 1119);
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (!sLoginService.Start(ioService.get()))
+    if (!sLoginService.Start(ioContext.get()))
     {
         TC_LOG_ERROR("server.bnetserver", "Failed to initialize login service");
         return 1;
@@ -172,13 +172,13 @@ int main(int argc, char** argv)
     std::shared_ptr<void> sLoginServiceHandle(nullptr, [](void*) { sLoginService.Stop(); });
 
     // Get the list of realms for the server
-    sRealmList->Initialize(*ioService, sConfigMgr->GetIntDefault("RealmsStateUpdateDelay", 10));
+    sRealmList->Initialize(*ioContext, sConfigMgr->GetIntDefault("RealmsStateUpdateDelay", 10));
 
     std::shared_ptr<void> sRealmListHandle(nullptr, [](void*) { sRealmList->Close(); });
 
     std::string bindIp = sConfigMgr->GetStringDefault("BindIP", "0.0.0.0");
 
-    if (!sSessionMgr.StartNetwork(*ioService, bindIp, bnport))
+    if (!sSessionMgr.StartNetwork(*ioContext, bindIp, bnport))
     {
         TC_LOG_ERROR("server.bnetserver", "Failed to initialize network");
         return 1;
@@ -187,23 +187,23 @@ int main(int argc, char** argv)
     std::shared_ptr<void> sSessionMgrHandle(nullptr, [](void*) { sSessionMgr.StopNetwork(); });
 
     // Set signal handlers
-    boost::asio::signal_set signals(*ioService, SIGINT, SIGTERM);
+    boost::asio::signal_set signals(*ioContext, SIGINT, SIGTERM);
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
     signals.add(SIGBREAK);
 #endif
-    signals.async_wait(std::bind(&SignalHandler, std::weak_ptr<boost::asio::io_service>(ioService), std::placeholders::_1, std::placeholders::_2));
+    signals.async_wait(std::bind(&SignalHandler, std::weak_ptr<boost::asio::io_context>(ioContext), std::placeholders::_1, std::placeholders::_2));
 
     // Set process priority according to configuration settings
     SetProcessPriority("server.bnetserver", sConfigMgr->GetIntDefault(CONFIG_PROCESSOR_AFFINITY, 0), sConfigMgr->GetBoolDefault(CONFIG_HIGH_PRIORITY, false));
 
     // Enabled a timed callback for handling the database keep alive ping
     int32 dbPingInterval = sConfigMgr->GetIntDefault("MaxPingTime", 30);
-    std::shared_ptr<boost::asio::deadline_timer> dbPingTimer = std::make_shared<boost::asio::deadline_timer>(*ioService);
+    std::shared_ptr<boost::asio::deadline_timer> dbPingTimer = std::make_shared<boost::asio::deadline_timer>(*ioContext);
     dbPingTimer->expires_from_now(boost::posix_time::minutes(dbPingInterval));
     dbPingTimer->async_wait(std::bind(&KeepDatabaseAliveHandler, std::weak_ptr<boost::asio::deadline_timer>(dbPingTimer), dbPingInterval, std::placeholders::_1));
 
     int32 banExpiryCheckInterval = sConfigMgr->GetIntDefault("BanExpiryCheckInterval", 60);
-    std::shared_ptr<boost::asio::deadline_timer> banExpiryCheckTimer = std::make_shared<boost::asio::deadline_timer>(*ioService);
+    std::shared_ptr<boost::asio::deadline_timer> banExpiryCheckTimer = std::make_shared<boost::asio::deadline_timer>(*ioContext);
     banExpiryCheckTimer->expires_from_now(boost::posix_time::seconds(banExpiryCheckInterval));
     banExpiryCheckTimer->async_wait(std::bind(&BanExpiryHandler, std::weak_ptr<boost::asio::deadline_timer>(banExpiryCheckTimer), banExpiryCheckInterval, std::placeholders::_1));
 
@@ -211,17 +211,17 @@ int main(int argc, char** argv)
     std::shared_ptr<boost::asio::deadline_timer> serviceStatusWatchTimer;
     if (m_ServiceStatus != -1)
     {
-        serviceStatusWatchTimer = std::make_shared<boost::asio::deadline_timer>(*ioService);
+        serviceStatusWatchTimer = std::make_shared<boost::asio::deadline_timer>(*ioContext);
         serviceStatusWatchTimer->expires_from_now(boost::posix_time::seconds(1));
         serviceStatusWatchTimer->async_wait(std::bind(&ServiceStatusWatcher,
             std::weak_ptr<boost::asio::deadline_timer>(serviceStatusWatchTimer),
-            std::weak_ptr<boost::asio::io_service>(ioService),
+            std::weak_ptr<boost::asio::io_context>(ioContext),
             std::placeholders::_1));
     }
 #endif
 
     // Start the io service worker loop
-    ioService->run();
+    ioContext->run();
 
     banExpiryCheckTimer->cancel();
     dbPingTimer->cancel();
@@ -258,11 +258,11 @@ void StopDB()
     MySQL::Library_End();
 }
 
-void SignalHandler(std::weak_ptr<boost::asio::io_service> ioServiceRef, boost::system::error_code const& error, int /*signalNumber*/)
+void SignalHandler(std::weak_ptr<boost::asio::io_context> ioContextRef, boost::system::error_code const& error, int /*signalNumber*/)
 {
     if (!error)
-        if (std::shared_ptr<boost::asio::io_service> ioService = ioServiceRef.lock())
-            ioService->stop();
+        if (std::shared_ptr<boost::asio::io_context> ioContext = ioContextRef.lock())
+            ioContext->stop();
 }
 
 void KeepDatabaseAliveHandler(std::weak_ptr<boost::asio::deadline_timer> dbPingTimerRef, int32 dbPingInterval, boost::system::error_code const& error)
@@ -297,20 +297,20 @@ void BanExpiryHandler(std::weak_ptr<boost::asio::deadline_timer> banExpiryCheckT
 }
 
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
-void ServiceStatusWatcher(std::weak_ptr<boost::asio::deadline_timer> serviceStatusWatchTimerRef, std::weak_ptr<boost::asio::io_service> ioServiceRef, boost::system::error_code const& error)
+void ServiceStatusWatcher(std::weak_ptr<boost::asio::deadline_timer> serviceStatusWatchTimerRef, std::weak_ptr<boost::asio::io_context> ioContextRef, boost::system::error_code const& error)
 {
     if (!error)
     {
-        if (std::shared_ptr<boost::asio::io_service> ioService = ioServiceRef.lock())
+        if (std::shared_ptr<boost::asio::io_context> ioContext = ioContextRef.lock())
         {
             if (m_ServiceStatus == 0)
             {
-                ioService->stop();
+                ioContext->stop();
             }
             else if (std::shared_ptr<boost::asio::deadline_timer> serviceStatusWatchTimer = serviceStatusWatchTimerRef.lock())
             {
                 serviceStatusWatchTimer->expires_from_now(boost::posix_time::seconds(1));
-                serviceStatusWatchTimer->async_wait(std::bind(&ServiceStatusWatcher, serviceStatusWatchTimerRef, ioService, std::placeholders::_1));
+                serviceStatusWatchTimer->async_wait(std::bind(&ServiceStatusWatcher, serviceStatusWatchTimerRef, ioContext, std::placeholders::_1));
             }
         }
     }

--- a/src/server/bnetserver/REST/LoginRESTService.h
+++ b/src/server/bnetserver/REST/LoginRESTService.h
@@ -21,7 +21,7 @@
 #include "Define.h"
 #include "Login.pb.h"
 #include "Session.h"
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <atomic>
@@ -40,11 +40,11 @@ enum class BanMode
 class LoginRESTService
 {
 public:
-    LoginRESTService() : _ioService(nullptr), _stopped(false), _port(0), _loginTicketDuration(0) { }
+    LoginRESTService() : _ioContext(nullptr), _stopped(false), _port(0), _loginTicketDuration(0) { }
 
     static LoginRESTService& Instance();
 
-    bool Start(boost::asio::io_service* ioService);
+    bool Start(boost::asio::io_context* ioContext);
     void Stop();
 
     boost::asio::ip::tcp::endpoint const& GetAddressForClient(boost::asio::ip::address const& address) const;
@@ -96,7 +96,7 @@ private:
         char const* ContentType;
     };
 
-    boost::asio::io_service* _ioService;
+    boost::asio::io_context* _ioContext;
     std::thread _thread;
     std::atomic<bool> _stopped;
     Battlenet::JSON::Login::FormInputs _formInputs;

--- a/src/server/bnetserver/Server/SessionManager.cpp
+++ b/src/server/bnetserver/Server/SessionManager.cpp
@@ -17,9 +17,9 @@
 
 #include "SessionManager.h"
 
-bool Battlenet::SessionManager::StartNetwork(boost::asio::io_service& service, std::string const& bindIp, uint16 port, int threadCount)
+bool Battlenet::SessionManager::StartNetwork(boost::asio::io_context& context, std::string const& bindIp, uint16 port, int threadCount)
 {
-    if (!BaseSocketMgr::StartNetwork(service, bindIp, port, threadCount))
+    if (!BaseSocketMgr::StartNetwork(context, bindIp, port, threadCount))
         return false;
 
     _acceptor->SetSocketFactory(std::bind(&BaseSocketMgr::GetSocketForAccept, this));

--- a/src/server/bnetserver/Server/SessionManager.h
+++ b/src/server/bnetserver/Server/SessionManager.h
@@ -30,7 +30,7 @@ namespace Battlenet
     public:
         static SessionManager& Instance();
 
-        bool StartNetwork(boost::asio::io_service& service, std::string const& bindIp, uint16 port, int threadCount = 1) override;
+        bool StartNetwork(boost::asio::io_context& context, std::string const& bindIp, uint16 port, int threadCount = 1) override;
 
     protected:
         NetworkThread<Session>* CreateThreads() const override;

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -133,7 +133,7 @@ void WorldSocket::CheckIpCallback(PreparedQueryResult result)
     initializer.Write(ServerConnectionInitialize.c_str(), ServerConnectionInitialize.length());
     initializer.Write("\n", 1);
 
-    // - io_service.run thread, safe.
+    // - io_context.run thread, safe.
     QueuePacket(std::move(initializer));
 }
 

--- a/src/server/game/Server/WorldSocketMgr.cpp
+++ b/src/server/game/Server/WorldSocketMgr.cpp
@@ -58,7 +58,7 @@ WorldSocketMgr& WorldSocketMgr::Instance()
     return instance;
 }
 
-bool WorldSocketMgr::StartWorldNetwork(boost::asio::io_service& service, std::string const& bindIp, uint16 port, uint16 instancePort, int threadCount)
+bool WorldSocketMgr::StartWorldNetwork(boost::asio::io_context& context, std::string const& bindIp, uint16 port, uint16 instancePort, int threadCount)
 {
     _tcpNoDelay = sConfigMgr->GetBoolDefault("Network.TcpNodelay", true);
 
@@ -76,13 +76,13 @@ bool WorldSocketMgr::StartWorldNetwork(boost::asio::io_service& service, std::st
         return false;
     }
 
-    if (!BaseSocketMgr::StartNetwork(service, bindIp, port, threadCount))
+    if (!BaseSocketMgr::StartNetwork(context, bindIp, port, threadCount))
         return false;
 
     AsyncAcceptor* instanceAcceptor = nullptr;
     try
     {
-        instanceAcceptor = new AsyncAcceptor(service, bindIp, instancePort);
+        instanceAcceptor = new AsyncAcceptor(context, bindIp, instancePort);
     }
     catch (boost::system::system_error const& err)
     {

--- a/src/server/game/Server/WorldSocketMgr.h
+++ b/src/server/game/Server/WorldSocketMgr.h
@@ -40,7 +40,7 @@ public:
     static WorldSocketMgr& Instance();
 
     /// Start network, listen at address:port .
-    bool StartWorldNetwork(boost::asio::io_service& service, std::string const& bindIp, uint16 port, uint16 instancePort, int networkThreads);
+    bool StartWorldNetwork(boost::asio::io_context& context, std::string const& bindIp, uint16 port, uint16 instancePort, int networkThreads);
 
     /// Stops all network threads, It will wait for all running threads .
     void StopNetwork() override;
@@ -56,9 +56,9 @@ protected:
 
 private:
     // private, must not be called directly
-    bool StartNetwork(boost::asio::io_service& service, std::string const& bindIp, uint16 port, int threadCount) override
+    bool StartNetwork(boost::asio::io_context& context, std::string const& bindIp, uint16 port, int threadCount) override
     {
-        return BaseSocketMgr::StartNetwork(service, bindIp, port, threadCount);
+        return BaseSocketMgr::StartNetwork(context, bindIp, port, threadCount);
     }
 
     AsyncAcceptor* _instanceAcceptor;

--- a/src/server/shared/Networking/AsyncAcceptor.h
+++ b/src/server/shared/Networking/AsyncAcceptor.h
@@ -31,9 +31,9 @@ class AsyncAcceptor
 public:
     typedef void(*AcceptCallback)(tcp::socket&& newSocket, uint32 threadIndex);
 
-    AsyncAcceptor(boost::asio::io_service& ioService, std::string const& bindIp, uint16 port) :
-        _acceptor(ioService), _endpoint(boost::asio::ip::address::from_string(bindIp), port),
-        _socket(ioService), _closed(false), _socketFactory(std::bind(&AsyncAcceptor::DefeaultSocketFactory, this))
+    AsyncAcceptor(boost::asio::io_context& ioContext, std::string const& bindIp, uint16 port) :
+        _acceptor(ioContext), _endpoint(boost::asio::ip::address::from_string(bindIp), port),
+        _socket(ioContext), _closed(false), _socketFactory(std::bind(&AsyncAcceptor::DefeaultSocketFactory, this))
     {
     }
 

--- a/src/server/shared/Networking/NetworkThread.h
+++ b/src/server/shared/Networking/NetworkThread.h
@@ -37,8 +37,8 @@ template<class SocketType>
 class NetworkThread
 {
 public:
-    NetworkThread() : _connections(0), _stopped(false), _thread(nullptr), _io_service(1),
-        _acceptSocket(_io_service), _updateTimer(_io_service)
+    NetworkThread() : _connections(0), _stopped(false), _thread(nullptr), _io_context(1),
+        _acceptSocket(_io_context), _updateTimer(_io_context)
     {
     }
 
@@ -55,7 +55,7 @@ public:
     void Stop()
     {
         _stopped = true;
-        _io_service.stop();
+        _io_context.stop();
     }
 
     bool Start()
@@ -123,7 +123,7 @@ protected:
 
         _updateTimer.expires_from_now(boost::posix_time::milliseconds(10));
         _updateTimer.async_wait(std::bind(&NetworkThread<SocketType>::Update, this));
-        _io_service.run();
+        _io_context.run();
 
         TC_LOG_DEBUG("misc", "Network Thread exits");
         _newSockets.clear();
@@ -170,7 +170,7 @@ private:
     std::mutex _newSocketsLock;
     SocketContainer _newSockets;
 
-    boost::asio::io_service _io_service;
+    boost::asio::io_context _io_context;
     tcp::socket _acceptSocket;
     boost::asio::deadline_timer _updateTimer;
 };

--- a/src/server/shared/Networking/SocketMgr.h
+++ b/src/server/shared/Networking/SocketMgr.h
@@ -35,14 +35,14 @@ public:
         ASSERT(!_threads && !_acceptor && !_threadCount, "StopNetwork must be called prior to SocketMgr destruction");
     }
 
-    virtual bool StartNetwork(boost::asio::io_service& service, std::string const& bindIp, uint16 port, int threadCount)
+    virtual bool StartNetwork(boost::asio::io_context& context, std::string const& bindIp, uint16 port, int threadCount)
     {
         ASSERT(threadCount > 0);
 
         AsyncAcceptor* acceptor = nullptr;
         try
         {
-            acceptor = new AsyncAcceptor(service, bindIp, port);
+            acceptor = new AsyncAcceptor(context, bindIp, port);
         }
         catch (boost::system::system_error const& err)
         {

--- a/src/server/shared/Realm/RealmList.cpp
+++ b/src/server/shared/Realm/RealmList.cpp
@@ -48,11 +48,11 @@ RealmList* RealmList::Instance()
 }
 
 // Load the realm list from the database
-void RealmList::Initialize(boost::asio::io_service& ioService, uint32 updateInterval)
+void RealmList::Initialize(boost::asio::io_context& ioContext, uint32 updateInterval)
 {
     _updateInterval = updateInterval;
-    _updateTimer = Trinity::make_unique<boost::asio::deadline_timer>(ioService);
-    _resolver = Trinity::make_unique<boost::asio::ip::tcp::resolver>(ioService);
+    _updateTimer = Trinity::make_unique<boost::asio::deadline_timer>(ioContext);
+    _resolver = Trinity::make_unique<boost::asio::ip::tcp::resolver>(ioContext);
 
     // Get the content of the realmlist table in the database
     UpdateRealms(boost::system::error_code());

--- a/src/server/shared/Realm/RealmList.h
+++ b/src/server/shared/Realm/RealmList.h
@@ -40,7 +40,7 @@ namespace boost
 
     namespace asio
     {
-        class io_service;
+        class io_context;
     }
 
     namespace system
@@ -82,7 +82,7 @@ public:
 
     ~RealmList();
 
-    void Initialize(boost::asio::io_service& ioService, uint32 updateInterval);
+    void Initialize(boost::asio::io_context& ioContext, uint32 updateInterval);
     void Close();
 
     Realm const* GetRealm(Battlenet::RealmHandle const& id) const;

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -50,7 +50,7 @@
 #include "WorldSocketMgr.h"
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -85,8 +85,8 @@ int m_ServiceStatus = -1;
 class FreezeDetector
 {
 public:
-    FreezeDetector(boost::asio::io_service& ioService, uint32 maxCoreStuckTime)
-        : _timer(ioService), _worldLoopCounter(0), _lastChangeMsTime(0), _maxCoreStuckTimeInMs(maxCoreStuckTime) { }
+    FreezeDetector(boost::asio::io_context& ioContext, uint32 maxCoreStuckTime)
+        : _timer(ioContext), _worldLoopCounter(0), _lastChangeMsTime(0), _maxCoreStuckTimeInMs(maxCoreStuckTime) { }
 
     static void Start(std::shared_ptr<FreezeDetector> const& freezeDetector)
     {
@@ -104,7 +104,7 @@ private:
 };
 
 void SignalHandler(boost::system::error_code const& error, int signalNumber);
-AsyncAcceptor* StartRaSocketAcceptor(boost::asio::io_service& ioService);
+AsyncAcceptor* StartRaSocketAcceptor(boost::asio::io_context& ioContext);
 bool StartDB();
 void StopDB();
 void WorldUpdateLoop();
@@ -148,11 +148,11 @@ extern int main(int argc, char** argv)
         return 1;
     }
 
-    std::shared_ptr<boost::asio::io_service> ioService = std::make_shared<boost::asio::io_service>();
+    std::shared_ptr<boost::asio::io_context> ioContext = std::make_shared<boost::asio::io_context>();
 
     sLog->RegisterAppender<AppenderDB>();
-    // If logs are supposed to be handled async then we need to pass the io_service into the Log singleton
-    sLog->Initialize(sConfigMgr->GetBoolDefault("Log.Async.Enable", false) ? ioService.get() : nullptr);
+    // If logs are supposed to be handled async then we need to pass the io_context into the Log singleton
+    sLog->Initialize(sConfigMgr->GetBoolDefault("Log.Async.Enable", false) ? ioContext.get() : nullptr);
 
     Trinity::Banner::Show("worldserver-daemon",
         [](char const* text)
@@ -189,8 +189,8 @@ extern int main(int argc, char** argv)
         }
     }
 
-    // Set signal handlers (this must be done before starting io_service threads, because otherwise they would unblock and exit)
-    boost::asio::signal_set signals(*ioService, SIGINT, SIGTERM);
+    // Set signal handlers (this must be done before starting io_context threads, because otherwise they would unblock and exit)
+    boost::asio::signal_set signals(*ioContext, SIGINT, SIGTERM);
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
     signals.add(SIGBREAK);
 #endif
@@ -198,9 +198,9 @@ extern int main(int argc, char** argv)
 
     // Start the Boost based thread pool
     int numThreads = sConfigMgr->GetIntDefault("ThreadPool", 1);
-    std::shared_ptr<std::vector<std::thread>> threadPool(new std::vector<std::thread>(), [ioService](std::vector<std::thread>* del)
+    std::shared_ptr<std::vector<std::thread>> threadPool(new std::vector<std::thread>(), [ioContext](std::vector<std::thread>* del)
     {
-        ioService->stop();
+        ioContext->stop();
         for (std::thread& thr : *del)
             thr.join();
 
@@ -211,7 +211,7 @@ extern int main(int argc, char** argv)
         numThreads = 1;
 
     for (int i = 0; i < numThreads; ++i)
-        threadPool->push_back(std::thread([ioService]() { ioService->run(); }));
+        threadPool->push_back(std::thread([ioContext]() { ioContext->run(); }));
 
     // Set process priority according to configuration settings
     SetProcessPriority("server.worldserver", sConfigMgr->GetIntDefault(CONFIG_PROCESSOR_AFFINITY, 0), sConfigMgr->GetBoolDefault(CONFIG_HIGH_PRIORITY, false));
@@ -225,13 +225,13 @@ extern int main(int argc, char** argv)
     // Set server offline (not connectable)
     LoginDatabase.DirectPExecute("UPDATE realmlist SET flag = flag | %u WHERE id = '%d'", REALM_FLAG_OFFLINE, realm.Id.Realm);
 
-    sRealmList->Initialize(*ioService, sConfigMgr->GetIntDefault("RealmsStateUpdateDelay", 10));
+    sRealmList->Initialize(*ioContext, sConfigMgr->GetIntDefault("RealmsStateUpdateDelay", 10));
 
     std::shared_ptr<void> sRealmListHandle(nullptr, [](void*) { sRealmList->Close(); });
 
     LoadRealmInfo();
 
-    sMetric->Initialize(realm.Name, *ioService, []()
+    sMetric->Initialize(realm.Name, *ioContext, []()
     {
         TC_METRIC_VALUE("online_players", sWorld->GetPlayerCount());
     });
@@ -267,7 +267,7 @@ extern int main(int argc, char** argv)
     // Start the Remote Access port (acceptor) if enabled
     std::unique_ptr<AsyncAcceptor> raAcceptor;
     if (sConfigMgr->GetBoolDefault("Ra.Enable", false))
-        raAcceptor.reset(StartRaSocketAcceptor(*ioService));
+        raAcceptor.reset(StartRaSocketAcceptor(*ioContext));
 
     // Start soap serving thread if enabled
     std::shared_ptr<std::thread> soapThread;
@@ -294,7 +294,7 @@ extern int main(int argc, char** argv)
         return 1;
     }
 
-    if (!sWorldSocketMgr.StartWorldNetwork(*ioService, worldListener, worldPort, instancePort, networkThreads))
+    if (!sWorldSocketMgr.StartWorldNetwork(*ioContext, worldListener, worldPort, instancePort, networkThreads))
     {
         TC_LOG_ERROR("server.worldserver", "Failed to initialize network");
         return 1;
@@ -331,7 +331,7 @@ extern int main(int argc, char** argv)
     std::shared_ptr<FreezeDetector> freezeDetector;
     if (int coreStuckTime = sConfigMgr->GetIntDefault("MaxCoreStuckTime", 0))
     {
-        freezeDetector = std::make_shared<FreezeDetector>(*ioService, coreStuckTime * 1000);
+        freezeDetector = std::make_shared<FreezeDetector>(*ioContext, coreStuckTime * 1000);
         FreezeDetector::Start(freezeDetector);
         TC_LOG_INFO("server.worldserver", "Starting up anti-freeze thread (%u seconds max stuck time)...", coreStuckTime);
     }
@@ -500,12 +500,12 @@ void FreezeDetector::Handler(std::weak_ptr<FreezeDetector> freezeDetectorRef, bo
     }
 }
 
-AsyncAcceptor* StartRaSocketAcceptor(boost::asio::io_service& ioService)
+AsyncAcceptor* StartRaSocketAcceptor(boost::asio::io_context& ioContext)
 {
     uint16 raPort = uint16(sConfigMgr->GetIntDefault("Ra.Port", 3443));
     std::string raListener = sConfigMgr->GetStringDefault("Ra.IP", "0.0.0.0");
 
-    AsyncAcceptor* acceptor = new AsyncAcceptor(ioService, raListener, raPort);
+    AsyncAcceptor* acceptor = new AsyncAcceptor(ioContext, raListener, raPort);
     if (!acceptor->Bind())
     {
         TC_LOG_ERROR("server.worldserver", "Failed to bind RA socket acceptor");

--- a/src/tools/connection_patcher/Helper.cpp
+++ b/src/tools/connection_patcher/Helper.cpp
@@ -51,16 +51,16 @@ namespace Connection_Patcher
             using namespace boost::asio;
             using boost::asio::ip::tcp;
 
-            io_service io_service;
+            io_context io_context;
 
             // Get a list of endpoints corresponding to the server name.
-            tcp::resolver resolver(io_service);
+            tcp::resolver resolver(io_context);
             tcp::resolver::query query(serverName, std::to_string(port));
             tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
             tcp::resolver::iterator end;
 
             // Try each endpoint until we successfully establish a connection.
-            tcp::socket socket(io_service);
+            tcp::socket socket(io_context);
             boost::system::error_code error = boost::asio::error::host_not_found;
             while (error && endpoint_iterator != end)
             {


### PR DESCRIPTION
**Changes proposed:**
This enable build with boost 1.66 (and broke build with <= 1.65)

**Target branch(es):** 
- [x] master

**Issues addressed:** 
Closes #21171 

**Tests performed:** 
Build on MacOSX, Login in the game

**Known issues and TODO list:** (add/remove lines as needed)
get_io_service() is deprected, but i don't know how to cast get_executor to the proper type