### PR TITLE
CR_INVALID_CONN_HANDLE to ER_INVALID_ON_UPDATE

### DIFF
--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -512,7 +512,7 @@ bool MySQLConnection::_HandleMySQLErrno(uint32 errNo, uint8 attempts /*= 5*/)
     {
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
-        case CR_INVALID_CONN_HANDLE:
+        case ER_INVALID_ON_UPDATE:
         case CR_SERVER_LOST_EXTENDED:
         {
             if (m_Mysql)


### PR DESCRIPTION
Got this error while trying to compile 3.3.5

```
/srv/trinity/src/src/server/database/Database/MySQLConnection.cpp: In member function ‘bool MySQLConnection::_HandleMySQLErrno(uint32, uint8)’:
/srv/trinity/src/src/server/database/Database/MySQLConnection.cpp:506:14: error: ‘CR_INVALID_CONN_HANDLE’ was not declared in this scope
         case CR_INVALID_CONN_HANDLE:
              ^~~~~~~~~~~~~~~~~~~~~~
/srv/trinity/src/src/server/database/Database/MySQLConnection.cpp:506:14: note: suggested alternative: ‘ER_INVALID_ON_UPDATE’
         case CR_INVALID_CONN_HANDLE:
              ^~~~~~~~~~~~~~~~~~~~~~
              ER_INVALID_ON_UPDATE
make[2]: *** [src/server/database/CMakeFiles/database.dir/build.make:228: src/server/database/CMakeFiles/database.dir/Database/MySQLConnection.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1125: src/server/database/CMakeFiles/database.dir/all] Error 2
```

I did what it suggested and changed `CR_INVALID_CONN_HANDLE` to `ER_INVALID_ON_UPDATE`, and the compile continued.

I'm not certain if this will cause problems or not.