### PR TITLE
Core/Packets: Reduce memory footprint of cached queries

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -216,6 +216,7 @@ WorldPacket CreatureTemplate::BuildQueryData(LocaleConstant loc) const
 
     queryTemp.Stats.CreatureMovementInfoID = movementId;
     queryTemp.Write();
+    queryTemp.ShrinkToFit();
     return queryTemp.Move();
 }
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -83,6 +83,7 @@ WorldPacket GameObjectTemplate::BuildQueryData(LocaleConstant loc) const
                 queryTemp.Stats.QuestItems[i] = (*items)[i];
 
     queryTemp.Write();
+    queryTemp.ShrinkToFit();
     return queryTemp.Move();
 }
 

--- a/src/server/game/Entities/Item/ItemTemplate.cpp
+++ b/src/server/game/Entities/Item/ItemTemplate.cpp
@@ -267,5 +267,6 @@ WorldPacket ItemTemplate::BuildQueryData(LocaleConstant loc) const
     response.Stats.HolidayId = HolidayId;
 
     response.Write();
+    response.ShrinkToFit();
     return response.Move();
 }

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -429,6 +429,7 @@ WorldPacket Quest::BuildQueryData(LocaleConstant loc) const
         response.Info.ObjectiveText[i] = locQuestObjectiveText[i];
 
     response.Write();
+    response.ShrinkToFit();
     return response.Move();
 }
 

--- a/src/server/game/Server/Packet.h
+++ b/src/server/game/Server/Packet.h
@@ -51,6 +51,7 @@ namespace WorldPackets
 
         void Clear() { _worldPacket.clear(); }
         WorldPacket&& Move() { return std::move(_worldPacket); }
+        void ShrinkToFit() { _worldPacket.shrink_to_fit(); }
 
         OpcodeServer GetOpcode() const { return OpcodeServer(_worldPacket.GetOpcode()); }
     };

--- a/src/server/shared/Packets/ByteBuffer.h
+++ b/src/server/shared/Packets/ByteBuffer.h
@@ -413,6 +413,11 @@ class TC_SHARED_API ByteBuffer
                 _storage.reserve(ressize);
         }
 
+        void shrink_to_fit()
+        {
+            _storage.shrink_to_fit();
+        }
+
         void append(const char *src, size_t cnt)
         {
             return append((const uint8 *)src, cnt);


### PR DESCRIPTION
Ensure only the minimum required memory is used by caching query packets by calling shrink_to_fit()

-  call shrink_to_fit() to the underlying storage of cached queries packets

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
None (or can't find the discussion about it anymore)

**Tests performed:** (Does it build, tested in-game, etc.)
It builds, logged ingame, talked to a NPC and it offered a quest.

Memory used in Release x64:
- without caching: 997 MB
- old code: 2428 MB
- new code: 1339 MB

**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
