### PR TITLE
Core/Spells: Reset Mangle cooldown in Berserk

### DIFF
--- a/sql/updates/world/3.3.5/2018_06_04_00_world.sql
+++ b/sql/updates/world/3.3.5/2018_06_04_00_world.sql
@@ -1,3 +1,3 @@
-DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_dru_berserk';
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_dru_berserk';
 INSERT INTO `spell_script_names`(`spell_id`, `ScriptName`) VALUES
 (-50334,'spell_dru_berserk');

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,3 +1,3 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` = -50334;
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_dru_berserk';
 INSERT INTO `spell_script_names`(`spell_id`, `ScriptName`) VALUES
 (-50334,'spell_dru_berserk');

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = -50334;
+INSERT INTO `spell_script_names`(`spell_id`, `ScriptName`) VALUES
+(-50334,'spell_dru_berserk');

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -93,6 +93,11 @@ enum DruidSpells
     SPELL_DRUID_FRENZIED_REGENERATION_HEAL  = 22845
 };
 
+enum MiscSpells
+{
+    SPELL_CATEGORY_MANGLE_BEAR              = 971
+};
+
 // 22812 - Barkskin
 class spell_dru_barkskin : public SpellScriptLoader
 {
@@ -174,6 +179,38 @@ class spell_dru_bear_form_passive : public SpellScriptLoader
         AuraScript* GetAuraScript() const override
         {
             return new spell_dru_bear_form_passive_AuraScript();
+        }
+};
+
+// -50334 - Berserk
+class spell_dru_berserk : public SpellScriptLoader
+{
+    public:
+        spell_dru_berserk() : SpellScriptLoader("spell_dru_berserk") { }
+
+            class spell_dru_berserk_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_dru_berserk_AuraScript);
+
+            void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+            {
+                // Remove cooldown on Mangle (bear)
+                GetTarget()->GetSpellHistory()->ResetCooldowns([](SpellHistory::CooldownStorageType::iterator itr) -> bool
+                {
+                    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
+                    return spellInfo && spellInfo->GetCategory() == SPELL_CATEGORY_MANGLE_BEAR;
+                }, true);
+            }
+
+            void Register() override
+            {
+                AfterEffectApply += AuraEffectApplyFn(spell_dru_berserk_AuraScript::HandleEffectApply, EFFECT_1, SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+            }
+        };
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new spell_dru_berserk_AuraScript();
         }
 };
 
@@ -2355,6 +2392,7 @@ void AddSC_druid_spell_scripts()
 {
     new spell_dru_barkskin();
     new spell_dru_bear_form_passive();
+    new spell_dru_berserk();
     new spell_dru_dash();
     new spell_dru_eclipse();
     new spell_dru_enrage();

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -183,35 +183,24 @@ class spell_dru_bear_form_passive : public SpellScriptLoader
 };
 
 // -50334 - Berserk
-class spell_dru_berserk : public SpellScriptLoader
+class spell_dru_berserk : public AuraScript
 {
-    public:
-        spell_dru_berserk() : SpellScriptLoader("spell_dru_berserk") { }
+    PrepareAuraScript(spell_dru_berserk);
 
-            class spell_dru_berserk_AuraScript : public AuraScript
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        // Remove cooldown on Mangle (bear)
+        GetTarget()->GetSpellHistory()->ResetCooldowns([](SpellHistory::CooldownStorageType::iterator itr) -> bool
         {
-            PrepareAuraScript(spell_dru_berserk_AuraScript);
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
+            return spellInfo && spellInfo->GetCategory() == SPELL_CATEGORY_MANGLE_BEAR;
+        }, true);
+    }
 
-            void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
-            {
-                // Remove cooldown on Mangle (bear)
-                GetTarget()->GetSpellHistory()->ResetCooldowns([](SpellHistory::CooldownStorageType::iterator itr) -> bool
-                {
-                    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(itr->first);
-                    return spellInfo && spellInfo->GetCategory() == SPELL_CATEGORY_MANGLE_BEAR;
-                }, true);
-            }
-
-            void Register() override
-            {
-                AfterEffectApply += AuraEffectApplyFn(spell_dru_berserk_AuraScript::HandleEffectApply, EFFECT_1, SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
-            }
-        };
-
-        AuraScript* GetAuraScript() const override
-        {
-            return new spell_dru_berserk_AuraScript();
-        }
+    void Register() override
+    {
+        AfterEffectApply += AuraEffectApplyFn(spell_dru_berserk::HandleEffectApply, EFFECT_1, SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+    }
 };
 
 // -1850 - Dash
@@ -2392,7 +2381,7 @@ void AddSC_druid_spell_scripts()
 {
     new spell_dru_barkskin();
     new spell_dru_bear_form_passive();
-    new spell_dru_berserk();
+    RegisterAuraScript(spell_dru_berserk);
     new spell_dru_dash();
     new spell_dru_eclipse();
     new spell_dru_enrage();


### PR DESCRIPTION
**Changes proposed:**
As of [patch 3.0.3](https://wow.gamepedia.com/Patch_3.0.3) Berserk must reset Mangle (bear) cooldown on use.

> [Berserk]: Now clears the cooldown on [Mangle] (Bear).

PR creates spell script that handles that behaviour.

**Target branch(es):**
- [x] 3.3.5
- [ ] master

**Tests performed:** Does build and works in-game.

P.S. 22000 PR!
