### PR TITLE
Core/Entities: Reduce probability of going under the map

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2503,6 +2503,20 @@ bool Map::GetAreaInfo(float x, float y, float z, uint32 &flags, int32 &adtId, in
     return false;
 }
 
+// This returns vmap data!
+float Map::GetAreaInfoFloorZ(float x, float y, float z) const
+{
+    float vmap_z = z;
+    VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager();
+    uint32 mogpFlags;
+    int32 adtId, rootId, groupId;
+
+    if (vmgr->getAreaInfo(GetId(), x, y, vmap_z, mogpFlags, adtId, rootId, groupId))
+        return vmap_z;
+
+    return VMAP_INVALID_HEIGHT_VALUE;
+}
+
 uint32 Map::GetAreaId(float x, float y, float z, bool *isOutdoors) const
 {
     uint32 mogpFlags;

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -388,6 +388,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         ZLiquidStatus GetLiquidStatus(float x, float y, float z, uint8 ReqLiquidType, LiquidData* data = nullptr, float collisionHeight = 2.03128f) const; // DEFAULT_COLLISION_HEIGHT in Object.h
 
         bool GetAreaInfo(float x, float y, float z, uint32& mogpflags, int32& adtId, int32& rootId, int32& groupId) const;
+        float GetAreaInfoFloorZ(float x, float y, float z) const;
         uint32 GetAreaId(float x, float y, float z, bool *isOutdoors = nullptr) const;
         uint32 GetAreaId(Position const& pos) const { return GetAreaId(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ()); }
         uint32 GetZoneId(float x, float y, float z) const;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Some tweaking in the check for following gridheight in SelectBestZForDestination
-  New function which adds the functionality I was kinda looking for (looking for vmap z without passing search dist). Which is just based of GetAreaInfo, kinda too tired of this to make a clean function for it.
-  Trying to not break tanaris dragons (which don't have vmap/gob above their head so they just have the gridheight by adding a check in updateallowedpositionz

**Target branch(es):** 3.3.5/master

- 3.3.5

**Issues addressed:** Closes #21625 #21516


**Tests performed:** (Does it build, tested in-game, etc.)

- https://puu.sh/zJFCm/52feb76e76.mp4
- https://puu.sh/zJFH9/8a3bb51e51.mp4
- https://puu.sh/zJFTs/d7caa21ecb.mp4
- https://puu.sh/zJFY0/627e62fb80.mp4
- https://puu.sh/zJG8p/03061d99ca.mp4
- https://puu.sh/zJGkd/312d2d4f2c.mp4

**Known issues and TODO list:** (add/remove lines as needed)
- Pathing is sometimes weird (not sure if this is on the list to fix as it might be related to pathfinder)
- If you blink on the lich king platform WHILE it is rebuilding, you blink into the void

if this makes things worse, i'm thinking about re-adding NormalizeZForCollision.
Might take a while for me to respond, sorry in advance, am tired
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
