### PR TITLE
[3.3.5][WIP] Spell maybe-pointer refactor

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -75,7 +75,7 @@ void PossessedAI::OnCharmed(bool /*apply*/)
     me->IsAIEnabled = false;
 }
 
-void CritterAI::DamageTaken(Unit* /*done_by*/, uint32&)
+void CritterAI::DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32&)
 {
     if (!me->HasUnitState(UNIT_STATE_FLEEING))
         me->SetControlled(true, UNIT_STATE_FLEEING);

--- a/src/server/game/AI/CoreAI/PassiveAI.h
+++ b/src/server/game/AI/CoreAI/PassiveAI.h
@@ -70,7 +70,7 @@ class TC_GAME_API CritterAI : public PassiveAI
     public:
         explicit CritterAI(Creature* c) : PassiveAI(c) { }
 
-        void DamageTaken(Unit* done_by, uint32& /*damage*/) override;
+        void DamageTaken(MemoryOf<Unit> const& done_by, uint32& /*damage*/) override;
         void EnterEvadeMode(EvadeReason why) override;
 
         static int32 Permissible(Creature const* creature);

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -42,7 +42,7 @@ class TC_GAME_API PetAI : public CreatureAI
         void MovementInform(uint32 moveType, uint32 data) override;
         void OwnerAttackedBy(Unit* attacker) override;
         void OwnerAttacked(Unit* target) override;
-        void DamageTaken(Unit* attacker, uint32& /*damage*/) override { AttackStart(attacker); }
+        void DamageTaken(MemoryOf<Unit> const& attacker, uint32& /*damage*/) override { AttackStart(attacker); }
         void ReceiveEmote(Player* player, uint32 textEmote) override;
 
         // The following aren't used by the PetAI but need to be defined to override

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -22,6 +22,7 @@
 #include "Containers.h"
 #include "Errors.h"
 #include "EventMap.h"
+#include "MemoryOf.h"
 #include "ObjectGuid.h"
 #include "SpellDefines.h"
 #include "ThreatManager.h"
@@ -288,13 +289,13 @@ class TC_GAME_API UnitAI
 
         // Called at any Damage from any attacker (before damage apply)
         // Note: it for recalculation damage or special reaction at damage
-        virtual void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) { }
+        virtual void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) { }
 
         // Called when the creature receives heal
-        virtual void HealReceived(Unit* /*done_by*/, uint32& /*addhealth*/) { }
+        virtual void HealReceived(MemoryOf<Unit> const& /*done_by*/, uint32& /*amount*/) { }
 
         // Called when the unit heals
-        virtual void HealDone(Unit* /*done_to*/, uint32& /*addhealth*/) { }
+        virtual void HealDone(Unit* /*done_to*/, uint32& /*amt*/) { }
 
         /// Called when a spell is interrupted by Spell::EffectInterruptCast
         /// Use to reschedule next planned cast of spell.

--- a/src/server/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/server/game/AI/PlayerAI/PlayerAI.cpp
@@ -1331,7 +1331,7 @@ void SimpleCharmedPlayerAI::UpdateAI(const uint32 diff)
         Player::AuraEffectList const& auras = me->GetAuraEffectsByType(SPELL_AURA_MOD_CHARM);
         for (Player::AuraEffectList::const_iterator iter = auras.begin(); iter != auras.end(); ++iter)
         {
-            if ((*iter)->GetCasterGUID() == charmer->GetGUID() && (*iter)->GetBase()->IsPermanent())
+            if ((*iter)->GetCaster() == charmer->GetGUID() && (*iter)->GetBase()->IsPermanent())
             {
                 me->KillSelf();
                 return;

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -142,7 +142,7 @@ struct TC_GAME_API ScriptedAI : public CreatureAI
     void AttackStartNoMove(Unit* target);
 
     // Called at any Damage from any attacker (before damage apply)
-    void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override { }
+    void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override { }
 
     //Called at World update tick
     virtual void UpdateAI(uint32 diff) override;

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -610,7 +610,7 @@ void SmartAI::SpellHitTarget(Unit* target, SpellInfo const* spellInfo)
     GetScript()->ProcessEventsFor(SMART_EVENT_SPELLHIT_TARGET, target, 0, 0, false, spellInfo);
 }
 
-void SmartAI::DamageTaken(Unit* doneBy, uint32& damage)
+void SmartAI::DamageTaken(MemoryOf<Unit> const& doneBy, uint32& damage)
 {
     GetScript()->ProcessEventsFor(SMART_EVENT_DAMAGED, doneBy, damage);
 
@@ -621,9 +621,9 @@ void SmartAI::DamageTaken(Unit* doneBy, uint32& damage)
         damage = me->GetHealth() - mInvincibilityHpLevel; // damage should not be nullified, because of player damage req.
 }
 
-void SmartAI::HealReceived(Unit* doneBy, uint32& addhealth)
+void SmartAI::HealReceived(MemoryOf<Unit> const& doneBy, uint32& amt)
 {
-    GetScript()->ProcessEventsFor(SMART_EVENT_RECEIVE_HEAL, doneBy, addhealth);
+    GetScript()->ProcessEventsFor(SMART_EVENT_RECEIVE_HEAL, doneBy, amt);
 }
 
 void SmartAI::ReceiveEmote(Player* player, uint32 textEmote)

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -110,10 +110,10 @@ class TC_GAME_API SmartAI : public CreatureAI
         void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override;
 
         // Called at any Damage from any attacker (before damage apply)
-        void DamageTaken(Unit* doneBy, uint32& damage) override;
+        void DamageTaken(MemoryOf<Unit> const& doneBy, uint32& damage) override;
 
         // Called when the creature receives heal
-        void HealReceived(Unit* doneBy, uint32& addhealth) override;
+        void HealReceived(MemoryOf<Unit> const& doneBy, uint32& amt) override;
 
         // Called at World update tick
         void UpdateAI(uint32 diff) override;

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -119,7 +119,7 @@ void ThreatReference::UpdateTauntState(bool victimIsTaunting)
 
     // Check for SPELL_AURA_MOD_DETAUNT (applied from owner to victim)
     for (AuraEffect const* eff : _victim->GetAuraEffectsByType(SPELL_AURA_MOD_DETAUNT))
-        if (eff->GetCasterGUID() == _owner->GetGUID())
+        if (eff->GetCaster() == _owner)
         {
             _taunted = TAUNT_STATE_DETAUNT;
             HeapNotifyDecreased();
@@ -429,7 +429,7 @@ void ThreatManager::TauntUpdate()
     // Only the last taunt effect applied by something still on our threat list is considered
     for (auto it = tauntEffects.rbegin(), end = tauntEffects.rend(); it != end; ++it)
     {
-        auto threatIt = _myThreatListEntries.find((*it)->GetCasterGUID());
+        auto threatIt = _myThreatListEntries.find((*it)->GetCaster());
         if (threatIt == threatEnd)
             continue;
         if (!threatIt->second->IsOnline())

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1278,7 +1278,7 @@ void Creature::SetLootRecipient(Unit* unit, bool withGroup)
             m_lootRecipientGroup = group->GetLowGUID();
     }
     else
-        m_lootRecipientGroup = ObjectGuid::Empty;
+        m_lootRecipientGroup = ObjectGuid::Empty.GetCounter();
 
     SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_TAPPED);
 }

--- a/src/server/game/Entities/DynamicObject/DynamicObject.cpp
+++ b/src/server/game/Entities/DynamicObject/DynamicObject.cpp
@@ -146,7 +146,7 @@ void DynamicObject::Update(uint32 p_time)
     if (_aura)
     {
         if (!_aura->IsRemoved())
-            _aura->UpdateOwner(p_time, this);
+            _aura->Update(p_time);
 
         // _aura may be set to null in Aura::UpdateOwner call
         if (_aura && (_aura->IsRemoved() || _aura->IsExpired()))

--- a/src/server/game/Entities/Object/MemoryOf.h
+++ b/src/server/game/Entities/Object/MemoryOf.h
@@ -45,7 +45,7 @@ struct MemoryOf : public ObjectGuid
     void Set(OBJ* obj)
     {
         if (obj)
-            ObjectGuid::Set(obj->GetGUID());
+            ObjectGuid::Set(obj->GetGUID().GetRawValue());
         else
             ObjectGuid::Clear();
         _obj = obj;

--- a/src/server/game/Entities/Object/MemoryOf.h
+++ b/src/server/game/Entities/Object/MemoryOf.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef TRINITY_MEMORYOF_H
+#define TRINITY_MEMORYOF_H
+
+#include "Errors.h"
+#include "Object.h"
+#include <type_traits>
+
+class Object;
+
+template <typename OBJ>
+struct MemoryOf : public ObjectGuid
+{
+    /*static_assert(std::is_base_of<Object, OBJ>::value, "Invalid MemoryOf declaration!");*/
+
+    MemoryOf() : ObjectGuid(), _obj(nullptr) {}
+    MemoryOf(OBJ* obj) : ObjectGuid(obj ? obj->GetGUID() : ObjectGuid::Empty), _obj(obj) {}
+
+    OBJ* unchecked_ptr() const { return _obj; }
+
+    explicit operator bool() const { return _obj != nullptr; }
+    operator OBJ*() const { return unchecked_ptr(); }
+
+    OBJ* operator*() const { return ASSERT_NOTNULL(unchecked_ptr()); }
+    OBJ* operator->() const { return operator*(); }
+
+    void operator=(OBJ* obj) { _obj = obj; }
+
+    void Set(OBJ* obj)
+    {
+        if (obj)
+            ObjectGuid::Set(obj->GetGUID());
+        else
+            ObjectGuid::Clear();
+        _obj = obj;
+    }
+
+    private:
+        OBJ * _obj;
+};
+
+#endif

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -289,8 +289,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
 
         virtual void SetPhaseMask(uint32 newPhaseMask, bool update);
         uint32 GetPhaseMask() const { return m_phaseMask; }
-        bool InSamePhase(uint32 phasemask) const { return (GetPhaseMask() & phasemask) != 0; }
-        bool InSamePhase(WorldObject const* obj) const { return obj && InSamePhase(obj->GetPhaseMask()); }
+        bool IsInAnyPhase(uint32 phasemask) const { return (GetPhaseMask() & phasemask) != 0; }
+        bool InSamePhase(WorldObject const* obj) const { return obj && IsInAnyPhase(obj->GetPhaseMask()); }
         static bool InSamePhase(WorldObject const* a, WorldObject const* b) { return a && a->InSamePhase(b); }
 
         uint32 GetZoneId() const { return m_zoneId; }

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -289,8 +289,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
 
         virtual void SetPhaseMask(uint32 newPhaseMask, bool update);
         uint32 GetPhaseMask() const { return m_phaseMask; }
-        bool IsInAnyPhase(uint32 phasemask) const { return (GetPhaseMask() & phasemask) != 0; }
-        bool InSamePhase(WorldObject const* obj) const { return obj && IsInAnyPhase(obj->GetPhaseMask()); }
+        bool InSamePhase(uint32 phasemask) const { return (GetPhaseMask() & phasemask) != 0; }
+        bool InSamePhase(WorldObject const* obj) const { return obj && InSamePhase(obj->GetPhaseMask()); }
         static bool InSamePhase(WorldObject const* a, WorldObject const* b) { return a && a->InSamePhase(b); }
 
         uint32 GetZoneId() const { return m_zoneId; }

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1257,7 +1257,7 @@ void Pet::_SaveAuras(SQLTransaction& trans)
         }
 
         // don't save guid of caster in case we are caster of the spell - guid for pet is generated every pet load, so it won't match saved guid anyways
-        ObjectGuid casterGUID = (itr->second->GetCasterGUID() == GetGUID()) ? ObjectGuid::Empty : itr->second->GetCasterGUID();
+        ObjectGuid casterGUID = (itr->second->GetCaster() == GetGUID()) ? ObjectGuid::Empty : itr->second->GetCaster();
 
         uint8 index = 0;
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7214,7 +7214,7 @@ void Player::DuelComplete(DuelCompleteType type)
     for (AuraApplicationMap::iterator i = itsAuras.begin(); i != itsAuras.end();)
     {
         Aura const* aura = i->second->GetBase();
-        if (!i->second->IsPositive() && aura->GetCasterGUID() == GetGUID() && aura->GetApplyTime() >= duel->startTime)
+        if (!i->second->IsPositive() && aura->GetCaster() == GetGUID() && aura->GetApplyTime() >= duel->startTime)
             duel->opponent->RemoveAura(i);
         else
             ++i;
@@ -7224,7 +7224,7 @@ void Player::DuelComplete(DuelCompleteType type)
     for (AuraApplicationMap::iterator i = myAuras.begin(); i != myAuras.end();)
     {
         Aura const* aura = i->second->GetBase();
-        if (!i->second->IsPositive() && aura->GetCasterGUID() == duel->opponent->GetGUID() && aura->GetApplyTime() >= duel->startTime)
+        if (!i->second->IsPositive() && aura->GetCaster() == duel->opponent->GetGUID() && aura->GetApplyTime() >= duel->startTime)
             RemoveAura(i);
         else
             ++i;
@@ -19501,7 +19501,7 @@ void Player::_SaveAuras(SQLTransaction& trans)
         uint8 index = 0;
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_AURA);
         stmt->setUInt32(index++, GetGUID().GetCounter());
-        stmt->setUInt64(index++, itr->second->GetCasterGUID().GetRawValue());
+        stmt->setUInt64(index++, itr->second->GetCaster().GetRawValue());
         stmt->setUInt32(index++, itr->second->GetId());
         stmt->setUInt8(index++, effMask);
         stmt->setUInt8(index++, recalculateMask);
@@ -23509,7 +23509,7 @@ void Player::RemoveItemDependentAurasAndCasts(Item* pItem)
 
         // skip not self applied auras
         SpellInfo const* spellInfo = aura->GetSpellInfo();
-        if (aura->GetCasterGUID() != GetGUID())
+        if (aura->GetCaster() != GetGUID())
         {
             ++itr;
             continue;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11858,7 +11858,7 @@ Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update
             // save data
             std::ostringstream ss;
             GuidSet::const_iterator itr = allowedLooters.begin();
-            ss << *itr;
+            ss << itr->GetCounter();
             for (++itr; itr != allowedLooters.end(); ++itr)
                 ss << ' ' << itr->GetCounter();
 
@@ -25453,7 +25453,7 @@ void Player::SendEquipmentSetList()
             if (eqSet.second.Data.IgnoreMask & (1 << i))
                 data.appendPackGUID(uint64(1));
             else
-                data.appendPackGUID(eqSet.second.Data.Pieces[i]);
+                data.appendPackGUID(eqSet.second.Data.Pieces[i].GetRawValue());
         }
 
         ++count;                                            // client have limit but it checked at loading and set

--- a/src/server/game/Entities/Player/SocialMgr.cpp
+++ b/src/server/game/Entities/Player/SocialMgr.cpp
@@ -97,8 +97,8 @@ void PlayerSocial::RemoveFromSocialList(ObjectGuid const& friendGuid, SocialFlag
         PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHARACTER_SOCIAL_FLAGS);
 
         stmt->setUInt8(0, itr->second.Flags);
-        stmt->setUInt32(1, GetPlayerGUID());
-        stmt->setUInt32(2, friendGuid);
+        stmt->setUInt32(1, GetPlayerGUID().GetCounter());
+        stmt->setUInt32(2, friendGuid.GetCounter());
 
         CharacterDatabase.Execute(stmt);
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -648,7 +648,7 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
     }
 }
 
