### PR TITLE
Core/GameObject: Set SpellVisualID to capturePoint.SpellVisual1 when creating Capture Points

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -360,6 +360,9 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
         case GAMEOBJECT_TYPE_PHASEABLE_MO:
             SetByteValue(GAMEOBJECT_FLAGS, 1, m_goInfo->phaseableMO.AreaNameSet & 0xF);
             break;
+        case GAMEOBJECT_TYPE_CAPTURE_POINT:
+            SetUInt32Value(GAMEOBJECT_SPELL_VISUAL_ID, m_goInfo->capturePoint.SpellVisual1);
+            break;
         default:
             SetGoAnimProgress(animProgress);
             break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Set GAMEOBJECT_SPELL_VISUAL_ID to m_goInfo->capturePoint.SpellVisual1 when creating a gameobject of type CAPTURE_POINT

**Target branch(es):** 3.3.5/master

- master

**Issues addressed:** Closes none


**Tests performed:** (Does it build, tested in-game, etc.)
- Builds
- Tested in game by adding a gameobject and checking if the spellvisual was set (.gob add 227420)

in case you are missing it
```sql
INSERT INTO `gameobject_template` VALUES (227420, 42, 21202, 'Capture Point', '', '', '', 1, 60000, 0, 1, 2178, 10200, 10204, 10201, 10199, 10203, 10202, 5834, 28523, 28527, 28525, 28522, 28526, 28524, 42975, 42976, 42978, 42979, 42980, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', 26124);
```
**Known issues and TODO list:** (add/remove lines as needed)
- Unsure about respawning (my guess: the spell visual resets to SpellVisual1)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
