### PR TITLE
MYSQL_SERVER_VERSION to MIN_MYSQL_SERVER_VERSION

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -58,7 +58,7 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
     WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below 5.1");
     WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile TrinityCore (%s). Search on forum for TCE00011.",
-        mysql_get_client_info(), MYSQL_SERVER_VERSION);
+        mysql_get_client_info(), MIN_MYSQL_SERVER_VERSION);
 }
 
 template <class T>


### PR DESCRIPTION
Got this error while trying to compile 3.3.5

```
In file included from /srv/trinity/src/src/server/database/PrecompiledHeaders/databasePCH.h:19:0,
                 from /srv/trinity/build/src/server/database/cotire/database_CXX_prefix.cxx:4,
                 from /srv/trinity/build/src/server/database/cotire/database_CXX_prefix.hxx:4:
/srv/trinity/src/src/server/database/Database/DatabaseWorkerPool.cpp: In constructor ‘DatabaseWorkerPool<T>::DatabaseWorkerPool()’:
/srv/trinity/src/src/server/database/Database/DatabaseWorkerPool.cpp:60:34: error: ‘MYSQL_SERVER_VERSION’ was not declared in this scope
         mysql_get_client_info(), MYSQL_SERVER_VERSION);
                                  ^
/srv/trinity/src/src/common/Debugging/Errors.h:50:110: note: in definition of macro ‘WPFatal’
 o { if (!(cond)) Trinity::Fatal(__FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); } while(0) ASSERT_END
                                                                     ^~~~~~~~~~~
/srv/trinity/src/src/server/database/Database/DatabaseWorkerPool.cpp:60:34: note: suggested alternative: ‘MIN_MYSQL_SERVER_VERSION’
         mysql_get_client_info(), MYSQL_SERVER_VERSION);
                                  ^
/srv/trinity/src/src/common/Debugging/Errors.h:50:110: note: in definition of macro ‘WPFatal’
 o { if (!(cond)) Trinity::Fatal(__FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__); } while(0) ASSERT_END
                                                                     ^~~~~~~~~~~
make[2]: *** [src/server/database/CMakeFiles/database.dir/build.make:178: src/server/database/CMakeFiles/database.dir/Database/DatabaseWorkerPool.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1125: src/server/database/CMakeFiles/database.dir/all] Error 2
```

I did what it suggested and changed `MYSQL_SERVER_VERSION` to `MIN_MYSQL_SERVER_VERSION`, and the compile continued.

I'm not certain if this will cause problems or not.