### PR TITLE
Fix SMSG_GUILD_BANK_LIST packet payload for enchantments and sockets

### DIFF
--- a/src/server/game/Guilds/Guild.cpp
+++ b/src/server/game/Guilds/Guild.cpp
@@ -497,18 +497,18 @@ bool Guild::BankTab::WriteSlotPacket(WorldPacket& data, uint8 slotId, bool ignor
             data << uint32(0);
 
         data << uint32(pItem->GetCount());                  // ITEM_FIELD_STACK_COUNT
-        data << uint32(0);
+        data << uint32(pItem->GetEnchantmentId(PERM_ENCHANTMENT_SLOT)); // Permanent enchantment
         data << uint8(abs(pItem->GetSpellCharges()));       // Spell charges
 
         uint8 enchCount = 0;
         size_t enchCountPos = data.wpos();
 
         data << uint8(enchCount);                           // Number of enchantments
-        for (uint32 i = PERM_ENCHANTMENT_SLOT; i < MAX_ENCHANTMENT_SLOT; ++i)
+        for (uint32 socketSlot = SOCK_ENCHANTMENT_SLOT; socketSlot < SOCK_ENCHANTMENT_SLOT + MAX_GEM_SOCKETS; ++socketSlot)
         {
-            if (uint32 enchId = pItem->GetEnchantmentId(EnchantmentSlot(i)))
+            if (uint32 enchId = pItem->GetEnchantmentId(EnchantmentSlot(socketSlot)))
             {
-                data << uint8(i);
+                data << uint8(socketSlot - SOCK_ENCHANTMENT_SLOT);
                 data << uint32(enchId);
                 ++enchCount;
             }


### PR DESCRIPTION
Changes proposed:

Filling missing data for packet SMSG_GUILD_BANK_LIST in regards to enchantments

Target branch(es): 3.3.5

Issues addressed: Closes #5504
When item has 3 socket slots, and they are socketed, they will now display properly.

Tests performed: (Does it build, tested in-game, etc.)
https://imgur.com/a/C5LZ9bF