### PR TITLE
Core/Item: fix null pointer ref in Item::Create()

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -319,7 +319,7 @@ bool Item::Create(ObjectGuid::LowType guidlow, uint32 itemId, Player const* owne
         if (i < 5)
             SetSpellCharges(i, itemProto->Effects[i]->Charges);
         if (SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itemProto->Effects[i]->SpellID))
-            if (spellInfo->HasEffect(SPELL_EFFECT_GIVE_ARTIFACT_POWER))
+            if (owner && spellInfo->HasEffect(SPELL_EFFECT_GIVE_ARTIFACT_POWER))
                 if (uint32 artifactKnowledgeLevel = owner->GetCurrency(CURRENCY_TYPE_ARTIFACT_KNOWLEDGE))
                     SetModifier(ITEM_MODIFIER_ARTIFACT_KNOWLEDGE_LEVEL, artifactKnowledgeLevel + 1);
     }


### PR DESCRIPTION
**Changes proposed:**
In /src/server/game/Entities/Item/Item.cpp:
    Add test for NULL owner value before evaluating newly created item for artifact effects.

**Target branch(es):** master

**Issues addressed:** Closes #21256 

**Tests performed:**
Built and ran debug for several hours, then repeated with release+symbols.   The segmentation fault does not occur with either build, test users reported that AH seller is now working. 

> Test system config:
HP Proliant DL360 G6
2x Intel Xeon x5670
80GB RAM
Ubuntu 16.04.3 LTS
GNU GCC v7.2.0, Boost 1.65.1, MySQL 5.7.20, etc

**Known issues and TODO list:**
The NULL owner pointer is passed in as a default argument from the ahbot code and `Item::Create` tests its value several times.
- [ ] Look at rearranging the code to minimize the number of tests. 