### PR TITLE
[3.3.5] Core/Entities: SummonedGameObject refactor

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -36,6 +36,7 @@
 #include "PoolMgr.h"
 #include "QueryPackets.h"
 #include "ScriptMgr.h"
+#include "SummonedGameObject.h"
 #include "SpellMgr.h"
 #include "Transport.h"
 #include "UpdateFieldFlags.h"
@@ -110,9 +111,7 @@ GameObject::GameObject() : WorldObject(false), MapObject(),
     m_respawnDelayTime = 300;
     m_despawnDelay = 0;
     m_lootState = GO_NOT_READY;
-    m_spawnedByDefault = true;
     m_usetimes = 0;
-    m_spellId = 0;
     m_cooldownTime = 0;
     m_prevGoState = GO_STATE_ACTIVE;
     m_goInfo = nullptr;
@@ -163,33 +162,6 @@ std::string const& GameObject::GetAIName() const
     return sObjectMgr->GetGameObjectTemplate(GetEntry())->AIName;
 }
 
-void GameObject::CleanupsBeforeDelete(bool finalCleanup)
-{
-    WorldObject::CleanupsBeforeDelete(finalCleanup);
-
-    if (m_uint32Values)                                      // field array can be not exist if GameOBject not loaded
-        RemoveFromOwner();
-}
-
-void GameObject::RemoveFromOwner()
-{
-    ObjectGuid ownerGUID = GetOwnerGUID();
-    if (!ownerGUID)
-        return;
-
-    if (Unit* owner = ObjectAccessor::GetUnit(*this, ownerGUID))
-    {
-        owner->RemoveGameObject(this, false);
-        ASSERT(!GetOwnerGUID());
-        return;
-    }
-
-    // This happens when a mage portal is despawned after the caster changes map (for example using the portal)
-    TC_LOG_DEBUG("misc", "Removed GameObject (GUID: %u Entry: %u SpellId: %u LinkedGO: %u) that just lost any reference to the owner (%s) GO list",
-        GetGUID().GetCounter(), GetGOInfo()->entry, m_spellId, GetGOInfo()->GetLinkedGameObjectEntry(), ownerGUID.ToString().c_str());
-    SetOwnerGUID(ObjectGuid::Empty);
-}
-
 void GameObject::AddToWorld()
 {
     ///- Register the gameobject for guid lookup
@@ -225,7 +197,6 @@ void GameObject::RemoveFromWorld()
         if (m_zoneScript)
             m_zoneScript->OnGameObjectRemove(this);
 
-        RemoveFromOwner();
         if (m_model)
             if (GetMap()->ContainsGameObjectModel(*m_model))
                 GetMap()->RemoveGameObjectModel(*m_model);
@@ -383,7 +354,12 @@ bool GameObject::Create(ObjectGuid::LowType guidlow, uint32 name_id, Map* map, u
 
     if (uint32 linkedEntry = GetGOInfo()->GetLinkedGameObjectEntry())
     {
-        GameObject* linkedGO = new GameObject();
+        GameObject* linkedGO;
+        if (SummonedGameObject* summon = ToSummonedGameObject())
+            linkedGO = new SummonedGameObject(summon->GetOwner(), sSpellMgr->GetSpellInfo(summon->GetSpellId()), summon->GetSummonType(), summon->GetFullDuration());
+        else
+            linkedGO = new GameObject();
+
         if (linkedGO->Create(map->GenerateLowGuid<HighGuid::GameObject>(), linkedEntry, map, phaseMask, pos, rotation, 255, GO_STATE_READY))
         {
             SetLinkedTrap(linkedGO);
@@ -530,13 +506,17 @@ void GameObject::Update(uint32 diff)
                         {
                             case GAMEOBJECT_TYPE_FISHINGNODE:   //  can't fish now
                             {
-                                Unit* caster = GetOwner();
-                                if (caster && caster->GetTypeId() == TYPEID_PLAYER)
+                                if (SummonedGameObject* summon = ToSummonedGameObject())
                                 {
-                                    caster->ToPlayer()->RemoveGameObject(this, false);
+                                    summon->UnlinkFromOwner();
 
-                                    WorldPacket data(SMSG_FISH_ESCAPED, 0);
-                                    caster->ToPlayer()->SendDirectMessage(&data);
+                                    Unit* caster = summon->GetOwner();
+                                    Player* pCaster = caster ? caster->ToPlayer() : nullptr;
+                                    if (pCaster)
+                                    {
+                                        WorldPacket data(SMSG_FISH_ESCAPED, 0);
+                                        pCaster->SendDirectMessage(&data);
+                                    }
                                 }
                                 // can be delete
                                 m_lootState = GO_JUST_DEACTIVATED;
@@ -557,7 +537,7 @@ void GameObject::Update(uint32 diff)
                         }
 
                         // Despawn timer
-                        if (!m_spawnedByDefault)
+                        if (!IsSpawnedByDefault())
                         {
                             // Can be despawned or destroyed
                             SetLootState(GO_JUST_DEACTIVATED);
@@ -750,7 +730,7 @@ void GameObject::Update(uint32 diff)
 
             //! If this is summoned by a spell with ie. SPELL_EFFECT_SUMMON_OBJECT_WILD, with or without owner, we check respawn criteria based on spell
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
-            if (GetSpellId() || GetOwnerGUID())
+            if (IsSummonedGameObject())
             {
                 SetRespawnTime(0);
                 Delete();
@@ -772,7 +752,7 @@ void GameObject::Update(uint32 diff)
                 return;
 
             // ToDo: Decide if we should properly despawn these. Maybe they expect to be able to manually respawn from script?
-            if (!m_spawnedByDefault)
+            if (!IsSpawnedByDefault())
             {
                 m_respawnTime = 0;
                 DestroyForNearbyPlayers(); // old UpdateObjectVisibility()
@@ -821,7 +801,7 @@ GameObjectOverride const* GameObject::GetGameObjectOverride() const
 void GameObject::Refresh()
 {
     // Do not refresh despawned GO from spellcast (GO's from spellcast are destroyed after despawn)
-    if (m_respawnTime > 0 && m_spawnedByDefault)
+    if (m_respawnTime > 0 && IsSpawnedByDefault())
         return;
 
     if (isSpawned())
@@ -856,7 +836,6 @@ void GameObject::DespawnOrUnsummon(Milliseconds const& delay, Seconds const& for
 void GameObject::Delete()
 {
     SetLootState(GO_NOT_READY);
-    RemoveFromOwner();
 
     SendObjectDeSpawnAnim(GetGUID());
 
@@ -945,7 +924,7 @@ void GameObject::SaveToDB(uint32 mapid, uint8 spawnMask, uint32 phaseMask)
     data.spawnPoint.WorldRelocate(this);
     data.phaseMask = phaseMask;
     data.rotation = m_worldRotation;
-    data.spawntimesecs = m_spawnedByDefault ? m_respawnDelayTime : -(int32)m_respawnDelayTime;
+    data.spawntimesecs = IsSpawnedByDefault() ? m_respawnDelayTime : -(int32)m_respawnDelayTime;
     data.animprogress = GetGoAnimProgress();
     data.goState = GetGoState();
     data.spawnMask = spawnMask;
@@ -1009,8 +988,6 @@ bool GameObject::LoadFromDB(ObjectGuid::LowType spawnId, Map* map, bool addToMap
 
     if (data->spawntimesecs >= 0)
     {
-        m_spawnedByDefault = true;
-
         if (!GetGOInfo()->GetDespawnPossibility() && !GetGOInfo()->IsDespawnAtAction())
         {
             SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NODESPAWN);
@@ -1037,8 +1014,6 @@ bool GameObject::LoadFromDB(ObjectGuid::LowType spawnId, Map* map, bool addToMap
             TC_LOG_WARN("sql.sql", "GameObject %u (SpawnID %u) is not spawned by default, but tries to use a non-hack spawn system. This will not work. Defaulting to compatibility mode.", entry, spawnId);
             m_respawnCompatibilityMode = true;
         }
-
-        m_spawnedByDefault = false;
         m_respawnDelayTime = -data->spawntimesecs;
         m_respawnTime = 0;
     }
@@ -1151,7 +1126,7 @@ bool GameObject::IsDestructibleBuilding() const
 
 void GameObject::SaveRespawnTime(uint32 forceDelay, bool savetodb)
 {
-    if (m_goData && (forceDelay || m_respawnTime > GameTime::GetGameTime()) && m_spawnedByDefault)
+    if (m_goData && (forceDelay || m_respawnTime > GameTime::GetGameTime()) && IsSpawnedByDefault())
     {
         if (m_respawnCompatibilityMode)
         {
@@ -1187,12 +1162,11 @@ bool GameObject::IsAlwaysVisibleFor(WorldObject const* seer) const
         return false;
 
     // Always seen by owner and friendly units
-    if (ObjectGuid guid = GetOwnerGUID())
+    if (Unit* owner = GetOwner())
     {
-        if (seer->GetGUID() == guid)
+        if (seer == owner)
             return true;
 
-        Unit* owner = GetOwner();
         if (Unit const* unitSeer = seer->ToUnit())
             if (owner && owner->IsFriendlyTo(unitSeer))
                 return true;
@@ -1221,6 +1195,12 @@ uint8 GameObject::getLevelForTarget(WorldObject const* target) const
     return 1;
 }
 
+Unit* GameObject::GetOwner() const
+{
+    if (SummonedGameObject const* gobj = ToSummonedGameObject())
+        return gobj->GetUnitOwner();
+}
+
 time_t GameObject::GetRespawnTimeEx() const
 {
     time_t now = GameTime::GetGameTime();
@@ -1234,13 +1214,13 @@ void GameObject::SetRespawnTime(int32 respawn)
 {
     m_respawnTime = respawn > 0 ? GameTime::GetGameTime() + respawn : 0;
     m_respawnDelayTime = respawn > 0 ? respawn : 0;
-    if (respawn && !m_spawnedByDefault)
+    if (respawn && !IsSpawnedByDefault())
         UpdateObjectVisibility(true);
 }
 
 void GameObject::Respawn()
 {
-    if (m_spawnedByDefault && m_respawnTime > 0)
+    if (IsSpawnedByDefault() && m_respawnTime > 0)
     {
         m_respawnTime = GameTime::GetGameTime();
         GetMap()->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, m_spawnId, true);
@@ -1614,7 +1594,9 @@ void GameObject::Use(Unit* user)
             if (!player)
                 return;
 
-            if (player->GetGUID() != GetOwnerGUID())
+            SummonedGameObject* summon = ToSummonedGameObject();
+
+            if (!summon || player->GetGUID() != summon->GetOwnerGUID())
                 return;
 
             switch (getLootState())
@@ -1659,9 +1641,8 @@ void GameObject::Use(Unit* user)
                     {
                         /// @todo I do not understand this hack. Need some explanation.
                         // prevent removing GO at spell cancel
-                        RemoveFromOwner();
-                        SetOwnerGUID(player->GetGUID());
-                        SetSpellId(0); // prevent removing unintended auras at Unit::RemoveGameObject
+                        summon->UnlinkFromOwner();
+                        summon->SetSpellId(0); // prevent removing unintended auras at Unit::RemoveGameObject
 
                         if (fishingPool)
                         {
@@ -2408,7 +2389,7 @@ void GameObject::BuildValuesUpdate(uint8 updateType, ByteBuffer* data, Player* t
 
     uint32* flags = GameObjectUpdateFieldFlags;
     uint32 visibleFlag = UF_FLAG_PUBLIC;
-    if (GetOwnerGUID() == target->GetGUID())
+    if (GetGuidValue(OBJECT_FIELD_CREATED_BY) == target->GetGUID())
         visibleFlag |= UF_FLAG_OWNER;
 
     for (uint16 index = 0; index < m_valuesCount; ++index)

--- a/src/server/game/Entities/GameObject/SummonedGameObject.cpp
+++ b/src/server/game/Entities/GameObject/SummonedGameObject.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "SummonedGameObject.h"
+#include "Log.h"
+#include "SpellHistory.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include "Unit.h"
+
+SummonedGameObject::SummonedGameObject(WorldObject* owner, SpellInfo const* spell, GOSummonType type, Milliseconds const& lifetime) : m_type(type), m_lifetime(lifetime.count()), m_spellId(spell ? spell->Id : 0)
+{
+    ASSERT(owner);
+    SetGuidValue(OBJECT_FIELD_CREATED_BY, owner->GetGUID());
+
+    switch (type)
+    {
+        case GO_SUMMON_TIMED_DESPAWN:
+        case GO_SUMMON_TIMED_OR_CORPSE_DESPAWN:
+            Despawn(lifetime);
+            break;
+        case GO_SUMMON_MANUAL_DESPAWN:
+            break;
+    }
+}
+
+bool SummonedGameObject::ShouldDespawnOnOwnerDeath() const
+{
+    if (GetOwnerGUID().IsPlayer())
+        return true;
+    return (m_type == GO_SUMMON_CORPSE_DESPAWN || m_type == GO_SUMMON_TIMED_OR_CORPSE_DESPAWN);
+}
+
+void SummonedGameObject::AddToWorld()
+{
+    if (ShouldDespawnOnOwnerDeath())
+        if (Unit* owner = GetUnitOwner())
+            owner->AddGameObject(this);
+}
+
+void SummonedGameObject::RemoveFromWorld()
+{
+    if (Unit* owner = GetUnitOwner())
+    {
+        // GO created by some spell
+        if (m_spellId)
+        {
+            // @todo all auras? what if another player has a gobj?
+            owner->RemoveAurasDueToSpell(m_spellId);
+
+            SpellInfo const* createBySpell = sSpellMgr->GetSpellInfo(m_spellId);
+            ASSERT(createBySpell, "GameObject %s (%u) was created by spell %u, but this spell does not exist.", GetName().c_str(), GetEntry(), m_spellId);
+            // Need activate spell use for owner
+            if (createBySpell->IsCooldownStartedOnEvent())
+                // note: item based cooldowns and cooldown spell mods with charges ignored (unknown existing cases)
+                owner->GetSpellHistory()->SendCooldownEvent(createBySpell);
+        }
+        owner->UnlinkGameObject(this);
+    }
+
+    GameObject::RemoveFromWorld();
+}
+
+void SummonedGameObject::UnlinkFromOwner()
+{
+    if (Unit* owner = GetUnitOwner())
+        owner->UnlinkGameObject(this);
+}
+
+WorldObject* SummonedGameObject::GetOwner() const
+{
+    return ObjectAccessor::GetWorldObject(*this, GetOwnerGUID());
+}
+
+Unit* SummonedGameObject::GetUnitOwner() const
+{
+    return ObjectAccessor::GetUnit(*this, GetOwnerGUID());
+}

--- a/src/server/game/Entities/GameObject/SummonedGameObject.h
+++ b/src/server/game/Entities/GameObject/SummonedGameObject.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITYCORE_SUMMONEDGAMEOBJECT_H
+#define TRINITYCORE_SUMMONEDGAMEOBJECT_H
+
+#include "GameObject.h"
+
+class SpellInfo;
+
+class TC_GAME_API SummonedGameObject : public GameObject
+{
+    public:
+        explicit SummonedGameObject(WorldObject* owner, SpellInfo const* spell, GOSummonType type, Milliseconds const& lifetime = 0ms);
+
+        void Despawn(Milliseconds const& delay) { DespawnOrUnsummon(delay); }
+
+        void AddToWorld() override;
+        void RemoveFromWorld() override;
+
+        void UnlinkFromOwner();
+        WorldObject* GetOwner() const;
+        Unit* GetUnitOwner() const;
+
+        void ClearSpellId() { m_spellId = 0; }
+        uint32 GetSpellId() const { return m_spellId; }
+
+        GOSummonType GetSummonType() const { return m_type; }
+        uint32 GetFullDuration() const { return m_lifetime; }
+
+    private:
+        bool ShouldDespawnOnOwnerDeath() const;
+
+        GOSummonType const m_type;
+        uint32 const m_lifetime;
+        uint32 m_spellId;
+};
+
+#endif

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -36,7 +36,9 @@
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "SpellAuraEffects.h"
+#include "SpellInfo.h"
 #include "SpellMgr.h"
+#include "SummonedGameObject.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -2021,7 +2023,7 @@ TempSummon* WorldObject::SummonCreature(uint32 id, float x, float y, float z, fl
     return SummonCreature(id, { x,y,z,o }, despawnType, despawnTime);
 }
 
-GameObject* WorldObject::SummonGameObject(uint32 entry, Position const& pos, QuaternionData const& rot, uint32 respawnTime, GOSummonType summonType)
+GameObject* WorldObject::SummonGameObject(uint32 entry, Position const& pos, QuaternionData const& rot, GOSummonType summonType, Seconds const& despawnTime, uint32 spellId)
 {
     if (!IsInWorld())
         return nullptr;
@@ -2033,25 +2035,21 @@ GameObject* WorldObject::SummonGameObject(uint32 entry, Position const& pos, Qua
         return nullptr;
     }
 
+    SpellInfo const* spell = spellId ? ASSERT_NOTNULL(sSpellMgr->GetSpellInfo(spellId)) : nullptr;
+
     Map* map = GetMap();
-    GameObject* go = new GameObject();
+    GameObject* go = new SummonedGameObject(this, spell, summonType, despawnTime);
     if (!go->Create(map->GenerateLowGuid<HighGuid::GameObject>(), entry, map, GetPhaseMask(), pos, rot, 255, GO_STATE_READY))
     {
         delete go;
         return nullptr;
     }
 
-    go->SetRespawnTime(respawnTime);
-    if (GetTypeId() == TYPEID_PLAYER || (GetTypeId() == TYPEID_UNIT && summonType == GO_SUMMON_TIMED_OR_CORPSE_DESPAWN)) //not sure how to handle this
-        ToUnit()->AddGameObject(go);
-    else
-        go->SetSpawnedByDefault(false);
-
     map->AddToMap(go);
     return go;
 }
 
-GameObject* WorldObject::SummonGameObject(uint32 entry, float x, float y, float z, float ang, QuaternionData const& rot, uint32 respawnTime)
+GameObject* WorldObject::SummonGameObject(uint32 entry, float x, float y, float z, float ang, QuaternionData const& rot, GOSummonType summonType, Seconds const& despawnTime)
 {
     if (!x && !y && !z)
     {
@@ -2060,7 +2058,7 @@ GameObject* WorldObject::SummonGameObject(uint32 entry, float x, float y, float 
     }
 
     Position pos(x, y, z, ang);
-    return SummonGameObject(entry, pos, rot, respawnTime);
+    return SummonGameObject(entry, pos, rot, summonType, despawnTime);
 }
 
 Creature* WorldObject::SummonTrigger(float x, float y, float z, float ang, uint32 duration, CreatureAI* (*GetAI)(Creature*))

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -387,8 +387,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         TempSummon* SummonCreature(uint32 entry, Position const& pos, TempSummonType despawnType = TEMPSUMMON_MANUAL_DESPAWN, uint32 despawnTime = 0, uint32 vehId = 0, uint32 spellId = 0);
         TempSummon* SummonCreature(uint32 entry, Position const& pos, TempSummonType despawnType, Milliseconds const& despawnTime, uint32 vehId = 0, uint32 spellId = 0) { return SummonCreature(entry, pos, despawnType, uint32(despawnTime.count()), vehId, spellId); }
         TempSummon* SummonCreature(uint32 entry, float x, float y, float z, float o = 0, TempSummonType despawnType = TEMPSUMMON_MANUAL_DESPAWN, uint32 despawnTime = 0);
-        GameObject* SummonGameObject(uint32 entry, Position const& pos, QuaternionData const& rot, uint32 respawnTime /* s */, GOSummonType summonType = GO_SUMMON_TIMED_OR_CORPSE_DESPAWN);
-        GameObject* SummonGameObject(uint32 entry, float x, float y, float z, float ang, QuaternionData const& rot, uint32 respawnTime /* s */);
+        GameObject* SummonGameObject(uint32 entry, Position const& pos, QuaternionData const& rot, GOSummonType summonType = GO_SUMMON_MANUAL_DESPAWN, Seconds const& respawnTime = 0s, uint32 spellId = 0);
+        GameObject* SummonGameObject(uint32 entry, float x, float y, float z, float ang, QuaternionData const& rot, GOSummonType summonType = GO_SUMMON_MANUAL_DESPAWN, Seconds const& respawnTime = 0s);
         Creature*   SummonTrigger(float x, float y, float z, float ang, uint32 dur, CreatureAI* (*GetAI)(Creature*) = nullptr);
         void SummonCreatureGroup(uint8 group, std::list<TempSummon*>* list = nullptr);
 

--- a/src/server/game/Entities/Object/ObjectDefines.h
+++ b/src/server/game/Entities/Object/ObjectDefines.h
@@ -66,8 +66,11 @@ enum NotifyFlags
 
 enum GOSummonType
 {
-   GO_SUMMON_TIMED_OR_CORPSE_DESPAWN = 0,    // despawns after a specified time OR when the summoner dies
-   GO_SUMMON_TIMED_DESPAWN = 1     // despawns after a specified time
+   
+    GO_SUMMON_TIMED_OR_CORPSE_DESPAWN = 0,    // despawns after a specified time OR when the summoner dies
+    GO_SUMMON_TIMED_DESPAWN           = 1,    // despawns after a specified time
+    GO_SUMMON_MANUAL_DESPAWN          = 2,    // never despawns automatically
+    GO_SUMMON_CORPSE_DESPAWN          = 3,    // despawn when summoner dies
 };
 
 inline uint64 MAKE_PAIR64(uint32 l, uint32 h)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7185,7 +7185,7 @@ void Player::DuelComplete(DuelCompleteType type)
     //Remove Duel Flag object
     GameObject* obj = GetMap()->GetGameObject(GetGuidValue(PLAYER_DUEL_ARBITER));
     if (obj)
-        duel->initiator->RemoveGameObject(obj, true);
+        obj->DespawnOrUnsummon();
 
     /* remove auras */
     AuraApplicationMap &itsAuras = duel->opponent->GetAppliedAuras();
@@ -8343,7 +8343,7 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
                 if (lootType != LOOT_FISHINGHOLE && ((lootType != LOOT_FISHING && lootType != LOOT_FISHING_JUNK) || go->GetOwnerGUID() != GetGUID()) && !go->IsWithinDistInMap(this, INTERACTION_DISTANCE))
                     return true;
 
-                if (lootType == LOOT_CORPSE && go->GetRespawnTime() && go->isSpawnedByDefault())
+                if (lootType == LOOT_CORPSE && go->GetRespawnTime() && go->IsSpawnedByDefault())
                     return true;
             }
 
@@ -8360,7 +8360,7 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
 
         // loot was generated and respawntime has passed since then, allow to recreate loot
         // to avoid bugs, this rule covers spawned gameobjects only
-        if (go->isSpawnedByDefault() && go->getLootState() == GO_ACTIVATED && !go->loot.isLooted() && go->GetLootGenerationTime() + go->GetRespawnDelay() < GameTime::GetGameTime())
+        if (go->IsSpawnedByDefault() && go->getLootState() == GO_ACTIVATED && !go->loot.isLooted() && go->GetLootGenerationTime() + go->GetRespawnDelay() < GameTime::GetGameTime())
             go->SetLootState(GO_READY);
 
         if (go->getLootState() == GO_READY)

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -82,6 +82,7 @@ class Spell;
 class SpellCastTargets;
 class SpellHistory;
 class SpellInfo;
+class SummonedGameObject;
 class Totem;
 class Transport;
 class TransportBase;
@@ -1467,8 +1468,8 @@ class TC_GAME_API Unit : public WorldObject
         void RemoveAllDynObjects();
 
         GameObject* GetGameObject(uint32 spellId) const;
-        void AddGameObject(GameObject* gameObj);
-        void RemoveGameObject(GameObject* gameObj, bool del);
+        void AddGameObject(SummonedGameObject* gameObj);
+        void UnlinkGameObject(SummonedGameObject* gameObj);
         void RemoveGameObject(uint32 spellid, bool del);
         void RemoveAllGameObjects();
 
@@ -1701,11 +1702,8 @@ class TC_GAME_API Unit : public WorldObject
 
         int32 m_procDeep;
 
-        typedef std::list<DynamicObject*> DynObjectList;
-        DynObjectList m_dynObj;
-
-        typedef std::list<GameObject*> GameObjectList;
-        GameObjectList m_gameObj;
+        std::list<DynamicObject*> m_dynObj;
+        std::list<SummonedGameObject*> m_gameObj;
 
         uint32 m_transform;
 

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -420,7 +420,7 @@ void PoolGroup<GameObject>::Spawn1Object(PoolObject* obj)
             }
             else
             {
-                if (pGameobject->isSpawnedByDefault())
+                if (pGameobject->IsSpawnedByDefault())
                     map->AddToMap(pGameobject);
             }
         }

--- a/src/server/scripts/Commands/cs_gobject.cpp
+++ b/src/server/scripts/Commands/cs_gobject.cpp
@@ -373,12 +373,10 @@ public:
                 handler->SetSentErrorMessage(true);
                 return false;
             }
-
-            owner->RemoveGameObject(object, false);
         }
 
         object->SetRespawnTime(0);                                 // not save respawn time
-        object->Delete();
+        object->DespawnOrUnsummon();
         object->DeleteFromDB();
 
         handler->PSendSysMessage(LANG_COMMAND_DELOBJMESSAGE, object->GetSpawnId());

--- a/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.cpp
+++ b/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.cpp
@@ -304,7 +304,7 @@ public:
                     me->SummonCreature(NPC_CAVERNDEEP_AMBUSHER, SpawnPosition[9], TEMPSUMMON_CORPSE_TIMED_DESPAWN, 1800000);
                     break;
                 case 2:
-                    if (GameObject* go = me->SummonGameObject(183410, -533.140f, -105.322f, -156.016f, 0.f, QuaternionData(), 1))
+                    if (GameObject* go = me->SummonGameObject(183410, -533.140f, -105.322f, -156.016f, 0.f, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 1s))
                     {
                         GoSummonList.push_back(go->GetGUID());
                         go->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE); //We can't use it!
@@ -319,7 +319,7 @@ public:
                     Talk(SAY_BLASTMASTER_7);
                     break;
                 case 4:
-                    if (GameObject* go = me->SummonGameObject(183410, -542.199f, -96.854f, -155.790f, 0.f, QuaternionData(), 1))
+                    if (GameObject* go = me->SummonGameObject(183410, -542.199f, -96.854f, -155.790f, 0.f, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 1s))
                     {
                         GoSummonList.push_back(go->GetGUID());
                         go->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
@@ -333,7 +333,7 @@ public:
                     me->SummonCreature(NPC_CAVERNDEEP_AMBUSHER, SpawnPosition[14], TEMPSUMMON_CORPSE_TIMED_DESPAWN, 1800000);
                     break;
                 case 6:
-                    if (GameObject* go = me->SummonGameObject(183410, -507.820f, -103.333f, -151.353f, 0.f, QuaternionData(), 1))
+                    if (GameObject* go = me->SummonGameObject(183410, -507.820f, -103.333f, -151.353f, 0.f, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 1s))))
                     {
                         GoSummonList.push_back(go->GetGUID());
                         go->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE); //We can't use it!
@@ -341,7 +341,7 @@ public:
                     }
                     break;
                 case 7:
-                    if (GameObject* go = me->SummonGameObject(183410, -511.829f, -86.249f, -151.431f, 0.f, QuaternionData(), 1))
+                    if (GameObject* go = me->SummonGameObject(183410, -511.829f, -86.249f, -151.431f, 0.f, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 1s))))
                     {
                         GoSummonList.push_back(go->GetGUID());
                         go->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE); //We can't use it!
@@ -353,9 +353,9 @@ public:
                     me->SummonCreature(NPC_CHOMPER, SpawnPosition[16], TEMPSUMMON_CORPSE_TIMED_DESPAWN, 1800000);
                     break;
                 case 9:
-                    me->SummonGameObject(GO_RED_ROCKET, SpawnPosition[17], QuaternionData(), 7200);
-                    me->SummonGameObject(GO_RED_ROCKET, SpawnPosition[18], QuaternionData(), 7200);
-                    me->SummonGameObject(GO_RED_ROCKET, SpawnPosition[19], QuaternionData(), 7200);
+                    me->SummonGameObject(GO_RED_ROCKET, SpawnPosition[17], QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 2h);
+                    me->SummonGameObject(GO_RED_ROCKET, SpawnPosition[18], QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 2h);
+                    me->SummonGameObject(GO_RED_ROCKET, SpawnPosition[19], QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 2h);
                     break;
             }
         }

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
@@ -1088,7 +1088,7 @@ public:
                         case 48: // Show the cleansing effect (dawn of light)
                             //if (GameObject* go = me->GetMap()->GetGameObject(uiDawnofLightGUID))
                             //    go->SetPhaseMask(128, true);
-                            me->SummonGameObject(GO_LIGHT_OF_DAWN, 2283.896f, -5287.914f, 83.066f, 0.f, QuaternionData(), 30);
+                            me->SummonGameObject(GO_LIGHT_OF_DAWN, 2283.896f, -5287.914f, 83.066f, 0.f, QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 30s);
                             if (Creature* temp = ObjectAccessor::GetCreature(*me, uiTirionGUID))
                             {
                                 if (temp->HasAura(SPELL_REBIRTH_OF_THE_ASHBRINGER))

--- a/src/server/scripts/EasternKingdoms/SunkenTemple/instance_sunken_temple.cpp
+++ b/src/server/scripts/EasternKingdoms/SunkenTemple/instance_sunken_temple.cpp
@@ -178,14 +178,14 @@ public:
 
         void UseStatue(GameObject* go)
         {
-            go->SummonGameObject(GO_ATALAI_LIGHT1, *go, QuaternionData(), 0);
+            go->SummonGameObject(GO_ATALAI_LIGHT1, *go, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
             go->SetUInt32Value(GAMEOBJECT_FLAGS, 4);
         }
 
         void UseLastStatue(GameObject* go)
         {
             for (uint8 i = 0; i < nStatues; ++i)
-                go->SummonGameObject(GO_ATALAI_LIGHT2, statuePositions[i], QuaternionData(), 0);
+                go->SummonGameObject(GO_ATALAI_LIGHT2, statuePositions[i], QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
 
             go->SummonCreature(NPC_ATALALARION, atalalarianPos, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 7200);
         }

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -174,7 +174,7 @@ class npc_zulaman_hostage : public CreatureScript
                 {
                     if (HostageEntry[i] == entry)
                     {
-                        me->SummonGameObject(ChestEntry[i], Position(x - 2, y, z, 0.f), QuaternionData(), 0);
+                        me->SummonGameObject(ChestEntry[i], Position(x - 2, y, z, 0.f), QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                         break;
                     }
                 }

--- a/src/server/scripts/Events/fireworks_show.cpp
+++ b/src/server/scripts/Events/fireworks_show.cpp
@@ -860,7 +860,7 @@ public:
 
                             if (_big)
                             {
-                                if (GameObject* firework = me->SummonGameObject(FireworksBIGOnlyPicker(), rndpos, QuaternionData(0.f, 0.f, rndrot, rndrot2), 300))
+                                if (GameObject* firework = me->SummonGameObject(FireworksBIGOnlyPicker(), rndpos, QuaternionData(0.f, 0.f, rndrot, rndrot2), GO_SUMMON_TIMED_DESPAWN, 6min))
                                 {
                                     firework->SetRespawnTime(0);
                                     firework->Delete();
@@ -868,7 +868,7 @@ public:
                             }
                             else
                             {
-                                if (GameObject* firework = me->SummonGameObject(FireworksPicker(), rndpos, QuaternionData(0.f, 0.f, rndrot, rndrot2), 300))
+                                if (GameObject* firework = me->SummonGameObject(FireworksPicker(), rndpos, QuaternionData(0.f, 0.f, rndrot, rndrot2), GO_SUMMON_TIMED_DESPAWN, 6min))
                                 {
                                     firework->SetRespawnTime(0);
                                     firework->Delete();

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjalAI.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjalAI.cpp
@@ -653,7 +653,7 @@ void hyjalAI::SpawnVeins()
             return;
         for (uint8 i = 0; i < 7; ++i)
         {
-            GameObject* gem = me->SummonGameObject(GO_ANCIENT_VEIN, VeinPos[i][0], VeinPos[i][1], VeinPos[i][2], VeinPos[i][3], QuaternionData(VeinPos[i][4], VeinPos[i][5], VeinPos[i][6], VeinPos[i][7]), 0);
+            GameObject* gem = me->SummonGameObject(GO_ANCIENT_VEIN, VeinPos[i][0], VeinPos[i][1], VeinPos[i][2], VeinPos[i][3], QuaternionData(VeinPos[i][4], VeinPos[i][5], VeinPos[i][6], VeinPos[i][7]), GO_SUMMON_MANUAL_DESPAWN);
             if (gem)
                 VeinGUID[i]=gem->GetGUID();
         }
@@ -665,7 +665,7 @@ void hyjalAI::SpawnVeins()
             return;
         for (uint8 i = 7; i < 14; ++i)
         {
-            GameObject* gem = me->SummonGameObject(GO_ANCIENT_VEIN, VeinPos[i][0], VeinPos[i][1], VeinPos[i][2], VeinPos[i][3], QuaternionData(VeinPos[i][4], VeinPos[i][5], VeinPos[i][6], VeinPos[i][7]), 0);
+            GameObject* gem = me->SummonGameObject(GO_ANCIENT_VEIN, VeinPos[i][0], VeinPos[i][1], VeinPos[i][2], VeinPos[i][3], QuaternionData(VeinPos[i][4], VeinPos[i][5], VeinPos[i][6], VeinPos[i][7]), GO_SUMMON_MANUAL_DESPAWN);
             if (gem)
                 VeinGUID[i] = gem->GetGUID();
         }
@@ -728,7 +728,7 @@ void hyjalAI::UpdateAI(uint32 diff)
                     HideNearPos(me->GetPositionX(), me->GetPositionY());
                     HideNearPos(5037.76f, -1889.71f);
                     for (uint8 i = 0; i < 92; ++i)//summon fires
-                        me->SummonGameObject(GO_ROARING_FLAME, AllianceFirePos[i][0], AllianceFirePos[i][1], AllianceFirePos[i][2], AllianceFirePos[i][3], QuaternionData(AllianceFirePos[i][4], AllianceFirePos[i][5], AllianceFirePos[i][6], AllianceFirePos[i][7]), 0);
+                        me->SummonGameObject(GO_ROARING_FLAME, AllianceFirePos[i][0], AllianceFirePos[i][1], AllianceFirePos[i][2], AllianceFirePos[i][3], QuaternionData(AllianceFirePos[i][4], AllianceFirePos[i][5], AllianceFirePos[i][6], AllianceFirePos[i][7]), GO_SUMMON_MANUAL_DESPAWN);
 
                 }
                 else me->SetVisible(true);
@@ -741,7 +741,7 @@ void hyjalAI::UpdateAI(uint32 diff)
                     HideNearPos(5563, -2763.19f);
                     HideNearPos(5542.2f, -2629.36f);
                     for (uint8 i = 0; i < 65; ++i)//summon fires
-                        me->SummonGameObject(GO_ROARING_FLAME, HordeFirePos[i][0], HordeFirePos[i][1], HordeFirePos[i][2], HordeFirePos[i][3], QuaternionData(HordeFirePos[i][4], HordeFirePos[i][5], HordeFirePos[i][6], HordeFirePos[i][7]), 0);
+                        me->SummonGameObject(GO_ROARING_FLAME, HordeFirePos[i][0], HordeFirePos[i][1], HordeFirePos[i][2], HordeFirePos[i][3], QuaternionData(HordeFirePos[i][4], HordeFirePos[i][5], HordeFirePos[i][6], HordeFirePos[i][7]), GO_SUMMON_MANUAL_DESPAWN);
 
                 }
                 else me->SetVisible(true);
@@ -1018,7 +1018,7 @@ void hyjalAI::DoOverrun(uint32 faction, const uint32 diff)
     {
         case 0://alliance
             for (uint8 i = 0; i < 92; ++i)//summon fires
-                me->SummonGameObject(GO_ROARING_FLAME, AllianceFirePos[i][0], AllianceFirePos[i][1], AllianceFirePos[i][2], AllianceFirePos[i][3], QuaternionData(AllianceFirePos[i][4], AllianceFirePos[i][5], AllianceFirePos[i][6], AllianceFirePos[i][7]), 0);
+                me->SummonGameObject(GO_ROARING_FLAME, AllianceFirePos[i][0], AllianceFirePos[i][1], AllianceFirePos[i][2], AllianceFirePos[i][3], QuaternionData(AllianceFirePos[i][4], AllianceFirePos[i][5], AllianceFirePos[i][6], AllianceFirePos[i][7]), GO_SUMMON_MANUAL_DESPAWN);
 
             for (uint8 i = 0; i < 25; ++i)//summon 25 ghouls
             {
@@ -1062,7 +1062,7 @@ void hyjalAI::DoOverrun(uint32 faction, const uint32 diff)
             break;
         case 1://horde
             for (uint8 i = 0; i < 65; ++i)//summon fires
-                me->SummonGameObject(GO_ROARING_FLAME, HordeFirePos[i][0], HordeFirePos[i][1], HordeFirePos[i][2], HordeFirePos[i][3], QuaternionData(HordeFirePos[i][4], HordeFirePos[i][5], HordeFirePos[i][6], HordeFirePos[i][7]), 0);
+                me->SummonGameObject(GO_ROARING_FLAME, HordeFirePos[i][0], HordeFirePos[i][1], HordeFirePos[i][2], HordeFirePos[i][3], QuaternionData(HordeFirePos[i][4], HordeFirePos[i][5], HordeFirePos[i][6], HordeFirePos[i][7]), GO_SUMMON_MANUAL_DESPAWN);
 
             for (uint8 i = 0; i < 26; ++i)//summon infernals
             {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -1253,7 +1253,7 @@ class npc_crate_helper : public CreatureScript
                         instance->SetData(DATA_CRATE_COUNT, instance->GetData(DATA_CRATE_COUNT) + 1);
                     if (GameObject* crate = me->FindNearestGameObject(GO_SUSPICIOUS_CRATE, 5.0f))
                     {
-                        crate->SummonGameObject(GO_PLAGUED_CRATE, *crate, QuaternionData(), DAY);
+                        crate->SummonGameObject(GO_PLAGUED_CRATE, *crate, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                         crate->Delete();
                     }
                 }

--- a/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
@@ -204,7 +204,7 @@ public:
                     case EVENT_COMPLETE:
                     {
                         DoCast(me, SPELL_IDOM_ROOM_CAMERA_SHAKE);
-                        me->SummonGameObject(GO_BELNISTRASZS_BRAZIER, 2577.196f, 947.0781f, 53.16757f, 2.356195f, QuaternionData(0.f, 0.f, 0.9238796f, 0.3826832f), 3600);
+                        me->SummonGameObject(GO_BELNISTRASZS_BRAZIER, 2577.196f, 947.0781f, 53.16757f, 2.356195f, QuaternionData(0.f, 0.f, 0.9238796f, 0.3826832f), GO_SUMMON_MANUAL_DESPAWN, 1h);
                         std::list<WorldObject*> ClusterList;
                         Trinity::AllWorldObjectsInRange objects(me, 50.0f);
                         Trinity::WorldObjectListSearcher<Trinity::AllWorldObjectsInRange> searcher(me, ClusterList, objects);

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -198,7 +198,7 @@ class boss_ossirian : public CreatureScript
                 if (Creature* Trigger = me->SummonCreature(NPC_OSSIRIAN_TRIGGER, CrystalCoordinates[CrystalIterator]))
                 {
                     TriggerGUID = Trigger->GetGUID();
-                    if (GameObject* Crystal = Trigger->SummonGameObject(GO_OSSIRIAN_CRYSTAL, CrystalCoordinates[CrystalIterator], QuaternionData(), uint32(-1)))
+                    if (GameObject* Crystal = Trigger->SummonGameObject(GO_OSSIRIAN_CRYSTAL, CrystalCoordinates[CrystalIterator], QuaternionData(), GO_SUMMON_MANUAL_DESPAWN))
                     {
                         CrystalGUID = Crystal->GetGUID();
                         ++CrystalIterator;

--- a/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
@@ -516,7 +516,7 @@ public:
                             _explosivesGuids.clear();
                             for (uint8 i = 0; i != MAX_EXPLOSIVES; ++i)
                             {
-                                if (GameObject* explosive = me->SummonGameObject(GO_DRAENEI_EXPLOSIVES_1, ExplosivesPos[0][i], QuaternionData(), 0))
+                                if (GameObject* explosive = me->SummonGameObject(GO_DRAENEI_EXPLOSIVES_1, ExplosivesPos[0][i], QuaternionData(), GO_SUMMON_CORPSE_DESPAWN))
                                     _explosivesGuids.push_back(explosive->GetGUID());
                             }
                             me->HandleEmoteCommand(EMOTE_ONESHOT_NONE); // reset anim state
@@ -545,7 +545,7 @@ public:
                             for (GuidList::iterator itr = _explosivesGuids.begin(); itr != _explosivesGuids.end(); ++itr)
                             {
                                 if (GameObject* explosive = ObjectAccessor::GetGameObject(*me, *itr))
-                                    me->RemoveGameObject(explosive, true);
+                                    explosive->DespawnOrUnsummon();
                             }
                             _explosivesGuids.clear();
                             me->HandleEmoteCommand(EMOTE_ONESHOT_CHEER);
@@ -612,7 +612,7 @@ public:
                             _explosivesGuids.clear();
                             for (uint8 i = 0; i != MAX_EXPLOSIVES; ++i)
                             {
-                                if (GameObject* explosive = me->SummonGameObject(GO_DRAENEI_EXPLOSIVES_2, ExplosivesPos[1][i], QuaternionData(), 0))
+                                if (GameObject* explosive = me->SummonGameObject(GO_DRAENEI_EXPLOSIVES_2, ExplosivesPos[1][i], QuaternionData(), GO_SUMMON_CORPSE_DESPAWN))
                                     _explosivesGuids.push_back(explosive->GetGUID());
                             }
                             Talk(SAY_LEGOSO_15);
@@ -642,7 +642,7 @@ public:
                             for (GuidList::iterator itr = _explosivesGuids.begin(); itr != _explosivesGuids.end(); ++itr)
                             {
                                 if (GameObject* explosive = ObjectAccessor::GetGameObject(*me, *itr))
-                                    me->RemoveGameObject(explosive, true);
+                                    explosive->DespawnOrUnsummon();
                             }
                             _explosivesGuids.clear();
                             if (Creature* sironas = me->FindNearestCreature(NPC_SIRONAS, SIZE_OF_GRIDS))

--- a/src/server/scripts/Kalimdor/zone_feralas.cpp
+++ b/src/server/scripts/Kalimdor/zone_feralas.cpp
@@ -167,8 +167,7 @@ class spell_gordunni_trap : public SpellScriptLoader
             void HandleDummy()
             {
                 GameObject* caster = GetGObjCaster();
-                if (GameObject* chest = caster->SummonGameObject(urand(0, 1) ? GO_GORDUNNI_DIRT_MOUND_1 : GO_GORDUNNI_DIRT_MOUND_2, *caster, QuaternionData(), 0))
-                    chest->SetSpellId(GetSpellInfo()->Id);
+                caster->SummonGameObject(urand(0, 1) ? GO_GORDUNNI_DIRT_MOUND_1 : GO_GORDUNNI_DIRT_MOUND_2, *caster, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN, 0s, GetSpellInfo()->Id);
             }
 
             void Register() override

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -510,11 +510,11 @@ public:
                         DoCast(player, SPELL_CALL_PRISMATIC_BARRIER, true);
                         break;
                     case 37:
-                        me->SummonGameObject(GO_GATE_OF_AHN_QIRAJ, Position(-8130.f, 1525.f, 17.5f, 0.f), QuaternionData(), 0);
+                        me->SummonGameObject(GO_GATE_OF_AHN_QIRAJ, Position(-8130.f, 1525.f, 17.5f, 0.f), QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                         break;
                     case 38:
                         DoCast(player, SPELL_CALL_GLYPHS_OF_WARDING, true);
-                        me->SummonGameObject(GO_GLYPH_OF_AHN_QIRAJ, Position(-8130.f, 1525.f, 17.5f, 0.f), QuaternionData(), 0);
+                        me->SummonGameObject(GO_GLYPH_OF_AHN_QIRAJ, Position(-8130.f, 1525.f, 17.5f, 0.f), QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                         break;
                     case 39:
                         Talk(ANACHRONOS_SAY_5, Fandral);
@@ -523,7 +523,7 @@ public:
                         Fandral->CastSpell(me, SPELL_CALL_ANCIENTS, true);
                         break;
                     case 41:
-                        Fandral->SummonGameObject(GO_ROOTS_OF_AHN_QIRAJ, Position(-8130.f, 1525.f, 17.5f, 0.f), QuaternionData(), 0);
+                        Fandral->SummonGameObject(GO_ROOTS_OF_AHN_QIRAJ, Position(-8130.f, 1525.f, 17.5f, 0.f), QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                         Fandral->AI()->Talk(FANDRAL_SAY_3);
                         break;
                     case 42:

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
@@ -185,7 +185,7 @@ public:
                             {
                                 pAnnouncer->GetMotionMaster()->MovePoint(0, 748.309f, 619.487f, 411.171f);
                                 pAnnouncer->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                                pAnnouncer->SummonGameObject(instance->IsHeroic()? GO_CHAMPIONS_LOOT_H : GO_CHAMPIONS_LOOT, 746.59f, 618.49f, 411.09f, 1.42f, QuaternionData(), 90000);
+                                pAnnouncer->SummonGameObject(instance->IsHeroic()? GO_CHAMPIONS_LOOT_H : GO_CHAMPIONS_LOOT, 746.59f, 618.49f, 411.09f, 1.42f, QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 150min);
                             }
                         }
                     }
@@ -208,7 +208,7 @@ public:
                     {
                         pAnnouncer->GetMotionMaster()->MovePoint(0, 748.309f, 619.487f, 411.171f);
                         pAnnouncer->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                        pAnnouncer->SummonGameObject(instance->IsHeroic()? GO_EADRIC_LOOT_H : GO_EADRIC_LOOT, 746.59f, 618.49f, 411.09f, 1.42f, QuaternionData(), 90000);
+                        pAnnouncer->SummonGameObject(instance->IsHeroic()? GO_EADRIC_LOOT_H : GO_EADRIC_LOOT, 746.59f, 618.49f, 411.09f, 1.42f, QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 150min);
                     }
                     break;
                 case BOSS_ARGENT_CHALLENGE_P:
@@ -217,7 +217,7 @@ public:
                     {
                         pAnnouncer->GetMotionMaster()->MovePoint(0, 748.309f, 619.487f, 411.171f);
                         pAnnouncer->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                        pAnnouncer->SummonGameObject(instance->IsHeroic()? GO_PALETRESS_LOOT_H : GO_PALETRESS_LOOT, 746.59f, 618.49f, 411.09f, 1.42f, QuaternionData(), 90000);
+                        pAnnouncer->SummonGameObject(instance->IsHeroic()? GO_PALETRESS_LOOT_H : GO_PALETRESS_LOOT, 746.59f, 618.49f, 411.09f, 1.42f, QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 150min);
                     }
                     break;
             }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -1342,11 +1342,7 @@ class spell_sindragosa_ice_tomb : public SpellScriptLoader
                         {
                             summon->AI()->SetGUID(GetTarget()->GetGUID(), DATA_TRAPPED_PLAYER);
                             GetTarget()->CastSpell(GetTarget(), SPELL_ICE_TOMB_UNTARGETABLE);
-                            if (GameObject* go = summon->SummonGameObject(GO_ICE_BLOCK, pos, QuaternionData(), 0))
-                            {
-                                go->SetSpellId(SPELL_ICE_TOMB_DAMAGE);
-                                summon->AddGameObject(go);
-                            }
+                            summon->SummonGameObject(GO_ICE_BLOCK, pos, QuaternionData(), GO_SUMMON_CORPSE_DESPAWN, 0s, SPELL_ICE_TOMB_DAMAGE);
                         }
                     }
                 }

--- a/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
@@ -564,7 +564,7 @@ class spell_sapphiron_icebolt : public SpellScriptLoader
                 return;
             float x, y, z;
             GetTarget()->GetPosition(x, y, z);
-            if (GameObject* block = GetTarget()->SummonGameObject(GO_ICEBLOCK, x, y, z, 0.f, QuaternionData(), 25))
+            if (GameObject* block = GetTarget()->SummonGameObject(GO_ICEBLOCK, x, y, z, 0.f, QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 25s))
                 _block = block->GetGUID();
         }
 

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -1002,7 +1002,7 @@ public:
             _JustDied();
             Talk(SAY_DEATH);
             if (Creature* alexstraszaGiftBoxBunny = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_GIFT_BOX_BUNNY_GUID)))
-                alexstraszaGiftBoxBunny->SummonGameObject(RAID_MODE(GO_HEART_OF_MAGIC_10, GO_HEART_OF_MAGIC_25), HeartOfMagicSpawnPos, QuaternionData(), 0);
+                alexstraszaGiftBoxBunny->SummonGameObject(RAID_MODE(GO_HEART_OF_MAGIC_10, GO_HEART_OF_MAGIC_25), HeartOfMagicSpawnPos, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
 
             me->SummonCreature(NPC_ALEXSTRASZA, AlexstraszaSpawnPos, TEMPSUMMON_MANUAL_DESPAWN);
             me->DespawnOrUnsummon(5*IN_MILLISECONDS);
@@ -2406,9 +2406,9 @@ class spell_alexstrasza_gift_beam_visual : public SpellScriptLoader
                 if (Creature* target = GetTarget()->ToCreature())
                 {
                     if (target->GetMap()->GetDifficulty() == RAID_DIFFICULTY_10MAN_NORMAL)
-                        _alexstraszaGift = target->SummonGameObject(GO_ALEXSTRASZA_S_GIFT_10, *target, QuaternionData(), 0);
+                        _alexstraszaGift = target->SummonGameObject(GO_ALEXSTRASZA_S_GIFT_10, *target, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                     else if (target->GetMap()->GetDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL)
-                        _alexstraszaGift = target->SummonGameObject(GO_ALEXSTRASZA_S_GIFT_25, *target, QuaternionData(), 0);
+                        _alexstraszaGift = target->SummonGameObject(GO_ALEXSTRASZA_S_GIFT_25, *target, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);
                 }
             }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "ScriptMgr.h"
+#include "GameObject.h"
 #include "InstanceScript.h"
 #include "Map.h"
 #include "ObjectAccessor.h"
@@ -1455,8 +1456,8 @@ class npc_nature_bomb : public CreatureScript
                     if (GameObject* go = me->FindNearestGameObject(OBJECT_NATURE_BOMB, 1.0f))
                     {
                         DoCast(me, SPELL_NATURE_BOMB);
-                        me->RemoveGameObject(go, true);
-                        me->RemoveFromWorld();
+                        go->DespawnOrUnsummon();
+                        me->DespawnOrUnsummon();
                     }
 
                     bombTimer = 10000;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -631,8 +631,8 @@ class npc_snowpacked_icicle : public CreatureScript
             {
                 if (despawnTimer <= diff)
                 {
-                    if (GameObject* Snowdrift = me->FindNearestGameObject(GO_SNOWDRIFT, 2.0f))
-                        me->RemoveGameObject(Snowdrift, true);
+                    if (GameObject* snowdrift = me->FindNearestGameObject(GO_SNOWDRIFT, 2.0f))
+                        snowdrift->DespawnOrUnsummon();
                     me->DespawnOrUnsummon();
                 }
                 else
@@ -963,8 +963,8 @@ class npc_toasty_fire : public CreatureScript
             {
                 if (spell->Id == SPELL_BLOCK_OF_ICE || spell->Id == SPELL_ICE_SHARD || spell->Id == SPELL_ICE_SHARD_HIT)
                 {
-                    if (GameObject* ToastyFire = me->FindNearestGameObject(GO_TOASTY_FIRE, 1.0f))
-                        me->RemoveGameObject(ToastyFire, true);
+                    if (GameObject* fire = me->FindNearestGameObject(GO_TOASTY_FIRE, 1.0f))
+                        fire->DespawnOrUnsummon();
                     me->DespawnOrUnsummon();
                 }
             }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -647,10 +647,10 @@ class boss_mimiron : public CreatureScript
                             {
                                 if (Creature* computer = instance->GetCreature(DATA_COMPUTER))
                                     computer->AI()->DoAction(DO_DEACTIVATE_COMPUTER);
-                                me->SummonGameObject(RAID_MODE(GO_CACHE_OF_INNOVATION_FIREFIGHTER, GO_CACHE_OF_INNOVATION_FIREFIGHTER_HERO), 2744.040f, 2569.352f, 364.3135f, 3.124123f, QuaternionData(0.f, 0.f, 0.9999619f, 0.008734641f), 604800);
+                                me->SummonGameObject(RAID_MODE(GO_CACHE_OF_INNOVATION_FIREFIGHTER, GO_CACHE_OF_INNOVATION_FIREFIGHTER_HERO), 2744.040f, 2569.352f, 364.3135f, 3.124123f, QuaternionData(0.f, 0.f, 0.9999619f, 0.008734641f), GO_SUMMON_TIMED_DESPAWN, 7*24h);
                             }
                             else
-                                me->SummonGameObject(RAID_MODE(GO_CACHE_OF_INNOVATION, GO_CACHE_OF_INNOVATION_HERO), 2744.040f, 2569.352f, 364.3135f, 3.124123f, QuaternionData(0.f, 0.f, 0.9999619f, 0.008734641f), 604800);
+                                me->SummonGameObject(RAID_MODE(GO_CACHE_OF_INNOVATION, GO_CACHE_OF_INNOVATION_HERO), 2744.040f, 2569.352f, 364.3135f, 3.124123f, QuaternionData(0.f, 0.f, 0.9999619f, 0.008734641f), GO_SUMMON_TIMED_DESPAWN, 7*24h);
                             events.ScheduleEvent(EVENT_OUTTRO_3, 11000);
                             break;
                         case EVENT_OUTTRO_3:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -704,7 +704,7 @@ struct npc_expedition_commander : public ScriptedAI
     {
         uint8 harpoonNumber = _is25Man ? 4 : 2;
         for (uint8 i = 0; i < harpoonNumber; ++i)
-            me->SummonGameObject(GO_RAZOR_BROKEN_HARPOON, PosBrokenHarpoon[i], QuaternionData(0.0f, 0.0f, -0.8987932f, 0.4383728f), WEEK);
+            me->SummonGameObject(GO_RAZOR_BROKEN_HARPOON, PosBrokenHarpoon[i], QuaternionData(0.0f, 0.0f, -0.8987932f, 0.4383728f), GO_SUMMON_CORPSE_DESPAWN);
     }
 
     void DestroyHarpoons()
@@ -737,19 +737,19 @@ struct npc_expedition_commander : public ScriptedAI
             switch (harpoonNumber)
             {
                 case HARPOON_1:
-                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_3, PosHarpoon[2], QuaternionData(0.0f, 0.0f, -0.573576f, 0.8191524f), WEEK))
+                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_3, PosHarpoon[2], QuaternionData(0.0f, 0.0f, -0.573576f, 0.8191524f), GO_SUMMON_CORPSE_DESPAWN))
                         _harpoons.emplace_back(harpoon->GetGUID());
                     break;
                 case HARPOON_2:
-                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_1, PosHarpoon[0], QuaternionData(0.0f, 0.0f, -0.6293201f, 0.7771462f), WEEK))
+                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_1, PosHarpoon[0], QuaternionData(0.0f, 0.0f, -0.6293201f, 0.7771462f), GO_SUMMON_CORPSE_DESPAWN))
                         _harpoons.emplace_back(harpoon->GetGUID());
                     break;
                 case HARPOON_3:
-                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_2, PosHarpoon[1], QuaternionData(0.0f, 0.0f, -0.6691303f, 0.743145f), WEEK))
+                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_2, PosHarpoon[1], QuaternionData(0.0f, 0.0f, -0.6691303f, 0.743145f), GO_SUMMON_CORPSE_DESPAWN))
                         _harpoons.emplace_back(harpoon->GetGUID());
                     break;
                 case HARPOON_4:
-                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_4, PosHarpoon[3], QuaternionData(0.0f, 0.0f, -0.7660437f, 0.6427886f), WEEK))
+                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_4, PosHarpoon[3], QuaternionData(0.0f, 0.0f, -0.7660437f, 0.6427886f), GO_SUMMON_CORPSE_DESPAWN))
                         _harpoons.emplace_back(harpoon->GetGUID());
                     break;
                 default:
@@ -761,11 +761,11 @@ struct npc_expedition_commander : public ScriptedAI
             switch (harpoonNumber)
             {
                 case HARPOON_1:
-                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_1, PosHarpoon[harpoonNumber], QuaternionData(0.0f, 0.0f, -0.6293201f, 0.7771462f), 0))
+                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_1, PosHarpoon[harpoonNumber], QuaternionData(0.0f, 0.0f, -0.6293201f, 0.7771462f), GO_SUMMON_CORPSE_DESPAWN))
                         _harpoons.emplace_back(harpoon->GetGUID());
                     break;
                 case HARPOON_2:
