### PR TITLE
Transitional Cryptography update for OpenSSL 1.1

### DIFF
--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -26,7 +26,7 @@
 # http://www.slproweb.com/products/Win32OpenSSL.html
 
 set(OPENSSL_EXPECTED_VERSION "1.0")
-set(OPENSSL_MAX_VERSION "1.1")
+set(OPENSSL_MAX_VERSION "1.2")
 
 SET(_OPENSSL_ROOT_HINTS
   "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"

--- a/src/common/Cryptography/ARC4.cpp
+++ b/src/common/Cryptography/ARC4.cpp
@@ -18,34 +18,34 @@
 
 #include "ARC4.h"
 
-ARC4::ARC4(uint32 len) : m_ctx()
+ARC4::ARC4(uint32 len) : m_ctx(EVP_CIPHER_CTX_new())
 {
-    EVP_CIPHER_CTX_init(&m_ctx);
-    EVP_EncryptInit_ex(&m_ctx, EVP_rc4(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_set_key_length(&m_ctx, len);
+    EVP_CIPHER_CTX_init(m_ctx);
+    EVP_EncryptInit_ex(m_ctx, EVP_rc4(), nullptr, nullptr, nullptr);
+    EVP_CIPHER_CTX_set_key_length(m_ctx, len);
 }
 
-ARC4::ARC4(uint8 *seed, uint32 len) : m_ctx()
+ARC4::ARC4(uint8* seed, uint32 len) : m_ctx(EVP_CIPHER_CTX_new())
 {
-    EVP_CIPHER_CTX_init(&m_ctx);
-    EVP_EncryptInit_ex(&m_ctx, EVP_rc4(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_set_key_length(&m_ctx, len);
-    EVP_EncryptInit_ex(&m_ctx, NULL, NULL, seed, NULL);
+    EVP_CIPHER_CTX_init(m_ctx);
+    EVP_EncryptInit_ex(m_ctx, EVP_rc4(), nullptr, nullptr, nullptr);
+    EVP_CIPHER_CTX_set_key_length(m_ctx, len);
+    EVP_EncryptInit_ex(m_ctx, nullptr, nullptr, seed, nullptr);
 }
 
 ARC4::~ARC4()
 {
-    EVP_CIPHER_CTX_cleanup(&m_ctx);
+    EVP_CIPHER_CTX_free(m_ctx);
 }
 
-void ARC4::Init(uint8 *seed)
+void ARC4::Init(uint8* seed)
 {
-    EVP_EncryptInit_ex(&m_ctx, NULL, NULL, seed, NULL);
+    EVP_EncryptInit_ex(m_ctx, nullptr, nullptr, seed, nullptr);
 }
 
-void ARC4::UpdateData(int len, uint8 *data)
+void ARC4::UpdateData(int len, uint8* data)
 {
     int outlen = 0;
-    EVP_EncryptUpdate(&m_ctx, data, &outlen, data, len);
-    EVP_EncryptFinal_ex(&m_ctx, data, &outlen);
+    EVP_EncryptUpdate(m_ctx, data, &outlen, data, len);
+    EVP_EncryptFinal_ex(m_ctx, data, &outlen);
 }

--- a/src/common/Cryptography/ARC4.h
+++ b/src/common/Cryptography/ARC4.h
@@ -19,19 +19,19 @@
 #ifndef _AUTH_SARC4_H
 #define _AUTH_SARC4_H
 
-#include <openssl/evp.h>
 #include "Define.h"
+#include <openssl/evp.h>
 
 class TC_COMMON_API ARC4
 {
     public:
         ARC4(uint32 len);
-        ARC4(uint8 *seed, uint32 len);
+        ARC4(uint8* seed, uint32 len);
         ~ARC4();
-        void Init(uint8 *seed);
-        void UpdateData(int len, uint8 *data);
+        void Init(uint8* seed);
+        void UpdateData(int len, uint8* data);
     private:
-        EVP_CIPHER_CTX m_ctx;
+        EVP_CIPHER_CTX* m_ctx;
 };
 
 #endif

--- a/src/common/Cryptography/HmacHash.cpp
+++ b/src/common/Cryptography/HmacHash.cpp
@@ -21,44 +21,58 @@
 #include "Errors.h"
 #include <cstring>
 
-template<HashCreateFn HashCreator, uint32 DigestLength>
-HmacHash<HashCreator, DigestLength>::HmacHash(uint32 len, uint8 const* seed)
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100000L
+HMAC_CTX* HMAC_CTX_new()
 {
-    HMAC_CTX_init(&_ctx);
-    HMAC_Init_ex(&_ctx, seed, len, HashCreator(), NULL);
+    HMAC_CTX *ctx = new HMAC_CTX();
+    HMAC_CTX_init(ctx);
+    return ctx;
+}
+
+void HMAC_CTX_free(HMAC_CTX* ctx)
+{
+    HMAC_CTX_cleanup(ctx);
+    delete ctx;
+}
+#endif
+
+template<HashCreateFn HashCreator, uint32 DigestLength>
+HmacHash<HashCreator, DigestLength>::HmacHash(uint32 len, uint8 const* seed) : _ctx(HMAC_CTX_new())
+{
+    HMAC_Init_ex(_ctx, seed, len, HashCreator(), nullptr);
     memset(_digest, 0, DigestLength);
 }
 
 template<HashCreateFn HashCreator, uint32 DigestLength>
 HmacHash<HashCreator, DigestLength>::~HmacHash()
 {
-    HMAC_CTX_cleanup(&_ctx);
+    HMAC_CTX_free(_ctx);
 }
 
 template<HashCreateFn HashCreator, uint32 DigestLength>
-void HmacHash<HashCreator, DigestLength>::UpdateData(const std::string &str)
+void HmacHash<HashCreator, DigestLength>::UpdateData(std::string const& str)
 {
-    HMAC_Update(&_ctx, (uint8 const*)str.c_str(), str.length());
+    HMAC_Update(_ctx, reinterpret_cast<uint8 const*>(str.c_str()), str.length());
 }
 
 template<HashCreateFn HashCreator, uint32 DigestLength>
-void HmacHash<HashCreator, DigestLength>::UpdateData(const uint8* data, size_t len)
+void HmacHash<HashCreator, DigestLength>::UpdateData(uint8 const* data, size_t len)
 {
-    HMAC_Update(&_ctx, data, len);
+    HMAC_Update(_ctx, data, len);
 }
 
 template<HashCreateFn HashCreator, uint32 DigestLength>
 void HmacHash<HashCreator, DigestLength>::Finalize()
 {
     uint32 length = 0;
-    HMAC_Final(&_ctx, _digest, &length);
+    HMAC_Final(_ctx, _digest, &length);
     ASSERT(length == DigestLength);
 }
 
 template<HashCreateFn HashCreator, uint32 DigestLength>
 uint8* HmacHash<HashCreator, DigestLength>::ComputeHash(BigNumber* bn)
 {
-    HMAC_Update(&_ctx, bn->AsByteArray().get(), bn->GetNumBytes());
+    HMAC_Update(_ctx, bn->AsByteArray().get(), bn->GetNumBytes());
     Finalize();
     return _digest;
 }

--- a/src/common/Cryptography/HmacHash.h
+++ b/src/common/Cryptography/HmacHash.h
@@ -43,7 +43,7 @@ class TC_COMMON_API HmacHash
         uint8* GetDigest() { return _digest; }
         uint32 GetLength() const { return DigestLength; }
     private:
-        HMAC_CTX _ctx;
+        HMAC_CTX* _ctx;
         uint8 _digest[DigestLength];
 };
 

--- a/src/common/Cryptography/RSA.cpp
+++ b/src/common/Cryptography/RSA.cpp
@@ -93,7 +93,13 @@ bool Trinity::Crypto::RSA::LoadFromString(std::string const& keyPem, KeyTag)
 BigNumber Trinity::Crypto::RSA::GetModulus() const
 {
     BigNumber bn;
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+    const BIGNUM* rsa_n;
+    RSA_get0_key(_rsa, &rsa_n, nullptr, nullptr);
+    BN_copy(bn.BN(), rsa_n);
+#else
     BN_copy(bn.BN(), _rsa->n);
+#endif
     return bn;
 }
 


### PR DESCRIPTION
Support for both OpenSSL 1.0 LTS and OpenSSL 1.1 versions.

Many Linux distributions are still on 1.0 and will stay on LTS for quite
some time.

Direct port of my CMaNGOS commit: https://github.com/cmangos/mangos-wotlk/commit/e1b0048f052eda46bb27d20224d0339960816ac2

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Adds transitional hybrid support for OpenSSL 1.0.x and 1.1.x versions.
-  Allows use and development in cutting edge Linux distros out of the box.

**Target branch(es):** 3.3.5/master

- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)

This is a direct port, only build was performed.

**Known issues and TODO list:** (add/remove lines as needed)

None to date.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
