### PR TITLE
Scripts/Stratholme: Baroness Anastari rework

### DIFF
--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
- * Copyright (C) 2006-2009 ScriptDev2 <https://scriptdev2.svn.sourceforge.net/>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -124,7 +124,7 @@ struct boss_baroness_anastari : public BossAI
                             events.CancelEvent(EVENT_CHECK_POSSESSED);
                         }
                         else
-                            events.ScheduleEvent(EVENT_CHECK_POSSESSED, 1s);
+                            events.Repeat(1s);
                     }
                     break;
             }

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -53,18 +53,14 @@ struct boss_baroness_anastari : public BossAI
 
     void Reset() override
     {
+        _possessedTargetGuid.Clear();
+
+        instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_POSSESS);
+        instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_POSSESSED);
+
         if (me->HasAura(SPELL_POSSESS_INV))
-        {
-            if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))
-            {
-                if (possessedTarget->IsAlive())
-                {
-                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
-                }
-            }
             me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
-        }
+
         _events.Reset();
     }
 
@@ -131,6 +127,7 @@ struct boss_baroness_anastari : public BossAI
                         me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
                         possessedTarget->SetFullHealth();
                         _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
+                        _possessedTargetGuid.Clear();
                     }
                     break;
                 case EVENT_CHECK_POSSESSED:

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -47,10 +47,9 @@ class boss_baroness_anastari : public CreatureScript
 public:
     boss_baroness_anastari() : CreatureScript("boss_baroness_anastari") { }
 
