### PR TITLE
Core/DataStores: Set default appearance if one does not exist

### DIFF
--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -855,6 +855,10 @@ void DB2Manager::LoadStores(std::string const& dataPath, uint32 defaultLocale)
     {
         ASSERT(appearanceMod->ItemID <= 0xFFFFFF);
         _itemModifiedAppearancesByItem[appearanceMod->ItemID | (appearanceMod->AppearanceModID << 24)] = appearanceMod;
+
+        auto it = _itemModifiedAppearancesByItem.find(appearanceMod->ItemID);
+        if (it == _itemModifiedAppearancesByItem.end() || appearanceMod->AppearanceModID < it->second->AppearanceModID)
+            _itemModifiedAppearancesByItem[appearanceMod->ItemID] = appearanceMod;
     }
 
     for (ItemSetSpellEntry const* itemSetSpell : sItemSetSpellStore)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Sets default appearance if one does not exist
-  Uses lowest appearancemodid of the ones available

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #21483

**Tests performed:** (Does it build, tested in-game, etc.)

- builds
- Fixes the issue of char selection screen not showing the equipped item (tested item 116244)
- Fixes aquiring transmogrification and transmogrifying to the item (tested item 116244)

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] I dont like the implicitness of this edit
- [ ] Unsure if using lowest modid is correct way to handle getting default appearance
- [ ] Unsure if we should fill in the other appearances too, like appearancemodid 1 that used to exist.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
