### PR TITLE
Core/ArenaTeam: Remove queues of members if a character is removed

### DIFF
--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -18,6 +18,8 @@
 
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
+#include "BattlegroundMgr.h"
+#include "BattlegroundQueue.h"
 #include "CharacterCache.h"
 #include "DatabaseEnv.h"
 #include "Group.h"
@@ -317,6 +319,16 @@ void ArenaTeam::DelMember(ObjectGuid guid, bool cleanDb)
     // Remove member from team
     for (MemberList::iterator itr = Members.begin(); itr != Members.end(); ++itr)
     {
+        // Remove queues of members
+        if (Player* player = ObjectAccessor::FindPlayer(itr->Guid))
+        {
+            if (BattlegroundQueueTypeId bgQueue = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_AA, GetType()))
+            {
+                BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueue);
+                queue.RemovePlayer(itr->Guid, true);
+            }
+        }
+
         if (itr->Guid == guid)
         {
             Members.erase(itr);

--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -19,7 +19,6 @@
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "BattlegroundMgr.h"
-#include "BattlegroundQueue.h"
 #include "CharacterCache.h"
 #include "DatabaseEnv.h"
 #include "Group.h"
@@ -324,8 +323,11 @@ void ArenaTeam::DelMember(ObjectGuid guid, bool cleanDb)
         {
             if (BattlegroundQueueTypeId bgQueue = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_AA, GetType()))
             {
+                GroupQueueInfo ginfo;
                 BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueue);
-                queue.RemovePlayer(itr->Guid, true);
+                if (queue.GetPlayerGroupInfoData(itr->Guid, &ginfo))
+                    if (!ginfo.IsInvitedToBGInstanceGUID)
+                        queue.RemovePlayer(itr->Guid, true);
             }
         }
 

--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -315,7 +315,8 @@ void ArenaTeam::SetCaptain(ObjectGuid guid)
 
 void ArenaTeam::DelMember(ObjectGuid guid, bool cleanDb)
 {
-    Player* player = ObjectAccessor::FindPlayer(guid);
+    Player* player = ObjectAccessor::FindConnectedPlayer(guid);
+    Group* group = (player && player->GetGroup()) ? player->GetGroup() : nullptr;
     
     // Remove member from team
     for (MemberList::iterator itr = Members.begin(); itr != Members.end(); ++itr)
@@ -323,7 +324,7 @@ void ArenaTeam::DelMember(ObjectGuid guid, bool cleanDb)
         // Remove queues of members
         if (Player* playerMember = ObjectAccessor::FindConnectedPlayer(itr->Guid))
         {
-            if (player && player->GetGroup() && playerMember->GetGroup() && player->GetGroup()->GetGUID() == playerMember->GetGroup()->GetGUID())
+            if (group && playerMember->GetGroup() && group->GetGUID() == playerMember->GetGroup()->GetGUID())
             {
                 if (BattlegroundQueueTypeId bgQueue = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_AA, GetType()))
                 {

--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -332,7 +332,7 @@ void ArenaTeam::DelMember(ObjectGuid guid, bool cleanDb)
                         player->RemoveBattlegroundQueueId(bgQueue);
                         sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, nullptr, player->GetBattlegroundQueueIndex(bgQueue), STATUS_NONE, 0, 0, 0, 0);
                         queue.RemovePlayer(player->GetGUID(), true);
-                        SendPacket(&data);
+                        player->GetSession()->SendPacket(&data);
                     }
             }
         }

--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -325,9 +325,15 @@ void ArenaTeam::DelMember(ObjectGuid guid, bool cleanDb)
             {
                 GroupQueueInfo ginfo;
                 BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueue);
-                if (queue.GetPlayerGroupInfoData(itr->Guid, &ginfo))
+                if (queue.GetPlayerGroupInfoData(player->GetGUID(), &ginfo))
                     if (!ginfo.IsInvitedToBGInstanceGUID)
-                        queue.RemovePlayer(itr->Guid, true);
+                    {
+                        WorldPacket data;
+                        player->RemoveBattlegroundQueueId(bgQueue);
+                        sBattlegroundMgr->BuildBattlegroundStatusPacket(&data, nullptr, player->GetBattlegroundQueueIndex(bgQueue), STATUS_NONE, 0, 0, 0, 0);
+                        queue.RemovePlayer(player->GetGUID(), true);
+                        SendPacket(&data);
+                    }
             }
         }
 

--- a/src/server/game/Handlers/ArenaTeamHandler.cpp
+++ b/src/server/game/Handlers/ArenaTeamHandler.cpp
@@ -19,6 +19,7 @@
 #include "WorldSession.h"
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
+#include "BattlegroundMgr.h"
 #include "CharacterCache.h"
 #include "Log.h"
 #include "ObjectAccessor.h"
@@ -233,6 +234,19 @@ void WorldSession::HandleArenaTeamLeaveOpcode(WorldPacket& recvData)
         return;
     }
 
+    // Player cannot be removed during queues
+    if (BattlegroundQueueTypeId bgQueue = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_AA, arenaTeam->GetType()))
+    {
+        GroupQueueInfo ginfo;
+        BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueue);
+        if (queue.GetPlayerGroupInfoData(_player->GetGUID(), &ginfo))
+            if (ginfo.IsInvitedToBGInstanceGUID)
+            {
+                SendArenaTeamCommandResult(ERR_ARENA_TEAM_QUIT_S, "", "", ERR_ARENA_TEAMS_LOCKED);
+                return;
+            }
+    }
+
     // If team consists only of the captain, disband the team
     if (_player->GetGUID() == arenaTeam->GetCaptain())
     {
@@ -262,6 +276,16 @@ void WorldSession::HandleArenaTeamDisbandOpcode(WorldPacket& recvData)
         // Only captain can disband the team
         if (arenaTeam->GetCaptain() != _player->GetGUID())
             return;
+
+        // Teams cannot be disbanded during queues
+        if (BattlegroundQueueTypeId bgQueue = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_AA, arenaTeam->GetType()))
+        {
+            GroupQueueInfo ginfo;
+            BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueue);
+            if (queue.GetPlayerGroupInfoData(_player->GetGUID(), &ginfo))
+                if (ginfo.IsInvitedToBGInstanceGUID)
+                    return;
+        }
 
         // Teams cannot be disbanded during fights
         if (arenaTeam->IsFighting())
@@ -310,6 +334,19 @@ void WorldSession::HandleArenaTeamRemoveOpcode(WorldPacket& recvData)
     {
         SendArenaTeamCommandResult(ERR_ARENA_TEAM_QUIT_S, "", "", ERR_ARENA_TEAM_LEADER_LEAVE_S);
         return;
+    }
+
+    // Team cannot be removed during queues
+    if (BattlegroundQueueTypeId bgQueue = BattlegroundMgr::BGQueueTypeId(BATTLEGROUND_AA, arenaTeam->GetType()))
+    {
+        GroupQueueInfo ginfo;
+        BattlegroundQueue& queue = sBattlegroundMgr->GetBattlegroundQueue(bgQueue);
+        if (queue.GetPlayerGroupInfoData(_player->GetGUID(), &ginfo))
+            if (ginfo.IsInvitedToBGInstanceGUID)
+            {
+                SendArenaTeamCommandResult(ERR_ARENA_TEAM_QUIT_S, "", "", ERR_ARENA_TEAMS_LOCKED);
+                return;
+            }
     }
 
     // Player cannot be removed during fights


### PR DESCRIPTION
**Changes proposed:**

If a character is removed of arena team, then the queues are removed of members.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #21487

**Tests performed:** Build

PR closed: #21490 