### PR TITLE
Removed a condition which blocked resummoning permanent pets after teleport.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1717,7 +1717,6 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
                 UnsummonPetTemporaryIfAny();
         }
 
-
         if (!(options & TELE_TO_NOT_LEAVE_COMBAT))
             CombatStop();
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1710,12 +1710,9 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             return true;
         }
 
-        if (!(options & TELE_TO_NOT_UNSUMMON_PET))
-        {
-            //same map, only remove pet if out of range for new position
-            if (pet && !pet->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
-                UnsummonPetTemporaryIfAny();
-        }
+        //same map, only remove pet if out of range for new position
+        if (pet && !pet->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
+            UnsummonPetTemporaryIfAny();
 
         if (!(options & TELE_TO_NOT_LEAVE_COMBAT))
             CombatStop();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1710,9 +1710,13 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             return true;
         }
 
-        //same map, only remove pet if out of range for new position
-        if (pet && !pet->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
-            UnsummonPetTemporaryIfAny();
+        if (!(options & TELE_TO_NOT_UNSUMMON_PET))
+        {
+            //same map, only remove pet if out of range for new position
+            if (pet && !pet->IsWithinDist3d(x, y, z, GetMap()->GetVisibilityRange()))
+                UnsummonPetTemporaryIfAny();
+        }
+
 
         if (!(options & TELE_TO_NOT_LEAVE_COMBAT))
             CombatStop();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12706,7 +12706,7 @@ void Unit::NearTeleportTo(Position const& pos, bool casting /*= false*/)
     if (GetTypeId() == TYPEID_PLAYER)
     {
         WorldLocation target(GetMapId(), pos);
-        ToPlayer()->TeleportTo(target, TELE_TO_NOT_LEAVE_TRANSPORT | TELE_TO_NOT_LEAVE_COMBAT | TELE_TO_NOT_UNSUMMON_PET | (casting ? TELE_TO_SPELL : 0));
+        ToPlayer()->TeleportTo(target, TELE_TO_NOT_LEAVE_TRANSPORT | TELE_TO_NOT_LEAVE_COMBAT | (casting ? TELE_TO_SPELL : 0));
     }
     else
     {


### PR DESCRIPTION
**Changes proposed:**
Removed a condition checking m_teleport_options and a constant which always seems to test false.  Original intent of the condition is unknown, although the alternate code which fires when a new map is loaded does not have this condition.

**Target branch(es):** 3.3.5/master

- [ x] 3.3.5
- [ ] master

**Issues addressed:** 
I didn't see any issues related to this.  I can add one if necessary.

**Tests performed:** (Does it build, tested in-game, etc.)
Builds successfully.  
Pets are successfully resummoned after teleport.  
Player death and pet death correctly require the pet to be resummoned.  
Behavior of non-combat pets is unchanged between commits - companions must be resummoned in all cases.
