### PR TITLE
Core/Movement: fix MovementInform scripts relying on WP_START or START_CLOSEST_WAYPOINT

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -109,7 +109,7 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature* creature)
     // inform AI
     if (creature->AI())
     {
-        creature->AI()->MovementInform(WAYPOINT_MOTION_TYPE, _currentNode);
+        creature->AI()->MovementInform(WAYPOINT_MOTION_TYPE, creature->GetAIName() == "SmartAI" ? waypoint.id : _currentNode);
         creature->AI()->WaypointReached(waypoint.id, _path->id);
     }
 

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -109,7 +109,7 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature* creature)
     // inform AI
     if (creature->AI())
     {
-        creature->AI()->MovementInform(WAYPOINT_MOTION_TYPE, creature->GetAIName() == "SmartAI" ? waypoint.id : _currentNode);
+        creature->AI()->MovementInform(WAYPOINT_MOTION_TYPE, waypoint.id);
         creature->AI()->WaypointReached(waypoint.id, _path->id);
     }
 


### PR DESCRIPTION
**Description:**
This pr will fixes SmartScripts that have `event_type=MOVEMENTINFORM`, `event_param2=1`(pointid) and rely's on one of the `WP_START`, `START_CLOSEST_WAYPOINT` actions.

`WP_START` and `START_CLOSEST_WAYPOINT` uses `StartPath` -> `MovePath` -> `WaypointMovementGenerator` to move a creature, and the `WaypointMovementGenerator::OnArrived` currently pass the `_currentNode` ( which starts from 0 ) to `MovementInform`. As `smart_scripts`, `waypoints`, `pointid` starts from 1, Those `smart_scripts` with `event_type=34`, `event_param2=1` always fail to run.

Example: [QuestLink](https://wotlk.evowow.com/?quest=27364)

**Target branch(es):** 3.3.5