### PR TITLE
Core/Spells: Fix usage of uninitialized variable in SpellMgr::LoadSpellProcs()

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1801,6 +1801,7 @@ void SpellMgr::LoadSpellProcs()
         procEntry.SchoolMask      = 0;
         procEntry.ProcFlags = spellInfo->ProcFlags;
         procEntry.SpellFamilyName = 0;
+        procEntry.SpellFamilyMask = 0;
         for (uint32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             if (spellInfo->Effects[i].IsEffect() && isTriggerAura[spellInfo->Effects[i].ApplyAuraName])
                 procEntry.SpellFamilyMask |= spellInfo->Effects[i].SpellClassMask;


### PR DESCRIPTION
**Changes proposed:**
Fixed unitialized variable procEntry.SpellFamilyMask in SpellMgr::LoadSpellProcs().

**Target branch(es):** 
-  3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
 This fixes random values assigned in SpellFamilyMask for spells with proc values deduced from Spell.dbc and no entry in spell_proc, such as the hunter Master Tactician talent (34506).
Some compilers may set the value to 0 by default and not suffer from this bug.