### PR TITLE
Core/Unit: do not stop movement on root and freeze when target is affected by parabolic spline before call of affected functions

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11280,7 +11280,9 @@ void Unit::SetStunned(bool apply)
         SetTarget(ObjectGuid::Empty);
         SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
 
-        StopMoving();
+        // Do not stop movement when the unit is affected by parabolic spline movement (knockbacks, pulls, scripted leaps etc.)
+        if (!movespline->isParabolic())
+            StopMoving();
 
         if (GetTypeId() == TYPEID_PLAYER)
             SetStandState(UNIT_STAND_STATE_STAND);
@@ -11315,7 +11317,10 @@ void Unit::SetRooted(bool apply, bool packetOnly /*= false*/)
             // setting MOVEMENTFLAG_ROOT
             RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
             AddUnitMovementFlag(MOVEMENTFLAG_ROOT);
-            StopMoving();
+
+            // Do not stop movement when the unit is affected by parabolic spline movement (knockbacks, pulls, scripted leaps etc.)
+            if (!movespline->isParabolic())
+                StopMoving();
         }
         else
             RemoveUnitMovementFlag(MOVEMENTFLAG_ROOT);

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -133,6 +133,7 @@ namespace Movement
         bool Finalized() const { return splineflags.done; }
         bool isCyclic() const { return splineflags.cyclic; }
         bool isFalling() const { return splineflags.falling; }
+        bool isParabolic() const { return splineflags.parabolic; }
         Vector3 const& FinalDestination() const { return Initialized() ? spline.getPoint(spline.last()) : Vector3::zero(); }
         Vector3 const& CurrentDestination() const { return Initialized() ? spline.getPoint(point_Idx + 1) : Vector3::zero(); }
         int32 currentPathIdx() const;


### PR DESCRIPTION

**Changes proposed:**

-  add a exception for root and freeze effects to not stop movement when the target is currently affected by parabolic splines like knockbacks, pulls or leaps.
There are some spells that do a pull and a root / freeze at the same time so with the current default handling the pull effect is getting supressed immediately. This fix here will handle this.
If you need an example spell: ID - 82168

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:**
- Tested ingame