-                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_2, PosHarpoon[harpoonNumber], QuaternionData(0.0f, 0.0f, -0.6691303f, 0.743145f), 0))
+                    if (GameObject* harpoon = me->SummonGameObject(GO_RAZOR_HARPOON_2, PosHarpoon[harpoonNumber], QuaternionData(0.0f, 0.0f, -0.6691303f, 0.743145f), GO_SUMMON_CORPSE_DESPAWN))
                         _harpoons.emplace_back(harpoon->GetGUID());
                     break;
                 default:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -771,7 +771,7 @@ class instance_ulduar : public InstanceMapScript
                         {
                             if (Creature* hodir = GetCreature(BOSS_HODIR))
                                 if (GameObject* gameObject = instance->GetGameObject(HodirRareCacheGUID))
-                                    hodir->RemoveGameObject(gameObject, false);
+                                    hodir->UnlinkGameObject(gameObject->ToSummonedGameObject());
                         }
                         break;
                     case DATA_UNBROKEN:

--- a/src/server/scripts/Northrend/zone_sholazar_basin.cpp
+++ b/src/server/scripts/Northrend/zone_sholazar_basin.cpp
@@ -98,7 +98,7 @@ public:
                 case 1:
                     Talk(SAY_WP_3);
                     me->CastSpell({ 5918.33f, 5372.91f, -98.770f }, SPELL_EXPLODE_CRYSTAL, true);
