### PR TITLE
[3.3.5] Scripts/VoA: Update timers to Chrono Literals

### DIFF
--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
@@ -78,10 +78,10 @@ class boss_archavon : public CreatureScript
 
             void JustEngagedWith(Unit* /*who*/) override
             {
-                events.ScheduleEvent(EVENT_ROCK_SHARDS, 15000);
-                events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30000);
-                events.ScheduleEvent(EVENT_STOMP, 45000);
-                events.ScheduleEvent(EVENT_BERSERK, 300000);
+                events.ScheduleEvent(EVENT_ROCK_SHARDS, 15s);
+                events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30s);
+                events.ScheduleEvent(EVENT_STOMP, 45s);
+                events.ScheduleEvent(EVENT_BERSERK, 5m);
 
                 _JustEngagedWith();
             }
@@ -104,7 +104,7 @@ class boss_archavon : public CreatureScript
                         case EVENT_ROCK_SHARDS:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                                 DoCast(target, SPELL_ROCK_SHARDS);
-                            events.ScheduleEvent(EVENT_ROCK_SHARDS, 15000);
+                            events.ScheduleEvent(EVENT_ROCK_SHARDS, 15s);
                             break;
                         case EVENT_CHOKING_CLOUD:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, -10.0f, true))
@@ -112,12 +112,12 @@ class boss_archavon : public CreatureScript
                                 DoCast(target, SPELL_CRUSHING_LEAP, true); //10y~80y, ignore range
                                 Talk(EMOTE_LEAP, target);
                             }
-                            events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30000);
+                            events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30s);
                             break;
                         case EVENT_STOMP:
                             DoCastVictim(SPELL_STOMP);
-                            events.ScheduleEvent(EVENT_IMPALE, 3000);
-                            events.ScheduleEvent(EVENT_STOMP, 45000);
+                            events.ScheduleEvent(EVENT_IMPALE, 3s);
+                            events.ScheduleEvent(EVENT_STOMP, 45s);
                             break;
                         case EVENT_IMPALE:
                             DoCastVictim(SPELL_IMPALE);
@@ -163,9 +163,9 @@ class npc_archavon_warder : public CreatureScript
             void Reset() override
             {
                 events.Reset();
-                events.ScheduleEvent(EVENT_ROCK_SHOWER, 2000);
-                events.ScheduleEvent(EVENT_SHIELD_CRUSH, 20000);
-                events.ScheduleEvent(EVENT_WHIRL, 7500);
+                events.ScheduleEvent(EVENT_ROCK_SHOWER, 2s);
+                events.ScheduleEvent(EVENT_SHIELD_CRUSH, 20s);
+                events.ScheduleEvent(EVENT_WHIRL, 7s);
             }
 
             void JustEngagedWith(Unit* /*who*/) override
@@ -190,15 +190,15 @@ class npc_archavon_warder : public CreatureScript
                         case EVENT_ROCK_SHOWER:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                                 DoCast(target, SPELL_ROCK_SHOWER);
-                            events.ScheduleEvent(EVENT_ROCK_SHARDS, 6000);
+                            events.ScheduleEvent(EVENT_ROCK_SHARDS, 6s);
                             break;
                         case EVENT_SHIELD_CRUSH:
                             DoCastVictim(SPELL_SHIELD_CRUSH);
-                            events.ScheduleEvent(EVENT_SHIELD_CRUSH, 20000);
+                            events.ScheduleEvent(EVENT_SHIELD_CRUSH, 20s);
                             break;
                         case EVENT_WHIRL:
                             DoCastVictim(SPELL_WHIRL);
-                            events.ScheduleEvent(EVENT_WHIRL, 8000);
+                            events.ScheduleEvent(EVENT_WHIRL, 8s);
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_archavon.cpp
@@ -81,7 +81,7 @@ class boss_archavon : public CreatureScript
                 events.ScheduleEvent(EVENT_ROCK_SHARDS, 15s);
                 events.ScheduleEvent(EVENT_CHOKING_CLOUD, 30s);
                 events.ScheduleEvent(EVENT_STOMP, 45s);
-                events.ScheduleEvent(EVENT_BERSERK, 5m);
+                events.ScheduleEvent(EVENT_BERSERK, 5min);
 
                 _JustEngagedWith();
             }

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
@@ -111,10 +111,10 @@ class boss_emalon : public CreatureScript
                     }
                 }
 
-                events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 5000);
-                events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 40000);
-                events.ScheduleEvent(EVENT_BERSERK, 360000);
-                events.ScheduleEvent(EVENT_OVERCHARGE, 45000);
+                events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 5s);
+                events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 40s);
+                events.ScheduleEvent(EVENT_BERSERK, 6m);
+                events.ScheduleEvent(EVENT_OVERCHARGE, 45s);
 
                 _JustEngagedWith();
             }
