### PR TITLE
DB/Spell: fix mistake in Blood Draining's CheckProc and remove Attack Power scaling

### DIFF
--- a/sql/updates/world/3.3.5/2019_01_10_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_01_10_00_world.sql
@@ -1,1 +1,2 @@
+--
 UPDATE `spell_bonus_data` SET `ap_bonus`=0, `ap_dot_bonus`=0 WHERE `entry`=64569;

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,5 +1,1 @@
-DELETE FROM `spell_proc` WHERE `SpellId`=64568;
-INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
-(64568, 0, 0, 0, 0, 0, 0x100000, 0, 0, 0, 0, 0, 0, 0, 0);
-
 UPDATE `spell_bonus_data` SET `ap_bonus`=0, `ap_dot_bonus`=0 WHERE `entry`=64569;

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_proc` WHERE `SpellId`=64568;
+INSERT INTO `spell_proc` (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`) VALUES
+(64568, 0, 0, 0, 0, 0, 0x100000, 0, 0, 0, 0, 0, 0, 0, 0);
+
+UPDATE `spell_bonus_data` SET `ap_bonus`=0, `ap_dot_bonus`=0 WHERE `entry`=64569;

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -479,10 +479,9 @@ class spell_gen_blood_reserve : public AuraScript
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
-        if (DamageInfo* dmgInfo = eventInfo.GetDamageInfo())
-            if (Unit* caster = eventInfo.GetActionTarget())
-                if (caster->HealthBelowPctDamaged(35, dmgInfo->GetDamage()))
-                    return true;
+        if (Unit* caster = eventInfo.GetActionTarget())
+            if (caster->HealthBelowPct(35))
+                return true;
 
         return false;
     }


### PR DESCRIPTION
**Changes proposed:**

- ~~Add missing entry in the spell_proc table for the spell [Blood Reserve](https://www.wowhead.com/spell=64568) (triggered after every damage received), which allows the [Blood Draining](https://www.wowhead.com/spell=64579) weapon enchant to work properly.~~
Plot twist: it was working fine all along.

- Fix small issue in the AuraScript. The proc is checked _after_ the damage is dealt, so using HealthBelowPctDamaged doesn't make sense (it would subtract the same damage from the current health before computing the percentage of health left, double-dipping).

- Don't allow the heal proc to scale with attack power.

**Target branch(es):** both.

**Issues addressed:** None.

**Tests performed:** builds, tested and working properly.

Issue #22817 was probably fixed by an earlier commit, or it was a wrong report. Should be closed.