-                    me->SummonGameObject(184743, 5918.33f, 5372.91f, -98.770f, 0, QuaternionData(), TEMPSUMMON_MANUAL_DESPAWN);     //approx 3 to 4 seconds
+                    me->SummonGameObject(184743, 5918.33f, 5372.91f, -98.770f, 0, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);     //approx 3 to 4 seconds
                     me->HandleEmoteCommand(EMOTE_ONESHOT_LAUGH);
                     break;
                 case 2:
@@ -109,7 +109,7 @@ public:
                     break;
                 case 8:
                     me->CastSpell({ 5887.37f, 5379.39f, -91.289f }, SPELL_EXPLODE_CRYSTAL, true);
-                    me->SummonGameObject(184743, 5887.37f, 5379.39f, -91.289f, 0, QuaternionData(), TEMPSUMMON_MANUAL_DESPAWN);      //approx 3 to 4 seconds
+                    me->SummonGameObject(184743, 5887.37f, 5379.39f, -91.289f, 0, QuaternionData(), GO_SUMMON_MANUAL_DESPAWN);      //approx 3 to 4 seconds
                     me->HandleEmoteCommand(EMOTE_ONESHOT_LAUGH);
                     break;
                 case 9:

--- a/src/server/scripts/Outland/BlackTemple/boss_warlord_najentus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_warlord_najentus.cpp
@@ -155,7 +155,7 @@ struct boss_najentus : public BossAI
                     DoCast(target, SPELL_IMPALING_SPINE, true);
                     _spineTargetGUID = target->GetGUID();
                     //must let target summon, otherwise you cannot click the spine
