### PR TITLE
fix boss_vazruden_the_herald

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -97,7 +97,8 @@ class boss_nazan : public CreatureScript
             void IsSummonedBy(Unit* summoner) override
             {
                 if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-                    VazrudenGUID = summoner->GetGUID();
+                   // VazrudenGUID = summoner->GetGUID();
+					Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
             }
 
             void JustSummoned(Creature* summoned) override
@@ -133,7 +134,7 @@ class boss_nazan : public CreatureScript
 
                 if (flight) // phase 1 - the flight
                 {
-                    Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
+                    //Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
                     if (Fly_Timer < diff || !(Vazruden && Vazruden->IsAlive() && Vazruden->HealthAbovePct(20)))
                     {
                         flight = false;
@@ -194,7 +195,7 @@ class boss_nazan : public CreatureScript
                 uint32 Fly_Timer;
                 uint32 Turn_Timer;
                 bool flight;
-                ObjectGuid VazrudenGUID;
+				Creature* Vazruden;
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -350,7 +351,11 @@ class boss_vazruden_the_herald : public CreatureScript
                     if (Creature* Vazruden = me->SummonCreature(NPC_VAZRUDEN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                         VazrudenGUID = Vazruden->GetGUID();
                     if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
-                        NazanGUID = Nazan->GetGUID();
+					{
+						NazanGUID = Nazan->GetGUID();
+						Unit* player = Nazan->SelectNearestPlayer(60.00f);
+						Nazan->AI()->AttackStart(player);
+					}
                     summoned = true;
                     me->SetVisible(false);
                     me->AddUnitState(UNIT_STATE_ROOT);
@@ -437,6 +442,10 @@ class boss_vazruden_the_herald : public CreatureScript
                                 return;
                             }
                         }
+						if (!(Nazan && Nazan->IsAlive()) && !(Vazruden && Vazruden->IsAlive()))
+						{
+							me->DisappearAndDie();
+						}
                         check = 2000;
                     }
                     else


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  When vazruden came down, nazan don't move or attack player.
-  after vazruden died, nazan enter evade mode derectly. It's a big bug.
-  I'm not sure my repairing is good or bad, cause I'm new here.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
I have test it servrel times, it works well.

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
