### PR TITLE
[WIP] Grouped reference references fixups

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -584,7 +584,7 @@ void LootTemplate::Process(Loot& loot, bool rate, uint16 lootMode, uint8 groupId
         if (!item->Roll(rate))
             continue;                                           // Bad luck for the entry
 
-        if (item->reference > 0)                            // References processing
+        if (item->reference > 0 && item->groupid == 0)          // Ungrouped references processing
         {
             LootTemplate const* Referenced = LootTemplates_Reference.GetLootFor(item->reference);
             if (!Referenced)
@@ -593,6 +593,10 @@ void LootTemplate::Process(Loot& loot, bool rate, uint16 lootMode, uint8 groupId
             uint32 maxcount = uint32(float(item->maxcount) * sWorld->getRate(RATE_DROP_ITEM_REFERENCED_AMOUNT));
             for (uint32 loop = 0; loop < maxcount; ++loop)      // Ref multiplicator
                 Referenced->Process(loot, rate, lootMode, item->groupid);
+        }
+        else if (item->reference > 0 && item->groupid > 0)          // Grouped references processing
+        {
+            // Todo: process refences of the same group at once rather than seperately
         }
         else                                                    // Plain entries (not a reference, not grouped)
             loot.AddItem(*item);                                // Chance is already checked, just add


### PR DESCRIPTION
**Changes proposed:**

- Disable reference processing for grouped references as this requires a seperate handling
-  _planned_ :fix processing grouped references. Need to find a proper way to gather all grouped references and process them in one strike

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:**
Closes #21725 when finished

**Known issues and TODO list:**
- [x] disable processing of grouped references 
- [ ] add handling for grouped references
