### PR TITLE
[WIP] [335] Core/AI: correct InitializeAI - JustAppeared duplicated logic

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.cpp
+++ b/src/server/game/AI/CoreAI/UnitAI.cpp
@@ -41,12 +41,6 @@ void UnitAI::AttackStart(Unit* victim)
     }
 }
 
-void UnitAI::InitializeAI()
-{
-    if (!me->isDead())
-        Reset();
-}
-
 void UnitAI::AttackStartCaster(Unit* victim, float dist)
 {
     if (victim && me->Attack(victim, false))

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -139,7 +139,7 @@ class TC_GAME_API UnitAI
         virtual void AttackStart(Unit* /*target*/);
         virtual void UpdateAI(uint32 diff) = 0;
 
-        virtual void InitializeAI();
+        virtual void InitializeAI() { }
 
         virtual void Reset() { }
 

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -32,7 +32,14 @@
 #include "Vehicle.h"
 #include "World.h"
 
-//Disable CreatureAI when charmed
+
+void CreatureAI::JustAppeared()
+{
+    if (!me->isDead())
+        Reset();
+}
+
+// Disable CreatureAI when charmed
 void CreatureAI::OnCharmed(bool apply)
 {
     if (apply)

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -137,7 +137,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         virtual bool IsEscorted() const { return false; }
 
         // Called when creature appears in the world (spawn, respawn, grid load etc...)
-        virtual void JustAppeared() { }
+        virtual void JustAppeared();
 
         // Called at waypoint reached or point movement finished
         virtual void MovementInform(uint32 /*type*/, uint32 /*id*/) { }

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -664,9 +664,6 @@ void SmartAI::PassengerBoarded(Unit* who, int8 seatId, bool apply)
 void SmartAI::InitializeAI()
 {
     GetScript()->OnInitialize(me);
-
-    if (!me->isDead())
-        GetScript()->OnReset();
 }
 
 void SmartAI::OnCharmed(bool apply)

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -982,7 +982,7 @@ void SmartGameObjectAI::UpdateAI(uint32 diff)
 void SmartGameObjectAI::InitializeAI()
 {
     GetScript()->OnInitialize(me);
-    //Reset();
+    Reset();
 }
 
 void SmartGameObjectAI::Reset()

--- a/src/server/scripts/Kalimdor/zone_durotar.cpp
+++ b/src/server/scripts/Kalimdor/zone_durotar.cpp
@@ -289,7 +289,7 @@ class npc_troll_volunteer : public CreatureScript
                 _complete = false;
             }
 
-            void InitializeAI() override
+            void JustAppeared() override
             {
                 if (me->isDead() || !me->GetOwner())
                     return;

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
@@ -141,10 +141,14 @@ class boss_tyrannus : public CreatureScript
 
             void InitializeAI() override
             {
-                if (instance->GetBossState(DATA_TYRANNUS) != DONE)
-                    Reset();
-                else
+                if (instance->GetBossState(DATA_TYRANNUS) == DONE)
                     me->DespawnOrUnsummon();
+            }
+
+            void JustAppeared() override
+            {
+                if (instance->GetBossState(DATA_TYRANNUS) != DONE)
+                    BossAI::JustAppeared();
             }
 
             void Reset() override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -442,9 +442,12 @@ struct BloodPrincesBossAI : public BossAI
 
     void InitializeAI() override
     {
+        if (Creature* controller = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_BLOOD_PRINCES_CONTROL)))
+            if (controller->AI()->GetData(DATA_INTRO) != DATA_INTRO_DONE)
+                DoCastSelf(SPELL_FEIGN_DEATH);
+
         _spawnHealth = 1;
-        if (!me->isDead())
-            JustAppeared();
+        me->SetHealth(_spawnHealth);
     }
 
     void Reset() override
@@ -490,15 +493,6 @@ struct BloodPrincesBossAI : public BossAI
             default:
                 break;
         }
-    }
-
-    void JustAppeared() override
-    {
-        if (Creature* controller = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_BLOOD_PRINCES_CONTROL)))
-            if (controller->AI()->GetData(DATA_INTRO) != DATA_INTRO_DONE)
-                DoCastSelf(SPELL_FEIGN_DEATH);
-
-        me->SetHealth(_spawnHealth);
     }
 
     void DamageTaken(Unit* attacker, uint32& damage) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -673,10 +673,7 @@ class npc_spinestalker : public CreatureScript
             {
                 // Increase add count
                 if (!me->isDead())
-                {
                     _instance->SetData(DATA_SINDRAGOSA_FROSTWYRMS, me->GetSpawnId());  // this cannot be in Reset because reset also happens on evade
-                    Reset();
-                }
             }
 
             void Reset() override
@@ -810,10 +807,7 @@ class npc_rimefang : public CreatureScript
             {
                 // Increase add count
                 if (!me->isDead())
-                {
                     _instance->SetData(DATA_SINDRAGOSA_FROSTWYRMS, me->GetSpawnId());  // this cannot be in Reset because reset also happens on evade
-                    Reset();
-                }
             }
 
             void Reset() override
@@ -980,7 +974,6 @@ class npc_sindragosa_trash : public CreatureScript
                 {
                     if (me->GetEntry() == NPC_FROSTWING_WHELP)
                         _instance->SetData(_frostwyrmId, me->GetSpawnId());  // this cannot be in Reset because reset also happens on evade
-                    Reset();
                 }
             }
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -269,9 +269,6 @@ class boss_valithria_dreamwalker : public CreatureScript
                 if (CreatureData const* data = sObjectMgr->GetCreatureData(me->GetSpawnId()))
                     if (data->curhealth)
                         _spawnHealth = data->curhealth;
-
-                if (!me->isDead())
-                    Reset();
             }
 
             void Reset() override


### PR DESCRIPTION
Removing the duplicated logic/calls from the core.

InitializeAI -> called after AI creation, helper that allows modifications/calls that may not be suitable before.
JustAppeared -> called everytime after a creature appears (respawn, grid load, etc), standard point to call AI Reset.

Note: The only two inherits from UnitAI are CreatureAI and PlayerAI, so its safe to remove the InitializeAI implementation from UnitAI.

Scripts and AIs will be adjusted slowly, but eventually this will be merged, heads up for anyone interested.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

tagging several issues, but on top of that, trying to stop the nonesense blaming.