### PR TITLE
Scripts/Spells: Glyph of Holy Light

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -792,6 +792,7 @@ class spell_pal_glyph_of_holy_light : public SpellScriptLoader
             {
                 uint32 const maxTargets = GetSpellInfo()->MaxAffectedTargets;
 
+                targets.remove(GetCaster());
                 if (targets.size() > maxTargets)
                 {
                     targets.sort(Trinity::HealthPctOrderPred());
@@ -833,8 +834,15 @@ class spell_pal_glyph_of_holy_light_dummy : public SpellScriptLoader
                 if (!healInfo || !healInfo->GetHeal())
                     return;
 
+                uint32 basePoints = healInfo->GetSpellInfo()->Effects[EFFECT_0].BasePoints + healInfo->GetSpellInfo()->Effects[EFFECT_0].DieSides;
+                uint32 healAmount;
+                if (healInfo->GetEffectiveHeal() >= basePoints)
+                    healAmount = healInfo->GetEffectiveHeal();
+                else
+                    healAmount = healInfo->GetHeal();
+
                 CastSpellExtraArgs args(aurEff);
-                args.AddSpellBP0(CalculatePct(healInfo->GetHeal(), aurEff->GetAmount()));
+                args.AddSpellBP0(CalculatePct(healAmount, aurEff->GetAmount()));
                 eventInfo.GetActor()->CastSpell(eventInfo.GetProcTarget(), SPELL_PALADIN_GLYPH_OF_HOLY_LIGHT_HEAL, args);
             }
 


### PR DESCRIPTION
**Changes proposed:**
- [Heal](https://woehead.way-of-elendil.fr/?spell=54968) can not be applied to the caster itself.
- Heal amount is a bit tricky part. Before changes it just took 10% from all healing done by [Holy Light](https://woehead.way-of-elendil.fr/?spell=48782). Instead, if effective healing of Holy Light is greater or equal to it's base part then Glyph of Holy Light should take 10% from effective amount. And only in other cases 10% from all healing done is taken.

**Target branch(es):** 3.3.5

**Tests performed:** Tested in game.
