### PR TITLE
Fixes wrong condition in SMART_EVENT_MOVEMENTINFORM

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3022,7 +3022,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
         }
         case SMART_EVENT_MOVEMENTINFORM:
         {
-            if ((e.event.movementInform.type && var0 != e.event.movementInform.type) || (e.event.movementInform.id && var1 != e.event.movementInform.id))
+            if ((e.event.movementInform.type && var0 != e.event.movementInform.type) || (e.event.movementInform.id && var1 == e.event.movementInform.id))
                 return;
             ProcessAction(e, unit, var0, var1);
             break;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3022,7 +3022,8 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
         }
         case SMART_EVENT_MOVEMENTINFORM:
         {
-            if ((e.event.movementInform.type && var0 != e.event.movementInform.type) || (e.event.movementInform.id && var1 == e.event.movementInform.id))
+            if ((e.event.movementInform.type == 0 || var0 != e.event.movementInform.type ) ||
+                (e.event.movementInform.id == 0 || var1 != e.event.movementInform.id))
                 return;
             ProcessAction(e, unit, var0, var1);
             break;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3022,8 +3022,9 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
         }
         case SMART_EVENT_MOVEMENTINFORM:
         {
-            if ((e.event.movementInform.type == 0 || var0 != e.event.movementInform.type ) ||
-                (e.event.movementInform.id == 0 || var1 != e.event.movementInform.id))
+            if (e.event.movementInform.type != 0 && var0 != e.event.movementInform.type)
+                return;
+            if (var1 != e.event.movementInform.id)
                 return;
             ProcessAction(e, unit, var0, var1);
             break;


### PR DESCRIPTION
**Changes proposed:**

Fixes a lot of Quest's/NPC's issues that are using this SMART_EVENT type.

You cant test the changes on this quest ( which is not working now ): [QuestLink](http://www.wowhead.com/quest=12069/return-of-the-high-chief)

**Target branch(es):** 3.3.5