### PR TITLE
Core/Entities: Superfluous InitStatsForLevel Call

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5589,9 +5589,6 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
         if (!summon)
             return;
 
-        if (summon->HasUnitTypeMask(UNIT_MASK_GUARDIAN))
-            ((Guardian*)summon)->InitStatsForLevel(level);
-
         if (properties && properties->Category == SUMMON_CATEGORY_ALLY)
             summon->SetFaction(unitCaster->GetFaction());
 


### PR DESCRIPTION
**Changes proposed:**
Remove unneeded call to `InitStatsForLevel`. Stats initialization is being already handled in [Object](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Object/Object.cpp#L1903)  class. 

**Target branch(es):** 3.3.5

**Tests performed:** Works on player summoned creatures.