### PR TITLE
Core/Entities: update Scaling to 7.3.5

### DIFF
--- a/sql/updates/world/master/2018_04_12_00_world.sql
+++ b/sql/updates/world/master/2018_04_12_00_world.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `creature_template_scaling`
+ CHANGE `LevelScalingDelta` `LevelScalingDeltaMin` smallint(5) NOT NULL DEFAULT '0' AFTER `LevelScalingMax`,
+ ADD `LevelScalingDeltaMax` smallint(5) NOT NULL DEFAULT '0' AFTER `LevelScalingDeltaMin`;
+
+UPDATE `creature_template_scaling` SET `LevelScalingDeltaMax`=`LevelScalingDeltaMin`;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1226,20 +1226,22 @@ void Creature::SelectLevel()
 {
     CreatureTemplate const* cInfo = GetCreatureTemplate();
 
-    if (!HasScalableLevels())
+    // level
+    uint8 minlevel = std::min(cInfo->maxlevel, cInfo->minlevel);
+    uint8 maxlevel = std::max(cInfo->maxlevel, cInfo->minlevel);
+    uint8 level = minlevel == maxlevel ? minlevel : urand(minlevel, maxlevel);
+    SetLevel(level);
+
+    if (HasScalableLevels())
     {
-        // level
-        uint8 minlevel = std::min(cInfo->maxlevel, cInfo->minlevel);
-        uint8 maxlevel = std::max(cInfo->maxlevel, cInfo->minlevel);
-        uint8 level = minlevel == maxlevel ? minlevel : urand(minlevel, maxlevel);
-        SetLevel(level);
-    }
-    else
-    {
-        SetLevel(cInfo->levelScaling->MaxLevel);
         SetUInt32Value(UNIT_FIELD_SCALING_LEVEL_MIN, cInfo->levelScaling->MinLevel);
         SetUInt32Value(UNIT_FIELD_SCALING_LEVEL_MAX, cInfo->levelScaling->MaxLevel);
-        SetUInt32Value(UNIT_FIELD_SCALING_LEVEL_DELTA, cInfo->levelScaling->DeltaLevel);
+
+        int8 mindelta = std::min(cInfo->levelScaling->DeltaLevelMax, cInfo->levelScaling->DeltaLevelMin);
+        int8 maxdelta = std::max(cInfo->levelScaling->DeltaLevelMax, cInfo->levelScaling->DeltaLevelMin);
+        int8 delta = mindelta == maxdelta ? mindelta : irand(mindelta, maxdelta);
+
+        SetInt32Value(UNIT_FIELD_SCALING_LEVEL_DELTA, delta);
     }
 
     UpdateLevelDependantStats();
@@ -2566,7 +2568,7 @@ uint8 Creature::GetLevelForTarget(WorldObject const* target) const
         // between UNIT_FIELD_SCALING_LEVEL_MIN and UNIT_FIELD_SCALING_LEVEL_MAX
         if (HasScalableLevels())
         {
-            uint8 targetLevelWithDelta = unitTarget->getLevel() + GetCreatureTemplate()->levelScaling->DeltaLevel;
+            uint8 targetLevelWithDelta = unitTarget->getLevel() + GetInt32Value(UNIT_FIELD_SCALING_LEVEL_DELTA);
 
             if (target->IsPlayer())
                 targetLevelWithDelta += target->GetUInt32Value(PLAYER_FIELD_SCALING_PLAYER_LEVEL_DELTA);

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -296,7 +296,8 @@ struct CreatureLevelScaling
 {
     uint16 MinLevel;
     uint16 MaxLevel;
-    int16 DeltaLevel;
+    int16 DeltaLevelMin;
+    int16 DeltaLevelMax;
 };
 
 // from `creature_template` table

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -634,8 +634,8 @@ void ObjectMgr::LoadCreatureScalingData()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                                 0            1
-    QueryResult result = WorldDatabase.Query("SELECT Entry, LevelScalingMin, LevelScalingMax, LevelScalingDelta FROM creature_template_scaling");
+    //                                                 0            1                2                  3                    4
+    QueryResult result = WorldDatabase.Query("SELECT Entry, LevelScalingMin, LevelScalingMax, LevelScalingDeltaMin, LevelScalingDeltaMax FROM creature_template_scaling");
 
     if (!result)
     {
@@ -660,7 +660,8 @@ void ObjectMgr::LoadCreatureScalingData()
         CreatureLevelScaling creatureLevelScaling;
         creatureLevelScaling.MinLevel              = fields[1].GetUInt16();
         creatureLevelScaling.MaxLevel              = fields[2].GetUInt16();
-        creatureLevelScaling.DeltaLevel            = fields[3].GetInt16();
+        creatureLevelScaling.DeltaLevelMin         = fields[3].GetInt16();
+        creatureLevelScaling.DeltaLevelMax         = fields[4].GetInt16();
         itr->second.levelScaling                   = creatureLevelScaling;
 
         ++count;

--- a/src/server/game/Server/Packets/CombatLogPacketsCommon.cpp
+++ b/src/server/game/Server/Packets/CombatLogPacketsCommon.cpp
@@ -71,7 +71,7 @@ namespace WorldPackets
             Class = creatureTemplate->unit_class;
             TargetMinScalingLevel = uint8(creatureTemplate->levelScaling->MinLevel);
             TargetMaxScalingLevel = uint8(creatureTemplate->levelScaling->MaxLevel);
-            TargetScalingLevelDelta = int8(creatureTemplate->levelScaling->DeltaLevel);
+            TargetScalingLevelDelta = int8(attacker->GetInt32Value(UNIT_FIELD_SCALING_LEVEL_DELTA));
             return true;
         }
 
@@ -88,14 +88,15 @@ namespace WorldPackets
             Class = creatureTemplate->unit_class;
             TargetMinScalingLevel = uint8(creatureTemplate->levelScaling->MinLevel);
             TargetMaxScalingLevel = uint8(creatureTemplate->levelScaling->MaxLevel);
-            TargetScalingLevelDelta = int8(creatureTemplate->levelScaling->DeltaLevel);
+            TargetScalingLevelDelta = int8(target->GetInt32Value(UNIT_FIELD_SCALING_LEVEL_DELTA));
             return true;
         }
 
         template<>
         bool SandboxScalingData::GenerateDataForUnits<Creature, Creature>(Creature* attacker, Creature* target)
         {
-            CreatureTemplate const* creatureTemplate = target->HasScalableLevels() ? target->GetCreatureTemplate() : attacker->GetCreatureTemplate();
+            Creature* accessor = target->HasScalableLevels() ? target : attacker;
+            CreatureTemplate const* creatureTemplate = accessor->GetCreatureTemplate();
 
             Type = TYPE_CREATURE_TO_CREATURE_DAMAGE;
             PlayerLevelDelta = 0;
@@ -105,7 +106,7 @@ namespace WorldPackets
             Class = creatureTemplate->unit_class;
             TargetMinScalingLevel = uint8(creatureTemplate->levelScaling->MinLevel);
             TargetMaxScalingLevel = uint8(creatureTemplate->levelScaling->MaxLevel);
-            TargetScalingLevelDelta = int8(creatureTemplate->levelScaling->DeltaLevel);
+            TargetScalingLevelDelta = int8(accessor->GetInt32Value(UNIT_FIELD_SCALING_LEVEL_DELTA));
             return true;
         }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Scaling creatures have a range in delta
- [#351](https://github.com/TrinityCore/WowPacketParser/pull/351)

**Target branch(es):** 3.3.5/master

- [x] master

**Known issues and TODO list:** (add/remove lines as needed)

- [x] ~~ScalingMin and Max might be taken from SandboxScaling.db2 since SandboxScalingId is part of Unit~~ _In BfA DB2 got renamed (it's only for item,quest,worlquest scaling_


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
