### PR TITLE
Core/Auras: Implemented Aura 178 (SPELL_AURA_MOD_MAX_POWER_PCT)

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -247,7 +247,7 @@ enum AuraType : uint32
     SPELL_AURA_MOD_SPELL_HEALING_OF_STAT_PERCENT            = 175,
     SPELL_AURA_SPIRIT_OF_REDEMPTION                         = 176,
     SPELL_AURA_AOE_CHARM                                    = 177,
-    SPELL_AURA_MOD_MAX_POWER_PCT                            = 178,  // NYI
+    SPELL_AURA_MOD_MAX_POWER_PCT                            = 178,
     SPELL_AURA_MOD_POWER_DISPLAY                            = 179,
     SPELL_AURA_MOD_FLAT_SPELL_DAMAGE_VERSUS                 = 180,
     SPELL_AURA_181                                          = 181,  // old SPELL_AURA_MOD_FLAT_SPELL_CRIT_DAMAGE_VERSUS - possible flat spell crit damage versus

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -251,6 +251,7 @@ class TC_GAME_API AuraEffect
         void HandleAuraModIncreaseBaseManaPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModPowerDisplay(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModOverridePowerDisplay(AuraApplication const* aurApp, uint8 mode, bool apply) const;
+        void HandleAuraModMaxPowerPct(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         //   fight
         void HandleAuraModParryPercent(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModDodgePercent(AuraApplication const* aurApp, uint8 mode, bool apply) const;


### PR DESCRIPTION
**Changes proposed:**

Implement aura 178 (SPELL_AURA_MOD_MAX_POWER_PCT)
Used mainly for add extra mana (specialization healer) or mastery for mage

Example :
[Mana] [Restoration Druid](http://www.wowhead.com/spell=137012/restoration-druid)
[Mana] [Mastery: Savant](http://www.wowhead.com/spell=190740/mastery-savant)
[Mana/Energy/Rage] [Stabilized Energy](http://www.wowhead.com/spell=228451/stabilized-energy)


**Target branch(es):**

- [X] master

**Issues addressed:**

Unk

**Tests performed:**

Tested IG & build
