### PR TITLE
Core/Command: fix .appear command provide wrong undermap position

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -453,7 +453,7 @@ public:
 
             // to point to see at target with same orientation
             float x, y, z;
-            target->GetContactPoint(_player, x, y, z);
+            target->GetClosePoint(x, y, z, _player->GetCombatReach(), 1.0f);
 
             _player->TeleportTo(target->GetMapId(), x, y, z, _player->GetAbsoluteAngle(target), TELE_TO_GM_MODE);
             _player->SetPhaseMask(target->GetPhaseMask(), true);


### PR DESCRIPTION
**Changes proposed:**

fix .appear command provide wrong undermap position

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #22514 

**Tests performed:** (Does it build, tested in-game, etc.) tested in-game
