### PR TITLE
Script/Spell: prevent Counterattack! and Charge from removing two charges of Defend

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2215,10 +2215,6 @@ class spell_gen_mounted_charge : public SpellScript
                         if (auraInfo && auraInfo->SpellIconID == 2007 && aura->HasEffectType(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN))
                         {
                             aura->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
-                            // Remove dummys from rider (Necessary for updating visual shields)
-                            if (Unit* rider = target->GetCharmer())
-                                if (Aura* defend = rider->GetAura(aura->GetId()))
-                                    defend->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
                             break;
                         }
                     }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -660,10 +660,6 @@ class spell_gen_break_shield: public SpellScriptLoader
                                 if (auraInfo && auraInfo->SpellIconID == 2007 && aura->HasEffectType(SPELL_AURA_MOD_DAMAGE_PERCENT_TAKEN))
                                 {
                                     aura->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
-                                    // Remove dummys from rider (Necessary for updating visual shields)
-                                    if (Unit* rider = target->GetCharmer())
-                                        if (Aura* defend = rider->GetAura(aura->GetId()))
-                                            defend->ModStackAmount(-1, AURA_REMOVE_BY_ENEMY_SPELL);
                                     break;
                                 }
                             }


### PR DESCRIPTION
**Changes proposed:**

I'm not sure how it worked in the past, but as of 9a924fb9d557434c5a2e4020c80db6e6bfe466ad the [Defend](https://www.wowhead.com/spell=62552) aura is shared between player and mount. So removing a stack from the mount will also remove it from the player, and the other way around.

For example, mounting an Argent Tournament mount, casting Defend and using .unaura 62552 on the mount will also remove it from the player.

The script currently removes one stack from the mount and one stack from the player, which results in two stacks taken from the aura instead of one.

**Target branch(es):** both.

**Issues addressed:** Closes #22193.

**Tests performed:** builds, tested and working properly.