### PR TITLE
[3.3.5] Map-wide update ticks

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1069,19 +1069,9 @@ void WorldObject::setActive(bool on)
         return;
 
     if (on)
-    {
-        if (GetTypeId() == TYPEID_UNIT)
-            map->AddToActive(ToCreature());
-        else if (GetTypeId() == TYPEID_DYNAMICOBJECT)
-            map->AddToActive((DynamicObject*)this);
-    }
+        map->AddToActive(this);
     else
-    {
-        if (GetTypeId() == TYPEID_UNIT)
-            map->RemoveFromActive(ToCreature());
-        else if (GetTypeId() == TYPEID_DYNAMICOBJECT)
-            map->RemoveFromActive((DynamicObject*)this);
-    }
+        map->RemoveFromActive(this);
 }
 
 void WorldObject::SetFarVisible(bool on)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25610,14 +25610,8 @@ void Player::RemoveAtLoginFlag(AtLoginFlags flags, bool persist /*= false*/)
 
 void Player::ResetMap()
 {
-    // this may be called during Map::Update
-    // after decrement+unlink, ++m_mapRefIter will continue correctly
-    // when the first element of the list is being removed
-    // nocheck_prev will return the padding element of the RefManager
-    // instead of nullptr in the case of prev
-    GetMap()->UpdateIteratorBack(this);
     Unit::ResetMap();
-    GetMapRef().unlink();
+    m_mapRef.unlink();
 }
 
 void Player::SetMap(Map* map)

--- a/src/server/game/Grids/Dynamic/TypeContainer.h
+++ b/src/server/game/Grids/Dynamic/TypeContainer.h
@@ -86,23 +86,15 @@ template<class OBJECT_TYPES>
 class TypeMapContainer
 {
     public:
-        template<class SPECIFIC_TYPE> size_t Count() const { return Trinity::Count(i_elements, (SPECIFIC_TYPE*)nullptr); }
+        template<class SPECIFIC_TYPE> size_t Count() const { return TypeContainer::Count(i_elements, (SPECIFIC_TYPE*)nullptr); }
 
         /// inserts a specific object into the container
         template<class SPECIFIC_TYPE>
         bool insert(SPECIFIC_TYPE *obj)
         {
-            SPECIFIC_TYPE* t = Trinity::Insert(i_elements, obj);
+            SPECIFIC_TYPE* t = TypeContainer::Insert(i_elements, obj);
             return (t != nullptr);
         }
-
-        ///  Removes the object from the container, and returns the removed object
-        //template<class SPECIFIC_TYPE>
-        //bool remove(SPECIFIC_TYPE* obj)
-        //{
-        //    SPECIFIC_TYPE* t = Trinity::Remove(i_elements, obj);
-        //    return (t != nullptr);
-        //}
 
         ContainerMapList<OBJECT_TYPES> & GetElements(void) { return i_elements; }
         const ContainerMapList<OBJECT_TYPES> & GetElements(void) const { return i_elements;}
@@ -118,19 +110,19 @@ public:
     template<class SPECIFIC_TYPE>
     bool Insert(KEY_TYPE const& handle, SPECIFIC_TYPE* obj)
     {
-        return Trinity::Insert(_elements, handle, obj);
+        return TypeContainer::Insert(_elements, handle, obj);
     }
 
     template<class SPECIFIC_TYPE>
     bool Remove(KEY_TYPE const& handle)
     {
-        return Trinity::Remove(_elements, handle, (SPECIFIC_TYPE*)nullptr);
+        return TypeContainer::Remove(_elements, handle, (SPECIFIC_TYPE*)nullptr);
     }
 
     template<class SPECIFIC_TYPE>
     SPECIFIC_TYPE* Find(KEY_TYPE const& handle)
     {
-        return Trinity::Find(_elements, handle, (SPECIFIC_TYPE*)nullptr);
+        return TypeContainer::Find(_elements, handle, (SPECIFIC_TYPE*)nullptr);
     }
 
     ContainerUnorderedMap<OBJECT_TYPES, KEY_TYPE>& GetElements() { return _elements; }

--- a/src/server/game/Grids/Dynamic/TypeContainerFunctions.h
+++ b/src/server/game/Grids/Dynamic/TypeContainerFunctions.h
@@ -30,7 +30,7 @@
 #include <map>
 #include <unordered_map>
 
-namespace Trinity
+namespace TypeContainer
 {
     // Helpers
     // Insert helpers
@@ -187,30 +187,5 @@ namespace Trinity
         SPECIFIC_TYPE* t = Insert(elements._elements, obj);
         return (t != nullptr ? t : Insert(elements._TailElements, obj));
     }
-
-    //// non-const remove method
-    //template<class SPECIFIC_TYPE> SPECIFIC_TYPE* Remove(ContainerMapList<SPECIFIC_TYPE> & /*elements*/, SPECIFIC_TYPE *obj)
-    //{
-    //    obj->GetGridRef().unlink();
-    //    return obj;
-    //}
-
-    //template<class SPECIFIC_TYPE> SPECIFIC_TYPE* Remove(ContainerMapList<TypeNull> &/*elements*/, SPECIFIC_TYPE * /*obj*/)
-    //{
-    //    return nullptr;
-    //}
-
-    //// this is a missed
-    //template<class SPECIFIC_TYPE, class T> SPECIFIC_TYPE* Remove(ContainerMapList<T> &/*elements*/, SPECIFIC_TYPE * /*obj*/)
-    //{
-    //    return nullptr;                                        // a missed
-    //}
-
-    //template<class SPECIFIC_TYPE, class T, class H> SPECIFIC_TYPE* Remove(ContainerMapList<TypeList<H, T> > &elements, SPECIFIC_TYPE *obj)
-    //{
-    //    // The head element is bad
-    //    SPECIFIC_TYPE* t = Remove(elements._elements, obj);
-    //    return (t != nullptr ? t : Remove(elements._TailElements, obj));
-    //}
 }
 #endif

