### PR TITLE
Scripts/BlackrockDepths: fix Ironhand Guardian

### DIFF
--- a/sql/updates/world/3.3.5/2019_07_05_03_world.sql
+++ b/sql/updates/world/3.3.5/2019_07_05_03_world.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `creature_template` SET `AIName`="", `ScriptName`="npc_ironhand_guardian" WHERE `entry`=8982;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=8982 AND `source_type`=0;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3904,6 +3904,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     ApplySpellFix({
+        15538, // Gout of Flame
         42490, // Energized!
         42492, // Cast Energized
         43115  // Plague Vial

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_magmus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_magmus.cpp
@@ -54,6 +54,8 @@ class boss_magmus : public CreatureScript
 
             void JustEngagedWith(Unit* /*who*/) override
             {
+                if (InstanceScript* instance = me->GetInstanceScript())
+                    instance->SetData(TYPE_IRON_HALL, IN_PROGRESS);
                 _events.SetPhase(PHASE_ONE);
                 _events.ScheduleEvent(EVENT_FIERY_BURST, 5s);
             }
@@ -97,7 +99,10 @@ class boss_magmus : public CreatureScript
             void JustDied(Unit* /*killer*/) override
             {
                 if (InstanceScript* instance = me->GetInstanceScript())
+                {
                     instance->HandleGameObject(instance->GetGuidData(DATA_THRONE_DOOR), true);
+                    instance->SetData(TYPE_IRON_HALL, DONE);
+                }
             }
 
         private:
@@ -110,7 +115,67 @@ class boss_magmus : public CreatureScript
         }
 };
 
+enum IronhandGuardian
+{
+    EVENT_GOUTOFFLAME = 1,
+    SPELL_GOUTOFFLAME = 15529
+};
+
+class npc_ironhand_guardian : public CreatureScript
+{
+public:
+    npc_ironhand_guardian() : CreatureScript("npc_ironhand_guardian") { }
+
+    struct npc_ironhand_guardianAI : public ScriptedAI
+    {
+        npc_ironhand_guardianAI(Creature* creature) : ScriptedAI(creature)
+        {
+            _instance = me->GetInstanceScript();
+            _active = false;
+        }
+
+        void Reset() override
+        {
+            _events.Reset();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (!_active)
+            {
+                if (_instance->GetData(TYPE_IRON_HALL) == NOT_STARTED)
+                    return;
+                // Once the boss is engaged, the guardians will stay activated until the next instance reset
+                _events.ScheduleEvent(EVENT_GOUTOFFLAME, 0s);
+                _active = true;
+            }
+
+            _events.Update(diff);
+
+            while (uint32 eventId = _events.ExecuteEvent())
+            {
+                if (eventId == EVENT_GOUTOFFLAME)
+                {
+                    DoCastAOE(SPELL_GOUTOFFLAME);
+                    _events.Repeat(16s);
+                }
+            }
+        }
+
+    private:
+        EventMap _events;
+        InstanceScript* _instance;
+        bool _active;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return GetBlackrockDepthsAI<npc_ironhand_guardianAI>(creature);
+    }
+};
+
 void AddSC_boss_magmus()
 {
     new boss_magmus();
+    new npc_ironhand_guardian();
 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
@@ -33,19 +33,19 @@
 
 enum Creatures
 {
-    NPC_EMPEROR             = 9019,
-    NPC_PHALANX             = 9502,
-    NPC_ANGERREL            = 9035,
-    NPC_DOPEREL             = 9040,
-    NPC_HATEREL             = 9034,
-    NPC_VILEREL             = 9036,
-    NPC_SEETHREL            = 9038,
-    NPC_GLOOMREL            = 9037,
-    NPC_DOOMREL             = 9039,
-    NPC_MAGMUS              = 9938,
-    NPC_MOIRA               = 8929,
+    NPC_EMPEROR              = 9019,
+    NPC_PHALANX              = 9502,
+    NPC_ANGERREL             = 9035,
+    NPC_DOPEREL              = 9040,
+    NPC_HATEREL              = 9034,
+    NPC_VILEREL              = 9036,
+    NPC_SEETHREL             = 9038,
+    NPC_GLOOMREL             = 9037,
+    NPC_DOOMREL              = 9039,
+    NPC_MAGMUS               = 9938,
+    NPC_MOIRA                = 8929,
     NPC_PRIESTESS_THAURISSAN = 10076,
-    NPC_COREN               = 23872
+    NPC_COREN                = 23872,
 };
 
 enum GameObjects


### PR DESCRIPTION
In BlackrockDepths in the Iron Hall Ironhand Guardians in the sides
should only cast "Gout of Flame" during the fight with Magmus (src:
https://github.com/classicdb/database/issues/715).

**Changes proposed**:
  
- Make Ironhand Guardions (near Magmus in Blackrock Depths) cast Gout of Flame
  only when battling Magmus. As descriped in
  https://github.com/classicdb/database/issues/715.

**Target branch(es)**: 335

**Issues addressed**: No issue open on this.

**Tests performed**: Patch is based on upstream commit 1e25b215e5 (DB/Creature:
Scarlet Infantryman equipments). This builds builds and described functionality
validated using:

- `.gm on`
- `.cheat god on`
- `.tele blackrock`
- `.go creature magmus`
- check that Ironhand Guradians don't cast
- `.gm off
- check that Ironhand Guradians now do cast
- `/target Magmus`
- `.damage 25000
- check that Ironhand Guradians stop casting

**Known issues and TODO list**: No known issues with this patch. Although it
probably would be prettier to move the SAI to BlackrockDepths scripts instead.
