### PR TITLE
Core/Creature: implement automatic distance correction for melee combat

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -382,7 +382,7 @@ void CreatureAI::SetBoundary(CreatureBoundary const* boundary, bool negateBounda
     me->DoImmediateBoundaryCheck();
 }
 
-void CreatureAI::CheckDistanceToCurrentVictim()
+void CreatureAI::CheckMeleeRepositionRequirements()
 {
     if (Unit* victim = me->GetVictim())
     {

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -382,6 +382,19 @@ void CreatureAI::SetBoundary(CreatureBoundary const* boundary, bool negateBounda
     me->DoImmediateBoundaryCheck();
 }
 
+void CreatureAI::CheckDistanceToCurrentVictim()
+{
+    if (Unit* victim = me->GetVictim())
+    {
+        Position victimPos;
+        victimPos.Relocate(victim->GetPosition());
+
+        // If we are closer than 50% of the combat reach we are going to reposition ourself
+        if (me->GetDistance(victimPos) < CalculatePct(me->GetCombatReach(), 50))
+            me->MoveAdvanceTo(victim);
+    }
+}
+
 Creature* CreatureAI::DoSummon(uint32 entry, Position const& pos, uint32 despawnTime, TempSummonType summonType)
 {
     return me->SummonCreature(entry, pos, summonType, despawnTime);

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -229,7 +229,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         static bool IsInBounds(CreatureBoundary const& boundary, Position const* who);
 
         // Called every 3 Seconds to check if the creature needs to reposition itself
-        void CheckDistanceToCurrentVictim();
+        void CheckMeleeRepositionRequirements();
 
     protected:
         virtual void MoveInLineOfSight(Unit* /*who*/);

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -228,6 +228,9 @@ class TC_GAME_API CreatureAI : public UnitAI
 
         static bool IsInBounds(CreatureBoundary const& boundary, Position const* who);
 
+        // Called every 3 Seconds to check if the creature needs to reposition itself
+        void CheckDistanceToCurrentVictim();
+
     protected:
         virtual void MoveInLineOfSight(Unit* /*who*/);
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -237,7 +237,7 @@ bool ForcedDespawnDelayEvent::Execute(uint64 /*e_time*/, uint32 /*p_time*/)
 }
 
 Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_groupLootTimer(0), lootingGroupLowGUID(0), m_PlayerDamageReq(0), m_lootRecipient(), m_lootRecipientGroup(0), _pickpocketLootRestore(0),
-    m_corpseRemoveTime(0), m_respawnTime(0), m_respawnDelay(300), m_corpseDelay(60), m_respawnradius(0.0f), m_boundaryCheckTime(2500), m_andvanceMovementTime(3000), m_combatPulseTime(0), m_combatPulseDelay(0), m_reactState(REACT_AGGRESSIVE),
+    m_corpseRemoveTime(0), m_respawnTime(0), m_respawnDelay(300), m_corpseDelay(60), m_respawnradius(0.0f), m_boundaryCheckTime(2500), m_advanceMovementTime(3000), m_combatPulseTime(0), m_combatPulseDelay(0), m_reactState(REACT_AGGRESSIVE),
     m_defaultMovementType(IDLE_MOTION_TYPE), m_spawnId(0), m_equipmentId(0), m_originalEquipmentId(0), m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false), m_cannotReachTarget(false), m_cannotReachTimer(0),
     m_AI_locked(false), m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), _waypointPathId(0), _currentWaypointNodeInfo(0, 0),
     m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), m_focusSpell(nullptr), m_focusDelay(0), m_shouldReacquireTarget(false), m_suppressedOrientation(0.0f), _lastDamagedTime(0),
@@ -763,12 +763,12 @@ void Creature::Update(uint32 diff)
                 } else
                     m_boundaryCheckTime -= diff;
 
-                if (diff >= m_andvanceMovementTime)
+                if (diff >= m_advanceMovementTime)
                 {
                     AI()->CheckMeleeRepositionRequirements();
-                    m_andvanceMovementTime = 3000;
+                    m_advanceMovementTime = 3000;
                 } else
