### PR TITLE
Core/Ulduar Vehicles

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -281,7 +281,10 @@ class instance_ulduar : public InstanceMapScript
                     case NPC_SALVAGED_DEMOLISHER:
                     case NPC_SALVAGED_SIEGE_ENGINE:
                     case NPC_SALVAGED_CHOPPER:
-                        LeviathanVehicleGUIDs.push_back(creature->GetGUID());
+                        if (GetBossState(BOSS_LEVIATHAN) == DONE)
+                            DespawnLeviatanVehicle(creature);
+                        else
+                            LeviathanVehicleGUIDs.push_back(creature->GetGUID());
                         break;
 
                     // XT-002 Deconstructor
@@ -1040,12 +1043,7 @@ class instance_ulduar : public InstanceMapScript
                             {
                                 if (Creature* vehicleCreature = instance->GetCreature(vehicleGuid))
                                 {
-                                    if (Vehicle* vehicle = vehicleCreature->GetVehicleKit())
-                                    {
-                                        vehicle->RemoveAllPassengers();
-                                        vehicleCreature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-                                        vehicleCreature->DespawnOrUnsummon(5 * MINUTE * IN_MILLISECONDS);
-                                    }
+                                    DespawnLeviatanVehicle(vehicleCreature);                                   
                                 }
                             }
                             break;
@@ -1056,6 +1054,16 @@ class instance_ulduar : public InstanceMapScript
                                 gameObject->SetGoState(GO_STATE_ACTIVE_ALTERNATIVE);
                             break;
                     }
+                }
+            }
+
+            void DespawnLeviatanVehicle(Creature* vehicleCreature)
+            {
+                if (Vehicle* vehicle = vehicleCreature->GetVehicleKit())
+                {
+                    vehicle->RemoveAllPassengers();
+                    vehicleCreature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
+                    vehicleCreature->DespawnOrUnsummon(5 * MINUTE * IN_MILLISECONDS);
                 }
             }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -1040,11 +1040,8 @@ class instance_ulduar : public InstanceMapScript
                             // Eject all players from vehicles and make them untargetable.
                             // They will be despawned after a while
                             for (auto const& vehicleGuid : LeviathanVehicleGUIDs)
-                            {
                                 if (Creature* vehicleCreature = instance->GetCreature(vehicleGuid))
-                                    DespawnLeviatanVehicle(vehicleCreature);                                   
-                                
-                            }
+                                    DespawnLeviatanVehicle(vehicleCreature);
                             break;
                         case EVENT_LEVIATHAN_BREAK_DOOR:
                             if (Creature* leviathan = GetCreature(BOSS_LEVIATHAN))

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -1042,9 +1042,8 @@ class instance_ulduar : public InstanceMapScript
                             for (auto const& vehicleGuid : LeviathanVehicleGUIDs)
                             {
                                 if (Creature* vehicleCreature = instance->GetCreature(vehicleGuid))
-                                {
                                     DespawnLeviatanVehicle(vehicleCreature);                                   
-                                }
+                                
                             }
                             break;
                         case EVENT_LEVIATHAN_BREAK_DOOR:


### PR DESCRIPTION
**Changes proposed:**

When Leviatan dies, any vehicle shouldn't be usable, but is posible use them if the HARDMODE is active becouse at respawn, the vehicles are usable.
For test the bug, just go Ulduar, set HARDMODE,kill any "extra" vehicles, then, kill leviatan (or set BossState to DONE) and wait a few minutes, the "extra" vehicles will respawn and they will be usable.
This changes fix the problem

**Target branch(es):** 3.3.5/master

- [√] 3.3.5
- [?] master

**Tests performed:** (Does it build, tested in-game, etc.)
Tested on my own server and it works fine

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
