### PR TITLE
[3.3.5] Core/Creature: Remove legacy creature behavior

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1112,32 +1112,8 @@ Unit* Creature::SelectVictim()
 {
     Unit* target = nullptr;
 
-    ThreatManager& mgr = GetThreatManager();
-
-    if (mgr.CanHaveThreatList())
-    {
-        target = mgr.SelectVictim();
-        while (!target)
-        {
-            Unit* newTarget = nullptr;
-            // nothing found to attack - try to find something we're in combat with (but don't have a threat entry for yet) and start attacking it
-            for (auto const& pair : GetCombatManager().GetPvECombatRefs())
-            {
-                newTarget = pair.second->GetOther(this);
-                if (!mgr.IsThreatenedBy(newTarget, true))
-                {
-                    mgr.AddThreat(newTarget, 0.0f, nullptr, true, true);
-                    ASSERT(mgr.IsThreatenedBy(newTarget, true), "%s tried to add combatant %s to threat list, but this failed - potential infinite loop", GetName().c_str(), newTarget->GetName().c_str()); // prevent potential infinite loop
-                    break;
-                }
-                else
-                    newTarget = nullptr;
-            }
-            if (!newTarget)
-                break;
-            target = mgr.SelectVictim();
-        }
-    }
+    if (CanHaveThreatList())
+        target = GetThreatManager().SelectVictim();
     else if (!HasReactState(REACT_PASSIVE))
     {
         // We're a player pet, probably
@@ -1176,15 +1152,6 @@ Unit* Creature::SelectVictim()
     /// @todo a vehicle may eat some mob, so mob should not evade
     if (GetVehicle())
         return nullptr;
-
-    // search nearby enemy before enter evade mode
-    if (HasReactState(REACT_AGGRESSIVE))
-    {
-        target = SelectNearestTargetInAttackDistance(m_CombatDistance ? m_CombatDistance : ATTACK_DISTANCE);
-
-        if (target && _IsTargetAcceptable(target) && CanCreatureAttack(target))
-            return target;
-    }
 
     Unit::AuraEffectList const& iAuras = GetAuraEffectsByType(SPELL_AURA_MOD_INVISIBILITY);
     if (!iAuras.empty())


### PR DESCRIPTION
Some adjustments to `Creature::SelectVictim`. PR for brief review and awareness.

- No more automatic combat -> threat promotion. This matches anecdotal retail behavior - spells already in transit will not cause mob to chase you if its primary target vanishes before the spell hits.
- Prevent mobbing by stopping creatures from auto-acquiring a nearby target just because the primary target vanished.
