### PR TITLE
Scripts/Magisters Terrace: Crash fix on Pure energy

### DIFF
--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_vexallus.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_vexallus.cpp
@@ -208,7 +208,8 @@ class npc_pure_energy : public CreatureScript
 
             void JustDied(Unit* killer) override
             {
-                killer->CastSpell(killer, SPELL_ENERGY_FEEDBACK, true);
+                if (killer)
+                    killer->CastSpell(killer, SPELL_ENERGY_FEEDBACK, true);
                 me->RemoveAurasDueToSpell(SPELL_PURE_ENERGY_PASSIVE);
             }
         };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

```
Unit::CastSpell (this=0x0, target=0x0, spellId=44335, args=...)
npc_pure_energy::npc_pure_energyAI::JustDied (this=0x7ffe812cdf10, killer=0x0)
```