### PR TITLE
Scripts/Uldaman: Archaedas should become attackable after clicking the altar

### DIFF
--- a/src/server/scripts/EasternKingdoms/Uldaman/instance_uldaman.cpp
+++ b/src/server/scripts/EasternKingdoms/Uldaman/instance_uldaman.cpp
@@ -263,6 +263,8 @@ class instance_uldaman : public InstanceMapScript
                 {
                     archaedas->RemoveAura(SPELL_FREEZE_ANIM);
                     archaedas->CastSpell(archaedas, SPELL_ARCHAEDAS_AWAKEN, false);
+                    archaedas->SetFaction(FACTION_TITAN);
+                    archaedas->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                     whoWokeuiArchaedasGUID = target;
                 }
             }


### PR DESCRIPTION
**Changes proposed:**

-  Archaedas should properly start now when clicking on the altar.

**Target branch(es):** 3.3.5

- [x] 3.3.5

**Issues addressed:** Closes #21399


**Tests performed:** (Does it build, tested in-game, etc.)

Builds and tested in-game. Works.

**Known issues and TODO list:** 

Hey - this is actually my first time i touch something inside the source and creating a PR. sorry if this solution is not good, it fixed the problem for me. thanks all :)