-                    m_andvanceMovementTime -= diff;
+                    m_advanceMovementTime -= diff;
             }
 
             // if periodic combat pulse is enabled and we are both in combat and in a dungeon, do this now

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -237,7 +237,7 @@ bool ForcedDespawnDelayEvent::Execute(uint64 /*e_time*/, uint32 /*p_time*/)
 }
 
 Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_groupLootTimer(0), lootingGroupLowGUID(0), m_PlayerDamageReq(0), m_lootRecipient(), m_lootRecipientGroup(0), _pickpocketLootRestore(0),
-    m_corpseRemoveTime(0), m_respawnTime(0), m_respawnDelay(300), m_corpseDelay(60), m_respawnradius(0.0f), m_boundaryCheckTime(2500), m_combatPulseTime(0), m_combatPulseDelay(0), m_reactState(REACT_AGGRESSIVE),
+    m_corpseRemoveTime(0), m_respawnTime(0), m_respawnDelay(300), m_corpseDelay(60), m_respawnradius(0.0f), m_boundaryCheckTime(2500), m_andvanceMovementTime(3000), m_combatPulseTime(0), m_combatPulseDelay(0), m_reactState(REACT_AGGRESSIVE),
     m_defaultMovementType(IDLE_MOTION_TYPE), m_spawnId(0), m_equipmentId(0), m_originalEquipmentId(0), m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false), m_cannotReachTarget(false), m_cannotReachTimer(0),
     m_AI_locked(false), m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), _waypointPathId(0), _currentWaypointNodeInfo(0, 0),
     m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), m_focusSpell(nullptr), m_focusDelay(0), m_shouldReacquireTarget(false), m_suppressedOrientation(0.0f), _lastDamagedTime(0),
@@ -751,7 +751,8 @@ void Creature::Update(uint32 diff)
                 LastCharmerGUID.Clear();
             }
 
-            // periodic check to see if the creature has passed an evade boundary
+            // periodic check to see if the creature has passed an evade boundary...
+            // or if the creature needs to reposition itself
             if (IsAIEnabled && !IsInEvadeMode() && IsEngaged())
             {
                 if (diff >= m_boundaryCheckTime)
@@ -761,6 +762,13 @@ void Creature::Update(uint32 diff)
                     m_boundaryCheckTime = 2500;
                 } else
                     m_boundaryCheckTime -= diff;
+
+                if (diff >= m_andvanceMovementTime)
+                {
+                    AI()->CheckDistanceToCurrentVictim();
+                    m_andvanceMovementTime = 3000;
+                } else
+                    m_andvanceMovementTime -= diff;
             }
 
             // if periodic combat pulse is enabled and we are both in combat and in a dungeon, do this now

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -765,7 +765,7 @@ void Creature::Update(uint32 diff)
 
                 if (diff >= m_andvanceMovementTime)
                 {
-                    AI()->CheckDistanceToCurrentVictim();
+                    AI()->CheckMeleeRepositionRequirements();
                     m_andvanceMovementTime = 3000;
                 } else
                     m_andvanceMovementTime -= diff;

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -380,6 +380,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 m_corpseDelay;                               // (secs) delay between death and corpse disappearance
         float m_respawnradius;
         uint32 m_boundaryCheckTime;                         // (msecs) remaining time for next evade boundary check
+        uint32 m_andvanceMovementTime;                      // (msecs) remaining time for next reposition update to avoid creatures standing inside each other
         uint32 m_combatPulseTime;                           // (msecs) remaining time for next zone-in-combat pulse
         uint32 m_combatPulseDelay;                          // (secs) how often the creature puts the entire zone in combat (only works in dungeons)
 

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -380,7 +380,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 m_corpseDelay;                               // (secs) delay between death and corpse disappearance
         float m_respawnradius;
         uint32 m_boundaryCheckTime;                         // (msecs) remaining time for next evade boundary check
