### PR TITLE
Core/Spells: fixed a edge case crash which happens if a player  is casting from via PassengerBoarded hook straight after exiting vehicle.

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2178,6 +2178,9 @@ SpellCastResult SpellInfo::CheckVehicle(Unit const* caster) const
             checkMask = VEHICLE_SEAT_FLAG_CAN_ATTACK;
 
         VehicleSeatEntry const* vehicleSeat = vehicle->GetSeatForPassenger(caster);
+        if (!vehicleSeat)
+            return SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW;
+        
         if (!HasAttribute(SPELL_ATTR6_CASTABLE_WHILE_ON_VEHICLE) && !HasAttribute(SPELL_ATTR0_CASTABLE_WHILE_MOUNTED)
             && (vehicleSeat->Flags & checkMask) != checkMask)
             return SPELL_FAILED_CANT_DO_THAT_RIGHT_NOW;


### PR DESCRIPTION
**Changes proposed:**
-  this little fix is solving a crash that happens if PassengerBoarded is being used with apply being marked as false to cast a spell which requires the passenger to cast a spell. For some reason the hook is being called before the vehicle is actually set to nullptr so the core is trying to get vehicle data while the player doesn't have a vehicle anymore. While this PR covers the crash only the real issue is the cause of the crash.


**Target branch(es):** 3.3.5/master
- [x] master