-    class boss_baroness_anastariAI : public ScriptedAI
+    struct boss_baroness_anastariAI : public BossAI
     {
-    public:
-        boss_baroness_anastariAI(Creature* creature) : ScriptedAI(creature)
+        boss_baroness_anastariAI(Creature* creature) : BossAI(creature, TYPE_BARONESS)
         {
             Initialize();
             instance = me->GetInstanceScript();

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -93,15 +93,15 @@ struct boss_baroness_anastari : public BossAI
             switch (eventId)
             {
             case EVENT_SPELL_BANSHEEWAIL:
-                DoCastVictim(SPELL_BANSHEEWAIL, SPELLMOD_NOT_LOSE_CASTING_TIME);
+                DoCastVictim(SPELL_BANSHEEWAIL);
                 _events.ScheduleEvent(EVENT_SPELL_BANSHEEWAIL, 4s);
                 break;
             case EVENT_SPELL_BANSHEECURSE:
-                DoCastVictim(SPELL_BANSHEECURSE, SPELLMOD_NOT_LOSE_CASTING_TIME);
+                DoCastVictim(SPELL_BANSHEECURSE);
                 _events.Repeat(18s);
                 break;
             case EVENT_SPELL_SILENCE:
-                DoCastVictim(SPELL_SILENCE,SPELLMOD_NOT_LOSE_CASTING_TIME);
+                DoCastVictim(SPELL_SILENCE);
                 _events.ScheduleEvent(EVENT_SPELL_SILENCE, 13s);
                 break;
             case EVENT_SPELL_POSSESS:

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -109,7 +109,7 @@ struct boss_baroness_anastari : public BossAI
                         events.ScheduleEvent(EVENT_CHECK_POSSESSED, 0s);
                     }
                     else
-                        events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
+                        events.Repeat(20s, 30s);
                     break;
                 case EVENT_CHECK_POSSESSED:
                     if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -53,7 +53,7 @@ public:
         boss_baroness_anastariAI(Creature* creature) : ScriptedAI(creature)
         {
             Initialize();
-            instance = creature->GetInstanceScript();
+            instance = me->GetInstanceScript();
         }
 
         void Initialize()

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -52,11 +52,11 @@ struct boss_baroness_anastari : public BossAI
 
     void Reset() override
     {
-        if (me->IsVisible())
+        if (!me->IsVisible())
         {
             Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid);
 
-            if (possessedTarget && possessedTarget->IsAlive())
+            if (possessedTarget->IsAlive())
             {
                 possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
                 possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -93,15 +93,15 @@ struct boss_baroness_anastari : public BossAI
             switch (eventId)
             {
             case EVENT_SPELL_BANSHEEWAIL:
-                DoCastVictim(SPELL_BANSHEEWAIL);
+                DoCastVictim(SPELL_BANSHEEWAIL, SPELLMOD_NOT_LOSE_CASTING_TIME);
                 _events.ScheduleEvent(EVENT_SPELL_BANSHEEWAIL, 4s);
                 break;
             case EVENT_SPELL_BANSHEECURSE:
-                DoCastVictim(SPELL_BANSHEECURSE);
+                DoCastVictim(SPELL_BANSHEECURSE, SPELLMOD_NOT_LOSE_CASTING_TIME);
                 _events.Repeat(18s);
                 break;
             case EVENT_SPELL_SILENCE:
-                DoCastVictim(SPELL_SILENCE);
+                DoCastVictim(SPELL_SILENCE,SPELLMOD_NOT_LOSE_CASTING_TIME);
                 _events.ScheduleEvent(EVENT_SPELL_SILENCE, 13s);
                 break;
             case EVENT_SPELL_POSSESS:
@@ -133,7 +133,7 @@ struct boss_baroness_anastari : public BossAI
                 }
                 break;
             case EVENT_CHECK_POSSESSED:
-                if (me->IsVisible())
+                if (!me->IsVisible())
                 {
                     if (Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid))
                     {

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -45,15 +45,7 @@ enum BaronessAnastariEvents
 
 struct boss_baroness_anastari : public BossAI
 {
-    boss_baroness_anastari(Creature* creature) : BossAI(creature, TYPE_BARONESS)
-    {
-        Initialize();
-    }
-
-    void Initialize()
-    {
-
-    }
+    boss_baroness_anastari(Creature* creature) : BossAI(creature, TYPE_BARONESS) { }
 
     EventMap _events;
     ObjectGuid _possessedTargetGuid;
@@ -73,7 +65,6 @@ struct boss_baroness_anastari : public BossAI
             }
         }
         _events.Reset();
-        Initialize();
     }
 
     void JustEngagedWith(Unit* /*who*/) override

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -55,7 +55,7 @@ struct boss_baroness_anastari : public BossAI
     {
         if (me->HasAura(SPELL_POSSESS_INV))
         {
-            if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))
+            if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))
             {
                 if (possessedTarget->IsAlive())
                 {
@@ -124,7 +124,7 @@ struct boss_baroness_anastari : public BossAI
                     }
                     break;
                 case EVENT_INVISIBLE:
-                    if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))    // When there's a possessed target
+                    if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))    // When there's a possessed target
                     {
                         possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
                         possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
@@ -136,7 +136,7 @@ struct boss_baroness_anastari : public BossAI
                 case EVENT_CHECK_POSSESSED:
                     if (me->HasAura(SPELL_POSSESS_INV))
                     {
-                        if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))
+                        if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))
                         {
                             if (!possessedTarget->HasAura(SPELL_POSSESSED) || possessedTarget->HealthBelowPct(50))
                                 _events.ScheduleEvent(EVENT_INVISIBLE, 0s);

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -88,6 +88,9 @@ struct boss_baroness_anastari : public BossAI
 
         _events.Update(diff);
 
+        if (me->HasUnitState(UNIT_STATE_CASTING))
+            return;
+
         while (uint32 eventId = _events.ExecuteEvent())
         {
             switch (eventId)

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -95,56 +95,56 @@ struct boss_baroness_anastari : public BossAI
         {
             switch (eventId)
             {
-            case EVENT_SPELL_BANSHEEWAIL:
-                DoCastVictim(SPELL_BANSHEEWAIL);
-                _events.Repeat(4s);
-                break;
-            case EVENT_SPELL_BANSHEECURSE:
-                DoCastVictim(SPELL_BANSHEECURSE);
-                _events.Repeat(18s);
-                break;
-            case EVENT_SPELL_SILENCE:
-                DoCastVictim(SPELL_SILENCE);
-                _events.ScheduleEvent(EVENT_SPELL_SILENCE, 13s);
-                break;
-            case EVENT_SPELL_POSSESS:
-                if (Unit* possessTarget = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true, false))    // Random target to be possessed
-                {
-                    if (possessTarget->IsAlive())
+                case EVENT_SPELL_BANSHEEWAIL:
+                    DoCastVictim(SPELL_BANSHEEWAIL);
+                    _events.Repeat(4s);
+                    break;
+                case EVENT_SPELL_BANSHEECURSE:
+                    DoCastVictim(SPELL_BANSHEECURSE);
+                    _events.Repeat(18s);
+                    break;
+                case EVENT_SPELL_SILENCE:
+                    DoCastVictim(SPELL_SILENCE);
+                    _events.ScheduleEvent(EVENT_SPELL_SILENCE, 13s);
+                    break;
+                case EVENT_SPELL_POSSESS:
+                    if (Unit* possessTarget = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true, false))    // Random target to be possessed
                     {
-                        me->CastStop();
-                        DoCast(possessTarget, SPELL_POSSESS);
-                        DoCast(possessTarget, SPELL_POSSESSED);
-                        DoCastSelf(SPELL_POSSESS_INV);
-                        _possessedTargetGuid = possessTarget->GetGUID();
-                        _events.ScheduleEvent(EVENT_CHECK_POSSESSED, 0s);
-                    }
-                    else
-                        _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
-                }
-                break;
-            case EVENT_INVISIBLE:
-                if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))    // When there's a possessed target
-                {
-                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
-                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
-                    possessedTarget->SetFullHealth();
-                    _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
-                }
-                break;
-            case EVENT_CHECK_POSSESSED:
-                if (me->HasAura(SPELL_POSSESS_INV))
-                {
-                    if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))
-                    {
-                        if (!possessedTarget->HasAura(SPELL_POSSESSED) || possessedTarget->HealthBelowPct(50))
-                            _events.ScheduleEvent(EVENT_INVISIBLE, 0s);
+                        if (possessTarget->IsAlive())
+                        {
+                            me->CastStop();
+                            DoCast(possessTarget, SPELL_POSSESS);
+                            DoCast(possessTarget, SPELL_POSSESSED);
+                            DoCastSelf(SPELL_POSSESS_INV);
+                            _possessedTargetGuid = possessTarget->GetGUID();
+                            _events.ScheduleEvent(EVENT_CHECK_POSSESSED, 0s);
+                        }
                         else
-                            _events.ScheduleEvent(EVENT_CHECK_POSSESSED, 1s);
+                            _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                     }
-                }
-                break;
+                    break;
+                case EVENT_INVISIBLE:
+                    if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))    // When there's a possessed target
+                    {
+                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
+                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
+                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
+                        possessedTarget->SetFullHealth();
+                        _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
+                    }
+                    break;
+                case EVENT_CHECK_POSSESSED:
+                    if (me->HasAura(SPELL_POSSESS_INV))
+                    {
+                        if (Player* possessedTarget = ObjectAccessor::GetPlayer(me->GetMap(), _possessedTargetGuid))
+                        {
+                            if (!possessedTarget->HasAura(SPELL_POSSESSED) || possessedTarget->HealthBelowPct(50))
+                                _events.ScheduleEvent(EVENT_INVISIBLE, 0s);
+                            else
+                                _events.ScheduleEvent(EVENT_CHECK_POSSESSED, 1s);
+                        }
+                    }
+                    break;
             }
         }
         DoMeleeAttackIfReady();

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -133,7 +133,7 @@ struct boss_baroness_anastari : public BossAI
                 }
                 break;
             case EVENT_CHECK_POSSESSED:
