### PR TITLE
Script/Boss: Warchief Rend Blackhand and Gyth improvements

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,4 @@
+UPDATE `creature_template` SET `ScriptName`='' WHERE `entry`=10162;
+UPDATE `creature` SET `ScriptName`='npc_victor_nefarius_brs' WHERE `id`=10162 AND `map`=229;
+UPDATE `creature` SET `ScriptName`='boss_victor_nefarius_bwl' WHERE `id`=10162 AND `map`=469;
+

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
@@ -98,9 +98,6 @@ enum BRSGameObjectsIds
     GO_EMBERSEER_IN                 = 175244, // First door to Pyroguard Emberseer
     GO_DOORS                        = 175705, // Second door to Pyroguard Emberseer
     GO_EMBERSEER_OUT                = 175153, // Door after Pyroguard Emberseer event
-    GO_GYTH_ENTRY_DOOR              = 164726,
-    GO_GYTH_COMBAT_DOOR             = 175185,
-    GO_GYTH_EXIT_DOOR               = 175186,
     GO_DRAKKISATH_DOOR_1            = 175946,
     GO_DRAKKISATH_DOOR_2            = 175947,
     // Runes in dragonspire hall

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/blackrock_spire.h
@@ -51,7 +51,8 @@ enum BRSDataTypes
     DATA_HALL_RUNE_5                = 20,
     DATA_HALL_RUNE_6                = 21,
     DATA_HALL_RUNE_7                = 22,
-    DATA_SCARSHIELD_INFILTRATOR     = 23
+    DATA_SCARSHIELD_INFILTRATOR     = 23,
+    DATA_LORD_VICTOR_NEFARIUS       = 24
 };
 
 enum BRSCreaturesIds

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
@@ -107,34 +107,21 @@ public:
 
             events.Update(diff);
 
-            if (!UpdateVictim())
-            {
-                while (uint32 eventId = events.ExecuteEvent())
-                {
-                    switch (eventId)
-                    {
-                        case EVENT_SUMMONED_1:
-                            me->AddAura(SPELL_REND_MOUNTS, me);
-                            if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(GO_DR_PORTCULLIS)))
-                                portcullis->UseDoorOrButton();
-                            if (Creature* victor = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_LORD_VICTOR_NEFARIUS)))
-                                victor->AI()->SetData(1, 1);
-                            events.ScheduleEvent(EVENT_SUMMONED_2, 2s);
-                            break;
-                        case EVENT_SUMMONED_2:
-                            me->GetMotionMaster()->MovePath(GYTH_PATH_1, false);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                return;
-            }
-
             while (uint32 eventId = events.ExecuteEvent())
             {
                 switch (eventId)
                 {
+                    case EVENT_SUMMONED_1:
+                        me->AddAura(SPELL_REND_MOUNTS, me);
+                        if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(GO_DR_PORTCULLIS)))
+                            portcullis->UseDoorOrButton();
+                        if (Creature* victor = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_LORD_VICTOR_NEFARIUS)))
+                            victor->AI()->SetData(1, 1);
+                        events.ScheduleEvent(EVENT_SUMMONED_2, 2s);
+                        break;
+                    case EVENT_SUMMONED_2:
+                        me->GetMotionMaster()->MovePath(GYTH_PATH_1, false);
+                        break;
                     case EVENT_BREATH:
                         if (breathCombo == 0)
                         {
@@ -142,8 +129,7 @@ public:
                             breathComboSpells[1] = SPELL_FREEZE;
                             breathComboSpells[2] = SPELL_FLAMEBREATH;
                             breathComboSpellsNum = 3;
-                            breathCombo          = 3;
-                            //breathCombo = urand(1, 3);
+                            breathCombo = urand(1, 3);
                         }
 
                         if (0 < breathComboSpellsNum && breathComboSpellsNum <= 3)

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
@@ -146,7 +146,7 @@ public:
                             //breathCombo = urand(1, 3);
                         }
 
-                        if (0 <= breathComboSpellsNum && breathComboSpellsNum <= 3)
+                        if (0 < breathComboSpellsNum && breathComboSpellsNum <= 3)
                         {
                             uint32 spellIndex = urand(0, breathComboSpellsNum - 1);
                             DoCast(me, breathComboSpells[spellIndex]);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
@@ -29,7 +29,6 @@ enum Spells
     SPELL_FLAMEBREATH               = 16390, // Combat (Self cast)
     SPELL_FREEZE                    = 16350, // Combat (Self cast)
     SPELL_KNOCK_AWAY                = 10101, // Combat
-    SPELL_CHROMATIC_CHAOS           = 16337,
     SPELL_SUMMON_REND               = 16328  // Summons Rend near death
 };
 
@@ -38,16 +37,14 @@ enum Misc
     NEFARIUS_PATH_2                 = 1379671,
     NEFARIUS_PATH_3                 = 1379672,
     GYTH_PATH_1                     = 1379681,