@@ -136,11 +136,11 @@ class boss_emalon : public CreatureScript
                         case EVENT_CHAIN_LIGHTNING:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                                 DoCast(target, SPELL_CHAIN_LIGHTNING);
-                            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 25000);
+                            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 25s);
                             break;
                         case EVENT_LIGHTNING_NOVA:
                             DoCastAOE(SPELL_LIGHTNING_NOVA);
-                            events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 40000);
+                            events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 40s);
                             break;
                         case EVENT_OVERCHARGE:
                             if (!summons.empty())
@@ -151,7 +151,7 @@ class boss_emalon : public CreatureScript
                                     minion->CastSpell(me, SPELL_OVERCHARGED, true);
                                     minion->SetFullHealth();
                                     Talk(EMOTE_OVERCHARGE);
-                                    events.ScheduleEvent(EVENT_OVERCHARGE, 45000);
+                                    events.ScheduleEvent(EVENT_OVERCHARGE, 45s);
                                 }
                             }
                             break;
@@ -219,7 +219,7 @@ class npc_tempest_minion : public CreatureScript
             void JustEngagedWith(Unit* who) override
             {
                 DoZoneInCombat();
-                events.ScheduleEvent(EVENT_SHOCK, 20000);
+                events.ScheduleEvent(EVENT_SHOCK, 20s);
 
                 if (Creature* pEmalon = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_EMALON)))
                 {
@@ -246,7 +246,7 @@ class npc_tempest_minion : public CreatureScript
                         if (OverchargedTimer <= diff)
                         {
                             DoCast(me, SPELL_OVERCHARGED);
-                            OverchargedTimer = 2000;
+                            OverchargedTimer = 2s;
                         }
                         else
                             OverchargedTimer -= diff;
@@ -265,7 +265,7 @@ class npc_tempest_minion : public CreatureScript
                 if (events.ExecuteEvent() == EVENT_SHOCK)
                 {
                     DoCastVictim(SPELL_SHOCK);
-                    events.ScheduleEvent(EVENT_SHOCK, 20000);
+                    events.ScheduleEvent(EVENT_SHOCK, 20s);
                 }
 
                 DoMeleeAttackIfReady();

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
@@ -113,7 +113,7 @@ class boss_emalon : public CreatureScript
 
                 events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 5s);
                 events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 40s);
-                events.ScheduleEvent(EVENT_BERSERK, 6m);
+                events.ScheduleEvent(EVENT_BERSERK, 6min);
                 events.ScheduleEvent(EVENT_OVERCHARGE, 45s);
 
                 _JustEngagedWith();
@@ -246,7 +246,7 @@ class npc_tempest_minion : public CreatureScript
                         if (OverchargedTimer <= diff)
                         {
                             DoCast(me, SPELL_OVERCHARGED);
-                            OverchargedTimer = 2s;
+                            OverchargedTimer = 2000; // ms
                         }
                         else
                             OverchargedTimer -= diff;

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_koralon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_koralon.cpp
@@ -64,10 +64,10 @@ class boss_koralon : public CreatureScript
             {
                 DoCast(me, SPELL_BURNING_FURY);
 
-                events.ScheduleEvent(EVENT_BURNING_FURY, 20000);    /// @todo check timer
-                events.ScheduleEvent(EVENT_BURNING_BREATH, 15000);  // 1st after 15sec, then every 45sec
-                events.ScheduleEvent(EVENT_METEOR_FISTS, 75000);    // 1st after 75sec, then every 45sec
-                events.ScheduleEvent(EVENT_FLAME_CINDER, 30000);    /// @todo check timer
+                events.ScheduleEvent(EVENT_BURNING_FURY, 20s);    /// @todo check timer
+                events.ScheduleEvent(EVENT_BURNING_BREATH, 15s);  // 1st after 15sec, then every 45sec
+                events.ScheduleEvent(EVENT_METEOR_FISTS, 75s);    // 1st after 75sec, then every 45sec
+                events.ScheduleEvent(EVENT_FLAME_CINDER, 30s);    /// @todo check timer
 
                 _JustEngagedWith();
             }