-                if (me->IsVisible())
+                if (!me->IsVisible())
                 {
                     if (Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid))
                     {

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -28,8 +28,8 @@ enum Spells
     SPELL_BANSHEEWAIL           = 16565,
     SPELL_BANSHEECURSE          = 16867,
     SPELL_SILENCE               = 18327,
-    SPELL_POSSESS               = 17244,    // The charm
-    SPELL_POSSESSED             = 17246,    // The damage buff
+    SPELL_POSSESS               = 17244,    // the charm on player
+    SPELL_POSSESSED             = 17246,    // the damage debuff on player
     SPELL_POSSESS_INV           = 17250     // baroness becomes invisible while possessing a target
 };
 
@@ -42,7 +42,6 @@ enum BaronessAnastariEvents
     EVENT_INVISIBLE             = 5,
     EVENT_CHECK_POSSESSED       = 6
 };
-
 
 struct boss_baroness_anastari : public BossAI
 {
@@ -74,7 +73,7 @@ struct boss_baroness_anastari : public BossAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        instance->SetData(TYPE_BARONESS, DONE);
+        instance->SetData(TYPE_BARONESS, IN_PROGRESS);
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -54,14 +54,15 @@ struct boss_baroness_anastari : public BossAI
     {
         if (!me->IsVisible())
         {
-            Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid);
-
-            if (possessedTarget->IsAlive())
+            if (Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid))
             {
-                possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
-                me->SetReactState(REACT_AGGRESSIVE);
-                me->SetVisible(true);
+                if (possessedTarget->IsAlive())
+                {
+                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
+                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    me->SetVisible(true);
+                }
             }
         }
         _events.Reset();

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -62,6 +62,7 @@ public:
                 {
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
+                    possessedTarget->SetObjectScale(1.0f);
                     me->SetReactState(REACT_AGGRESSIVE);
                     me->SetVisible(true);
                     _invisible = false;
@@ -113,6 +114,7 @@ public:
                             me->CastStop();
                             DoCast(possessTarget, SPELL_POSSESS);
                             DoCast(possessTarget, SPELL_POSSESSED);
+                            possessTarget->SetObjectScale(1.5f);
                             me->SetReactState(REACT_PASSIVE);
                             me->SetVisible(false);
                             _invisible = true;

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -128,7 +128,7 @@ struct boss_baroness_anastari : public BossAI
                     {
                         possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
                         possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
+                        me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
                         possessedTarget->SetFullHealth();
                         _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                     }

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -78,7 +78,7 @@ struct boss_baroness_anastari : public BossAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        me->GetInstanceScript()->SetData(TYPE_BARONESS, IN_PROGRESS);
+        instance->SetData(TYPE_BARONESS, IN_PROGRESS);
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -126,8 +126,8 @@ struct boss_baroness_anastari : public BossAI
                         possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
                         me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
                         possessedTarget->SetFullHealth();
-                        _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                         _possessedTargetGuid.Clear();
+                        _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                     }
                     break;
                 case EVENT_CHECK_POSSESSED:

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -78,7 +78,7 @@ struct boss_baroness_anastari : public BossAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        instance->SetData(TYPE_BARONESS, IN_PROGRESS);
+        instance->SetData(TYPE_BARONESS, DONE);
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -16,24 +16,30 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* ScriptData
-SDName: Boss_Baroness_Anastari
-SD%Complete: 90
-SDComment: MC disabled
-SDCategory: Stratholme
-EndScriptData */
-
-#include "ScriptMgr.h"
 #include "InstanceScript.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "stratholme.h"
 
 enum Spells
 {
-    SPELL_BANSHEEWAIL       = 16565,
-    SPELL_BANSHEECURSE      = 16867,
-    SPELL_SILENCE           = 18327
-    //SPELL_POSSESS           = 17244
+    SPELL_BANSHEEWAIL           = 16565,
+    SPELL_BANSHEECURSE          = 16867,
+    SPELL_SILENCE               = 18327,
+    SPELL_POSSESS               = 17244,
+    SPELL_POSSESSED             = 17246
+};
+
+enum BaronessAnastariEvents
+{
+    EVENT_SPELL_BANSHEEWAIL     = 1,
+    EVENT_SPELL_BANSHEECURSE    = 2,
+    EVENT_SPELL_SILENCE         = 3,
+    EVENT_SPELL_POSSESS         = 4,
+    EVENT_INVISIBLE             = 5,
+    EVENT_CHECK_POSSESSED       = 6
 };
 
 class boss_baroness_anastari : public CreatureScript
