### PR TITLE
Core/Player: update player phase before updating area depending auras

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6974,8 +6974,8 @@ void Player::UpdateArea(uint32 newArea)
     pvpInfo.IsInFFAPvPArea = area && (area->Flags[0] & AREA_FLAG_ARENA);
     UpdatePvPState(true);
 
-    UpdateAreaDependentAuras(newArea);
     PhasingHandler::OnAreaChange(this);
+    UpdateAreaDependentAuras(newArea);
 
     if (IsAreaThatActivatesPvpTalents(newArea))
         EnablePvpRules();


### PR DESCRIPTION
**Changes proposed:**
-  Update the player phase when updating an area before updating the area auras. After some research for Gilneas' transition into chapter 2 I have seen that Blizzard is using a own phase for that intro (Phase 105) This phase contains several dummy npc's which serve as summon targets for the intro stuff. Since this intro needs to be retro-active for players who have logged out for example they are using spell_area like mechanics to trigger the intro over again which requires the player to be in that phase before doing the corresponding area cast.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [X] master


**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame with own custom implementations of Gilneas on my fork.
