### PR TITLE
Core/Unit: Fix display for Shaman totems

### DIFF
--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -76,7 +76,7 @@ void Totem::InitStats(uint32 duration)
             });
 
             if (summonEffect != effects.end())
-                SetDisplayId(owner->GetModelForTotem(PlayerTotemType((*summonEffect)->MiscValueB)));
+                SetDisplayId(owner->GetModelForTotem(uint32((*summonEffect)->MiscValueB)));
         }
     }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12612,22 +12612,22 @@ uint32 Unit::GetCategoryForTotem(uint32 totemCategory)
         case TOTEM_CATEGORY_FIRE:
         case TOTEM_CATEGORY_FIRE_2:
         case TOTEM_CATEGORY_FIRE_3:
-            return SUMMON_TYPE_TOTEM_FIRE;
+            return TC_FIRE_TOTEM;
         case TOTEM_CATEGORY_EARTH:
         case TOTEM_CATEGORY_EARTH_2:
         case TOTEM_CATEGORY_EARTH_3:
         case TOTEM_CATEGORY_EARTH_4:
-            return SUMMON_TYPE_TOTEM_EARTH;
+            return TC_EARTH_TOTEM;
         case TOTEM_CATEGORY_WATER:
         case TOTEM_CATEGORY_WATER_2:
-            return SUMMON_TYPE_TOTEM_WATER;
+            return TC_WATER_TOTEM;
         case TOTEM_CATEGORY_AIR:
         case TOTEM_CATEGORY_AIR_2:
         case TOTEM_CATEGORY_AIR_3:
         case TOTEM_CATEGORY_AIR_4:
         case TOTEM_CATEGORY_AIR_5:
         case TOTEM_CATEGORY_AIR_6:
-            return SUMMON_TYPE_TOTEM_AIR;
+            return TC_AIR_TOTEM;
         default:
             break;
     }
@@ -12644,13 +12644,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 30758;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 30757;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 30759;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 30756;
             }
             break;
@@ -12659,13 +12659,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 30754;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 30753;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 30755;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 30736;
             }
             break;
@@ -12674,13 +12674,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 30762;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 30761;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 30763;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 30760;
             }
             break;
@@ -12689,13 +12689,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 4589;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 4588;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 4587;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 4590;
             }
             break;
@@ -12704,13 +12704,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 19074;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 19073;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 19075;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 19071;
             }
             break;
@@ -12719,13 +12719,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 30783;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 30782;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 30784;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 30781;
             }
             break;
@@ -12736,13 +12736,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 41670;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 41669;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 41671;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 41668;
             }
             break;
@@ -12751,13 +12751,13 @@ uint32 Unit::GetModelForTotem(uint32 totemType)
         {
             switch (totemType)
             {
-                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                case TC_FIRE_TOTEM:    // fire
                     return 81444;
-                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                case TC_EARTH_TOTEM:   // earth
                     return 81443;
-                case SUMMON_TYPE_TOTEM_WATER:   // water
+                case TC_WATER_TOTEM:   // water
                     return 81442;
-                case SUMMON_TYPE_TOTEM_AIR:     // air
+                case TC_AIR_TOTEM:     // air
                     return 81441;
             }
             break;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12629,9 +12629,9 @@ uint32 Unit::GetCategoryForTotem(uint32 totemCategory)
         case TOTEM_CATEGORY_AIR_6:
             return TC_AIR_TOTEM;
         default:
-            break;
+            TC_LOG_ERROR("entities.unit", "Can't find TotemCategory for PlayerTotemCategory %u.", totemCategory);
+            return 0;
     }
-    return 0;
 }
 
 uint32 Unit::GetModelForTotem(uint32 totemType)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12605,31 +12605,31 @@ uint32 Unit::GetModelForForm(ShapeshiftForm form) const
     return modelid;
 }
 
