### PR TITLE
Core/Maps: initialize PositionFullTerrainStatus

### DIFF
--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -177,6 +177,7 @@ struct PositionFullTerrainStatus
         uint32 const mogpFlags;
     };
 
+    PositionFullTerrainStatus() : areaId(0), floorZ(0.0f), outdoors(true) { }
     uint32 areaId;
     float floorZ;
     bool outdoors;


### PR DESCRIPTION
**Changes proposed:**
-  Initialize stuff that obviously should get initialized at its current usage

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**
- Getting rid of super weird areaID returns under some very special circumstances
- Getting rid of unintended dismounting when outdoor state is getting set to false due to missing initialization.

**Tests performed:**
- Tested ingame, areaID in named case is now returned properly.