-                    target->SummonGameObject(GO_NAJENTUS_SPINE, *target, QuaternionData(), 30);
+                    target->SummonGameObject(GO_NAJENTUS_SPINE, *target, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 30s);
                     Talk(SAY_NEEDLE);
                 }
                 events.Repeat(Seconds(20), Seconds(25));

--- a/src/server/scripts/Outland/CoilfangReservoir/TheSlavePens/boss_ahune.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/TheSlavePens/boss_ahune.cpp
@@ -406,7 +406,7 @@ public:
             _summons.DespawnAll();
             ResetFlameCallers();
 
-            me->SummonGameObject(GO_ICE_STONE, -69.90455f, -162.2449f, -2.366563f, 2.426008f, QuaternionData(0.0f, 0.0f, 0.9366722f, 0.3502074f), 0);
+            me->SummonGameObject(GO_ICE_STONE, -69.90455f, -162.2449f, -2.366563f, 2.426008f, QuaternionData(0.0f, 0.0f, 0.9366722f, 0.3502074f), GO_SUMMON_MANUAL_DESPAWN);
         }
 
         void DoAction(int32 action) override

--- a/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
+++ b/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
@@ -989,7 +989,7 @@ public:
             {
                 // Spell 37392 does not exist in dbc, manually spawning
                 me->SummonCreature(NPC_OSCILLATING_FREQUENCY_SCANNER_TOP_BUNNY, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 0.5f, me->GetOrientation(), TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 50000);
-                me->SummonGameObject(GO_OSCILLATING_FREQUENCY_SCANNER, *me, QuaternionData(), 50);
+                me->SummonGameObject(GO_OSCILLATING_FREQUENCY_SCANNER, *me, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, 50s);
                 me->DespawnOrUnsummon(50000);
             }
 

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -2459,7 +2459,7 @@ class spell_item_crystal_prison_dummy_dnd : public SpellScript
         if (Creature* target = GetHitCreature())
             if (target->isDead() && !target->IsPet())
             {
-                GetCaster()->SummonGameObject(OBJECT_IMPRISONED_DOOMGUARD, *target, QuaternionData(), uint32(target->GetRespawnTime() - GameTime::GetGameTime()));
+                GetCaster()->SummonGameObject(OBJECT_IMPRISONED_DOOMGUARD, *target, QuaternionData(), GO_SUMMON_TIMED_OR_CORPSE_DESPAWN, Seconds(target->GetRespawnTime() - GameTime::GetGameTime()));
                 target->DespawnOrUnsummon();
             }
     }

