### PR TITLE
[Pre-WIP] [3.3.5] The AI system redesign

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world_ACTIONSCRIPT_TABLES.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world_ACTIONSCRIPT_TABLES.sql
@@ -1,0 +1,11 @@
+-- 
+DROP TABLE IF EXISTS `actionscript_assign`;
+CREATE TABLE `actionscript_assign` (
+    `spawnType` TINYINT UNSIGNED NOT NULL,
+    `entry` INT UNSIGNED NOT NULL,
+    `index` INT UNSIGNED NOT NULL,
+    `scriptId` INT UNSIGNED NOT NULL,
+    PRIMARY KEY USING BTREE (`spawnType`,`entry`,`index`)
+);
+
+DROP TABLE IF EXISTS `actionscript_data`;

--- a/src/common/Utilities/Duration.h
+++ b/src/common/Utilities/Duration.h
@@ -32,6 +32,10 @@ typedef std::chrono::minutes Minutes;
 /// Hours shorthand typedef.
 typedef std::chrono::hours Hours;
 
+/// time_point shorthand typedefs
+typedef std::chrono::steady_clock::time_point TimePoint;
+typedef std::chrono::system_clock::time_point SystemTimePoint;
+
 /// Makes std::chrono_literals globally available.
 using namespace std::chrono_literals;
 

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -2294,7 +2294,7 @@ bool AchievementGlobalMgr::IsRealmCompleted(AchievementEntry const* achievement)
     // it may allow more than one group to achieve it (highly unlikely)
     // but apparently this is how blizz handles it as well
     if (achievement->Flags & ACHIEVEMENT_FLAG_REALM_FIRST_KILL)
-        return (GameTime::GetGameTimeSystemPoint() - itr->second) > Minutes(1);
+        return (GameTime::GetSystemTime() - itr->second) > Minutes(1);
 
     return true;
 }
@@ -2304,7 +2304,7 @@ void AchievementGlobalMgr::SetRealmCompleted(AchievementEntry const* achievement
     if (IsRealmCompleted(achievement))
         return;
 
-    _allCompletedAchievements[achievement->ID] = GameTime::GetGameTimeSystemPoint();
+    _allCompletedAchievements[achievement->ID] = GameTime::GetSystemTime();
 }
 
 //==========================================================

--- a/src/server/game/Behavior/ActionScript/ActionScript.cpp
+++ b/src/server/game/Behavior/ActionScript/ActionScript.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ActionScript.h"
+#include "GameTime.h"
+
+ActionScriptThread::ActionScriptThread(ActionScript const& script, size_t initialStep)
+    : _script(script)
+{
+    StepTo(initialStep);
+}
+
+void ActionScriptThread::Update()
+{
+    if (!_currentStep)
+        return;
+
+    if (Optional<bool> success = EvaluateCurrentStep())
+    {
+        if (*success)
+            StepTo(_currentStep->GotoSuccess);
+        else
+            StepTo(_currentStep->GotoFailure);
+    }
+    else if (_stepTimeout <= GameTime::Now())
+        StepTo(_currentStep->GotoTimeout);
+    else
+        return;
+
+    return Update();
+}
+
+// true means success, false means failure, none means no result
+Optional<bool> ActionScriptThread::EvaluateCurrentStep()
+{
+    return {};
+}
+
+void ActionScriptThread::StepTo(Optional<size_t> step)
+{
+    if (!step)
+    {
+        _currentStep = nullptr;
+        return;
+    }
+
+    _currentStep = &_script[*step];
+    _stepTimeout = GameTime::Now() + _currentStep->Timeout;
+    // @todo execute step
+}

--- a/src/server/game/Behavior/ActionScript/ActionScript.h
+++ b/src/server/game/Behavior/ActionScript/ActionScript.h
@@ -19,10 +19,10 @@
 #define TRINITY_ACTIONSCRIPT_H
 
 #include "ActionScriptDefines.h"
-#include "Define.h"
 #include "Duration.h"
 #include "Optional.h"
 #include <array>
+#include <memory>
 #include <vector>
 
 struct TC_GAME_API ActionScriptVariableContent
@@ -66,22 +66,25 @@ class TC_GAME_API ActionScript
     friend class ActionScriptManager;
 };
 
-class TC_GAME_API ActionScriptThread
+class ActionThreadStep;
+class TC_GAME_API ActionThread
 {
     public:
-        ActionScriptThread(ActionScript const& script, size_t initialStep);
+        ActionThread(Unit* owner, ActionScript const& script, size_t initialStep);
+        ~ActionThread();
         // @todo this needs a return value indicating whether behavior should control
         void Update();
 
+        Unit* GetOwner() const { return _owner; }
         
     private:
+        Unit* const _owner;
         ActionScript const& _script;
-        ActionScriptStep const* _currentStep;
+        std::unique_ptr<ActionThreadStep> _currentStep;
         TimePoint _stepTimeout;
 
         std::vector<ActionScriptVariableContent> _variables;
 
-        Optional<bool> EvaluateCurrentStep();
         void StepTo(Optional<size_t> step);
 };
 