-/*static*/ uint32 Unit::DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellInfo const* spellProto, bool durabilityLoss)
+/*static*/ uint32 Unit::DealDamage(MemoryOf<Unit> const& attacker, Unit* victim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellInfo const* spellProto, bool durabilityLoss)
 {
     uint32 rage_damage = damage + (cleanDamage ? cleanDamage->absorbed_damage : 0);
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2964,7 +2964,7 @@ float Unit::GetUnitCriticalChanceTaken(Unit const* attacker, WeaponAttackType at
 
     chance += GetTotalAuraModifier(SPELL_AURA_MOD_CRIT_CHANCE_FOR_CASTER, [attacker](AuraEffect const* aurEff) -> bool
     {
-        if (aurEff->GetCasterGUID() == attacker->GetGUID())
+        if (aurEff->GetCaster() == attacker->GetGUID())
             return true;
         return false;
     });
@@ -3070,7 +3070,7 @@ void Unit::_UpdateSpells(uint32 time)
     {
         Aura* i_aura = m_auraUpdateIterator->second;
         ++m_auraUpdateIterator;                            // need shift to next for allow update if need into aura update
-        i_aura->UpdateOwner(time, this);
+        i_aura->Update(time);
     }
 
     // remove expired auras - do that after updates(used in scripts?)
@@ -3477,7 +3477,7 @@ void Unit::_AddAura(UnitAura* aura, Unit* caster)
     aura->SetIsSingleTarget(caster && (aura->GetSpellInfo()->IsSingleTarget() || aura->HasEffectType(SPELL_AURA_CONTROL_VEHICLE)));
     if (aura->IsSingleTarget())
     {
-        ASSERT((IsInWorld() && !IsDuringRemoveFromWorld()) || (aura->GetCasterGUID() == GetGUID()) ||
+        ASSERT((IsInWorld() && !IsDuringRemoveFromWorld()) || (aura->GetCaster() == GetGUID()) ||
                 (IsLoading() && aura->HasEffectType(SPELL_AURA_CONTROL_VEHICLE)));
                 /* @HACK: Player is not in world during loading auras.
                  *        Single target auras are not saved or loaded from database
@@ -3779,7 +3779,7 @@ void Unit::RemoveOwnedAura(AuraMap::iterator &i, AuraRemoveMode removeMode)
 void Unit::RemoveOwnedAura(uint32 spellId, ObjectGuid casterGUID, uint8 reqEffMask, AuraRemoveMode removeMode)
 {
     for (AuraMap::iterator itr = m_ownedAuras.lower_bound(spellId); itr != m_ownedAuras.upper_bound(spellId);)
-        if (((itr->second->GetEffectMask() & reqEffMask) == reqEffMask) && (!casterGUID || itr->second->GetCasterGUID() == casterGUID))
+        if (((itr->second->GetEffectMask() & reqEffMask) == reqEffMask) && (!casterGUID || itr->second->GetCaster() == casterGUID))
         {
             RemoveOwnedAura(itr, removeMode);
             itr = m_ownedAuras.lower_bound(spellId);
@@ -3822,7 +3822,7 @@ Aura* Unit::GetOwnedAura(uint32 spellId, ObjectGuid casterGUID, ObjectGuid itemC
     for (AuraMap::const_iterator itr = range.first; itr != range.second; ++itr)
     {
         if (((itr->second->GetEffectMask() & reqEffMask) == reqEffMask)
-                && (!casterGUID || itr->second->GetCasterGUID() == casterGUID)
+                && (!casterGUID || itr->second->GetCaster() == casterGUID)
                 && (!itemCasterGUID || itr->second->GetCastItemGUID() == itemCasterGUID)
                 && (!except || except != itr->second))
         {
@@ -3852,7 +3852,7 @@ void Unit::RemoveAura(uint32 spellId, ObjectGuid caster, uint8 reqEffMask, AuraR
     {
         Aura const* aura = iter->second->GetBase();
         if (((aura->GetEffectMask() & reqEffMask) == reqEffMask)
-                && (!caster || aura->GetCasterGUID() == caster))
+                && (!caster || aura->GetCaster() == caster))
         {
             RemoveAura(iter, removeMode);
             return;
@@ -3982,7 +3982,7 @@ void Unit::RemoveAurasDueToSpell(uint32 spellId, ObjectGuid casterGUID, uint8 re
     {
         Aura const* aura = iter->second->GetBase();
         if (((aura->GetEffectMask() & reqEffMask) == reqEffMask)
-            && (!casterGUID || aura->GetCasterGUID() == casterGUID))
+            && (!casterGUID || aura->GetCaster() == casterGUID))
         {
             RemoveAura(iter, removeMode);
             iter = m_appliedAuras.lower_bound(spellId);
@@ -3999,7 +3999,7 @@ void Unit::RemoveAuraFromStack(uint32 spellId, ObjectGuid casterGUID, AuraRemove
     {
         Aura* aura = iter->second;
         if ((aura->GetType() == UNIT_AURA_TYPE)
-                && (!casterGUID || aura->GetCasterGUID() == casterGUID))
+                && (!casterGUID || aura->GetCaster() == casterGUID))
         {
             aura->ModStackAmount(-1, removeMode);
             return;
@@ -4015,7 +4015,7 @@ void Unit::RemoveAurasDueToSpellByDispel(uint32 spellId, uint32 dispellerSpellId
     for (AuraMap::iterator iter = range.first; iter != range.second;)
     {
         Aura* aura = iter->second;
-        if (aura->GetCasterGUID() == casterGUID)
+        if (aura->GetCaster() == casterGUID)
         {
             DispelInfo dispelInfo(dispeller, dispellerSpellId, chargesRemoved);
 
@@ -4043,7 +4043,7 @@ void Unit::RemoveAurasDueToSpellBySteal(uint32 spellId, ObjectGuid casterGUID, U
     for (AuraMap::iterator iter = range.first; iter != range.second;)
     {
         Aura* aura = iter->second;
-        if (aura->GetCasterGUID() == casterGUID)
+        if (aura->GetCaster() == casterGUID)
         {
             int32 damage[MAX_SPELL_EFFECTS];
             int32 baseDamage[MAX_SPELL_EFFECTS];
@@ -4071,7 +4071,7 @@ void Unit::RemoveAurasDueToSpellBySteal(uint32 spellId, ObjectGuid casterGUID, U
             // Cast duration to unsigned to prevent permanent aura's such as Righteous Fury being permanently added to caster
             uint32 dur = std::min(2u * MINUTE * IN_MILLISECONDS, uint32(aura->GetDuration()));
 
-            if (Aura* oldAura = stealer->GetAura(aura->GetId(), aura->GetCasterGUID()))
+            if (Aura* oldAura = stealer->GetAura(aura->GetId(), aura->GetCaster()))
             {
                 if (stealCharge)
                     oldAura->ModCharges(1);
@@ -4085,7 +4085,7 @@ void Unit::RemoveAurasDueToSpellBySteal(uint32 spellId, ObjectGuid casterGUID, U
                 if (aura->IsSingleTarget())
                     aura->UnregisterSingleTarget();
 
-                if (Aura* newAura = Aura::TryRefreshStackOrCreate(aura->GetSpellInfo(), effMask, stealer, nullptr, &baseDamage[0], nullptr, aura->GetCasterGUID()))
+                if (Aura* newAura = Aura::TryRefreshStackOrCreate(aura->GetSpellInfo(), effMask, stealer, nullptr, &baseDamage[0], nullptr, aura->GetCaster()))
                 {
                     // created aura must not be single target aura,, so stealer won't loose it on recast
                     if (newAura->IsSingleTarget())
@@ -4136,7 +4136,7 @@ void Unit::RemoveAurasByType(AuraType auraType, ObjectGuid casterGUID, Aura* exc
         ASSERT(aurApp);
 
         ++iter;
-        if (aura != except && (!casterGUID || aura->GetCasterGUID() == casterGUID)
+        if (aura != except && (!casterGUID || aura->GetCaster() == casterGUID)
             && ((negative && !aurApp->IsPositive()) || (positive && aurApp->IsPositive())))
         {
             uint32 removedAuras = m_removedAurasCount;
@@ -4174,7 +4174,7 @@ void Unit::RemoveNotOwnSingleTargetAuras(uint32 newPhase)
     {
         Aura const* aura = iter->second;
 
-        if (aura->GetCasterGUID() != GetGUID() && aura->IsSingleTarget())
+        if (aura->GetCaster() != GetGUID() && aura->IsSingleTarget())
         {
             if (!newPhase)
                 RemoveOwnedAura(iter);
@@ -4240,7 +4240,7 @@ void Unit::RemoveAurasWithFamily(SpellFamilyNames family, uint32 familyFlag1, ui
     for (AuraApplicationMap::iterator iter = m_appliedAuras.begin(); iter != m_appliedAuras.end();)
     {
         Aura const* aura = iter->second->GetBase();
-        if (!casterGUID || aura->GetCasterGUID() == casterGUID)
+        if (!casterGUID || aura->GetCaster() == casterGUID)
         {
             SpellInfo const* spell = aura->GetSpellInfo();
             if (spell->SpellFamilyName == uint32(family) && spell->SpellFamilyFlags.HasFlag(familyFlag1, familyFlag2, familyFlag3))
@@ -4473,7 +4473,7 @@ void Unit::RemoveAllGroupBuffsFromCaster(ObjectGuid casterGUID)
     for (AuraMap::iterator iter = m_ownedAuras.begin(); iter != m_ownedAuras.end();)
     {
         Aura* aura = iter->second;
-        if (aura->GetCasterGUID() == casterGUID && aura->GetSpellInfo()->IsGroupBuff())
+        if (aura->GetCaster() == casterGUID && aura->GetSpellInfo()->IsGroupBuff())
         {
             RemoveOwnedAura(iter);
             continue;
@@ -4488,7 +4488,7 @@ void Unit::DelayOwnedAuras(uint32 spellId, ObjectGuid caster, int32 delaytime)
     for (; range.first != range.second; ++range.first)
     {
         Aura* aura = range.first->second;
-        if (!caster || aura->GetCasterGUID() == caster)
+        if (!caster || aura->GetCaster() == caster)
         {
             if (aura->GetDuration() < delaytime)
                 aura->SetDuration(0);
@@ -4520,7 +4520,7 @@ AuraEffect* Unit::GetAuraEffect(uint32 spellId, uint8 effIndex, ObjectGuid caste
     for (AuraApplicationMap::const_iterator itr = range.first; itr != range.second; ++itr)
     {
         if (itr->second->HasEffect(effIndex)
-                && (!caster || itr->second->GetBase()->GetCasterGUID() == caster))
+                && (!caster || itr->second->GetBase()->GetCaster() == caster))
         {
             return itr->second->GetBase()->GetEffect(effIndex);
         }
@@ -4562,7 +4562,7 @@ AuraEffect* Unit::GetAuraEffect(AuraType type, SpellFamilyNames family, uint32 f
         SpellInfo const* spell = (*i)->GetSpellInfo();
         if (spell->SpellFamilyName == uint32(family) && spell->SpellFamilyFlags.HasFlag(familyFlag1, familyFlag2, familyFlag3))
         {
-            if (casterGUID && (*i)->GetCasterGUID() != casterGUID)
+            if (casterGUID && (*i)->GetCaster() != casterGUID)
                 continue;
             return (*i);
         }
@@ -4584,7 +4584,7 @@ AuraApplication * Unit::GetAuraApplication(uint32 spellId, ObjectGuid casterGUID
         Aura const* aura = app->GetBase();
 
         if (((aura->GetEffectMask() & reqEffMask) == reqEffMask)
-                && (!casterGUID || aura->GetCasterGUID() == casterGUID)
+                && (!casterGUID || aura->GetCaster() == casterGUID)
                 && (!itemCasterGUID || aura->GetCastItemGUID() == itemCasterGUID)
                 && (!except || except != app))
         {
@@ -4666,7 +4666,7 @@ bool Unit::HasAuraEffect(uint32 spellId, uint8 effIndex, ObjectGuid caster) cons
     for (AuraApplicationMap::const_iterator itr = range.first; itr != range.second; ++itr)
     {
         if (itr->second->HasEffect(effIndex)
-                && (!caster || itr->second->GetBase()->GetCasterGUID() == caster))
+                && (!caster || itr->second->GetBase()->GetCaster() == caster))
         {
             return true;
         }
@@ -4706,7 +4706,7 @@ bool Unit::HasAuraTypeWithCaster(AuraType auratype, ObjectGuid caster) const
 {
     AuraEffectList const& mTotalAuraList = GetAuraEffectsByType(auratype);
     for (AuraEffectList::const_iterator i = mTotalAuraList.begin(); i != mTotalAuraList.end(); ++i)
-        if (caster == (*i)->GetCasterGUID())
+        if (caster == (*i)->GetCaster())
             return true;
     return false;
 }
@@ -4744,7 +4744,7 @@ bool Unit::HasNegativeAuraWithInterruptFlag(uint32 flag, ObjectGuid guid) const
         return false;
     for (AuraApplicationList::const_iterator iter = m_interruptableAuras.begin(); iter != m_interruptableAuras.end(); ++iter)
     {
-        if (!(*iter)->IsPositive() && (*iter)->GetBase()->GetSpellInfo()->AuraInterruptFlags & flag && (!guid || (*iter)->GetBase()->GetCasterGUID() == guid))
+        if (!(*iter)->IsPositive() && (*iter)->GetBase()->GetSpellInfo()->AuraInterruptFlags & flag && (!guid || (*iter)->GetBase()->GetCaster() == guid))
             return true;
     }
     return false;
@@ -4814,13 +4814,13 @@ uint32 Unit::GetDiseasesByCaster(ObjectGuid casterGUID, bool remove)
         {
             // Get auras with disease dispel type by caster
             if ((*itr)->GetSpellInfo()->Dispel == DISPEL_DISEASE
-                && (*itr)->GetCasterGUID() == casterGUID)
+                && (*itr)->GetCaster() == casterGUID)
             {
                 ++diseases;
 
                 if (remove)
                 {
-                    RemoveAura((*itr)->GetId(), (*itr)->GetCasterGUID());
+                    RemoveAura((*itr)->GetId(), (*itr)->GetCaster());
                     itr = m_modAuras[aType].begin();
                     continue;
                 }
@@ -4847,7 +4847,7 @@ uint32 Unit::GetDoTsByCaster(ObjectGuid casterGUID) const
         for (AuraEffectList::const_iterator i = auras.begin(); i != auras.end(); ++i)
         {
             // Get auras by caster
-            if ((*i)->GetCasterGUID() == casterGUID)
+            if ((*i)->GetCaster() == casterGUID)
                 ++dots;
         }
     }
@@ -5376,7 +5376,7 @@ void Unit::SendPeriodicAuraLog(SpellPeriodicAuraLogInfo* pInfo)
 
     WorldPacket data(SMSG_PERIODICAURALOG, 30);
     data << GetPackGUID();
-    data << aura->GetCasterGUID().WriteAsPacked();
+    data << aura->GetCaster().WriteAsPacked();
     data << uint32(aura->GetId());                          // spellId
     data << uint32(1);                                      // count
     data << uint32(aura->GetAuraType());                    // auraId
@@ -6075,7 +6075,7 @@ void Unit::ModifyAuraState(AuraStateType flag, bool apply)
             for (Unit::AuraApplicationMap::iterator itr = tAuras.begin(); itr != tAuras.end();)
             {
                 SpellInfo const* spellProto = itr->second->GetBase()->GetSpellInfo();
-                if (itr->second->GetBase()->GetCasterGUID() == GetGUID() && spellProto->CasterAuraState == uint32(flag) && (spellProto->IsPassive() || flag != AURA_STATE_ENRAGE))
+                if (itr->second->GetBase()->GetCaster() == GetGUID() && spellProto->CasterAuraState == uint32(flag) && (spellProto->IsPassive() || flag != AURA_STATE_ENRAGE))
                     RemoveAura(itr);
                 else
                     ++itr;
@@ -6089,7 +6089,7 @@ uint32 Unit::BuildAuraStateUpdateForTarget(Unit* target) const
     uint32 auraStates = GetUInt32Value(UNIT_FIELD_AURASTATE) &~(PER_CASTER_AURA_STATE_MASK);
     for (AuraStateAurasMap::const_iterator itr = m_auraStateAuras.begin(); itr != m_auraStateAuras.end(); ++itr)
         if ((1 << (itr->first - 1)) & PER_CASTER_AURA_STATE_MASK)
-            if (itr->second->GetBase()->GetCasterGUID() == target->GetGUID())
+            if (itr->second->GetBase()->GetCaster() == target->GetGUID())
                 auraStates |= (1 << (itr->first - 1));
 
     return auraStates;
@@ -6111,7 +6111,7 @@ bool Unit::HasAuraState(AuraStateType flag, SpellInfo const* spellProto, Unit co
         {
             AuraStateAurasMapBounds range = m_auraStateAuras.equal_range(flag);
             for (AuraStateAurasMap::const_iterator itr = range.first; itr != range.second; ++itr)
-                if (itr->second->GetBase()->GetCasterGUID() == Caster->GetGUID())
+                if (itr->second->GetBase()->GetCaster() == Caster->GetGUID())
                     return true;
             return false;
         }
@@ -7179,7 +7179,7 @@ float Unit::SpellDamagePctDone(Unit* victim, SpellInfo const* spellProto, Damage
                 Unit::AuraEffectList const& auras = victim->GetAuraEffectsByType(SPELL_AURA_PERIODIC_DAMAGE);
                 for (Unit::AuraEffectList::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
                 {
-                    if (((*itr)->GetId() == 31803 || (*itr)->GetId() == 53742) && (*itr)->GetCasterGUID() == GetGUID())
+                    if (((*itr)->GetId() == 31803 || (*itr)->GetId() == 53742) && (*itr)->GetCaster() == GetGUID())
                     {
                         stacks = (*itr)->GetBase()->GetStackAmount();
                         break;
@@ -7293,7 +7293,7 @@ uint32 Unit::SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, ui
         {
             TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_FROM_CASTER, [caster, spellProto](AuraEffect const* aurEff) -> bool
             {
-                if (aurEff->GetCasterGUID() == caster->GetGUID() && aurEff->IsAffectedOnSpell(spellProto))
+                if (aurEff->GetCaster() == caster->GetGUID() && aurEff->IsAffectedOnSpell(spellProto))
                     return true;
                 return false;
             });
@@ -7598,7 +7598,7 @@ float Unit::SpellCritChanceTaken(Unit const* caster, SpellInfo const* spellInfo,
     {
         crit_chance += GetTotalAuraModifier(SPELL_AURA_MOD_CRIT_CHANCE_FOR_CASTER, [caster, spellInfo](AuraEffect const* aurEff) -> bool
         {
-            if (aurEff->GetCasterGUID() == caster->GetGUID() && aurEff->IsAffectedOnSpell(spellInfo))
+            if (aurEff->GetCaster() == caster->GetGUID() && aurEff->IsAffectedOnSpell(spellInfo))
                 return true;
             return false;
         });
@@ -7868,7 +7868,7 @@ float Unit::SpellHealingPctDone(Unit* victim, SpellInfo const* spellProto) const
                 for (AuraApplicationMap::const_iterator itr = victimAuras.begin(); itr != victimAuras.end(); ++itr)
                 {
                     Aura const* aura = itr->second->GetBase();
-                    if (aura->GetCasterGUID() != GetGUID())
+                    if (aura->GetCaster() != GetGUID())
                         continue;
 
                     SpellInfo const* m_spell = aura->GetSpellInfo();
@@ -7970,7 +7970,7 @@ uint32 Unit::SpellHealingBonusTaken(Unit* caster, SpellInfo const* spellProto, u
     {
         TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_HEALING_RECEIVED, [caster, spellProto](AuraEffect const* aurEff) -> bool
         {
-            if (caster->GetGUID() == aurEff->GetCasterGUID() && aurEff->IsAffectedOnSpell(spellProto))
+            if (caster->GetGUID() == aurEff->GetCaster() && aurEff->IsAffectedOnSpell(spellProto))
                 return true;
             return false;
         });
@@ -8412,7 +8412,7 @@ uint32 Unit::MeleeDamageBonusTaken(Unit* attacker, uint32 pdamage, WeaponAttackT
         // From caster spells
         TakenTotalMod *= GetTotalAuraMultiplier(SPELL_AURA_MOD_DAMAGE_FROM_CASTER, [attacker, spellProto](AuraEffect const* aurEff) -> bool
         {
-            if (aurEff->GetCasterGUID() == attacker->GetGUID() && aurEff->IsAffectedOnSpell(spellProto))
+            if (aurEff->GetCaster() == attacker->GetGUID() && aurEff->IsAffectedOnSpell(spellProto))
                 return true;
             return false;
         });
@@ -12208,7 +12208,7 @@ void Unit::SetFeared(bool apply)
         Unit* caster = nullptr;
         Unit::AuraEffectList const& fearAuras = GetAuraEffectsByType(SPELL_AURA_MOD_FEAR);
         if (!fearAuras.empty())
-            caster = ObjectAccessor::GetUnit(*this, fearAuras.front()->GetCasterGUID());
+            caster = ObjectAccessor::GetUnit(*this, fearAuras.front()->GetCaster());
         if (!caster)
             caster = getAttackerForHelper();
         GetMotionMaster()->MoveFleeing(caster, fearAuras.empty() ? sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_FLEE_DELAY) : 0);             // caster == NULL processed in MoveFleeing
@@ -13463,7 +13463,7 @@ void Unit::ChangeSeat(int8 seatId, bool next)
     AuraEffectList const& vehicleAuras = m_vehicle->GetBase()->GetAuraEffectsByType(SPELL_AURA_CONTROL_VEHICLE);
     for (AuraEffectList::const_iterator itr = vehicleAuras.begin(); itr != vehicleAuras.end(); ++itr)
     {
-        if ((*itr)->GetCasterGUID() != GetGUID())
+        if ((*itr)->GetCaster() != GetGUID())
             continue;
 
         // Make sure there is only one ride vehicle aura on target cast by the unit changing seat
@@ -13865,7 +13865,7 @@ uint32 Unit::GetRemainingPeriodicAmount(ObjectGuid caster, uint32 spellId, AuraT
     AuraEffectList const& periodicAuras = GetAuraEffectsByType(auraType);
     for (AuraEffect const* aurEff : periodicAuras)
     {
-        if (aurEff->GetCasterGUID() != caster || aurEff->GetId() != spellId || aurEff->GetEffIndex() != effectIndex || !aurEff->GetTotalTicks())
+        if (aurEff->GetCaster() != caster || aurEff->GetId() != spellId || aurEff->GetEffIndex() != effectIndex || !aurEff->GetTotalTicks())
             continue;
         amount += uint32((aurEff->GetAmount() * static_cast<int32>(aurEff->GetRemainingTicks())) / aurEff->GetTotalTicks());
         break;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4181,7 +4181,7 @@ void Unit::RemoveNotOwnSingleTargetAuras(uint32 newPhase)
             else
             {
                 Unit* caster = aura->GetCaster();
-                if (!caster || !caster->IsInAnyPhase(newPhase))
+                if (!caster || !caster->InSamePhase(newPhase))
                     RemoveOwnedAura(iter);
                 else
                     ++iter;
@@ -4196,7 +4196,7 @@ void Unit::RemoveNotOwnSingleTargetAuras(uint32 newPhase)
     for (AuraList::iterator iter = scAuras.begin(); iter != scAuras.end();)
     {
         Aura* aura = *iter;
-        if (aura->GetUnitOwner() != this && !aura->GetUnitOwner()->IsInAnyPhase(newPhase))
+        if (aura->GetUnitOwner() != this && !aura->GetUnitOwner()->InSamePhase(newPhase))
         {
             aura->Remove();
             iter = scAuras.begin();

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -19,11 +19,12 @@
 #ifndef __UNIT_H
 #define __UNIT_H
 
-#include "Object.h"
+#include "CombatManager.h"
 #include "EventProcessor.h"
 #include "FollowerReference.h"
 #include "FollowerRefManager.h"
-#include "CombatManager.h"
+#include "MemoryOf.h"
+#include "Object.h"
 #include "OptionalFwd.h"
 #include "SpellAuraDefines.h"
 #include "SpellDefines.h"
@@ -933,7 +934,7 @@ class TC_GAME_API Unit : public WorldObject
 
         uint32 GetMaxSkillValueForLevel(Unit const* target = nullptr) const { return (target ? getLevelForTarget(target) : getLevel()) * 5; }
         static void DealDamageMods(Unit const* victim, uint32& damage, uint32* absorb);
-        static uint32 DealDamage(Unit* attacker, Unit* victim, uint32 damage, CleanDamage const* cleanDamage = nullptr, DamageEffectType damagetype = DIRECT_DAMAGE, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NORMAL, SpellInfo const* spellProto = nullptr, bool durabilityLoss = true);
+        static uint32 DealDamage(MemoryOf<Unit> const& attacker, Unit* victim, uint32 damage, CleanDamage const* cleanDamage = nullptr, DamageEffectType damagetype = DIRECT_DAMAGE, SpellSchoolMask damageSchoolMask = SPELL_SCHOOL_MASK_NORMAL, SpellInfo const* spellProto = nullptr, bool durabilityLoss = true);
         static void Kill(Unit* attacker, Unit* victim, bool durabilityLoss = true);
         void KillSelf(bool durabilityLoss = true) { Unit::Kill(this, this, durabilityLoss); }
         static void DealHeal(HealInfo& healInfo);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -436,7 +436,7 @@ class TC_GAME_API DamageInfo
 class TC_GAME_API HealInfo
 {
     private:
-        Unit* const _healer;
+        MemoryOf<Unit> const _healer;
         Unit* const _target;
         uint32 _heal;
         uint32 _effectiveHeal;
@@ -446,12 +446,12 @@ class TC_GAME_API HealInfo
         uint32 _hitMask;
 
     public:
-        HealInfo(Unit* healer, Unit* target, uint32 heal, SpellInfo const* spellInfo, SpellSchoolMask schoolMask);
+        HealInfo(MemoryOf<Unit> const& healer, Unit* target, uint32 heal, SpellInfo const* spellInfo, SpellSchoolMask schoolMask);
 
         void AbsorbHeal(uint32 amount);
         void SetEffectiveHeal(uint32 amount) { _effectiveHeal = amount; }
 
-        Unit* GetHealer() const { return _healer; }
+        MemoryOf<Unit> const& GetHealer() const { return _healer; }
         Unit* GetTarget() const { return _target; }
         uint32 GetHeal() const { return _heal; }
         uint32 GetEffectiveHeal() const { return _effectiveHeal; }

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -256,7 +256,7 @@ void MessageDistDeliverer::Visit(PlayerMapType &m)
     for (PlayerMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Player* target = iter->GetSource();
-        if (!target->IsInAnyPhase(i_phaseMask))
+        if (!target->InSamePhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -281,7 +281,7 @@ void MessageDistDeliverer::Visit(CreatureMapType &m)
     for (CreatureMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Creature* target = iter->GetSource();
-        if (!target->IsInAnyPhase(i_phaseMask))
+        if (!target->InSamePhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -303,7 +303,7 @@ void MessageDistDeliverer::Visit(DynamicObjectMapType &m)
     for (DynamicObjectMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         DynamicObject* target = iter->GetSource();
-        if (!target->IsInAnyPhase(i_phaseMask))
+        if (!target->InSamePhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -324,7 +324,7 @@ void MessageDistDelivererToHostile::Visit(PlayerMapType &m)
     for (PlayerMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Player* target = iter->GetSource();
-        if (!target->IsInAnyPhase(i_phaseMask))
+        if (!target->InSamePhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -349,7 +349,7 @@ void MessageDistDelivererToHostile::Visit(CreatureMapType &m)
     for (CreatureMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Creature* target = iter->GetSource();
-        if (!target->IsInAnyPhase(i_phaseMask))
+        if (!target->InSamePhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -371,7 +371,7 @@ void MessageDistDelivererToHostile::Visit(DynamicObjectMapType &m)
     for (DynamicObjectMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         DynamicObject* target = iter->GetSource();
-        if (!target->IsInAnyPhase(i_phaseMask))
+        if (!target->InSamePhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -256,7 +256,7 @@ void MessageDistDeliverer::Visit(PlayerMapType &m)
     for (PlayerMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Player* target = iter->GetSource();
-        if (!target->InSamePhase(i_phaseMask))
+        if (!target->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -281,7 +281,7 @@ void MessageDistDeliverer::Visit(CreatureMapType &m)
     for (CreatureMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Creature* target = iter->GetSource();
-        if (!target->InSamePhase(i_phaseMask))
+        if (!target->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -303,7 +303,7 @@ void MessageDistDeliverer::Visit(DynamicObjectMapType &m)
     for (DynamicObjectMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         DynamicObject* target = iter->GetSource();
-        if (!target->InSamePhase(i_phaseMask))
+        if (!target->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -324,7 +324,7 @@ void MessageDistDelivererToHostile::Visit(PlayerMapType &m)
     for (PlayerMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Player* target = iter->GetSource();
-        if (!target->InSamePhase(i_phaseMask))
+        if (!target->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -349,7 +349,7 @@ void MessageDistDelivererToHostile::Visit(CreatureMapType &m)
     for (CreatureMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         Creature* target = iter->GetSource();
-        if (!target->InSamePhase(i_phaseMask))
+        if (!target->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)
@@ -371,7 +371,7 @@ void MessageDistDelivererToHostile::Visit(DynamicObjectMapType &m)
     for (DynamicObjectMapType::iterator iter = m.begin(); iter != m.end(); ++iter)
     {
         DynamicObject* target = iter->GetSource();
-        if (!target->InSamePhase(i_phaseMask))
+        if (!target->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (target->GetExactDist2dSq(i_source) > i_distSq)

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -291,7 +291,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_GAMEOBJECT))
                 return;
             for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -300,7 +300,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_PLAYER))
                 return;
             for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
         void Visit(CreatureMapType &m)
@@ -308,7 +308,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_CREATURE))
                 return;
             for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -317,7 +317,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_CORPSE))
                 return;
             for (CorpseMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -326,7 +326,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_DYNAMICOBJECT))
                 return;
             for (DynamicObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -391,7 +391,7 @@ namespace Trinity
         void Visit(GameObjectMapType& m)
         {
             for (GameObjectMapType::iterator itr = m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(_phaseMask))
                     _func(itr->GetSource());
         }
 
@@ -517,7 +517,7 @@ namespace Trinity
         void Visit(CreatureMapType &m)
         {
             for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -590,7 +590,7 @@ namespace Trinity
         void Visit(PlayerMapType &m)
         {
             for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->InSamePhase(i_phaseMask))
+                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -291,7 +291,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_GAMEOBJECT))
                 return;
             for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -300,7 +300,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_PLAYER))
                 return;
             for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
         void Visit(CreatureMapType &m)
@@ -308,7 +308,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_CREATURE))
                 return;
             for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -317,7 +317,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_CORPSE))
                 return;
             for (CorpseMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -326,7 +326,7 @@ namespace Trinity
             if (!(i_mapTypeMask & GRID_MAP_TYPE_MASK_DYNAMICOBJECT))
                 return;
             for (DynamicObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -391,7 +391,7 @@ namespace Trinity
         void Visit(GameObjectMapType& m)
         {
             for (GameObjectMapType::iterator itr = m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(_phaseMask))
+                if (itr->GetSource()->InSamePhase(_phaseMask))
                     _func(itr->GetSource());
         }
 
@@ -517,7 +517,7 @@ namespace Trinity
         void Visit(CreatureMapType &m)
         {
             for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 
@@ -590,7 +590,7 @@ namespace Trinity
         void Visit(PlayerMapType &m)
         {
             for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-                if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+                if (itr->GetSource()->InSamePhase(i_phaseMask))
                     i_do(itr->GetSource());
         }
 

--- a/src/server/game/Grids/Notifiers/GridNotifiersImpl.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiersImpl.h
@@ -54,7 +54,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(GameObjectMapType &m)
 
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -77,7 +77,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -100,7 +100,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -123,7 +123,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(CorpseMapType &m)
 
     for (CorpseMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -146,7 +146,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(DynamicObjectMapType &m)
 
     for (DynamicObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -166,7 +166,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(GameObjectMapType &m)
 
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -182,7 +182,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -198,7 +198,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -214,7 +214,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(CorpseMapType &m)
 
     for (CorpseMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -230,7 +230,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(DynamicObjectMapType &m)
 
     for (DynamicObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -304,7 +304,7 @@ void Trinity::GameObjectSearcher<Check>::Visit(GameObjectMapType &m)
 
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -320,7 +320,7 @@ void Trinity::GameObjectLastSearcher<Check>::Visit(GameObjectMapType &m)
 {
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -332,7 +332,7 @@ template<class Check>
 void Trinity::GameObjectListSearcher<Check>::Visit(GameObjectMapType &m)
 {
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (itr->GetSource()->InSamePhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -348,7 +348,7 @@ void Trinity::UnitSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -368,7 +368,7 @@ void Trinity::UnitSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -384,7 +384,7 @@ void Trinity::UnitLastSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -397,7 +397,7 @@ void Trinity::UnitLastSearcher<Check>::Visit(PlayerMapType &m)
 {
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -409,7 +409,7 @@ template<class Check>
 void Trinity::UnitListSearcher<Check>::Visit(PlayerMapType &m)
 {
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (itr->GetSource()->InSamePhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -418,7 +418,7 @@ template<class Check>
 void Trinity::UnitListSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (itr->GetSource()->InSamePhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -434,7 +434,7 @@ void Trinity::CreatureSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -450,7 +450,7 @@ void Trinity::CreatureLastSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -462,7 +462,7 @@ template<class Check>
 void Trinity::CreatureListSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (itr->GetSource()->InSamePhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -471,7 +471,7 @@ template<class Check>
 void Trinity::PlayerListSearcher<Check>::Visit(PlayerMapType &m)
 {
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (itr->GetSource()->InSamePhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -485,7 +485,7 @@ void Trinity::PlayerSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -501,7 +501,7 @@ void Trinity::PlayerLastSearcher<Check>::Visit(PlayerMapType& m)
 {
     for (PlayerMapType::iterator itr = m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
+        if (!itr->GetSource()->InSamePhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))

--- a/src/server/game/Grids/Notifiers/GridNotifiersImpl.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiersImpl.h
@@ -54,7 +54,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(GameObjectMapType &m)
 
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -77,7 +77,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -100,7 +100,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -123,7 +123,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(CorpseMapType &m)
 
     for (CorpseMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -146,7 +146,7 @@ void Trinity::WorldObjectSearcher<Check>::Visit(DynamicObjectMapType &m)
 
     for (DynamicObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -166,7 +166,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(GameObjectMapType &m)
 
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -182,7 +182,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -198,7 +198,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -214,7 +214,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(CorpseMapType &m)
 
     for (CorpseMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -230,7 +230,7 @@ void Trinity::WorldObjectLastSearcher<Check>::Visit(DynamicObjectMapType &m)
 
     for (DynamicObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -304,7 +304,7 @@ void Trinity::GameObjectSearcher<Check>::Visit(GameObjectMapType &m)
 
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -320,7 +320,7 @@ void Trinity::GameObjectLastSearcher<Check>::Visit(GameObjectMapType &m)
 {
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -332,7 +332,7 @@ template<class Check>
 void Trinity::GameObjectListSearcher<Check>::Visit(GameObjectMapType &m)
 {
     for (GameObjectMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->InSamePhase(i_phaseMask))
+        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -348,7 +348,7 @@ void Trinity::UnitSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -368,7 +368,7 @@ void Trinity::UnitSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -384,7 +384,7 @@ void Trinity::UnitLastSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -397,7 +397,7 @@ void Trinity::UnitLastSearcher<Check>::Visit(PlayerMapType &m)
 {
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -409,7 +409,7 @@ template<class Check>
 void Trinity::UnitListSearcher<Check>::Visit(PlayerMapType &m)
 {
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->InSamePhase(i_phaseMask))
+        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -418,7 +418,7 @@ template<class Check>
 void Trinity::UnitListSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->InSamePhase(i_phaseMask))
+        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -434,7 +434,7 @@ void Trinity::CreatureSearcher<Check>::Visit(CreatureMapType &m)
 
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -450,7 +450,7 @@ void Trinity::CreatureLastSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -462,7 +462,7 @@ template<class Check>
 void Trinity::CreatureListSearcher<Check>::Visit(CreatureMapType &m)
 {
     for (CreatureMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->InSamePhase(i_phaseMask))
+        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -471,7 +471,7 @@ template<class Check>
 void Trinity::PlayerListSearcher<Check>::Visit(PlayerMapType &m)
 {
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
-        if (itr->GetSource()->InSamePhase(i_phaseMask))
+        if (itr->GetSource()->IsInAnyPhase(i_phaseMask))
             if (i_check(itr->GetSource()))
                 Insert(itr->GetSource());
 }
@@ -485,7 +485,7 @@ void Trinity::PlayerSearcher<Check>::Visit(PlayerMapType &m)
 
     for (PlayerMapType::iterator itr=m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))
@@ -501,7 +501,7 @@ void Trinity::PlayerLastSearcher<Check>::Visit(PlayerMapType& m)
 {
     for (PlayerMapType::iterator itr = m.begin(); itr != m.end(); ++itr)
     {
-        if (!itr->GetSource()->InSamePhase(i_phaseMask))
+        if (!itr->GetSource()->IsInAnyPhase(i_phaseMask))
             continue;
 
         if (i_check(itr->GetSource()))

--- a/src/server/game/Petitions/PetitionMgr.cpp
+++ b/src/server/game/Petitions/PetitionMgr.cpp
@@ -232,7 +232,7 @@ void Petition::AddSignature(uint32 accountId, ObjectGuid playerGuid, bool isLoad
 
     stmt->setUInt32(0, OwnerGuid.GetCounter());
     stmt->setUInt32(1, PetitionGuid.GetCounter());
-    stmt->setUInt32(2, playerGuid);
+    stmt->setUInt32(2, playerGuid.GetCounter());
     stmt->setUInt32(3, accountId);
 
     CharacterDatabase.Execute(stmt);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -839,7 +839,7 @@ void AuraEffect::SendTickImmune(Unit* target, Unit* caster) const
         caster->SendSpellDamageImmune(target, m_spellInfo->Id);
 }
 
-void AuraEffect::PeriodicTick(AuraApplication* aurApp, Unit* caster) const
+void AuraEffect::PeriodicTick(AuraApplication* aurApp, MemoryOf<Unit> const& caster) const
 {
     bool prevented = GetBase()->CallScriptEffectPeriodicHandlers(this, aurApp);
     if (prevented)
@@ -5076,7 +5076,7 @@ void AuraEffect::HandlePeriodicTriggerSpellWithValueAuraTick(Unit* target, Unit*
         TC_LOG_WARN("spells","AuraEffect::HandlePeriodicTriggerSpellWithValueAuraTick: Spell %u has non-existent spell %u in EffectTriggered[%d] and is therefore not triggered.", GetId(), triggerSpellId, GetEffIndex());
 }
 
-void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
+void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, MemoryOf<Unit> const& caster) const
 {
     if (!target->IsAlive())
         return;
@@ -5090,7 +5090,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const
     // Consecrate ticks can miss and will not show up in the combat log
     // dynobj auras must always have a caster
     if (GetSpellInfo()->Effects[GetEffIndex()].Effect == SPELL_EFFECT_PERSISTENT_AREA_AURA &&
-        ASSERT_NOTNULL(caster)->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
+        caster->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
         return;
 
     CleanDamage cleanDamage = CleanDamage(0, 0, BASE_ATTACK, MELEE_HIT_NORMAL);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5220,7 +5220,7 @@ void AuraEffect::HandlePeriodicDamageAurasTick(Unit* target, MemoryOf<Unit> cons
     Unit::ProcSkillsAndAuras(caster, target, procAttacker, procVictim, PROC_SPELL_TYPE_DAMAGE, PROC_SPELL_PHASE_HIT, hitMask, nullptr, &damageInfo, nullptr);
 }
 
-void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) const
+void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, MemoryOf<Unit> const& caster) const
 {
     if (!target->IsAlive())
         return;
@@ -5233,7 +5233,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     // dynobj auras must always have a caster
     if (GetSpellInfo()->Effects[GetEffIndex()].Effect == SPELL_EFFECT_PERSISTENT_AREA_AURA &&
-        ASSERT_NOTNULL(caster)->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
+        caster->SpellHitResult(target, GetSpellInfo(), false) != SPELL_MISS_NONE)
         return;
 
     CleanDamage cleanDamage = CleanDamage(0, 0, GetSpellInfo()->GetAttackType(), MELEE_HIT_NORMAL);
@@ -5246,7 +5246,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
 
     // dynobj auras must always have a caster
     if (GetBase()->GetType() == DYNOBJ_AURA_TYPE)
-        damage = ASSERT_NOTNULL(caster)->SpellDamageBonusDone(target, GetSpellInfo(), damage, DOT, { }, GetBase()->GetStackAmount());
+        damage = caster->SpellDamageBonusDone(target, GetSpellInfo(), damage, DOT, { }, GetBase()->GetStackAmount());
     damage = target->SpellDamageBonusTaken(caster, GetSpellInfo(), damage, DOT, GetBase()->GetStackAmount());
 
     bool crit = roll_chance_f(GetCritChanceFor(caster, target));
@@ -5344,7 +5344,7 @@ void AuraEffect::HandlePeriodicHealthFunnelAuraTick(Unit* target, Unit* caster) 
     Unit::ProcSkillsAndAuras(caster, target, PROC_FLAG_DONE_PERIODIC, PROC_FLAG_TAKEN_PERIODIC, PROC_SPELL_TYPE_HEAL, PROC_SPELL_PHASE_HIT, PROC_HIT_NORMAL, nullptr, nullptr, &healInfo);
 }
 
-void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const
+void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, MemoryOf<Unit> const& caster) const
 {
     if (!target->IsAlive())
         return;
@@ -5375,7 +5375,7 @@ void AuraEffect::HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const
     {
         // dynobj auras must always have a caster
         if (GetBase()->GetType() == DYNOBJ_AURA_TYPE)
-            damage = ASSERT_NOTNULL(caster)->SpellHealingBonusDone(target, GetSpellInfo(), damage, DOT, { }, GetBase()->GetStackAmount());
+            damage = caster->SpellHealingBonusDone(target, GetSpellInfo(), damage, DOT, { }, GetBase()->GetStackAmount());
     }
 
     damage = target->SpellHealingBonusTaken(caster, GetSpellInfo(), damage, DOT, GetBase()->GetStackAmount());
@@ -5540,7 +5540,7 @@ void AuraEffect::HandleObsModPowerAuraTick(Unit* target, Unit* caster) const
         target->GetThreatManager().ForwardThreatForAssistingMe(caster, float(gain)*0.5f, GetSpellInfo(), true);
 }
 
-void AuraEffect::HandlePeriodicEnergizeAuraTick(Unit* target, Unit* caster) const
+void AuraEffect::HandlePeriodicEnergizeAuraTick(Unit* target, MemoryOf<Unit> const& caster) const
 {
     Powers powerType = Powers(GetMiscValue());
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -87,7 +87,7 @@ class TC_GAME_API AuraEffect
         bool HasSpellClassMask() const { return m_spellInfo->Effects[m_effIndex].SpellClassMask; }
 
         void SendTickImmune(Unit* target, Unit* caster) const;
-        void PeriodicTick(AuraApplication* aurApp, Unit* caster) const;
+        void PeriodicTick(AuraApplication* aurApp, MemoryOf<Unit> const& caster) const;
 
         bool CheckEffectProc(AuraApplication* aurApp, ProcEventInfo& eventInfo) const;
         void HandleProc(AuraApplication* aurApp, ProcEventInfo& eventInfo);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -36,8 +36,7 @@ class TC_GAME_API AuraEffect
         ~AuraEffect();
         explicit AuraEffect(Aura* base, uint8 effIndex, int32 *baseAmount, Unit* caster);
     public:
-        Unit* GetCaster() const { return GetBase()->GetCaster(); }
-        ObjectGuid GetCasterGUID() const { return GetBase()->GetCasterGUID(); }
+        MemoryOf<Unit> const& GetCaster() const { return GetBase()->GetCaster(); }
         Aura* GetBase() const { return m_base; }
 
         template <typename Container>
@@ -73,7 +72,7 @@ class TC_GAME_API AuraEffect
         void HandleEffect(Unit* target, uint8 mode, bool apply);
         void ApplySpellMod(Unit* target, bool apply);
 
-        void Update(uint32 diff, Unit* caster);
+        void Update(uint32 diff, MemoryOf<Unit> const& caster);
 
         uint32 GetTickNumber() const { return _ticksDone; }
         uint32 GetRemainingTicks() const { return GetTotalTicks() - _ticksDone; }
@@ -292,7 +291,7 @@ class TC_GAME_API AuraEffect
         // aura effect periodic tick handlers
         void HandlePeriodicTriggerSpellAuraTick(Unit* target, Unit* caster) const;
         void HandlePeriodicTriggerSpellWithValueAuraTick(Unit* target, Unit* caster) const;
-        void HandlePeriodicDamageAurasTick(Unit* target, Unit* caster) const;
+        void HandlePeriodicDamageAurasTick(Unit* target, MemoryOf<Unit> const& caster) const;
         void HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) const;
         void HandlePeriodicHealthFunnelAuraTick(Unit* target, Unit* caster) const;
         void HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -292,12 +292,12 @@ class TC_GAME_API AuraEffect
         void HandlePeriodicTriggerSpellAuraTick(Unit* target, Unit* caster) const;
         void HandlePeriodicTriggerSpellWithValueAuraTick(Unit* target, Unit* caster) const;
         void HandlePeriodicDamageAurasTick(Unit* target, MemoryOf<Unit> const& caster) const;
-        void HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) const;
+        void HandlePeriodicHealthLeechAuraTick(Unit* target, MemoryOf<Unit> const& caster) const;
         void HandlePeriodicHealthFunnelAuraTick(Unit* target, Unit* caster) const;
-        void HandlePeriodicHealAurasTick(Unit* target, Unit* caster) const;
+        void HandlePeriodicHealAurasTick(Unit* target, MemoryOf<Unit> const& caster) const;
         void HandlePeriodicManaLeechAuraTick(Unit* target, Unit* caster) const;
         void HandleObsModPowerAuraTick(Unit* target, Unit* caster) const;
-        void HandlePeriodicEnergizeAuraTick(Unit* target, Unit* caster) const;
+        void HandlePeriodicEnergizeAuraTick(Unit* target, MemoryOf<Unit> const& caster) const;
         void HandlePeriodicPowerBurnAuraTick(Unit* target, Unit* caster) const;
         void HandleModAttackPowerOfArmorAuraTick(Unit* target, Unit* caster) const;
 

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -110,8 +110,7 @@ class TC_GAME_API Aura
         uint32 GetId() const{ return GetSpellInfo()->Id; }
 
         ObjectGuid GetCastItemGUID() const { return m_castItemGuid; }
-        ObjectGuid GetCasterGUID() const { return m_casterGuid; }
-        Unit* GetCaster() const;
+        MemoryOf<Unit> const& GetCaster() const { return m_caster; }
         WorldObject* GetOwner() const { return m_owner; }
         Unit* GetUnitOwner() const { ASSERT(GetType() == UNIT_AURA_TYPE); return (Unit*)m_owner; }
         DynamicObject* GetDynobjOwner() const { ASSERT(GetType() == DYNOBJ_AURA_TYPE); return (DynamicObject*)m_owner; }
@@ -130,8 +129,7 @@ class TC_GAME_API Aura
         void ApplyForTargets() {Unit* caster = GetCaster(); UpdateTargetMap(caster, true);}
         void _ApplyEffectForTargets(uint8 effIndex);
 
-        void UpdateOwner(uint32 diff, WorldObject* owner);
-        void Update(uint32 diff, Unit* caster);
+        void Update(uint32 diff);
 
         time_t GetApplyTime() const { return m_applyTime; }
         int32 GetMaxDuration() const { return m_maxDuration; }
@@ -173,7 +171,7 @@ class TC_GAME_API Aura
 
         bool IsRemovedOnShapeLost(Unit* target) const
         {
-            return GetCasterGUID() == target->GetGUID()
+            return GetCaster() == target->GetGUID()
                     && m_spellInfo->Stances
                     && !m_spellInfo->HasAttribute(SPELL_ATTR2_NOT_NEED_SHAPESHIFT)
                     && !m_spellInfo->HasAttribute(SPELL_ATTR0_NOT_SHAPESHIFT);
@@ -266,7 +264,7 @@ class TC_GAME_API Aura
 
     protected:
         SpellInfo const* const m_spellInfo;
-        ObjectGuid const m_casterGuid;
+        MemoryOf<Unit> m_caster;
         ObjectGuid const m_castItemGuid;                    // it is NOT safe to keep a pointer to the item because it may get deleted
         time_t const m_applyTime;
         WorldObject* const m_owner;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -21,6 +21,7 @@
 
 #include "ConditionMgr.h"
 #include "DBCEnums.h"
+#include "MemoryOf.h"
 #include "ObjectGuid.h"
 #include "Position.h"
 #include "SharedDefines.h"
@@ -144,16 +145,13 @@ class TC_GAME_API SpellCastTargets
         ObjectGuid GetCorpseTargetGUID() const;
         Corpse* GetCorpseTarget() const;
 
-        WorldObject* GetObjectTarget() const;
-        ObjectGuid GetObjectTargetGUID() const;
+        MemoryOf<WorldObject> const& GetObjectTarget() const { return m_objectTarget; }
         void RemoveObjectTarget();
 
-        ObjectGuid GetItemTargetGUID() const { return m_itemTargetGUID; }
-        Item* GetItemTarget() const { return m_itemTarget; }
+        MemoryOf<Item> const& GetItemTarget() const { return m_itemTarget; }
         uint32 GetItemTargetEntry() const { return m_itemTargetEntry; }
         void SetItemTarget(Item* item);
         void SetTradeItemTarget(Player* caster);
-        void UpdateTradeSlotItem();
 
         SpellDestination const* GetSrc() const;
         Position const* GetSrcPos() const;
@@ -194,13 +192,11 @@ class TC_GAME_API SpellCastTargets
         uint32 m_targetMask;
 
         // objects (can be used at spell creating and after Update at casting)
-        WorldObject* m_objectTarget;
-        Item* m_itemTarget;
+        MemoryOf<WorldObject> m_objectTarget;
+        MemoryOf<Item> m_itemTarget;
 
         // object GUID/etc, can be used always
         ObjectGuid m_origObjectTargetGUID;
-        ObjectGuid m_objectTargetGUID;
-        ObjectGuid m_itemTargetGUID;
         uint32 m_itemTargetEntry;
 
         SpellDestination m_src;
@@ -538,7 +534,7 @@ class TC_GAME_API Spell
         CurrentSpellTypes GetCurrentContainer() const;
 
         Unit* GetCaster() const { return m_caster; }
-        Unit* GetOriginalCaster() const { return m_originalCaster; }
+        MemoryOf<Unit> const& GetOriginalCaster() const { return m_originalCaster; }
         SpellInfo const* GetSpellInfo() const { return m_spellInfo; }
         int32 GetPowerCost() const { return m_powerCost; }
 
@@ -563,9 +559,8 @@ class TC_GAME_API Spell
 
         SpellValue* const m_spellValue;
 
-        ObjectGuid m_originalCasterGUID;                    // real source of cast (aura caster/etc), used for spell targets selection
-                                                            // e.g. damage around area spell trigered by victim aura and damage enemies of aura caster
-        Unit* m_originalCaster;                             // cached pointer for m_originalCaster, updated at Spell::UpdatePointers()
+        MemoryOf<Unit> m_originalCaster;                // real source of cast (aura caster/etc), used for spell targets selection
+                                                        // e.g. damage around area spell trigered by victim aura and damage enemies of aura caster
 
         //Spell data
         SpellSchoolMask m_spellSchoolMask;                  // Spell school (can be overwrite for some spells (wand shoot for example)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -411,7 +411,7 @@ void Spell::EffectSchoolDMG(SpellEffIndex effIndex)
                     {
                         // for caster applied auras only
                         if ((*i)->GetSpellInfo()->SpellFamilyName != SPELLFAMILY_WARLOCK ||
-                            (*i)->GetCasterGUID() != m_caster->GetGUID())
+                            (*i)->GetCaster() != m_caster->GetGUID())
                             continue;
 
                         // Immolate
@@ -1377,7 +1377,7 @@ void Spell::EffectHeal(SpellEffIndex /*effIndex*/)
 
             // Glyph of Swiftmend
             if (!caster->HasAura(54824))
-                unitTarget->RemoveAura(targetAura->GetId(), targetAura->GetCasterGUID());
+                unitTarget->RemoveAura(targetAura->GetId(), targetAura->GetCaster());
 
             //addhealth += tickheal * tickcount;
             //addhealth = caster->SpellHealingBonus(m_spellInfo, addhealth, HEAL, unitTarget);
@@ -1394,7 +1394,7 @@ void Spell::EffectHeal(SpellEffIndex /*effIndex*/)
                 Unit::AuraEffectList const& periodicHeals = unitTarget->GetAuraEffectsByType(SPELL_AURA_PERIODIC_HEAL);
                 for (AuraEffect const* hot : periodicHeals)
                 {
-                    if (m_caster->GetGUID() == hot->GetCasterGUID())
+                    if (m_caster->GetGUID() == hot->GetCaster())
                         ++auraCount;
                 }
 
@@ -2400,7 +2400,7 @@ void Spell::EffectDispel(SpellEffIndex effIndex)
         // Send dispelled spell info
         dataSuccess << uint32(itr->GetAura()->GetId());         // Spell Id
         dataSuccess << uint8(0);                                // 0 - dispelled !=0 cleansed
-        unitTarget->RemoveAurasDueToSpellByDispel(itr->GetAura()->GetId(), m_spellInfo->Id, itr->GetAura()->GetCasterGUID(), m_caster, itr->GetDispelCharges());
+        unitTarget->RemoveAurasDueToSpellByDispel(itr->GetAura()->GetId(), m_spellInfo->Id, itr->GetAura()->GetCaster(), m_caster, itr->GetDispelCharges());
     }
     m_caster->SendMessageToSet(&dataSuccess, true);
 
@@ -3478,7 +3478,7 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
                         SpellInfo const* spellInfo = aurEff->GetSpellInfo();
                         // search our Blood Plague and Frost Fever on target
                         if (spellInfo->SpellFamilyName == SPELLFAMILY_DEATHKNIGHT && spellInfo->SpellFamilyFlags[2] & 0x2 &&
-                            aurEff->GetCasterGUID() == m_caster->GetGUID())
+                            aurEff->GetCaster() == m_caster->GetGUID())
                         {
                             uint32 countMin = aurEff->GetBase()->GetMaxDuration();
                             uint32 countMax = spellInfo->GetMaxDuration();
@@ -4786,7 +4786,7 @@ void Spell::EffectDispelMechanic(SpellEffIndex effIndex)
             continue;
         if (roll_chance_i(aura->CalcDispelChance(unitTarget, !unitTarget->IsFriendlyTo(m_caster))))
             if ((aura->GetSpellInfo()->GetAllEffectsMechanicMask() & (1 << mechanic)))
-                dispel_list.emplace_back(aura->GetId(), aura->GetCasterGUID());
+                dispel_list.emplace_back(aura->GetId(), aura->GetCaster());
     }
 
     for (auto itr = dispel_list.begin(); itr != dispel_list.end(); ++itr)
@@ -5233,7 +5233,7 @@ void Spell::EffectStealBeneficialBuff(SpellEffIndex effIndex)
 
         if (itr->RollDispel())
         {
-            successList.emplace_back(itr->GetAura()->GetId(), itr->GetAura()->GetCasterGUID());
+            successList.emplace_back(itr->GetAura()->GetId(), itr->GetAura()->GetCaster());
             if (!itr->DecrementCharge())
             {
                 --remaining;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -845,7 +845,7 @@ void Spell::EffectTriggerSpell(SpellEffIndex effIndex)
             targets.SetUnitTarget(m_caster);
     }
 
-    CastSpellExtraArgs args(m_originalCasterGUID);
+    CastSpellExtraArgs args(GetOriginalCaster());
     // set basepoints for trigger with value effect
     if (m_spellInfo->Effects[effIndex].Effect == SPELL_EFFECT_TRIGGER_SPELL_WITH_VALUE)
         for (uint32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
@@ -889,7 +889,7 @@ void Spell::EffectTriggerMissileSpell(SpellEffIndex effIndex)
         targets.SetUnitTarget(m_caster);
     }
 
-    CastSpellExtraArgs args(m_originalCasterGUID);
+    CastSpellExtraArgs args(GetOriginalCaster());
     // set basepoints for trigger with value effect
     if (m_spellInfo->Effects[effIndex].Effect == SPELL_EFFECT_TRIGGER_MISSILE_SPELL_WITH_VALUE)
         for (uint32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
@@ -929,7 +929,7 @@ void Spell::EffectForceCast(SpellEffIndex effIndex)
             case 52463: // Hide In Mine Car
             case 52349: // Overtake
             {
-                CastSpellExtraArgs args(m_originalCasterGUID);
+                CastSpellExtraArgs args(GetOriginalCaster());
                 args.AddSpellMod(SPELLVALUE_BASE_POINT0, damage);
                 unitTarget->CastSpell(unitTarget, spellInfo->Id, args);
                 return;
@@ -940,7 +940,7 @@ void Spell::EffectForceCast(SpellEffIndex effIndex)
     switch (spellInfo->Id)
     {
         case 72298: // Malleable Goo Summon
-            unitTarget->CastSpell(unitTarget, spellInfo->Id, m_originalCasterGUID);
+            unitTarget->CastSpell(unitTarget, spellInfo->Id, GetOriginalCaster());
             return;
     }
 
@@ -1000,7 +1000,7 @@ void Spell::EffectJumpDest(SpellEffIndex effIndex)
 
     float speedXY, speedZ;
     CalculateJumpSpeeds(effIndex, m_caster->GetExactDist2d(destTarget), speedXY, speedZ);
-    m_caster->GetMotionMaster()->MoveJump(*destTarget, speedXY, speedZ, EVENT_JUMP, !m_targets.GetObjectTargetGUID().IsEmpty());
+    m_caster->GetMotionMaster()->MoveJump(*destTarget, speedXY, speedZ, EVENT_JUMP, !m_targets.GetObjectTarget().IsEmpty());
 }
 
 void Spell::CalculateJumpSpeeds(uint8 i, float dist, float & speedXY, float & speedZ)
@@ -1309,7 +1309,7 @@ void Spell::EffectHeal(SpellEffIndex /*effIndex*/)
     if (unitTarget && unitTarget->IsAlive() && damage >= 0)
     {
         // Try to get original caster
-        Unit* caster = m_originalCasterGUID ? m_originalCaster : m_caster;
+        MemoryOf<Unit> caster = GetOriginalCaster();
 
         // Skip if m_originalCaster not available
         if (!caster)

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -1033,12 +1033,7 @@ uint32 AuraScript::GetId() const
     return m_aura->GetId();
 }
 
-ObjectGuid AuraScript::GetCasterGUID() const
-{
-    return m_aura->GetCasterGUID();
-}
-
-Unit* AuraScript::GetCaster() const
+MemoryOf<Unit> const& AuraScript::GetCaster() const
 {
     return m_aura->GetCaster();
 }

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -18,6 +18,7 @@
 #ifndef __SPELL_SCRIPT_H
 #define __SPELL_SCRIPT_H
 
+#include "MemoryOf.h"
 #include "ObjectGuid.h"
 #include "SharedDefines.h"
 #include "SpellAuraDefines.h"
@@ -851,10 +852,8 @@ class TC_GAME_API AuraScript : public _SpellScript
         // returns spellid of the spell
         uint32 GetId() const;
 
-        // returns guid of object which cast the aura (m_originalCaster of the Spell class)
-        ObjectGuid GetCasterGUID() const;
-        // returns unit which cast the aura or NULL if not avalible (caster logged out for example)
-        Unit* GetCaster() const;
+        // returns unit which cast the aura
+        MemoryOf<Unit> const& GetCaster() const;
         // returns object on which aura was cast, target for non-area auras, area aura source for area auras
         WorldObject* GetOwner() const;
         // returns owner if it's unit or unit derived object, NULL otherwise (only for persistent area auras NULL is returned)

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -1074,7 +1074,7 @@ public:
             return false;
         }
 
-        switch (PlayerDumpWriter().WriteDump(fileStr, uint32(guid)))
+        switch (PlayerDumpWriter().WriteDump(fileStr, guid.GetCounter()))
         {
             case DUMP_SUCCESS:
                 handler->PSendSysMessage(LANG_COMMAND_EXPORT_SUCCESS);

--- a/src/server/scripts/Commands/cs_list.cpp
+++ b/src/server/scripts/Commands/cs_list.cpp
@@ -514,8 +514,8 @@ public:
             handler->PSendSysMessage(LANG_COMMAND_TARGET_AURADETAIL, aura->GetId(), (handler->GetSession() ? ss_name.str().c_str() : name),
                 aurApp->GetEffectMask(), aura->GetCharges(), aura->GetStackAmount(), aurApp->GetSlot(),
                 aura->GetDuration(), aura->GetMaxDuration(), (aura->IsPassive() ? passiveStr : ""),
-                (talent ? talentStr : ""), aura->GetCasterGUID().IsPlayer() ? "player" : "creature",
-                aura->GetCasterGUID().GetCounter());
+                (talent ? talentStr : ""), aura->GetCaster().IsPlayer() ? "player" : "creature",
+                aura->GetCaster().GetCounter());
         }
 
         for (uint16 i = 0; i < TOTAL_AURAS; ++i)

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -1552,7 +1552,7 @@ public:
         {
             if (!pair.second)
                 continue;
-            ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(pair.first);
+            ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(pair.first.GetCounter());
             Player const* player = ObjectAccessor::FindConnectedPlayer(guid);
             handler->PSendSysMessage(LANG_COMMAND_NPC_SHOWLOOT_SUBLABEL, player ? player->GetName() : Trinity::StringFormat("Offline player (GuidLow 0x%08x)", pair.first).c_str(), pair.second->size());
 

--- a/src/server/scripts/EasternKingdoms/AlteracValley/boss_balinda.cpp
+++ b/src/server/scripts/EasternKingdoms/AlteracValley/boss_balinda.cpp
@@ -112,7 +112,7 @@ public:
                 Talk(SAY_AGGRO);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (me->HealthBelowPctDamaged(40, damage) && !HasCastIceblock)
             {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_coren_direbrew.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_coren_direbrew.cpp
@@ -179,7 +179,7 @@ struct boss_coren_direbrew : public BossAI
         }
     }
 
-    void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
     {
         if (me->HealthBelowPctDamaged(66, damage) && events.IsInPhase(PHASE_ONE))
         {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_general_angerforge.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_general_angerforge.cpp
@@ -63,7 +63,7 @@ class boss_general_angerforge : public CreatureScript
                 _events.ScheduleEvent(EVENT_CLEAVE, 16000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(20, damage) && _events.IsInPhase(PHASE_ONE))
                 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_magmus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_magmus.cpp
@@ -58,7 +58,7 @@ class boss_magmus : public CreatureScript
                 _events.ScheduleEvent(EVENT_FIERY_BURST, 5000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(50, damage) && _events.IsInPhase(PHASE_ONE))
                 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_tomb_of_seven.cpp
@@ -169,7 +169,7 @@ class boss_doomrel : public CreatureScript
                 _events.ScheduleEvent(EVENT_DEMONARMOR, 16000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!_voidwalkers && !HealthAbovePct(50))
                 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_mother_smolderweb.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_mother_smolderweb.cpp
@@ -64,7 +64,7 @@ public:
             _JustDied();
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (me->GetHealth() <= damage)
                 DoCast(me, SPELL_SUMMON_SPIRE_SPIDERLING, true);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -116,7 +116,7 @@ public:
                 DoChangePhase();
         }
 
-        void DamageTaken(Unit* /*who*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
         {
             // @todo this is wrong - razorgore should still take damage, he should just nuke the whole room and respawn if he dies during P1
             if (!secondPhase)

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_garr.cpp
@@ -128,7 +128,7 @@ class npc_firesworn : public CreatureScript
                 Initialize();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 uint32 const health10pct = me->CountPctFromMaxHealth(10);
                 uint32 health = me->GetHealth();

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp
@@ -77,7 +77,7 @@ class boss_golemagg : public CreatureScript
                 events.ScheduleEvent(EVENT_PYROBLAST, 7000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!HealthBelowPct(10) || me->HasAura(SPELL_ENRAGE))
                     return;
@@ -150,7 +150,7 @@ class npc_core_rager : public CreatureScript
                 Initialize();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (HealthAbovePct(50) || !instance)
                     return;

--- a/src/server/scripts/EasternKingdoms/Deadmines/boss_vancleef.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/boss_vancleef.cpp
@@ -89,7 +89,7 @@ struct boss_vancleef : public BossAI
                 DoSummon(NPC_BLACKGUARD, BlackguardPosition, 60000, TEMPSUMMON_CORPSE_TIMED_DESPAWN);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
         {
             if (!_guardsCalled && HealthBelowPct(50))
             {

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_curator.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_curator.cpp
@@ -87,7 +87,7 @@ public:
             events.ScheduleEvent(EVENT_BERSERK, Minutes(12));
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
         {
             if (!HealthAbovePct(15) && !_infused)
             {

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
@@ -123,7 +123,7 @@ public:
             });
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
         {
             // Attumen does not die until he mounts Midnight, let health fall to 1 and prevent further damage.
             if (damage >= me->GetHealth() && _phase != PHASE_MOUNTED)
@@ -306,7 +306,7 @@ public:
             me->SetReactState(REACT_DEFENSIVE);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
         {
             // Midnight never dies, let health fall to 1 and prevent further damage.
             if (damage >= me->GetHealth())

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -187,7 +187,7 @@ public:
             SetupGroundPhase();
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (events.IsInPhase(PHASE_FLY))
             {

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -166,7 +166,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* done_by, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& done_by, uint32 &damage) override
         {
             if (!done_by || done_by->GetGUID() != malchezaar)
                 damage = 0;

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -473,7 +473,7 @@ public:
                 DoMeleeAttackIfReady();
         }
 
-        void DamageTaken(Unit* /*pAttacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pAttacker*/, uint32 &damage) override
         {
             if (!DrinkInturrupted && Drinking && damage)
                 DrinkInturrupted = true;

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -1146,7 +1146,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override;
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override;
 
         void JustDied(Unit* /*killer*/) override
         {
@@ -1224,7 +1224,7 @@ public:
             me->DespawnOrUnsummon();
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage < me->GetHealth())
                 return;
@@ -1487,7 +1487,7 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
     DoMeleeAttackIfReady();
 }
 
-void boss_julianne::boss_julianneAI::DamageTaken(Unit* /*done_by*/, uint32 &damage)
+void boss_julianne::boss_julianneAI::DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage)
 {
     if (damage < me->GetHealth())
         return;

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -171,7 +171,7 @@ public:
                 escapeOrb->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage > me->GetHealth())
                 RemoveGravityLapse(); // Remove Gravity Lapse so that players fall to ground if they kill him when in air.
@@ -505,7 +505,7 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override { }
 
-        void DamageTaken(Unit* /*killer*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*killer*/, uint32 &damage) override
         {
             if (damage < me->GetHealth())
                 return;

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_vexallus.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_vexallus.cpp
@@ -100,7 +100,7 @@ class boss_vexallus : public CreatureScript
                 summons.Summon(summoned);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& /*damage*/) override
             {
                 if (_enraged)
                     return;

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -524,7 +524,7 @@ public:
             }
         }
 
