### PR TITLE
[WIP] Core/Movement: fix the enter cyclic movement procedure

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -510,6 +510,7 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
         init.SetFly();
         init.SetCyclic();
         init.SetEnterCycle(enterCycle);
+        init.SetUncompressed();
         init.SetAnimation(Movement::ToFly);
     }
     else
@@ -517,6 +518,7 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
         init.SetWalk(true);
         init.SetCyclic();
         init.SetEnterCycle(enterCycle);
+        init.SetUncompressed();
     }
 
     init.Launch();

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -510,7 +510,6 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
         init.SetFly();
         init.SetCyclic();
         init.SetEnterCycle(enterCycle);
-        init.SetUncompressed();
         init.SetAnimation(Movement::ToFly);
     }
     else
@@ -518,7 +517,6 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
         init.SetWalk(true);
         init.SetCyclic();
         init.SetEnterCycle(enterCycle);
-        init.SetUncompressed();
     }
 
     init.Launch();

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -482,7 +482,7 @@ void MotionMaster::MoveJump(float x, float y, float z, float o, float speedXY, f
     Mutate(new EffectMovementGenerator(id), MOTION_SLOT_CONTROLLED);
 }
 
-void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool clockwise, uint8 stepCount)
+void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool clockwise, uint8 stepCount, bool enterCycle)
 {
     float step = 2 * float(M_PI) / stepCount * (clockwise ? -1.0f : 1.0f);
     Position const& pos = { x, y, z, 0.0f };
@@ -490,7 +490,8 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
 
     Movement::MoveSplineInit init(_owner);
 
-    for (uint8 i = 0; i < stepCount; angle += step, ++i)
+    uint32 totalStepCount = enterCycle ? stepCount + 1 : stepCount;
+    for (uint8 i = 0; i < totalStepCount; angle += step, ++i)
     {
         G3D::Vector3 point;
         point.x = x + radius * cosf(angle);
@@ -508,12 +509,14 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
     {
         init.SetFly();
         init.SetCyclic();
+        init.SetEnterCycle(enterCycle);
         init.SetAnimation(Movement::ToFly);
     }
     else
     {
         init.SetWalk(true);
         init.SetCyclic();
+        init.SetEnterCycle(enterCycle);
     }
 
     init.Launch();

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -150,7 +150,7 @@ class TC_GAME_API MotionMaster
             MoveJump(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation(), speedXY, speedZ, id, hasOrientation);
         }
         void MoveJump(float x, float y, float z, float o, float speedXY, float speedZ, uint32 id = EVENT_JUMP, bool hasOrientation = false);
-        void MoveCirclePath(float x, float y, float z, float radius, bool clockwise, uint8 stepCount);
+        void MoveCirclePath(float x, float y, float z, float radius, bool clockwise, uint8 stepCount, bool enterCycle = true);
         void MoveSmoothPath(uint32 pointId, Position const* pathPoints, size_t pathSize, bool walk);
         // Walk along spline chain stored in DB (script_spline_chain_meta and script_spline_chain_waypoints)
         void MoveAlongSplineChain(uint32 pointId, uint16 dbChainId, bool walk);

--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -122,10 +122,7 @@ void MoveSpline::init_spline(MoveSplineInitArgs const& args)
     static SplineBase::EvaluationMode const modes[2] = { SplineBase::ModeLinear, SplineBase::ModeCatmullrom };
     if (args.flags.cyclic)
     {
-        uint32 cyclic_point = 0;
-        // MoveSplineFlag::Enter_Cycle support dropped
-        //if (splineflags & SPLINEFLAG_ENTER_CYCLE)
-        //cyclic_point = 1;   // shouldn't be modified, came from client
+        uint32 cyclic_point = args.flags.enter_cycle ? 1 : 0;
         spline.init_cyclic_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()], cyclic_point);
     }
     else

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -102,6 +102,9 @@ namespace Movement
         if (moveFlags & MOVEMENTFLAG_ROOT)
             moveFlags &= ~MOVEMENTFLAG_MASK_MOVING;
 