--- a/src/server/scripts/World/item_scripts.cpp
+++ b/src/server/scripts/World/item_scripts.cpp
@@ -245,7 +245,7 @@ public:
 
         float x, y, z;
         go->GetClosePoint(x, y, z, go->GetCombatReach() / 3, 7.0f);
-        go->SummonGameObject(GO_HIGH_QUALITY_FUR, *go, QuaternionData(), 1);
+        go->SummonGameObject(GO_HIGH_QUALITY_FUR, *go, QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 1s);
         if (TempSummon* summon = player->SummonCreature(NPC_NESINGWARY_TRAPPER, x, y, z, go->GetOrientation(), TEMPSUMMON_DEAD_DESPAWN, 1000))
         {
             summon->SetVisible(false);

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2306,7 +2306,7 @@ public:
 
                 float displacement = 0.7f;
                 for (uint8 i = 0; i < 4; i++)
-                    me->SummonGameObject(GetFireworkGameObjectId(), me->GetPositionX() + (i % 2 == 0 ? displacement : -displacement), me->GetPositionY() + (i > 1 ? displacement : -displacement), me->GetPositionZ() + 4.0f, me->GetOrientation(), QuaternionData(), 1);
+                    me->SummonGameObject(GetFireworkGameObjectId(), me->GetPositionX() + (i % 2 == 0 ? displacement : -displacement), me->GetPositionY() + (i > 1 ? displacement : -displacement), me->GetPositionZ() + 4.0f, me->GetOrientation(), QuaternionData(), GO_SUMMON_TIMED_DESPAWN, 1s);
             }
             else
                 //me->CastSpell(me, GetFireworkSpell(me->GetEntry()), true);


### PR DESCRIPTION
Split off various creaky GO code that handled temporary summons and unify it in `SummonedGameObject`, akin to `TempSummon`. Step 1 in cleaning up negative respawn timer gobjs and porting them to dynspawn.

TODO: build fix refactoring