@@ -41,41 +47,34 @@ class boss_baroness_anastari : public CreatureScript
 public:
     boss_baroness_anastari() : CreatureScript("boss_baroness_anastari") { }
 
-    CreatureAI* GetAI(Creature* creature) const override
+    class boss_baroness_anastariAI : public ScriptedAI
     {
-        return GetStratholmeAI<boss_baroness_anastariAI>(creature);
-    }
-
-    struct boss_baroness_anastariAI : public ScriptedAI
-    {
-        boss_baroness_anastariAI(Creature* creature) : ScriptedAI(creature)
-        {
-            Initialize();
-            instance = me->GetInstanceScript();
-        }
-
-        void Initialize()
-        {
-            BansheeWail_Timer = 1000;
-            BansheeCurse_Timer = 11000;
-            Silence_Timer = 13000;
-            //Possess_Timer = 35000;
-        }
-
-        InstanceScript* instance;
-
-        uint32 BansheeWail_Timer;
-        uint32 BansheeCurse_Timer;
-        uint32 Silence_Timer;
-        //uint32 Possess_Timer;
+    public:
+        boss_baroness_anastariAI(Creature* creature) : ScriptedAI(creature) { }
 
         void Reset() override
         {
-            Initialize();
+            if (_invisible)
+            {
+                Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid);
+
+                if (possessedTarget && possessedTarget->IsAlive())
+                {
+                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
+                    possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    me->SetVisible(true);
+                    _invisible = false;
+                }
+            }
         }
 
         void JustEngagedWith(Unit* /*who*/) override
         {
+            _events.ScheduleEvent(EVENT_SPELL_BANSHEEWAIL, Seconds(1));
+            _events.ScheduleEvent(EVENT_SPELL_BANSHEECURSE, Seconds(11));
+            _events.ScheduleEvent(EVENT_SPELL_SILENCE, Seconds(13));
+            _events.ScheduleEvent(EVENT_SPELL_POSSESS, Seconds(20), Seconds(30));
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -88,37 +87,82 @@ public:
             if (!UpdateVictim())
                 return;
 
-            //BansheeWail
-            if (BansheeWail_Timer <= diff)
+            _events.Update(diff);
+
+            while (uint32 eventId = _events.ExecuteEvent())
             {
-                if (rand32() % 100 < 95)
+                switch (eventId)
+                {
+                case EVENT_SPELL_BANSHEEWAIL:
                     DoCastVictim(SPELL_BANSHEEWAIL);
-                //4 seconds until we should cast this again
-                BansheeWail_Timer = 4000;
-            } else BansheeWail_Timer -= diff;
-
-            //BansheeCurse
-            if (BansheeCurse_Timer <= diff)
-            {
-                if (rand32() % 100 < 75)
+                    _events.ScheduleEvent(EVENT_SPELL_BANSHEEWAIL, Seconds(4));
+                    break;
+                case EVENT_SPELL_BANSHEECURSE:
                     DoCastVictim(SPELL_BANSHEECURSE);
-                //18 seconds until we should cast this again
-                BansheeCurse_Timer = 18000;
-            } else BansheeCurse_Timer -= diff;
-
-            //Silence
-            if (Silence_Timer <= diff)
-            {
-                if (rand32() % 100 < 80)
+                    _events.Repeat(Seconds(18));
+                    break;
+                case EVENT_SPELL_SILENCE:
                     DoCastVictim(SPELL_SILENCE);
-                //13 seconds until we should cast this again
-                Silence_Timer = 13000;
-            } else Silence_Timer -= diff;
-
+                    _events.ScheduleEvent(EVENT_SPELL_SILENCE, Seconds(13));
+                    break;
+                case EVENT_SPELL_POSSESS:
+                    if (Unit* possessTarget = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true, false))    // Random target to be possessed
+                    {
+                        if (possessTarget && possessTarget->IsAlive())
+                        {
+                            me->CastStop();
+                            DoCast(possessTarget, SPELL_POSSESS);
+                            DoCast(possessTarget, SPELL_POSSESSED);
+                            me->SetReactState(REACT_PASSIVE);
+                            me->SetVisible(false);
+                            _invisible = true;
+                            _possessedTargetGuid = possessTarget->GetGUID();
+                            _events.ScheduleEvent(EVENT_CHECK_POSSESSED, Seconds(0));
+                        }
+                        else
+                            _events.ScheduleEvent(EVENT_SPELL_POSSESS, Seconds(20), Seconds(30));
+                    }
+                    break;
+                case EVENT_INVISIBLE:
+                    if (Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid))          // When there's a possessed target
+                    {
+                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
+                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
+                        possessedTarget->SetObjectScale(1.0f);
+                        me->SetVisible(true);
+                        _invisible = false;
+                        _events.ScheduleEvent(EVENT_SPELL_POSSESS, Seconds(20), Seconds(30));
+                    }
+                    break;
+                case EVENT_CHECK_POSSESSED:
+                    if (_invisible)
+                    {
+                        if (Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid))
+                        {
+                            if (!possessedTarget->HasAura(SPELL_POSSESSED) || possessedTarget->GetHealthPct() <= 50)
+                                _events.ScheduleEvent(EVENT_INVISIBLE, Seconds(0));
+                            else
+                                _events.ScheduleEvent(EVENT_CHECK_POSSESSED, Seconds(1));
+                        }
+                    }
+                    break;
+                }
+            }
             DoMeleeAttackIfReady();
         }
