### PR TITLE
Core/Spell: Eviscerate SpellID update

### DIFF
--- a/sql/updates/world/master/9999_99_99_00_world.sql
+++ b/sql/updates/world/master/9999_99_99_00_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` where `ScriptName` IN ('spell_rog_eviscerate');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(196819, 'spell_rog_eviscerate');

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -915,7 +915,7 @@ public:
     }
 };
 
-// 2098 - Eviscerate
+// 196819 - Eviscerate
 class spell_rog_eviscerate : public SpellScriptLoader
 {
 public:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

Rogue Spell **Eviscerate** had SpellID changed in Patch 7.0.3
https://wow.gamepedia.com/Eviscerate#Patches_and_hotfixes

**Changes proposed:**
- Fix by @ArcaneFox
-  Update SpellID in .cpp comment and SQL

**Target branch(es):** 3.3.5/master

- [x] master

**Issues addressed:** Closes #21874 

**Tests performed:** Reported as tested and working by @ArcaneFox

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
