### PR TITLE
Core/Spells: Skip shapeshift removal while in Shadow Dance

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1713,7 +1713,9 @@ void AuraEffect::HandleAuraModShapeshift(AuraApplication const* aurApp, uint8 mo
         }
 
         // remove other shapeshift before applying a new one
-        target->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT, ObjectGuid::Empty, GetBase());
+        // skip on rogue shadow dance
+        if (!target->HasAura(51713))
+            target->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT, ObjectGuid::Empty, GetBase());
 
         // stop handling the effect if it was removed by linked event
         if (aurApp->GetRemoveMode())

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1713,8 +1713,8 @@ void AuraEffect::HandleAuraModShapeshift(AuraApplication const* aurApp, uint8 mo
         }
 
         // remove other shapeshift before applying a new one
-        // skip on rogue shadow dance
-        if (!target->HasAura(51713))
+        // skip for rogue
+        if (target->getClass() != CLASS_ROGUE)
             target->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT, ObjectGuid::Empty, GetBase());
 
         // stop handling the effect if it was removed by linked event


### PR DESCRIPTION
**Changes proposed:**
[Shadow Dance](https://dbwotlk.com/?spell=51713) (51713) is a shapeshift effect. It means that applying [Stealth](https://dbwotlk.com/?spell=1784) or [Vanish](https://dbwotlk.com/?spell=26889) cancels Shadow Dance prematurely.

PR allows to skip shapeshifts removal while rogue is in Shadow Dance state.

**Target branch(es):**
- [x] 3.3.5
- [ ] master

**Tests performed:** Does build and works in-game.
