### PR TITLE
Scripts/Nagrand: Fix crash added in PR #22806

### DIFF
--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -730,14 +730,14 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (!UpdateVictim())
+            if (!UpdateVictim() || !me->GetVictim())
                 return;
 
             interrupt_cooldown += diff;
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;
 
-            if (me->GetVictim()->HasUnitState(UNIT_STATE_CASTING) && interrupt_cooldown > 25000)
+            if (me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING) && interrupt_cooldown > 25000)
             {
                 DoCastVictim(SPELL_COUNTERSPELL);
                 interrupt_cooldown = 0;


### PR DESCRIPTION
Fix crash added in PR #22806 happening in quest "Ruthless Cunning and Returning the Favor"

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add a null check

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
None

**Tests performed:** (Does it build, tested in-game, etc.)
None

**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
