### PR TITLE
Core/LFG: fixed random dungeon cooldown

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -960,10 +960,12 @@ void LFGMgr::MakeNewGroup(LfgProposal const& proposal)
         // Add the cooldown spell if queued for a random dungeon
         const LfgDungeonSet& dungeons = GetSelectedDungeons(player->GetGUID());
         if (!dungeons.empty())
-            if (uint32 rDungeonId = (*dungeons.begin()))
-                if (LFGDungeonEntry const* dungeon = sLFGDungeonStore.LookupEntry(rDungeonId))
-                    if (dungeon->type == LFG_TYPE_RANDOM)
-                        player->CastSpell(player, LFG_SPELL_DUNGEON_COOLDOWN, false);
+        {
+            uint32 rDungeonId = (*dungeons.begin());
+            LFGDungeonEntry const* dungeon = sLFGDungeonStore.LookupEntry(rDungeonId);
+            if (dungeon && dungeon->type == LFG_TYPE_RANDOM)
+                player->CastSpell(player, LFG_SPELL_DUNGEON_COOLDOWN, false);
+        }
     }
 
     ASSERT(grp);

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -958,8 +958,12 @@ void LFGMgr::MakeNewGroup(LfgProposal const& proposal)
         grp->SetLfgRoles(pguid, proposal.players.find(pguid)->second.role);
 
         // Add the cooldown spell if queued for a random dungeon
-        if (dungeon->type == LFG_TYPE_RANDOM)
-            player->CastSpell(player, LFG_SPELL_DUNGEON_COOLDOWN, false);
+        const LfgDungeonSet& dungeons = GetSelectedDungeons(player->GetGUID());
+        if (!dungeons.empty())
+            if (uint32 rDungeonId = (*dungeons.begin()))
+                if (LFGDungeonEntry const* dungeon = sLFGDungeonStore.LookupEntry(rDungeonId))
+                    if (dungeon->type == LFG_TYPE_RANDOM)
+                        player->CastSpell(player, LFG_SPELL_DUNGEON_COOLDOWN, false);
     }
 
     ASSERT(grp);


### PR DESCRIPTION
The issue was that queuing up for random dungeons puts you into a queue for a already selected dungeon from the beginning so the dungeonId that we use here is actually the dungeonId that we will enter when our group is complete. We change that and use our selected dungeons as reference instead which contains the random dungeon at the very beginning (if we queued up for random dungeons so we check that too).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #14155
Ref #14331

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame, works for me (tm)

![wowscrnshot_082718_192838](https://user-images.githubusercontent.com/18347559/44676488-b914c400-aa33-11e8-8a70-cb50b87b7fa4.jpg)
