### PR TITLE
Core/Spell: Crit of SPELL_EFFECT_HEALTH_LEECH

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6981,6 +6981,9 @@ float Unit::SpellCritChanceTaken(Unit const* caster, SpellInfo const* spellInfo,
     if (!isPeriodic && !spellInfo->HasAttribute(SPELL_ATTR0_CU_CAN_CRIT))
         return 0.0f;
 
+    if (spellInfo->HasEffect(SPELL_EFFECT_HEALTH_LEECH))
+        return 0.0f;
+
     float crit_chance = doneChance;
     switch (spellInfo->DmgClass)
     {


### PR DESCRIPTION
**Changes proposed:**
Disable critical chance for spells having `SPELL_EFFECT_HEALTH_LEECH` effect (Health Leech Spells).

**Target branch(es):** 3.3.5

**Tests performed:** Tested in game.
