### PR TITLE
Core/map: small fix to check if outdoors

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2696,7 +2696,6 @@ void Map::GetFullTerrainStatusForPosition(float x, float y, float z, PositionFul
     {
         data.areaId = areaEntry->ID;
         data.floorZ = vmapData.floorZ;
-        data.outdoors = IsOutdoorWMO(vmapData.areaInfo->mogpFlags, wmoEntry, areaEntry);
     }
     else
     {
@@ -2710,8 +2709,12 @@ void Map::GetFullTerrainStatusForPosition(float x, float y, float z, PositionFul
             areaEntry = sAreaTableStore.LookupEntry(data.areaId);
 
         data.floorZ = mapHeight;
-        data.outdoors = true; // @todo default true taken from old GetAreaId check, maybe review
     }
+
+    if (vmapData.areaInfo)
+        data.outdoors = IsOutdoorWMO(vmapData.areaInfo->mogpFlags, wmoEntry, areaEntry);
+    else
+        data.outdoors = true; // @todo default true taken from old GetAreaId check, maybe review
 
     // liquid processing
     data.liquidStatus = LIQUID_MAP_NO_WATER;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Move the initialisation of outdoors data out of the if that checked if there was an AreaEntry. Instead we just check if vmap data returned areaInfo

**Target branch(es):** 3.3.5/master

- 3.3.5
- master

**Issues addressed:** Closes #21550


**Tests performed:**
- Sloppy test, did a .gps in the warsong gulch houses and told me I am indoors now (previously it told me I was outdoors)


**Known issues and TODO list:** (add/remove lines as needed)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