--- a/src/server/game/Behavior/ActionScript/ActionScript.h
+++ b/src/server/game/Behavior/ActionScript/ActionScript.h
@@ -25,6 +25,16 @@
 #include <array>
 #include <vector>
 
+struct TC_GAME_API ActionScriptVariableContent
+{
+
+};
+
+struct TC_GAME_API ActionScriptVariableReference
+{
+
+};
+
 struct TC_GAME_API ActionScriptStepArgument
 {
 
@@ -68,6 +78,8 @@ class TC_GAME_API ActionScriptThread
         ActionScript const& _script;
         ActionScriptStep const* _currentStep;
         TimePoint _stepTimeout;
+
+        std::vector<ActionScriptVariableContent> _variables;
 
         Optional<bool> EvaluateCurrentStep();
         void StepTo(Optional<size_t> step);

--- a/src/server/game/Behavior/ActionScript/ActionScript.h
+++ b/src/server/game/Behavior/ActionScript/ActionScript.h
@@ -23,6 +23,7 @@
 #include "Optional.h"
 #include <array>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 struct TC_GAME_API ActionScriptVariableContent
@@ -67,25 +68,30 @@ class TC_GAME_API ActionScript
 };
 
 class ActionThreadStep;
+constexpr size_t ACTIONSCRIPT_MAX_STEP_SIZE = 32;
 class TC_GAME_API ActionThread
 {
     public:
         ActionThread(Unit* owner, ActionScript const& script, size_t initialStep);
         ~ActionThread();
-        // @todo this needs a return value indicating whether behavior should control
-        void Update();
+
+        // @todo return value needs to indicate whether behavior should control
+        enum ActionThreadState { STATE_RUNNING, STATE_FINISHED };
+        ActionThreadState Update();
 
         Unit* GetOwner() const { return _owner; }
         
     private:
         Unit* const _owner;
         ActionScript const& _script;
-        std::unique_ptr<ActionThreadStep> _currentStep;
         TimePoint _stepTimeout;
+
+        ActionThreadStep& GetCurrentStep() { return *reinterpret_cast<ActionThreadStep*>(_currentStep); }
+        unsigned char _currentStep[ACTIONSCRIPT_MAX_STEP_SIZE];
 
         std::vector<ActionScriptVariableContent> _variables;
 
-        void StepTo(Optional<size_t> step);
+        void StepTo(size_t step);
 };
 
 #endif

--- a/src/server/game/Behavior/ActionScript/ActionScript.h
+++ b/src/server/game/Behavior/ActionScript/ActionScript.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_ACTIONSCRIPT_H
+#define TRINITY_ACTIONSCRIPT_H
+
+#include "ActionScriptDefines.h"
+#include "Define.h"
+#include "Duration.h"
+#include "Optional.h"
+#include <array>
+#include <vector>
+
+struct TC_GAME_API ActionScriptStepArgument
+{
+
+};
+
+struct TC_GAME_API ActionScriptStep
+{
+    ActionScriptStepType StepType;
+    std::array<ActionScriptStepArgument, ACTIONSCRIPT_STEP_ARGS_MAX> StepArgs;
+
+    Milliseconds Timeout;
+
+    Optional<size_t> GotoSuccess;
+    Optional<size_t> GotoFailure;
+    Optional<size_t> GotoTimeout;
+};
+
+class TC_GAME_API ActionScript
+{
+    public:
+        ActionScriptStep const& operator[](size_t i) const { return steps.at(i); }
+
+        auto begin() const { return steps.cbegin(); }
+        auto end() const { return steps.cend(); }
+        size_t size() const { return steps.size(); }
+
+    private:
+        std::vector<ActionScriptStep> steps;
+    friend class ActionScriptManager;
+};
+
+class TC_GAME_API ActionScriptThread
+{
+    public:
+        ActionScriptThread(ActionScript const& script, size_t initialStep);
+        // @todo this needs a return value indicating whether behavior should control
+        void Update();
+
+        
+    private:
+        ActionScript const& _script;
+        ActionScriptStep const* _currentStep;
+        TimePoint _stepTimeout;
+
+        Optional<bool> EvaluateCurrentStep();
+        void StepTo(Optional<size_t> step);
+};
+
+#endif

--- a/src/server/game/Behavior/ActionScript/ActionScriptManager.cpp
+++ b/src/server/game/Behavior/ActionScript/ActionScriptManager.cpp
@@ -20,6 +20,12 @@
 #include "Duration.h"
 #include "Log.h"
 
