### PR TITLE
Core/AI: added CreatureAI hook for successful spell casts

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -160,6 +160,9 @@ class TC_GAME_API CreatureAI : public UnitAI
         // Called when a spell cast gets interrupted
         virtual void OnSpellCastInterrupt(SpellInfo const* /*spell*/) { }
 
+        // Called when a spell cast has been successfully finished
+        virtual void OnSuccessfulSpellCast(SpellInfo const* /*spell*/) { }
+
         // Called at reaching home after evade
         virtual void JustReachedHome() { }
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3417,6 +3417,11 @@ void Spell::cast(bool skipCheck)
         hitMask |= PROC_HIT_NORMAL;
 
     m_originalCaster->ProcSkillsAndAuras(nullptr, procAttacker, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_CAST, hitMask, this, nullptr, nullptr);
+
+    // Call CreatureAI hook OnSuccessfulSpellCast
+    if (Creature* caster = m_originalCaster->ToCreature())
+        if (caster->IsAIEnabled)
+            caster->AI()->OnSuccessfulSpellCast(GetSpellInfo());
 }
 
 void Spell::handle_immediate()


### PR DESCRIPTION
**Description:**

Implement a new AI hook to allow us to notify a scripted creature when a spell cast has been successfully finished. Needed for future boss implementations that need interrupt immunities applied when their spell cast has been finished (or interrupted which has been supported by my last AI hook PR). This will save us from a ton of OnEffectLaunch spell scripts in the future.

Example bosses:
- Temple Guardian Anhuur
- Rajh
- Ammunae
- Baron Ashbury
- Lord Godfrey
- and many, many more.

**Todo:**
- Maybe we should add a target pointer as well to save even more spell scripts (?)
