### PR TITLE
Core/Movement: Properly calculate the first Catmull-Rom spline point

### DIFF
--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -126,10 +126,10 @@ void MoveSpline::init_spline(MoveSplineInitArgs const& args)
         // MoveSplineFlag::Enter_Cycle support dropped
         //if (splineflags & SPLINEFLAG_ENTER_CYCLE)
         //cyclic_point = 1;   // shouldn't be modified, came from client
-        spline.init_cyclic_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()], cyclic_point);
+        spline.init_cyclic_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()], cyclic_point, args.initialOrientation);
     }
     else
-        spline.init_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()]);
+        spline.init_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()], args.initialOrientation);
 
     // init spline timestamps
     if (splineflags.falling)

--- a/src/server/game/Movement/Spline/Spline.cpp
+++ b/src/server/game/Movement/Spline/Spline.cpp
@@ -255,14 +255,14 @@ void SplineBase::InitCatmullRom(Vector3 const* controls, index_type count, index
         if (cyclic_point == 0)
             points[0] = controls[count-1];
         else
-            points[0] = controls[0] - G3D::Vector3{ cos(initialOrientation), sin(initialOrientation), 0.0f };
+            points[0] = controls[0] - G3D::Vector3{ std::cos(initialOrientation), std::sin(initialOrientation), 0.0f };
 
         points[high_index+1] = controls[cyclic_point];
         points[high_index+2] = controls[cyclic_point+1];
     }
     else
     {
-        points[0] = controls[0] - G3D::Vector3{ cos(initialOrientation), sin(initialOrientation), 0.0f };
+        points[0] = controls[0] - G3D::Vector3{ std::cos(initialOrientation), std::sin(initialOrientation), 0.0f };
         points[high_index+1] = controls[count-1];
     }
 

--- a/src/server/game/Movement/Spline/Spline.cpp
+++ b/src/server/game/Movement/Spline/Spline.cpp
@@ -199,18 +199,20 @@ float SplineBase::SegLengthBezier3(index_type index) const
     return length;
 }
 
-void SplineBase::init_spline(const Vector3 * controls, index_type count, EvaluationMode m)
+void SplineBase::init_spline(const Vector3 * controls, index_type count, EvaluationMode m, float orientation)
 {
     m_mode = m;
     cyclic = false;
+    initialOrientation = orientation;
 
     (this->*initializers[m_mode])(controls, count, 0);
 }
 
-void SplineBase::init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point)
+void SplineBase::init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point, float orientation)
 {
     m_mode = m;
     cyclic = true;
+    initialOrientation = orientation;
 
     (this->*initializers[m_mode])(controls, count, cyclic_point);
 }
@@ -253,14 +255,14 @@ void SplineBase::InitCatmullRom(Vector3 const* controls, index_type count, index
         if (cyclic_point == 0)
             points[0] = controls[count-1];
         else
-            points[0] = controls[0].lerp(controls[1], -1);
+            points[0] = controls[0] - G3D::Vector3{ cos(initialOrientation), sin(initialOrientation), 0.0f };
 
         points[high_index+1] = controls[cyclic_point];
         points[high_index+2] = controls[cyclic_point+1];
     }
     else
     {
-        points[0] = controls[0].lerp(controls[1], -1);
+        points[0] = controls[0] - G3D::Vector3{ cos(initialOrientation), sin(initialOrientation), 0.0f };
         points[high_index+1] = controls[count-1];
     }
 

--- a/src/server/game/Movement/Spline/Spline.h
+++ b/src/server/game/Movement/Spline/Spline.h
@@ -50,6 +50,7 @@ protected:
 
     uint8 m_mode;
     bool cyclic;
+    float initialOrientation;
 
     enum{
         // could be modified, affects segment length evaluation precision
@@ -115,8 +116,8 @@ public:
     Vector3 const& getPoint(index_type i) const { return points[i];}
 
     /** Initializes spline. Don't call other methods while spline not initialized. */
-    void init_spline(const Vector3 * controls, index_type count, EvaluationMode m);
-    void init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point);
+    void init_spline(const Vector3 * controls, index_type count, EvaluationMode m, float orientation);
+    void init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point, float orientation);
 
     /** As i can see there are a lot of ways how spline can be initialized
         would be no harm to have some custom initializers. */
@@ -171,8 +172,8 @@ public:
     void computeIndex(float t, index_type& out_idx, float& out_u) const;
 
     /** Initializes spline. Don't call other methods while spline not initialized. */
-    void init_spline(const Vector3 * controls, index_type count, EvaluationMode m) { SplineBase::init_spline(controls, count, m);}
-    void init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point) { SplineBase::init_cyclic_spline(controls, count, m, cyclic_point);}
+    void init_spline(const Vector3 * controls, index_type count, EvaluationMode m, float orientation = 0) { SplineBase::init_spline(controls, count, m, orientation);}
+    void init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point, float orientation = 0) { SplineBase::init_cyclic_spline(controls, count, m, cyclic_point, orientation);}
 
     /**  Initializes lengths with SplineBase::SegLength method. */
     void initLengths();


### PR DESCRIPTION
**Changes proposed:**
Implement #22435.
Credit @xvwyh.

**Target branch(es):** 3.3.5

**Tests performed:** _Somewhat_ tested in-game.