### PR TITLE
Core/Vehicles: Fix accessories disappearing on evade and multiple join events on seat -1

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -167,7 +167,10 @@ void CreatureAI::EnterEvadeMode(EvadeReason why)
     }
 
     Reset();
+}
 
+void CreatureAI::JustReachedHome()
+{
     if (me->IsVehicle()) // use the same sequence of addtoworld, aireset may remove all summons!
         me->GetVehicleKit()->Reset(true);
 }

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -142,7 +142,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         void OnCharmed(bool isNew) override;
 
         // Called at reaching home after evade
-        virtual void JustReachedHome() { }
+        virtual void JustReachedHome();
 
         void DoZoneInCombat(Creature* creature = nullptr);
 

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -324,7 +324,7 @@ class TC_GAME_API BossAI : public ScriptedAI
         void Reset() override { _Reset(); }
         void JustEngagedWith(Unit* /*who*/) override { _JustEngagedWith(); }
         void JustDied(Unit* /*killer*/) override { _JustDied(); }
-        void JustReachedHome() override { _JustReachedHome(); }
+        void JustReachedHome() override { ScriptedAI::JustReachedHome(); _JustReachedHome(); }
 
         bool CanAIAttack(Unit const* target) const override;
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -283,7 +283,7 @@ class boss_professor_putricide : public CreatureScript
 
             void JustReachedHome() override
             {
-                _JustReachedHome();
+                BossAI::JustReachedHome();
                 me->SetWalk(false);
                 if (events.IsInPhase(PHASE_COMBAT_1) || events.IsInPhase(PHASE_COMBAT_2) || events.IsInPhase(PHASE_COMBAT_3))
                     instance->SetBossState(DATA_PROFESSOR_PUTRICIDE, FAIL);


### PR DESCRIPTION
**Changes proposed:**

- Move Vehicle::Reset from CreatureAI::EnterEvadeMode to CreatureAI::JustReachedHome
- Check all pending join events on add passenger with seat -1

**Description:**
First issue can be reproduced by .go creature 33113 on 10man and calling .npc evade on him (Flame Leviathan). The seats and his turret should disappear (not entirely sure since I already worked on 10 different versions of this). The problem is, Vehicle::InstallAccessories is called when creature evades, so it spawns accessories, they try to cast vehicle ride spell on leviathan, but it is evaded so they are immediatelly despawned.

Second issue can be reproduced by going to Ulduar 25man somewhere, logging 2nd account and going to the same place, then .npc add temp 32934, targetting right arm and .cast self 63981. The arm looks like it's grabbing both players, but in the end only grabs one.

This PR is needed for my upcoming (soon™) rewrite of Kologarn and Flame Leviathan.
It shouldn't break anything else, maybe fix some more things, I can't think of any right now through, since both are pretty rare cases.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master ??

**Issues addressed:**
 probably none

**Tests performed:** (Does it build, tested in-game, etc.)
builds, tested

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Debug and fix vehicles on vehicles with accessories, ~~for example Flame Leviathan having seats and seats should have overload device and attackable creature on them, but they are despawned immediatelly~~ Better described in #15224. I know calling Vehicle::Reset(true) for seats a few milliseconds after they spawn helps, but that is not a fix. (will come soon, hopefully)