-uint32 Unit::GetCategoryForTotem(uint32 totemCategory)
+uint32 Unit::GetCategoryForTotem(uint32 summonProperty)
 {
-    switch (totemCategory)
+    switch (summonProperty)
     {
-        case TOTEM_CATEGORY_FIRE:
-        case TOTEM_CATEGORY_FIRE_2:
-        case TOTEM_CATEGORY_FIRE_3:
+        case SUMMON_PROPERTY_TOTEM_FIRE:
+        case SUMMON_PROPERTY_TOTEM_FIRE_2:
+        case SUMMON_PROPERTY_TOTEM_FIRE_3:
             return TC_FIRE_TOTEM;
-        case TOTEM_CATEGORY_EARTH:
-        case TOTEM_CATEGORY_EARTH_2:
-        case TOTEM_CATEGORY_EARTH_3:
-        case TOTEM_CATEGORY_EARTH_4:
+        case SUMMON_PROPERTY_TOTEM_EARTH:
+        case SUMMON_PROPERTY_TOTEM_EARTH_2:
+        case SUMMON_PROPERTY_TOTEM_EARTH_3:
+        case SUMMON_PROPERTY_TOTEM_EARTH_4:
             return TC_EARTH_TOTEM;
-        case TOTEM_CATEGORY_WATER:
-        case TOTEM_CATEGORY_WATER_2:
+        case SUMMON_PROPERTY_TOTEM_WATER:
+        case SUMMON_PROPERTY_TOTEM_WATER_2:
             return TC_WATER_TOTEM;
-        case TOTEM_CATEGORY_AIR:
-        case TOTEM_CATEGORY_AIR_2:
-        case TOTEM_CATEGORY_AIR_3:
-        case TOTEM_CATEGORY_AIR_4:
-        case TOTEM_CATEGORY_AIR_5:
-        case TOTEM_CATEGORY_AIR_6:
+        case SUMMON_PROPERTY_TOTEM_AIR:
+        case SUMMON_PROPERTY_TOTEM_AIR_2:
+        case SUMMON_PROPERTY_TOTEM_AIR_3:
+        case SUMMON_PROPERTY_TOTEM_AIR_4:
+        case SUMMON_PROPERTY_TOTEM_AIR_5:
+        case SUMMON_PROPERTY_TOTEM_AIR_6:
             return TC_AIR_TOTEM;
         default:
-            TC_LOG_ERROR("entities.unit", "Can't find TotemCategory for PlayerTotemCategory %u.", totemCategory);
+            TC_LOG_ERROR("entities.unit", "Can't find TotemCategory for SummonProperty %u.", summonProperty);
             return 0;
     }
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12605,8 +12605,39 @@ uint32 Unit::GetModelForForm(ShapeshiftForm form) const
     return modelid;
 }
 
-uint32 Unit::GetModelForTotem(PlayerTotemType totemType)
+uint32 Unit::GetCategoryForTotem(uint32 totemCategory)
 {
+    switch (totemCategory)
+    {
+        case TOTEM_CATEGORY_FIRE:
+        case TOTEM_CATEGORY_FIRE_2:
+        case TOTEM_CATEGORY_FIRE_3:
+            return SUMMON_TYPE_TOTEM_FIRE;
+        case TOTEM_CATEGORY_EARTH:
+        case TOTEM_CATEGORY_EARTH_2:
+        case TOTEM_CATEGORY_EARTH_3:
+        case TOTEM_CATEGORY_EARTH_4:
+            return SUMMON_TYPE_TOTEM_EARTH;
+        case TOTEM_CATEGORY_WATER:
+        case TOTEM_CATEGORY_WATER_2:
+            return SUMMON_TYPE_TOTEM_WATER;
+        case TOTEM_CATEGORY_AIR:
+        case TOTEM_CATEGORY_AIR_2:
+        case TOTEM_CATEGORY_AIR_3:
+        case TOTEM_CATEGORY_AIR_4:
+        case TOTEM_CATEGORY_AIR_5:
+        case TOTEM_CATEGORY_AIR_6:
+            return SUMMON_TYPE_TOTEM_AIR;
+        default:
+            break;
+    }
+    return 0;
+}
+
+uint32 Unit::GetModelForTotem(uint32 totemType)
+{
+    totemType = GetCategoryForTotem(totemType);
+
     switch (getRace())
     {
         case RACE_ORC:
@@ -12696,6 +12727,38 @@ uint32 Unit::GetModelForTotem(PlayerTotemType totemType)
                     return 30784;
                 case SUMMON_TYPE_TOTEM_AIR:     // air
                     return 30781;
+            }
+            break;
+        }
+        case RACE_PANDAREN_NEUTRAL:
+        case RACE_PANDAREN_ALLIANCE:
+        case RACE_PANDAREN_HORDE:
+        {
+            switch (totemType)
+            {
+                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                    return 41670;
+                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                    return 41669;
+                case SUMMON_TYPE_TOTEM_WATER:   // water
+                    return 41671;
+                case SUMMON_TYPE_TOTEM_AIR:     // air
+                    return 41668;
+            }
+            break;
+        }
+        case RACE_HIGHMOUNTAIN_TAUREN:
+        {
+            switch (totemType)
+            {
+                case SUMMON_TYPE_TOTEM_FIRE:    // fire
+                    return 81444;
+                case SUMMON_TYPE_TOTEM_EARTH:   // earth
+                    return 81443;
+                case SUMMON_TYPE_TOTEM_WATER:   // water
+                    return 81442;
+                case SUMMON_TYPE_TOTEM_AIR:     // air
+                    return 81441;
             }
             break;
         }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -885,14 +885,6 @@ enum ReactiveType
 
 #define MAX_GAMEOBJECT_SLOT 4
 
