### PR TITLE
Flag Explosive Shot as a negative spell effect. Closes #21922.

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3439,6 +3439,9 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
             // Aspect of the Viper
             if (spellInfo->Id == 34074)
                 return true;
+            // Explosive Shot
+            if (spellInfo->SpellFamilyFlags[1] == SPELLFAMILYFLAG1_HUNTER_EXPLOSIVE_SHOT)
+                return false;
             break;
         case SPELLFAMILY_DRUID:
             // Starfall

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -73,6 +73,9 @@ enum SpellFamilyFlag
     // Warlock
     SPELLFAMILYFLAG_WARLOCK_LIFETAP         = 0x00040000,
 
+    // Hunter
+    SPELLFAMILYFLAG1_HUNTER_EXPLOSIVE_SHOT  = 0x80000000,
+
     // Druid
     SPELLFAMILYFLAG2_DRUID_STARFALL         = 0x00000100,
 


### PR DESCRIPTION
**Changes proposed:**

-  Flag Explosive Shot's only effect as a negative effect in `SpellInfo::_isPositiveEffectImpl()`.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #21922

**Tests performed:**

* Compiled and run.
* Successfully cast Explosive Shot on targets below level 50.

Prior behavior was flagging Explosive Shot as positive, causing downranking. #21922 observed the spell not being usable on targets under level 50 (Rank 1 is a level 60 spell)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
