### PR TITLE
Core/Player: fix HasItemFitToSpellRequirements for SPELL_ATTR8_ARMOR_SPECIALIZATION

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -24666,7 +24666,7 @@ bool Player::HasItemFitToSpellRequirements(SpellInfo const* spellInfo, Item cons
                 for (uint8 i : {EQUIPMENT_SLOT_HEAD, EQUIPMENT_SLOT_SHOULDERS, EQUIPMENT_SLOT_CHEST, EQUIPMENT_SLOT_WAIST, EQUIPMENT_SLOT_LEGS, EQUIPMENT_SLOT_FEET, EQUIPMENT_SLOT_WRISTS, EQUIPMENT_SLOT_HANDS})
                 {
                     Item* item = GetUseableItemByPos(INVENTORY_SLOT_BAG_0, i);
-                    if (!item || !item->IsFitToSpellRequirements(spellInfo))
+                    if (!item || item == ignoreItem || !item->IsFitToSpellRequirements(spellInfo))
                         return false;
                 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -24669,6 +24669,8 @@ bool Player::HasItemFitToSpellRequirements(SpellInfo const* spellInfo, Item cons
                     if (!item || !item->IsFitToSpellRequirements(spellInfo))
                         return false;
                 }
+
+                return true;
             }
 
             break;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -24663,6 +24663,7 @@ bool Player::HasItemFitToSpellRequirements(SpellInfo const* spellInfo, Item cons
             }
             else
             {
+                // requires item equipped in all armor slots
                 for (uint8 i : {EQUIPMENT_SLOT_HEAD, EQUIPMENT_SLOT_SHOULDERS, EQUIPMENT_SLOT_CHEST, EQUIPMENT_SLOT_WAIST, EQUIPMENT_SLOT_LEGS, EQUIPMENT_SLOT_FEET, EQUIPMENT_SLOT_WRISTS, EQUIPMENT_SLOT_HANDS})
                 {
                     Item* item = GetUseableItemByPos(INVENTORY_SLOT_BAG_0, i);


### PR DESCRIPTION
**Changes proposed:**

-  Fix HasItemFitToSpellRequirements when it come to SPELL_ATTR8_ARMOR_SPECIALIZATION

**Target branch(es):** 3.3.5/master

- [x] master

**Issues addressed:** ?

**Tests performed:**
Tested with spell 89744, didn't apply before, apply now


**Known issues and TODO list:** (add/remove lines as needed)

- [x] Spell don't get removed if you remove a required item