### PR TITLE
Core/Conditions: allow CONDITION_QUEST_COMPLETE to handle spellclick conditions

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23307,7 +23307,7 @@ void Player::UpdateForQuestWorldObjects()
                 {
                     bool buildUpdateBlock = false;
                     for (ConditionContainer::const_iterator jtr = conds->begin(); jtr != conds->end() && !buildUpdateBlock; ++jtr)
-                        if ((*jtr)->ConditionType == CONDITION_QUESTREWARDED || (*jtr)->ConditionType == CONDITION_QUESTTAKEN)
+                        if ((*jtr)->ConditionType == CONDITION_QUESTREWARDED || (*jtr)->ConditionType == CONDITION_QUESTTAKEN || (*jtr)->ConditionType == CONDITION_QUEST_COMPLETE)
                             buildUpdateBlock = true;
 
                     if (buildUpdateBlock)


### PR DESCRIPTION
This is a needed change in order to make spellclicks functional that are only available when you have a already completed quest.
Needed quite often for 4.x and above but I am pretty sure that 335 has this as well in some scenarios.

**Changes proposed:**

-  CONDITION_QUEST_COMPLETE can now be used to enable / disable spellclicks

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame, works like a charm
