### PR TITLE
[3.3.5] Scripts/Spells: handle auras on unequipping scripted items

### DIFF
--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -258,7 +258,8 @@ class spell_item_anger_capacitor : public SpellScriptLoader
 
             void OnRemove(AuraEffect const*, AuraEffectHandleModes)
             {
-            	GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
+            	if (GetTarget())
+            		GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
             }
 
             void Register() override
@@ -1793,7 +1794,8 @@ class spell_item_shadowmourne : public AuraScript
 
     void OnRemove(AuraEffect const*, AuraEffectHandleModes)
     {
-        GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
+    	if (GetTarget())
+        	GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
     }
 
     void Register() override
@@ -3470,7 +3472,8 @@ public:
 
         void OnRemove(AuraEffect const*, AuraEffectHandleModes)
         {
-        	GetTarget()->RemoveAurasDueToSpell(_stackSpell);
+        	if (GetTarget())
+       			GetTarget()->RemoveAurasDueToSpell(_stackSpell);
         }
 
         void Register() override

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -258,8 +258,7 @@ class spell_item_anger_capacitor : public SpellScriptLoader
 
             void OnRemove(AuraEffect const*, AuraEffectHandleModes)
             {
-                if (GetTarget())
-                    GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
+                GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
             }
 
             void Register() override
@@ -1794,8 +1793,7 @@ class spell_item_shadowmourne : public AuraScript
 
     void OnRemove(AuraEffect const*, AuraEffectHandleModes)
     {
-        if (GetTarget())
-            GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
+        GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
     }
 
     void Register() override
@@ -3472,8 +3470,7 @@ public:
 
         void OnRemove(AuraEffect const*, AuraEffectHandleModes)
         {
-            if (GetTarget())
-                GetTarget()->RemoveAurasDueToSpell(_stackSpell);
+            GetTarget()->RemoveAurasDueToSpell(_stackSpell);
         }
 
         void Register() override

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -259,7 +259,7 @@ class spell_item_anger_capacitor : public SpellScriptLoader
             void OnRemove(AuraEffect const*, AuraEffectHandleModes)
             {
             	if (GetTarget())
-            		GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
+            	    GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
             }
 
             void Register() override

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1800,6 +1800,7 @@ class spell_item_shadowmourne : public AuraScript
     {
         DoCheckProc += AuraCheckProcFn(spell_item_shadowmourne::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_item_shadowmourne::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_item_shadowmourne::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -256,9 +256,15 @@ class spell_item_anger_capacitor : public SpellScriptLoader
                 caster->CastSpell(target, spellId, aurEff);
             }
 
+            void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+            {
+            	GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
+        	}
+
             void Register() override
             {
                 OnEffectProc += AuraEffectProcFn(spell_item_anger_capacitor_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+                AfterEffectRemove += AuraEffectRemoveFn(spell_item_anger_capacitor_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
             }
         };
 
@@ -1785,10 +1791,16 @@ class spell_item_shadowmourne : public AuraScript
         }
     }
 
