### PR TITLE
Core/Spells: Shadow of Death & Spiritual Vengeance should be negative spells (BlackTemple/Teron Gorefiend)

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3398,6 +3398,7 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
         case SPELLFAMILY_GENERIC:
             switch (spellInfo->Id)
             {
+                case 40268: // Spiritual Vengeance, Teron Gorefiend, Black Temple
                 case 61987: // Avenging Wrath Marker
                 case 61988: // Divine Shield exclude aura
                 case 72410: // Rune of Blood, Saurfang, Icecrown Citadel
@@ -3413,6 +3414,11 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
                 default:
                     break;
             }
+            break;
+        case SPELLFAMILY_ROGUE:
+            // Shadow of Death, Teron Gorefiend, Black Temple
+            if (spellInfo->Id == 40251)
+                return false;
             break;
         case SPELLFAMILY_MAGE:
             // Amplify Magic, Dampen Magic


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Auras:
-  ID - 40268 Spiritual Vengeance
-  ID - 40251 Shadow of Death
 
Should be negative.

I put 40251 in SPELLFAMILY_ROGUE because:
```
ID - 40251 Shadow of Death
=================================================
Description: The shadow of death looms.  Kills the target after $d.
ToolTip: The shadowy fingers of death close around you.
Category = 0, SpellIconID = 2126, activeIconID = 0, SpellVisual = (8927,0)
Family SPELLFAMILY_ROGUE, flag [0] 0x00000000 [1] 0x00000000 [2] 0x00000000
```
and only works here
I can change spellfamily in spellmgr.cpp....but seems hacky 😄 

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes: #22160 
Closes: #22161

**Tests performed:**

Tested in-game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
