### PR TITLE
Core/Spells: Add helper to reset proc cooldowns directly

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1990,6 +1990,11 @@ void Aura::AddProcCooldown(std::chrono::steady_clock::time_point cooldownEnd)
     m_procCooldown = cooldownEnd;
 }
 
+void Aura::ResetProcCooldown()
+{
+    m_procCooldown = std::chrono::steady_clock::now();
+}
+
 void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, std::chrono::steady_clock::time_point now)
 {
     bool prepare = CallScriptPrepareProcHandlers(aurApp, eventInfo);

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -216,6 +216,7 @@ class TC_GAME_API Aura
 
         bool IsProcOnCooldown(std::chrono::steady_clock::time_point now) const;
         void AddProcCooldown(std::chrono::steady_clock::time_point cooldownEnd);
+        void ResetProcCooldown();
         bool IsUsingCharges() const { return m_isUsingCharges; }
         void SetUsingCharges(bool val) { m_isUsingCharges = val; }
         void PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, std::chrono::steady_clock::time_point now);


### PR DESCRIPTION
**Changes proposed:**

-  implement a helper to allow us to reset proc cooldowns manually. This helper is most likely needed for mechanics that are suposed to reset a proc cooldown via script. Most likely a must-have for 4.x and above

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame.
