### PR TITLE
Core/Spells: fix issues with delayed spells and auras

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2763,7 +2763,7 @@ void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
             bool refresh = false;
 
             // delayed spells with multiple targets need to create a new aura object, otherwise we'll access a deleted aura
-            if (!_spellAura || m_spellInfo->Speed > 0.0f && !m_spellInfo->IsChanneled())
+            if (!_spellAura || (m_spellInfo->Speed > 0.0f && !m_spellInfo->IsChanneled()))
             {
                 bool const resetPeriodicTimer = !(_triggeredCastFlags & TRIGGERED_DONT_RESET_PERIODIC_TIMER);
                 uint8 const allAuraEffectMask = Aura::BuildEffectMaskForOwner(hitInfo.AuraSpellInfo, MAX_EFFECT_MASK, unit);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2763,14 +2763,7 @@ void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
             bool refresh = false;
 
             // delayed spells with multiple targets need to create a new aura object, otherwise we'll access a deleted aura
-            if (m_spellInfo->Speed > 0.0f && !m_spellInfo->IsChanneled())
-            {
-                _spellAura = nullptr;
-                if (Aura* aura = unit->GetAura(m_spellInfo->Id, caster->GetGUID(), m_CastItem ? m_CastItem->GetGUID() : ObjectGuid::Empty, aura_effmask))
-                    _spellAura = aura->ToUnitAura();
-            }
-
-            if (!_spellAura)
+            if (!_spellAura || m_spellInfo->Speed > 0.0f && !m_spellInfo->IsChanneled())
             {
                 bool const resetPeriodicTimer = !(_triggeredCastFlags & TRIGGERED_DONT_RESET_PERIODIC_TIMER);
                 uint8 const allAuraEffectMask = Aura::BuildEffectMaskForOwner(hitInfo.AuraSpellInfo, MAX_EFFECT_MASK, unit);


### PR DESCRIPTION
**Changes proposed:**
Improve upon https://github.com/TrinityCore/TrinityCore/commit/28288698441524081d583af95f19cb1c9fb90387 to restore aura stacking.

The issue with #21609 #21612 was that _spellAura was reused between targets without resetting for the same spell cast.
Ideally I would like to just NULL it between target handling here,
https://github.com/TrinityCore/TrinityCore/blob/a10870571558424033c2ffb41e4759e6581c8d86/src/server/game/Spells/Spell.cpp#L3465
but I don't know what side effects this could cause.

Ariels solution was incomplete as he forced delayed spells into 
https://github.com/TrinityCore/TrinityCore/blob/a10870571558424033c2ffb41e4759e6581c8d86/src/server/game/Spells/Spell.cpp#L2822
this PR switches it into the other block.

**Target branch(es):**
3.3.5

**Issues addressed:** 
Closes #22272

**Tests performed:** (Does it build, tested in-game, etc.)
Builds and works

**Proof of stability**
```
.go instance 619
.cheat god on
```
enter anh'kahet with 2 characters and keybind the following as a macro
```
.cast 33657
.cooldown
```

**Proof of correctness**
```
.go xyz 5811 2747 670 571 (or wherever your favorite empty place)
.npc add 28203
```
keybind the following as a macro, cast 3 times
```
.cast 33657
.cooldown
```
Add a new target and run the macro again, observe proper stacks.
