### PR TITLE
Core/Spells: Fixed School Immune being ignored by NOT SPELL_AURA_XXX

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7713,16 +7713,16 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index, Worl
             SpellImmuneContainer const& list = m_spellImmune[IMMUNITY_STATE];
             if (list.count(aura) > 0)
                 return true;
+        }
 
-            if (!spellInfo->HasAttribute(SPELL_ATTR2_UNAFFECTED_BY_AURA_SCHOOL_IMMUNE))
-            {
-                // Check for immune to application of harmful magical effects
-                AuraEffectList const& immuneAuraApply = GetAuraEffectsByType(SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL);
-                for (AuraEffectList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
-                    if (((*iter)->GetMiscValue() & spellInfo->GetSchoolMask()) &&                   // Check school
-                        ((caster && !IsFriendlyTo(caster)) || !spellInfo->IsPositiveEffect(index))) // Harmful
-                        return true;
-            }
+        if (!spellInfo->HasAttribute(SPELL_ATTR2_UNAFFECTED_BY_AURA_SCHOOL_IMMUNE))
+        {
+            // Check for immune to application of harmful magical effects
+            AuraEffectList const& immuneAuraApply = GetAuraEffectsByType(SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL);
+            for (AuraEffectList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
+                if (((*iter)->GetMiscValue() & spellInfo->GetSchoolMask()) &&                   // Check school
+                    ((caster && !IsFriendlyTo(caster)) || !spellInfo->IsPositiveEffect(index))) // Harmful
+                    return true;
         }
     }
 


### PR DESCRIPTION
**Changes proposed:**

-  Move school check to outside of ApplyAuraName Check (Spells with not aura effects was skiping the check)
-  It fix all SPELL_EFFECTS ignoring School Immune with Anti-Magic Shell
- E.g. Shadowflame (SPELL_EFFECT_SCHOOL_DAMAGE), Spell Lock (SPELL_EFFECT_INTERRUPT_CAST + SPELL_EFFECT_TRIGGER_SPELL)  

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #21343 and Update #20326

Just not fix Blood Plague issue, but idk if Blood plague issue is real.
If is real, i think is caused by bad handle  of Blood Plague (spell_linked_spell maybe, need search)


**Tests performed:** Builded and tested in game