--- a/src/server/game/Grids/Dynamic/TypeContainerVisitor.h
+++ b/src/server/game/Grids/Dynamic/TypeContainerVisitor.h
@@ -32,28 +32,28 @@
 template<class T, class Y> class TypeContainerVisitor;
 
 // visitor helper
-template<class VISITOR, class TYPE_CONTAINER> void VisitorHelper(VISITOR &v, TYPE_CONTAINER &c)
+template<class VISITOR, class TYPE_CONTAINER> void VisitorHelper(VISITOR& v, TYPE_CONTAINER& c)
 {
     v.Visit(c);
 }
 
 // terminate condition container map list
-template<class VISITOR> void VisitorHelper(VISITOR &/*v*/, ContainerMapList<TypeNull> &/*c*/) { }
+template<class VISITOR> void VisitorHelper(VISITOR&, ContainerMapList<TypeNull>&) { }
 
-template<class VISITOR, class T> void VisitorHelper(VISITOR &v, ContainerMapList<T> &c)
+template<class VISITOR, class T> void VisitorHelper(VISITOR &v, ContainerMapList<T>& c)
 {
     v.Visit(c._element);
 }
 
 // recursion container map list
-template<class VISITOR, class H, class T> void VisitorHelper(VISITOR &v, ContainerMapList<TypeList<H, T> > &c)
+template<class VISITOR, class H, class T> void VisitorHelper(VISITOR &v, ContainerMapList<TypeList<H,T>>& c)
 {
     VisitorHelper(v, c._elements);
     VisitorHelper(v, c._TailElements);
 }
 
 // for TypeMapContainer
-template<class VISITOR, class OBJECT_TYPES> void VisitorHelper(VISITOR &v, TypeMapContainer<OBJECT_TYPES> &c)
+template<class VISITOR, class OBJECT_TYPES> void VisitorHelper(VISITOR &v, TypeMapContainer<OBJECT_TYPES>& c)
 {
     VisitorHelper(v, c.GetElements());
 }
