### PR TITLE
[master] Core/Player: Old expansion raid instance boot prevention for solo players

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -19789,7 +19789,7 @@ bool Player::CheckInstanceValidity(bool /*isLogin*/)
         return true;
 
     // raid instances require the player to be in a raid group to be valid
-    if (map->IsRaid() && !sWorld->getBoolConfig(CONFIG_INSTANCE_IGNORE_RAID))
+    if (map->IsRaid() && !sWorld->getBoolConfig(CONFIG_INSTANCE_IGNORE_RAID) && (map->GetEntry()->Expansion() >= sWorld->getIntConfig(CONFIG_EXPANSION)))
         if (!GetGroup() || !GetGroup()->isRaidGroup())
             return false;
 


### PR DESCRIPTION
**Changes proposed:**

-  Fix an issue where players were met with a "homebind" prompt when entering an old expansion raid instance without being in a raid group.


**Target branch(es):**
- [ ] 3.3.5
- [x] master


**Issues addressed:** No issues submitted


**Tests performed:**
* Teleport to argent tournament grounds in Northrend (.tele argenttournament)
* Enter the Trial of the Crusader raid on any difficulty
* No longer met with a "homebind" prompt once inside the instance.


**Known issues and TODO list:** None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
