### PR TITLE
Core/Player: Fix issue with pvp rules not being permanent in pvp areas

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26405,9 +26405,9 @@ void Player::EnablePvpRules(bool dueToCombat /*= false*/)
     if (!HasPvpRulesEnabled())
     {
         if (!HasSpell(195710)) // Honorable Medallion
-            CastSpell(this, 208682); // Learn Gladiator's Medallion
+            CastSpell(this, 208682, true); // Learn Gladiator's Medallion
 
-        CastSpell(this, SPELL_PVP_RULES_ENABLED);
+        CastSpell(this, SPELL_PVP_RULES_ENABLED, true);
     }
 
     if (!dueToCombat)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26402,19 +26402,23 @@ bool Player::HasPvpTalent(uint32 talentID, uint8 activeTalentGroup) const
 
 void Player::EnablePvpRules(bool dueToCombat /*= false*/)
 {
-    if (HasPvpRulesEnabled())
-        return;
+    if (!HasPvpRulesEnabled())
+    {
+        if (!HasSpell(195710)) // Honorable Medallion
+            CastSpell(this, 208682); // Learn Gladiator's Medallion
 
-    if (!HasSpell(195710)) // Honorable Medallion
-        CastSpell(this, 208682); // Learn Gladiator's Medallion
+        CastSpell(this, SPELL_PVP_RULES_ENABLED);
+    }
 
-    CastSpell(this, SPELL_PVP_RULES_ENABLED);
     if (!dueToCombat)
     {
         if (Aura* aura = GetAura(SPELL_PVP_RULES_ENABLED))
         {
-            aura->SetMaxDuration(-1);
-            aura->SetDuration(-1);
+            if (!aura->IsPermanent())
+            {
+                aura->SetMaxDuration(-1);
+                aura->SetDuration(-1);
+            }
         }
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Make pvp rules enabled aura permanent when walking into a pvp zone while in pvp combat

**Target branch(es):** master

**Issues addressed:** Closes #  none

**Tests performed:**
- Went to gurubashi arena, went out, added the aura manually and went back in and aura was not removed after 20 seconds


**Known issues and TODO list:** (add/remove lines as needed)
- none

note: Is there any way to make non-visible auras visible clientside ? Would be helpful for this kind of issues
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