+    protected:
+        InstanceScript * instance;
+
+    private:
+        EventMap _events;
+        bool _invisible;
+        ObjectGuid _possessedTargetGuid;
     };
 
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new boss_baroness_anastariAI(creature);
+    }
 };
 
 void AddSC_boss_baroness_anastari()

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -28,8 +28,8 @@ enum Spells
     SPELL_BANSHEEWAIL           = 16565,
     SPELL_BANSHEECURSE          = 16867,
     SPELL_SILENCE               = 18327,
-    SPELL_POSSESS               = 17244,
-    SPELL_POSSESSED             = 17246
+    SPELL_POSSESS               = 17244, // The charm
+    SPELL_POSSESSED             = 17246  // The damage buff
 };
 
 enum BaronessAnastariEvents
@@ -70,7 +70,6 @@ struct boss_baroness_anastari : public BossAI
             {
                 possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
                 possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
-                possessedTarget->SetObjectScale(1.0f);
                 me->SetReactState(REACT_AGGRESSIVE);
                 me->SetVisible(true);
                 _invisible = false;
@@ -124,7 +123,6 @@ struct boss_baroness_anastari : public BossAI
                         me->CastStop();
                         DoCast(possessTarget, SPELL_POSSESS);
                         DoCast(possessTarget, SPELL_POSSESSED);
-                        possessTarget->SetObjectScale(1.5f);
                         me->SetReactState(REACT_PASSIVE);
                         me->SetVisible(false);
                         _invisible = true;
@@ -140,7 +138,6 @@ struct boss_baroness_anastari : public BossAI
                 {
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                    possessedTarget->SetObjectScale(1.0f);
                     me->SetVisible(true);
                     _invisible = false;
                     _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -38,8 +38,7 @@ enum BaronessAnastariEvents
     EVENT_SPELL_BANSHEECURSE    = 2,
     EVENT_SPELL_SILENCE         = 3,
     EVENT_SPELL_POSSESS         = 4,
-    EVENT_INVISIBLE             = 5,
-    EVENT_CHECK_POSSESSED       = 6
+    EVENT_CHECK_POSSESSED       = 5
 };
 
 struct boss_baroness_anastari : public BossAI
@@ -112,23 +111,18 @@ struct boss_baroness_anastari : public BossAI
                     else
                         events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                     break;
-                case EVENT_INVISIBLE:
-                    // When there's a possessed target
-                    if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))
-                    {
-                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
-                        possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                        me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
-                        _possessedTargetGuid.Clear();
-                        events.CancelEvent(EVENT_CHECK_POSSESSED);
-                        events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
-                    }
-                    break;
                 case EVENT_CHECK_POSSESSED:
                     if (Player* possessedTarget = ObjectAccessor::GetPlayer(*me, _possessedTargetGuid))
                     {
                         if (!possessedTarget->HasAura(SPELL_POSSESSED) || possessedTarget->HealthBelowPct(50))
-                            events.ScheduleEvent(EVENT_INVISIBLE, 0s);
+                        {
+                            possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
+                            possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
+                            me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
+                            _possessedTargetGuid.Clear();
+                            events.CancelEvent(EVENT_CHECK_POSSESSED);
+                            events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
+                        }
                         else
                             events.ScheduleEvent(EVENT_CHECK_POSSESSED, 1s);
                     }

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -28,8 +28,8 @@ enum Spells
     SPELL_BANSHEEWAIL           = 16565,
     SPELL_BANSHEECURSE          = 16867,
     SPELL_SILENCE               = 18327,
