### PR TITLE
Fix gameobject turn orientation saving

### DIFF
--- a/src/server/scripts/Commands/cs_gobject.cpp
+++ b/src/server/scripts/Commands/cs_gobject.cpp
@@ -432,7 +432,7 @@ public:
         }
 
         Map* map = object->GetMap();
-        object->Relocate(object->GetPositionX(), object->GetPositionY(), object->GetPositionZ());
+        object->Relocate(object->GetPositionX(), object->GetPositionY(), object->GetPositionZ(), oz);
         object->SetWorldRotationAngles(oz, oy, ox);
         object->SaveToDB();
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fix orientation not saved properly when turning object
- Before this if you use .gob target, then use .gob turn and then .gob target again, the orientation in the info would not be changed.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame that `.gob target` has new orientation after `.gob turn <guid> <orient>`