-    NEFARIUS_CHROMATIC_CHAOS_LINE   = 9
 };
 
 enum Events
 {
     EVENT_BREATH                    = 1,
     EVENT_KNOCK_AWAY                = 2,
-    EVENT_CHROMATIC_CHAOS           = 3,
-    EVENT_SUMMONED_1                = 4,
-    EVENT_SUMMONED_2                = 5
+    EVENT_SUMMONED_1                = 3,
+    EVENT_SUMMONED_2                = 4
 };
 
 class boss_gyth : public CreatureScript

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
@@ -145,7 +145,8 @@ public:
                             breathComboSpells[1] = SPELL_FREEZE;
                             breathComboSpells[2] = SPELL_FLAMEBREATH;
                             breathComboSpellsNum = 3;
-                            breathCombo = urand(1, 3);
+                            breathCombo          = 3;
+                            //breathCombo = urand(1, 3);
                         }
 
                         if (0 <= breathComboSpellsNum && breathComboSpellsNum <= 3)

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
@@ -91,6 +91,8 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             instance->SetBossState(DATA_GYTH, DONE);
+            if (!me->FindNearestCreature(NPC_WARCHIEF_REND_BLACKHAND, 100.0f))
+                DoCast(me, SPELL_SUMMON_REND, true);
         }
 
         void SetData(uint32 /*type*/, uint32 data) override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_gyth.cpp
@@ -59,26 +59,18 @@ public:
     {
         boss_gythAI(Creature* creature) : BossAI(creature, DATA_GYTH)
         {
-            Initialize();
-        }
-
-        void Initialize()
-        {
             SummonedRend = false;
             breathCombo = 0;
             breathComboSpellsNum = 0;
         }
 
-        bool SummonedRend;
-
-        void Reset() override
+        void EnterEvadeMode(EvadeReason /*why*/) override
         {
-            Initialize();
-            if (instance->GetBossState(DATA_GYTH) == IN_PROGRESS)
-            {
-                instance->SetBossState(DATA_GYTH, DONE);
-                me->DespawnOrUnsummon();
-            }
+//RESPAWN REND HERE
+//            if (!SummonedRend)
+//                if (Creature* og_rend = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_WARCHIEF_REND_BLACKHAND)))
+//                    og_rend->Respawn(true);
+            me->DespawnOrUnsummon();
         }
 
         void JustEngagedWith(Unit* /*who*/) override
@@ -87,11 +79,6 @@ public:
 
             events.ScheduleEvent(EVENT_BREATH, 8s, 16s);
             events.ScheduleEvent(EVENT_KNOCK_AWAY, 12s, 18s);
-        }
-
-        void JustDied(Unit* /*killer*/) override
-        {
-            instance->SetBossState(DATA_GYTH, DONE);
         }
 
         void DamageTaken(Unit* /*attacker*/, uint32& damage) override
@@ -131,9 +118,9 @@ public:
                     {
                         case EVENT_SUMMONED_1:
                             me->AddAura(SPELL_REND_MOUNTS, me);
-                            if (GameObject* portcullis = me->FindNearestGameObject(GO_DR_PORTCULLIS, 40.0f))
+                            if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(GO_DR_PORTCULLIS)))
                                 portcullis->UseDoorOrButton();
-                            if (Creature* victor = me->FindNearestCreature(NPC_LORD_VICTOR_NEFARIUS, 75.0f, true))
+                            if (Creature* victor = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_LORD_VICTOR_NEFARIUS)))
                                 victor->AI()->SetData(1, 1);
                             events.ScheduleEvent(EVENT_SUMMONED_2, 2s);
                             break;
@@ -190,6 +177,7 @@ public:
         }
 
         private:
+            bool SummonedRend;
             uint32 breathCombo;
             uint32 breathComboSpells[3];
             uint32 breathComboSpellsNum;

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
@@ -464,20 +464,20 @@ public:
 
 enum Nefarius
 {
-    SAY_CHAOS_SPELL = 9,
-    SAY_SUCCESS = 10,
-    SAY_FAILURE = 11,
+    SAY_CHAOS_SPELL          = 9,
+    SAY_SUCCESS              = 10,
+    SAY_FAILURE              = 11,
 
-    EVENT_CHAOS_1 = 20,
-    EVENT_CHAOS_2 = 21,
-    EVENT_PATH_2 = 22,
-    EVENT_PATH_3 = 23,
-    EVENT_SUCCESS_1 = 24,
-    EVENT_SUCCESS_2 = 25,
-    EVENT_SUCCESS_3 = 26,
+    EVENT_CHAOS_1            = 20,
+    EVENT_CHAOS_2            = 21,
+    EVENT_PATH_2             = 22,
+    EVENT_PATH_3             = 23,
+    EVENT_SUCCESS_1          = 24,
+    EVENT_SUCCESS_2          = 25,
+    EVENT_SUCCESS_3          = 26,
 
-    SPELL_CHROMATIC_CHAOS = 16337, // Self Cast hits 10339
-    SPELL_VAELASTRASZZ_SPAWN = 16354 // Self Cast Depawn one sec after
+    SPELL_CHROMATIC_CHAOS    = 16337, // Self Cast hits 10339
+    SPELL_VAELASTRASZZ_SPAWN = 16354  // Self Cast Depawn one sec after
 };
 
 class npc_victor_nefarius_brs : public CreatureScript