+        if (args.flags.cyclic)
+            args.flags.EnableCatmullRom();
+
         if (!args.HasVelocity)
         {
             // If spline is initialized with SetWalk method it only means we need to select

--- a/src/server/game/Movement/Spline/MoveSplineInit.h
+++ b/src/server/game/Movement/Spline/MoveSplineInit.h
@@ -113,6 +113,9 @@ namespace Movement
         /* Makes movement cyclic. Disabled by default
          */
         void SetCyclic();
+        /* Makes cyclic movement skip the first vertex after first loop. Disabled by default
+        */
+        void SetEnterCycle(bool enable);
         /* Enables falling mode. Disabled by default
          */
         void SetFall();
@@ -151,6 +154,7 @@ namespace Movement
     inline void MoveSplineInit::SetWalk(bool enable) { args.walk = enable; }
     inline void MoveSplineInit::SetSmooth() { args.flags.EnableCatmullRom(); }
     inline void MoveSplineInit::SetCyclic() { args.flags.cyclic = true; }
+    inline void MoveSplineInit::SetEnterCycle(bool enable) { args.flags.enter_cycle = enable; }
     inline void MoveSplineInit::SetFall() { args.flags.EnableFalling(); }
     inline void MoveSplineInit::SetVelocity(float vel) { args.velocity = vel; args.HasVelocity = true; }
     inline void MoveSplineInit::SetBackward() { args.flags.backward = true; }

--- a/src/server/game/Movement/Spline/MovementPacketBuilder.cpp
+++ b/src/server/game/Movement/Spline/MovementPacketBuilder.cpp
@@ -126,8 +126,7 @@ namespace Movement
     void WriteCatmullRomCyclicPath(Spline<int32> const& spline, ByteBuffer& data)
     {
         uint32 count = spline.getPointCount() - 3;
-        data << uint32(count + 1);
-        data << spline.getPoint(1); // fake point, client will erase it from the spline after first cycle done
+        data << uint32(count);
         data.append<G3D::Vector3>(&spline.getPoint(1), count);
     }
 

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -2651,7 +2651,7 @@ class npc_quel_delar_sword : public CreatureScript
                                 break;
                             case EVENT_QUEL_DELAR_FLIGHT:
                             {
-                                me->GetMotionMaster()->MoveCirclePath(QuelDelarCenterPos.GetPositionX(), QuelDelarCenterPos.GetPositionY(), 718.046f, 18.0f, true, 16);
+                                me->GetMotionMaster()->MoveCirclePath(QuelDelarCenterPos.GetPositionX(), QuelDelarCenterPos.GetPositionY(), 718.046f, 18.0f, true, 16, false);
                                 _events.ScheduleEvent(EVENT_QUEL_DELAR_LAND, 15000);
                                 break;
                             }

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -521,7 +521,7 @@ public:
                     _despawned = false;
                     break;
                 case ACTION_CYCLIC_MOVEMENT:
-                    me->GetMotionMaster()->MoveCirclePath(MalygosPositions[3].GetPositionX(), MalygosPositions[3].GetPositionY(), 283.2763f, 120.0f, true, 16);
+                    me->GetMotionMaster()->MoveCirclePath(MalygosPositions[3].GetPositionX(), MalygosPositions[3].GetPositionY(), 283.2763f, 120.0f, true, 16, false);
                     break;
             }
         }


### PR DESCRIPTION
**Changes proposed:**
- rework the cyclic movement part of the spline movement so we will get retail-like behaivior now

**Target branch(es):** both

- [x] 3.3.5
- [x] master

**Issues addressed:**
 Closes #20238
 Closes #21387

**Todo:**
- [x] fix packet structure to send the first vertex only once
- [ ] make the cyclic path ignore the first vertext on repeating
- [ ] update scripts to apply changes correcrly

**Tests performed:** tested ingame; issues noticed. need to fix

