### PR TITLE
Core/Map: fix outdoors logic part 2

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2686,9 +2686,14 @@ void Map::GetFullTerrainStatusForPosition(float x, float y, float z, PositionFul
     //  - the vmap floor is above the gridmap floor
     // or
     //  - we are below the gridmap floor
+    data.outdoors = true;
     if (vmapData.areaInfo && (G3D::fuzzyLt(z, mapHeight - GROUND_HEIGHT_TOLERANCE) || mapHeight <= vmapData.floorZ))
+    {
         if ((wmoEntry = GetWMOAreaTableEntryByTripple(vmapData.areaInfo->rootId, vmapData.areaInfo->adtId, vmapData.areaInfo->groupId)))
             areaEntry = sAreaTableStore.LookupEntry(wmoEntry->areaId);
+
+        data.outdoors = IsOutdoorWMO(vmapData.areaInfo->mogpFlags, wmoEntry, areaEntry);
+    }
 
     data.areaId = 0;
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2716,11 +2716,6 @@ void Map::GetFullTerrainStatusForPosition(float x, float y, float z, PositionFul
         data.floorZ = mapHeight;
     }
 
-    if (vmapData.areaInfo)
-        data.outdoors = IsOutdoorWMO(vmapData.areaInfo->mogpFlags, wmoEntry, areaEntry);
-    else
-        data.outdoors = true; // @todo default true taken from old GetAreaId check, maybe review
-
     // liquid processing
     data.liquidStatus = LIQUID_MAP_NO_WATER;
     if (vmapData.liquidInfo && vmapData.liquidInfo->level > vmapData.floorZ && z > vmapData.floorZ)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Change it to how it works in GetAreaId, which means that IsOutdoorWMO would only be called when GetAreaInfo returned true (which is kinda what happens in this check)

**Target branch(es):** 3.3.5/master

- 3.3.5
- master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:**
- Running around in warsong gulch with .gps and checking if outdoors/indoors was correct


**Known issues and TODO list:** (add/remove lines as needed)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
