### PR TITLE
Core/Spells: Allow Frenzied Regeneration to crit

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3072,6 +3072,7 @@ void SpellMgr::LoadSpellInfoCorrections()
     ApplySpellFix({
         379,   // Earth Shield
         33778, // Lifebloom Final Bloom
+        22845, // Frenzied Regeneration
 
         52042, // Healing Stream Totem
         // this one is here because we have no SP bonus for dmgclass none spell
@@ -3086,6 +3087,12 @@ void SpellMgr::LoadSpellInfoCorrections()
     {
         // We need more spells to find a general way (if there is any)
         spellInfo->DmgClass = SPELL_DAMAGE_CLASS_MAGIC;
+    });
+
+    // Frenzied Regeneration
+    ApplySpellFix({ 22845 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->SchoolMask = SPELL_SCHOOL_MASK_NATURE;
     });
 
     // Spell Reflection


### PR DESCRIPTION
**Changes proposed:**
Frenzied Regeneration spell (22845) has `SPELL_SCHOOL_MASK_NORMAL` and `SPELL_DAMAGE_CLASS_NONE` that makes it not having chance to crit.

PR enforces school mask and damage class like it is done with some similar healing spells and it makes Frenzied Regeneration to work offlike.

**Target branch(es):**
- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #20798


**Tests performed:** Does build and works in-game.