### PR TITLE
[3.3.5] Scripts/Spells: Life Tap

### DIFF
--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -819,8 +819,7 @@ class spell_warl_life_tap : public SpellScriptLoader
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
                 Unit* caster = GetCaster();
-                int32 base = GetSpellInfo()->Effects[EFFECT_0].CalcValue();
-                int32 damage = base + (int32)round(caster->GetStat(STAT_SPIRIT) * 1.5f);
+                int32 base = GetEffectValue();
 
                 float fmana = (float)base + caster->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW) * 0.5f;
                 // Improved Life Tap mod
@@ -829,7 +828,7 @@ class spell_warl_life_tap : public SpellScriptLoader
                 int32 mana = round(fmana);
 
                 // Shouldn't Appear in Combat Log
-                caster->ModifyHealth(-damage);
+                caster->ModifyHealth(-base);
 
                 CastSpellExtraArgs args;
                 args.AddSpellBP0(mana);
@@ -851,10 +850,7 @@ class spell_warl_life_tap : public SpellScriptLoader
 
             SpellCastResult CheckCast()
             {
-                Unit* caster = GetCaster();
-                int32 damage = GetSpellInfo()->Effects[EFFECT_0].CalcValue() + (int32)round(caster->GetStat(STAT_SPIRIT) * 1.5f);
-
-                if (int32(caster->GetHealth()) > damage)
+                if (int32(GetCaster()->GetHealth()) > int32(GetSpellInfo()->Effects[EFFECT_0].CalcValue()))
                     return SPELL_CAST_OK;
                 return SPELL_FAILED_FIZZLE;
             }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -818,41 +818,43 @@ class spell_warl_life_tap : public SpellScriptLoader
 
             void HandleDummy(SpellEffIndex /*effIndex*/)
             {
-                Player* caster = GetCaster()->ToPlayer();
-                if (Unit* target = GetHitUnit())
+                Unit* caster = GetCaster();
+                int32 base = GetSpellInfo()->Effects[EFFECT_0].CalcValue();
+                int32 damage = base + (int32)round(caster->GetStat(STAT_SPIRIT) * 1.5f);
+
+                float fmana = (float)base + caster->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW) * 0.5f;
+                // Improved Life Tap mod
+                if (AuraEffect const* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_IMPROVED_LIFE_TAP, 0))
+                    AddPct(fmana, aurEff->GetAmount());
+                int32 mana = round(fmana);
+
+                // Shouldn't Appear in Combat Log
+                caster->ModifyHealth(-damage);
+
+                CastSpellExtraArgs args;
+                args.AddSpellBP0(mana);
+                caster->CastSpell(caster, SPELL_WARLOCK_LIFE_TAP_ENERGIZE, args);
+
+                // Mana Feed
+                int32 manaFeedVal = 0;
+                if (AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_MANA_FEED, 0))
+                    manaFeedVal = aurEff->GetAmount();
+
+                if (manaFeedVal > 0)
                 {
-                    int32 damage = GetEffectValue();
-                    int32 mana = int32(damage + (caster->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS+SPELL_SCHOOL_SHADOW) * 0.5f));
-
-                    // Shouldn't Appear in Combat Log
-                    target->ModifyHealth(-damage);
-
-                    // Improved Life Tap mod
-                    if (AuraEffect const* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_IMPROVED_LIFE_TAP, 0))
-                        AddPct(mana, aurEff->GetAmount());
-
-                    CastSpellExtraArgs args;
-                    args.AddSpellBP0(mana);
-                    caster->CastSpell(target, SPELL_WARLOCK_LIFE_TAP_ENERGIZE, args);
-
-                    // Mana Feed
-                    int32 manaFeedVal = 0;
-                    if (AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_AURA_ADD_FLAT_MODIFIER, SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_MANA_FEED, 0))
-                        manaFeedVal = aurEff->GetAmount();
-
-                    if (manaFeedVal > 0)
-                    {
-                        ApplyPct(manaFeedVal, mana);
-                        CastSpellExtraArgs manaFeedArgs(TRIGGERED_FULL_MASK);
-                        manaFeedArgs.AddSpellBP0(manaFeedVal);
-                        caster->CastSpell(caster, SPELL_WARLOCK_LIFE_TAP_ENERGIZE_2, manaFeedArgs);
-                    }
+                    ApplyPct(manaFeedVal, mana);
+                    CastSpellExtraArgs manaFeedArgs(TRIGGERED_FULL_MASK);
+                    manaFeedArgs.AddSpellBP0(manaFeedVal);
+                    caster->CastSpell(caster, SPELL_WARLOCK_LIFE_TAP_ENERGIZE_2, manaFeedArgs);
                 }
             }
 
             SpellCastResult CheckCast()
             {
-                if ((int32(GetCaster()->GetHealth()) > int32(GetSpellInfo()->Effects[EFFECT_0].CalcValue() + (6.3875 * GetSpellInfo()->BaseLevel))))
+                Unit* caster = GetCaster();
+                int32 damage = GetSpellInfo()->Effects[EFFECT_0].CalcValue() + (int32)round(caster->GetStat(STAT_SPIRIT) * 1.5f);
+
+                if (int32(caster->GetHealth()) > damage)
                     return SPELL_CAST_OK;
                 return SPELL_FAILED_FIZZLE;
             }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -821,7 +821,9 @@ class spell_warl_life_tap : public SpellScriptLoader
                 Unit* caster = GetCaster();
                 int32 base = GetEffectValue();
 
-                float fmana = (float)base + caster->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW) * 0.5f;
+                float penalty = caster->CalculateSpellpowerCoefficientLevelPenalty(GetSpellInfo());
+                float fmana = (float)base + caster->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW) * 0.5f * penalty;
+
                 // Improved Life Tap mod
                 if (AuraEffect const* aurEff = caster->GetDummyAuraEffect(SPELLFAMILY_WARLOCK, WARLOCK_ICON_ID_IMPROVED_LIFE_TAP, 0))
                     AddPct(fmana, aurEff->GetAmount());


### PR DESCRIPTION
This PR hurts me as a warlock main, life tap was already rough at lower levels.
On my lvl 56 GD lock life tap would go from 346 life -> 492 mana to 482 life -> 444 mana, and that's with improved life tap :cry: 

**Changes proposed:**
Fixes Life tap to accurately drain life and grant mana according to the tooltip.

Life tap costs a base amount for each rank + spirit * 1.5, while granting the same base amount + shadow power * 0.5.
https://wotlk.evowow.com/?spell=57946
https://web.archive.org/web/20100813053911/http://www.wowhead.com/spell=57946

Life tap can now be used 1 hp above the drain cost.
https://www.wowhead.com/spell=1454/life-tap#comments:id=19418

Wowhead comments on ranks 2-8 seem to be lost, what a shame.

**Target branch(es):**
3.3.5

**Issues addressed:** Closes #17559

**Tests performed:** (Does it build, tested in-game, etc.)
I tested at various levels with different combination of heirloom gear, couldn't find any difference between tooltip and results.