-    SPELL_POSSESS               = 17244, // The charm
-    SPELL_POSSESSED             = 17246  // The damage buff
+    SPELL_POSSESS               = 17244,    // The charm
+    SPELL_POSSESSED             = 17246     // The damage buff
 };
 
 enum BaronessAnastariEvents
@@ -52,7 +52,7 @@ struct boss_baroness_anastari : public BossAI
 
     void Initialize()
     {
-        _invisible = false;
+
     }
 
     bool _invisible;
@@ -62,7 +62,7 @@ struct boss_baroness_anastari : public BossAI
 
     void Reset() override
     {
-        if (_invisible)
+        if (me->IsVisible())
         {
             Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid);
 
@@ -72,7 +72,6 @@ struct boss_baroness_anastari : public BossAI
                 possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
                 me->SetReactState(REACT_AGGRESSIVE);
                 me->SetVisible(true);
-                _invisible = false;
             }
         }
         _events.Reset();
@@ -125,7 +124,6 @@ struct boss_baroness_anastari : public BossAI
                         DoCast(possessTarget, SPELL_POSSESSED);
                         me->SetReactState(REACT_PASSIVE);
                         me->SetVisible(false);
-                        _invisible = true;
                         _possessedTargetGuid = possessTarget->GetGUID();
                         _events.ScheduleEvent(EVENT_CHECK_POSSESSED, 0s);
                     }
