### PR TITLE
Core/Player: do not expect a MSG_MOVE_TELEPORT_ACK when near-teleporting on transports

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1522,9 +1522,11 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
         SetFallInformation(0, z);
 
         // code for finish transfer called in WorldSession::HandleMovementOpcodes()
-        // at client packet CMSG_MOVE_TELEPORT_ACK
-        SetSemaphoreTeleportNear(true);
-        // near teleport, triggering send CMSG_MOVE_TELEPORT_ACK from client at landing
+        // at client packet MSG_MOVE_TELEPORT_ACK
+        // Near teleports on transports do not send MSG_MOVE_TELEPORT_ACK
+        if (!(options & TELE_TO_NOT_LEAVE_TRANSPORT))
+            SetSemaphoreTeleportNear(true);
+        // near teleport, triggering send MSG_MOVE_TELEPORT_ACK from client at landing
         if (!GetSession()->PlayerLogout())
             SendTeleportPacket(m_teleport_dest);
     }


### PR DESCRIPTION
Tests have shown that the client is smart enough to see that a near teleport ack opcode on the same transport is not necessary so it does not send the ack opcode which causes the core to block all movement packets once a transport repeats its path (eg. Icecrown or Deepholm gunships). This is because the HandleMovementOpcode handler is checking for pending teleports which are usually reset at the ack ocpode handler so it never resets for transports. We simply do not set the teleport flag and it is done.

**Changes proposed:**
-  added a extra check for teleports on transports that will block setting a teleport flag which would break movements entirely due to a missing packet teleport confirmation

**Target branch(es):** master
- master

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame, works for me (tm).
- The first tests were made by checking the incomming opcodes. Near teleporting on the same map such as kalimdor will return the ack opcode as intended.

- The second test was made on a transport. I have been sitting on a transport with two characters and waited until the deepholm gunship repeated its cycle. At the moment this was happening, the teleport flag was added so it blocked all incomming movements which caused players not being able to interact with anything on the transport or leave the transport at all.
- The tests have shown that the ack opcode is not being sent by the client when the player is on a transport which probably indicates a check inside the client that is smart enough to see that using that packet on a transport that cycles is pointless.

