### PR TITLE
Core/Player: Send Instance greet message depending on the actual map difficulty, not the players preferred map difficulty

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -175,7 +175,7 @@ void WorldSession::HandleMoveWorldportAck()
     if (mInstance)
     {
         // check if this instance has a reset time and send it to player if so
-        Difficulty diff = GetPlayer()->GetDifficultyID(mEntry);
+        Difficulty diff = newMap->GetDifficultyID();
         if (MapDifficultyEntry const* mapDiff = sDB2Manager.GetMapDifficultyData(mEntry->ID, diff))
         {
             if (mapDiff->GetRaidDuration())


### PR DESCRIPTION
**Changes proposed:**

-  Fix an issue where either an invalid, or no instance greet message was shown to the player entering a dungeon, when the dungeon difficulty was changed due to a difficulty fallback scenario, when entering an instance.


**Target branch(es):**
- [ ] 3.3.5 (Someone able to verify if this is valid for 3.3.5 as well?)
- [x] master


**Issues addressed:** No issues submitted


**Tests performed:**
* Teleport to Utgarde Keep in Northrend (.tele utgardekeep)
* Enter Utgarde Keep with X dungeon difficulty selected in the UI.
##### Before
  * Normal, result:
  * Heroic, result: Welcome to Utgarde Keep (Heroic). Instance locks are scheduled to expire in Y.
  * Mythic (Unsupported difficulty, fallback to Heroic), result:

##### After
  * Normal, result:
  * Heroic, result: Welcome to Utgarde Keep (Heroic). Instance locks are scheduled to expire in Y.
  * Mythic (Unsupported difficulty, fallback to Heroic), result: Welcome to Utgarde Keep (Heroic). Instance locks are scheduled to expire in Y.

Same tests were performed on live servers, and the After result correctly mimics the live server behavior.

**Known issues and TODO list:** None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