-       void DamageTaken(Unit* pDoneBy, uint32 &uiDamage) override
+       void DamageTaken(MemoryOf<Unit> const& pDoneBy, uint32 &uiDamage) override
         {
             if (m_bIsDuelInProgress && pDoneBy && pDoneBy->IsControlledByPlayer())
             {

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_azshir_the_sleepless.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_azshir_the_sleepless.cpp
@@ -63,7 +63,7 @@ class boss_azshir_the_sleepless : public CreatureScript
                 _JustDied();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!_siphon && me->HealthBelowPctDamaged(50, damage))
                 {

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_bloodmage_thalnos.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_bloodmage_thalnos.cpp
@@ -80,7 +80,7 @@ class boss_bloodmage_thalnos : public CreatureScript
                 Talk(SAY_KILL);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!_hpYell && me->HealthBelowPctDamaged(35, damage))
                 {

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_headless_horseman.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_headless_horseman.cpp
@@ -273,7 +273,7 @@ public:
             laugh += 3000;
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (withbody)
                 return;
@@ -609,7 +609,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage >= me->GetHealth() && withhead)
             {

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_herod.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_herod.cpp
@@ -100,7 +100,7 @@ class boss_herod : public CreatureScript
                     me->SummonCreature(NPC_SCARLET_TRAINEE, ScarletTraineePos, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 600000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!_enrage && me->HealthBelowPctDamaged(30, damage))
                 {

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_interrogator_vishas.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_interrogator_vishas.cpp
@@ -83,7 +83,7 @@ class boss_interrogator_vishas : public CreatureScript
                     vorrel->AI()->Talk(SAY_TRIGGER_VORREL);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
             {
                 if (me->HealthBelowPctDamaged(60, damage) && _yellCount < 1)
                 {

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
@@ -129,7 +129,7 @@ public:
             Talk(SAY_MO_KILL);
         }
 
-        void DamageTaken(Unit* /*doneBy*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*doneBy*/, uint32 &damage) override
         {
             if (damage < me->GetHealth() || _bHasDied || _bFakeDeath)
                 return;
@@ -289,7 +289,7 @@ public:
             Talk(SAY_WH_KILL);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (!_bCanResurrectCheck && damage >= me->GetHealth())
                 damage = me->GetHealth() - 1;

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_death_knight_darkreaver.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_death_knight_darkreaver.cpp
@@ -45,7 +45,7 @@ public:
         {
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (me->GetHealth() <= damage)
                 DoCast(me, 23261, true);   //Summon Darkreaver's Fallen Charger

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_kormok.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_kormok.cpp
@@ -77,7 +77,7 @@ public:
             summoned->AI()->AttackStart(me->GetVictim());
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (me->HealthBelowPctDamaged(25, damage) && !Mages)
             {

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_vectus.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_vectus.cpp
@@ -59,7 +59,7 @@ public:
             events.ScheduleEvent(EVENT_BLAST_WAVE, 14000);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (me->HealthBelowPctDamaged(25, damage))
             {

--- a/src/server/scripts/EasternKingdoms/ShadowfangKeep/boss_apothecary_hummel.cpp
+++ b/src/server/scripts/EasternKingdoms/ShadowfangKeep/boss_apothecary_hummel.cpp
@@ -142,7 +142,7 @@ class boss_apothecary_hummel : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                     if (_deadCount < 2)

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
@@ -237,7 +237,7 @@ public:
                 events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1);
         }
 
-        void DamageTaken(Unit*, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const&, uint32 &damage) override
         {
             if (phase != PHASE_GROUND && damage >= me->GetHealth())
                 damage = 0;

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
@@ -202,7 +202,7 @@ struct boss_kalecgos : public BossAI
         }
     }
 
-    void DamageTaken(Unit* who, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && (!who || who->GetGUID() != me->GetGUID()))
             damage = 0;
@@ -370,7 +370,7 @@ struct boss_kalecgos_human : public ScriptedAI
         Talk(SAY_GOOD_DEATH);
     }
 
-    void DamageTaken(Unit* who, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
     {
         if (!who || who->GetGUID() != _sathGUID)
             damage = 0;
@@ -483,7 +483,7 @@ struct boss_sathrovarr : public BossAI
         }
     }
 
-    void DamageTaken(Unit* who, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && (!who || who->GetGUID() != me->GetGUID()))
             damage = 0;

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
@@ -1092,7 +1092,7 @@ public:
             Initialize();
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage > me->GetHealth())
                 DoCast(me, SPELL_FELFIRE_FISSION, true);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -284,7 +284,7 @@ public:
             DoCast(me, SPELL_NEGATIVE_ENERGY_PERIODIC, true);
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage >= me->GetHealth())
             {

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_halazzi.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_halazzi.cpp
@@ -130,7 +130,7 @@ class boss_halazzi : public CreatureScript
                 summons.Summon(summon);
             }
 
-            void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
             {
                 if (damage >= me->GetHealth() && Phase != PHASE_ENRAGE)
                     damage = 0;
@@ -364,7 +364,7 @@ class npc_halazzi_lynx : public CreatureScript
                 Initialize();
             }
 
-            void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
             {
                 if (damage >= me->GetHealth())
                     damage = 0;

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
@@ -111,7 +111,7 @@ class boss_jeklik : public CreatureScript
                 DoCast(me, SPELL_BAT_FORM);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (events.IsInPhase(PHASE_ONE) && !HealthAbovePct(50))
                 {

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_venoxis.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_venoxis.cpp
@@ -139,7 +139,7 @@ class boss_venoxis : public CreatureScript
                 DoZoneInCombat();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 // check if venoxis is ready to transform
                 if (!_transformed && !HealthAbovePct(50))

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -68,7 +68,7 @@ public:
                 me->SetFaction(m_uiNormalFaction);
         }
 
-        void DamageTaken(Unit* pDoneBy, uint32 &uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& pDoneBy, uint32 &uiDamage) override
         {
             if (uiDamage > me->GetHealth() || me->HealthBelowPctDamaged(15, uiDamage))
             {

--- a/src/server/scripts/EasternKingdoms/zone_tirisfal_glades.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_tirisfal_glades.cpp
@@ -71,7 +71,7 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override { }
 
-        void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
         {
             if (damage > me->GetHealth() || me->HealthBelowPctDamaged(15, damage))
             {

--- a/src/server/scripts/EasternKingdoms/zone_wetlands.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_wetlands.cpp
@@ -106,7 +106,7 @@ public:
                 summoned->AI()->AttackStart(player);
         }
 
-        void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pDoneBy*/, uint32& uiDamage) override
         {
             if (HealthBelowPct(20))
             {

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/boss_aku_mai.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/boss_aku_mai.cpp
@@ -60,7 +60,7 @@ public:
             events.ScheduleEvent(EVENT_POISON_CLOUD, urand(5000, 9000));
         }
 
-        void DamageTaken(Unit* /*atacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*atacker*/, uint32 &damage) override
         {
             if (!IsEnraged && me->HealthBelowPctDamaged(30, damage))
             {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -134,7 +134,7 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override { }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             damage = 0;
         }
@@ -178,7 +178,7 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override { }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             damage = 0;
         }
@@ -228,7 +228,7 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override { }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             damage = 0;
         }
@@ -400,7 +400,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
         {
             if (me->HealthBelowPctDamaged(10, damage))
             {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.cpp
@@ -192,7 +192,7 @@ hyjal_trashAI::hyjal_trashAI(Creature* creature) : EscortAI(creature)
     Reset();
 }
 
-void hyjal_trashAI::DamageTaken(Unit* done_by, uint32 &damage)
+void hyjal_trashAI::DamageTaken(MemoryOf<Unit> const& done_by, uint32 &damage)
 {
     if (!done_by || done_by->GetTypeId() == TYPEID_PLAYER || done_by->IsPet())
     {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.h
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.h
@@ -29,7 +29,7 @@ struct hyjal_trashAI : public EscortAI
 
     void JustDied(Unit* /*killer*/) override;
 
-    void DamageTaken(Unit* done_by, uint32 &damage) override;
+    void DamageTaken(MemoryOf<Unit> const& done_by, uint32 &damage) override;
 
     public:
         InstanceScript* instance;

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_mal_ganis.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_mal_ganis.cpp
@@ -118,7 +118,7 @@ public:
             instance->SetBossState(DATA_MAL_GANIS, IN_PROGRESS);
         }
 
-        void DamageTaken(Unit* done_by, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& done_by, uint32 &damage) override
         {
             if (damage >= me->GetHealth() && done_by != me)
                 damage = me->GetHealth()-1;

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
@@ -72,7 +72,7 @@ class boss_kurinnaxx : public CreatureScript
                 events.ScheduleEvent(EVENT_WIDE_SLASH, 11000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!_enraged && HealthBelowPct(30))
                 {

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
@@ -77,7 +77,7 @@ class boss_moam : public CreatureScript
                 //events.ScheduleEvent(EVENT_WIDE_SLASH, 11000);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!_isStonePhase && HealthBelowPct(45))
                 {

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -404,7 +404,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             switch (instance->GetData(DATA_CTHUN_PHASE))
             {
@@ -849,7 +849,7 @@ public:
             instance->SetData(DATA_CTHUN_PHASE, PHASE_CTHUN_DONE);
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             switch (instance->GetData(DATA_CTHUN_PHASE))
             {

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_twinemperors.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_twinemperors.cpp
@@ -117,7 +117,7 @@ struct boss_twinemperorsAI : public ScriptedAI
         return ObjectAccessor::GetCreature(*me, instance->GetGuidData(IAmVeklor() ? DATA_VEKNILASH : DATA_VEKLOR));
     }
 
-    void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
     {
         Unit* pOtherBoss = GetOtherBoss();
         if (pOtherBoss)

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
@@ -112,7 +112,7 @@ class boss_viscidus : public CreatureScript
                 Initialize();
             }
 
-            void DamageTaken(Unit* attacker, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& /*damage*/) override
             {
                 if (_phase != PHASE_MELEE)
                     return;

--- a/src/server/scripts/Kalimdor/zone_durotar.cpp
+++ b/src/server/scripts/Kalimdor/zone_durotar.cpp
@@ -194,7 +194,7 @@ class npc_tiger_matriarch : public CreatureScript
                 me->DespawnOrUnsummon();
             }
 
-            void DamageTaken(Unit* attacker, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
             {
                 if (!attacker || !attacker->IsSummon())
                     return;

--- a/src/server/scripts/Kalimdor/zone_dustwallow_marsh.cpp
+++ b/src/server/scripts/Kalimdor/zone_dustwallow_marsh.cpp
@@ -123,7 +123,7 @@ public:
             me->RestoreFaction();
         }
 
-        void DamageTaken(Unit* pDoneBy, uint32 &Damage) override
+        void DamageTaken(MemoryOf<Unit> const& pDoneBy, uint32 &Damage) override
         {
             if (Damage > me->GetHealth() || me->HealthBelowPctDamaged(20, Damage))
             {

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_herald_volazj.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_herald_volazj.cpp
@@ -96,7 +96,7 @@ public:
             return 100*(me->GetHealth()-damage)/me->GetMaxHealth();
         }
 
-        void DamageTaken(Unit* /*pAttacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pAttacker*/, uint32 &damage) override
         {
             if (me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE))
                 damage = 0;

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
@@ -206,7 +206,7 @@ struct boss_jedoga_shadowseeker : public BossAI
         return 0;
     }
 
-    void DamageTaken(Unit* /*done_by*/, uint32& /*damage*/) override
+    void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32& /*damage*/) override
     {
         if (HealthBelowPct(55) && events.IsInPhase(PHASE_ONE))
         {

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
@@ -226,7 +226,7 @@ class boss_prince_taldaram : public CreatureScript
                 DoMeleeAttackIfReady();
             }
 
-            void DamageTaken(Unit* /*doneBy*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*doneBy*/, uint32& damage) override
             {
                 Unit* embraceTarget = GetEmbraceTarget();
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -348,7 +348,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*source*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*source*/, uint32& damage) override
         {
             if (me->HasAura(SPELL_SUBMERGE))
                 damage = 0;

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -358,7 +358,7 @@ public:
         }
 
         // Safeguard to prevent Hadronox dying to NPCs
-        void DamageTaken(Unit* who, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& who, uint32& damage) override
         {
             if ((!who || !who->IsControlledByPlayer()) && me->HealthBelowPct(70))
             {
@@ -530,7 +530,7 @@ class npc_anub_ar_crusher : public CreatureScript
                 Talk(CRUSHER_SAY_AGGRO);
             }
 
-            void DamageTaken(Unit* /*source*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*source*/, uint32& damage) override
             {
                 if (_hadFrenzy || !me->HealthBelowPctDamaged(25, damage))
                     return;

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_baltharus_the_warborn.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_baltharus_the_warborn.cpp
@@ -139,7 +139,7 @@ class boss_baltharus_the_warborn : public CreatureScript
                 events.ScheduleEvent(EVENT_SUMMONS_ATTACK, Seconds(2));
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (GetDifficulty() == RAID_DIFFICULTY_10MAN_NORMAL)
                 {
@@ -262,7 +262,7 @@ class npc_baltharus_the_warborn_clone : public CreatureScript
 
             void EnterEvadeMode(EvadeReason /*why*/) override { }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 // Setting DATA_BALTHARUS_SHARED_HEALTH to 0 when killed would bug the boss.
                 if (me->GetHealth() > damage)

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -300,7 +300,7 @@ class boss_halion : public CreatureScript
                 if (events.IsInPhase(PHASE_THREE))
                 {
                     // Don't consider copied damage.
-                    if (!Object::InSamePhase(attacker, me))
+                    if (!WorldObject::InSamePhase(attacker, me))
                         return;
 
                     if (Creature* controller = instance->GetCreature(DATA_HALION_CONTROLLER))
@@ -481,7 +481,7 @@ class boss_twilight_halion : public CreatureScript
                 if (events.IsInPhase(PHASE_THREE))
                 {
                     // Don't consider copied damage.
-                    if (!Object::InSamePhase(me, attacker))
+                    if (!WorldObject::InSamePhase(me, attacker))
                         return;
 
                     if (Creature* controller = instance->GetCreature(DATA_HALION_CONTROLLER))

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -278,7 +278,7 @@ class boss_halion : public CreatureScript
 
             Position const* GetMeteorStrikePosition() const { return &_meteorStrikePos; }
 
-            void DamageTaken(Unit* attacker, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
             {
                 if (damage >= me->GetHealth() && !events.IsInPhase(PHASE_THREE))
                     damage = me->GetHealth() - 1;
@@ -461,7 +461,7 @@ class boss_twilight_halion : public CreatureScript
                 instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
             }
 
-            void DamageTaken(Unit* attacker, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
             {
                 if (damage >= me->GetHealth() && !events.IsInPhase(PHASE_THREE))
                     damage = me->GetHealth() - 1;

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -1567,7 +1567,7 @@ class spell_halion_marks : public SpellScriptLoader
                     return;
 
                 // Stacks marker
-                CastSpellExtraArgs args(GetCasterGUID());
+                CastSpellExtraArgs args(GetCaster());
                 args.AddSpellMod(SPELLVALUE_BASE_POINT1, aurEff->GetBase()->GetStackAmount());
                 GetTarget()->CastSpell(GetTarget(), _summonSpellId, args);
             }

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -300,7 +300,7 @@ class boss_halion : public CreatureScript
                 if (events.IsInPhase(PHASE_THREE))
                 {
                     // Don't consider copied damage.
-                    if (!me->InSamePhase(attacker))
+                    if (!Object::InSamePhase(attacker, me))
                         return;
 
                     if (Creature* controller = instance->GetCreature(DATA_HALION_CONTROLLER))
@@ -481,7 +481,7 @@ class boss_twilight_halion : public CreatureScript
                 if (events.IsInPhase(PHASE_THREE))
                 {
                     // Don't consider copied damage.
-                    if (!me->InSamePhase(attacker))
+                    if (!Object::InSamePhase(me, attacker))
                         return;
 
                     if (Creature* controller = instance->GetCreature(DATA_HALION_CONTROLLER))

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_argent_challenge.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_argent_challenge.cpp
@@ -189,7 +189,7 @@ public:
             Initialize();
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage >= me->GetHealth())
             {
@@ -317,7 +317,7 @@ public:
                 me->RemoveAura(SPELL_SHIELD);
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (damage >= me->GetHealth())
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_black_knight.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_black_knight.cpp
@@ -265,7 +265,7 @@ public:
                 DoMeleeAttackIfReady();
         }
 
-        void DamageTaken(Unit* /*pDoneBy*/, uint32& uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pDoneBy*/, uint32& uiDamage) override
         {
             if (uiDamage > me->GetHealth() && uiPhase <= PHASE_SKELETON)
             {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -634,7 +634,7 @@ class npc_frost_sphere : public CreatureScript
                 me->GetMotionMaster()->MoveRandom(20.0f);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (me->GetHealth() <= damage)
                 {
@@ -728,7 +728,7 @@ class npc_anubarak_spike : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& uiDamage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& uiDamage) override
             {
                 uiDamage = 0;
             }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -1152,7 +1152,7 @@ class spell_jormungars_paralytic_toxin : public AuraScript
             slowEff->ChangeAmount(newAmount);
 
             if (newAmount == -100 && !GetTarget()->HasAura(SPELL_PARALYSIS))
-                GetTarget()->CastSpell(GetTarget(), SPELL_PARALYSIS, CastSpellExtraArgs(slowEff).SetOriginalCaster(GetCasterGUID()));
+                GetTarget()->CastSpell(GetTarget(), SPELL_PARALYSIS, CastSpellExtraArgs(slowEff).SetOriginalCaster(GetCaster()));
         }
     }
 

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
@@ -114,7 +114,7 @@ class boss_bronjahm : public CreatureScript
                     Talk(SAY_SLAY);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (events.IsInPhase(PHASE_1) && !HealthAbovePct(30))
                 {

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/boss_falric.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/boss_falric.cpp
@@ -84,7 +84,7 @@ class boss_falric : public CreatureScript
                 events.ScheduleEvent(EVENT_DEFILING_HORROR, urand(21000, 39000));
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if ((_hopelessnessCount < 1 && me->HealthBelowPctDamaged(66, damage))
                     || (_hopelessnessCount < 2 && me->HealthBelowPctDamaged(33, damage))

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -821,7 +821,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                     lichking->AI()->EnterEvadeMode(); // event failed
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth() && _invincibility)
                     damage = me->GetHealth() - 1;
@@ -1171,7 +1171,7 @@ class npc_the_lich_king_escape_hor : public CreatureScript
                 _despawn = false;
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                     damage = me->GetHealth() - 1;
@@ -2457,7 +2457,7 @@ class npc_uther_quel_delar : public CreatureScript
                 _events.ScheduleEvent(EVENT_UTHER_1, 1);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                     damage = me->GetHealth() - 1;

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
@@ -129,7 +129,7 @@ class boss_garfrost : public CreatureScript
                     tyrannus->AI()->Talk(SAY_TYRANNUS_DEATH);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (events.IsInPhase(PHASE_ONE) && !HealthAbovePct(66))
                 {

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
@@ -449,7 +449,7 @@ class spell_tyrannus_overlord_brand : public SpellScriptLoader
                 Player* pTarget = GetTarget()->ToPlayer();
                 oldAI = pTarget->AI();
                 oldAIState = pTarget->IsAIEnabled;
-                GetTarget()->SetAI(new player_overlord_brandAI(pTarget, GetCasterGUID()));
+                GetTarget()->SetAI(new player_overlord_brandAI(pTarget, GetCaster()));
                 GetTarget()->IsAIEnabled = true;
             }
 

--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -158,7 +158,7 @@ class boss_drakkari_colossus : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->IsImmuneToPC())
                     damage = 0;
@@ -311,7 +311,7 @@ class boss_drakkari_elemental : public CreatureScript
                 }
            }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (HealthBelowPct(50))
                 {

--- a/src/server/scripts/Northrend/Gundrak/boss_eck.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_eck.cpp
@@ -74,7 +74,7 @@ class boss_eck : public CreatureScript
                 events.ScheduleEvent(EVENT_BERSERK, urand(60 * IN_MILLISECONDS, 90 * IN_MILLISECONDS)); // 60-90 secs according to wowwiki
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!_berserk && me->HealthBelowPctDamaged(20, damage))
                 {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -501,7 +501,7 @@ struct BloodPrincesBossAI : public BossAI
         me->SetHealth(_spawnHealth);
     }
 
-    void DamageTaken(Unit* attacker, uint32& damage) override
+    void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
     {
         if (!_isEmpowered)
         {
@@ -1147,7 +1147,7 @@ class npc_dark_nucleus : public CreatureScript
                 DoCast(who, SPELL_SHADOW_RESONANCE_RESIST);
             }
 
-            void DamageTaken(Unit* attacker, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& /*damage*/) override
             {
                 if (attacker == me)
                     return;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -352,7 +352,7 @@ class boss_deathbringer_saurfang : public CreatureScript
                     Talk(SAY_KILL);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                     damage = me->GetHealth() - 1;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -679,7 +679,7 @@ class npc_gunship : public CreatureScript
                 me->SetRegenerateHealth(false);
             }
 
-            void DamageTaken(Unit* /*source*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*source*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {
@@ -981,7 +981,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 return false;
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(65, damage) && !me->HasAura(SPELL_TASTE_OF_BLOOD))
                     DoCast(me, SPELL_TASTE_OF_BLOOD, true);
@@ -1251,7 +1251,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 return false;
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(65, damage) && me->HasAura(SPELL_TASTE_OF_BLOOD))
                     DoCast(me, SPELL_TASTE_OF_BLOOD, true);
@@ -1501,7 +1501,7 @@ struct npc_gunship_boarding_addAI : public gunship_npc_AI
         }
     }
 
-    void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
     {
         if (_usedDesperateResolve)
             return;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -406,7 +406,7 @@ class boss_lady_deathwhisper : public CreatureScript
                     Talk(SAY_KILL);
             }
 
-            void DamageTaken(Unit* /*damageDealer*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*damageDealer*/, uint32& damage) override
             {
                 // phase transition
                 if (_phase == PHASE_ONE && damage > me->GetPower(POWER_MANA))

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -651,8 +651,9 @@ class spell_marrowgar_bone_spike_graveyard : public SpellScriptLoader
                         {
                             if (Aura* aura = target->GetAura(SPELL_IMPALED))
                             {
-                                if (Creature* spike = ObjectAccessor::GetCreature(*target, aura->GetCasterGUID()))
-                                    spike->DespawnOrUnsummon();
+                                if (auto const& spike = aura->GetCaster())
+                                    if (Creature* cSpike = spike->ToCreature())
+                                        cSpike->DespawnOrUnsummon();
                                 aura->Remove();
                             }
                         }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -348,7 +348,7 @@ class boss_professor_putricide : public CreatureScript
                     DoZoneInCombat(summon);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (me->HasUnitState(UNIT_STATE_CASTING))
                     return;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -851,7 +851,7 @@ class spell_putricide_gaseous_bloat : public SpellScriptLoader
                 Unit* target = GetTarget();
                 if (Unit* caster = GetCaster())
                 {
-                    target->RemoveAuraFromStack(GetSpellInfo()->Id, GetCasterGUID());
+                    target->RemoveAuraFromStack(GetSpellInfo()->Id, GetCaster());
                     if (!target->HasAura(GetId()))
                     {
                         CastSpellExtraArgs args;
@@ -1332,7 +1332,7 @@ class spell_putricide_mutated_plague : public SpellScriptLoader
                 damage = int32(damage * 1.5f);
 
                 CastSpellExtraArgs args(aurEff);
-                args.OriginalCaster = GetCasterGUID();
+                args.OriginalCaster = GetCaster();
                 args.AddSpellBP0(damage);
                 GetTarget()->CastSpell(GetTarget(), triggerSpell, args);
             }
@@ -1346,7 +1346,7 @@ class spell_putricide_mutated_plague : public SpellScriptLoader
                     return;
 
                 int32 heal = healSpellInfo->Effects[0].CalcValue() * GetStackAmount();
-                CastSpellExtraArgs args(GetCasterGUID());
+                CastSpellExtraArgs args(GetCaster());
                 args.AddSpellBP0(heal);
                 GetTarget()->CastSpell(GetTarget(), healSpell, args);
             }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
@@ -557,7 +557,7 @@ class spell_rotface_mutated_infection : public SpellScriptLoader
             void HandleEffectRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {
                 Unit* target = GetTarget();
-                target->CastSpell(target, uint32(GetSpellInfo()->Effects[EFFECT_2].CalcValue()), { aurEff, GetCasterGUID() });
+                target->CastSpell(target, uint32(GetSpellInfo()->Effects[EFFECT_2].CalcValue()), { aurEff, GetCaster() });
             }
 
             void Register() override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -1252,7 +1252,7 @@ class spell_sindragosa_instability : public SpellScriptLoader
                 if (GetTargetApplication()->GetRemoveMode() == AURA_REMOVE_BY_EXPIRE)
                 {
                     CastSpellExtraArgs args(aurEff);
-                    args.OriginalCaster = GetCasterGUID();
+                    args.OriginalCaster = GetCaster();
                     args.AddSpellBP0(aurEff->GetAmount());
                     GetTarget()->CastSpell(GetTarget(), SPELL_BACKLASH, args);
                 }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -403,7 +403,7 @@ class boss_sindragosa : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!_isThirdPhase && !HealthAbovePct(35))
                 {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -681,7 +681,7 @@ class boss_the_lich_king : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (events.IsInPhase(PHASE_ONE) && !HealthAbovePct(70))
                 {
@@ -1328,7 +1328,7 @@ class npc_shambling_horror_icc : public CreatureScript
                 _events.ScheduleEvent(EVENT_ENRAGE, urand(11000, 14000));
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!_frenzied && IsHeroic() && me->HealthBelowPctDamaged(20, damage))
                 {
@@ -1502,7 +1502,7 @@ class npc_valkyr_shadowguard : public CreatureScript
                 _events.ScheduleEvent(EVENT_GRAB_PLAYER, 2500);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!IsHeroic())
                     return;
@@ -1795,7 +1795,7 @@ class npc_terenas_menethil : public CreatureScript
                 me->CombatStop(false);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -2141,7 +2141,7 @@ class spell_the_lich_king_necrotic_plague : public SpellScriptLoader
                         return;
                 }
 
-                CastSpellExtraArgs args(GetCasterGUID());
+                CastSpellExtraArgs args(GetCaster());
                 args.AddSpellMod(SPELLVALUE_MAX_TARGETS, 1);
                 GetTarget()->CastSpell(nullptr, SPELL_NECROTIC_PLAGUE_JUMP, args);
                 if (Unit* caster = GetCaster())
@@ -2237,7 +2237,7 @@ class spell_the_lich_king_necrotic_plague_jump : public SpellScriptLoader
                         return;
                 }
 
-                CastSpellExtraArgs args(GetCasterGUID());
+                CastSpellExtraArgs args(GetCaster());
                 args.AddSpellMod(SPELLVALUE_AURA_STACK, GetStackAmount());
                 GetTarget()->CastSpell(nullptr, SPELL_NECROTIC_PLAGUE_JUMP, args);
                 if (Unit* caster = GetCaster())
@@ -2255,7 +2255,7 @@ class spell_the_lich_king_necrotic_plague_jump : public SpellScriptLoader
                 if (aurEff->GetAmount() > _lastAmount)
                     return;
 
-                CastSpellExtraArgs args(GetCasterGUID());
+                CastSpellExtraArgs args(GetCaster());
                 args.AddSpellMod(SPELLVALUE_AURA_STACK, GetStackAmount());
                 args.AddSpellMod(SPELLVALUE_BASE_POINT1, AURA_REMOVE_BY_ENEMY_SPELL); // add as marker (spell has no effect 1)
                 GetTarget()->CastSpell(nullptr, SPELL_NECROTIC_PLAGUE_JUMP, args);
@@ -2713,7 +2713,7 @@ class spell_the_lich_king_vile_spirits : public SpellScriptLoader
             void OnPeriodic(AuraEffect const* aurEff)
             {
                 if (_is25Man || ((aurEff->GetTickNumber() - 1) % 5))
-                    GetTarget()->CastSpell(nullptr, GetSpellInfo()->Effects[aurEff->GetEffIndex()].TriggerSpell, { aurEff, GetCasterGUID() });
+                    GetTarget()->CastSpell(nullptr, GetSpellInfo()->Effects[aurEff->GetEffIndex()].TriggerSpell, { aurEff, GetCaster() });
             }
 
             void Register() override
@@ -2939,7 +2939,7 @@ class spell_the_lich_king_soul_rip : public SpellScriptLoader
                 if (Unit* caster = GetCaster())
                 {
                     CastSpellExtraArgs args(aurEff);
-                    args.OriginalCaster = GetCasterGUID();
+                    args.OriginalCaster = GetCaster();
                     args.AddSpellBP0(5000 * aurEff->GetTickNumber());
                     caster->CastSpell(GetTarget(), SPELL_SOUL_RIP_DAMAGE, args);
                 }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -321,9 +321,9 @@ class boss_valithria_dreamwalker : public CreatureScript
                     _events.ScheduleEvent(EVENT_BERSERK, 420000);
             }
 
-            void HealReceived(Unit* healer, uint32& heal) override
+            void HealReceived(MemoryOf<Unit> const& healer, uint32& heal) override
             {
-                if (!me->hasLootRecipient())
+                if (healer && !me->hasLootRecipient())
                     me->SetLootRecipient(healer);
 
                 me->LowerPlayerDamageReq(heal);
@@ -346,12 +346,12 @@ class boss_valithria_dreamwalker : public CreatureScript
                     _over75PercentTalkDone = true;
                     Talk(SAY_VALITHRIA_75_PERCENT);
                 }
-                else if (_instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == NOT_STARTED)
+                else if (healer && _instance->GetBossState(DATA_VALITHRIA_DREAMWALKER) == NOT_STARTED)
                     if (Creature* archmage = me->FindNearestCreature(NPC_RISEN_ARCHMAGE, 30.0f))
                         archmage->EngageWithTarget(healer);   // call JustEngagedWith on one of them, that will make it all start
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(25, damage))
                 {

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -1117,7 +1117,7 @@ class npc_crok_scourgebane : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 // check wipe
                 if (!_wipeCheckTimer)

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -387,7 +387,7 @@ class boss_gothik : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (!events.IsInPhase(PHASE_TWO))
                     damage = 0;
@@ -582,7 +582,7 @@ struct npc_gothik_minion_baseAI : public ScriptedAI
             return IsOnSameSide(me, who);
         }
 
-        void DamageTaken(Unit* attacker, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& attacker, uint32 &damage) override
         { // do not allow minions to take damage before the gate is opened
             if (!_gateIsOpen && (!attacker || !isOnSameSide(attacker)))
                 damage = 0;
@@ -901,7 +901,7 @@ public:
         void EnterEvadeMode(EvadeReason /*why*/) override { }
         void UpdateAI(uint32 /*diff*/) override { }
         void JustEngagedWith(Unit* /*who*/) override { }
-        void DamageTaken(Unit* /*who*/, uint32& damage) override { damage = 0;  }
+        void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override { damage = 0;  }
 
         Creature* SelectRandomSkullPile()
         {

--- a/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_grobbulus.cpp
@@ -163,7 +163,7 @@ class spell_grobbulus_mutating_injection : public SpellScriptLoader
                 if (Unit* caster = GetCaster())
                 {
                     caster->CastSpell(GetTarget(), SPELL_MUTATING_EXPLOSION, true);
-                    GetTarget()->CastSpell(GetTarget(), SPELL_POISON_CLOUD, { aurEff, GetCasterGUID() });
+                    GetTarget()->CastSpell(GetTarget(), SPELL_POISON_CLOUD, { aurEff, GetCaster() });
                 }
             }
 

--- a/src/server/scripts/Northrend/Naxxramas/boss_kelthuzad.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_kelthuzad.cpp
@@ -273,7 +273,7 @@ public:
                 Talk(SAY_DEATH);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (events.IsInPhase(PHASE_ONE))
                     damage = 0;

--- a/src/server/scripts/Northrend/Naxxramas/boss_loatheb.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_loatheb.cpp
@@ -181,7 +181,7 @@ class spell_loatheb_deathbloom : public SpellScriptLoader
                 if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_EXPIRE)
                     return;
 
-                GetTarget()->CastSpell(nullptr, SPELL_DEATHBLOOM_FINAL_DAMAGE, CastSpellExtraArgs(eff).SetOriginalCaster(GetCasterGUID()));
+                GetTarget()->CastSpell(nullptr, SPELL_DEATHBLOOM_FINAL_DAMAGE, CastSpellExtraArgs(eff).SetOriginalCaster(GetCaster()));
             }
 
             void Register() override

--- a/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
@@ -174,7 +174,7 @@ public:
             Talk(SAY_DEATH);
         }
 
-        void DamageTaken(Unit* /*who*/, uint32& damage) override // prevent noth from somehow dying in the balcony phase
+        void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override // prevent noth from somehow dying in the balcony phase
         {
             if (!events.IsInPhase(PHASE_BALCONY))
                 return;

--- a/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
@@ -168,7 +168,7 @@ class boss_sapphiron : public CreatureScript
                 Initialize();
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (damage < me->GetHealth() || !events.IsInPhase(PHASE_FLIGHT))
                     return;

--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -575,7 +575,7 @@ public:
                         AddThreat(who, 0.0f, feugen);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (damage < me->GetHealth())
                     return;
@@ -833,7 +833,7 @@ public:
                         AddThreat(who, 0.0f, stalagg);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (damage < me->GetHealth())
                     return;
@@ -982,7 +982,7 @@ public:
         void EnterEvadeMode(EvadeReason /*why*/) override { } // never stop casting due to evade
         void UpdateAI(uint32 /*diff*/) override { } // never do anything unless told
         void JustEngagedWith(Unit* /*who*/) override { }
-        void DamageTaken(Unit* /*who*/, uint32& damage) override { damage = 0; } // no, you can't kill it
+        void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override { damage = 0; } // no, you can't kill it
     };
 };
 

--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_keristrasza.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_keristrasza.cpp
@@ -157,7 +157,7 @@ class boss_keristrasza : public CreatureScript
                     _intenseColdList.push_back(guid);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!_enrage && me->HealthBelowPctDamaged(25, damage))
                 {

--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_ormorok.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_ormorok.cpp
@@ -98,7 +98,7 @@ public:
             Talk(SAY_AGGRO);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
         {
             if (!frenzy && HealthBelowPct(25))
             {

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_eregos.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_eregos.cpp
@@ -178,7 +178,7 @@ class boss_eregos : public CreatureScript
                 summon->CastSpell(summon, SPELL_PLANAR_BLAST, true);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!IsHeroic())
                     return;

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
@@ -189,7 +189,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*pDoneBy*/, uint32 &uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pDoneBy*/, uint32 &uiDamage) override
         {
             if (!me->IsVisible())
                 uiDamage = 0;
@@ -337,7 +337,7 @@ public:
                 me->DespawnOrUnsummon();
         }
 
-        void DamageTaken(Unit* /*pDoneBy*/, uint32 &uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pDoneBy*/, uint32 &uiDamage) override
         {
             uiDamage = 0;
         }

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
@@ -178,7 +178,7 @@ public:
             DoMeleeAttackIfReady();
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (me->HealthBelowPctDamaged(100 - 25 * _healthAmountModifier, damage))
             {

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_volkhan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_volkhan.cpp
@@ -419,7 +419,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*pDoneBy*/, uint32 &uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& /*pDoneBy*/, uint32 &uiDamage) override
         {
             if (uiDamage > me->GetHealth())
             {

--- a/src/server/scripts/Northrend/Ulduar/HallsOfStone/halls_of_stone.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfStone/halls_of_stone.cpp
@@ -402,7 +402,7 @@ public:
             Start();
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32& /*damage*/) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32& /*damage*/) override
         {
             if (instance->GetBossState(DATA_TRIBUNAL_OF_AGES) == IN_PROGRESS)
                 brannSparklinNews = false;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -509,7 +509,7 @@ class boss_algalon_the_observer : public CreatureScript
                 me->SetSheath(SHEATH_STATE_UNARMED);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (_fightWon)
                 {
@@ -848,7 +848,7 @@ class npc_collapsing_star : public CreatureScript
                 me->DespawnOrUnsummon(1);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (_dying)
                 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -424,7 +424,7 @@ struct npc_feral_defender : public ScriptedAI
         DoMeleeAttackIfReady();
     }
 
-    void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && me->HasAura(SPELL_FERAL_ESSENCE))
         {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -731,7 +731,7 @@ class boss_flame_leviathan_defense_turret : public CreatureScript
         {
             boss_flame_leviathan_defense_turretAI(Creature* creature) : TurretAI(creature) { }
 
-            void DamageTaken(Unit* who, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
             {
                 if (!CanAIAttack(who))
                     damage = 0;
@@ -902,7 +902,7 @@ class npc_pool_of_tar : public CreatureScript
                 me->CastSpell(me, SPELL_TAR_PASSIVE, true);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 damage = 0;
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -328,7 +328,7 @@ class boss_freya : public CreatureScript
                     Talk(SAY_SLAY);
             }
 
-            void DamageTaken(Unit* who, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {
@@ -836,7 +836,7 @@ class boss_elder_stonebark : public CreatureScript
                     Talk(SAY_ELDER_AGGRO);
             }
 
-            void DamageTaken(Unit* who, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32& damage) override
             {
                 if (!who || who == me)
                     return;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -417,7 +417,7 @@ class npc_saronite_vapors : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 // This can't be on JustDied. In 63322 dummy handler caster needs to be this NPC
                 // if caster == target then damage mods will increase the damage taken

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -287,7 +287,7 @@ class npc_ice_block : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* who, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32& /*damage*/) override
             {
                 if (Creature* helper = ObjectAccessor::GetCreature(*me, targetGUID))
                 {
@@ -382,7 +382,7 @@ class boss_hodir : public CreatureScript
                     Talk(SAY_SLAY);
             }
 
-            void DamageTaken(Unit* who, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -323,7 +323,7 @@ class npc_iron_construct : public CreatureScript
                 Initialize();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HasAura(RAID_MODE(SPELL_BRITTLE, SPELL_BRITTLE_25)) && damage >= 5000)
                 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -692,7 +692,7 @@ class boss_leviathan_mk_ii : public CreatureScript
                 _setupRocket = true;
             }
 
-            void DamageTaken(Unit* who, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
             {
                 if (damage >= me->GetHealth())
                 {
@@ -938,7 +938,7 @@ class boss_vx_001 : public CreatureScript
                 _fireFighter = false;
             }
 
-            void DamageTaken(Unit* who, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
             {
                 if (damage >= me->GetHealth())
                 {
@@ -1120,7 +1120,7 @@ class boss_aerial_command_unit : public CreatureScript
                 fireFigther = false;
             }
 
-            void DamageTaken(Unit* who, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
             {
                 if (damage >= me->GetHealth())
                 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -548,7 +548,7 @@ struct boss_razorscale : public BossAI
         me->SummonCreature(NPC_RAZORSCALE_SPAWNER, x, y, z, 0, TEMPSUMMON_TIMED_DESPAWN, 15000);
     }
 
-    void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
     {
         if (!_permaGround && me->HealthBelowPctDamaged(50, damage) && events.IsInPhase(PHASE_GROUND))
         {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -920,7 +920,7 @@ class boss_thorim : public CreatureScript
                 return runicColossus && !runicColossus->IsAlive() && runeGiant && !runeGiant->IsAlive();
             }
 
-            void DamageTaken(Unit* attacker, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
             {
                 if (events.IsInPhase(PHASE_1) && CanStartPhase2(attacker))
                 {
@@ -1168,7 +1168,7 @@ class npc_thorim_pre_phase : public CreatureScript
                 return !target->GetAffectingPlayer();
             }
 
-            void DamageTaken(Unit* attacker, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
             {
                 // nullify spell damage
                 if (!attacker || !attacker->GetAffectingPlayer())

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -250,7 +250,7 @@ class boss_xt002 : public CreatureScript
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!_hardMode && _phase == 1 && !HealthAbovePct(100 - 25 * (_heartExposed+1)))
                     ExposeHeart();
@@ -687,7 +687,7 @@ class npc_boombot : public CreatureScript
                     me->GetMotionMaster()->MoveFollow(xt002, 0.0f, 0.0f);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (damage >= (me->GetHealth() - me->GetMaxHealth() * 0.5f) && !_boomed)
                 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
@@ -713,7 +713,7 @@ class boss_sara : public CreatureScript
                 _linkData.erase(player1);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {
@@ -1054,7 +1054,7 @@ class boss_brain_of_yogg_saron : public CreatureScript
                 _summons.DespawnAll();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(30, damage) && !me->HasAura(SPELL_BRAIN_HURT_VISUAL))
                 {
@@ -1476,7 +1476,7 @@ class npc_immortal_guardian : public CreatureScript
                 _events.ScheduleEvent(EVENT_DRAIN_LIFE, urand(3000, 13000));
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(1, damage))
                     damage = me->GetHealth() - me->CountPctFromMaxHealth(1);   // or set immune to damage? should be done here or in SPELL_WEAKENED spell script?

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
@@ -119,7 +119,7 @@ class boss_ingvar_the_plunderer : public CreatureScript
                 _Reset();
             }
 
-            void DamageTaken(Unit* /*doneBy*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*doneBy*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth() && events.IsInPhase(PHASE_HUMAN))
                 {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -256,7 +256,7 @@ class npc_vrykul_skeleton : public CreatureScript
                 events.ScheduleEvent(EVENT_DECREPIFY, urand(4, 6) * IN_MILLISECONDS);
             }
 
-            void DamageTaken(Unit* /*doneBy*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*doneBy*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_skarvald_dalronn.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_skarvald_dalronn.cpp
@@ -217,7 +217,7 @@ class boss_skarvald_the_constructor : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (!Enraged && !IsInGhostForm && me->HealthBelowPctDamaged(15, damage))
                 {

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -557,7 +557,7 @@ class npc_scourge_hulk : public CreatureScript
                 return type == DATA_INCREDIBLE_HULK ? killedByRitualStrike : 0;
             }
 
-            void DamageTaken(Unit* attacker, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32 &damage) override
             {
                 if (damage >= me->GetHealth() && attacker && attacker->GetEntry() == NPC_SVALA_SORROWGRAVE)
                     killedByRitualStrike = true;

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_ymiron.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_ymiron.cpp
@@ -205,7 +205,7 @@ public:
             summons.Summon(summon);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (me->HealthBelowPctDamaged(100 - HealthAmountMultipler * HealthAmountModifier, damage) && !(damage >= me->GetHealth()))
             {

--- a/src/server/scripts/Northrend/VioletHold/boss_ichoron.cpp
+++ b/src/server/scripts/Northrend/VioletHold/boss_ichoron.cpp
@@ -272,7 +272,7 @@ class npc_ichor_globule : public CreatureScript
 
             // on retail spell casted on a creature's death are not casted after death but keeping mob at 1 health, casting it and then letting the mob die.
             // this feature should be still implemented
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (_splashTriggered)
                     return;

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -73,7 +73,7 @@ public:
             me->SetFaction(FACTION_MONSTER);
         }
 
-        void DamageTaken(Unit* pDoneBy, uint32& uiDamage) override
+        void DamageTaken(MemoryOf<Unit> const& pDoneBy, uint32& uiDamage) override
         {
             if (uiDamage > me->GetHealth() && pDoneBy && pDoneBy->GetTypeId() == TYPEID_PLAYER)
             {
@@ -229,7 +229,7 @@ class npc_tournament_training_dummy : public CreatureScript
                 Reset();
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 damage = 0;
                 events.RescheduleEvent(EVENT_DUMMY_RESET, 10000);

--- a/src/server/scripts/Northrend/zone_storm_peaks.cpp
+++ b/src/server/scripts/Northrend/zone_storm_peaks.cpp
@@ -788,7 +788,7 @@ class npc_wild_wyrm : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (damage >= me->GetHealth())
                 {

--- a/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_anzu.cpp
+++ b/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_anzu.cpp
@@ -97,7 +97,7 @@ class boss_anzu : public CreatureScript
                 _JustDied();
             }
 
-            void DamageTaken(Unit* /*killer*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*killer*/, uint32 &damage) override
             {
                 if (me->HealthBelowPctDamaged(33, damage) && !_under33Percent)
                 {

--- a/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_darkweaver_syth.cpp
+++ b/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_darkweaver_syth.cpp
@@ -121,7 +121,7 @@ public:
             summons.Summon(summoned);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
         {
             if (me->HealthBelowPctDamaged(90, damage) && !_summon90)
             {

--- a/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_talon_king_ikiss.cpp
+++ b/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_talon_king_ikiss.cpp
@@ -129,7 +129,7 @@ public:
             }
         }
 
-        void DamageTaken(Unit* /*who*/, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
         {
             if (!ManaShield && me->HealthBelowPctDamaged(20, damage))
             {

--- a/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
@@ -701,7 +701,7 @@ struct boss_illidan_stormrage : public BossAI
         }
     }
 
-    void DamageTaken(Unit* who, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && (!who || who->GetGUID() != me->GetGUID()))
         {
@@ -1193,7 +1193,7 @@ struct npc_akama_illidan : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*who*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32 &damage) override
     {
         if (damage >= me->GetHealth())
             damage = me->GetHealth() - 1;
@@ -1649,7 +1649,7 @@ struct npc_maiev : public ScriptedAI
             _canDown = true;
     }
 
-    void DamageTaken(Unit* /*who*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && _canDown)
         {

--- a/src/server/scripts/Outland/BlackTemple/boss_illidari_council.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidari_council.cpp
@@ -273,7 +273,7 @@ struct IllidariCouncilBossAI : public BossAI
             illidari->AI()->EnterEvadeMode(why);
     }
 
-    void DamageTaken(Unit* who, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& who, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && (!who || who->GetGUID() != me->GetGUID()))
             damage = me->GetHealth() - 1;
@@ -457,10 +457,10 @@ struct boss_lady_malande : public IllidariCouncilBossAI
         events.ScheduleEvent(EVENT_DIVINE_WRATH, Seconds(32));
     }
 
-    void HealReceived(Unit* /*who*/, uint32& addhealth) override
+    void HealReceived(MemoryOf<Unit> const& /*who*/, uint32& amount) override
     {
         // Need be negative to heal trigger
-        me->CastSpell(nullptr, SPELL_SHARED_RULE, CastSpellExtraArgs(TRIGGERED_FULL_MASK).AddSpellBP0(-int32(addhealth)));
+        me->CastSpell(nullptr, SPELL_SHARED_RULE, CastSpellExtraArgs(TRIGGERED_FULL_MASK).AddSpellBP0(-int32(amount)));
     }
 
     void ExecuteEvent(uint32 eventId) override

--- a/src/server/scripts/Outland/BlackTemple/boss_mother_shahraz.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_mother_shahraz.cpp
@@ -146,7 +146,7 @@ struct boss_mother_shahraz : public BossAI
         _DespawnAtEvade();
     }
 
-    void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
     {
         if (!_enraged && me->HealthBelowPctDamaged(10, damage))
         {

--- a/src/server/scripts/Outland/BlackTemple/boss_reliquary_of_souls.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_reliquary_of_souls.cpp
@@ -321,7 +321,7 @@ struct boss_essence_of_suffering : public BossAI
         }
     }
 
-    void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
     {
         if (damage >= me->GetHealth())
         {
@@ -440,7 +440,7 @@ struct boss_essence_of_desire : public BossAI
         }
     }
 
-    void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
     {
         if (damage >= me->GetHealth())
         {

--- a/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
@@ -398,7 +398,7 @@ struct npc_akama_shade : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* /*who*/, uint32& /*damage*/) override
+    void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& /*damage*/) override
     {
         if (me->HealthBelowPct(20) && !_hasYelledOnce)
         {
@@ -984,7 +984,7 @@ struct npc_ashtongue_spiritbinder : public ScriptedAI
         _events.ScheduleEvent(EVENT_SPIRIT_HEAL, Seconds(5), Seconds(6));
     }
 
-    void DamageTaken(Unit* /*who*/, uint32& /*damage*/) override
+    void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& /*damage*/) override
     {
         if (!_spiritMend)
             if (HealthBelowPct(30))

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
@@ -127,7 +127,7 @@ public:
                 unit->RemoveAurasDueToSpell(SPELL_INSIDIOUS_WHISPER);
         }
 
-        void DamageTaken(Unit* done_by, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& done_by, uint32 &damage) override
         {
             if (!done_by || (done_by->GetGUID() != victimGUID && done_by->GetGUID() != me->GetGUID()))
             {

--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_warlord_kalithresh.cpp
@@ -88,7 +88,7 @@ public:
             instance->SetData(DATA_DISTILLER, IN_PROGRESS);
         }
 
-        void DamageTaken(Unit* /*done_by*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*done_by*/, uint32 &damage) override
         {
             if (me->GetHealth() <= damage)
                 instance->SetData(DATA_DISTILLER, DONE);

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -191,7 +191,7 @@ class boss_magtheridon : public CreatureScript
                     Talk(SAY_BANISHED);
             }
 
-            void DamageTaken(Unit* /*who*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*who*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(30, damage) && !events.IsInPhase(PHASE_3))
                 {

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
@@ -196,7 +196,7 @@ class boss_alar : public CreatureScript
                     ScriptedAI::AttackStart(who);
             }
 
-            void DamageTaken(Unit* /*killer*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*killer*/, uint32 &damage) override
             {
                 if (damage >= me->GetHealth() && Phase1)
                 {
@@ -521,7 +521,7 @@ class npc_ember_of_alar : public CreatureScript
                 me->setDeathState(JUST_DIED);
             }
 
-            void DamageTaken(Unit* killer, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& killer, uint32& damage) override
             {
                 if (damage >= me->GetHealth() && killer != me && !toDie)
                 {

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -370,7 +370,7 @@ struct advisorbase_ai : public ScriptedAI
         }
     }
 
-    void DamageTaken(Unit* killer, uint32 &damage) override
+    void DamageTaken(MemoryOf<Unit> const& killer, uint32 &damage) override
     {
         if (damage >= me->GetHealth() && !_inFakeDeath && !_hasRessurrected)
         {
@@ -568,7 +568,7 @@ class boss_kaelthas : public CreatureScript
                 }
             }
 
-            void DamageTaken(Unit* attacker, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& attacker, uint32& damage) override
             {
                 if (_phase == PHASE_NONE)
                 {

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_pathaleon_the_calculator.cpp
@@ -98,7 +98,7 @@ class boss_pathaleon_the_calculator : public CreatureScript
                 Talk(SAY_DEATH);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& damage) override
             {
                 if (me->HealthBelowPctDamaged(20, damage) && !me->HasAura(SPELL_FRENZY))
                 {

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_commander_sarannis.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_commander_sarannis.cpp
@@ -86,7 +86,7 @@ class boss_commander_sarannis : public CreatureScript
                 Talk(SAY_DEATH);
             }
 
-            void DamageTaken(Unit* /*killer*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*killer*/, uint32 &damage) override
             {
                 if (me->HealthBelowPctDamaged(50, damage) && _phase)
                 {

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
@@ -88,7 +88,7 @@ class boss_thorngrin_the_tender : public CreatureScript
                 Talk(SAY_DEATH);
             }
 
-            void DamageTaken(Unit* /*killer*/, uint32 &damage) override
+            void DamageTaken(MemoryOf<Unit> const& /*killer*/, uint32 &damage) override
             {
                 if (me->HealthBelowPctDamaged(50, damage) && _phase1)
                 {

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -964,7 +964,7 @@ public:
             me->SetImmuneToPC(true);
         }
 
-        void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32 &damage) override
         {
             if (damage > me->GetHealth() || me->HealthBelowPctDamaged(20, damage))
             {

--- a/src/server/scripts/Outland/zone_terokkar_forest.cpp
+++ b/src/server/scripts/Outland/zone_terokkar_forest.cpp
@@ -98,7 +98,7 @@ public:
             UnkorUnfriendly_Timer = 60000;
         }
 
-        void DamageTaken(Unit* done_by, uint32 &damage) override
+        void DamageTaken(MemoryOf<Unit> const& done_by, uint32 &damage) override
         {
             if (!done_by || !me->HealthBelowPctDamaged(30, damage))
                 return;

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -966,10 +966,10 @@ class spell_dru_leader_of_the_pack : public SpellScriptLoader
                 caster->GetSpellHistory()->AddCooldown(SPELL_DRUID_IMP_LEADER_OF_THE_PACK_HEAL, 0, Seconds(6));
 
                 // only proc on self
-                if (aurEff->GetCasterGUID() != caster->GetGUID())
+                if (aurEff->GetCaster() != caster->GetGUID())
                     return;
 
-                AuraEffect const* impLotpMana = caster->GetAuraEffectOfRankedSpell(SPELL_DRUID_IMP_LEADER_OF_THE_PACK_R1, EFFECT_0, aurEff->GetCasterGUID());
+                AuraEffect const* impLotpMana = caster->GetAuraEffectOfRankedSpell(SPELL_DRUID_IMP_LEADER_OF_THE_PACK_R1, EFFECT_0, aurEff->GetCaster());
                 ASSERT(impLotpMana);
 
                 CastSpellExtraArgs args2(aurEff);
@@ -1015,13 +1015,13 @@ class spell_dru_lifebloom : public SpellScriptLoader
                 {
                     // restore mana
                     CastSpellExtraArgs args(aurEff);
-                    args.OriginalCaster = GetCasterGUID();
+                    args.OriginalCaster = GetCaster();
                     args.AddSpellBP0(CalculatePct(caster->GetCreateMana(), GetSpellInfo()->ManaCostPercentage) * stack / 2);
                     caster->CastSpell(caster, SPELL_DRUID_LIFEBLOOM_ENERGIZE, args);
                 }
 
                 CastSpellExtraArgs args(aurEff);
-                args.OriginalCaster = GetCasterGUID();
+                args.OriginalCaster = GetCaster();
                 args.AddSpellBP0(healAmount);
                 target->CastSpell(GetTarget(), SPELL_DRUID_LIFEBLOOM_FINAL_HEAL, args);
             }
@@ -1511,7 +1511,7 @@ class spell_dru_savage_roar : public SpellScriptLoader
             void AfterApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
             {
                 Unit* target = GetTarget();
-                target->CastSpell(target, SPELL_DRUID_SAVAGE_ROAR, { aurEff, GetCasterGUID() });
+                target->CastSpell(target, SPELL_DRUID_SAVAGE_ROAR, { aurEff, GetCaster() });
             }
 
             void AfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -722,7 +722,7 @@ class spell_gen_burning_depths_necrolyte_image : public AuraScript
 
     void HandleRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        GetTarget()->RemoveAurasDueToSpell(uint32(GetSpellInfo()->Effects[EFFECT_2].CalcValue()), GetCasterGUID());
+        GetTarget()->RemoveAurasDueToSpell(uint32(GetSpellInfo()->Effects[EFFECT_2].CalcValue()), GetCaster());
     }
 
     void Register() override
@@ -1645,7 +1645,7 @@ class spell_gen_lifebloom : public SpellScriptLoader
                     return;
 
                 // final heal
-                GetTarget()->CastSpell(GetTarget(), _spellId, { aurEff, GetCasterGUID() });
+                GetTarget()->CastSpell(GetTarget(), _spellId, { aurEff, GetCaster() });
             }
 
             void Register() override
@@ -3101,7 +3101,7 @@ class spell_gen_turkey_marker : public AuraScript
 
         // on stack 15 cast the achievement crediting spell
         if (GetStackAmount() >= 15)
-            target->CastSpell(target, SPELL_TURKEY_VENGEANCE, { aurEff, GetCasterGUID() });
+            target->CastSpell(target, SPELL_TURKEY_VENGEANCE, { aurEff, GetCaster() });
     }
 
     void OnPeriodic(AuraEffect const* /*aurEff*/)

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -239,7 +239,7 @@ class spell_hun_chimera_shot : public SpellScriptLoader
                     for (Unit::AuraApplicationMap::const_iterator i = auras.begin(); i != auras.end(); ++i)
                     {
                         Aura* aura = i->second->GetBase();
-                        if (aura->GetCasterGUID() != caster->GetGUID())
+                        if (aura->GetCaster() != caster->GetGUID())
                             continue;
 
                         // Search only Serpent Sting, Viper Sting, Scorpid Sting auras
@@ -423,7 +423,7 @@ class spell_hun_glyph_of_arcane_shot : public SpellScriptLoader
                     for (Unit::AuraApplicationMap::const_iterator i = auras.begin(); i != auras.end(); ++i)
                     {
                         Aura const* aura = i->second->GetBase();
-                        if (aura->GetCasterGUID() != GetTarget()->GetGUID())
+                        if (aura->GetCaster() != GetTarget()->GetGUID())
                             continue;
                         // Search only Serpent Sting, Viper Sting, Scorpid Sting, Wyvern Sting
                         if (aura->GetSpellInfo()->SpellFamilyName == SPELLFAMILY_HUNTER

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1550,7 +1550,7 @@ class spell_item_power_circle : public AuraScript
 
     bool CheckCaster(Unit* target)
     {
-        return target->GetGUID() == GetCasterGUID();
+        return target->GetGUID() == GetCaster();
     }
 
     void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -238,7 +238,7 @@ class spell_pal_aura_mastery : public SpellScriptLoader
 
             void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
-                GetTarget()->RemoveOwnedAura(SPELL_PALADIN_AURA_MASTERY_IMMUNE, GetCasterGUID());
+                GetTarget()->RemoveOwnedAura(SPELL_PALADIN_AURA_MASTERY_IMMUNE, GetCaster());
             }
 
             void Register() override
@@ -271,7 +271,7 @@ class spell_pal_aura_mastery_immune : public SpellScriptLoader
 
             bool CheckAreaTarget(Unit* target)
             {
-                return target->HasAura(SPELL_PALADIN_CONCENTRACTION_AURA, GetCasterGUID());
+                return target->HasAura(SPELL_PALADIN_CONCENTRACTION_AURA, GetCaster());
             }
 
             void Register() override
@@ -449,7 +449,7 @@ class spell_pal_blessing_of_sanctuary : public SpellScriptLoader
             void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 Unit* target = GetTarget();
-                target->RemoveAura(SPELL_PALADIN_BLESSING_OF_SANCTUARY_BUFF, GetCasterGUID());
+                target->RemoveAura(SPELL_PALADIN_BLESSING_OF_SANCTUARY_BUFF, GetCaster());
             }
 
             bool CheckProc(ProcEventInfo& /*eventInfo*/)
@@ -1140,7 +1140,7 @@ class spell_pal_improved_aura : public SpellScriptLoader
             void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 Unit* target = GetTarget();
-                GetTarget()->RemoveOwnedAura(_spellId, GetCasterGUID()); // need to remove to reapply spellmods
+                GetTarget()->RemoveOwnedAura(_spellId, GetCaster()); // need to remove to reapply spellmods
                 target->CastSpell(target, _spellId, true);
             }
 
@@ -1152,7 +1152,7 @@ class spell_pal_improved_aura : public SpellScriptLoader
                     || (spellId == SPELL_PALADIN_SWIFT_RETRIBUTION_R1 && GetTarget()->GetAuraOfRankedSpell(SPELL_PALADIN_SANCTIFIED_RETRIBUTION_R1)))
                     return;
 
-                GetTarget()->RemoveOwnedAura(_spellId, GetCasterGUID());
+                GetTarget()->RemoveOwnedAura(_spellId, GetCaster());
             }
 
             void Register() override
@@ -1192,7 +1192,7 @@ class spell_pal_improved_aura_effect : public SpellScriptLoader
                 for (Unit::AuraApplicationMap::iterator itr = appliedAuras.begin(); itr != appliedAuras.end(); ++itr)
                 {
                     Aura const* aura = itr->second->GetBase();
-                    if (aura->GetSpellInfo()->GetSpellSpecific() == SPELL_SPECIFIC_AURA && aura->GetCasterGUID() == GetCasterGUID())
+                    if (aura->GetSpellInfo()->GetSpellSpecific() == SPELL_SPECIFIC_AURA && aura->GetCaster() == GetCaster())
                     {
                         // Not allow for Retribution Aura (prevent stacking) - Retribution Aura Overflow and Retribution Aura has same spell effects
                         if (GetSpellInfo()->Id == SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA && aura->GetSpellInfo()->SpellIconID == PALADIN_ICON_ID_RETRIBUTION_AURA)
@@ -1526,7 +1526,7 @@ class spell_pal_judgement_of_light_heal : public SpellScriptLoader
                 Unit* caster = eventInfo.GetProcTarget();
 
                 CastSpellExtraArgs args(aurEff);
-                args.OriginalCaster = GetCasterGUID();
+                args.OriginalCaster = GetCaster();
                 args.AddSpellBP0(caster->CountPctFromMaxHealth(aurEff->GetAmount()));
                 caster->CastSpell(nullptr, SPELL_PALADIN_JUDGEMENT_OF_LIGHT_HEAL, args);
             }
@@ -1572,7 +1572,7 @@ class spell_pal_judgement_of_wisdom_mana : public SpellScriptLoader
                 Unit* caster = eventInfo.GetProcTarget();
                 int32 const amount = CalculatePct(static_cast<int32>(caster->GetCreateMana()), spellInfo->Effects[EFFECT_0].CalcValue());
                 CastSpellExtraArgs args(aurEff);
-                args.OriginalCaster = GetCasterGUID();
+                args.OriginalCaster = GetCaster();
                 args.AddSpellBP0(amount);
                 caster->CastSpell(nullptr, spellInfo->Id, args);
             }

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1018,7 +1018,7 @@ class spell_pri_power_word_shield : public SpellScriptLoader
                     amount += int32(bonus);
 
                     // Twin Disciplines
-                    if (AuraEffect const* twinDisciplines = caster->GetAuraEffect(SPELL_AURA_ADD_PCT_MODIFIER, SPELLFAMILY_PRIEST, 0x400000, 0, 0, GetCasterGUID()))
+                    if (AuraEffect const* twinDisciplines = caster->GetAuraEffect(SPELL_AURA_ADD_PCT_MODIFIER, SPELLFAMILY_PRIEST, 0x400000, 0, 0, GetCaster()))
                         AddPct(amount, twinDisciplines->GetAmount());
 
                     // Focused Power

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -438,7 +438,7 @@ class spell_sha_earth_shield : public SpellScriptLoader
                 PreventDefaultAction();
 
                 CastSpellExtraArgs args(aurEff);
-                args.OriginalCaster = GetCasterGUID();
+                args.OriginalCaster = GetCaster();
                 args.AddSpellBP0(aurEff->GetAmount());
                 GetTarget()->CastSpell(GetTarget(), SPELL_SHAMAN_EARTH_SHIELD_HEAL, args);
             }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -729,7 +729,7 @@ class spell_warl_haunt : public SpellScriptLoader
                 if (Unit* caster = GetCaster())
                 {
                     CastSpellExtraArgs args(aurEff);
-                    args.OriginalCaster = GetCasterGUID();
+                    args.OriginalCaster = GetCaster();
                     args.AddSpellBP0(aurEff->GetAmount());
                     GetTarget()->CastSpell(caster, SPELL_WARLOCK_HAUNT_HEAL, args);
                 }
@@ -1343,7 +1343,7 @@ class spell_warl_soul_leech : public SpellScriptLoader
                 caster->CastSpell(caster, SPELL_WARLOCK_SOUL_LEECH_HEAL, args);
 
                 // Improved Soul Leech code below
-                AuraEffect const* impSoulLeech = GetTarget()->GetAuraEffectOfRankedSpell(SPELL_WARLOCK_IMP_SOUL_LEECH_R1, EFFECT_1, aurEff->GetCasterGUID());
+                AuraEffect const* impSoulLeech = GetTarget()->GetAuraEffectOfRankedSpell(SPELL_WARLOCK_IMP_SOUL_LEECH_R1, EFFECT_1, aurEff->GetCaster());
                 if (!impSoulLeech)
                     return;
 

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -1099,7 +1099,7 @@ class spell_warr_vigilance : public SpellScriptLoader
                     target->RemoveAurasDueToSpell(SPELL_GEN_DAMAGE_REDUCTION_AURA);
                 }
 
-                target->GetThreatManager().UnregisterRedirectThreat(SPELL_WARRIOR_VIGILANCE_REDIRECT_THREAT, GetCasterGUID());
+                target->GetThreatManager().UnregisterRedirectThreat(SPELL_WARRIOR_VIGILANCE_REDIRECT_THREAT, GetCaster());
             }
 
             bool CheckProc(ProcEventInfo& /*eventInfo*/)

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -281,7 +281,7 @@ class boss_ysondre : public CreatureScript
             }
 
             // Summon druid spirits on 75%, 50% and 25% health
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!HealthAbovePct(100 - 25 * _stage))
                 {
@@ -374,7 +374,7 @@ class boss_lethon : public CreatureScript
                 WorldBossAI::JustEngagedWith(who);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!HealthAbovePct(100 - 25 * _stage))
                 {
@@ -509,7 +509,7 @@ class boss_emeriss : public CreatureScript
                 WorldBossAI::JustEngagedWith(who);
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 if (!HealthAbovePct(100 - 25 * _stage))
                 {
@@ -612,7 +612,7 @@ class boss_taerar : public CreatureScript
                 --_shades;
             }
 
-            void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/) override
+            void DamageTaken(MemoryOf<Unit> const& /*attacker*/, uint32& /*damage*/) override
             {
                 // At 75, 50 or 25 percent health, we need to activate the shades and go "banished"
                 // Note: _stage holds the amount of times they have been summoned

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -1779,7 +1779,7 @@ public:
             Reset();
         }
 
-        void DamageTaken(Unit* doneBy, uint32& damage) override
+        void DamageTaken(MemoryOf<Unit> const& doneBy, uint32& damage) override
         {
             if (doneBy)
                 _damageTimes[doneBy->GetGUID()] = GameTime::GetGameTime();


### PR DESCRIPTION
Currently, `Spell` (and related classes, such as `Aura`), hold a GUID + pointer for units that may go away - the pointer is updated on each tick from the GUID.

In this PR, @ariel- and myself codify this behavior into a new template class that I've dubbed `MemoryOf<T>`, which natively casts to `ObjectGuid` and `T*`, as well as (explicitly) to `bool`. Via operator overloads, it also supports the methods of both `ObjectGuid` (through `.`) and `T` (through `->`, not-`nullptr` asserted).

This allows us to pass `MemoryOf<T> const&` in place of `T*` through most of the call stack all the way into AI hooks, making original GUID information available even if the unit has gone away in the meantime.

**PR status:**
* `MemoryOf<T>` added
* `Spell` refactored
* `Aura` and derived in the progress of refactoring
* `SpellScript` untouched for now

_(**Note:** this PR may or may not build at any given point in time. Please limit feedback to components listed as finished.)_