### PR TITLE
Core/Spell: Fix Debuff vs Debuff calculation for level scaling Auras

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3392,6 +3392,8 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
 
     visited.insert({ spellInfo->Id, effIndex });
 
+    //We need scaling level info for some auras that compute bp 0 or positive but should be debuffs
+    float bpScalePerLevel = spellInfo->Effects[effIndex].RealPointsPerLevel;
     int32 bp = spellInfo->Effects[effIndex].CalcValue();
     switch (spellInfo->SpellFamilyName)
     {
@@ -3627,7 +3629,7 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
             case SPELL_AURA_MOD_INCREASE_HEALTH_PERCENT:
             case SPELL_AURA_MOD_TOTAL_STAT_PERCENTAGE:
             case SPELL_AURA_MOD_INCREASE_SWIM_SPEED:
-                if (bp < 0)
+                if (bp < 0 || bpScalePerLevel < 0) //TODO: What if both are 0? Should it be a buff or debuff?
                     return false;
                 break;
             case SPELL_AURA_MOD_ATTACKSPEED:            // some buffs have negative bp, check both target and bp


### PR DESCRIPTION
**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)

Some auras that put negative effects on a unit, like a sunder armor, are treated as buffs and removable by the player too. These should be treated as debuffs.

Closed an issue on a fork of mine related to this: https://github.com/KurthosWoW/TrinityCore/issues/30 and https://github.com/KurthosWoW/TrinityCore/issues/28

This fix makes the following assumptions.

1. That any aura will only ever be a debuff or a buff invariant of level of caster/target.
2. That level scaling is the only scaling factor to cover checks for.

**Tests performed:** (Does it build, tested in-game, etc.)

Addresses the spell ID provided in the issue, 15572. Doesn't seem to cause any regressions with some random buffs and debuffs I tried.