-enum PlayerTotemType
-{
-    SUMMON_TYPE_TOTEM_FIRE  = 0,
-    SUMMON_TYPE_TOTEM_EARTH = 1,
-    SUMMON_TYPE_TOTEM_WATER = 2,
-    SUMMON_TYPE_TOTEM_AIR   = 3
-};
-
 enum PlayerTotemCategory
 {
     TOTEM_CATEGORY_FIRE     = 3211, // Skyfury Totem

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -887,10 +887,32 @@ enum ReactiveType
 
 enum PlayerTotemType
 {
-    SUMMON_TYPE_TOTEM_FIRE  = 63,
-    SUMMON_TYPE_TOTEM_EARTH = 81,
-    SUMMON_TYPE_TOTEM_WATER = 82,
-    SUMMON_TYPE_TOTEM_AIR   = 83
+    SUMMON_TYPE_TOTEM_FIRE  = 0,
+    SUMMON_TYPE_TOTEM_EARTH = 1,
+    SUMMON_TYPE_TOTEM_WATER = 2,
+    SUMMON_TYPE_TOTEM_AIR   = 3
+};
+
+enum PlayerTotemCategory
+{
+    TOTEM_CATEGORY_FIRE     = 3211, // Skyfury Totem
+    TOTEM_CATEGORY_FIRE_2   = 3697, // Liquid Magma Totem
+    TOTEM_CATEGORY_FIRE_3   = 3722, // Voodoo Totem
+
+    TOTEM_CATEGORY_EARTH    = 3400, // Earthbind Totem
+    TOTEM_CATEGORY_EARTH_2  = 3404, // Earthgrab Totem
+    TOTEM_CATEGORY_EARTH_3  = 3737, // Earthen Shield Totem
+    TOTEM_CATEGORY_EARTH_4  = 3787, // Ancestral Protection Totem
+
+    TOTEM_CATEGORY_WATER    = 82,   // Healing Tide Totem
+    TOTEM_CATEGORY_WATER_2  = 3402, // Healing Stream & Cloudburst Totem
+
+    TOTEM_CATEGORY_AIR      = 3399, // Spirit Link Totem
+    TOTEM_CATEGORY_AIR_2    = 3406, // Grounding Totem
+    TOTEM_CATEGORY_AIR_3    = 3407, // Lightning Surge Totem
+    TOTEM_CATEGORY_AIR_4    = 3695, // Winrush Totem
+    TOTEM_CATEGORY_AIR_5    = 3804, // Counterstrike Totem
+    TOTEM_CATEGORY_AIR_6    = 3806  // Windfury Totem
 };
 
 // delay time next attack to prevent client attack animation problems
@@ -1799,7 +1821,8 @@ class TC_GAME_API Unit : public WorldObject
         void RemovePetAura(PetAura const* petSpell);
 
         uint32 GetModelForForm(ShapeshiftForm form) const;
-        uint32 GetModelForTotem(PlayerTotemType totemType);
+        uint32 GetCategoryForTotem(uint32 totemCategory);
+        uint32 GetModelForTotem(uint32 totemType);
 
         // Redirect Threat
         void SetRedirectThreat(ObjectGuid guid, uint32 pct) { _redirectThreadInfo.Set(guid, pct); }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -885,26 +885,26 @@ enum ReactiveType
 
 #define MAX_GAMEOBJECT_SLOT 4
 
-enum PlayerTotemCategory
+enum SummonProperties
 {
-    TOTEM_CATEGORY_FIRE     = 3211, // Skyfury Totem
-    TOTEM_CATEGORY_FIRE_2   = 3697, // Liquid Magma Totem
-    TOTEM_CATEGORY_FIRE_3   = 3722, // Voodoo Totem
+    SUMMON_PROPERTY_TOTEM_FIRE      = 3211, // Skyfury Totem
+    SUMMON_PROPERTY_TOTEM_FIRE_2    = 3697, // Liquid Magma Totem
+    SUMMON_PROPERTY_TOTEM_FIRE_3    = 3722, // Voodoo Totem
 
-    TOTEM_CATEGORY_EARTH    = 3400, // Earthbind Totem
-    TOTEM_CATEGORY_EARTH_2  = 3404, // Earthgrab Totem
-    TOTEM_CATEGORY_EARTH_3  = 3737, // Earthen Shield Totem
-    TOTEM_CATEGORY_EARTH_4  = 3787, // Ancestral Protection Totem
+    SUMMON_PROPERTY_TOTEM_EARTH     = 3400, // Earthbind Totem
+    SUMMON_PROPERTY_TOTEM_EARTH_2   = 3404, // Earthgrab Totem
+    SUMMON_PROPERTY_TOTEM_EARTH_3   = 3737, // Earthen Shield Totem
+    SUMMON_PROPERTY_TOTEM_EARTH_4   = 3787, // Ancestral Protection Totem
 
-    TOTEM_CATEGORY_WATER    = 82,   // Healing Tide Totem
-    TOTEM_CATEGORY_WATER_2  = 3402, // Healing Stream & Cloudburst Totem
+    SUMMON_PROPERTY_TOTEM_WATER     = 82,   // Healing Tide Totem
+    SUMMON_PROPERTY_TOTEM_WATER_2   = 3402, // Healing Stream & Cloudburst Totem
 
-    TOTEM_CATEGORY_AIR      = 3399, // Spirit Link Totem
-    TOTEM_CATEGORY_AIR_2    = 3406, // Grounding Totem
-    TOTEM_CATEGORY_AIR_3    = 3407, // Lightning Surge Totem
-    TOTEM_CATEGORY_AIR_4    = 3695, // Winrush Totem
-    TOTEM_CATEGORY_AIR_5    = 3804, // Counterstrike Totem
-    TOTEM_CATEGORY_AIR_6    = 3806  // Windfury Totem
+    SUMMON_PROPERTY_TOTEM_AIR       = 3399, // Spirit Link Totem
+    SUMMON_PROPERTY_TOTEM_AIR_2     = 3406, // Grounding Totem
+    SUMMON_PROPERTY_TOTEM_AIR_3     = 3407, // Lightning Surge Totem
+    SUMMON_PROPERTY_TOTEM_AIR_4     = 3695, // Winrush Totem
+    SUMMON_PROPERTY_TOTEM_AIR_5     = 3804, // Counterstrike Totem
+    SUMMON_PROPERTY_TOTEM_AIR_6     = 3806  // Windfury Totem
 };
 
 // delay time next attack to prevent client attack animation problems
@@ -1813,7 +1813,7 @@ class TC_GAME_API Unit : public WorldObject
         void RemovePetAura(PetAura const* petSpell);
 
         uint32 GetModelForForm(ShapeshiftForm form) const;
-        uint32 GetCategoryForTotem(uint32 totemCategory);
+        uint32 GetCategoryForTotem(uint32 summonProperty);
         uint32 GetModelForTotem(uint32 totemType);
 
         // Redirect Threat


### PR DESCRIPTION
**Changes proposed:**

What the title say !
- Add display for Pandaren and Highmountain Tauren 
Currently all totems display are broken, probably not updated since lich king

**Target branch(es):** 3.3.5/master

- [X] master

**Tests performed:** (Does it build, tested in-game, etc.)

Tested IG & build
