### PR TITLE
Core/Player: fix for Player Instant Logout

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -287,6 +287,7 @@ class TC_GAME_API PlayerMenu
         void SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUID, bool enableNext) const;
         void SendQuestGiverRequestItems(Quest const* quest, ObjectGuid npcGUID, bool canComplete, bool closeOnCancel) const;
 
+        void SetSession(WorldSession* ws) { _session = ws; };
     private:
         GossipMenu _gossipMenu;
         QuestMenu  _questMenu;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -688,6 +688,12 @@ bool Player::Create(ObjectGuid::LowType guidlow, CharacterCreateInfo* createInfo
     return true;
 }
 
+void Player::SetSession(WorldSession* ws) {
+    m_session = ws;
+    if (PlayerTalkClass)
+        PlayerTalkClass->SetSession(ws);
+};
+
 bool Player::StoreNewItemInBestSlots(uint32 titem_id, uint32 titem_amount)
 {
     TC_LOG_DEBUG("entities.player.items", "Player::StoreNewItemInBestSlots: Player '%s' (%s) creates initial item (ItemID: %u, Count: %u)",

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2138,6 +2138,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         std::string GetMapAreaAndZoneString() const;
         std::string GetCoordsMapAreaAndZoneString() const;
 
+        void SetSession(WorldSession* ws);
     protected:
         // Gamemaster whisper whitelist
         GuidList WhisperList;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -748,8 +748,11 @@ void Map::Update(uint32 t_diff)
         {
             //player->Update(t_diff);
             WorldSession* session = player->GetSession();
-            MapSessionFilter updater(session);
-            session->Update(t_diff, updater);
+            if (session && !session->PlayerLogout())
+            {
+                MapSessionFilter updater(session);
+                session->Update(t_diff, updater);
+            }
         }
     }
 

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -330,7 +330,7 @@ class TC_GAME_API WorldSession
         /// Is logout cooldown expired?
         bool ShouldLogOut(time_t currTime) const
         {
-            return (_logoutTime > 0 && currTime >= _logoutTime + 20);
+            return (_logoutTime > 0 && currTime >= _logoutTime + 60);
         }
 
         void LogoutPlayer(bool save);
@@ -1055,6 +1055,10 @@ class TC_GAME_API WorldSession
         bool m_playerLogout;                                // code processed in LogoutPlayer
         bool m_playerRecentlyLogout;
         bool m_playerSave;
+        bool m_playerDestroy;
+        bool m_playerReloaded;
+        uint32 m_playerGuid;
+
         LocaleConstant m_sessionDbcLocale;
         LocaleConstant m_sessionDbLocaleIndex;
         std::atomic<uint32> m_latency;
@@ -1068,7 +1072,6 @@ class TC_GAME_API WorldSession
         LockedQueue<WorldPacket*> _recvQueue;
         rbac::RBACData* _RBACData;
         uint32 expireTime;
-        bool forceExit;
         ObjectGuid m_currentBankerGUID;
 
         WorldSession(WorldSession const& right) = delete;

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -575,6 +575,7 @@ class TC_GAME_API World
         void AddSession(WorldSession* s);
         void SendAutoBroadcast();
         bool RemoveSession(uint32 id);
+		void AddOldSession(WorldSession * ws);
         /// Get the number of current active sessions
         void UpdateMaxSessionCounters();
         SessionMap const& GetAllSessions() const { return m_sessions; }
@@ -804,6 +805,7 @@ class TC_GAME_API World
         time_t mail_timer_expires;
 
         SessionMap m_sessions;
+        SessionMap m_oldSessions;
         typedef std::unordered_map<uint32, time_t> DisconnectMap;
         DisconnectMap m_disconnects;
         uint32 m_maxActiveSessionCount;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Players will have a 1 minute remain in world timer if forced a disconnect. If the player re-logs in before then they will get the existing session. If the player relogs and switches to another character the old logged in character will still remain in the world for 1 minute. Tested on retail and confirmed is correct.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5


**Issues addressed:** Closes #  (insert issue tracker number)

#19926 
#18458

**Tests performed:** (Does it build, tested in-game, etc.)
Patch was tested on a different repository. so needs to be tested properly.

**Known issues and TODO list:** (add/remove lines as needed)
I had an elusive crash when closing the server, no logs saved. Not sure if it was my changes or some other bug.
This re-uses the old sessions memory so extensive testing needed for dangling pointers.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