@@ -511,20 +511,18 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (!UpdateVictim())
-            {
-                events.Update(diff);
+            events.Update(diff);
 
-                while (uint32 eventId = events.ExecuteEvent())
+            while (uint32 eventId = events.ExecuteEvent())
+            {
+                switch (eventId)
                 {
-                    switch (eventId)
-                    {
                     case EVENT_PATH_2:
                         me->GetMotionMaster()->MovePath(NEFARIUS_PATH_2, false);
                         events.ScheduleEvent(EVENT_CHAOS_1, 7000);
                         break;
                     case EVENT_CHAOS_1:
-                        if (Creature* gyth = me->FindNearestCreature(NPC_GYTH, 75.0f, true))
+                        if (Creature* gyth = ObjectAccessor::GetCreature(*me, me->GetInstanceScript()->GetGuidData(DATA_GYTH)))
                         {
                             me->SetFacingToObject(gyth);
                             Talk(SAY_CHAOS_SPELL);
@@ -556,9 +554,7 @@ public:
                         break;
                     default:
                         break;
-                    }
                 }
-                return;
             }
         }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
@@ -68,7 +68,6 @@ enum Misc
     REND_PATH_2                     = 1379681,
 };
 
-/*
 struct Wave
 {
     uint32 entry;
@@ -80,45 +79,44 @@ struct Wave
 
 static Wave Wave2[]= // 22 sec
 {
-    { 10447, 209.8637f, -428.2729f, 110.9877f, 0.6632251f },
-    { 10442, 209.3122f, -430.8724f, 110.9814f, 2.9147f    },
-    { 10442, 211.3309f, -425.9111f, 111.0006f, 1.727876f  }
+    { NPC_CHROMATIC_DRAGONSPAWN, 209.8637f, -428.2729f, 110.9877f, 0.6632251f },
+    { NPC_CHROMATIC_WHELP, 209.3122f, -430.8724f, 110.9814f, 2.9147f    },
+    { NPC_CHROMATIC_WHELP, 211.3309f, -425.9111f, 111.0006f, 1.727876f  }
 };
 
 static Wave Wave3[]= // 60 sec
 {
-    { 10742, 208.6493f, -424.5787f, 110.9872f, 5.8294f    },
-    { 10447, 203.9482f, -428.9446f, 110.982f,  4.677482f  },
-    { 10442, 203.3441f, -426.8668f, 110.9772f, 4.712389f  },
-    { 10442, 206.3079f, -424.7509f, 110.9943f, 4.08407f   }
+    { NPC_BLACKHAND_DRAGON_HANDLER, 208.6493f, -424.5787f, 110.9872f, 5.8294f    },
+    { NPC_CHROMATIC_DRAGONSPAWN, 203.9482f, -428.9446f, 110.982f,  4.677482f  },
+    { NPC_CHROMATIC_WHELP, 203.3441f, -426.8668f, 110.9772f, 4.712389f  },
+    { NPC_CHROMATIC_WHELP, 206.3079f, -424.7509f, 110.9943f, 4.08407f   }
 };
 
 static Wave Wave4[]= // 49 sec
 {
-    { 10742, 212.3541f, -412.6826f, 111.0352f, 5.88176f   },
-    { 10447, 212.5754f, -410.2841f, 111.0296f, 2.740167f  },
-    { 10442, 212.3449f, -414.8659f, 111.0348f, 2.356194f  },
-    { 10442, 210.6568f, -412.1552f, 111.0124f, 0.9773844f }
+    { NPC_BLACKHAND_DRAGON_HANDLER, 212.3541f, -412.6826f, 111.0352f, 5.88176f   },
+    { NPC_CHROMATIC_DRAGONSPAWN, 212.5754f, -410.2841f, 111.0296f, 2.740167f  },
+    { NPC_CHROMATIC_WHELP, 212.3449f, -414.8659f, 111.0348f, 2.356194f  },
+    { NPC_CHROMATIC_WHELP, 210.6568f, -412.1552f, 111.0124f, 0.9773844f }
 };
 
 static Wave Wave5[]= // 60 sec
 {
-    { 10742, 210.2188f, -410.6686f, 111.0211f, 5.8294f    },
-    { 10447, 209.4078f, -414.13f,   111.0264f, 4.677482f  },
-    { 10442, 208.0858f, -409.3145f, 111.0118f, 4.642576f  },
-    { 10442, 207.9811f, -413.0728f, 111.0098f, 5.288348f  },
-    { 10442, 208.0854f, -412.1505f, 111.0057f, 4.08407f   }
+    { NPC_BLACKHAND_DRAGON_HANDLER, 210.2188f, -410.6686f, 111.0211f, 5.8294f    },
+    { NPC_CHROMATIC_DRAGONSPAWN, 209.4078f, -414.13f,   111.0264f, 4.677482f  },
+    { NPC_CHROMATIC_WHELP, 208.0858f, -409.3145f, 111.0118f, 4.642576f  },
+    { NPC_CHROMATIC_WHELP, 207.9811f, -413.0728f, 111.0098f, 5.288348f  },
+    { NPC_CHROMATIC_WHELP, 208.0854f, -412.1505f, 111.0057f, 4.08407f   }
 };
 
 static Wave Wave6[]= // 27 sec
 {
-    { 10742, 213.9138f, -426.512f,  111.0013f, 3.316126f  },
-    { 10447, 213.7121f, -429.8102f, 110.9888f, 1.413717f  },
-    { 10447, 213.7157f, -424.4268f, 111.009f,  3.001966f  },
-    { 10442, 210.8935f, -423.913f,  111.0125f, 5.969026f  },
-    { 10442, 212.2642f, -430.7648f, 110.9807f, 5.934119f  }
+    { NPC_BLACKHAND_DRAGON_HANDLER, 213.9138f, -426.512f,  111.0013f, 3.316126f  },
+    { NPC_CHROMATIC_DRAGONSPAWN, 213.7121f, -429.8102f, 110.9888f, 1.413717f  },
+    { NPC_CHROMATIC_DRAGONSPAWN, 213.7157f, -424.4268f, 111.009f,  3.001966f  },
+    { NPC_CHROMATIC_WHELP, 210.8935f, -423.913f,  111.0125f, 5.969026f  },
+    { NPC_CHROMATIC_WHELP, 212.2642f, -430.7648f, 110.9807f, 5.934119f  }
 };
-*/
 
 Position const GythLoc =      { 211.762f,  -397.5885f, 111.1817f,  4.747295f   };
 Position const Teleport1Loc = { 194.2993f, -474.0814f, 121.4505f, -0.01225555f };
