### PR TITLE
[WIP] Core/Chat Add a "CommandArgs" helper to deal with command parameters

### DIFF
--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -193,6 +193,24 @@ inline bool isNumeric(char const* str)
     return true;
 }
 
+inline bool isSignedNumeric(char const* str)
+{
+    for (char const* c = str; *c; ++c)
+        if (!isNumeric(*c) && *c != '-' && *c != '+')
+            return false;
+
+    return true;
+}
+
+inline bool isDecimal(char const* str)
+{
+    for (char const* c = str; *c; ++c)
+        if (!isNumeric(*c) && *c != '-' && *c != '+' && *c != '.')
+            return false;
+
+    return true;
+}
+
 inline bool isNumericOrSpace(wchar_t wchar)
 {
     return isNumeric(wchar) || wchar == L' ';

--- a/src/server/scripts/Commands/cs_go.cpp
+++ b/src/server/scripts/Commands/cs_go.cpp
@@ -168,7 +168,7 @@ public:
     {
         Player* player = handler->GetSession()->GetPlayer();
 
-        CommandArgs commandArgs = CommandArgs(handler, args, { CommandArgs::ARG_UINT });
+        CommandArgs commandArgs = CommandArgs(handler, args, { COMMAND_ARG_UINT });
 
         if (commandArgs.ValidArgs())
             return false;

--- a/src/server/scripts/Commands/cs_go.cpp
+++ b/src/server/scripts/Commands/cs_go.cpp
@@ -168,14 +168,12 @@ public:
     {
         Player* player = handler->GetSession()->GetPlayer();
 
-        if (!*args)
+        CommandArgs commandArgs = CommandArgs(handler, args, { CommandArgs::ARG_UINT });
+
+        if (commandArgs.ValidArgs())
             return false;
 
-        char* gyId = strtok((char*)args, " ");
-        if (!gyId)
-            return false;
-
-        uint32 graveyardId = atoul(gyId);
+        uint32 graveyardId = commandArgs.GetNextArg<uint32>();
 
         if (!graveyardId)
             return false;


### PR DESCRIPTION
**Changes proposed:**

- Add a "CommandArgs" class, usable in every command script
- Provide a simpler way to get command parameters, by declaring what you expect and checking what you got
- Support for optional args
- Update HandleGoGraveyardCommand to use this class in order to provide an use case

**Target branch(es):**

- [X] master

**Issues addressed:** None


**Tests performed:** Build, tested ingame with .go graveyard


**Known issues and TODO list:**

- I did not use built-in tokenizer because of limitation when it come to quoted args (iirc you have to know if it's a quoted arg before calling tokenizer, but i may be wrong)
- No issue known, would require testing & improvement ideas (support more "ARG_...", code optimization, ...)
