### PR TITLE
Core/Unit: Patch 3.0.8 tagging

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8183,6 +8183,11 @@ void Unit::AttackedTarget(Unit* target, bool canInitialAggro)
     if (Unit* targetOwner = target->GetCharmerOrOwner())
         targetOwner->EngageWithTarget(this);
 
+    //Patch 3.0.8: All player spells which cause a creature to become aggressive to you will now also immediately cause the creature to be tapped.
+    if (Creature* creature = target->ToCreature())
+        if (!creature->hasLootRecipient() && GetTypeId() == TYPEID_PLAYER)
+            creature->SetLootRecipient(this);
+
     Player* myPlayerOwner = GetCharmerOrOwnerPlayerOrPlayerItself();
     Player* targetPlayerOwner = target->GetCharmerOrOwnerPlayerOrPlayerItself();
     if (myPlayerOwner && targetPlayerOwner && !(myPlayerOwner->duel && myPlayerOwner->duel->Opponent == targetPlayerOwner))


### PR DESCRIPTION
**Changes proposed:**
http://wowwiki.wikia.com/wiki/Patch_3.0.8
> Tapping: All player spells which cause a creature to become aggressive to you will now also immediately cause the creature to be tapped.

https://kotaku.com/5135695/wow-patch-308-brings-important-changes-to-clams
> and the fact that damage over time spells that don't immediately damage monsters now tag the critters as yours anyway is a great boon for several casting classes,

This PR makes all attack interactions that engages a mob tag that mob if possible.

I wanted to remove [the old](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Unit/Unit.cpp#L804-L805) for cleanness, but this commit addition doesn't tag on reflect damage (tried retri aura and thorns) or `.damage X`.

**Target branch(es):** 3.3.5

**Tests performed:** 
Builds and tags by any warlock spell hit I tried.
