### PR TITLE
Scripts/Trial Of The Crusader: make Acidmaw and Dreadscale pools visible (Beasts of Northrend)

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -805,6 +805,7 @@ struct boss_jormungarAI : public boss_northrend_beastsAI
                 break;
             case EVENT_SLIME_POOL:
                 DoCastSelf(SUMMON_SLIME_POOL);
+                DoCastSelf(SPELL_SLIME_POOL_EFFECT);
                 events.Repeat(12s);
                 break;
             case EVENT_SUMMON_ACIDMAW:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

The slime pools made by Acidmaw and Dreadscale are not visible by players. this should make them visible.

**Changes proposed:**

-  The Slime pools in the Beasts of northrend fight in Trial of crusader fight should now be visible.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