-        uint32 m_andvanceMovementTime;                      // (msecs) remaining time for next reposition update to avoid creatures standing inside each other
+        uint32 m_advanceMovementTime;                       // (msecs) remaining time for next reposition update to avoid creatures standing inside each other
         uint32 m_combatPulseTime;                           // (msecs) remaining time for next zone-in-combat pulse
         uint32 m_combatPulseDelay;                          // (secs) how often the creature puts the entire zone in combat (only works in dungeons)
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -470,6 +470,27 @@ void Unit::MonsterMoveWithSpeed(float x, float y, float z, float speed, bool gen
     init.Launch();
 }
 
+void Unit::MoveAdvanceTo(Unit* target)
+{
+    if (!target) // Just in case
+        return;
+
+    // Do not reposition ourself when we are not allowed to move
+    if (IsMovementPreventedByCasting() || isMoving() || !CanFreeMove())
+        return;
+
+    float x, y, z;
+    GetNearPoint(target, x, y, z, 0.0f, 0.0f, target->GetAngle(this));
+    Movement::MoveSplineInit init(this);
+    init.MoveTo(x, y, z, true, false);
+
+    // Beasts move backwards instead of turning arround
+    if (ToCreature() && ToCreature()->GetCreatureTemplate()->type == CREATURE_TYPE_BEAST)
+        init.SetOrientationFixed(true);
+
+    init.Launch();
+}
+
 void Unit::UpdateSplineMovement(uint32 t_diff)
 {
     if (movespline->Finalized())
@@ -12770,7 +12791,7 @@ void Unit::SendPlaySpellVisual(uint32 id)
     WorldPacket data(SMSG_PLAY_SPELL_VISUAL, 8 + 4);
     data << uint64(GetGUID());
     data << uint32(id); // SpellVisualKit.dbc index
-    SendMessageToSet(&data, false);
+    SendMessageToSet(&data, true);
 }
 
 void Unit::SendPlaySpellImpact(ObjectGuid guid, uint32 id)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -476,7 +476,8 @@ void Unit::MoveAdvanceTo(Unit* target)
         return;
 
     // Do not reposition ourself when we are not allowed to move
-    if (IsMovementPreventedByCasting() || isMoving() || !CanFreeMove())
+    if ((IsMovementPreventedByCasting() || isMoving() || !CanFreeMove()) &&
+        GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
         return;
 
     float x, y, z;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12791,7 +12791,7 @@ void Unit::SendPlaySpellVisual(uint32 id)
     WorldPacket data(SMSG_PLAY_SPELL_VISUAL, 8 + 4);
     data << uint64(GetGUID());
     data << uint32(id); // SpellVisualKit.dbc index
-    SendMessageToSet(&data, true);
+    SendMessageToSet(&data, false);
 }
 
 void Unit::SendPlaySpellImpact(ObjectGuid guid, uint32 id)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1132,6 +1132,7 @@ class TC_GAME_API Unit : public WorldObject
         //void SetFacing(float ori, WorldObject* obj = nullptr);
         //void SendMonsterMove(float NewPosX, float NewPosY, float NewPosZ, uint8 type, uint32 MovementFlags, uint32 Time, Player* player = nullptr);
         void SendMovementFlagUpdate(bool self = false);
+        void MoveAdvanceTo(Unit* target);
 
         bool IsLevitating() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY); }
         bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING); }


### PR DESCRIPTION
The following PR adds support for creatures to correct their distance to their target automaticly when standing too close to each other. According to retail research they use a internal 3 seconds timer to check the distance. That's why the creatures sometimes react very fast and sometimes they need their time.

**Changes proposed:**
-  add support for creatures to reposition theirself when they are too close to their current victim by getting their new contactpoint and moving to there

**Target branch(es):** 3.3.5
- [x] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.)
https://www.youtube.com/watch?v=sy-d8Zl0c5I