@@ -180,8 +178,7 @@ public:
             gythEvent = false;
             victorGUID.Clear();
             portcullisGUID.Clear();
-            if (instance->GetBossState(DATA_GYTH) == DONE)
-                me->SetImmuneToPC(false);
+            me->SetImmuneToPC(true);
         }
 
         void JustEngagedWith(Unit* /*who*/) override
@@ -201,7 +198,7 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             _JustDied();
-            if (Creature* victor = me->FindNearestCreature(NPC_LORD_VICTOR_NEFARIUS, 75.0f, true))
+            if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                 victor->AI()->SetData(1, 2);
         }
 
@@ -222,21 +219,18 @@ public:
 
         void SetData(uint32 type, uint32 data) override
         {
-            if (type == AREATRIGGER && data == AREATRIGGER_BLACKROCK_STADIUM)
+            if (type == AREATRIGGER && data == AREATRIGGER_BLACKROCK_STADIUM && !gythEvent)
             {
-                if (!gythEvent)
-                {
-                    gythEvent = true;
+                gythEvent = true;
 
-                    if (Creature* victor = me->FindNearestCreature(NPC_LORD_VICTOR_NEFARIUS, 5.0f, true))
-                        victorGUID = victor->GetGUID();
+                if (Creature* victor = me->FindNearestCreature(NPC_LORD_VICTOR_NEFARIUS, 5.0f, true))
+                    victorGUID = victor->GetGUID();
 
-                    if (GameObject* portcullis = me->FindNearestGameObject(GO_DR_PORTCULLIS, 50.0f))
-                        portcullisGUID = portcullis->GetGUID();
+                if (GameObject* portcullis = me->FindNearestGameObject(GO_DR_PORTCULLIS, 50.0f))
+                    portcullisGUID = portcullis->GetGUID();
 
-                    events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
-                    events.ScheduleEvent(EVENT_START_1, 1000);
-                }
+                events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                events.ScheduleEvent(EVENT_START_1, 1000);
             }
         }
 
