### PR TITLE
Core/Players: Fix display for new race

### DIFF
--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -581,8 +581,8 @@ struct PlayerInfo
     float positionY;
     float positionZ;
     float orientation;
-    uint16 displayId_m;
-    uint16 displayId_f;
+    uint32 displayId_m;
+    uint32 displayId_f;
     PlayerCreateInfoItems item;
     PlayerCreateInfoSpells customSpells;
     PlayerCreateInfoSpells castSpells;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

**MaleDisplayID** and **FemaleDisplayID** in ChrRaces are uint32 now
Fix new display for allied races

**Target branch(es):**

- [X] master

**Tests performed:**

Tested IG & build

**TODO**
After a expired polymorph or hex (SPELL_AURA_TRANSFORM), new race get a model broken for example Void Elf get tatoo and face of Lightforged Draenei. I have no idea about this, all others variable are correct.
- [ ] Fixed