+ActionScriptManager& ActionScriptManager::_instance()
+{
+    static ActionScriptManager i;
+    return i;
+}
+
 void ActionScriptManager::GlobalInit()
 {
     TimePoint start = std::chrono::steady_clock::now();

--- a/src/server/game/Behavior/ActionScript/ActionScriptManager.cpp
+++ b/src/server/game/Behavior/ActionScript/ActionScriptManager.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ActionScriptManager.h"
+#include "DatabaseEnv.h"
+#include "Duration.h"
+#include "Log.h"
+
+void ActionScriptManager::GlobalInit()
+{
+    TimePoint start = std::chrono::steady_clock::now();
+
+    auto& i = _instance();
+    assert(!i);
+    i = std::make_unique<ActionScriptManager>();
+    i->Init();
+
+    uint32 ms = std::chrono::duration_cast<Milliseconds>(std::chrono::steady_clock::now() - start).count();
+    TC_LOG_INFO("server.loading", ">> Loaded %u behavior scripts in %u ms", i->GetScriptCount(), ms);
+}
+
+void ActionScriptManager::Init()
+{
+    // @todo init the actual script data
+
+    QueryResult result = WorldDatabase.Query("SELECT spawnType, entry, index, scriptId FROM actionscript_assign ORDER BY spawnType ASC, entry ASC, index DESC");
+    do
+    {
+        Field* fields = result->Fetch();
+        SpawnObjectType type = SpawnObjectType(fields[0].GetUInt8());
+        uint32 templateId = fields[1].GetUInt32();
+        uint32 index = fields[2].GetUInt32();
+        uint32 scriptId = fields[3].GetUInt32();
+
+        std::vector<Optional<uint32>>& data = _scriptsByTemplate[{type, templateId}];
+        if (data.empty())
+            data.resize(index + 1);
+        data[index] = scriptId;
+    } while (result->NextRow());
+}

--- a/src/server/game/Behavior/ActionScript/ActionScriptManager.cpp
+++ b/src/server/game/Behavior/ActionScript/ActionScriptManager.cpp
@@ -31,12 +31,10 @@ void ActionScriptManager::GlobalInit()
     TimePoint start = std::chrono::steady_clock::now();
 
     auto& i = _instance();
-    assert(!i);
-    i = std::make_unique<ActionScriptManager>();
-    i->Init();
+    i.Init();
 
     uint32 ms = std::chrono::duration_cast<Milliseconds>(std::chrono::steady_clock::now() - start).count();
-    TC_LOG_INFO("server.loading", ">> Loaded %u behavior scripts in %u ms", i->GetScriptCount(), ms);
+    TC_LOG_INFO("server.loading", ">> Loaded %u behavior scripts in %u ms", i.GetScriptCount(), ms);
 }
 
 void ActionScriptManager::Init()

--- a/src/server/game/Behavior/ActionScript/ActionScriptManager.h
+++ b/src/server/game/Behavior/ActionScript/ActionScriptManager.h
@@ -15,33 +15,25 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GAMETIME_H
-#define __GAMETIME_H
+#ifndef TRINITY_ACTIONSCRIPTMANAGER_H
+#define TRINITY_ACTIONSCRIPTMANAGER_H
 
 #include "Define.h"
-#include "Duration.h"
+#include <memory>
 
-namespace GameTime
+class ActionScript;
+
+class TC_GAME_API ActionScriptManager
 {
-    // Server start time
-    TC_GAME_API time_t GetStartTime();
+    private:
+        static std::unique_ptr<ActionScriptManager const> i;
+    public:
+        static std::unique_ptr<ActionScriptManager const>& instance() { return i; }
+        static void GlobalInit();
+        
+};
 
-    // Current server time (unix) in seconds
-    TC_GAME_API time_t GetGameTime();
-
-    // Milliseconds since server start
-    TC_GAME_API uint32 GetGameTimeMS();
-
-    /// Current chrono system_clock time point
-    TC_GAME_API SystemTimePoint GetSystemTime();
-
-    /// Current chrono steady_clock time point
-    TC_GAME_API TimePoint Now();
-
-    /// Uptime (in secs)
-    TC_GAME_API uint32 GetUptime();
-
-    void UpdateGameTimers();
-}
+#define sActionScriptManager ActionScriptManager::instance()
+        
 
 #endif

--- a/src/server/game/Behavior/ActionScript/ActionScriptManager.h
+++ b/src/server/game/Behavior/ActionScript/ActionScriptManager.h
@@ -27,9 +27,9 @@
 class TC_GAME_API ActionScriptManager
 {
     private:
-        static auto& _instance() { static std::unique_ptr<ActionScriptManager> i; return i; }
+        static ActionScriptManager& _instance();
     public:
-        static ActionScriptManager const& instance() { return *_instance(); }
+        static ActionScriptManager const& instance() { return _instance(); }
         static void GlobalInit();
 
         ActionScript const* GetScriptForTemplate(SpawnObjectType type, uint32 templateId, uint32 index)

--- a/src/server/game/Behavior/ActionScript/ActionThreadStep.cpp
+++ b/src/server/game/Behavior/ActionScript/ActionThreadStep.cpp
@@ -29,15 +29,16 @@ class NullStep : public ActionThreadStep
         void Abort() override {}
 };
 