@@ -260,10 +254,9 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (gythEvent)
+            events.Update(diff);
+            if (!UpdateVictim())
             {
-                events.Update(diff);
-
                 while (uint32 eventId = events.ExecuteEvent())
                 {
                     switch (eventId)
@@ -385,7 +378,7 @@ public:
                             break;
                         case EVENT_TELEPORT_1:
                             me->NearTeleportTo(194.2993f, -474.0814f, 121.4505f, -0.01225555f);
-                            events.ScheduleEvent(EVENT_TELEPORT_2, 50000);
+                            events.ScheduleEvent(EVENT_TELEPORT_2, 1000);
                             break;
                         case EVENT_TELEPORT_2:
                             me->NearTeleportTo(216.485f, -434.93f, 110.888f, -0.01225555f);
@@ -394,60 +387,43 @@ public:
                         case EVENT_WAVE_1:
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 209.8637f, -428.2729f, 110.9877f, 0.6632251f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 209.3122f, -430.8724f, 110.9814f, 2.9147f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 211.3309f, -425.9111f, 111.0006f, 1.727876f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_2:
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 208.6493f, -424.5787f, 110.9872f, 5.8294f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 203.9482f, -428.9446f, 110.982f, 4.677482f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 203.3441f, -426.8668f, 110.9772f, 4.712389f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 206.3079f, -424.7509f, 110.9943f, 4.08407f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            for (Wave &w : Wave2)
+                                me->SummonCreature(w.entry, w.x_pos, w.y_pos, w.z_pos, w.o_pos, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_3:
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 212.3541f, -412.6826f, 111.0352f, 5.88176f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 212.5754f, -410.2841f, 111.0296f, 2.740167f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 212.3449f, -414.8659f, 111.0348f, 2.356194f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 210.6568f, -412.1552f, 111.0124f, 0.9773844f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            for (Wave &w : Wave3)
+                                me->SummonCreature(w.entry, w.x_pos, w.y_pos, w.z_pos, w.o_pos, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_4:
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 210.2188f, -410.6686f, 111.0211f, 5.8294f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 209.4078f, -414.13f, 111.0264f, 4.677482f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 208.0858f, -409.3145f, 111.0118f, 4.642576f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 207.9811f, -413.0728f, 111.0098f, 5.288348f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 208.0854f, -412.1505f, 111.0057f, 4.08407f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            for (Wave &w : Wave4)
+                                me->SummonCreature(w.entry, w.x_pos, w.y_pos, w.z_pos, w.o_pos, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_5:
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 213.9138f, -426.512f, 111.0013f, 3.316126f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 213.7121f, -429.8102f, 110.9888f, 1.413717f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 213.7157f, -424.4268f, 111.009f, 3.001966f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 210.8935f, -423.913f, 111.0125f, 5.969026f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            me->SummonCreature(NPC_CHROMATIC_WHELP, 212.2642f, -430.7648f, 110.9807f, 5.934119f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
-                            break;
+                            for (Wave &w : Wave5)
+                                me->SummonCreature(w.entry, w.x_pos, w.y_pos, w.z_pos, w.o_pos, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                           break;
                         case EVENT_WAVE_6:
-                            // spawn wave
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            // move wave
+                            for (Wave &w : Wave6)
+                                me->SummonCreature(w.entry, w.x_pos, w.y_pos, w.z_pos, w.o_pos, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         default:
                             break;
                     }
                 }
-            }
-
-            if (!UpdateVictim())
                 return;
-
-            events.Update(diff);
+            }
 
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
@@ -180,6 +180,8 @@ public:
             gythEvent = false;
             victorGUID.Clear();
             portcullisGUID.Clear();
+            if (instance->GetBossState(DATA_GYTH) == DONE)
+                me->SetImmuneToPC(false);
         }
 
         void JustEngagedWith(Unit* /*who*/) override
@@ -201,6 +203,21 @@ public:
             _JustDied();
             if (Creature* victor = me->FindNearestCreature(NPC_LORD_VICTOR_NEFARIUS, 75.0f, true))
                 victor->AI()->SetData(1, 2);
+        }
+
+        void JustSummoned(Creature* summoned) override
+        {
+            switch (summoned->GetEntry())
+            {
+                case NPC_CHROMATIC_WHELP:
+                case NPC_CHROMATIC_DRAGONSPAWN:
+                case NPC_BLACKHAND_DRAGON_HANDLER:
+                    if (Unit* target = summoned->SelectNearestPlayer(100.0f))
+                        summoned->AI()->AttackStart(target);
+                    break;
+                default:
+                    break;
+            }
         }
 
         void SetData(uint32 type, uint32 data) override
@@ -377,31 +394,43 @@ public:
                         case EVENT_WAVE_1:
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            // move wave
+                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 209.8637f, -428.2729f, 110.9877f, 0.6632251f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 209.3122f, -430.8724f, 110.9814f, 2.9147f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 211.3309f, -425.9111f, 111.0006f, 1.727876f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_2:
-                            // spawn wave
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            // move wave
+                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 208.6493f, -424.5787f, 110.9872f, 5.8294f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 203.9482f, -428.9446f, 110.982f, 4.677482f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 203.3441f, -426.8668f, 110.9772f, 4.712389f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 206.3079f, -424.7509f, 110.9943f, 4.08407f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_3:
-                            // spawn wave
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            // move wave
+                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 212.3541f, -412.6826f, 111.0352f, 5.88176f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 212.5754f, -410.2841f, 111.0296f, 2.740167f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 212.3449f, -414.8659f, 111.0348f, 2.356194f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 210.6568f, -412.1552f, 111.0124f, 0.9773844f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_4:
-                            // spawn wave
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            // move wave
+                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 210.2188f, -410.6686f, 111.0211f, 5.8294f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 209.4078f, -414.13f, 111.0264f, 4.677482f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 208.0858f, -409.3145f, 111.0118f, 4.642576f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 207.9811f, -413.0728f, 111.0098f, 5.288348f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 208.0854f, -412.1505f, 111.0057f, 4.08407f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_5:
-                            // spawn wave
                             if (GameObject* portcullis = ObjectAccessor::GetGameObject(*me, portcullisGUID))
                                 portcullis->UseDoorOrButton();
-                            // move wave
+                            me->SummonCreature(NPC_BLACKHAND_DRAGON_HANDLER, 213.9138f, -426.512f, 111.0013f, 3.316126f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 213.7121f, -429.8102f, 110.9888f, 1.413717f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_DRAGONSPAWN, 213.7157f, -424.4268f, 111.009f, 3.001966f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 210.8935f, -423.913f, 111.0125f, 5.969026f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
+                            me->SummonCreature(NPC_CHROMATIC_WHELP, 212.2642f, -430.7648f, 110.9807f, 5.934119f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 250 * IN_MILLISECONDS);
                             break;
                         case EVENT_WAVE_6:
                             // spawn wave

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -97,10 +97,13 @@ public:
                     if (GetBossState(DATA_PYROGAURD_EMBERSEER) == DONE)
                         creature->DespawnOrUnsummon(0, 24h * 7);
                     break;
+                case NPC_LORD_VICTOR_NEFARIUS:
+                    LordVictorNefarius = creature->GetGUID();
+                    if (GetBossState(DATA_WARCHIEF_REND_BLACKHAND) == DONE)
+                        creature->DespawnOrUnsummon(0, 24h * 7);
+                    break;
                 case NPC_WARCHIEF_REND_BLACKHAND:
                     WarchiefRendBlackhand = creature->GetGUID();
-                    if (GetBossState(DATA_GYTH) == DONE)
-                        creature->DespawnOrUnsummon(0, 24h * 7);
                     break;
                 case NPC_GYTH:
                     Gyth = creature->GetGUID();
@@ -110,11 +113,6 @@ public:
                     break;
                 case NPC_GENERAL_DRAKKISATH:
                     GeneralDrakkisath = creature->GetGUID();
-                    break;
-                case NPC_LORD_VICTOR_NEFARIUS:
-                    LordVictorNefarius = creature->GetGUID();
-                    if (GetBossState(DATA_GYTH) == DONE)
-                        creature->DespawnOrUnsummon(0, 24h * 7);
                     break;
                 case NPC_SCARSHIELD_INFILTRATOR:
                     ScarshieldInfiltrator = creature->GetGUID();
@@ -219,14 +217,17 @@ public:
                     if (GetBossState(DATA_PYROGAURD_EMBERSEER) == DONE)
                         HandleGameObject(ObjectGuid::Empty, false, go);
                     break;
+                case GO_DR_PORTCULLIS:
+                    go_portcullis_arena = go->GetGUID();
+                    break;
                 case GO_PORTCULLIS_ACTIVE:
                     go_portcullis_active = go->GetGUID();
-                    if (GetBossState(DATA_GYTH) == DONE)
+                    if (GetBossState(DATA_WARCHIEF_REND_BLACKHAND) == DONE)
                         HandleGameObject(ObjectGuid::Empty, true, go);
                     break;
                 case GO_PORTCULLIS_TOBOSSROOMS:
                     go_portcullis_tobossrooms = go->GetGUID();
-                    if (GetBossState(DATA_GYTH) == DONE)
+                    if (GetBossState(DATA_WARCHIEF_REND_BLACKHAND) == DONE)
                         HandleGameObject(ObjectGuid::Empty, true, go);
                     break;
                 default:
@@ -326,6 +327,8 @@ public:
                     return OverlordWyrmthalak;
                 case DATA_PYROGAURD_EMBERSEER:
                     return PyroguardEmberseer;
+                case DATA_LORD_VICTOR_NEFARIUS:
+                    return LordVictorNefarius;
                 case DATA_WARCHIEF_REND_BLACKHAND:
                     return WarchiefRendBlackhand;
                 case DATA_GYTH:
@@ -370,6 +373,8 @@ public:
                     return go_emberseerrunes[5];
                 case GO_EMBERSEER_RUNE_7:
                     return go_emberseerrunes[6];
+                case GO_DR_PORTCULLIS:
+                    return go_portcullis_arena;
                 case GO_PORTCULLIS_ACTIVE:
                     return go_portcullis_active;
                 case GO_PORTCULLIS_TOBOSSROOMS:
@@ -522,6 +527,7 @@ public:
             ObjectGuid go_roomrunes[7];
             ObjectGuid go_emberseerrunes[7];
             ObjectGuid runecreaturelist[7][5];
+            ObjectGuid go_portcullis_arena;
             ObjectGuid go_portcullis_active;
             ObjectGuid go_portcullis_tobossrooms;
     };

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -38,25 +38,12 @@ enum Events
     EVENT_VEILOFSHADOW         = 6,
     EVENT_CLEAVE               = 7,
     EVENT_TAILLASH             = 8,
-    EVENT_CLASSCALL            = 9,
-    // UBRS
-    EVENT_CHAOS_1              = 10,
-    EVENT_CHAOS_2              = 11,
-    EVENT_PATH_2               = 12,
-    EVENT_PATH_3               = 13,
-    EVENT_SUCCESS_1            = 14,
-    EVENT_SUCCESS_2            = 15,
-    EVENT_SUCCESS_3            = 16,
+    EVENT_CLASSCALL            = 9
 };
 
 enum Says
 {
     // Nefarius
-    // UBRS
-    SAY_CHAOS_SPELL            = 9,
-    SAY_SUCCESS                = 10,
-    SAY_FAILURE                = 11,
-    // BWL
     SAY_GAMESBEGIN_1           = 12,
     SAY_GAMESBEGIN_2           = 13,
  // SAY_VAEL_INTRO             = 14, Not used - when he corrupts Vaelastrasz
@@ -85,18 +72,6 @@ enum Gossip
    GOSSIP_OPTION_ID            = 0
 };
 
-enum Paths
-{
-    NEFARIUS_PATH_2            = 1379671,
-    NEFARIUS_PATH_3            = 1379672
-};
-
-enum GameObjects
-{
-    GO_PORTCULLIS_ACTIVE       = 164726,
-    GO_PORTCULLIS_TOBOSSROOMS  = 175186
-};
-
 enum Creatures
 {
     NPC_BRONZE_DRAKANOID       = 14263,
@@ -106,17 +81,11 @@ enum Creatures
     NPC_BLACK_DRAKANOID        = 14265,
     NPC_CHROMATIC_DRAKANOID    = 14302,
     NPC_BONE_CONSTRUCT         = 14605,
-    // UBRS
-    NPC_GYTH                   = 10339
 };
 
 enum Spells
 {
     // Victor Nefarius
-    // UBRS Spells
-    SPELL_CHROMATIC_CHAOS       = 16337, // Self Cast hits 10339
-    SPELL_VAELASTRASZZ_SPAWN    = 16354, // Self Cast Depawn one sec after
-    // BWL Spells
     SPELL_SHADOWBOLT            = 22677,
     SPELL_SHADOWBOLT_VOLLEY     = 22665,
     SPELL_SHADOW_COMMAND        = 22667,
@@ -163,14 +132,14 @@ Position const NefarianLoc[2] =
 
 uint32 const Entry[5] = {NPC_BRONZE_DRAKANOID, NPC_BLUE_DRAKANOID, NPC_RED_DRAKANOID, NPC_GREEN_DRAKANOID, NPC_BLACK_DRAKANOID};
 
-class boss_victor_nefarius : public CreatureScript
+class boss_victor_nefarius_bwl : public CreatureScript
 {
 public:
-    boss_victor_nefarius() : CreatureScript("boss_victor_nefarius") { }
+    boss_victor_nefarius_bwl() : CreatureScript("boss_victor_nefarius_bwl") { }
 
-    struct boss_victor_nefariusAI : public BossAI
+    struct boss_victor_nefarius_bwlAI : public BossAI
     {
-        boss_victor_nefariusAI(Creature* creature) : BossAI(creature, DATA_NEFARIAN)
+        boss_victor_nefarius_bwlAI(Creature* creature) : BossAI(creature, DATA_NEFARIAN)
         {
             Initialize();
         }
@@ -184,18 +153,15 @@ public:
         {
             Initialize();
 
-            if (me->GetMapId() == 469)
-            {
-                if (!me->FindNearestCreature(NPC_NEFARIAN, 1000.0f, true))
-                    _Reset();
+            if (!me->FindNearestCreature(NPC_NEFARIAN, 1000.0f, true))
+                _Reset();
 
-                me->SetVisible(true);
-                me->SetPhaseMask(1, true);
-                me->SetUInt32Value(UNIT_NPC_FLAGS, 1);
-                me->SetFaction(FACTION_FRIENDLY);
-                me->SetStandState(UNIT_STAND_STATE_SIT_HIGH_CHAIR);
-                me->RemoveAura(SPELL_NEFARIANS_BARRIER);
-            }
+            me->SetVisible(true);
+            me->SetPhaseMask(1, true);
+            me->SetUInt32Value(UNIT_NPC_FLAGS, 1);
+            me->SetFaction(FACTION_FRIENDLY);
+            me->SetStandState(UNIT_STAND_STATE_SIT_HIGH_CHAIR);
+            me->RemoveAura(SPELL_NEFARIANS_BARRIER);
         }
 
         void JustReachedHome() override
@@ -232,72 +198,8 @@ public:
             }
         }
 
-        void JustSummoned(Creature* /*summon*/) override { }
-
-        void SetData(uint32 type, uint32 data) override
-        {
-            if ( type == 1 && data == 1)
-            {
-                me->StopMoving();
-                events.ScheduleEvent(EVENT_PATH_2, 9000);
-            }
-
-            if (type == 1 && data == 2)
-                events.ScheduleEvent(EVENT_SUCCESS_1, 5000);
-        }
-
         void UpdateAI(uint32 diff) override
         {
-            if (!UpdateVictim())
-            {
-                events.Update(diff);
-
-                while (uint32 eventId = events.ExecuteEvent())
-                {
-                    switch (eventId)
-                    {
-                        case EVENT_PATH_2:
-                            me->GetMotionMaster()->MovePath(NEFARIUS_PATH_2, false);
-                            events.ScheduleEvent(EVENT_CHAOS_1, 7000);
-                            break;
-                        case EVENT_CHAOS_1:
-                            if (Creature* gyth = me->FindNearestCreature(NPC_GYTH, 75.0f, true))
-                            {
-                                me->SetFacingToObject(gyth);
-                                Talk(SAY_CHAOS_SPELL);
-                            }
-                            events.ScheduleEvent(EVENT_CHAOS_2, 2000);
-                            break;
-                        case EVENT_CHAOS_2:
-                            DoCast(SPELL_CHROMATIC_CHAOS);
-                            me->SetFacingTo(1.570796f);
-                            break;
-                        case EVENT_SUCCESS_1:
-                            if (Unit* player = me->SelectNearestPlayer(60.0f))
-                            {
-                                me->SetFacingToObject(player);
-                                Talk(SAY_SUCCESS);
-                                if (GameObject* portcullis1 = me->FindNearestGameObject(GO_PORTCULLIS_ACTIVE, 65.0f))
-                                    portcullis1->SetGoState(GO_STATE_ACTIVE);
-                                if (GameObject* portcullis2 = me->FindNearestGameObject(GO_PORTCULLIS_TOBOSSROOMS, 80.0f))
-                                    portcullis2->SetGoState(GO_STATE_ACTIVE);
-                            }
-                            events.ScheduleEvent(EVENT_SUCCESS_2, 4000);
-                            break;
-                        case EVENT_SUCCESS_2:
-                            DoCast(me, SPELL_VAELASTRASZZ_SPAWN);
-                            me->DespawnOrUnsummon(1000);
-                            break;
-                        case EVENT_PATH_3:
-                            me->GetMotionMaster()->MovePath(NEFARIUS_PATH_3, false);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                return;
-            }
-
             // Only do this if we haven't spawned nefarian yet
             if (UpdateVictim() && SpawnedAdds <= 42)
             {
@@ -393,7 +295,7 @@ public:
 
     CreatureAI* GetAI(Creature* creature) const override
     {
-        return GetBlackwingLairAI<boss_victor_nefariusAI>(creature);
+        return GetBlackwingLairAI<boss_victor_nefarius_bwlAI>(creature);
     }
 };
 
@@ -605,6 +507,6 @@ public:
 
 void AddSC_boss_nefarian()
 {
-    new boss_victor_nefarius();
+    new boss_victor_nefarius_bwl();
     new boss_nefarian();
 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -153,7 +153,7 @@ public:
         {
             Initialize();
 
-            if (!me->FindNearestCreature(NPC_NEFARIAN, 1000.0f, true))
+            if (!me->FindNearestCreature(NPC_NEFARIAN, 160.0f, true))
                 _Reset();
 
             me->SetVisible(true);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -139,7 +139,7 @@ public:
 
     struct boss_victor_nefarius_bwlAI : public BossAI
     {
-        boss_victor_nefarius_bwlAI(Creature* creature) : BossAI(creature, DATA_NEFARIAN)
+        boss_victor_nefarius_bwlAI(Creature* creature) : BossAI(creature, DATA_LORD_VICTOR_NEFARIUS)
         {
             Initialize();
         }
@@ -153,7 +153,7 @@ public:
         {
             Initialize();
 
-            if (!me->FindNearestCreature(NPC_NEFARIAN, 160.0f, true))
+            if (!instance->GetCreature(DATA_NEFARIAN))
                 _Reset();
 
             me->SetVisible(true);


### PR DESCRIPTION
**Changes proposed:**
1) Lord Victor Nefarius' script split into a version for UBRS and BWL; he wasn't casting Chromatic Chaos or doing the outro script which opened the doors of the arena. He couldn't even be triggered by a .npc set data 1 1

2) Gyth given a system for his breaths, currently all 3 are on 8-12 sec timers making them overlap a lot of the time.
https://youtu.be/jC32eb-rQ8Q?t=28s
0:44 Freeze Breath, 0:46 Flame Breath, 0:48 Corrosive Acid Breath
1:00 Flame Breath, 1:02 Corrosive Acid Breath, 1:04 Freeze Breath
1:20 Flame Breath and died
System randomly cycles through the 3 breaths, with artificial GCD.

3) Rend will properly dismount from Gyth and not instantly respawn on the ledge when mounting Gyth.

4) Fixed a bug with doors opening if only Gyth was dead.

5) Added the waves of adds before Gyth appears, data for these was just lying there unused...

**Target branch(es):** 
3.3.5

**Tests performed:**
Builds, works and doesn't crash.

**Known issues and TODO list:**
- [ ] Make the first wave of adds move out of the port.
- [ ] Make the first wave of adds respawn when the event fails.
- [ ] The waves should walk out of the port before starting combat.
- [ ] Warchief Rend Blackhand needs to respawn up on the ledge when the event fails.
- [ ] Warchief Rend Blackhand has weird pathing, goes up and down the stairs.

