### PR TITLE
Scripts/VoA: Archavon Only leap on players far away

### DIFF
--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
@@ -107,7 +107,7 @@ class boss_archavon : public CreatureScript
                             events.ScheduleEvent(EVENT_ROCK_SHARDS, 15000);
                             break;
                         case EVENT_CHOKING_CLOUD:
-                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, [&](Unit* u) { return u && !(u->GetDistance(me->GetPosition()) < 10.0f); }))
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, -10.0f, true))
                             {
                                 DoCast(target, SPELL_CRUSHING_LEAP, true); //10y~80y, ignore range
                                 Talk(EMOTE_LEAP, target);

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
@@ -23,7 +23,7 @@
 enum Emotes
 {
     EMOTE_BERSERK           = 0,
-    EMOTE_LEAP              = 1 // Not in use
+    EMOTE_LEAP              = 1
 };
 
 enum Spells
@@ -107,15 +107,17 @@ class boss_archavon : public CreatureScript
                             events.ScheduleEvent(EVENT_ROCK_SHARDS, 15000);
                             break;
                         case EVENT_CHOKING_CLOUD:
-                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, [&](Unit* u) { return u && !(u->GetDistance(me->GetPosition()) < 25.0f); }))
+                            {
                                 DoCast(target, SPELL_CRUSHING_LEAP, true); //10y~80y, ignore range
+                                Talk(EMOTE_LEAP, me->GetVictim());
+                            }
                             events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30000);
                             break;
                         case EVENT_STOMP:
                             DoCastVictim(SPELL_STOMP);
                             events.ScheduleEvent(EVENT_IMPALE, 3000);
                             events.ScheduleEvent(EVENT_STOMP, 45000);
-                            Talk(EMOTE_LEAP, me->GetVictim());
                             break;
                         case EVENT_IMPALE:
                             DoCastVictim(SPELL_IMPALE);

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
@@ -107,10 +107,10 @@ class boss_archavon : public CreatureScript
                             events.ScheduleEvent(EVENT_ROCK_SHARDS, 15000);
                             break;
                         case EVENT_CHOKING_CLOUD:
-                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, [&](Unit* u) { return u && !(u->GetDistance(me->GetPosition()) < 25.0f); }))
+                            if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1, [&](Unit* u) { return u && !(u->GetDistance(me->GetPosition()) < 10.0f); }))
                             {
                                 DoCast(target, SPELL_CRUSHING_LEAP, true); //10y~80y, ignore range
-                                Talk(EMOTE_LEAP, me->GetVictim());
+                                Talk(EMOTE_LEAP, target);
                             }
                             events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30000);
                             break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Adding mid-Range requirement to ensure Leap only occurs on players that aren't in melee range.
Values is educational guess, taking his model size into consideration to get the ingame view perspective fitting Retail encounter.

Contains correction of https://github.com/TrinityCore/TrinityCore/pull/17588

**Target branch(es):** 3.3.5/master

 3.3.5


**Tests performed:** 

> ========== Build: 5 succeeded, 0 failed, 11 up-to-date, 2 skipped ==========

> Tested ingame, does emote during the leap instead of after it.



