### PR TITLE
Scripts/Hellfire Ramparts: Vazruden the Herald & Nazan (Vazruden's Mount) death+evade fix

### DIFF
--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -351,10 +351,16 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
             if (bossInfo->state == state)
                 return false;
 
-            if (bossInfo->state == DONE)
+            if (bossInfo->state == DONE && state != SPECIAL)
             {
                 TC_LOG_ERROR("map", "InstanceScript: Tried to set instance boss %u state from %s back to %s for map %u, instance id %u. Blocked!", id, GetBossStateName(bossInfo->state), GetBossStateName(state), instance->GetId(), instance->GetInstanceId());
                 return false;
+            }
+            if (bossInfo->state == DONE && state == SPECIAL)
+            {
+                bossInfo->state = state;
+                SaveToDB();//Not quite sure if this is necessary
+                return true;
             }
 
             if (state == DONE)

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -97,7 +97,6 @@ class boss_nazan : public CreatureScript
             void IsSummonedBy(Unit* summoner) override
             {
                 if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-                   // VazrudenGUID = summoner->GetGUID();
 					Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
             }
 
@@ -134,7 +133,6 @@ class boss_nazan : public CreatureScript
 
                 if (flight) // phase 1 - the flight
                 {
-                    //Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
                     if (Fly_Timer < diff || !(Vazruden && Vazruden->IsAlive() && Vazruden->HealthAbovePct(20)))
                     {
                         flight = false;
@@ -195,7 +193,7 @@ class boss_nazan : public CreatureScript
                 uint32 Fly_Timer;
                 uint32 Turn_Timer;
                 bool flight;
-				Creature* Vazruden;
+				Creature* Vazruden;  //just i don't know how to use guid to start attack,so I change to Creature*, pls help me.
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -353,7 +351,7 @@ class boss_vazruden_the_herald : public CreatureScript
                     if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
 					{
 						NazanGUID = Nazan->GetGUID();
-						Unit* player = Nazan->SelectNearestPlayer(60.00f);
+						Unit* player = Nazan->SelectNearestPlayer(60.00f);//nazan start attack
 						Nazan->AI()->AttackStart(player);
 					}
                     summoned = true;

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -97,7 +97,7 @@ class boss_nazan : public CreatureScript
             void IsSummonedBy(Unit* summoner) override
             {
                 if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-				    Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
+                    Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
             }
 
             void JustSummoned(Creature* summoned) override
@@ -193,7 +193,7 @@ class boss_nazan : public CreatureScript
                 uint32 Fly_Timer;
                 uint32 Turn_Timer;
                 bool flight;
-			    Creature* Vazruden;  //just i don't know how to use guid to start attack,so I change to Creature*, pls help me.
+                Creature* Vazruden;  //just i don't know how to use guid to start attack,so I change to Creature*, pls help me.
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -349,11 +349,11 @@ class boss_vazruden_the_herald : public CreatureScript
                     if (Creature* Vazruden = me->SummonCreature(NPC_VAZRUDEN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                         VazrudenGUID = Vazruden->GetGUID();
                     if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
-					{
-					    NazanGUID = Nazan->GetGUID();
-					    Unit* player = Nazan->SelectNearestPlayer(60.00f);//nazan start attack
-						Nazan->AI()->AttackStart(player);
-					}
+                    {
+                        NazanGUID = Nazan->GetGUID();
+                        Unit* player = Nazan->SelectNearestPlayer(60.00f);//nazan start attack
+                        Nazan->AI()->AttackStart(player);
+                    }
                     summoned = true;
                     me->SetVisible(false);
                     me->AddUnitState(UNIT_STATE_ROOT);
@@ -440,10 +440,10 @@ class boss_vazruden_the_herald : public CreatureScript
                                 return;
                             }
                         }
-						if (!(Nazan && Nazan->IsAlive()) && !(Vazruden && Vazruden->IsAlive()))
-						{
-						    me->DisappearAndDie();
-						}
+                        if (!(Nazan && Nazan->IsAlive()) && !(Vazruden && Vazruden->IsAlive()))
+                        {
+                            me->DisappearAndDie();
+                        }
                         check = 2000;
                     }
                     else

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -97,7 +97,8 @@ class boss_nazan : public CreatureScript
             void IsSummonedBy(Unit* summoner) override
             {
                 if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-                    VazrudenGUID = summoner->GetGUID();
+                   // VazrudenGUID = summoner->GetGUID();
+					Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
             }
 
             void JustSummoned(Creature* summoned) override
@@ -133,7 +134,7 @@ class boss_nazan : public CreatureScript
 
                 if (flight) // phase 1 - the flight
                 {
-                    Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
+                    //Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
                     if (Fly_Timer < diff || !(Vazruden && Vazruden->IsAlive() && Vazruden->HealthAbovePct(20)))
                     {
                         flight = false;
@@ -194,7 +195,7 @@ class boss_nazan : public CreatureScript
                 uint32 Fly_Timer;
                 uint32 Turn_Timer;
                 bool flight;
-                ObjectGuid VazrudenGUID;
+				Creature* Vazruden;
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -350,7 +351,11 @@ class boss_vazruden_the_herald : public CreatureScript
                     if (Creature* Vazruden = me->SummonCreature(NPC_VAZRUDEN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                         VazrudenGUID = Vazruden->GetGUID();
                     if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
-                        NazanGUID = Nazan->GetGUID();
+					{
+						NazanGUID = Nazan->GetGUID();
+						Unit* player = Nazan->SelectNearestPlayer(60.00f);
+						Nazan->AI()->AttackStart(player);
+					}
                     summoned = true;
                     me->SetVisible(false);
                     me->AddUnitState(UNIT_STATE_ROOT);
@@ -437,6 +442,10 @@ class boss_vazruden_the_herald : public CreatureScript
                                 return;
                             }
                         }
+						if (!(Nazan && Nazan->IsAlive()) && !(Vazruden && Vazruden->IsAlive()))
+						{
+							me->DisappearAndDie();
+						}
                         check = 2000;
                     }
                     else

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -96,8 +96,11 @@ class boss_nazan : public CreatureScript
 
             void IsSummonedBy(Unit* summoner) override
             {
-                if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-                    VazrudenGUID = summoner->FindNearestCreature(NPC_VAZRUDEN, 5000)->GetGUID();//Is it possible to get the GUID directly?
+                if (summoner->GetEntry() == NPC_VAZRUDEN)
+                    VazrudenGUID = summoner->GetGUID();
+                else
+                    VazrudenGUID = summoner->FindNearestCreature(NPC_VAZRUDEN, 100.0f)->GetGUID();
+  
             }
 
             void JustSummoned(Creature* summoned) override
@@ -348,14 +351,16 @@ class boss_vazruden_the_herald : public CreatureScript
                 if (!summoned)
                 {
                     if (Creature* Vazruden = me->SummonCreature(NPC_VAZRUDEN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
-                        VazrudenGUID = Vazruden->GetGUID();
-                    if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                     {
-                        NazanGUID = Nazan->GetGUID();
-                        Unit* player = Nazan->GetThreatManager().GetAnyTarget();
-                        if (player)
+                        VazrudenGUID = Vazruden->GetGUID();
+                        if (Creature* Nazan = Vazruden->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000);)
                         {
-                            Nazan->AI()->AttackStart(player);
+                            NazanGUID = Nazan->GetGUID();
+                            Unit* player = Nazan->GetThreatManager().GetAnyTarget();
+                            if (player)
+                            {
+                                Nazan->AI()->AttackStart(player);
+                            }
                         }
                     }
                     summoned = true;

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -97,7 +97,7 @@ class boss_nazan : public CreatureScript
             void IsSummonedBy(Unit* summoner) override
             {
                 if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-                    Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
+                    VazrudenGUID = summoner->FindNearestCreature(NPC_VAZRUDEN, 5000)->GetGUID();//Is it possible to get the GUID directly?
             }
 
             void JustSummoned(Creature* summoned) override
@@ -133,6 +133,7 @@ class boss_nazan : public CreatureScript
 
                 if (flight) // phase 1 - the flight
                 {
+                    Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
                     if (Fly_Timer < diff || !(Vazruden && Vazruden->IsAlive() && Vazruden->HealthAbovePct(20)))
                     {
                         flight = false;
@@ -193,7 +194,7 @@ class boss_nazan : public CreatureScript
                 uint32 Fly_Timer;
                 uint32 Turn_Timer;
                 bool flight;
-                Creature* Vazruden;  //just i don't know how to use guid to start attack,so I change to Creature*, pls help me.
+                ObjectGuid VazrudenGUID;
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -351,8 +352,11 @@ class boss_vazruden_the_herald : public CreatureScript
                     if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                     {
                         NazanGUID = Nazan->GetGUID();
-                        Unit* player = Nazan->SelectNearestPlayer(60.00f);//nazan start attack
-                        Nazan->AI()->AttackStart(player);
+                        Unit* player = Nazan->GetThreatManager().GetAnyTarget();
+                        if (player)
+                        {
+                            Nazan->AI()->AttackStart(player);
+                        }
                     }
                     summoned = true;
                     me->SetVisible(false);

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -97,7 +97,7 @@ class boss_nazan : public CreatureScript
             void IsSummonedBy(Unit* summoner) override
             {
                 if (summoner->GetEntry() == NPC_VAZRUDEN_HERALD)
-					Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
+				    Vazruden = me->FindNearestCreature(NPC_VAZRUDEN, 5000);
             }
 
             void JustSummoned(Creature* summoned) override
@@ -193,7 +193,7 @@ class boss_nazan : public CreatureScript
                 uint32 Fly_Timer;
                 uint32 Turn_Timer;
                 bool flight;
-				Creature* Vazruden;  //just i don't know how to use guid to start attack,so I change to Creature*, pls help me.
+			    Creature* Vazruden;  //just i don't know how to use guid to start attack,so I change to Creature*, pls help me.
         };
 
         CreatureAI* GetAI(Creature* creature) const override
@@ -350,8 +350,8 @@ class boss_vazruden_the_herald : public CreatureScript
                         VazrudenGUID = Vazruden->GetGUID();
                     if (Creature* Nazan = me->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
 					{
-						NazanGUID = Nazan->GetGUID();
-						Unit* player = Nazan->SelectNearestPlayer(60.00f);//nazan start attack
+					    NazanGUID = Nazan->GetGUID();
+					    Unit* player = Nazan->SelectNearestPlayer(60.00f);//nazan start attack
 						Nazan->AI()->AttackStart(player);
 					}
                     summoned = true;
@@ -442,7 +442,7 @@ class boss_vazruden_the_herald : public CreatureScript
                         }
 						if (!(Nazan && Nazan->IsAlive()) && !(Vazruden && Vazruden->IsAlive()))
 						{
-							me->DisappearAndDie();
+						    me->DisappearAndDie();
 						}
                         check = 2000;
                     }

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -353,7 +353,7 @@ class boss_vazruden_the_herald : public CreatureScript
                     if (Creature* Vazruden = me->SummonCreature(NPC_VAZRUDEN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                     {
                         VazrudenGUID = Vazruden->GetGUID();
-                        if (Creature* Nazan = Vazruden->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000);)
+                        if (Creature* Nazan = Vazruden->SummonCreature(NPC_NAZAN, VazrudenMiddle[0], VazrudenMiddle[1], VazrudenMiddle[2], 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 6000000))
                         {
                             NazanGUID = Nazan->GetGUID();
                             Unit* player = Nazan->GetThreatManager().GetAnyTarget();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  When vazruden came down, nazan don't move or attack player.
-  after vazruden died, nazan enter evade mode derectly. It's a big bug.
-  instance_steam_vault MainChambersDoor not open, I found that func SetBossState in InstanceScript.cpp can not set bossstate special after boss died. If my change not good, I'll fix instance script insead. 

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
I have test it servrel times, it works well.

**Known issues and TODO list:** (add/remove lines as needed)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
