### PR TITLE
Core/Entities: reset creature states when Hunter dismisses a pet

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -40,6 +40,11 @@ void CreatureAI::OnCharmed(bool apply)
         me->NeedChangeAI = true;
         me->IsAIEnabled = false;
     }
+    else
+    {
+        me->NeedChangeAI = false;
+        me->IsAIEnabled = true;
+    }
 }
 
 AISpellInfoType* UnitAI::AISpellInfo;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -20528,19 +20528,26 @@ void Player::StopCastingCharm()
         else if (charm->IsVehicle())
             ExitVehicle();
     }
-    if (GetCharmGUID())
-        charm->RemoveCharmAuras();
 
     if (GetCharmGUID())
     {
-        TC_LOG_FATAL("entities.player", "Player::StopCastingCharm: Player '%s' (%s) is not able to uncharm unit (%s)", GetName().c_str(), GetGUID().ToString().c_str(), GetCharmGUID().ToString().c_str());
-        if (!charm->GetCharmerGUID().IsEmpty())
+        if (charm->GetCharmerGUID() != GetGUID())
+            TC_LOG_FATAL("entities.player", "Player::StopCastingCharm: Player '%s' (%s) is not able to uncharm unit (%s)", GetName().c_str(), GetGUID().ToString().c_str(), GetCharmGUID().ToString().c_str());
+        if (!charm->GetCharmGUID().IsEmpty())
         {
             TC_LOG_FATAL("entities.player", "Player::StopCastingCharm: Charmed unit has charmer %s", charm->GetCharmerGUID().ToString().c_str());
             ABORT();
         }
-
+        bool bIsHunter = (charm->GetCharmer()->getClass() == CLASS_HUNTER);
         SetCharm(charm, false);
+        charm->RemoveCharmAuras();
+        if (bIsHunter)
+        {
+            SetCharmerGUID(ObjectGuid::Empty); // Needed so AI will revert to default.
+            charm->UpdateCharmAI();
+            charm->AddUnitTypeMask(UNIT_MASK_HUNTER_PET); // Added so removePet can be called later.
+            charm->ToCreature()->SetReactState(REACT_NONE); // No reaction for pets that are reverted back to Creatures.
+        }
     }
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6322,6 +6322,9 @@ void Unit::SetCharm(Unit* charm, bool apply)
             charm->m_ControlledByPlayer = false;
             charm->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
             charm->SetByteValue(UNIT_FIELD_BYTES_2, UNIT_BYTES_2_OFFSET_PVP_FLAG, 0);
+            charm->GetCharmInfo()->SetIsFollowing(false);
+            if (charm->_oldFactionId)
+                charm->SetFaction(charm->_oldFactionId);
         }
 
         if (charm->IsWalking() != _isWalkingBeforeCharm)
@@ -11572,6 +11575,7 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
 {
     pet->SetCreatorGUID(GetGUID());
     pet->SetFaction(GetFaction());
+    
     pet->SetUInt32Value(UNIT_CREATED_BY_SPELL, spell_id);
 
     if (GetTypeId() == TYPEID_PLAYER)
@@ -11588,6 +11592,7 @@ bool Unit::InitTamedPet(Pet* pet, uint8 level, uint32 spell_id)
     pet->InitPetCreateSpells();
     //pet->InitLevelupSpellsForLevel();
     pet->SetFullHealth();
+    pet->GetCharmInfo()->SetIsFollowing(true);
     return true;
 }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1151,6 +1151,7 @@ class TC_GAME_API Unit : public WorldObject
         ObjectGuid GetCharmerGUID() const { return GetGuidValue(UNIT_FIELD_CHARMEDBY); }
         void SetCharmerGUID(ObjectGuid owner) { SetGuidValue(UNIT_FIELD_CHARMEDBY, owner); }
         ObjectGuid GetCharmGUID() const { return  GetGuidValue(UNIT_FIELD_CHARM); }
+        void SetCharmGUID(ObjectGuid owner) { SetGuidValue(UNIT_FIELD_CHARM, owner); }
         void SetPetGUID(ObjectGuid guid) { m_SummonSlot[SUMMON_SLOT_PET] = guid; }
         ObjectGuid GetPetGUID() const { return m_SummonSlot[SUMMON_SLOT_PET]; }
         void SetCritterGUID(ObjectGuid guid) { SetGuidValue(UNIT_FIELD_CRITTER, guid); }

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -336,9 +336,10 @@ enum ActiveStates
 
 enum ReactStates
 {
-    REACT_PASSIVE    = 0,
-    REACT_DEFENSIVE  = 1,
-    REACT_AGGRESSIVE = 2
+    REACT_NONE       = 0,
+    REACT_PASSIVE    = 1,
+    REACT_DEFENSIVE  = 2,
+    REACT_AGGRESSIVE = 3,
 };
 
 enum CommandStates : uint8

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -249,18 +249,19 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                 case COMMAND_ABANDON:                       // abandon (hunter pet) or dismiss (summoned pet)
                     if (pet->GetCharmerGUID() == GetPlayer()->GetGUID())
                         _player->StopCastingCharm();
-                    else if (pet->GetOwnerGUID() == GetPlayer()->GetGUID())
+                    if (pet->GetOwnerGUID() == GetPlayer()->GetGUID() || pet->GetCharmerGUID() == ObjectGuid::Empty)
                     {
                         ASSERT(pet->GetTypeId() == TYPEID_UNIT);
-                        if (pet->IsPet())
+                        if (pet->IsHunterPet())
                         {
-                            if (((Pet*)pet)->getPetType() == HUNTER_PET)
-                                GetPlayer()->RemovePet((Pet*)pet, PET_SAVE_AS_DELETED);
-                            else
-                                //dismissing a summoned pet is like killing them (this prevents returning a soulshard...)
-                                pet->setDeathState(CORPSE);
+                            GetPlayer()->RemovePet((Pet*)pet, PET_SAVE_AS_DELETED);
                         }
-                        else if (pet->HasUnitTypeMask(UNIT_MASK_MINION))
+                        else if (pet->IsPet())
+                        {
+                            //dismissing a summoned pet is like killing them (this prevents returning a soulshard...)
+                            pet->setDeathState(CORPSE);
+                        }
+                        if (pet->HasUnitTypeMask(UNIT_MASK_MINION))
                         {
                             ((Minion*)pet)->UnSummon();
                         }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Fixes Creature states when Hunter dismisses a pet.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #20769

**Tests performed:**
Tested on different repository and patch applied and tested.

**Known issues and TODO list:**

- [ ] Needs to be tested with all Minions/Pets.
- [x] No SQL change needed.