+    void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+    {
+        GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
+    }
+
     void Register() override
     {
         DoCheckProc += AuraCheckProcFn(spell_item_shadowmourne::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_item_shadowmourne::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_item_shadowmourne::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -3456,9 +3468,15 @@ public:
                 caster->CastSpell(target, _triggerSpell, aurEff);
         }
 
+        void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+        {
+        	GetTarget()->RemoveAurasDueToSpell(_stackSpell);
+    	}
+
         void Register() override
         {
             OnEffectProc += AuraEffectProcFn(spell_item_trinket_stack_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+            AfterEffectRemove += AuraEffectRemoveFn(spell_item_trinket_stack_AuraScript::OnRemove, EFFECT_0,SPELL_AURA_PROC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
         }
 
         uint32 _stackSpell;

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -256,15 +256,9 @@ class spell_item_anger_capacitor : public SpellScriptLoader
                 caster->CastSpell(target, spellId, aurEff);
             }
 
-            void OnRemove(AuraEffect const*, AuraEffectHandleModes)
-            {
-            	GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
-        	}
-
             void Register() override
             {
                 OnEffectProc += AuraEffectProcFn(spell_item_anger_capacitor_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
-                AfterEffectRemove += AuraEffectRemoveFn(spell_item_anger_capacitor_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
             }
         };
 
@@ -1791,16 +1785,10 @@ class spell_item_shadowmourne : public AuraScript
         }
     }
 
-    void OnRemove(AuraEffect const*, AuraEffectHandleModes)
-    {
-        GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
-    }
-
     void Register() override
     {
         DoCheckProc += AuraCheckProcFn(spell_item_shadowmourne::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_item_shadowmourne::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
-        AfterEffectRemove += AuraEffectRemoveFn(spell_item_shadowmourne::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -3468,15 +3456,9 @@ public:
                 caster->CastSpell(target, _triggerSpell, aurEff);
         }
 
-        void OnRemove(AuraEffect const*, AuraEffectHandleModes)
-        {
-        	GetTarget()->RemoveAurasDueToSpell(_stackSpell);
-    	}
-
         void Register() override
         {
             OnEffectProc += AuraEffectProcFn(spell_item_trinket_stack_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
-            AfterEffectRemove += AuraEffectRemoveFn(spell_item_trinket_stack_AuraScript::OnRemove, EFFECT_0,SPELL_AURA_PROC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
         }
 
         uint32 _stackSpell;

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -256,9 +256,15 @@ class spell_item_anger_capacitor : public SpellScriptLoader
                 caster->CastSpell(target, spellId, aurEff);
             }
 
+            void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+            {
+            	GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
+            }
+
             void Register() override
             {
                 OnEffectProc += AuraEffectProcFn(spell_item_anger_capacitor_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
+                AfterEffectRemove += AuraEffectRemoveFn(spell_item_anger_capacitor_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
             }
         };
 
@@ -1783,6 +1789,11 @@ class spell_item_shadowmourne : public AuraScript
                 soulFragments->Remove();
             }
         }
+    }
+
+    void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+    {
+        GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
     }
 
     void Register() override
@@ -3456,9 +3467,15 @@ public:
                 caster->CastSpell(target, _triggerSpell, aurEff);
         }
 
+        void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+        {
+        	GetTarget()->RemoveAurasDueToSpell(_stackSpell);
+        }
+
         void Register() override
         {
             OnEffectProc += AuraEffectProcFn(spell_item_trinket_stack_AuraScript::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+            AfterEffectRemove += AuraEffectRemoveFn(spell_item_trinket_stack_AuraScript::OnRemove, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
         }
 
         uint32 _stackSpell;

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -256,7 +256,7 @@ class spell_item_anger_capacitor : public SpellScriptLoader
                 caster->CastSpell(target, spellId, aurEff);
             }
 
-            void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+            void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
             }
@@ -1791,7 +1791,7 @@ class spell_item_shadowmourne : public AuraScript
         }
     }
 
-    void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
     }
@@ -3468,7 +3468,7 @@ public:
                 caster->CastSpell(target, _triggerSpell, aurEff);
         }
 
-        void OnRemove(AuraEffect const*, AuraEffectHandleModes)
+        void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
             GetTarget()->RemoveAurasDueToSpell(_stackSpell);
         }

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -258,8 +258,8 @@ class spell_item_anger_capacitor : public SpellScriptLoader
 
             void OnRemove(AuraEffect const*, AuraEffectHandleModes)
             {
-            	if (GetTarget())
-            	    GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
+                if (GetTarget())
+                    GetTarget()->RemoveAurasDueToSpell(SPELL_MOTE_OF_ANGER);
             }
 
             void Register() override
@@ -1794,8 +1794,8 @@ class spell_item_shadowmourne : public AuraScript
 
     void OnRemove(AuraEffect const*, AuraEffectHandleModes)
     {
-    	if (GetTarget())
-        	GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
+        if (GetTarget())
+            GetTarget()->RemoveAurasDueToSpell(SPELL_SHADOWMOURNE_SOUL_FRAGMENT);
     }
 
     void Register() override
@@ -3472,8 +3472,8 @@ public:
 
         void OnRemove(AuraEffect const*, AuraEffectHandleModes)
         {
-        	if (GetTarget())
-       			GetTarget()->RemoveAurasDueToSpell(_stackSpell);
+            if (GetTarget())
+                GetTarget()->RemoveAurasDueToSpell(_stackSpell);
         }
 
         void Register() override


### PR DESCRIPTION
**Changes proposed:**
When some scripted items (capacitor-like) are unequiped, remove their auras from owner. List of handled items:
- [Tiny Abomination in a Jar](http://www.wowhead.com/item=50351)
- [Shadowmourne](http://www.wowhead.com/item=49623)
- [Lightning Capacitor](http://www.wowhead.com/item=28785)
- [Thunder Capacitor](http://www.wowhead.com/item=38072)
- [Reign of the Dead](http://www.wowhead.com/item=47316)

Not sure that this is complete list, so help here would be appreciated.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Issues addressed:** Ref #20415

**Tests performed:** Builds, tested in-game.
