### PR TITLE
Core/AI: initialize run state for EscortAI::Start before filling wayp…

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -303,6 +303,8 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
         return;
     }
 
+    _running = run;
+    
     if (!_manualPath && resetWaypoints)
         FillPointMovementListForCreature();
 
@@ -314,7 +316,6 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
 
     // set variables
     _activeAttacker = isActiveAttacker;
-    _running = run;
     _playerGUID = playerGUID;
     _escortQuest = quest;
     _instantRespawn = instantRespawn;


### PR DESCRIPTION
**Changes proposed:**
-  fixed an issue that caused escortAI not considering the run argument in EscortAI::Start which lead to alot of npc's were walking instead of running. This was caused due to filling the waypoints with their corresponding run / walk state before initializing the run argument


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #21290 maybe?

**Tests performed:** (Does it build, tested in-game, etc.)
- works for me (tm)