@@ -139,12 +137,13 @@ struct boss_baroness_anastari : public BossAI
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
                     me->SetVisible(true);
-                    _invisible = false;
+                    possessedTarget->SetFullHealth();
+                    me->SetReactState(REACT_AGGRESSIVE);
                     _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                 }
                 break;
             case EVENT_CHECK_POSSESSED:
-                if (_invisible)
+                if (me->IsVisible())
                 {
                     if (Player* possessedTarget = ObjectAccessor::FindConnectedPlayer(_possessedTargetGuid))
                     {

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -55,8 +55,6 @@ struct boss_baroness_anastari : public BossAI
 
     }
 
-    bool _invisible;
-
     EventMap _events;
     ObjectGuid _possessedTargetGuid;
 

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -98,7 +98,7 @@ struct boss_baroness_anastari : public BossAI
                     break;
                 case EVENT_SPELL_SILENCE:
                     DoCastVictim(SPELL_SILENCE);
-                    events.ScheduleEvent(EVENT_SPELL_SILENCE, 13s);
+                    events.Repeat(13s);
                     break;
                 case EVENT_SPELL_POSSESS:
                     if (Unit* possessTarget = SelectTarget(SELECT_TARGET_RANDOM, 1, 0, true, false))

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -64,7 +64,6 @@ struct boss_baroness_anastari : public BossAI
                 }
             }
             me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
-            me->SetReactState(REACT_AGGRESSIVE);
         }
         _events.Reset();
     }