@@ -88,19 +88,19 @@ class boss_koralon : public CreatureScript
                     {
                         case EVENT_BURNING_FURY:
                             DoCast(me, SPELL_BURNING_FURY);
-                            events.ScheduleEvent(EVENT_BURNING_FURY, 20000);
+                            events.ScheduleEvent(EVENT_BURNING_FURY, 20s);
                             break;
                         case EVENT_BURNING_BREATH:
                             DoCast(me, SPELL_BURNING_BREATH);
-                            events.ScheduleEvent(EVENT_BURNING_BREATH, 45000);
+                            events.ScheduleEvent(EVENT_BURNING_BREATH, 45s);
                             break;
                         case EVENT_METEOR_FISTS:
                             DoCast(me, SPELL_METEOR_FISTS);
-                            events.ScheduleEvent(EVENT_METEOR_FISTS, 45000);
+                            events.ScheduleEvent(EVENT_METEOR_FISTS, 45s);
                             break;
                         case EVENT_FLAME_CINDER:
                             DoCast(me, SPELL_FLAME_CINDER_A);
-                            events.ScheduleEvent(EVENT_FLAME_CINDER, 30000);
+                            events.ScheduleEvent(EVENT_FLAME_CINDER, 30s);
                             break;
                         default:
                             break;
@@ -143,8 +143,8 @@ class npc_flame_warder : public CreatureScript
             {
                 DoZoneInCombat();
 
-                events.ScheduleEvent(EVENT_FW_LAVA_BIRST, 5000);
-                events.ScheduleEvent(EVENT_FW_METEOR_FISTS, 10000);
+                events.ScheduleEvent(EVENT_FW_LAVA_BIRST, 5s);
+                events.ScheduleEvent(EVENT_FW_METEOR_FISTS, 10s);
             }
 
             void UpdateAI(uint32 diff) override
@@ -160,11 +160,11 @@ class npc_flame_warder : public CreatureScript
                     {
                         case EVENT_FW_LAVA_BIRST:
                             DoCastVictim(SPELL_FW_LAVA_BIRST);
-                            events.ScheduleEvent(EVENT_FW_LAVA_BIRST, 15000);
+                            events.ScheduleEvent(EVENT_FW_LAVA_BIRST, 15s);
                             break;
                         case EVENT_FW_METEOR_FISTS:
                             DoCast(me, SPELL_FW_METEOR_FISTS);
-                            events.ScheduleEvent(EVENT_FW_METEOR_FISTS, 20000);
+                            events.ScheduleEvent(EVENT_FW_METEOR_FISTS, 20s);
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_toravon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_toravon.cpp
@@ -56,9 +56,9 @@ struct boss_toravon : public BossAI
     {
         DoCastSelf(SPELL_FROZEN_MALLET);
 
-        events.ScheduleEvent(EVENT_FROZEN_ORB, Seconds(12));
-        events.ScheduleEvent(EVENT_WHITEOUT, Seconds(25));
-        events.ScheduleEvent(EVENT_FREEZING_GROUND, Seconds(7));
+        events.ScheduleEvent(EVENT_FROZEN_ORB, 12s);
+        events.ScheduleEvent(EVENT_WHITEOUT, 25s);
+        events.ScheduleEvent(EVENT_FREEZING_GROUND, 7s);
 
         _JustEngagedWith();
     }
@@ -80,17 +80,17 @@ struct boss_toravon : public BossAI
                 case EVENT_FROZEN_ORB:
                 {
                     me->CastSpell(me, SPELL_FROZEN_ORB, CastSpellExtraArgs().AddSpellMod(SPELLVALUE_MAX_TARGETS, RAID_MODE(1, 3)));
-                    events.Repeat(Seconds(32));
+                    events.Repeat(32s);
                     break;
                 }
                 case EVENT_WHITEOUT:
                     DoCastSelf(SPELL_WHITEOUT);
-                    events.Repeat(Seconds(38));
+                    events.Repeat(38s);
                     break;
                 case EVENT_FREEZING_GROUND:
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1))
                         DoCast(target, SPELL_FREEZING_GROUND);
-                    events.Repeat(Seconds(38));
+                    events.Repeat(38s);
                     break;
                 default:
                     break;
@@ -119,7 +119,7 @@ struct npc_frost_warder : public ScriptedAI
 
         DoCastSelf(SPELL_FROZEN_MALLET_2);
 
-        _events.ScheduleEvent(EVENT_FROST_BLAST, 5000);
+        _events.ScheduleEvent(EVENT_FROST_BLAST, 5s);
     }
 
     void UpdateAI(uint32 diff) override
@@ -135,7 +135,7 @@ struct npc_frost_warder : public ScriptedAI
         if (_events.ExecuteEvent() == EVENT_FROST_BLAST)
         {
             DoCastVictim(SPELL_FROST_BLAST);
-            _events.ScheduleEvent(EVENT_FROST_BLAST, 20000);
+            _events.ScheduleEvent(EVENT_FROST_BLAST, 20s);
         }
 
         DoMeleeAttackIfReady();


### PR DESCRIPTION
**Changes proposed:**

As per @Treeston 's request, updating VoA boss timers to Chrono literals.
Build tested without any comp error

**Target branch(es):** 

3.3.5