-/*static*/ std::unique_ptr<ActionThreadStep> ActionThreadStep::StepTo(ActionThread const& thread, ActionScriptStep const& stepTemplate)
+/*static*/ void ActionThreadStep::StepTo(unsigned char* ptr, ActionThread const& thread, ActionScriptStep const& stepTemplate)
 {
-    ActionThreadStep* step;
+    if (ptr[ACTIONSCRIPT_MAX_STEP_SIZE])
+        reinterpret_cast<ActionThreadStep*>(ptr)->~ActionThreadStep();
+
     switch (stepTemplate.StepType)
     {
         case ACTIONSCRIPT_NULL:
-            step = new NullStep(thread, stepTemplate);
+            new(ptr) NullStep(thread, stepTemplate);
             break;
     }
-    step->Initialize();
-    return std::unique_ptr<ActionThreadStep>(step);
+    reinterpret_cast<ActionThreadStep*>(ptr)->Initialize();
 }

--- a/src/server/game/Behavior/ActionScript/ActionThreadStep.cpp
+++ b/src/server/game/Behavior/ActionScript/ActionThreadStep.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ActionThreadStep.h"
+#include "ActionScript.h"
+
+class NullStep : public ActionThreadStep
+{
+    public:
+        NullStep(ActionThread const& thread, ActionScriptStep const& temp) : ActionThreadStep(thread, temp) {}
+        void Initialize() override {}
+        Optional<bool> Evaluate() override {
+            return {};
+        }
+        void Abort() override {}
+};
+
+/*static*/ std::unique_ptr<ActionThreadStep> ActionThreadStep::StepTo(ActionThread const& thread, ActionScriptStep const& stepTemplate)
+{
+    ActionThreadStep* step;
+    switch (stepTemplate.StepType)
+    {
+        case ACTIONSCRIPT_NULL:
+            step = new NullStep(thread, stepTemplate);
+            break;
+    }
+    step->Initialize();
+    return std::unique_ptr<ActionThreadStep>(step);
+}

--- a/src/server/game/Behavior/ActionScript/ActionThreadStep.h
+++ b/src/server/game/Behavior/ActionScript/ActionThreadStep.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_ACTIONTHREADSTEP_H
+#define TRINITY_ACTIONTHREADSTEP_H
+
+#include "ActionScriptDefines.h"
+#include "Optional.h"
+#include <memory>
+
+class ActionThread;
+struct ActionScriptStep;
+class TC_GAME_API ActionThreadStep
+{
+    public:
+        virtual ~ActionThreadStep() {}
+
+        static std::unique_ptr<ActionThreadStep> StepTo(ActionThread const& thread, ActionScriptStep const& stepTemplate);
+
+        virtual void Initialize() = 0;
+        virtual Optional<bool> Evaluate() = 0;
+        virtual void Abort() = 0;
+
+        ActionThread const& GetThread() const { return _thread; }
+        ActionScriptStep const& GetTemplate() const { return _template; }
+
+    protected:
+        ActionThreadStep(ActionThread const& thread, ActionScriptStep const& stepTemplate) : _thread(thread), _template(stepTemplate) {}
+
+        ActionThread const& _thread;
+        ActionScriptStep const& _template;
+};
+
+#endif

--- a/src/server/game/Behavior/ActionScript/ActionThreadStep.h
+++ b/src/server/game/Behavior/ActionScript/ActionThreadStep.h
@@ -29,7 +29,7 @@ class TC_GAME_API ActionThreadStep
     public:
         virtual ~ActionThreadStep() {}
 
-        static std::unique_ptr<ActionThreadStep> StepTo(ActionThread const& thread, ActionScriptStep const& stepTemplate);
+        static void StepTo(unsigned char* ptr, ActionThread const& thread, ActionScriptStep const& stepTemplate);
 
         virtual void Initialize() = 0;
         virtual Optional<bool> Evaluate() = 0;