@@ -98,7 +97,7 @@ struct boss_baroness_anastari : public BossAI
             {
             case EVENT_SPELL_BANSHEEWAIL:
                 DoCastVictim(SPELL_BANSHEEWAIL);
-                _events.ScheduleEvent(EVENT_SPELL_BANSHEEWAIL, 4s);
+                _events.Repeat(4s);
                 break;
             case EVENT_SPELL_BANSHEECURSE:
                 DoCastVictim(SPELL_BANSHEECURSE);
@@ -116,7 +115,6 @@ struct boss_baroness_anastari : public BossAI
                         me->CastStop();
                         DoCast(possessTarget, SPELL_POSSESS);
                         DoCast(possessTarget, SPELL_POSSESSED);
-                        me->SetReactState(REACT_PASSIVE);
                         DoCastSelf(SPELL_POSSESS_INV);
                         _possessedTargetGuid = possessTarget->GetGUID();
                         _events.ScheduleEvent(EVENT_CHECK_POSSESSED, 0s);
@@ -132,7 +130,6 @@ struct boss_baroness_anastari : public BossAI
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
                     possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
                     possessedTarget->SetFullHealth();
-                    me->SetReactState(REACT_AGGRESSIVE);
                     _events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
                 }
                 break;

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_baroness_anastari.cpp
@@ -118,10 +118,10 @@ struct boss_baroness_anastari : public BossAI
                         {
                             possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESS);
                             possessedTarget->RemoveAurasDueToSpell(SPELL_POSSESSED);
-                            me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);
+                            me->RemoveAurasDueToSpell(SPELL_POSSESS_INV);                 
                             _possessedTargetGuid.Clear();
-                            events.CancelEvent(EVENT_CHECK_POSSESSED);
                             events.ScheduleEvent(EVENT_SPELL_POSSESS, 20s, 30s);
+                            events.CancelEvent(EVENT_CHECK_POSSESSED);
                         }
                         else
                             events.ScheduleEvent(EVENT_CHECK_POSSESSED, 1s);

--- a/src/server/scripts/EasternKingdoms/Stratholme/stratholme.h
+++ b/src/server/scripts/EasternKingdoms/Stratholme/stratholme.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
- * Copyright (C) 2006-2009 ScriptDev2 <https://scriptdev2.svn.sourceforge.net/>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/src/server/scripts/EasternKingdoms/Stratholme/stratholme.h
+++ b/src/server/scripts/EasternKingdoms/Stratholme/stratholme.h
@@ -109,4 +109,6 @@ inline AI* GetStratholmeAI(T* obj)
     return GetInstanceAI<AI>(obj, StratholmeScriptName);
 }
 
+#define RegisterStratholmeCreatureAI(ai_name) RegisterCreatureAIWithFactory(ai_name, GetStratholmeAI)
+
 #endif


### PR DESCRIPTION
**Changes proposed:**
- Original rework was written by @hiMalleus (https://github.com/TrinityCore/TrinityCore/pull/20336)

- Changed handling how the script does get the player GUID

- Changed `DoCast(me->GetVictim(),SPELL_XXX);` to `DoCastVictim(SPELL_XXX);` to match all things together

- added register model like implemented here https://github.com/TrinityCore/TrinityCore/commit/fb87ac8e8da3d215d4988b8c2fa25d7a98cf9ee0

- replaced essential parts of boolean `_invisible` and `REACT_STATE` to spell `17250` which is used by baroness anastari to get invisible / get stunned

**Target branch(es):** 3.3.5/master
- [X] 3.3.5

**Issues addressed:**
- Closes #20335
- Fixes #20336 

**Tests performed:**
- Performed tests with 2 accounts (rogue & paladin)
- Performed tests with a hunter (with and without pet)
- Tested possession phase
- Tested case if you are soloing Baroness with pet
- Tested if PvP Trinket can be used to cancel the possession
- Theoretical research via wowhead (+comments) and wowpedia (+patch-changes)

**Known issues and TODO list:**
- [X] Does build x86 release on Windows 10 Pro (Version 1709 / OS Build 16299.334)
- [X] Does build x64 on Ubuntu Server Release: 17.10 
- [X] Handle SetObjectScale in #20336 , which I've removed, because there's no change of ObjectScale (good to see here: https://www.youtube.com/watch?v=wqygMyNzwe4)
- [ ] If player got possessed, you can hit the player down to 50% to become control again, but player will not get full health as it should
- [x] Handle situation if player does solo her, also with pet & elemental etc. (http://www.wowhead.com/npc=10436/baroness-anastari#comments:id=62785)
- [x] Check if PvP Trinket does clear possession (it shouldn't)