### PR TITLE
Core/Spells: implemented proc flag PROC_FLAG_ON_TICK

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10981,7 +10981,7 @@ void Unit::Kill(Unit* victim, bool durabilityLoss)
     }
 
     if (!victim->IsCritter())
-        ProcSkillsAndAuras(victim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
+        ProcSkillsAndAuras(nullptr, PROC_FLAG_KILL, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
 
     // Proc auras on death - must be before aura/combat remove
     victim->ProcSkillsAndAuras(victim, PROC_FLAG_NONE, PROC_FLAG_DEATH, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -312,6 +312,7 @@ class TC_GAME_API Aura
         int32 m_timeCla;                                    // Timer for power per sec calcultion
         std::vector<SpellPowerEntry const*> m_periodicCosts;// Periodic costs
         int32 m_updateTargetMapInterval;                    // Timer for UpdateTargetMapOfEffect
+        uint32 m_procOnTickTimer;                           // Timer for PROC_FLAG_ON_TICK
 
         uint8 const m_casterLevel;                          // Aura level (store caster level for correct show level dep amount)
         uint8 m_procCharges;                                // Aura charges (0 for infinite)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -454,7 +454,7 @@ bool SpellMgr::CanSpellTriggerProcOnEvent(SpellProcEntry const& procEntry, ProcE
     }
 
     // always trigger for these types
-    if (eventInfo.GetTypeMask() & (PROC_FLAG_KILLED | PROC_FLAG_KILL | PROC_FLAG_DEATH))
+    if (eventInfo.GetTypeMask() & (PROC_FLAG_KILL | PROC_FLAG_DEATH))
         return true;
 
     // do triggered cast checks

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -125,7 +125,8 @@ enum ProcFlags
 {
     PROC_FLAG_NONE                            = 0x00000000,
 
-    PROC_FLAG_KILLED                          = 0x00000001,    // 00 Killed by agressor - not sure about this flag
+    PROC_FLAG_ON_TICK                         = 0x00000001,    // 00 Every tick
+
     PROC_FLAG_KILL                            = 0x00000002,    // 01 Kill target (in most cases need XP/Honor reward)
 
     PROC_FLAG_DONE_MELEE_AUTO_ATTACK          = 0x00000004,    // 02 Done melee auto attack


### PR DESCRIPTION
**Changes proposed:**

-  Implement PROC_FLAG_ON_TICK, was previously named PROC_FLAG_KILLED, which seems to be wrong

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)
https://github.com/TrinityCore/TrinityCore/pull/22194 (has to be ported, but it works the same way in 335)

**Tests performed:** (Does it build, tested in-game, etc.)
Does build, tested ingame with:
42760 Goblin Gumbo
42556 Headless Horseman Climax - Body Regen (removed on death)

**Known issues and TODO list:** (add/remove lines as needed)

TODO:
- [ ] Verify tickrate with multiple sniffs / might also be the case that it's just PROC_ASAP instead of every tick (Headless Horseman would be best to check this I think)
- [ ] Check whether aura or unit update ticks are used for this proc on retail

