### PR TITLE
Core/Spells: do not set the focus on target tracking channeled spells before channeling starts

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3067,7 +3067,7 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
         {
             if (m_targets.GetObjectTarget() && m_caster != m_targets.GetObjectTarget())
                 m_caster->ToCreature()->FocusTarget(this, m_targets.GetObjectTarget());
-            else if (m_spellInfo->HasAttribute(SPELL_ATTR5_DONT_TURN_DURING_CAST))
+            else if (m_spellInfo->HasAttribute(SPELL_ATTR5_DONT_TURN_DURING_CAST) && !m_spellInfo->HasAttribute(SPELL_ATTR1_CHANNEL_TRACK_TARGET))
                 m_caster->ToCreature()->FocusTarget(this, nullptr);
         }
 


### PR DESCRIPTION
- Fixes an issue that was causing asynch clientside and server side facing getting asynch because some channeled tracking target spells select their channel target after a cast time so we do not set the focus yet and let SendChannelStart do the actual focusing instead.

For example you have an spell with a cast time and with attributes

- SPELL_ATTR1_CHANNELED_1, SPELL_ATTR1_CHANNEL_TRACK_TARGET
- SPELL_ATTR5_DONT_TURN_DURING_CAST

and TARGET_UNIT_NEARBY_ENTRY as channel target. By blocking the focusing before the channel starts we prevent a collision with SPELL_ATTR5_DONT_TURN_DURING_CAST that will lock our focus on the caster's current victim instead of the channel target which will cause asynch serverside / clientside facing and thus some ugly bugs.

And hi Trokli :*