### PR TITLE
Core/Movement: Fixed MotionMaster::MoveChase default parameters

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -595,16 +595,6 @@ void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<C
     Add(new ChaseMovementGenerator(target, dist, angle));
 }
 
-void MotionMaster::MoveChase(Unit* target, float dist, float angle)
-{
-    MoveChase(target, Optional<ChaseRange>(dist), Optional<ChaseAngle>(angle));
-}
-
-void MotionMaster::MoveChase(Unit* target, float dist)
-{
-    MoveChase(target, Optional<ChaseRange>(dist));
-}
-
 void MotionMaster::MoveConfused()
 {
     if (_owner->GetTypeId() == TYPEID_PLAYER)

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -585,11 +585,6 @@ void MotionMaster::MoveFollow(Unit* target, float dist, ChaseAngle angle, Moveme
     Add(new FollowMovementGenerator(target, dist, angle), slot);
 }
 
-void MotionMaster::MoveChase(Unit* target, float dist, float angle /*= 0.0f*/)
-{
-    MoveChase(target, Optional<ChaseRange>(dist), angle ? Optional<ChaseAngle>(angle) : Optional<ChaseAngle>());
-}
-
 void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle)
 {
     // Ignore movement request if target not exist
@@ -598,6 +593,16 @@ void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<C
 
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveChase: '%s', starts chasing '%s'", _owner->GetGUID().ToString().c_str(), target->GetGUID().ToString().c_str());
     Add(new ChaseMovementGenerator(target, dist, angle));
+}
+
+void MotionMaster::MoveChase(Unit* target, float dist, float angle)
+{
+    MoveChase(target, Optional<ChaseRange>(dist), Optional<ChaseAngle>(angle));
+}
+
+void MotionMaster::MoveChase(Unit* target, float dist)
+{
+    MoveChase(target, Optional<ChaseRange>(dist));
 }
 
 void MotionMaster::MoveConfused()

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -585,6 +585,11 @@ void MotionMaster::MoveFollow(Unit* target, float dist, ChaseAngle angle, Moveme
     Add(new FollowMovementGenerator(target, dist, angle), slot);
 }
 
+void MotionMaster::MoveChase(Unit* target, float dist, float angle /*= 0.0f*/)
+{
+    MoveChase(target, Optional<ChaseRange>(dist), angle ? Optional<ChaseAngle>(angle) : Optional<ChaseAngle>());
+}
+
 void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle)
 {
     // Ignore movement request if target not exist

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -141,7 +141,7 @@ class TC_GAME_API MotionMaster
         void MoveRandom(float spawndist = 0.0f);
         void MoveFollow(Unit* target, float dist, ChaseAngle angle, MovementSlot slot = MOTION_SLOT_ACTIVE);
         void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
-        void MoveChase(Unit* target, float dist, float angle = 0.0f) { MoveChase(target, Optional<ChaseRange>(dist), Optional<ChaseAngle>(angle)); }
+        void MoveChase(Unit* target, float dist, float angle = 0.0f);
         void MoveConfused();
         void MoveFleeing(Unit* enemy, uint32 time = 0);
         void MovePoint(uint32 id, Position const& pos, bool generatePath = true, Optional<float> finalOrient = {});

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -141,7 +141,8 @@ class TC_GAME_API MotionMaster
         void MoveRandom(float spawndist = 0.0f);
         void MoveFollow(Unit* target, float dist, ChaseAngle angle, MovementSlot slot = MOTION_SLOT_ACTIVE);
         void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
-        void MoveChase(Unit* target, float dist, float angle = 0.0f);
+        void MoveChase(Unit* target, float dist, float angle);
+        void MoveChase(Unit* target, float dist);
         void MoveConfused();
         void MoveFleeing(Unit* enemy, uint32 time = 0);
         void MovePoint(uint32 id, Position const& pos, bool generatePath = true, Optional<float> finalOrient = {});

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -141,8 +141,8 @@ class TC_GAME_API MotionMaster
         void MoveRandom(float spawndist = 0.0f);
         void MoveFollow(Unit* target, float dist, ChaseAngle angle, MovementSlot slot = MOTION_SLOT_ACTIVE);
         void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
-        inline void MoveChase(Unit* target, float dist, float angle) { MoveChase(target, Optional<ChaseRange>(dist), Optional<ChaseAngle>(angle)); }
-        inline void MoveChase(Unit* target, float dist) { MoveChase(target, Optional<ChaseRange>(dist)); }
+        void MoveChase(Unit* target, float dist, float angle) { MoveChase(target, ChaseRange(dist), ChaseAngle(angle)); }
+        void MoveChase(Unit* target, float dist) { MoveChase(target, ChaseRange(dist)); }
         void MoveConfused();
         void MoveFleeing(Unit* enemy, uint32 time = 0);
         void MovePoint(uint32 id, Position const& pos, bool generatePath = true, Optional<float> finalOrient = {});

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -141,8 +141,8 @@ class TC_GAME_API MotionMaster
         void MoveRandom(float spawndist = 0.0f);
         void MoveFollow(Unit* target, float dist, ChaseAngle angle, MovementSlot slot = MOTION_SLOT_ACTIVE);
         void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
-        void MoveChase(Unit* target, float dist, float angle);
-        void MoveChase(Unit* target, float dist);
+        inline void MoveChase(Unit* target, float dist, float angle) { MoveChase(target, Optional<ChaseRange>(dist), Optional<ChaseAngle>(angle)); }
+        inline void MoveChase(Unit* target, float dist) { MoveChase(target, Optional<ChaseRange>(dist)); }
         void MoveConfused();
         void MoveFleeing(Unit* enemy, uint32 time = 0);
         void MovePoint(uint32 id, Position const& pos, bool generatePath = true, Optional<float> finalOrient = {});


### PR DESCRIPTION
**Changes proposed:**

When calling MotionMaster::MoveChase with a distance, the angle was intended to be optional but actually wasn't.
In the declaration:
https://github.com/TrinityCore/TrinityCore/blob/70955ed3a68a58701ae50c8f0f9afdec4f60853d/src/server/game/Movement/MotionMaster.h#L144
Angle was never optional because the Optional object was always initialized at 0.0f if no value was provided by the caller.

**Target branch(es):** 3.3.5

**Issues addressed:** 
This fixes for example ranged PlayerAI's chasing at an angle instead of chasing directly towards target.
This should also fix a lot of other seemingly strange chase behavior in scripts, when a chase distance is used.

**Tests performed:**
Does build, tested with a hunter character mind controlled by a creature.
