### PR TITLE
Core/Spells: Suppresser not channeling (Suppression) and instead attacking players

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4194,6 +4194,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->RangeEntry = sSpellRangeStore.LookupEntry(157); // 90yd
     });
 
+    // Suppression ( Valithria Dreamwalker )
+    ApplySpellFix({ 70588 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->ChannelInterruptFlags = 0;
+    });
+
     ApplySpellFix({
         72706, // Achievement Check (Valithria Dreamwalker)
         71357  // Order Whelp

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -867,14 +867,8 @@ class npc_suppresser : public CreatureScript
             void MovementInform(uint32 /*type*/, uint32 id) override
             {
                 if (id == 42)
-                {
-                    me->SetReactState(REACT_AGGRESSIVE);
                     if (Creature* valithria = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_VALITHRIA_DREAMWALKER)))
-                    {
-                        AttackStart(valithria);
                         DoCastAOE(SPELL_SUPPRESSION);
-                    }
-                }
             }
 
             void UpdateAI(uint32 diff) override


### PR DESCRIPTION
Suppresser suppression channel interrupt instantly and the npc tries to hit ppl instead.

**Changes proposed:**

- Prevent Suppression interrupt ( i think npc turning was the interruption reason )
- Prevent npc to attack ppl

**Target branch(es):** 3.3.5