--- a/src/server/game/Behavior/UnitBehavior.cpp
+++ b/src/server/game/Behavior/UnitBehavior.cpp
@@ -1,0 +1,57 @@
+#include "UnitBehavior.h"
+#include "GameTime.h"
+#include "ThreatManager.h"
+
+UnitBehavior::UnitBehavior(Unit* owner) : _owner(owner)
+{
+}
+
+void UnitBehavior::Update()
+{
+    if (!_owner->IsEngaged())
+    {
+        if (!ShouldAutoEngage())
+            return;
+        LookForAutoEngage();
+    }
+
+    // intentional duplicate conditional
+    // we may now be engaged, even though we weren't before!
+    if (_owner->IsEngaged())
+    {
+        if (ShouldTargetFromThreat())
+            UpdatePrimaryTargetFromThreat();
+        UpdateAutoAttackState();
+    }
+}
+
+void UnitBehavior::LookForAutoEngage()
+{
+    // @todo
+}
+
+void UnitBehavior::UpdatePrimaryTargetFromThreat()
+{
+    ThreatManager& threat = _owner->GetThreatManager();
+    // @todo update threat victim
+    Unit* const target = threat.GetCurrentVictim();
+    if (!target && ShouldEvadeWithoutTargets())
+    {
+        // @todo enter evade mode
+        return;
+    }
+    SetPrimaryTarget(target);
+}
+
+void UnitBehavior::UpdateAutoAttackState()
+{
+    Unit* const toAttack = ShouldAutoAttack() ? GetPrimaryTarget() : nullptr;
+        // @todo split "Victim" and "auto-attack target"
+    if (_owner->GetVictim() != toAttack)
+    {
+        if (toAttack)
+            _owner->Attack(toAttack, true);
+        else
+            _owner->AttackStop();
+    }
+}

--- a/src/server/game/Behavior/UnitBehavior.h
+++ b/src/server/game/Behavior/UnitBehavior.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2008-2018 TrinityCore <https://www.trinitycore.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_UNITBEHAVIOR_H
+#define TRINITY_UNITBEHAVIOR_H
+
+#include "Duration.h"
+
+class Unit;
+
+class TC_GAME_API UnitBehavior
+{
+    private:
+        void LookForAutoEngage();
+        void UpdatePrimaryTargetFromThreat();
+        void UpdateAutoAttackState();
+
+    public:
+        UnitBehavior(Unit* owner);
+        
+        void Engage();
+        void Update();
+
+        bool ShouldAutoEngage() const { return true; }
+        bool ShouldAutoAttack() const { return true; }
+        bool ShouldTargetFromThreat() const { return true; }
+        bool ShouldEvadeWithoutTargets() const { return true; }
+
+        void SetPrimaryTarget(Unit* target) { _primaryTarget = target; }
+        Unit* GetPrimaryTarget() const { return _primaryTarget; }
+    
+    private:
+        Unit* const _owner;
+        Unit* _primaryTarget = nullptr;
+}
+
+#endif

--- a/src/server/game/Behavior/UnitBehavior.h
+++ b/src/server/game/Behavior/UnitBehavior.h
@@ -18,6 +18,7 @@
 #ifndef TRINITY_UNITBEHAVIOR_H
 #define TRINITY_UNITBEHAVIOR_H
 
+#include "Define.h"
 #include "Duration.h"
 
 class Unit;
@@ -46,6 +47,6 @@ class TC_GAME_API UnitBehavior
     private:
         Unit* const _owner;
         Unit* _primaryTarget = nullptr;
-}
+};
 
 #endif

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22629,7 +22629,7 @@ void Player::ApplyEquipCooldown(Item* pItem)
     if (pItem->GetTemplate()->Flags & ITEM_FLAG_NO_EQUIP_COOLDOWN)
         return;
 