@@ -92,12 +92,18 @@ class TypeContainerVisitor
             VisitorHelper(i_visitor, c);
         }
 
-        void Visit(TYPE_CONTAINER const& c) const
-        {
-            VisitorHelper(i_visitor, c);
-        }
-
     private:
         VISITOR &i_visitor;
 };
+
+namespace TypeContainer
+{
+    // visit helper
+    template <class VISITOR, class CONTAINER>
+    void Visit(CONTAINER& c, VISITOR& v)
+    {
+        TypeContainerVisitor<VISITOR, CONTAINER>(v).Visit(c);
+    }
+}
+
 #endif

--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -398,14 +398,6 @@ MessageDistDeliverer::VisitObject(Player* player)
 }
 */
 
-template<class T>
-void ObjectUpdater::Visit(GridRefManager<T> &m)
-{
-    for (typename GridRefManager<T>::iterator iter = m.begin(); iter != m.end(); ++iter)
-        if (iter->GetSource()->IsInWorld())
-            iter->GetSource()->Update(i_timeDiff);
-}
-
 bool AnyDeadUnitObjectInRangeCheck::operator()(Player* u)
 {
     return !u->IsAlive() && !u->HasAuraType(SPELL_AURA_GHOST) && i_searchObj->IsWithinDistInMap(u, i_range);
@@ -435,7 +427,3 @@ bool AnyDeadUnitSpellTargetInRangeCheck::operator()(Creature* u)
 {
     return AnyDeadUnitObjectInRangeCheck::operator()(u) && WorldObjectSpellTargetCheck::operator()(u);
 }
-
-template void ObjectUpdater::Visit<Creature>(CreatureMapType&);
-template void ObjectUpdater::Visit<GameObject>(GameObjectMapType&);
-template void ObjectUpdater::Visit<DynamicObject>(DynamicObjectMapType&);

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -177,15 +177,6 @@ namespace Trinity
         }
     };
 
-    struct ObjectUpdater
-    {
-        uint32 i_timeDiff;
-        explicit ObjectUpdater(const uint32 diff) : i_timeDiff(diff) { }
-        template<class T> void Visit(GridRefManager<T> &m);
-        void Visit(PlayerMapType &) { }
-        void Visit(CorpseMapType &) { }
-    };
-
     // SEARCHERS & LIST SEARCHERS & WORKERS
 
     // WorldObject searchers & workers

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -826,8 +826,6 @@ void Map::ProcessRelocationNotifies(const uint32 diff)
         {
             for (uint32 y = cell_min.y_coord; y < cell_max.y_coord; ++y)
             {
-                uint32 cell_id = (y * TOTAL_NUMBER_OF_CELLS_PER_MAP) + x;
-
                 CellCoord pair(x, y);
                 Cell cell(pair);
                 cell.SetNoCreate();
@@ -865,9 +863,6 @@ void Map::ProcessRelocationNotifies(const uint32 diff)
         {
             for (uint32 y = cell_min.y_coord; y < cell_max.y_coord; ++y)
             {
-                uint32 cell_id = (y * TOTAL_NUMBER_OF_CELLS_PER_MAP) + x;
-                    continue;
-
                 CellCoord pair(x, y);
                 Cell cell(pair);
                 cell.SetNoCreate();

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -62,7 +62,6 @@ struct ScriptAction;
 struct ScriptInfo;
 struct SummonPropertiesEntry;
 enum Difficulty : uint8;
-namespace Trinity { struct ObjectUpdater; }
 namespace VMAP { enum class ModelIgnoreFlags : uint32; }
 
 struct ScriptAction


### PR DESCRIPTION
We currently do a bunch of iterating over all players and active objects and transports in the map, and then we iterate over all grids near each of these, and then we check if that grid has had an update tick already, and _then_ if it hasn't we finally do the update tick.

All of that is a ton of pointless work, and still it leads to eternal bugs.

We're ripping all of that out. Updates now happen for everything that's loaded.