### PR TITLE
[3.3.5] Core/Spell: Chain heal won't bounce on 100% hp targets 

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1931,7 +1931,7 @@ void Spell::SearchChainTargets(std::list<WorldObject*>& targets, uint32 chainTar
                 if (Unit* unit = (*itr)->ToUnit())
                 {
                     uint32 deficit = unit->GetMaxHealth() - unit->GetHealth();
-                    if ((deficit > maxHPDeficit || foundItr == tempTargets.end()) && target->IsWithinDist(unit, jumpRadius) && target->IsWithinLOSInMap(unit, LINEOFSIGHT_ALL_CHECKS, VMAP::ModelIgnoreFlags::M2))
+                    if (deficit > maxHPDeficit && target->IsWithinDist(unit, jumpRadius) && target->IsWithinLOSInMap(unit, LINEOFSIGHT_ALL_CHECKS, VMAP::ModelIgnoreFlags::M2))
                     {
                         foundItr = itr;
                         maxHPDeficit = deficit;


### PR DESCRIPTION
**Changes proposed:**
Chain heal should not bounce on targets with 100% hp, rather stop early, or not bounce at all if cast in a fully healed raid.
It's been a while since I fixed this issue, so I don't have any reference videos anymore.
This matters as rshamans get incorrect procs of Improved Water Shield.

The condition I removed translates to "pick the first target in the list, no matter what", while now it's picking the highest hp deficit target every bounce.

**Target branch(es):**
- [x] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.)
Builds and works in-game
