### PR TITLE
Core/Spells: fixed a logic mistake in IsMovementPreventedByCasting()

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3329,17 +3329,17 @@ int32 Unit::GetCurrentSpellCastTime(uint32 spell_id) const
 bool Unit::IsMovementPreventedByCasting() const
 {
     // can always move when not casting
-    if (!HasUnitState(UNIT_STATE_CASTING))
-        return false;
+    if (HasUnitState(UNIT_STATE_CASTING))
+        return true;
 
     // channeled spells during channel stage (after the initial cast timer) allow movement with a specific spell attribute
     if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
         if (spell->getState() != SPELL_STATE_FINISHED && spell->IsChannelActive())
-            if (spell->GetSpellInfo()->IsMoveAllowedChannel())
-                return false;
+            if (!spell->GetSpellInfo()->IsMoveAllowedChannel())
+                return true;
 
     // prohibit movement for all other spell casts
-    return true;
+    return false;
 }
 
 bool Unit::isInFrontInMap(Unit const* target, float distance,  float arc) const


### PR DESCRIPTION
**Changes proposed:**

-  fixed stupid inverted logic that was causing some channelled spells getting interrupted because the caster was moving while he should not be allowed to move.


**Target branch(es):** 3.3.5/master
- [x] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame, works for me (tm)