-    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+    TimePoint now = GameTime::Now();
     for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
     {
         _Spell const& spellData = pItem->GetTemplate()->Spells[i];

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10010,7 +10010,7 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* procTarget, uint32 typeMa
 
 void Unit::GetProcAurasTriggeredOnEvent(AuraApplicationProcContainer& aurasTriggeringProc, AuraApplicationList* procAuras, ProcEventInfo& eventInfo)
 {
-    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+    TimePoint now = GameTime::Now();
 
     // use provided list of auras which can proc
     if (procAuras)

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -140,7 +140,7 @@ void SpellHistory::SaveToDB(SQLTransaction& trans)
 
 void SpellHistory::Update()
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     for (auto itr = _categoryCooldowns.begin(); itr != _categoryCooldowns.end();)
     {
         if (itr->second->CategoryEnd < now)
@@ -202,7 +202,7 @@ bool SpellHistory::IsReady(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, bo
 template<>
 void SpellHistory::WritePacket<Pet>(WorldPacket& packet) const
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
 
     uint8 cooldownsCount = _spellCooldowns.size();
     packet << uint8(cooldownsCount);
@@ -239,7 +239,7 @@ void SpellHistory::WritePacket<Pet>(WorldPacket& packet) const
 template<>
 void SpellHistory::WritePacket<Player>(WorldPacket& packet) const
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     Clock::time_point infTime = now + InfinityCooldownDelayCheck;
 
     packet << uint16(_spellCooldowns.size());
@@ -289,7 +289,7 @@ void SpellHistory::StartCooldown(SpellInfo const* spellInfo, uint32 itemId, Spel
 
     GetCooldownDurations(spellInfo, itemId, &cooldown, &categoryId, &categoryCooldown);
 
-    Clock::time_point curTime = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point curTime = GameTime::GetSystemTime();
     Clock::time_point catrecTime;
     Clock::time_point recTime;
     bool needsCooldownPacket = false;
@@ -412,7 +412,7 @@ void SpellHistory::ModifyCooldown(uint32 spellId, int32 cooldownModMs)
     if (!cooldownModMs || itr == _spellCooldowns.end())
         return;
 
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     Clock::duration offset = std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(cooldownModMs));
     if (itr->second.CooldownEnd + offset > now)
         itr->second.CooldownEnd += offset;
@@ -506,7 +506,7 @@ uint32 SpellHistory::GetRemainingCooldown(SpellInfo const* spellInfo) const
         end = catItr->second->CategoryEnd;
     }
 
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     if (end < now)
         return 0;
 
@@ -516,7 +516,7 @@ uint32 SpellHistory::GetRemainingCooldown(SpellInfo const* spellInfo) const
 
 void SpellHistory::LockSpellSchool(SpellSchoolMask schoolMask, uint32 lockoutTime)
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     Clock::time_point lockoutEnd = now + std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(lockoutTime));
     for (uint32 i = 0; i < MAX_SPELL_SCHOOL; ++i)
         if (SpellSchoolMask(1 << i) & schoolMask)
@@ -573,7 +573,7 @@ void SpellHistory::LockSpellSchool(SpellSchoolMask schoolMask, uint32 lockoutTim
 
 bool SpellHistory::IsSchoolLocked(SpellSchoolMask schoolMask) const
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     for (uint32 i = 0; i < MAX_SPELL_SCHOOL; ++i)
         if (SpellSchoolMask(1 << i) & schoolMask)
             if (_schoolLockouts[i] > now)
@@ -585,12 +585,12 @@ bool SpellHistory::IsSchoolLocked(SpellSchoolMask schoolMask) const
 bool SpellHistory::HasGlobalCooldown(SpellInfo const* spellInfo) const
 {
     auto itr = _globalCooldowns.find(spellInfo->StartRecoveryCategory);
-    return itr != _globalCooldowns.end() && itr->second > GameTime::GetGameTimeSystemPoint();
+    return itr != _globalCooldowns.end() && itr->second > GameTime::GetSystemTime();
 }
 
 void SpellHistory::AddGlobalCooldown(SpellInfo const* spellInfo, uint32 duration)
 {
-    _globalCooldowns[spellInfo->StartRecoveryCategory] = GameTime::GetGameTimeSystemPoint() + std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(duration));
+    _globalCooldowns[spellInfo->StartRecoveryCategory] = GameTime::GetSystemTime() + std::chrono::milliseconds(duration);
 }
 
 void SpellHistory::CancelGlobalCooldown(SpellInfo const* spellInfo)
@@ -712,7 +712,7 @@ void SpellHistory::RestoreCooldownStateAfterDuel()
 
         for (auto itr = _spellCooldowns.begin(); itr != _spellCooldowns.end(); ++itr)
         {
-            Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+            Clock::time_point now = GameTime::GetSystemTime();
             uint32 cooldownDuration = itr->second.CooldownEnd > now ? std::chrono::duration_cast<std::chrono::milliseconds>(itr->second.CooldownEnd - now).count() : 0;
 
             // cooldownDuration must be between 0 and 10 minutes in order to avoid any visual bugs

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -86,7 +86,7 @@ public:
     template<class Type, class Period>
     void AddCooldown(uint32 spellId, uint32 itemId, std::chrono::duration<Type, Period> cooldownDuration)
     {
-        Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+        Clock::time_point now = GameTime::GetSystemTime();
         AddCooldown(spellId, itemId, now + std::chrono::duration_cast<Clock::duration>(cooldownDuration), 0, now);
     }
 

--- a/src/server/game/Time/GameTime.cpp
+++ b/src/server/game/Time/GameTime.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "GameTime.h"
+#include "Duration.h"
 #include "Timer.h"
 
 namespace GameTime
@@ -43,12 +44,12 @@ namespace GameTime
         return GameMSTime;
     }
 
-    std::chrono::system_clock::time_point GetGameTimeSystemPoint()
+    SystemTimePoint GetSystemTime()
     {
         return GameTimeSystemPoint;
     }
 
-    std::chrono::steady_clock::time_point GetGameTimeSteadyPoint()
+    TimePoint Now()
     {
         return GameTimeSteadyPoint;
     }

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -23,6 +23,7 @@
 #include "World.h"
 #include "AccountMgr.h"
 #include "AchievementMgr.h"
+#include "ActionScriptManager.h"
 #include "AddonMgr.h"
 #include "ArenaTeamMgr.h"
 #include "AuctionHouseBot.h"
@@ -1639,6 +1640,9 @@ void World::SetInitialWorldSettings()
 
     TC_LOG_INFO("server.loading", "Loading Account Roles and Permissions...");
     sAccountMgr->LoadRBAC();
+
+    TC_LOG_INFO("server.loading", "Loading Creature behavior data...");
+    ActionScriptManager::GlobalInit();
 
     TC_LOG_INFO("server.loading", "Loading Page Texts...");
     sObjectMgr->LoadPageTexts();

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -265,7 +265,7 @@ class spell_dru_eclipse : public SpellScriptLoader
                 if (!spellInfo || !(spellInfo->SpellFamilyFlags[0] & 4)) // Starfire
                     return false;
 
-                return _solarProcCooldownEnd <= GameTime::GetGameTimeSteadyPoint();
+                return _solarProcCooldownEnd <= GameTime::Now();
             }
 
             bool CheckLunar(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
@@ -278,14 +278,14 @@ class spell_dru_eclipse : public SpellScriptLoader
                 if (!roll_chance_i(60))
                     return false;
 
-                return _lunarProcCooldownEnd <= GameTime::GetGameTimeSteadyPoint();
+                return _lunarProcCooldownEnd <= GameTime::Now();
             }
 
             void ProcSolar(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
             {
                 PreventDefaultAction();
 
-                _solarProcCooldownEnd = GameTime::GetGameTimeSteadyPoint() + Seconds(30);
+                _solarProcCooldownEnd = GameTime::Now() + 30s;
                 eventInfo.GetActor()->CastSpell(eventInfo.GetActor(), SPELL_DRUID_ECLIPSE_SOLAR_PROC, aurEff);
             }
 
@@ -293,7 +293,7 @@ class spell_dru_eclipse : public SpellScriptLoader
             {
                 PreventDefaultAction();
 
-                _lunarProcCooldownEnd = GameTime::GetGameTimeSteadyPoint() + Seconds(30);
+                _lunarProcCooldownEnd = GameTime::Now() + 30s;
                 eventInfo.GetActor()->CastSpell(eventInfo.GetActor(), SPELL_DRUID_ECLIPSE_LUNAR_PROC, aurEff);
             }
 

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1972,7 +1972,7 @@ class spell_pal_sacred_shield_dummy : public SpellScriptLoader
                 if (!caster)
                     return;
 
-                std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+                TimePoint now = GameTime::Now();
                 if (_cooldownEnd > now)
                     return;
 

--- a/src/server/shared/ActionScriptDefines.h
+++ b/src/server/shared/ActionScriptDefines.h
@@ -15,33 +15,16 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GAMETIME_H
-#define __GAMETIME_H
+#ifndef TRINITY_ACTIONSCRIPTDEFINES_H
+#define TRINITY_ACTIONSCRIPTDEFINES_H
 
 #include "Define.h"
-#include "Duration.h"
 
-namespace GameTime
+constexpr size_t ACTIONSCRIPT_STEP_ARGS_MAX = 4;
+
+enum ActionScriptStepType : uint8
 {
-    // Server start time
-    TC_GAME_API time_t GetStartTime();
-
-    // Current server time (unix) in seconds
-    TC_GAME_API time_t GetGameTime();
-
-    // Milliseconds since server start
-    TC_GAME_API uint32 GetGameTimeMS();
-
-    /// Current chrono system_clock time point
-    TC_GAME_API SystemTimePoint GetSystemTime();
-
-    /// Current chrono steady_clock time point
-    TC_GAME_API TimePoint Now();
-
-    /// Uptime (in secs)
-    TC_GAME_API uint32 GetUptime();
-
-    void UpdateGameTimers();
-}
+    ACTIONSCRIPT_NULL = 0, // do nothing, never finish by itself
+};
 
 #endif


### PR DESCRIPTION
It's Happening™. Eventually. Keep reading.

So.

Our current AI system micromanages practically everything. From making sure the creature keeps swinging in melee, to attacking a new victim, to updating eventmaps or checking health. It also has a bunch of hooks that get invoked from the outside on the most miniscule of events (spell hit, _any_ damage taken, _any movement_ at all).

It's also ridiculously rigid. Events are timed down to the millisecond (+- one server tick) and will always execute at exactly that time.

Retail.... doesn't do any of that. Retail AI is (mostly) asynchronous, and written in a way where delaying AI callbacks a few ticks doesn't make much of a difference. Their scripts set behavior flags for common behavior (should auto attack, should be unkillable, etc.) and those behavior flags are then handled by the core. The result is a _large_ reduction in script complexity, and the core can also make assumptions about what scripts will or won't do. Scripts become less powerful, which is actually a good thing.

_(@xvwyh actually wrote a very nice summary of some more differences [over here](https://github.com/TrinityCore/TrinityCore/pull/22296#issuecomment-420112383) - you should read that)_

This PR is where all of that changes. We're throwing out the old AI system in its entirety.
_(Realistic aside: it'll survive as `LegacyCreatureAI` or something for now, likely with reduced capabilities.)_

Let's talk about the replacement. Timetable for actual implementation is, most likely, christmas break, because I'm about to be consumed by the upcoming semester, so there's that. Until then, let's figure out what _won't_ work in the proposed model, and then change the proposed model so it _does_ work.

Here's how I see this working out.

# The broad strokes _(aka: How Do I Do Things)_

It's a callback-based model. The script registers callbacks (functions) to happen upon certain events.

Examples of events are health thresholds and timers. Replicating the current update loop with these is possible, but not the intended usage.

Callbacks can be registered/unregistered on the fly. The idea is that any given callback sets up the next "steps".

For example, if a boss changes phases at 60% and 40%, this would look like this:

* initial setup:
  * set self unkillable (behavior flag, see further down)
  * setup callback 1 on engage
* callback 1:
  * setup callback 2 at health threshold 60%
  * setup any necessary periodic callbacks
* callback 2:
  * cancel any unneeded periodic callbacks (i'm considering a validator model so this isn't needed)
  * setup callback 3 at health threshold 40%
  * setup periodic stuff for phase 2
* callback 3:
  * same as above
  * set self killable

Not that different from our current scripts, right? The main difference is that all of the handling of callbacks is done core-side, and we don't need to call into the actual script on every tick anymore.

_(Aside: Evading would also be core-side, and that'd let us get rid of quite a few hacks. I'm also intending to fully reset the "AI object" (I'm not sure I'd even call it that - "Behavior object"?) when reaching home after an evade.)_

# Behavior flags _(aka: How Do I Do When I'm Not Doing)_

Pretty much all of our scripts do the same things. Yes, depending on the boss, there's a few special things (that's why callbacks exist) but overall they all do the same thing. We can handle those things coreside using what I call "behavior flags" that tell the core how the creature should act.

Below is a list of behavior flags I'm currently considering for implementation. Please comment if you can think of things you can't do with these.

## The combat flags _(aka: How Do I Do When I'm Doing The Do-Do)_
* Auto-engage?
  * `true`
    * if not engaged, periodically check for nearby targets we can engage
    * (this is the behavior of current `REACT_AGGRESSIVE` in base CAI)
  * `false`
    * never engage on our own, wait for other things to engage us first
* Auto-attack?
  * `true`/`false` - whether we should ever do melee swings
  * even if this is `true` we might use spells instead depending on priority!
* Using threat?
  * `NO`/`FIXATE`/`YES` - whether we should care about the threat list
  * if this is set to `NO` or `FIXATE`, the core will never override the victim selection
  * if this is set to `FIXATE` and current victim goes away, snaps back to `YES`
* Can evade?
  * `true`/`false` - what it says on the tin; whether we should evade if there's no targets to punch anymore
  * Is this even necessary? Feels like the previous flag might handle this just fine.

## The interaction flags _(aka: How The Do-Do Is Done To Me)_
* Can I take damage?
  * `true`/`false`
* Unkillable?
  * `true`/`false`
  * Will remain at 1 HP without dying if `true` is set - bosses should set this outside their final phase

## Spell priority system _(aka: I Do The Do-Do Without Any Do!)_
* Inspired by PlayerAI
* Creature has a list of spells it can cast
  * Each spell comes with properties (priority, "cooldown", target selection...)
  * Kind of like SAI, just flexible!
* This is for non-boss mobs that should be even more dynamic
* Some randomness in the selection of spell to cast

# Some more thoughts on callbacks _(aka: How Do I Do It Do the Doing)_
I'm envisioning three different kinds of callbacks that can be used more-or-less interchangably:
* "Regular" C++ callback
  * I am quite tempted to restrain what these can do, but it may be hard
  * Restraining can bite you, we might need the flexibility
  * With Great Power etc
* Lua callback (IT'S HAPPENING)
  * Because we only go into the callback rarely, we can afford the overhead now!
  * Lua is sandboxed, so less possibility for hacks 😊 
    * Relevant behavior manipulation functions exposed in the sandbox
    * Core itself isn't exposed - because callbacks shouldn't touch the core! Bad!
* DB-based callback
  * Kind of like current SAI already works!
  * Mostly for stuff like quest credit
  * "Native" spell casts should be handled by spell priority system!

Callbacks don't _have to_ be real time, and shouldn't depend on this! If a callback happens to happen a second or two late, this shouldn't break anything.

_(Aura scripts are for precise stuff. Those are staying as is.)_

# What I Want You To Do(-Do)

Think about scripts you've worked on. What things do they do that doesn't cleanly fit the model above? Bring it up. I would prefer to find out now rather than halfway into the implementation.

What things would you like it to do it currently doesn't? Do you think some things could be more streamlined? More input on how you've found retail does things? I'm interested.

Like anything above a bunch? Tell me, so I can make sure not to cut it if possible. This is a draft after all.


PS: I am truly a bit of a masochist, I suspect.