### PR TITLE
Fixes for building with MariaDB.

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -56,8 +56,16 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
     WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below 5.1");
+    #ifdef MARIADB_VERSION_ID
+    // Server appears to be using MariaDB instead of MySQL
+    // Hackfix for slightly different constant names.
+    WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile TrinityCore (%s). Search on forum for TCE00011.",
+        mysql_get_client_info(), MARIADB_BASE_VERSION);
+#else
+    // Normal MySQL server.
     WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile TrinityCore (%s). Search on forum for TCE00011.",
         mysql_get_client_info(), MYSQL_SERVER_VERSION);
+#endif
 }
 
 template <class T>

--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -25,6 +25,9 @@
 #include "Transaction.h"
 #include "Util.h"
 #include <errmsg.h>
+#ifdef MARIADB_VERSION_ID // hack for MariaDB storing necessary values in server/errmsg.h instead of the expected `errmsg.h` from MySQL.
+#include <server/errmsg.h>
+#endif
 #ifdef _WIN32 // hack for broken mysql.h not including the correct winsock header for SOCKET definition, fixed in 5.7
 #include <winsock2.h>
 #endif

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -138,7 +138,16 @@ public:
         handler->PSendSysMessage("%s", GitRevision::GetFullVersion());
         handler->PSendSysMessage("Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
         handler->PSendSysMessage("Using Boost version: %i.%i.%i", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
+
+#ifdef MARIADB_VERSION_ID
+        // Server appears to be using MariaDB instead of MySQL
+        // Hackfix for slightly different constant names.
+        handler->PSendSysMessage("Using MySQL version: %s", MARIADB_BASE_VERSION);
+#else
+        // Normal MySQL server.
         handler->PSendSysMessage("Using MySQL version: %s", MYSQL_SERVER_VERSION);
+#endif
+
         handler->PSendSysMessage("Using CMake version: %s", GitRevision::GetCMakeVersion());
 
         handler->PSendSysMessage("Compiled on: %s", GitRevision::GetHostOSVersion());


### PR DESCRIPTION
**Changes Proposed**:

Adjust 2 information printouts and load one additional header if MariaDB is detected.

* `DatabaseWorkerPool.cpp`: Adjust MySQL version check error message to use a different constant if MariaDB is detected. The error message is the component being adjusted. The error check itself remains unchanged (goes off of `MYSQL_VERSION_ID`, which is available in MariaDB as-is and is not a problem).
* `cs_server.cpp`: Adjust MySQL version announcement to use a different constant if MariaDB is detected.
* `MySQLConnection.cpp`: If MariaDB is detected, then also load in `server/errmsg.h`. The file contains necessary constants that TC normally expects to be in `errmsg.h`.

Build changes all hinge on `MARIADB_VERSION_ID` being defined. Information printouts will else back to the pre-existing message using `MYSQL_SERVER_VERSION` if `MARIADB_VERSION_ID` is not defined.

**Target branch(es)**: 3.3.5

**Issues addressed**: Brought up in #21755.

Strictly-speaking, MariaDB is not supported by TC. Putting this forward for consideration based on the affected sections being mostly console printouts.

If this PR gets rejected on those grounds, then putting this code here will at least provide a clear paper trail for people to be able to Google and work into their own codebase at their discretion.

**Tests performed**: Built auth and world servers using `mariadb-devel` on Fedora 28. Successfully authenticated, signed in, mugged an NPC, and signed out.
