### PR TITLE
[3.3.5] Core/Loot/Gameobject: Tempspawned Gameobjects after looting

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -752,8 +752,8 @@ void GameObject::Update(uint32 diff)
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
             if (GetSpellId() || GetOwnerGUID())
             {
-                //Don't delete spell spawned chests
-                if (m_respawnTime > 0 && GetGoType() == GAMEOBJECT_TYPE_CHEST)
+                //Don't delete spell spawned chests, which are not consumed on loot
+                if (m_respawnTime > 0 && GetGoType() == GAMEOBJECT_TYPE_CHEST && !GetGOInfo()->IsDespawnAtAction())
                 {
                     UpdateObjectVisibility();
                     SetLootState(GO_READY);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -752,8 +752,17 @@ void GameObject::Update(uint32 diff)
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
             if (GetSpellId() || GetOwnerGUID())
             {
-                SetRespawnTime(0);
-                Delete();
+                //Don't delete spell spawned chests
+                if (m_respawnTime > 0 && GetGoType() == GAMEOBJECT_TYPE_CHEST)
+                {
+                    UpdateObjectVisibility();
+                    SetLootState(GO_READY);
+                }
+                else
+                {
+                    SetRespawnTime(0);
+                    Delete();
+                }
                 return;
             }
 


### PR DESCRIPTION
This time PR to the correct branch!

Thanks to @runningnak3d #17256 for the groundwork.

This fixes summoned chest game objects for both quests where the chest should stay after looting and where it should despawn on the first loot.

Target branch(es): 3.3.5/master
- 3.3.5

Issues addressed: Closes # (insert issue tracker number)
#12842

Tests performed: (Does it build, tested in-game, etc.)
builds and works in-game

Quests tested
https://wotlk.evowow.com/?quest=5803
https://wotlk.evowow.com/?quest=10997
https://wotlk.evowow.com/?quest=10995
https://wotlk.evowow.com/?quest=10996
https://wotlk.evowow.com/?quest=4021
Game object stays and can be relooted.

https://wotlk.evowow.com/?quest=10514
https://wotlk.evowow.com/?quest=12828
https://wotlk.evowow.com/?quest=10629
https://wotlk.evowow.com/?quest=4726
Game object despawns on loot.