### PR TITLE
[3.3.5] Entities/Unit: Targeting revamp (AI refactor prep part 1)

### DIFF
--- a/src/server/game/AI/CoreAI/CombatAI.cpp
+++ b/src/server/game/AI/CoreAI/CombatAI.cpp
@@ -156,7 +156,7 @@ void CasterAI::UpdateAI(uint32 diff)
 
     events.Update(diff);
 
-    if (me->GetVictim() && me->EnsureVictim()->HasBreakableByDamageCrowdControlAura(me))
+    if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HasBreakableByDamageCrowdControlAura(me))
     {
         me->InterruptNonMeleeSpells(false);
         return;
@@ -198,12 +198,12 @@ void ArcherAI::AttackStart(Unit* who)
 
     if (me->IsWithinCombatRange(who, m_minRange))
     {
-        if (me->Attack(who, true) && !who->IsFlying())
+        if (me->AutoAttackStart(who, true) && !who->IsFlying())
             me->GetMotionMaster()->MoveChase(who);
     }
     else
     {
-        if (me->Attack(who, false) && !who->IsFlying())
+        if (me->AutoAttackStart(who, false) && !who->IsFlying())
             me->GetMotionMaster()->MoveChase(who, me->m_CombatDistance);
     }
 
@@ -216,7 +216,7 @@ void ArcherAI::UpdateAI(uint32 /*diff*/)
     if (!UpdateVictim())
         return;
 
-    if (!me->IsWithinCombatRange(me->GetVictim(), m_minRange))
+    if (!me->IsWithinCombatRange(me->GetAutoAttackVictim(), m_minRange))
         DoSpellAttackIfReady(me->m_spells[0]);
     else
         DoMeleeAttackIfReady();
@@ -249,7 +249,7 @@ bool TurretAI::CanAIAttack(Unit const* who) const
 void TurretAI::AttackStart(Unit* who)
 {
     if (who)
-        me->Attack(who, false);
+        me->AutoAttackStart(who, false);
 }
 
 void TurretAI::UpdateAI(uint32 /*diff*/)

--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -42,15 +42,15 @@ void PassiveAI::UpdateAI(uint32)
 
 void PossessedAI::AttackStart(Unit* target)
 {
-    me->Attack(target, true);
+    me->AutoAttackStart(target, true);
 }
 
 void PossessedAI::UpdateAI(uint32 /*diff*/)
 {
-    if (me->GetVictim())
+    if (me->GetAutoAttackVictim())
     {
-        if (!me->IsValidAttackTarget(me->GetVictim()))
-            me->AttackStop();
+        if (!me->IsValidAttackTarget(me->GetAutoAttackVictim()))
+            me->AutoAttackStop();
         else
             DoMeleeAttackIfReady();
     }

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -225,7 +225,7 @@ class TC_GAME_API UnitAI
                     if (ref->IsOffline())
                         continue;
 
-                    targetList.push_back(ref->GetVictim());
+                    targetList.push_back(ref->GetAutoAttackVictim());
                 }
             }
             else
@@ -239,7 +239,7 @@ class TC_GAME_API UnitAI
                     if (ref->IsOffline())
                         continue;
 
-                    Unit* thisTarget = ref->GetVictim();
+                    Unit* thisTarget = ref->GetAutoAttackVictim();
                     if (thisTarget != currentVictim)
                         targetList.push_back(thisTarget);
                 }

--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -225,7 +225,7 @@ class TC_GAME_API UnitAI
                     if (ref->IsOffline())
                         continue;
 
-                    targetList.push_back(ref->GetAutoAttackVictim());
+                    targetList.push_back(ref->GetVictim());
                 }
             }
             else
@@ -239,7 +239,7 @@ class TC_GAME_API UnitAI
                     if (ref->IsOffline())
                         continue;
 
-                    Unit* thisTarget = ref->GetAutoAttackVictim();
+                    Unit* thisTarget = ref->GetVictim();
                     if (thisTarget != currentVictim)
                         targetList.push_back(thisTarget);
                 }

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -179,19 +179,22 @@ bool CreatureAI::UpdateVictim()
 
     if (!me->HasReactState(REACT_PASSIVE))
     {
-        if (Unit* victim = me->SelectVictim())
-            if (!me->IsFocusing(nullptr, true) && victim != me->GetVictim())
-                AttackStart(victim);
+        Unit* victim = me->SelectVictim();
+        if (victim)
+            AttackStart(victim);
+        else if (me->GetAutoAttackVictim())
+            me->AutoAttackStop();
+        me->SetPrimaryTarget(victim);
 
-        return me->GetVictim() != nullptr;
+        return me->IsEngaged();
     }
     else if (!me->IsInCombat())
     {
         EnterEvadeMode(EVADE_REASON_NO_HOSTILES);
         return false;
     }
-    else if (me->GetVictim())
-        me->AttackStop();
+    else if (me->GetAutoAttackVictim())
+        me->AutoAttackStop();
 
     return true;
 }
@@ -211,7 +214,7 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     me->ResetPlayerDamageReq();
     me->SetLastDamagedTime(0);
     me->SetCannotReachTarget(false);
-    me->DoNotReacquireTarget();
+    me->ClearSpellFocus();
 
     if (me->IsInEvadeMode())
         return false;

--- a/src/server/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/server/game/AI/PlayerAI/PlayerAI.cpp
@@ -469,7 +469,7 @@ PlayerAI::TargetedSpell PlayerAI::VerifySpellCast(uint32 spellId, SpellTarget ta
         case TARGET_NONE:
             break;
         case TARGET_VICTIM:
-            pTarget = me->GetVictim();
+            pTarget = me->GetAutoAttackVictim();
             if (!pTarget)
                 return {};
             break;
@@ -530,7 +530,7 @@ void PlayerAI::DoRangedAttackIfReady()
     if (!me->isAttackReady(RANGED_ATTACK))
         return;
 
-    Unit* victim = me->GetVictim();
+    Unit* victim = me->GetAutoAttackVictim();
     if (!victim)
         return;
 
@@ -609,7 +609,7 @@ void PlayerAI::CancelAllShapeshifts()
 
 Unit* PlayerAI::SelectAttackTarget() const
 {
-    return me->GetCharmer() ? me->GetCharmer()->GetVictim() : nullptr;
+    return me->GetCharmer() ? me->GetCharmer()->GetAutoAttackVictim() : nullptr;
 }
 
 struct ValidTargetSelectPredicate
@@ -638,7 +638,7 @@ Unit* SimpleCharmedPlayerAI::SelectAttackTarget() const
     {
         if (UnitAI* charmerAI = charmer->GetAI())
             return charmerAI->SelectTarget(SELECT_TARGET_RANDOM, 0, ValidTargetSelectPredicate(this));
-        return charmer->GetVictim();
+        return charmer->GetAutoAttackVictim();
     }
     return nullptr;
 }
@@ -650,14 +650,14 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
     switch (me->getClass())
     {
         case CLASS_WARRIOR:
-            if (!me->IsWithinMeleeRange(me->GetVictim()))
+            if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
             {
                 VerifyAndPushSpellCast(spells, SPELL_CHARGE, TARGET_VICTIM, 15);
                 VerifyAndPushSpellCast(spells, SPELL_INTERCEPT, TARGET_VICTIM, 10);
             }
             VerifyAndPushSpellCast(spells, SPELL_ENRAGED_REGEN, TARGET_NONE, 3);
             VerifyAndPushSpellCast(spells, SPELL_INTIMIDATING_SHOUT, TARGET_VICTIM, 4);
-            if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+            if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HasUnitState(UNIT_STATE_CASTING))
             {
                 VerifyAndPushSpellCast(spells, SPELL_PUMMEL, TARGET_VICTIM, 15);
                 VerifyAndPushSpellCast(spells, SPELL_SHIELD_BASH, TARGET_VICTIM, 15);
@@ -752,7 +752,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             VerifyAndPushSpellCast(spells, SPELL_FREEZING_ARROW, TARGET_VICTIM, 2);
             VerifyAndPushSpellCast(spells, SPELL_RAPID_FIRE, TARGET_NONE, 10);
             VerifyAndPushSpellCast(spells, SPELL_KILL_SHOT, TARGET_VICTIM, 10);
-            if (me->GetVictim() && me->GetVictim()->GetPowerType() == POWER_MANA && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_VIPER_STING, me->GetGUID()))
+            if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->GetPowerType() == POWER_MANA && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_VIPER_STING, me->GetGUID()))
                 VerifyAndPushSpellCast(spells, SPELL_VIPER_STING, TARGET_VICTIM, 5);
 
             switch (GetSpec())
@@ -803,13 +803,13 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                 case SPEC_ROGUE_SUBLETY:
                     builder = SPELL_HEMORRHAGE, finisher = SPELL_EVISCERATE;
                     VerifyAndPushSpellCast(spells, SPELL_PREPARATION, TARGET_NONE, 10);
-                    if (!me->IsWithinMeleeRange(me->GetVictim()))
+                    if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                         VerifyAndPushSpellCast(spells, SPELL_SHADOWSTEP, TARGET_VICTIM, 25);
                     VerifyAndPushSpellCast(spells, SPELL_SHADOW_DANCE, TARGET_NONE, 10);
                     break;
             }
 
-            if (Unit* victim = me->GetVictim())
+            if (Unit* victim = me->GetAutoAttackVictim())
             {
                 if (victim->HasUnitState(UNIT_STATE_CASTING))
                     VerifyAndPushSpellCast(spells, SPELL_KICK, TARGET_VICTIM, 25);
@@ -853,7 +853,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                         VerifyAndPushSpellCast(spells, SPELL_SHADOWFORM, TARGET_NONE, 100);
                         break;
                     }
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         if (!victim->GetAuraApplicationOfRankedSpell(SPELL_VAMPIRIC_TOUCH, me->GetGUID()))
                             VerifyAndPushSpellCast(spells, SPELL_VAMPIRIC_TOUCH, TARGET_VICTIM, 4);
@@ -870,7 +870,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             break;
         case CLASS_DEATH_KNIGHT:
         {
-            if (!me->IsWithinMeleeRange(me->GetVictim()))
+            if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                 VerifyAndPushSpellCast(spells, SPELL_DEATH_GRIP, TARGET_VICTIM, 25);
             VerifyAndPushSpellCast(spells, SPELL_STRANGULATE, TARGET_VICTIM, 15);
             VerifyAndPushSpellCast(spells, SPELL_EMPOWER_RUNE_WEAP, TARGET_NONE, 5);
@@ -878,7 +878,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             VerifyAndPushSpellCast(spells, SPELL_ANTI_MAGIC_SHELL, TARGET_NONE, 10);
 
             bool hasFF = false, hasBP = false;
-            if (Unit* victim = me->GetVictim())
+            if (Unit* victim = me->GetAutoAttackVictim())
             {
                 if (victim->HasUnitState(UNIT_STATE_CASTING))
                     VerifyAndPushSpellCast(spells, SPELL_MIND_FREEZE, TARGET_VICTIM, 25);
@@ -946,7 +946,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     VerifyAndPushSpellCast(spells, SPELL_MANA_TIDE_TOTEM, TARGET_NONE, 3);
                     break;
                 case SPEC_SHAMAN_ELEMENTAL:
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         if (victim->GetAuraOfRankedSpell(SPELL_FLAME_SHOCK, GetGUID()))
                             VerifyAndPushSpellCast(spells, SPELL_LAVA_BURST, TARGET_VICTIM, 5);
@@ -970,7 +970,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             }
             break;
         case CLASS_MAGE:
-            if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+            if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HasUnitState(UNIT_STATE_CASTING))
                 VerifyAndPushSpellCast(spells, SPELL_COUNTERSPELL, TARGET_VICTIM, 25);
             VerifyAndPushSpellCast(spells, SPELL_DAMPEN_MAGIC, TARGET_CHARMER, 2);
             VerifyAndPushSpellCast(spells, SPELL_EVOCATION, TARGET_NONE, 3);
@@ -991,7 +991,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     VerifyAndPushSpellCast(spells, SPELL_PRESENCE_OF_MIND, TARGET_NONE, 7);
                     break;
                 case SPEC_MAGE_FIRE:
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_LIVING_BOMB))
+                    if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_LIVING_BOMB))
                         VerifyAndPushSpellCast(spells, SPELL_LIVING_BOMB, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_COMBUSTION, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_FIREBALL, TARGET_VICTIM, 2);
@@ -1004,7 +1004,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     VerifyAndPushSpellCast(spells, SPELL_FROST_NOVA, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_FROSTBOLT, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_COLD_SNAP, TARGET_VICTIM, 5);
-                    if (me->GetVictim() && me->GetVictim()->HasAuraState(AURA_STATE_FROZEN, nullptr, me))
+                    if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HasAuraState(AURA_STATE_FROZEN, nullptr, me))
                         VerifyAndPushSpellCast(spells, SPELL_ICE_LANCE, TARGET_VICTIM, 5);
                     break;
             }
@@ -1014,12 +1014,12 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             VerifyAndPushSpellCast(spells, SPELL_FEAR, TARGET_VICTIM, 2);
             VerifyAndPushSpellCast(spells, SPELL_SEED_OF_CORRUPTION, TARGET_VICTIM, 4);
             VerifyAndPushSpellCast(spells, SPELL_HOWL_OF_TERROR, TARGET_NONE, 2);
-            if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_CORRUPTION, me->GetGUID()))
+            if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_CORRUPTION, me->GetGUID()))
                 VerifyAndPushSpellCast(spells, SPELL_CORRUPTION, TARGET_VICTIM, 10);
             switch (GetSpec())
             {
                 case SPEC_WARLOCK_AFFLICTION:
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         VerifyAndPushSpellCast(spells, SPELL_SHADOW_BOLT, TARGET_VICTIM, 7);
                         if (!victim->GetAuraApplicationOfRankedSpell(SPELL_UNSTABLE_AFFLICTION, me->GetGUID()))
@@ -1040,18 +1040,18 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     if (me->HasAura(SPELL_METAMORPHOSIS))
                     {
                         VerifyAndPushSpellCast(spells, SPELL_IMMOLATION_AURA, TARGET_NONE, 30);
-                        if (!me->IsWithinMeleeRange(me->GetVictim()))
+                        if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                             VerifyAndPushSpellCast(spells, SPELL_DEMON_CHARGE, TARGET_VICTIM, 20);
                     }
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
+                    if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_IMMOLATE, TARGET_VICTIM, 5);
                     if (me->HasAura(AURA_MOLTEN_CORE))
                         VerifyAndPushSpellCast(spells, SPELL_INCINERATE, TARGET_VICTIM, 10);
                     break;
                 case SPEC_WARLOCK_DESTRUCTION:
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
+                    if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_IMMOLATE, TARGET_VICTIM, 8);
-                    if (me->GetVictim() && me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
+                    if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_CONFLAGRATE, TARGET_VICTIM, 8);
                     VerifyAndPushSpellCast(spells, SPELL_SHADOWFURY, TARGET_VICTIM, 5);
                     VerifyAndPushSpellCast(spells, SPELL_CHAOS_BOLT, TARGET_VICTIM, 10);
@@ -1105,11 +1105,11 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     uint32 const mainAttackSpell = me->HasAura(AURA_ECLIPSE_LUNAR) ? SPELL_STARFIRE : SPELL_WRATH;
                     VerifyAndPushSpellCast(spells, SPELL_STARFALL, TARGET_NONE, 20);
                     VerifyAndPushSpellCast(spells, mainAttackSpell, TARGET_VICTIM, 10);
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_INSECT_SWARM, me->GetGUID()))
+                    if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_INSECT_SWARM, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_INSECT_SWARM, TARGET_VICTIM, 7);
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_MOONFIRE, me->GetGUID()))
+                    if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->GetAuraApplicationOfRankedSpell(SPELL_MOONFIRE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_MOONFIRE, TARGET_VICTIM, 5);
-                    if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+                    if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HasUnitState(UNIT_STATE_CASTING))
                         VerifyAndPushSpellCast(spells, SPELL_TYPHOON, TARGET_NONE, 15);
                     break;
                 }
@@ -1124,7 +1124,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     VerifyAndPushSpellCast(spells, SPELL_SURVIVAL_INSTINCTS, TARGET_NONE, 15);
                     VerifyAndPushSpellCast(spells, SPELL_TIGER_FURY, TARGET_NONE, 15);
                     VerifyAndPushSpellCast(spells, SPELL_DASH, TARGET_NONE, 5);
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         uint8 const cp = me->GetComboPoints(victim);
                         if (victim->HasUnitState(UNIT_STATE_CASTING) && cp >= 1)
@@ -1174,7 +1174,7 @@ void SimpleCharmedPlayerAI::UpdateAI(const uint32 diff)
 
     if (charmer->IsEngaged())
     {
-        Unit* target = me->GetVictim();
+        Unit* target = me->GetAutoAttackVictim();
         if (!target || !CanAIAttack(target))
         {
             target = SelectAttackTarget();
@@ -1183,7 +1183,7 @@ void SimpleCharmedPlayerAI::UpdateAI(const uint32 diff)
                 if (!_isFollowing)
                 {
                     _isFollowing = true;
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->CastStop();
                     me->StopMoving();
                     me->GetMotionMaster()->Clear();
@@ -1247,7 +1247,7 @@ void SimpleCharmedPlayerAI::UpdateAI(const uint32 diff)
     else if (!_isFollowing)
     {
         _isFollowing = true;
-        me->AttackStop();
+        me->AutoAttackStop();
         me->CastStop();
         me->StopMoving();
         me->GetMotionMaster()->Clear();
@@ -1260,7 +1260,7 @@ void SimpleCharmedPlayerAI::OnCharmed(bool isNew)
     if (me->IsCharmed())
     {
         me->CastStop();
-        me->AttackStop();
+        me->AutoAttackStop();
         me->StopMoving();
         me->GetMotionMaster()->Clear();
         me->GetMotionMaster()->MovePoint(0, me->GetPosition(), false); // force re-sync of current position for all clients
@@ -1268,7 +1268,7 @@ void SimpleCharmedPlayerAI::OnCharmed(bool isNew)
     else
     {
         me->CastStop();
-        me->AttackStop();
+        me->AutoAttackStop();
         // @todo only voluntary movement (don't cancel stuff like death grip or charge mid-animation)
         me->GetMotionMaster()->Clear();
         me->StopMoving();

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -136,7 +136,7 @@ void ScriptedAI::AttackStartNoMove(Unit* who)
     if (!who)
         return;
 
-    if (me->Attack(who, true))
+    if (me->AutoAttackStart(who, true))
         DoStartNoMovement(who);
 }
 
@@ -173,8 +173,8 @@ void ScriptedAI::DoStartNoMovement(Unit* victim)
 
 void ScriptedAI::DoStopAttack()
 {
-    if (me->GetVictim())
-        me->AttackStop();
+    if (me->GetAutoAttackVictim())
+        me->AutoAttackStop();
 }
 
 void ScriptedAI::DoCastSpell(Unit* target, SpellInfo const* spellInfo, bool triggered)

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -291,7 +291,7 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
         }
     }
 
-    if (me->GetVictim())
+    if (me->GetAutoAttackVictim())
     {
         TC_LOG_ERROR("scripts", "EscortAI::Start: (script: %s, creature entry: %u) attempts to Start while in combat", me->GetScriptName().c_str(), me->GetEntry());
         return;
@@ -393,7 +393,7 @@ Player* EscortAI::GetPlayerForEscort()
 // see followerAI
 bool EscortAI::AssistPlayerInCombatAgainst(Unit* who)
 {
-    if (!who || !who->GetVictim())
+    if (!who || !who->GetAutoAttackVictim())
         return false;
 
     if (me->HasReactState(REACT_PASSIVE))
@@ -404,7 +404,7 @@ bool EscortAI::AssistPlayerInCombatAgainst(Unit* who)
         return false;
 
     // not a player
-    if (!who->EnsureVictim()->GetCharmerOrOwnerPlayerOrPlayerItself())
+    if (!who->GetAutoAttackVictim()->GetCharmerOrOwnerPlayerOrPlayerItself())
         return false;
 
     if (!who->isInAccessiblePlaceFor(me))
@@ -421,7 +421,7 @@ bool EscortAI::AssistPlayerInCombatAgainst(Unit* who)
     if (who->GetTypeId() == TYPEID_UNIT && who->ToCreature()->IsInEvadeMode())
         return false;
 
-    if (!me->IsValidAssistTarget(who->GetVictim()))
+    if (!me->IsValidAssistTarget(who->GetAutoAttackVictim()))
         return false;
 
     // too far away and no free sight

--- a/src/server/game/AI/ScriptedAI/ScriptedFollowerAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedFollowerAI.cpp
@@ -50,7 +50,7 @@ void FollowerAI::AttackStart(Unit* who)
     if (!who)
         return;
 
-    if (me->Attack(who, true))
+    if (me->AutoAttackStart(who, true))
     {
         me->EngageWithTarget(who); // in case it doesn't have threat+combat yet
 
@@ -67,7 +67,7 @@ void FollowerAI::AttackStart(Unit* who)
 //The flag (type_flag) is unconfirmed, but used here for further research and is a good candidate.
 bool FollowerAI::AssistPlayerInCombatAgainst(Unit* who)
 {
-    if (!who || !who->GetVictim())
+    if (!who || !who->GetAutoAttackVictim())
         return false;
 
     //experimental (unknown) flag not present
@@ -75,7 +75,7 @@ bool FollowerAI::AssistPlayerInCombatAgainst(Unit* who)
         return false;
 
     //not a player
-    if (!who->EnsureVictim()->GetCharmerOrOwnerPlayerOrPlayerItself())
+    if (!who->GetAutoAttackVictim()->GetCharmerOrOwnerPlayerOrPlayerItself())
         return false;
 
     //never attack friendly
@@ -107,7 +107,7 @@ void FollowerAI::MoveInLineOfSight(Unit* who)
             float fAttackRadius = me->GetAttackDistance(who);
             if (me->IsWithinDistInMap(who, fAttackRadius) && me->IsWithinLOSInMap(who))
             {
-                if (!me->GetVictim())
+                if (!me->GetAutoAttackVictim())
                 {
                     // Clear distracted state on combat
                     if (me->HasUnitState(UNIT_STATE_DISTRACTED))
@@ -187,7 +187,7 @@ void FollowerAI::EnterEvadeMode(EvadeReason /*why*/)
 
 void FollowerAI::UpdateAI(uint32 uiDiff)
 {
-    if (HasFollowState(STATE_FOLLOW_INPROGRESS) && !me->GetVictim())
+    if (HasFollowState(STATE_FOLLOW_INPROGRESS) && !me->GetAutoAttackVictim())
     {
         if (m_uiUpdateFollowTimer <= uiDiff)
         {
@@ -273,7 +273,7 @@ void FollowerAI::MovementInform(uint32 motionType, uint32 pointId)
 
 void FollowerAI::StartFollow(Player* player, uint32 factionForFollower, Quest const* quest)
 {
-    if (me->GetVictim())
+    if (me->GetAutoAttackVictim())
     {
         TC_LOG_DEBUG("scripts", "FollowerAI attempt to StartFollow while in combat.");
         return;

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -416,7 +416,7 @@ void SmartAI::EnterEvadeMode(EvadeReason /*why*/)
 
     if (!IsAIControlled())
     {
-        me->AttackStop();
+        me->AutoAttackStop();
         return;
     }
 
@@ -473,7 +473,7 @@ bool SmartAI::AssistPlayerInCombatAgainst(Unit* who)
     if (me->HasReactState(REACT_PASSIVE) || !IsAIControlled())
         return false;
 
-    if (!who || !who->GetVictim())
+    if (!who || !who->GetAutoAttackVictim())
         return false;
 
     // experimental (unknown) flag not present
@@ -481,7 +481,7 @@ bool SmartAI::AssistPlayerInCombatAgainst(Unit* who)
         return false;
 
     // not a player
-    if (!who->EnsureVictim()->GetCharmerOrOwnerPlayerOrPlayerItself())
+    if (!who->GetAutoAttackVictim()->GetCharmerOrOwnerPlayerOrPlayerItself())
         return false;
 
     if (!who->isInAccessiblePlaceFor(me))
@@ -498,7 +498,7 @@ bool SmartAI::AssistPlayerInCombatAgainst(Unit* who)
     if (who->GetTypeId() == TYPEID_UNIT && who->ToCreature()->IsInEvadeMode())
         return false;
 
-    if (!me->IsValidAssistTarget(who->GetVictim()))
+    if (!me->IsValidAssistTarget(who->GetAutoAttackVictim()))
         return false;
 
     // too far away and no free sight
@@ -588,11 +588,11 @@ void SmartAI::AttackStart(Unit* who)
     if (!IsAIControlled())
     {
         if (who)
-            me->Attack(who, mCanAutoAttack);
+            me->AutoAttackStart(who, mCanAutoAttack);
         return;
     }
 
-    if (who && me->Attack(who, mCanAutoAttack))
+    if (who && me->AutoAttackStart(who, mCanAutoAttack))
     {
         me->GetMotionMaster()->Clear(MOTION_PRIORITY_NORMAL);
         me->PauseMovement();
@@ -787,13 +787,13 @@ void SmartAI::SetCombatMove(bool on)
     {
         if (on)
         {
-            if (!me->HasReactState(REACT_PASSIVE) && me->GetVictim() && !me->GetMotionMaster()->HasMovementGenerator([](MovementGenerator const* movement) -> bool
+            if (!me->HasReactState(REACT_PASSIVE) && me->GetAutoAttackVictim() && !me->GetMotionMaster()->HasMovementGenerator([](MovementGenerator const* movement) -> bool
             {
                 return movement->Mode == MOTION_MODE_DEFAULT && movement->Priority == MOTION_PRIORITY_NORMAL;
             }))
             {
                 SetRun(mRun);
-                me->GetMotionMaster()->MoveChase(me->GetVictim());
+                me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
             }
         }
         else if (MovementGenerator* movement = me->GetMotionMaster()->GetMovementGenerator([](MovementGenerator const* a) -> bool

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -481,7 +481,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             {
                 ref->ModifyThreatByPercent(std::max<int32>(-100,int32(e.action.threatPCT.threatINC) - int32(e.action.threatPCT.threatDEC)));
                 TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_THREAT_ALL_PCT: Creature guidLow %u modify threat for unit %u, value %i",
-                    me->GetGUID().GetCounter(), ref->GetAutoAttackVictim()->GetGUID().GetCounter(), int32(e.action.threatPCT.threatINC)-int32(e.action.threatPCT.threatDEC));
+                    me->GetGUID().GetCounter(), ref->GetVictim()->GetGUID().GetCounter(), int32(e.action.threatPCT.threatINC)-int32(e.action.threatPCT.threatDEC));
             }
             break;
         }
@@ -2727,8 +2727,8 @@ void SmartScript::GetTargets(ObjectVector& targets, SmartScriptHolder const& e, 
         {
             if (me && me->CanHaveThreatList())
                 for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
-                    if (!e.target.hostilRandom.maxDist || me->IsWithinCombatRange(ref->GetAutoAttackVictim(), float(e.target.hostilRandom.maxDist)))
-                        targets.push_back(ref->GetAutoAttackVictim());
+                    if (!e.target.hostilRandom.maxDist || me->IsWithinCombatRange(ref->GetVictim(), float(e.target.hostilRandom.maxDist)))
+                        targets.push_back(ref->GetVictim());
             break;
         }
         case SMART_TARGET_CLOSEST_ENEMY:

--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -313,7 +313,7 @@ bool ChatHandler::ExecuteCommandInTable(std::vector<ChatCommand> const& table, c
             Player* player = m_session->GetPlayer();
             if (!AccountMgr::IsPlayerAccount(m_session->GetSecurity()))
             {
-                ObjectGuid guid = player->GetTarget();
+                ObjectGuid guid = player->GetSelectedUnitGUID();
                 uint32 areaId = player->GetAreaId();
                 std::string areaName = "Unknown";
                 std::string zoneName = "Unknown";
@@ -650,7 +650,7 @@ Player* ChatHandler::getSelectedPlayer()
     if (!m_session)
         return nullptr;
 
-    ObjectGuid selected = m_session->GetPlayer()->GetTarget();
+    ObjectGuid selected = m_session->GetPlayer()->GetSelectedUnitGUID();
     if (!selected)
         return m_session->GetPlayer();
 
@@ -673,7 +673,7 @@ WorldObject* ChatHandler::getSelectedObject()
     if (!m_session)
         return nullptr;
 
-    ObjectGuid guid = m_session->GetPlayer()->GetTarget();
+    ObjectGuid guid = m_session->GetPlayer()->GetSelectedUnitGUID();
 
     if (!guid)
         return GetNearbyGameObject();
@@ -686,7 +686,7 @@ Creature* ChatHandler::getSelectedCreature()
     if (!m_session)
         return nullptr;
 
-    return ObjectAccessor::GetCreatureOrPetOrVehicle(*m_session->GetPlayer(), m_session->GetPlayer()->GetTarget());
+    return ObjectAccessor::GetCreatureOrPetOrVehicle(*m_session->GetPlayer(), m_session->GetPlayer()->GetSelectedUnitGUID());
 }
 
 Player* ChatHandler::getSelectedPlayerOrSelf()
@@ -694,7 +694,7 @@ Player* ChatHandler::getSelectedPlayerOrSelf()
     if (!m_session)
         return nullptr;
 
-    ObjectGuid selected = m_session->GetPlayer()->GetTarget();
+    ObjectGuid selected = m_session->GetPlayer()->GetSelectedUnitGUID();
     if (!selected)
         return m_session->GetPlayer();
 

--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -321,6 +321,9 @@ void CombatManager::PutReference(ObjectGuid const& guid, CombatReference* ref)
 
 void CombatManager::PurgeReference(ObjectGuid const& guid, bool pvp)
 {
+    if (Unit::GetGUID(_owner->GetPrimaryTarget()) == guid)
+        _owner->SetPrimaryTarget(nullptr);
+
     if (pvp)
         _pvpRefs.erase(guid);
     else

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -175,7 +175,7 @@ ThreatManager::ThreatManager(Unit* owner) : _owner(owner), _ownerCanHaveThreatLi
 ThreatManager::~ThreatManager()
 {
     ASSERT(_myThreatListEntries.empty(), "ThreatManager::~ThreatManager - %s: we still have %zu things threatening us, one of them is %s.", _owner->GetGUID().ToString().c_str(), _myThreatListEntries.size(), _myThreatListEntries.begin()->first.ToString().c_str());
-    ASSERT(_sortedThreatList.empty(), "ThreatManager::~ThreatManager - %s: we still have %zu things threatening us, one of them is %s.", _owner->GetGUID().ToString().c_str(), _sortedThreatList.size(), (*_sortedThreatList.begin())->GetVictim()->GetGUID().ToString().c_str());
+    ASSERT(_sortedThreatList.empty(), "ThreatManager::~ThreatManager - %s: we still have %zu things threatening us, one of them is %s.", _owner->GetGUID().ToString().c_str(), _sortedThreatList.size(), (*_sortedThreatList.begin())->GetAutoAttackVictim()->GetGUID().ToString().c_str());
     ASSERT(_threatenedByMe.empty(), "ThreatManager::~ThreatManager - %s: we are still threatening %zu things, one of them is %s.", _owner->GetGUID().ToString().c_str(), _threatenedByMe.size(), _threatenedByMe.begin()->first.ToString().c_str());
 }
 
@@ -207,7 +207,7 @@ Unit* ThreatManager::GetCurrentVictim()
 Unit* ThreatManager::GetCurrentVictim() const
 {
     if (_currentVictimRef && !_currentVictimRef->ShouldBeOffline())
-        return _currentVictimRef->GetVictim();
+        return _currentVictimRef->GetAutoAttackVictim();
     return nullptr;
 }
 
@@ -215,7 +215,7 @@ Unit* ThreatManager::GetAnyTarget() const
 {
     for (ThreatReference const* ref : _sortedThreatList)
         if (!ref->IsOffline())
-            return ref->GetVictim();
+            return ref->GetAutoAttackVictim();
     return nullptr;
 }
 
@@ -513,7 +513,7 @@ void ThreatManager::FixateTarget(Unit* target)
 Unit* ThreatManager::GetFixateTarget() const
 {
     if (_fixateRef)
-        return _fixateRef->GetVictim();
+        return _fixateRef->GetAutoAttackVictim();
     else
         return nullptr;
 }
@@ -766,7 +766,7 @@ void ThreatManager::SendThreatListToClients(bool newHighest) const
     WorldPacket data(newHighest ? SMSG_HIGHEST_THREAT_UPDATE : SMSG_THREAT_UPDATE, (_sortedThreatList.size() + 2) * 8); // guess
     data << _owner->GetPackGUID();
     if (newHighest)
-        data << _currentVictimRef->GetVictim()->GetPackGUID();
+        data << _currentVictimRef->GetAutoAttackVictim()->GetPackGUID();
     size_t countPos = data.wpos();
     data << uint32(0); // placeholder
     uint32 count = 0;
@@ -774,7 +774,7 @@ void ThreatManager::SendThreatListToClients(bool newHighest) const
     {
         if (!ref->IsAvailable())
             continue;
-        data << ref->GetVictim()->GetPackGUID();
+        data << ref->GetAutoAttackVictim()->GetPackGUID();
         data << uint32(ref->GetThreat() * 100);
         ++count;
     }

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -175,7 +175,7 @@ ThreatManager::ThreatManager(Unit* owner) : _owner(owner), _ownerCanHaveThreatLi
 ThreatManager::~ThreatManager()
 {
     ASSERT(_myThreatListEntries.empty(), "ThreatManager::~ThreatManager - %s: we still have %zu things threatening us, one of them is %s.", _owner->GetGUID().ToString().c_str(), _myThreatListEntries.size(), _myThreatListEntries.begin()->first.ToString().c_str());
-    ASSERT(_sortedThreatList.empty(), "ThreatManager::~ThreatManager - %s: we still have %zu things threatening us, one of them is %s.", _owner->GetGUID().ToString().c_str(), _sortedThreatList.size(), (*_sortedThreatList.begin())->GetAutoAttackVictim()->GetGUID().ToString().c_str());
+    ASSERT(_sortedThreatList.empty(), "ThreatManager::~ThreatManager - %s: we still have %zu things threatening us, one of them is %s.", _owner->GetGUID().ToString().c_str(), _sortedThreatList.size(), (*_sortedThreatList.begin())->GetVictim()->GetGUID().ToString().c_str());
     ASSERT(_threatenedByMe.empty(), "ThreatManager::~ThreatManager - %s: we are still threatening %zu things, one of them is %s.", _owner->GetGUID().ToString().c_str(), _threatenedByMe.size(), _threatenedByMe.begin()->first.ToString().c_str());
 }
 
@@ -207,7 +207,7 @@ Unit* ThreatManager::GetCurrentVictim()
 Unit* ThreatManager::GetCurrentVictim() const
 {
     if (_currentVictimRef && !_currentVictimRef->ShouldBeOffline())
-        return _currentVictimRef->GetAutoAttackVictim();
+        return _currentVictimRef->GetVictim();
     return nullptr;
 }
 
@@ -215,7 +215,7 @@ Unit* ThreatManager::GetAnyTarget() const
 {
     for (ThreatReference const* ref : _sortedThreatList)
         if (!ref->IsOffline())
-            return ref->GetAutoAttackVictim();
+            return ref->GetVictim();
     return nullptr;
 }
 
@@ -513,7 +513,7 @@ void ThreatManager::FixateTarget(Unit* target)
 Unit* ThreatManager::GetFixateTarget() const
 {
     if (_fixateRef)
-        return _fixateRef->GetAutoAttackVictim();
+        return _fixateRef->GetVictim();
     else
         return nullptr;
 }
@@ -766,7 +766,7 @@ void ThreatManager::SendThreatListToClients(bool newHighest) const
     WorldPacket data(newHighest ? SMSG_HIGHEST_THREAT_UPDATE : SMSG_THREAT_UPDATE, (_sortedThreatList.size() + 2) * 8); // guess
     data << _owner->GetPackGUID();
     if (newHighest)
-        data << _currentVictimRef->GetAutoAttackVictim()->GetPackGUID();
+        data << _currentVictimRef->GetVictim()->GetPackGUID();
     size_t countPos = data.wpos();
     data << uint32(0); // placeholder
     uint32 count = 0;
@@ -774,7 +774,7 @@ void ThreatManager::SendThreatListToClients(bool newHighest) const
     {
         if (!ref->IsAvailable())
             continue;
-        data << ref->GetAutoAttackVictim()->GetPackGUID();
+        data << ref->GetVictim()->GetPackGUID();
         data << uint32(ref->GetThreat() * 100);
         ++count;
     }

--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -257,7 +257,7 @@ class TC_GAME_API ThreatReference
         enum OnlineState { ONLINE_STATE_ONLINE = 2, ONLINE_STATE_SUPPRESSED = 1, ONLINE_STATE_OFFLINE = 0 };
 
         Creature* GetOwner() const { return _owner; }
-        Unit* GetAutoAttackVictim() const { return _victim; }
+        Unit* GetVictim() const { return _victim; }
         float GetThreat() const { return std::max<float>(_baseAmount + (float)_tempModifier, 0.0f); }
         OnlineState GetOnlineState() const { return _online; }
         bool IsOnline() const { return (_online >= ONLINE_STATE_ONLINE); }

--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -257,7 +257,7 @@ class TC_GAME_API ThreatReference
         enum OnlineState { ONLINE_STATE_ONLINE = 2, ONLINE_STATE_SUPPRESSED = 1, ONLINE_STATE_OFFLINE = 0 };
 
         Creature* GetOwner() const { return _owner; }
-        Unit* GetVictim() const { return _victim; }
+        Unit* GetAutoAttackVictim() const { return _victim; }
         float GetThreat() const { return std::max<float>(_baseAmount + (float)_tempModifier, 0.0f); }
         OnlineState GetOnlineState() const { return _online; }
         bool IsOnline() const { return (_online >= ONLINE_STATE_ONLINE); }

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -335,14 +335,6 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
 
         bool m_isTempWorldObject; //true when possessed
 
-        // Handling caster facing during spellcast
-        void SetTarget(ObjectGuid guid) override;
-        void MustReacquireTarget() { m_shouldReacquireTarget = true; } // flags the Creature for forced (client displayed) target reacquisition in the next ::Update call
-        void DoNotReacquireTarget() { m_shouldReacquireTarget = false; m_suppressedTarget = ObjectGuid::Empty; m_suppressedOrientation = 0.0f; }
-        void FocusTarget(Spell const* focusSpell, WorldObject const* target);
-        bool IsFocusing(Spell const* focusSpell = nullptr, bool withDelay = false) override;
-        void ReleaseFocus(Spell const* focusSpell = nullptr, bool withDelay = true);
-
         bool IsMovementPreventedByCasting() const override;
 
         // Part of Evade mechanics
@@ -425,13 +417,6 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         CreatureGroup* m_formation;
         bool m_triggerJustAppeared;
         bool m_respawnCompatibilityMode;
-
-        /* Spell focus system */
-        Spell const* m_focusSpell;   // Locks the target during spell cast for proper facing
-        uint32 m_focusDelay;
-        bool m_shouldReacquireTarget;
-        ObjectGuid m_suppressedTarget; // Stores the creature's "real" target while casting
-        float m_suppressedOrientation; // Stores the creature's "real" orientation while casting
 
         time_t _lastDamagedTime; // Part of Evade mechanics
         CreatureTextRepeatGroup m_textRepeat;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1844,7 +1844,7 @@ void GameObject::Use(Unit* user)
 
             Player* player = user->ToPlayer();
 
-            Player* targetPlayer = ObjectAccessor::FindPlayer(player->GetTarget());
+            Player* targetPlayer = ObjectAccessor::FindPlayer(player->GetSelectedUnitGUID());
 
             // accept only use by player from same raid as caster, except caster itself
             if (!targetPlayer || targetPlayer == player || !targetPlayer->IsInSameRaidWith(player))

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -177,7 +177,7 @@ void Object::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) c
 
     if (isType(TYPEMASK_UNIT))
     {
-        if (ToUnit()->GetVictim())
+        if (ToUnit()->GetAutoAttackVictim())
             flags |= UPDATEFLAG_HAS_TARGET;
     }
 
@@ -415,7 +415,7 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint16 flags) const
     if (flags & UPDATEFLAG_HAS_TARGET)
     {
         ASSERT(unit);
-        if (Unit* victim = unit->GetVictim())
+        if (Unit* victim = unit->GetAutoAttackVictim())
             *data << victim->GetPackGUID();
         else
             *data << uint8(0);

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -73,6 +73,7 @@ class TC_GAME_API Object
         virtual void AddToWorld();
         virtual void RemoveFromWorld();
 
+        static ObjectGuid GetGUID(Object* o) { return o ? o->GetGUID() : ObjectGuid::Empty; }
         ObjectGuid GetGUID() const { return GetGuidValue(OBJECT_FIELD_GUID); }
         PackedGuid const& GetPackGUID() const { return m_PackGUID; }
         uint32 GetEntry() const { return GetUInt32Value(OBJECT_FIELD_ENTRY); }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -7890,7 +7890,7 @@ void Player::UpdateEquipSpellsAtFormChange()
 
 void Player::CastItemCombatSpell(DamageInfo const& damageInfo)
 {
-    Unit* target = damageInfo.GetAutoAttackVictim();
+    Unit* target = damageInfo.GetVictim();
     if (!target || !target->IsAlive() || target == this)
         return;
 
@@ -7979,8 +7979,8 @@ void Player::CastItemCombatSpell(DamageInfo const& damageInfo, Item* item, ItemT
             else if (chance > 100.0f)
                 chance = GetWeaponProcChance();
 
-            if (roll_chance_f(chance) && sScriptMgr->OnCastItemCombatSpell(this, damageInfo.GetAutoAttackVictim(), spellInfo, item))
-                CastSpell(damageInfo.GetAutoAttackVictim(), spellInfo->Id, item);
+            if (roll_chance_f(chance) && sScriptMgr->OnCastItemCombatSpell(this, damageInfo.GetVictim(), spellInfo, item))
+                CastSpell(damageInfo.GetVictim(), spellInfo->Id, item);
         }
     }
 
@@ -8042,7 +8042,7 @@ void Player::CastItemCombatSpell(DamageInfo const& damageInfo, Item* item, ItemT
 
             if (roll_chance_f(chance))
             {
-                Unit* target = spellInfo->IsPositive() ? this : damageInfo.GetAutoAttackVictim();
+                Unit* target = spellInfo->IsPositive() ? this : damageInfo.GetVictim();
 
                 CastSpellExtraArgs args(item);
                 // reduce effect values if enchant is limited

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1761,7 +1761,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
                 return true;
             }
 
-            SetPrimaryTarget(ObjectGuid::Empty);
+            SetSelection(ObjectGuid::Empty);
 
             CombatStop();
 
@@ -22439,6 +22439,16 @@ bool Player::IsQuestRewarded(uint32 quest_id) const
     return m_RewardedQuests.find(quest_id) != m_RewardedQuests.end();
 }
 
+void Player::SetSelection(ObjectGuid guid)
+{
+    if (IsDirectlyControlledByPlayer())
+        SetGuidValue(UNIT_FIELD_TARGET, guid);
+
+    if (Unit* moved = GetUnitBeingMoved())
+        if (moved != this && moved->IsDirectlyControlledByPlayer())
+            moved->SetGuidValue(UNIT_FIELD_TARGET, guid);
+}
+
 void Player::SetGroup(Group* group, int8 subgroup)
 {
     if (group == nullptr)
@@ -23796,6 +23806,7 @@ void Player::SetMovedUnit(Unit* target)
 
     m_unitMovedByMe = target;
     m_unitMovedByMe->m_playerMovingMe = this;
+    ASSERT(!m_unitMovedByMe->GetPrimaryTarget(), "Player just took direct control of unit, but unit has primary target: %s", m_unitMovedByMe->GetDebugInfo().c_str());
 }
 
 void Player::UpdateZoneDependentAuras(uint32 newZone)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1347,6 +1347,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         size_t GetRewardedQuestCount() const { return m_RewardedQuests.size(); }
         bool IsQuestRewarded(uint32 quest_id) const;
 
+        void SetSelection(ObjectGuid guid);
+
         void SendMailResult(uint32 mailId, MailResponseType mailAction, MailResponseResult mailError, uint32 equipError = 0, ObjectGuid::LowType item_guid = 0, uint32 item_count = 0) const;
         void SendNewMail() const;
         void UpdateNextMailTimeAndUnreads();

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1347,12 +1347,6 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         size_t GetRewardedQuestCount() const { return m_RewardedQuests.size(); }
         bool IsQuestRewarded(uint32 quest_id) const;
 
-        Unit* GetSelectedUnit() const;
-        Player* GetSelectedPlayer() const;
-
-        void SetTarget(ObjectGuid /*guid*/) override { } /// Used for serverside target changes, does not apply to players
-        void SetSelection(ObjectGuid guid) { SetGuidValue(UNIT_FIELD_TARGET, guid); }
-
         void SendMailResult(uint32 mailId, MailResponseType mailAction, MailResponseResult mailError, uint32 equipError = 0, ObjectGuid::LowType item_guid = 0, uint32 item_count = 0) const;
         void SendNewMail() const;
         void UpdateNextMailTimeAndUnreads();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12844,7 +12844,7 @@ void Unit::SendClearTarget()
 
 ObjectGuid Unit::ChooseSelectedUnit() const
 {
-    ASSERT(!IsDirectlyControlledByPlayer(), "Core is trying to hijack target of unit under direct player control", GetName());
+    ASSERT(!IsDirectlyControlledByPlayer(), "Core is trying to hijack target of unit under direct player control");
 
     if (HasUnitState(UNIT_STATE_CONTROLLED) || !IsAlive())
         return ObjectGuid::Empty;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -420,7 +420,7 @@ class TC_GAME_API DamageInfo
         void BlockDamage(uint32 amount);
 
         Unit* GetAttacker() const { return m_attacker; }
-        Unit* GetAutoAttackVictim() const { return m_victim; }
+        Unit* GetVictim() const { return m_victim; }
         SpellInfo const* GetSpellInfo() const { return m_spellInfo; }
         SpellSchoolMask GetSchoolMask() const { return m_schoolMask; }
         DamageEffectType GetDamageType() const { return m_damageType; }

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -2019,9 +2019,9 @@ bool Group::InCombatToInstance(uint32 instanceId)
     for (GroupReference* itr = GetFirstMember(); itr != nullptr; itr = itr->next())
     {
         Player* player = itr->GetSource();
-        if (player && player->GetInstanceId() == instanceId && !player->getAttackers().empty() && (player->GetMap()->IsRaidOrHeroicDungeon()))
-            for (std::set<Unit*>::const_iterator i = player->getAttackers().begin(); i != player->getAttackers().end(); ++i)
-                if ((*i) && (*i)->GetTypeId() == TYPEID_UNIT && (*i)->ToCreature()->GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_INSTANCE_BIND)
+        if (player && player->GetInstanceId() == instanceId && !player->GetAutoAttackingMe().empty() && (player->GetMap()->IsRaidOrHeroicDungeon()))
+            for (Unit* attacker : player->GetAutoAttackingMe())
+                if (attacker && attacker->GetTypeId() == TYPEID_UNIT && attacker->ToCreature()->GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_INSTANCE_BIND)
                     return true;
     }
     return false;

--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -63,12 +63,12 @@ void WorldSession::HandleAttackSwingOpcode(WorldPacket& recvData)
         }
     }
 
-    _player->Attack(pEnemy, true);
+    _player->AutoAttackStart(pEnemy, true);
 }
 
 void WorldSession::HandleAttackStopOpcode(WorldPacket & /*recvData*/)
 {
-    GetPlayer()->AttackStop();
+    GetPlayer()->AutoAttackStop();
 }
 
 void WorldSession::HandleSetSheathedOpcode(WorldPacket& recvData)

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -491,7 +491,7 @@ void WorldSession::HandleSetSelectionOpcode(WorldPacket& recvData)
     ObjectGuid guid;
     recvData >> guid;
 
-    _player->SetSelection(guid);
+    _player->SetPrimaryTarget(guid);
 }
 
 void WorldSession::HandleStandStateChangeOpcode(WorldPacket& recvData)

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -491,7 +491,7 @@ void WorldSession::HandleSetSelectionOpcode(WorldPacket& recvData)
     ObjectGuid guid;
     recvData >> guid;
 
-    _player->SetPrimaryTarget(guid);
+    _player->SetSelection(guid);
 }
 
 void WorldSession::HandleStandStateChangeOpcode(WorldPacket& recvData)

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -140,7 +140,7 @@ void WorldSession::HandlePetStopAttack(WorldPacket &recvData)
     if (!pet->IsAlive())
         return;
 
-    pet->AttackStop();
+    pet->AutoAttackStop();
 }
 
 void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spellid, uint16 flag, ObjectGuid guid2)
@@ -172,7 +172,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                     charmInfo->SaveStayPosition();
                     break;
                 case COMMAND_FOLLOW:                        //spellid=1792  //FOLLOW
-                    pet->AttackStop();
+                    pet->AutoAttackStop();
                     pet->InterruptNonMeleeSpells(false);
                     pet->GetMotionMaster()->MoveFollow(_player, PET_FOLLOW_DIST, pet->GetFollowAngle());
                     charmInfo->SetCommandState(COMMAND_FOLLOW);
@@ -204,10 +204,10 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
 
                     pet->ClearUnitState(UNIT_STATE_FOLLOW);
                     // This is true if pet has no target or has target but targets differs.
-                    if (pet->GetVictim() != TargetUnit || !pet->GetCharmInfo()->IsCommandAttack())
+                    if (pet->GetAutoAttackVictim() != TargetUnit || !pet->GetCharmInfo()->IsCommandAttack())
                     {
-                        if (pet->GetVictim())
-                            pet->AttackStop();
+                        if (pet->GetAutoAttackVictim())
+                            pet->AutoAttackStop();
 
                         if (pet->GetTypeId() != TYPEID_PLAYER && pet->ToCreature()->IsAIEnabled())
                         {
@@ -240,7 +240,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                             charmInfo->SetIsCommandFollow(false);
                             charmInfo->SetIsReturning(false);
 
-                            pet->Attack(TargetUnit, true);
+                            pet->AutoAttackStart(TargetUnit, true);
                             pet->SendPetAIReaction(guid1);
                         }
                     }
@@ -274,7 +274,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
             switch (spellid)
             {
                 case REACT_PASSIVE:                         //passive
-                    pet->AttackStop();
+                    pet->AutoAttackStop();
                     // no break;
                 case REACT_DEFENSIVE:                       //recovery
                 case REACT_AGGRESSIVE:                      //activete
@@ -329,14 +329,14 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
             {
                 if (unit_target)
                 {
-                    if (!pet->IsFocusing())
+                    if (!pet->HasSpellFocusTarget())
                         pet->SetInFront(unit_target);
                     if (Player* player = unit_target->ToPlayer())
                         pet->SendUpdateToPlayer(player);
                 }
                 else if (Unit* unit_target2 = spell->m_targets.GetUnitTarget())
                 {
-                    if (!pet->IsFocusing())
+                    if (!pet->HasSpellFocusTarget())
                         pet->SetInFront(unit_target2);
                     if (Player* player = unit_target2->ToPlayer())
                         pet->SendUpdateToPlayer(player);
@@ -365,7 +365,7 @@ void WorldSession::HandlePetActionHelper(Unit* pet, ObjectGuid guid1, uint32 spe
                 if (unit_target && !GetPlayer()->IsFriendlyTo(unit_target) && !pet->isPossessed() && !pet->IsVehicle())
                 {
                     // This is true if pet has no target or has target but targets differs.
-                    if (pet->GetVictim() != unit_target)
+                    if (pet->GetAutoAttackVictim() != unit_target)
                     {
                         pet->GetMotionMaster()->Clear();
                         if (CreatureAI* AI = pet->ToCreature()->AI())

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -228,7 +228,7 @@ void InstanceScript::UpdateMinionState(Creature* minion, EncounterState state)
         case IN_PROGRESS:
             if (!minion->IsAlive())
                 minion->Respawn();
-            else if (!minion->GetVictim())
+            else if (!minion->GetAutoAttackVictim())
                 minion->AI()->DoZoneInCombat();
             break;
         default:

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -921,7 +921,7 @@ void MotionMaster::MoveSeekAssistance(float x, float y, float z)
     if (_owner->GetTypeId() == TYPEID_UNIT)
     {
         TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveSeekAssistance: '%s', seeks assistance (X: %f, Y: %f, Z: %f)", _owner->GetGUID().ToString().c_str(), x, y, z);
-        _owner->AttackStop();
+        _owner->AutoAttackStop();
         _owner->CastStop();
         _owner->ToCreature()->SetReactState(REACT_PASSIVE);
         Add(new AssistanceMovementGenerator(EVENT_ASSIST_MOVE, x, y, z));

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -94,7 +94,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
         return false;
 
     // the owner might've selected a different target (feels like we shouldn't check this here...)
-    if (owner->GetVictim() != target)
+    if (owner->GetAutoAttackVictim() != target)
         return false;
 
     // the owner might be unable to move (rooted or casting), pause movement

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -149,8 +149,6 @@ void ConfusedMovementGenerator<Creature>::DoFinalize(Creature* owner, bool activ
     {
         owner->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED);
         owner->ClearUnitState(UNIT_STATE_CONFUSED_MOVE);
-        if (owner->GetVictim())
-            owner->SetTarget(owner->EnsureVictim()->GetGUID());
     }
 }
 

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -129,8 +129,6 @@ void FleeingMovementGenerator<Creature>::DoFinalize(Creature* owner, bool active
     {
         owner->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING);
         owner->ClearUnitState(UNIT_STATE_FLEEING_MOVE);
-        if (owner->GetVictim())
-            owner->SetTarget(owner->EnsureVictim()->GetGUID());
     }
 }
 
@@ -257,11 +255,11 @@ void TimedFleeingMovementGenerator::Finalize(Unit* owner, bool active, bool/* mo
 
     owner->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING);
     owner->StopMoving();
-    if (Unit* victim = owner->GetVictim())
+    if (Unit* victim = owner->GetAutoAttackVictim())
     {
         if (owner->IsAlive())
         {
-            owner->AttackStop();
+            owner->AutoAttackStop();
             owner->ToCreature()->AI()->AttackStart(victim);
         }
     }

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
@@ -81,10 +81,10 @@ void RotateMovementGenerator::Initialize(Unit* owner)
     /*
      *  TODO: This code should be handled somewhere else, like MovementInform
      *
-     *  if (owner->GetVictim())
-     *      owner->SetInFront(owner->GetVictim());
+     *  if (owner->GetAutoAttackVictim())
+     *      owner->SetInFront(owner->GetAutoAttackVictim());
      *
-     *  owner->AttackStop();
+     *  owner->AutoAttackStop();
      */
 }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2192,7 +2192,7 @@ void AuraEffect::HandleFeignDeath(AuraApplication const* aurApp, uint8 mode, boo
 
         if (target->GetMap()->IsDungeon()) // feign death does not remove combat in dungeons
         {
-            target->AttackStop();
+            target->AutoAttackStop();
             if (Player* targetPlayer = target->ToPlayer())
                 targetPlayer->SendAttackSwingCancelAttack();
         }
@@ -2255,7 +2255,7 @@ void AuraEffect::HandleModUnattackable(AuraApplication const* aurApp, uint8 mode
     {
         if (target->GetMap()->IsDungeon())
         {
-            target->AttackStop();
+            target->AutoAttackStop();
             if (Player* targetPlayer = target->ToPlayer())
                 targetPlayer->SendAttackSwingCancelAttack();
         }
@@ -2370,7 +2370,7 @@ void AuraEffect::HandleAuraModPacify(AuraApplication const* aurApp, uint8 mode, 
     if (apply)
     {
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED);
-        target->AttackStop();
+        target->AutoAttackStop();
     }
     else
     {
@@ -2897,7 +2897,7 @@ void AuraEffect::HandleModPossessPet(AuraApplication const* aurApp, uint8 mode, 
             caster->ToPlayer()->PetSpellInitialize();
 
             // TODO: remove this
-            if (!pet->GetVictim() && !pet->GetCharmInfo()->HasCommandState(COMMAND_STAY))
+            if (!pet->GetAutoAttackVictim() && !pet->GetCharmInfo()->HasCommandState(COMMAND_STAY))
                 pet->GetMotionMaster()->MoveFollow(caster, PET_FOLLOW_DIST, pet->GetFollowAngle());
         }
     }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3058,7 +3058,7 @@ void Spell::prepare(SpellCastTargets const& targets, AuraEffect const* triggered
     // focus if not controlled creature
     if (Creature* creatureCaster = m_caster->ToCreature())
     {
-        if (!creatureCaster->GetPlayerMovingMe() && !(m_spellInfo->IsNextMeleeSwingSpell() || IsAutoRepeat()))
+        if (!m_spellInfo->IsNextMeleeSwingSpell() && !IsAutoRepeat())
         {
             if (m_targets.GetObjectTarget() && m_caster != m_targets.GetObjectTarget())
                 creatureCaster->SetSpellFocus(m_targets.GetObjectTarget(), this);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4538,13 +4538,12 @@ void Spell::EffectForceDeselect(SpellEffIndex /*effIndex*/)
     Cell::VisitWorldObjects(unitCaster, notifierClear, dist);
 
     // we should also force pets to remove us from current target
-    Unit::AttackerSet attackerSet;
-    for (Unit::AttackerSet::const_iterator itr = unitCaster->getAttackers().begin(); itr != unitCaster->getAttackers().end(); ++itr)
-        if ((*itr)->GetTypeId() == TYPEID_UNIT && !(*itr)->CanHaveThreatList())
-            attackerSet.insert(*itr);
-
-    for (Unit::AttackerSet::const_iterator itr = attackerSet.begin(); itr != attackerSet.end(); ++itr)
-        (*itr)->AttackStop();
+    std::vector<Unit*> toRemove;
+    for (Unit* attacker : unitCaster->GetAutoAttackingMe())
+        if (attacker->GetTypeId() == TYPEID_UNIT && attacker->IsControlledByPlayer())
+            toRemove.push_back(attacker);
+    for (Unit* attacker : toRemove)
+        attacker->AutoAttackStop();
 }
 
 void Spell::EffectSelfResurrect(SpellEffIndex effIndex)
@@ -4641,7 +4640,7 @@ void Spell::EffectCharge(SpellEffIndex /*effIndex*/)
     {
         // not all charge effects used in negative spells
         if (!m_spellInfo->IsPositive() && m_caster->GetTypeId() == TYPEID_PLAYER)
-            unitCaster->Attack(unitTarget, true);
+            unitCaster->AutoAttackStart(unitTarget, true);
     }
 }
 

--- a/src/server/scripts/Commands/cs_cast.cpp
+++ b/src/server/scripts/Commands/cs_cast.cpp
@@ -206,7 +206,7 @@ public:
             return false;
         }
 
-        if (!caster->GetVictim())
+        if (!caster->GetAutoAttackVictim())
         {
             handler->SendSysMessage(LANG_SELECTED_TARGET_NOT_HAVE_VICTIM);
             handler->SetSentErrorMessage(true);
@@ -230,7 +230,7 @@ public:
         }
 
         TriggerCastFlags triggered = (triggeredStr != nullptr) ? TRIGGERED_FULL_DEBUG_MASK : TRIGGERED_NONE;
-        caster->CastSpell(caster->GetVictim(), spellId, triggered);
+        caster->CastSpell(caster->GetAutoAttackVictim(), spellId, triggered);
 
         return true;
     }

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -208,7 +208,7 @@ public:
             return false;
         }
 
-        if (player->GetTarget())
+        if (player->GetSelectedUnitGUID())
             unit->PlayDistanceSound(soundId, player);
         else
             unit->PlayDirectSound(soundId, player);
@@ -889,7 +889,7 @@ public:
                 Unit* fixateVictim = mgr.GetFixateTarget();
                 for (ThreatReference const* ref : mgr.GetSortedThreatList())
                 {
-                    Unit* unit = ref->GetVictim();
+                    Unit* unit = ref->GetAutoAttackVictim();
                     char const* onlineStr;
                     switch (ref->GetOnlineState())
                     {

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -889,7 +889,7 @@ public:
                 Unit* fixateVictim = mgr.GetFixateTarget();
                 for (ThreatReference const* ref : mgr.GetSortedThreatList())
                 {
-                    Unit* unit = ref->GetAutoAttackVictim();
+                    Unit* unit = ref->GetVictim();
                     char const* onlineStr;
                     switch (ref->GetOnlineState())
                     {

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -614,7 +614,7 @@ public:
     {
         Unit* target = handler->getSelectedUnit();
 
-        if (!target || !handler->GetSession()->GetPlayer()->GetTarget())
+        if (!target || !handler->GetSession()->GetPlayer()->GetSelectedUnitGUID())
         {
             handler->SendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
             handler->SetSentErrorMessage(true);
@@ -684,7 +684,7 @@ public:
 
     static bool HandleGUIDCommand(ChatHandler* handler, char const* /*args*/)
     {
-        ObjectGuid guid = handler->GetSession()->GetPlayer()->GetTarget();
+        ObjectGuid guid = handler->GetSession()->GetPlayer()->GetSelectedUnitGUID();
 
         if (guid.IsEmpty())
         {
@@ -1882,8 +1882,7 @@ public:
     {
         Player* player = handler->GetSession()->GetPlayer();
 
-        // accept only explicitly selected target (not implicitly self targeting case)
-        Creature* target = player->GetTarget() ? handler->getSelectedCreature() : nullptr;
+        Creature* target = handler->getSelectedCreature();
         if (target)
         {
             if (target->IsPet())
@@ -2272,7 +2271,7 @@ public:
         }
 
         Unit* target = handler->getSelectedUnit();
-        if (!target || !handler->GetSession()->GetPlayer()->GetTarget())
+        if (!target || !handler->GetSession()->GetPlayer()->GetSelectedUnitGUID())
         {
             handler->SendSysMessage(LANG_SELECT_CHAR_OR_CREATURE);
             handler->SetSentErrorMessage(true);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_ambassador_flamelash.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_ambassador_flamelash.cpp
@@ -73,7 +73,7 @@ class boss_ambassador_flamelash : public CreatureScript
                             break;
                         case EVENT_SUMMON_SPIRITS:
                             for (uint32 i = 0; i < 4; ++i)
-                                SummonSpirit(me->GetVictim());
+                                SummonSpirit(me->GetAutoAttackVictim());
                             _events.ScheduleEvent(EVENT_SUMMON_SPIRITS, 30s);
                             break;
                         default:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_general_angerforge.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_general_angerforge.cpp
@@ -110,11 +110,11 @@ class boss_general_angerforge : public CreatureScript
                             break;
                         case EVENT_MEDIC:
                             for (uint8 i = 0; i < 2; ++i)
-                                SummonMedic(me->GetVictim());
+                                SummonMedic(me->GetAutoAttackVictim());
                             break;
                         case EVENT_ADDS:
                             for (uint8 i = 0; i < 3; ++i)
-                                SummonAdd(me->GetVictim());
+                                SummonAdd(me->GetAutoAttackVictim());
                             _events.ScheduleEvent(EVENT_ADDS, 25s, 0, PHASE_TWO);
                             break;
                         default:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
@@ -380,7 +380,7 @@ public:
             for (std::list<Creature*>::iterator itr = creatureList.begin(); itr != creatureList.end(); ++itr)
             {
                 if (Creature* creature = *itr)
-                    DoZoneInCombat(creature);    // AI()->AttackStart(me->GetVictim());
+                    DoZoneInCombat(creature);    // AI()->AttackStart(me->GetAutoAttackVictim());
             }
 
             _events.ScheduleEvent(EVENT_STRIKE, 8s, 16s);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_broodlord_lashlayer.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_broodlord_lashlayer.cpp
@@ -89,8 +89,8 @@ public:
                         break;
                     case EVENT_KNOCKBACK:
                         DoCastVictim(SPELL_KNOCKBACK);
-                        if (GetThreat(me->GetVictim()))
-                            ModifyThreatByPercent(me->GetVictim(), -50);
+                        if (GetThreat(me->GetAutoAttackVictim()))
+                            ModifyThreatByPercent(me->GetAutoAttackVictim(), -50);
                         events.ScheduleEvent(EVENT_KNOCKBACK, 15s, 30s);
                         break;
                     case EVENT_CHECK:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_firemaw.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_firemaw.cpp
@@ -72,8 +72,8 @@ public:
                         break;
                     case EVENT_WINGBUFFET:
                         DoCastVictim(SPELL_WINGBUFFET);
-                        if (GetThreat(me->GetVictim()))
-                            ModifyThreatByPercent(me->GetVictim(), -75);
+                        if (GetThreat(me->GetAutoAttackVictim()))
+                            ModifyThreatByPercent(me->GetAutoAttackVictim(), -75);
                         events.ScheduleEvent(EVENT_WINGBUFFET, 30s);
                         break;
                     case EVENT_FLAMEBUFFET:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_flamegor.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_flamegor.cpp
@@ -77,8 +77,8 @@ public:
                         break;
                     case EVENT_WINGBUFFET:
                         DoCastVictim(SPELL_WINGBUFFET);
-                        if (GetThreat(me->GetVictim()))
-                            ModifyThreatByPercent(me->GetVictim(), -75);
+                        if (GetThreat(me->GetAutoAttackVictim()))
+                            ModifyThreatByPercent(me->GetAutoAttackVictim(), -75);
                         events.ScheduleEvent(EVENT_WINGBUFFET, 30s);
                         break;
                     case EVENT_FRENZY:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -345,7 +345,7 @@ public:
                                 if (Creature* dragon = me->SummonCreature(CreatureID, DrakeSpawnLoc[i]))
                                 {
                                     dragon->SetFaction(FACTION_DRAGONFLIGHT_BLACK);
-                                    dragon->AI()->AttackStart(me->GetVictim());
+                                    dragon->AI()->AttackStart(me->GetAutoAttackVictim());
                                 }
 
                                 if (++SpawnedAdds >= 42)
@@ -459,8 +459,8 @@ public:
             if (id == 1)
             {
                 DoZoneInCombat();
-                if (me->GetVictim())
-                    AttackStart(me->GetVictim());
+                if (me->GetAutoAttackVictim())
+                    AttackStart(me->GetAutoAttackVictim());
             }
         }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_razorgore.cpp
@@ -188,7 +188,7 @@ class go_orb_of_domination : public GameObjectScript
                 {
                     if (Creature* razorgore = instance->GetCreature(DATA_RAZORGORE_THE_UNTAMED))
                     {
-                        razorgore->Attack(player, true);
+                        razorgore->AutoAttackStart(player, true);
                         player->CastSpell(razorgore, SPELL_MINDCONTROL);
                     }
                 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
@@ -184,9 +184,9 @@ public:
                         break;
                     case EVENT_TAILSWIPE:
                         //Only cast if we are behind
-                        /*if (!me->HasInArc(M_PI, me->GetVictim()))
+                        /*if (!me->HasInArc(M_PI, me->GetAutoAttackVictim()))
                         {
-                        DoCast(me->GetVictim(), SPELL_TAILSWIPE);
+                        DoCast(me->GetAutoAttackVictim(), SPELL_TAILSWIPE);
                         }*/
                         events.ScheduleEvent(EVENT_TAILSWIPE, 15s);
                         break;
@@ -204,7 +204,7 @@ public:
                         break;
                     case EVENT_BURNINGADRENALINE_TANK:
                         //Vael has to cast it himself; contrary to the previous commit's comment. Nothing happens otherwise.
-                        me->CastSpell(me->GetVictim(), SPELL_BURNINGADRENALINE, true);
+                        me->CastSpell(me->GetAutoAttackVictim(), SPELL_BURNINGADRENALINE, true);
                         events.ScheduleEvent(EVENT_BURNINGADRENALINE_TANK, 45s);
                         break;
                 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
@@ -230,7 +230,7 @@ class boss_ragnaros : public CreatureScript
                                 events.ScheduleEvent(EVENT_ELEMENTAL_FIRE, 10s, 14s);
                                 break;
                             case EVENT_MAGMA_BLAST:
-                                if (!me->IsWithinMeleeRange(me->GetVictim()))
+                                if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                                 {
                                     DoCastVictim(SPELL_MAGMA_BLAST);
                                     if (!_hasYelledMagmaBurst)
@@ -249,7 +249,7 @@ class boss_ragnaros : public CreatureScript
                                     //Creature spawning and ragnaros becomming unattackable
                                     //is not very well supported in the core //no it really isnt
                                     //so added normaly spawning and banish workaround and attack again after 90 secs.
-                                    me->AttackStop();
+                                    me->AutoAttackStop();
                                     ResetThreatList();
                                     me->SetReactState(REACT_PASSIVE);
                                     me->InterruptNonMeleeSpells(false);

--- a/src/server/scripts/EasternKingdoms/Deadmines/boss_mr_smite.cpp
+++ b/src/server/scripts/EasternKingdoms/Deadmines/boss_mr_smite.cpp
@@ -154,7 +154,7 @@ public:
                 ++uiHealth;
                 DoCastAOE(SPELL_SMITE_STOMP, false);
                 SetCombatMovement(false);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->InterruptNonMeleeSpells(false);
                 me->SetReactState(REACT_PASSIVE);
                 uiTimer = 2500;
@@ -206,7 +206,7 @@ public:
                         case 4:
                             me->SetReactState(REACT_AGGRESSIVE);
                             SetCombatMovement(true);
-                            me->GetMotionMaster()->MoveChase(me->GetVictim(), me->m_CombatDistance);
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim(), me->m_CombatDistance);
                             uiIsMoving = false;
                             uiPhase = 0;
                             break;

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
@@ -177,7 +177,7 @@ public:
 
                     for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                     {
-                        target = ref->GetVictim();
+                        target = ref->GetAutoAttackVictim();
                         if (target && !target->IsWithinDist(me, 8.00f, false) && target->IsWithinDist(me, 25.0f, false))
                             target_list.push_back(target);
 
@@ -235,14 +235,14 @@ public:
                     _phase = PHASE_NONE;
                     scheduler.CancelAll();
 
-                    midnight->AttackStop();
-                    midnight->RemoveAllAttackers();
+                    midnight->AutoAttackStop();
+                    midnight->StopAutoAttackingMe();
                     midnight->SetReactState(REACT_PASSIVE);
                     midnight->GetMotionMaster()->MoveFollow(me, 2.0f, 0.0f);
                     midnight->AI()->Talk(EMOTE_MOUNT_UP);
 
-                    me->AttackStop();
-                    me->RemoveAllAttackers();
+                    me->AutoAttackStop();
+                    me->StopAutoAttackingMe();
                     me->SetReactState(REACT_PASSIVE);
                     me->GetMotionMaster()->MoveFollow(midnight, 2.0f, 0.0f);
                     Talk(SAY_MOUNT);
@@ -331,7 +331,7 @@ public:
             {
                 _attumenGUID = summon->GetGUID();
                 summon->AI()->SetGUID(me->GetGUID(), NPC_MIDNIGHT);
-                summon->AI()->AttackStart(me->GetVictim());
+                summon->AI()->AttackStart(me->GetAutoAttackVictim());
                 summon->AI()->Talk(SAY_APPEAR);
             }
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_midnight.cpp
@@ -177,7 +177,7 @@ public:
 
                     for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                     {
-                        target = ref->GetAutoAttackVictim();
+                        target = ref->GetVictim();
                         if (target && !target->IsWithinDist(me, 8.00f, false) && target->IsWithinDist(me, 25.0f, false))
                             target_list.push_back(target);
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_moroes.cpp
@@ -247,7 +247,7 @@ public:
                     Creature* temp = ObjectAccessor::GetCreature((*me), AddGUID[i]);
                     if (temp && temp->IsAlive())
                     {
-                        temp->AI()->AttackStart(me->GetVictim());
+                        temp->AI()->AttackStart(me->GetAutoAttackVictim());
                         DoZoneInCombat(temp);
                     } else
                         EnterEvadeMode();
@@ -274,8 +274,8 @@ public:
                     {
                         Creature* temp = ObjectAccessor::GetCreature((*me), AddGUID[i]);
                         if (temp && temp->IsAlive())
-                            if (!temp->GetVictim())
-                                temp->AI()->AttackStart(me->GetVictim());
+                            if (!temp->GetAutoAttackVictim())
+                                temp->AI()->AttackStart(me->GetAutoAttackVictim());
                     }
                 }
                 CheckAdds_Timer = 5000;

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_netherspite.cpp
@@ -226,7 +226,7 @@ public:
                         }
                     }
                     // aggro target if Red Beam
-                    if (j == RED_PORTAL && me->GetVictim() != target && target->GetTypeId() == TYPEID_PLAYER)
+                    if (j == RED_PORTAL && me->GetAutoAttackVictim() != target && target->GetTypeId() == TYPEID_PLAYER)
                         AddThreat(target, 100000.0f);
                 }
         }

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -258,7 +258,7 @@ public:
             me->HandleEmoteCommand(EMOTE_ONESHOT_LIFTOFF);
             me->SetDisableGravity(true);
             me->SetReactState(REACT_PASSIVE);
-            me->AttackStop();
+            me->AutoAttackStop();
 
             if (me->GetDistance(FlyPositionLeft) < me->GetDistance(FlyPosition))
                 me->GetMotionMaster()->MovePoint(POINT_PHASE_TWO_PRE_FLY, FlyPositionLeft, true);

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -321,7 +321,7 @@ public:
 
             for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
             {
-                Unit* target = ref->GetAutoAttackVictim();
+                Unit* target = ref->GetVictim();
                 if (target != tank && target->IsAlive() && target->GetTypeId() == TYPEID_PLAYER)
                     targets.push_back(target);
             }

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_prince_malchezaar.cpp
@@ -321,7 +321,7 @@ public:
 
             for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
             {
-                Unit* target = ref->GetVictim();
+                Unit* target = ref->GetAutoAttackVictim();
                 if (target != tank && target->IsAlive() && target->GetTypeId() == TYPEID_PLAYER)
                     targets.push_back(target);
             }
@@ -403,8 +403,8 @@ public:
             if (me->HasUnitState(UNIT_STATE_STUNNED))      // While shifting to phase 2 malchezaar stuns himself
                 return;
 
-            if (me->GetVictim() && me->GetTarget() != me->EnsureVictim()->GetGUID())
-                me->SetTarget(me->EnsureVictim()->GetGUID());
+            if (me->GetAutoAttackVictim() && me->GetSelectedUnitGUID() != me->GetAutoAttackVictim()->GetGUID())
+                me->SetPrimaryTarget(me->GetAutoAttackVictim()->GetGUID());
 
             if (phase == 1)
             {
@@ -492,8 +492,8 @@ public:
                         {
                             if (Unit* axe = ObjectAccessor::GetUnit(*me, axes[i]))
                             {
-                                if (axe->GetVictim())
-                                    ResetThreat(axe->GetVictim(), axe);
+                                if (axe->GetAutoAttackVictim())
+                                    ResetThreat(axe->GetAutoAttackVictim(), axe);
                                 AddThreat(target, 1000000.0f, axe);
                             }
                         }
@@ -527,7 +527,7 @@ public:
                 {
                     Unit* target = nullptr;
                     if (phase == 1)
-                        target = me->GetVictim();        // the tank
+                        target = me->GetAutoAttackVictim();        // the tank
                     else                                          // anyone but the tank
                         target = SelectTarget(SELECT_TARGET_RANDOM, 1, 100, true);
 
@@ -557,18 +557,18 @@ public:
 
         void DoMeleeAttacksIfReady()
         {
-            if (me->IsWithinMeleeRange(me->GetVictim()) && !me->IsNonMeleeSpellCast(false))
+            if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()) && !me->IsNonMeleeSpellCast(false))
             {
                 //Check for base attack
-                if (me->isAttackReady() && me->GetVictim())
+                if (me->isAttackReady() && me->GetAutoAttackVictim())
                 {
-                    me->AttackerStateUpdate(me->GetVictim());
+                    me->AttackerStateUpdate(me->GetAutoAttackVictim());
                     me->resetAttackTimer();
                 }
                 //Check for offhand attack
-                if (me->isAttackReady(OFF_ATTACK) && me->GetVictim())
+                if (me->isAttackReady(OFF_ATTACK) && me->GetAutoAttackVictim())
                 {
-                    me->AttackerStateUpdate(me->GetVictim(), OFF_ATTACK);
+                    me->AttackerStateUpdate(me->GetAutoAttackVictim(), OFF_ATTACK);
                     me->resetAttackTimer(OFF_ATTACK);
                 }
             }

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -188,8 +188,8 @@ public:
             //store the threat list in a different container
             for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
             {
-                Unit* target = ref->GetVictim();
-                if (ref->GetVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetVictim()->IsAlive())
+                Unit* target = ref->GetAutoAttackVictim();
+                if (ref->GetAutoAttackVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetAutoAttackVictim()->IsAlive())
                     targets.push_back(target);
             }
 
@@ -419,7 +419,7 @@ public:
                 {
                     if (Creature* unit = me->SummonCreature(CREATURE_WATER_ELEMENTAL, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 90000))
                     {
-                        unit->Attack(me->GetVictim(), true);
+                        unit->AutoAttackStart(me->GetAutoAttackVictim(), true);
                         unit->SetFaction(me->GetFaction());
                     }
                 }
@@ -433,7 +433,7 @@ public:
                 {
                     if (Creature* unit = me->SummonCreature(CREATURE_SHADOW_OF_ARAN, 0.0f, 0.0f, 0.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5000))
                     {
-                        unit->Attack(me->GetVictim(), true);
+                        unit->AutoAttackStart(me->GetAutoAttackVictim(), true);
                         unit->SetFaction(me->GetFaction());
                     }
                 }

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_shade_of_aran.cpp
@@ -188,8 +188,8 @@ public:
             //store the threat list in a different container
             for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
             {
-                Unit* target = ref->GetAutoAttackVictim();
-                if (ref->GetAutoAttackVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetAutoAttackVictim()->IsAlive())
+                Unit* target = ref->GetVictim();
+                if (ref->GetVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetVictim()->IsAlive())
                     targets.push_back(target);
             }
 

--- a/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/bosses_opera.cpp
@@ -110,8 +110,8 @@ void SummonCroneIfReady(InstanceScript* instance, Creature* creature)
     {
         if (Creature* pCrone = creature->SummonCreature(CREATURE_CRONE, -10891.96f, -1755.95f, creature->GetPositionZ(), 4.64f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, HOUR*2*IN_MILLISECONDS))
         {
-            if (creature->GetVictim())
-                pCrone->AI()->AttackStart(creature->GetVictim());
+            if (creature->GetAutoAttackVictim())
+                pCrone->AI()->AttackStart(creature->GetAutoAttackVictim());
         }
     }
 }
@@ -304,7 +304,7 @@ void boss_dorothee::boss_dorotheeAI::SummonTito()
     {
         Talk(SAY_DOROTHEE_SUMMON);
         ENSURE_AI(npc_tito::npc_titoAI, pTito->AI())->DorotheeGUID = me->GetGUID();
-        pTito->AI()->AttackStart(me->GetVictim());
+        pTito->AI()->AttackStart(me->GetAutoAttackVictim());
         SummonedTito = true;
         TitoDied = false;
     }
@@ -1033,10 +1033,10 @@ void Resurrect(Creature* target)
     target->SetFullHealth();
     target->SetStandState(UNIT_STAND_STATE_STAND);
     target->CastSpell(target, SPELL_RES_VISUAL, true);
-    if (target->GetVictim())
+    if (target->GetAutoAttackVictim())
     {
-        target->GetMotionMaster()->MoveChase(target->GetVictim());
-        target->AI()->AttackStart(target->GetVictim());
+        target->GetMotionMaster()->MoveChase(target->GetAutoAttackVictim());
+        target->AI()->AttackStart(target->GetAutoAttackVictim());
     }
         else
             target->GetMotionMaster()->Initialize();
@@ -1284,10 +1284,10 @@ public:
             if (JulianneGUID)
             {
                 Creature* Julianne = (ObjectAccessor::GetCreature((*me), JulianneGUID));
-                if (Julianne && Julianne->GetVictim())
+                if (Julianne && Julianne->GetAutoAttackVictim())
                 {
-                    AddThreat(Julianne->GetVictim(), 1.0f);
-                    AttackStart(Julianne->GetVictim());
+                    AddThreat(Julianne->GetAutoAttackVictim(), 1.0f);
+                    AttackStart(Julianne->GetAutoAttackVictim());
                 }
             }
         }
@@ -1426,8 +1426,8 @@ void boss_julianne::boss_julianneAI::UpdateAI(uint32 diff)
             Phase = PHASE_BOTH;
             IsFakingDeath = false;
 
-            if (me->GetVictim())
-                AttackStart(me->GetVictim());
+            if (me->GetAutoAttackVictim())
+                AttackStart(me->GetAutoAttackVictim());
 
             ResurrectSelfTimer = 0;
             ResurrectTimer = 1000;

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -201,7 +201,7 @@ public:
 
             for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
             {
-                Unit* unit = ref->GetVictim();
+                Unit* unit = ref->GetAutoAttackVictim();
                 if (unit && unit->IsAlive())
                     AddThreat(unit, ref->GetThreat(), summonedUnit);
             }
@@ -532,7 +532,7 @@ public:
                 me->ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, false);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 me->ClearAllReactives();
-                me->SetTarget(ObjectGuid::Empty);
+                me->SetPrimaryTarget(ObjectGuid::Empty);
                 me->GetMotionMaster()->Clear();
                 me->GetMotionMaster()->MoveIdle();
                 me->SetStandState(UNIT_STAND_STATE_DEAD);

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_felblood_kaelthas.cpp
@@ -201,7 +201,7 @@ public:
 
             for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
             {
-                Unit* unit = ref->GetAutoAttackVictim();
+                Unit* unit = ref->GetVictim();
                 if (unit && unit->IsAlive())
                     AddThreat(unit, ref->GetThreat(), summonedUnit);
             }

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_priestess_delrissa.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_priestess_delrissa.cpp
@@ -1070,7 +1070,7 @@ public:
 
             boss_priestess_lackey_commonAI::UpdateAI(diff);
 
-            if (me->IsWithinDistInMap(me->GetVictim(), ATTACK_DISTANCE))
+            if (me->IsWithinDistInMap(me->GetAutoAttackVictim(), ATTACK_DISTANCE))
             {
                 if (Wing_Clip_Timer <= diff)
                 {

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_selin_fireheart.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/boss_selin_fireheart.cpp
@@ -95,8 +95,8 @@ class boss_selin_fireheart : public CreatureScript
                     case ACTION_SWITCH_PHASE:
                         events.SetPhase(PHASE_NORMAL);
                         events.ScheduleEvent(EVENT_FEL_EXPLOSION, 2s, 0, PHASE_NORMAL);
-                        AttackStart(me->GetVictim());
-                        me->GetMotionMaster()->MoveChase(me->GetVictim());
+                        AttackStart(me->GetAutoAttackVictim());
+                        me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                         break;
                     default:
                         break;
@@ -211,7 +211,7 @@ class boss_selin_fireheart : public CreatureScript
                             CrystalGUID.Clear();
 
                             me->GetMotionMaster()->Clear();
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                             break;
                         }
                         default:

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -529,7 +529,7 @@ public:
                     if (!lose)
                     {
                         pDoneBy->RemoveGameObject(SPELL_DUEL_FLAG, true);
-                        pDoneBy->AttackStop();
+                        pDoneBy->AutoAttackStop();
                         me->CastSpell(pDoneBy, SPELL_DUEL_VICTORY, true);
                         lose = true;
                         me->CastSpell(me, SPELL_GROVEL, true);
@@ -566,10 +566,10 @@ public:
                         EnterEvadeMode();
                     return;
                 }
-                else if (me->GetVictim() && me->EnsureVictim()->GetTypeId() == TYPEID_PLAYER && me->EnsureVictim()->HealthBelowPct(10))
+                else if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->GetTypeId() == TYPEID_PLAYER && me->GetAutoAttackVictim()->HealthBelowPct(10))
                 {
-                    me->EnsureVictim()->CastSpell(me->GetVictim(), SPELL_GROVEL, true); // beg
-                    me->EnsureVictim()->RemoveGameObject(SPELL_DUEL_FLAG, true);
+                    me->GetAutoAttackVictim()->CastSpell(me->GetAutoAttackVictim(), SPELL_GROVEL, true); // beg
+                    me->GetAutoAttackVictim()->RemoveGameObject(SPELL_DUEL_FLAG, true);
                     EnterEvadeMode();
                     return;
                 }
@@ -706,7 +706,7 @@ class npc_dark_rider_of_acherus : public CreatureScript
                 me->SetWalk(true);
                 me->SetSpeedRate(MOVE_RUN, 0.4f);
                 me->GetMotionMaster()->MoveChase(who);
-                me->SetTarget(TargetGUID);
+                me->SetPrimaryTarget(TargetGUID);
                 Intro = true;
             }
 
@@ -954,9 +954,9 @@ public:
                 {
                     if ((*itr)->GetOwner()->GetGUID() == me->GetOwner()->GetGUID())
                     {
-                        if ((*itr)->IsInCombat() && (*itr)->getAttackerForHelper())
+                        if ((*itr)->IsInCombat() && (*itr)->GetAttackerForHelper())
                         {
-                            AttackStart((*itr)->getAttackerForHelper());
+                            AttackStart((*itr)->GetAttackerForHelper());
                         }
                     }
                 }
@@ -972,27 +972,27 @@ public:
                     Player* plrOwner = owner->ToPlayer();
                     if (plrOwner && plrOwner->IsInCombat())
                     {
-                        if (plrOwner->getAttackerForHelper() && plrOwner->getAttackerForHelper()->GetEntry() == NPC_GHOSTS)
-                            AttackStart(plrOwner->getAttackerForHelper());
+                        if (plrOwner->GetAttackerForHelper() && plrOwner->GetAttackerForHelper()->GetEntry() == NPC_GHOSTS)
+                            AttackStart(plrOwner->GetAttackerForHelper());
                         else
                             FindMinions(owner);
                     }
                 }
             }
 
-            if (!UpdateVictim() || !me->GetVictim())
+            if (!UpdateVictim() || !me->GetAutoAttackVictim())
                 return;
 
             //ScriptedAI::UpdateAI(diff);
             //Check if we have a current target
-            if (me->EnsureVictim()->GetEntry() == NPC_GHOSTS)
+            if (me->GetAutoAttackVictim()->GetEntry() == NPC_GHOSTS)
             {
                 if (me->isAttackReady())
                 {
                     //If we are within range melee the target
-                    if (me->IsWithinMeleeRange(me->GetVictim()))
+                    if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     {
-                        me->AttackerStateUpdate(me->GetVictim());
+                        me->AttackerStateUpdate(me->GetAutoAttackVictim());
                         me->resetAttackTimer();
                     }
                 }

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter2.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter2.cpp
@@ -674,7 +674,7 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (PlayerGUID && !me->GetVictim() && me->IsAlive())
+            if (PlayerGUID && !me->GetAutoAttackVictim() && me->IsAlive())
             {
                 if (ExecuteSpeech_Timer <= diff)
                 {

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
@@ -428,7 +428,7 @@ public:
             if (who == me)
                 return;
 
-            if (me->Attack(who, true))
+            if (me->AutoAttackStart(who, true))
             {
                 AddThreat(who, 0.0f);
                 me->SetInCombatWith(who);
@@ -1407,7 +1407,7 @@ public:
                         temp->RemoveAllAuras();
                         temp->GetThreatManager().ClearAllThreat();
                         temp->CombatStop(true);
-                        temp->AttackStop();
+                        temp->AutoAttackStop();
                         temp->SetFaction(me->GetFaction());
                         temp->SetWalk(false);
                         temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[9]);
@@ -1418,7 +1418,7 @@ public:
                         temp->RemoveAllAuras();
                         temp->GetThreatManager().ClearAllThreat();
                         temp->CombatStop(true);
-                        temp->AttackStop();
+                        temp->AutoAttackStop();
                         temp->SetFaction(me->GetFaction());
                         temp->SetWalk(false);
                         temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[12]);
@@ -1429,7 +1429,7 @@ public:
                         temp->RemoveAllAuras();
                         temp->GetThreatManager().ClearAllThreat();
                         temp->CombatStop(true);
-                        temp->AttackStop();
+                        temp->AutoAttackStop();
                         temp->SetFaction(me->GetFaction());
                         temp->SetWalk(false);
                         temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[15]);
@@ -1441,7 +1441,7 @@ public:
                         temp->RemoveAllAuras();
                         temp->GetThreatManager().ClearAllThreat();
                         temp->CombatStop(true);
-                        temp->AttackStop();
+                        temp->AutoAttackStop();
                         temp->SetFaction(me->GetFaction());
                         temp->SetWalk(false);
                         temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[18]);
@@ -1456,7 +1456,7 @@ public:
                         temp->RemoveAllAuras();
                         temp->GetThreatManager().ClearAllThreat();
                         temp->CombatStop(true);
-                        temp->AttackStop();
+                        temp->AutoAttackStop();
                         temp->SetFaction(me->GetFaction());
                         temp->SetWalk(false);
                         temp->GetMotionMaster()->MovePoint(0, LightofDawnLoc[20]);

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/zone_the_scarlet_enclave.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/zone_the_scarlet_enclave.cpp
@@ -107,7 +107,7 @@ public:
                         x -= 2.0f;
                         y -= 1.5f;
                         me->GetMotionMaster()->MovePoint(0, x, y, z);
-                        me->SetTarget(player->GetGUID());
+                        me->SetPrimaryTarget(player->GetGUID());
                         me->SetVisible(true);
                         FlyBackTimer = 4500;
                         break;

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_headless_horseman.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_headless_horseman.cpp
@@ -325,7 +325,7 @@ public:
                 DoCast(me, SPELL_HEAD, false);
                 SaySound(SAY_LOST_HEAD);
                 me->GetMotionMaster()->Clear();
-                me->GetMotionMaster()->MoveFleeing(caster->GetVictim());
+                me->GetMotionMaster()->MoveFleeing(caster->GetAutoAttackVictim());
             }
         }
 
@@ -337,10 +337,10 @@ public:
                 if (wait <= diff)
                 {
                     wait = 1000;
-                    if (!me->GetVictim())
+                    if (!me->GetAutoAttackVictim())
                         return;
                     me->GetMotionMaster()->Clear();
-                    me->GetMotionMaster()->MoveFleeing(me->GetVictim());
+                    me->GetMotionMaster()->MoveFleeing(me->GetAutoAttackVictim());
                 }
                 else wait -= diff;
 
@@ -548,7 +548,7 @@ public:
 
             std::list<Player*> temp;
             for (Map::PlayerList::const_iterator i = PlayerList.begin(); i != PlayerList.end(); ++i)
-                if ((me->IsWithinLOSInMap(i->GetSource()) || !checkLoS) && me->GetVictim() != i->GetSource() &&
+                if ((me->IsWithinLOSInMap(i->GetSource()) || !checkLoS) && me->GetAutoAttackVictim() != i->GetSource() &&
                     me->IsWithinDistInMap(i->GetSource(), range) && i->GetSource()->IsAlive())
                     temp.push_back(i->GetSource());
 
@@ -827,7 +827,7 @@ public:
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED);
                 DoCast(me, SPELL_SPROUT_BODY, true);
                 me->UpdateEntry(PUMPKIN_FIEND);
-                DoStartMovement(me->GetVictim());
+                DoStartMovement(me->GetAutoAttackVictim());
             }
         }
 
@@ -852,7 +852,7 @@ public:
 
         void MoveInLineOfSight(Unit* who) override
         {
-            if (!who || !me->IsValidAttackTarget(who) || me->GetVictim())
+            if (!who || !me->IsValidAttackTarget(who) || me->GetAutoAttackVictim())
                 return;
 
             AddThreat(who, 0.0f);

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_mograine_and_whitemane.cpp
@@ -192,8 +192,8 @@ public:
                     CrusaderStrike_Timer = 10000;
                     HammerOfJustice_Timer = 10000;
 
-                    if (me->GetVictim())
-                        me->GetMotionMaster()->MoveChase(me->GetVictim());
+                    if (me->GetAutoAttackVictim())
+                        me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
 
                     _bHeal = true;
                 }

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_jandice_barov.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_jandice_barov.cpp
@@ -91,7 +91,7 @@ public:
                         DoCast(SPELL_ILLUSION);
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         me->SetDisplayId(11686);  // Invisible Model
-                        ModifyThreatByPercent(me->GetVictim(), -99);
+                        ModifyThreatByPercent(me->GetAutoAttackVictim(), -99);
                         events.ScheduleEvent(EVENT_SET_VISIBILITY, 3s);
                         events.ScheduleEvent(EVENT_ILLUSION, 25s);
                         break;

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_kormok.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_kormok.cpp
@@ -74,7 +74,7 @@ public:
 
         void JustSummoned(Creature* summoned) override
         {
-            summoned->AI()->AttackStart(me->GetVictim());
+            summoned->AI()->AttackStart(me->GetAutoAttackVictim());
         }
 
         void DamageTaken(Unit* /*attacker*/, uint32& damage) override

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_nerubenkan.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_nerubenkan.cpp
@@ -120,7 +120,7 @@ public:
             //RaiseUndeadScarab
             if (RaiseUndeadScarab_Timer <= diff)
             {
-                RaiseUndeadScarab(me->GetVictim());
+                RaiseUndeadScarab(me->GetAutoAttackVictim());
                 RaiseUndeadScarab_Timer = 16000;
             } else RaiseUndeadScarab_Timer -= diff;
 

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_brutallus.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_brutallus.cpp
@@ -158,8 +158,8 @@ public:
                 Madrigosa->SetMaxHealth(me->GetMaxHealth());
                 Madrigosa->SetHealth(me->GetMaxHealth());
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                me->Attack(Madrigosa, true);
-                Madrigosa->Attack(me, true);
+                me->AutoAttackStart(Madrigosa, true);
+                Madrigosa->AutoAttackStart(me, true);
             }
             else
             {
@@ -211,8 +211,8 @@ public:
                 case 3:
                     DoCast(me, SPELL_INTRO_FROST_BLAST);
                     Madrigosa->SetDisableGravity(true);
-                    me->AttackStop();
-                    Madrigosa->AttackStop();
+                    me->AutoAttackStop();
+                    Madrigosa->AutoAttackStop();
                     IntroFrostBoltTimer = 3000;
                     IntroPhaseTimer = 28000;
                     ++IntroPhase;
@@ -238,7 +238,7 @@ public:
                     Unit::Kill(me, Madrigosa);
                     Madrigosa->AI()->Talk(YELL_MADR_DEATH);
                     me->SetFullHealth();
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     IntroPhaseTimer = 4000;
                     ++IntroPhase;
                     break;

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_eredar_twins.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_eredar_twins.cpp
@@ -119,8 +119,8 @@ public:
             {
                 if (temp->isDead())
                     temp->Respawn();
-                else if (temp->GetVictim())
-                    AddThreat(temp->GetVictim(), 0.0f);
+                else if (temp->GetAutoAttackVictim())
+                    AddThreat(temp->GetAutoAttackVictim(), 0.0f);
             }
 
             if (!me->IsInCombat())
@@ -136,7 +136,7 @@ public:
             DoZoneInCombat();
 
             Creature* temp = instance->GetCreature(DATA_ALYTHESS);
-            if (temp && temp->IsAlive() && !temp->GetVictim())
+            if (temp && temp->IsAlive() && !temp->GetAutoAttackVictim())
                 temp->AI()->AttackStart(who);
 
             instance->SetBossState(DATA_EREDAR_TWINS, IN_PROGRESS);
@@ -302,10 +302,10 @@ public:
             if (me->isAttackReady() && !me->IsNonMeleeSpellCast(false))
             {
                 //If we are within range melee the target
-                if (me->IsWithinMeleeRange(me->GetVictim()))
+                if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                 {
-                    HandleTouchedSpells(me->GetVictim(), SPELL_DARK_TOUCHED);
-                    me->AttackerStateUpdate(me->GetVictim());
+                    HandleTouchedSpells(me->GetAutoAttackVictim(), SPELL_DARK_TOUCHED);
+                    me->AttackerStateUpdate(me->GetAutoAttackVictim());
                     me->resetAttackTimer();
                 }
             }
@@ -371,8 +371,8 @@ public:
             {
                 if (temp->isDead())
                     temp->Respawn();
-                else if (temp->GetVictim())
-                    AddThreat(temp->GetVictim(), 0.0f);
+                else if (temp->GetAutoAttackVictim())
+                    AddThreat(temp->GetAutoAttackVictim(), 0.0f);
             }
 
             if (!me->IsInCombat())
@@ -388,7 +388,7 @@ public:
             DoZoneInCombat();
 
             Creature* temp = instance->GetCreature(DATA_SACROLASH);
-            if (temp && temp->IsAlive() && !temp->GetVictim())
+            if (temp && temp->IsAlive() && !temp->GetAutoAttackVictim())
                 temp->AI()->AttackStart(who);
 
             instance->SetBossState(DATA_EREDAR_TWINS, IN_PROGRESS);
@@ -402,7 +402,7 @@ public:
 
         void MoveInLineOfSight(Unit* who) override
         {
-            if (!who || me->GetVictim())
+            if (!who || me->GetAutoAttackVictim())
                 return;
 
             if (me->CanCreatureAttack(who))
@@ -545,14 +545,14 @@ public:
                     SisterDeath = true;
                 }
             }
-            if (!me->GetVictim())
+            if (!me->GetAutoAttackVictim())
             {
                 Creature* sisiter = instance->GetCreature(DATA_SACROLASH);
-                if (sisiter && !sisiter->isDead() && sisiter->GetVictim())
+                if (sisiter && !sisiter->isDead() && sisiter->GetAutoAttackVictim())
                 {
-                    AddThreat(sisiter->GetVictim(), 0.0f);
-                    DoStartNoMovement(sisiter->GetVictim());
-                    me->Attack(sisiter->GetVictim(), false);
+                    AddThreat(sisiter->GetAutoAttackVictim(), 0.0f);
+                    DoStartNoMovement(sisiter->GetAutoAttackVictim());
+                    me->AutoAttackStart(sisiter->GetAutoAttackVictim(), false);
                 }
             }
 
@@ -717,7 +717,7 @@ public:
                 if (!me->IsNonMeleeSpellCast(false))
                 {
                     //If we are within range melee the target
-                    if (me->IsWithinMeleeRange(me->GetVictim()))
+                    if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                         DoCastVictim(SPELL_DARK_STRIKE);
                 }
                 DarkstrikeTimer = 3000;

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
@@ -276,7 +276,7 @@ public:
             switch (uiFlightCount)
             {
                 case 0:
-                    //me->AttackStop();
+                    //me->AutoAttackStop();
                     me->GetMotionMaster()->Clear();
                     me->HandleEmoteCommand(EMOTE_ONESHOT_LIFTOFF);
                     me->StopMoving();
@@ -537,7 +537,7 @@ public:
 
         void UpdateAI(uint32 /*diff*/) override
         {
-            if (!me->GetVictim())
+            if (!me->GetAutoAttackVictim())
                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                     AttackStart(target);
         }
@@ -560,7 +560,7 @@ public:
         {
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             DoCast(me, SPELL_TRAIL_TRIGGER, true);
-            me->SetTarget(me->GetGUID());
+            me->SetPrimaryTarget(me->GetGUID());
             me->SetFloatValue(UNIT_FIELD_BOUNDINGRADIUS, 0.01f); // core bug
         }
 

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kalecgos.cpp
@@ -314,8 +314,8 @@ struct boss_kalecgos : public BossAI
                     me->SetRegenerateHealth(false);
                     me->SetReactState(REACT_PASSIVE);
                     me->InterruptNonMeleeSpells(true);
-                    me->RemoveAllAttackers();
-                    me->AttackStop();
+                    me->StopAutoAttackingMe();
+                    me->AutoAttackStop();
                     me->SetFaction(FACTION_FRIENDLY);
                     me->RemoveAllAuras();
                     instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
@@ -996,7 +996,7 @@ public:
             {
                 if (Creature* pPortal = DoSpawnCreature(NPC_FELFIRE_PORTAL, 0, 0, 0, 0, TEMPSUMMON_TIMED_DESPAWN, 20000))
                     for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                        AddThreat(ref->GetAutoAttackVictim(), 1.0f, pPortal);
+                        AddThreat(ref->GetVictim(), 1.0f, pPortal);
                 FelfirePortalTimer = 20000;
             } else FelfirePortalTimer -= diff;
 

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_kiljaeden.cpp
@@ -473,7 +473,7 @@ public:
                     break;
                 case NPC_KILJAEDEN:
                     summoned->CastSpell(summoned, SPELL_REBIRTH, false);
-                    AddThreat(me->GetVictim(), 1.0f, summoned);
+                    AddThreat(me->GetAutoAttackVictim(), 1.0f, summoned);
                     break;
             }
             summons.Summon(summoned);
@@ -996,7 +996,7 @@ public:
             {
                 if (Creature* pPortal = DoSpawnCreature(NPC_FELFIRE_PORTAL, 0, 0, 0, 0, TEMPSUMMON_TIMED_DESPAWN, 20000))
                     for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                        AddThreat(ref->GetVictim(), 1.0f, pPortal);
+                        AddThreat(ref->GetAutoAttackVictim(), 1.0f, pPortal);
                 FelfirePortalTimer = 20000;
             } else FelfirePortalTimer -= diff;
 
@@ -1109,7 +1109,7 @@ public:
 
             if (!bLockedTarget)
             {
-                AddThreat(me->GetVictim(), 10000000.0f);
+                AddThreat(me->GetAutoAttackVictim(), 10000000.0f);
                 bLockedTarget = true;
             }
 
@@ -1119,7 +1119,7 @@ public:
                     uiExplodeTimer = 0;
                 else uiExplodeTimer -= diff;
             }
-            else if (me->IsWithinDistInMap(me->GetVictim(), 3)) // Explode if it's close enough to it's target
+            else if (me->IsWithinDistInMap(me->GetAutoAttackVictim(), 3)) // Explode if it's close enough to it's target
             {
                 DoCastVictim(SPELL_FELFIRE_FISSION);
                 me->KillSelf();
@@ -1324,9 +1324,9 @@ public:
             if (!UpdateVictim())
                 return;
 
-            if ((victimClass == 0) && me->GetVictim())
+            if ((victimClass == 0) && me->GetAutoAttackVictim())
             {
-                victimClass = me->EnsureVictim()->getClass();
+                victimClass = me->GetAutoAttackVictim()->getClass();
                 switch (victimClass)
                 {
                     case CLASS_DRUID:
@@ -1374,7 +1374,7 @@ public:
                         DoCastVictim(SPELL_SR_SHOOT, false);
                         uiTimer[2] = urand(4000, 6000);
                     }
-                    if (me->IsWithinMeleeRange(me->GetVictim()))
+                    if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     {
                         if (uiTimer[0] <= diff)
                         {

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -418,7 +418,7 @@ public:
 
             _scheduler.Schedule(Seconds(3), [this](TaskContext context)
             {
-                if (me->IsWithinDist(me->GetVictim(), 5.0f) && me->HasAura(SPELL_DARKFIEND_SKIN))
+                if (me->IsWithinDist(me->GetAutoAttackVictim(), 5.0f) && me->HasAura(SPELL_DARKFIEND_SKIN))
                 {
                     DoCastAOE(SPELL_DARKFIEND_DAMAGE, false);
                     me->DisappearAndDie();
@@ -653,7 +653,7 @@ class spell_dark_fiend_skin : public SpellScriptLoader
                 if (Creature* target = GetTarget()->ToCreature())
                 {
                     target->SetReactState(REACT_PASSIVE);
-                    target->AttackStop();
+                    target->AutoAttackStop();
                     target->StopMoving();
                     target->CastSpell(target, SPELL_DARKFIEND_VISUAL, true);
                     target->DespawnOrUnsummon(3000);

--- a/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp
+++ b/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp
@@ -75,10 +75,10 @@ class boss_ironaya : public CreatureScript
                     return;
 
                 //If we are <50% hp do knockaway ONCE
-                if (!bHasCastKnockaway && HealthBelowPct(50) && me->GetVictim())
+                if (!bHasCastKnockaway && HealthBelowPct(50) && me->GetAutoAttackVictim())
                 {
                     DoCastVictim(SPELL_KNOCKAWAY, true);
-                    me->GetThreatManager().ResetThreat(me->EnsureVictim());
+                    me->GetThreatManager().ResetThreat(me->GetAutoAttackVictim());
 
                     //Shouldn't cast this agian
                     bHasCastKnockaway = true;

--- a/src/server/scripts/EasternKingdoms/Uldaman/uldaman.cpp
+++ b/src/server/scripts/EasternKingdoms/Uldaman/uldaman.cpp
@@ -93,7 +93,7 @@ class npc_jadespine_basilisk : public CreatureScript
                     //Stop attacking target thast asleep and pick new target
                     uiCslumberTimer = 28000;
 
-                    me->GetThreatManager().ResetThreat(me->GetVictim());
+                    me->GetThreatManager().ResetThreat(me->GetAutoAttackVictim());
 
                 } else uiCslumberTimer -= uiDiff;
 

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_akilzon.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_akilzon.cpp
@@ -238,7 +238,7 @@ class boss_akilzon : public CreatureScript
                             {
                             Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1);
                             if (!target)
-                                target = me->GetVictim();
+                                target = me->GetAutoAttackVictim();
                             if (target)
                             {
                                 TargetGUID = target->GetGUID();
@@ -253,7 +253,7 @@ class boss_akilzon : public CreatureScript
                             {
                                 Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1);
                                 if (!target)
-                                    target = me->GetVictim();
+                                    target = me->GetAutoAttackVictim();
                                 if (target)
                                     DoCast(target, SPELL_GUST_OF_WIND);
                                 events.ScheduleEvent(EVENT_GUST_OF_WIND, 20s, 30s);
@@ -345,8 +345,8 @@ class boss_akilzon : public CreatureScript
                                     Creature* creature = me->SummonCreature(NPC_SOARING_EAGLE, x, y, z, 0, TEMPSUMMON_CORPSE_DESPAWN, 0);
                                     if (creature)
                                     {
-                                        AddThreat(me->GetVictim(), 1.0f, creature);
-                                        creature->AI()->AttackStart(me->GetVictim());
+                                        AddThreat(me->GetAutoAttackVictim(), 1.0f, creature);
+                                        creature->AI()->AttackStart(me->GetAutoAttackVictim());
                                         BirdGUIDs[i] = creature->GetGUID();
                                     }
                                 }

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_halazzi.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_halazzi.cpp
@@ -124,7 +124,7 @@ class boss_halazzi : public CreatureScript
 
             void JustSummoned(Creature* summon) override
             {
-                summon->AI()->AttackStart(me->GetVictim());
+                summon->AI()->AttackStart(me->GetAutoAttackVictim());
                 if (summon->GetEntry() == NPC_SPIRIT_LYNX)
                     LynxGUID = summon->GetGUID();
                 summons.Summon(summon);
@@ -157,8 +157,8 @@ class boss_halazzi : public CreatureScript
                         if (Phase == PHASE_MERGE)
                         {
                             DoCast(me, SPELL_TRANSFORM_MERGE, true);
-                            me->Attack(me->GetVictim(), true);
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->AutoAttackStart(me->GetAutoAttackVictim(), true);
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                         }
                         if (Creature* Lynx = ObjectAccessor::GetCreature(*me, LynxGUID))
                             Lynx->DisappearAndDie();

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_hexlord.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_hexlord.cpp
@@ -300,7 +300,7 @@ class boss_hexlord_malacrass : public CreatureScript
                 {
                     Creature* creature = ObjectAccessor::GetCreature(*me, AddGUID[i]);
                     if (creature && creature->IsAlive())
-                        creature->AI()->AttackStart(me->GetVictim());
+                        creature->AI()->AttackStart(me->GetAutoAttackVictim());
                     else
                     {
                         EnterEvadeMode();
@@ -388,8 +388,8 @@ class boss_hexlord_malacrass : public CreatureScript
                 {
                     for (uint8 i = 0; i < 4; ++i)
                         if (Creature* temp = ObjectAccessor::GetCreature(*me, AddGUID[i]))
-                            if (temp->IsAlive() && !temp->GetVictim())
-                                temp->AI()->AttackStart(me->GetVictim());
+                            if (temp->IsAlive() && !temp->GetAutoAttackVictim())
+                                temp->AI()->AttackStart(me->GetAutoAttackVictim());
 
                     CheckAddState_Timer = 5000;
                 }
@@ -481,7 +481,7 @@ class boss_hexlord_malacrass : public CreatureScript
                         target = me;
                         break;
                     case ABILITY_TARGET_VICTIM:
-                        target = me->GetVictim();
+                        target = me->GetAutoAttackVictim();
                         break;
                     case ABILITY_TARGET_ENEMY:
                     default:
@@ -611,7 +611,7 @@ class boss_alyson_antille : public CreatureScript
 
                 if (who->isTargetableForAttack())
                 {
-                    if (me->Attack(who, false))
+                    if (me->AutoAttackStart(who, false))
                     {
                         me->GetMotionMaster()->MoveChase(who, 20);
                         AddThreat(who, 0.0f);
@@ -871,7 +871,7 @@ class boss_slither : public CreatureScript
 
                 if (who->isTargetableForAttack())
                 {
-                    if (me->Attack(who, false))
+                    if (me->AutoAttackStart(who, false))
                     {
                         me->GetMotionMaster()->MoveChase(who, 20);
                         AddThreat(who, 0.0f);
@@ -936,8 +936,8 @@ class boss_fenstalker : public CreatureScript
                 if (volatileinf_timer <= diff)
                 {
                     // core bug
-                    if (me->GetVictim())
-                        me->EnsureVictim()->CastSpell(me->GetVictim(), SPELL_VOLATILE_INFECTION, false);
+                    if (me->GetAutoAttackVictim())
+                        me->GetAutoAttackVictim()->CastSpell(me->GetAutoAttackVictim(), SPELL_VOLATILE_INFECTION, false);
                     volatileinf_timer = 12000;
                 }
                 else

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_janalai.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_janalai.cpp
@@ -352,7 +352,7 @@ class boss_janalai : public CreatureScript
                 {
                     Talk(SAY_FIRE_BOMBS);
 
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->GetMotionMaster()->Clear();
                     DoTeleportTo(JanalainPos[0][0], JanalainPos[0][1], JanalainPos[0][2]);
                     me->StopMoving();
@@ -387,7 +387,7 @@ class boss_janalai : public CreatureScript
                     {
                         Talk(SAY_ALL_EGGS);
 
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->GetMotionMaster()->Clear();
                         DoTeleportTo(JanalainPos[0][0], JanalainPos[0][1], JanalainPos[0][2]);
                         me->StopMoving();
@@ -415,7 +415,7 @@ class boss_janalai : public CreatureScript
                 {
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                     {
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->GetMotionMaster()->Clear();
                         DoCast(target, SPELL_FLAME_BREATH, false);
                         me->StopMoving();

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_nalorakk.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_nalorakk.cpp
@@ -371,7 +371,7 @@ class boss_nalorakk : public CreatureScript
 
                     if (Mangle_Timer <= diff)
                     {
-                        if (me->GetVictim() && !me->EnsureVictim()->HasAura(SPELL_MANGLEEFFECT))
+                        if (me->GetAutoAttackVictim() && !me->GetAutoAttackVictim()->HasAura(SPELL_MANGLEEFFECT))
                         {
                             DoCastVictim(SPELL_MANGLE);
                             Mangle_Timer = 1000;

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
@@ -242,20 +242,20 @@ class boss_zuljin : public CreatureScript
             {
                 if (!me->IsNonMeleeSpellCast(false))
                 {
-                    if (me->isAttackReady() && me->IsWithinMeleeRange(me->GetVictim()))
+                    if (me->isAttackReady() && me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     {
                         if (Phase == 1 && !Overpower_Timer)
                         {
-                            uint32 health = me->EnsureVictim()->GetHealth();
-                            me->AttackerStateUpdate(me->GetVictim());
-                            if (me->GetVictim() && health == me->EnsureVictim()->GetHealth())
+                            uint32 health = me->GetAutoAttackVictim()->GetHealth();
+                            me->AttackerStateUpdate(me->GetAutoAttackVictim());
+                            if (me->GetAutoAttackVictim() && health == me->GetAutoAttackVictim()->GetHealth())
                             {
                                 DoCastVictim(SPELL_OVERPOWER, false);
                                 Overpower_Timer = 5000;
                             }
                         }
                         else
-                            me->AttackerStateUpdate(me->GetVictim());
+                            me->AttackerStateUpdate(me->GetAutoAttackVictim());
                         me->resetAttackTimer();
                     }
                 }
@@ -334,13 +334,13 @@ class boss_zuljin : public CreatureScript
                             }
                         }
                         else
-                            AttackStart(me->GetVictim());
+                            AttackStart(me->GetAutoAttackVictim());
 
                         if (NextPhase == 3)
                         {
                             me->RemoveAurasDueToSpell(SPELL_ENERGY_STORM);
                             summons.DespawnEntry(CREATURE_FEATHER_VORTEX);
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                         }
                         break;
                     default:
@@ -429,8 +429,8 @@ class boss_zuljin : public CreatureScript
                             {
                                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                                 {
-                                    if (me->GetVictim())
-                                        TankGUID = me->EnsureVictim()->GetGUID();
+                                    if (me->GetAutoAttackVictim())
+                                        TankGUID = me->GetAutoAttackVictim()->GetGUID();
 
                                     me->SetSpeedRate(MOVE_RUN, 5.0f);
                                     AttackStart(target); // change victim
@@ -443,7 +443,7 @@ class boss_zuljin : public CreatureScript
                             {
                                 if (Claw_Loop_Timer <= diff)
                                 {
-                                    Unit* target = me->GetVictim();
+                                    Unit* target = me->GetAutoAttackVictim();
                                     if (!target || !target->isTargetableForAttack())
                                         target = ObjectAccessor::GetUnit(*me, TankGUID);
                                     if (!target || !target->isTargetableForAttack())
@@ -485,7 +485,7 @@ class boss_zuljin : public CreatureScript
                             {
                                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                                 {
-                                    TankGUID = me->EnsureVictim()->GetGUID();
+                                    TankGUID = me->GetAutoAttackVictim()->GetGUID();
                                     me->SetSpeedRate(MOVE_RUN, 5.0f);
                                     AttackStart(target); // change victim
                                     Lynx_Rush_Timer = 0;
@@ -494,7 +494,7 @@ class boss_zuljin : public CreatureScript
                             }
                             else if (!Lynx_Rush_Timer)
                             {
-                                Unit* target = me->GetVictim();
+                                Unit* target = me->GetAutoAttackVictim();
                                 if (!target || !target->isTargetableForAttack())
                                 {
                                     target = SelectTarget(SELECT_TARGET_RANDOM, 0);
@@ -592,7 +592,7 @@ class npc_zuljin_vortex : public CreatureScript
             void UpdateAI(uint32 /*diff*/) override
             {
                 //if the vortex reach the target, it change his target to another player
-                if (me->IsWithinMeleeRange(me->GetVictim()))
+                if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     AttackStart(SelectTarget(SELECT_TARGET_RANDOM, 0));
             }
         };

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -302,7 +302,7 @@ class npc_harrison_jones : public CreatureScript
                     me->RemoveAllAuras();
                     me->SetEntry(NPC_HARRISON_JONES_2);
                     me->SetDisplayId(MODEL_HARRISON_JONES_2);
-                    me->SetTarget(ObjectGuid::Empty);
+                    me->SetPrimaryTarget(ObjectGuid::Empty);
                     me->SetByteValue(UNIT_FIELD_BYTES_1, 0, UNIT_STAND_STATE_DEAD);
                     me->SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
                     instance->SetData(DATA_GONGEVENT, DONE);

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
@@ -229,7 +229,7 @@ class boss_arlokk : public CreatureScript
                         {
                             Unit* target = SelectTarget(SELECT_TARGET_MAXTHREAT, urand(1, 3), 0.0f, false, true, -SPELL_MARK_OF_ARLOKK);
                             if (!target)
-                                target = me->GetVictim();
+                                target = me->GetAutoAttackVictim();
                             if (target)
                             {
                                 DoCast(target, SPELL_MARK_OF_ARLOKK, true);
@@ -249,7 +249,7 @@ class boss_arlokk : public CreatureScript
                             me->SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, (cinfo->maxdmg +((cinfo->maxdmg/100) * 35)));
                             me->UpdateDamagePhysical(BASE_ATTACK);
                             */
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             ResetThreatList();
                             me->SetReactState(REACT_PASSIVE);
                             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);
@@ -385,7 +385,7 @@ class npc_zulian_prowler : public CreatureScript
             void SpellHit(Unit* caster, SpellInfo const* spell) override
             {
                 if (spell->Id == SPELL_MARK_OF_ARLOKK_TRIGGER) // Should only hit if line of sight
-                    me->Attack(caster, true);
+                    me->AutoAttackStart(caster, true);
             }
 
             void JustDied(Unit* /*killer*/) override
@@ -414,7 +414,7 @@ class npc_zulian_prowler : public CreatureScript
                     {
                         case EVENT_ATTACK:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0.0f, 100, false))
-                                me->Attack(target, true);
+                                me->AutoAttackStart(target, true);
                             break;
                         default:
                             break;

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_grilek.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_grilek.cpp
@@ -81,7 +81,7 @@ class boss_grilek : public CreatureScript // grilek
                     {
                         case EVENT_AVATAR:
                             DoCast(me, SPELL_AVATAR);
-                            if (Unit* victim = me->GetVictim())
+                            if (Unit* victim = me->GetAutoAttackVictim())
                             {
                                 if (GetThreat(victim))
                                     ModifyThreatByPercent(victim, -50);

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jindo.cpp
@@ -121,7 +121,7 @@ class boss_jindo : public CreatureScript
                             events.ScheduleEvent(EVENT_POWERFULL_HEALING_WARD, 14s, 20s);
                             break;
                         case EVENT_HEX:
-                            if (Unit* target = me->GetVictim())
+                            if (Unit* target = me->GetAutoAttackVictim())
                             {
                                 DoCast(target, SPELL_HEX, true);
                                 if (GetThreat(target))
@@ -143,7 +143,7 @@ class boss_jindo : public CreatureScript
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
                             {
                                 DoTeleportPlayer(target, TeleportLoc.GetPositionX(), TeleportLoc.GetPositionY(), TeleportLoc.GetPositionZ(), TeleportLoc.GetOrientation());
-                                if (GetThreat(me->GetVictim()))
+                                if (GetThreat(me->GetAutoAttackVictim()))
                                     ModifyThreatByPercent(target, -100);
 
                                 // Summon a formation of trolls

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_mandokir.cpp
@@ -261,7 +261,7 @@ class boss_mandokir : public CreatureScript
                             events.ScheduleEvent(EVENT_OVERPOWER, 6s, 12s);
                             break;
                         case EVENT_MORTAL_STRIKE:
-                            if (me->GetVictim() && me->EnsureVictim()->HealthBelowPct(50))
+                            if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HealthBelowPct(50))
                                 DoCastVictim(SPELL_MORTAL_STRIKE, true);
                             events.ScheduleEvent(EVENT_MORTAL_STRIKE, 12s, 18s);
                             break;

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_marli.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_marli.cpp
@@ -160,8 +160,8 @@ class boss_marli : public CreatureScript
                             */
                             me->ApplyStatPctModifier(UNIT_MOD_DAMAGE_MAINHAND, TOTAL_PCT, DamageIncrease); // hack
                             DoCastVictim(SPELL_ENVOLWINGWEB);
-                            if (GetThreat(me->GetVictim()))
-                                ModifyThreatByPercent(me->GetVictim(), -100);
+                            if (GetThreat(me->GetAutoAttackVictim()))
+                                ModifyThreatByPercent(me->GetAutoAttackVictim(), -100);
                             events.ScheduleEvent(EVENT_CHARGE_PLAYER, 1500ms, 0, PHASE_THREE);
                             events.ScheduleEvent(EVENT_TRANSFORM_BACK, 25s, 0, PHASE_THREE);
                             events.SetPhase(PHASE_THREE);

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_renataki.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_renataki.cpp
@@ -144,8 +144,8 @@ class boss_renataki : public CreatureScript
                     {
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
                         {
-                            if (GetThreat(me->GetVictim()))
-                                ModifyThreatByPercent(me->GetVictim(), -50);
+                            if (GetThreat(me->GetAutoAttackVictim()))
+                                ModifyThreatByPercent(me->GetAutoAttackVictim(), -50);
                             AttackStart(target);
                         }
 

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_thekal.cpp
@@ -257,7 +257,7 @@ class boss_thekal : public CreatureScript
                         me->RemoveAurasByType(SPELL_AURA_PERIODIC_LEECH);
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         me->SetStandState(UNIT_STAND_STATE_SLEEP);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         instance->SetBossState(DATA_THEKAL, SPECIAL);
                         WasDead = true;
                     }
@@ -411,7 +411,7 @@ class npc_zealot_lorkhan : public CreatureScript
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                     me->SetStandState(UNIT_STAND_STATE_SLEEP);
                     me->SetFaction(FACTION_FRIENDLY);
-                    me->AttackStop();
+                    me->AutoAttackStop();
 
                     instance->SetBossState(DATA_LORKHAN, SPECIAL);
 
@@ -503,8 +503,8 @@ class npc_zealot_zath : public CreatureScript
                 {
                     DoCastVictim(SPELL_GOUGE);
 
-                    if (GetThreat(me->GetVictim()))
-                        ModifyThreatByPercent(me->GetVictim(), -100);
+                    if (GetThreat(me->GetAutoAttackVictim()))
+                        ModifyThreatByPercent(me->GetAutoAttackVictim(), -100);
 
                     Gouge_Timer = 17000 + rand32() % 10000;
                 } else Gouge_Timer -= diff;
@@ -561,7 +561,7 @@ class npc_zealot_zath : public CreatureScript
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                     me->SetStandState(UNIT_STAND_STATE_SLEEP);
                     me->SetFaction(35);
-                    me->AttackStop();
+                    me->AutoAttackStop();
 
                     instance->SetBossState(DATA_ZATH, SPECIAL);
 

--- a/src/server/scripts/EasternKingdoms/zone_ghostlands.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_ghostlands.cpp
@@ -92,8 +92,8 @@ public:
                         Creature* Summ2 = me->SummonCreature(NPC_SHADOWPINE_ORACLE, 7620.432129f, -7532.550293f, 152.454865f, 0.827478f, TEMPSUMMON_DEAD_DESPAWN, 0);
                         if (Summ1 && Summ2)
                         {
-                            Summ1->Attack(me, true);
-                            Summ2->Attack(player, true);
+                            Summ1->AutoAttackStart(me, true);
+                            Summ2->AutoAttackStart(player, true);
                         }
                         AttackStart(Summ1);
                     }

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -186,7 +186,7 @@ public:
                         // add a blink to simulate a stealthed movement and reappearing elsewhere
                         DoCast(me, SPELL_FADE_BLINK);
                         // if the victim is out of melee range she cast multi shot
-                        if (Unit* victim = me->GetVictim())
+                        if (Unit* victim = me->GetAutoAttackVictim())
                             if (me->GetDistance(victim) > 10.0f)
                                 DoCast(victim, SPELL_MULTI_SHOT);
                         _events.ScheduleEvent(EVENT_FADE, 30s, 35s);
@@ -196,17 +196,17 @@ public:
                         _events.ScheduleEvent(EVENT_SUMMON_SKELETON, 20s, 30s);
                         break;
                     case EVENT_BLACK_ARROW:
-                        if (Unit* victim = me->GetVictim())
+                        if (Unit* victim = me->GetAutoAttackVictim())
                             DoCast(victim, SPELL_BLACK_ARROW);
                         _events.ScheduleEvent(EVENT_BLACK_ARROW, 15s, 20s);
                         break;
                     case EVENT_SHOOT:
-                        if (Unit* victim = me->GetVictim())
+                        if (Unit* victim = me->GetAutoAttackVictim())
                             DoCast(victim, SPELL_SHOT);
                         _events.ScheduleEvent(EVENT_SHOOT, 8s, 10s);
                         break;
                     case EVENT_MULTI_SHOT:
-                        if (Unit* victim = me->GetVictim())
+                        if (Unit* victim = me->GetAutoAttackVictim())
                             DoCast(victim, SPELL_MULTI_SHOT);
                         _events.ScheduleEvent(EVENT_MULTI_SHOT, 10s, 13s);
                         break;

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_archimonde.cpp
@@ -379,7 +379,7 @@ public:
                     if (Unit* temp = SelectTarget(SELECT_TARGET_RANDOM, 1))
                         SummonDoomfire(temp);
                     else
-                        SummonDoomfire(me->GetVictim());
+                        SummonDoomfire(me->GetAutoAttackVictim());
                     events.ScheduleEvent(EVENT_DOOMFIRE, 20s);
                     break;
                 case EVENT_DISTANCE_CHECK:

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjalAI.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjalAI.cpp
@@ -870,7 +870,7 @@ void hyjalAI::UpdateAI(uint32 diff)
                         break;
 
                     case TARGETTYPE_VICTIM:
-                        target = me->GetVictim();
+                        target = me->GetAutoAttackVictim();
                         break;
                 }
 

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.cpp
@@ -757,7 +757,7 @@ public:
         {
             Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 30, true);
             if (target)
-                summon->Attack(target, false);
+                summon->AutoAttackStart(target, false);
             summons.Summon(summon);
         }
 
@@ -1217,11 +1217,11 @@ public:
             if (!UpdateVictim())
                 return;
 
-            if (!me->IsWithinDist(me->GetVictim(), 25))
+            if (!me->IsWithinDist(me->GetAutoAttackVictim(), 25))
             {
                 if (MoveTimer <= diff)
                 {
-                    me->GetMotionMaster()->MoveChase(me->GetVictim());
+                    me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                     MoveTimer = 2000;
                 }
                 else
@@ -1230,7 +1230,7 @@ public:
 
             if (FrostBreathTimer <= diff)
             {
-                if (!me->IsWithinDist(me->GetVictim(), 25))
+                if (!me->IsWithinDist(me->GetAutoAttackVictim(), 25))
                 {
                     DoCastVictim(SPELL_FROST_BREATH);
                     me->StopMoving();
@@ -1348,18 +1348,18 @@ public:
             if (!UpdateVictim())
                 return;
 
-            if (!me->IsWithinDist(me->GetVictim(), 20) || forcemove)
+            if (!me->IsWithinDist(me->GetAutoAttackVictim(), 20) || forcemove)
             {
                 if (forcemove)
                 {
                     forcemove = false;
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
-                        me->Attack(target, false);
+                        me->AutoAttackStart(target, false);
                 }
                 if (MoveTimer <= diff)
                 {
                     float x, y, z;
-                    me->EnsureVictim()->GetPosition(x, y, z);
+                    me->GetAutoAttackVictim()->GetPosition(x, y, z);
                     me->GetMotionMaster()->MovePoint(0, x, y, z + Zpos);
                     Zpos -= 1.0f;
                     if (Zpos <= 0)
@@ -1372,7 +1372,7 @@ public:
 
             if (StrikeTimer <= diff)
             {
-                if (me->IsWithinDist(me->GetVictim(), 20))
+                if (me->IsWithinDist(me->GetAutoAttackVictim(), 20))
                 {
                     DoCastVictim(SPELL_GARGOYLE_STRIKE);
                     me->StopMoving();
@@ -1425,7 +1425,7 @@ public:
         void MoveInLineOfSight(Unit* who) override
 
         {
-            if (!who || me->GetVictim())
+            if (!who || me->GetAutoAttackVictim())
                 return;
 
             if (me->IsValidAttackTarget(who))
@@ -1447,14 +1447,14 @@ public:
                 return;
             if (ExplodeTimer <= diff)
             {
-                if (!me->IsWithinDistInMap(me->GetVictim(), 30))
+                if (!me->IsWithinDistInMap(me->GetAutoAttackVictim(), 30))
                 {
                     EnterEvadeMode();
                     return;
                 }
                 CastSpellExtraArgs args;
                 args.AddSpellMod(SPELLVALUE_BASE_POINT0, 500 + rand32() % 700);
-                me->CastSpell(me->GetVictim(), SPELL_EXPLODING_SHOT, args);
+                me->CastSpell(me->GetAutoAttackVictim(), SPELL_EXPLODING_SHOT, args);
                 ExplodeTimer = 5000 + rand32() % 5000;
             } else ExplodeTimer -= diff;
             DoMeleeAttackIfReady();

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_mal_ganis.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_mal_ganis.cpp
@@ -203,7 +203,7 @@ public:
                                 uiOutroTimer = 8000;
                                 break;
                             case 2:
-                                me->SetTarget(instance->GetGuidData(DATA_ARTHAS));
+                                me->SetPrimaryTarget(instance->GetGuidData(DATA_ARTHAS));
                                 me->HandleEmoteCommand(29);
                                 Talk(SAY_ESCAPE_SPEECH_2);
                                 ++uiOutroStep;

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -432,9 +432,9 @@ public:
                             if (Unit* disguised2 = me->SummonCreature(NPC_CITY_MAN, 2400.82f, 1201.69f, 134.01f, 1.534082f, TEMPSUMMON_DEAD_DESPAWN, 180000))
                             {
                                 infiniteDraconianGUID[2] = disguised2->GetGUID();
-                                disguised0->SetTarget(infiniteDraconianGUID[1]);
-                                disguised1->SetTarget(infiniteDraconianGUID[0]);
-                                disguised2->SetTarget(infiniteDraconianGUID[1]);
+                                disguised0->SetPrimaryTarget(infiniteDraconianGUID[1]);
+                                disguised1->SetPrimaryTarget(infiniteDraconianGUID[0]);
+                                disguised2->SetPrimaryTarget(infiniteDraconianGUID[1]);
                             }
                         }
                     }
@@ -539,8 +539,8 @@ public:
                                 utherGUID = uther->GetGUID();
                                 uther->SetWalk(false);
                                 uther->GetMotionMaster()->MovePoint(0, 1897.018f, 1287.487f, 143.481f);
-                                uther->SetTarget(me->GetGUID());
-                                me->SetTarget(utherGUID);
+                                uther->SetPrimaryTarget(me->GetGUID());
+                                me->SetPrimaryTarget(utherGUID);
                             }
                             JumpToNextStep(17000);
                             break;
@@ -565,7 +565,7 @@ public:
                         //After waypoint 1
                         case 5:
                             if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
-                                jaina->SetTarget(me->GetGUID());
+                                jaina->SetPrimaryTarget(me->GetGUID());
                             Talk(SAY_PHASE104);
                             JumpToNextStep(10000);
                             break;
@@ -630,7 +630,7 @@ public:
                         case 18:
                             if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
                             {
-                                me->SetTarget(jainaGUID);
+                                me->SetPrimaryTarget(jainaGUID);
                                 jaina->SetWalk(true);
                                 jaina->GetMotionMaster()->MovePoint(0, 1794.357f, 1272.183f, 140.558f);
                             }
@@ -648,13 +648,13 @@ public:
                         case 21:
                             SetEscortPaused(false);
                             bStepping = false;
-                            me->SetTarget(ObjectGuid::Empty);
+                            me->SetPrimaryTarget(ObjectGuid::Empty);
                             JumpToNextStep(0);
                             break;
                         //After waypoint 3
                         case 22:
                             Talk(SAY_PHASE118);
-                            me->SetTarget(jainaGUID);
+                            me->SetPrimaryTarget(jainaGUID);
                             JumpToNextStep(10000);
                             break;
                         case 23:
@@ -668,7 +668,7 @@ public:
                             if (Creature* uther = ObjectAccessor::GetCreature(*me, utherGUID))
                                 uther->DisappearAndDie();
 
-                            me->SetTarget(ObjectGuid::Empty);
+                            me->SetPrimaryTarget(ObjectGuid::Empty);
                             JumpToNextStep(0);
                             break;
                         //After Gossip 1 (waypoint 8)
@@ -676,7 +676,7 @@ public:
                             if (Unit* pStalker = me->SummonCreature(NPC_INVIS_TARGET, 2026.469f, 1287.088f, 143.596f, 1.37f, TEMPSUMMON_TIMED_DESPAWN, 14000))
                             {
                                 stalkerGUID = pStalker->GetGUID();
-                                me->SetTarget(stalkerGUID);
+                                me->SetPrimaryTarget(stalkerGUID);
                             }
 
                             instance->DoUpdateWorldState(WORLDSTATE_WAVE_COUNT, 0);
@@ -691,15 +691,15 @@ public:
                             SetEscortPaused(false);
                             bStepping = false;
                             SetRun(false);
-                            me->SetTarget(ObjectGuid::Empty);
+                            me->SetPrimaryTarget(ObjectGuid::Empty);
                             JumpToNextStep(0);
                             break;
                         //After waypoint 9
                         case 27:
-                            me->SetTarget(citymenGUID[0]);
+                            me->SetPrimaryTarget(citymenGUID[0]);
                             if (Creature* cityman = ObjectAccessor::GetCreature(*me, citymenGUID[0]))
                             {
-                                cityman->SetTarget(me->GetGUID());
+                                cityman->SetPrimaryTarget(me->GetGUID());
                                 cityman->SetWalk(true);
                                 cityman->GetMotionMaster()->MovePoint(0, 2088.625f, 1279.191f, 140.743f);
                             }
@@ -727,10 +727,10 @@ public:
                             if (Creature* cityman1 = ObjectAccessor::GetCreature(*me, citymenGUID[1]))
                             {
                                 cityman1->AI()->Talk(SAY_PHASE204);
-                                cityman1->SetTarget(me->GetGUID());
+                                cityman1->SetPrimaryTarget(me->GetGUID());
                                 if (Creature* cityman0 = ObjectAccessor::GetCreature(*me, citymenGUID[0]))
                                     cityman0->KillSelf();
-                                me->SetTarget(citymenGUID[1]);
+                                me->SetPrimaryTarget(citymenGUID[1]);
                             }
                             JumpToNextStep(0);
                             break;
@@ -748,7 +748,7 @@ public:
                             if (Unit* pStalker = me->SummonCreature(NPC_INVIS_TARGET, 2081.447f, 1287.770f, 141.3241f, 1.37f, TEMPSUMMON_TIMED_DESPAWN, 10000))
                             {
                                 stalkerGUID = pStalker->GetGUID();
-                                me->SetTarget(stalkerGUID);
+                                me->SetPrimaryTarget(stalkerGUID);
                             }
                             Talk(SAY_PHASE205);
                             JumpToNextStep(3000);
@@ -757,7 +757,7 @@ public:
                             if (Unit* pStalkerM = me->SummonCreature(NPC_INVIS_TARGET, 2117.349f, 1288.624f, 136.271f, 1.37f, TEMPSUMMON_TIMED_DESPAWN, 60000))
                             {
                                 stalkerGUID = pStalkerM->GetGUID();
-                                me->SetTarget(stalkerGUID);
+                                me->SetPrimaryTarget(stalkerGUID);
                             }
                             JumpToNextStep(1000);
                             break;
@@ -769,7 +769,7 @@ public:
 
                                 malganisGUID = malganis->GetGUID();
                                 malganis->AI()->Talk(SAY_PHASE206);
-                                malganis->SetTarget(me->GetGUID());
+                                malganis->SetPrimaryTarget(me->GetGUID());
                                 malganis->SetReactState(REACT_PASSIVE);
                             }
                             JumpToNextStep(11000);
@@ -804,7 +804,7 @@ public:
                             if (Unit* pStalker = me->SummonCreature(NPC_INVIS_TARGET, 2081.447f, 1287.770f, 141.3241f, 1.37f, TEMPSUMMON_TIMED_DESPAWN, 10000))
                             {
                                 stalkerGUID = pStalker->GetGUID();
-                                me->SetTarget(stalkerGUID);
+                                me->SetPrimaryTarget(stalkerGUID);
                             }
                             Talk(SAY_PHASE209);
 
@@ -909,11 +909,11 @@ public:
                         case 61:
                             me->SetReactState(REACT_AGGRESSIVE);
                             if (Creature* disguised0 = ObjectAccessor::GetCreature(*me, infiniteDraconianGUID[0]))
-                                disguised0->SetTarget(me->GetGUID());
+                                disguised0->SetPrimaryTarget(me->GetGUID());
                             if (Creature* disguised1 = ObjectAccessor::GetCreature(*me, infiniteDraconianGUID[1]))
-                                disguised1->SetTarget(me->GetGUID());
+                                disguised1->SetPrimaryTarget(me->GetGUID());
                             if (Creature* disguised2 = ObjectAccessor::GetCreature(*me, infiniteDraconianGUID[2]))
-                                disguised2->SetTarget(me->GetGUID());
+                                disguised2->SetPrimaryTarget(me->GetGUID());
                             JumpToNextStep(1000);
                             break;
                         case 62:
@@ -1028,7 +1028,7 @@ public:
                                 SpawnTimeRift(17, &epochGUID);
                                 if (Creature* epoch = ObjectAccessor::GetCreature(*me, epochGUID))
                                     epoch->AI()->Talk(SAY_PHASE314);
-                                me->SetTarget(epochGUID);
+                                me->SetPrimaryTarget(epochGUID);
                             }
                             JumpToNextStep(18000);
                             break;
@@ -1089,7 +1089,7 @@ public:
                         case 86:
                             Talk(SAY_PHASE502);
                             JumpToNextStep(6000);
-                            me->SetTarget(malganisGUID);
+                            me->SetPrimaryTarget(malganisGUID);
                             break;
                         case 87:
                             if (Creature* malganis = ObjectAccessor::GetCreature(*me, malganisGUID))
@@ -1113,13 +1113,13 @@ public:
                         //After waypoint 56
                         case 89:
                             SetRun(true);
-                            me->SetTarget(malganisGUID);
+                            me->SetPrimaryTarget(malganisGUID);
                             Talk(SAY_PHASE503);
                             JumpToNextStep(7000);
                             break;
                         case 90:
                             instance->SetBossState(DATA_ARTHAS, DONE); //Rewards: Achiev & Chest ;D
-                            me->SetTarget(instance->GetGuidData(DATA_MAL_GANIS_GATE_2)); //Look behind
+                            me->SetPrimaryTarget(instance->GetGuidData(DATA_MAL_GANIS_GATE_2)); //Look behind
                             Talk(SAY_PHASE504);
                             bStepping = false;
                             break;
@@ -1128,7 +1128,7 @@ public:
             }
 
             //Battling skills
-            if (!me->GetVictim())
+            if (!me->GetAutoAttackVictim())
                 return;
 
             if (exorcismTimer < diff)

--- a/src/server/scripts/Kalimdor/Maraudon/boss_noxxion.cpp
+++ b/src/server/scripts/Kalimdor/Maraudon/boss_noxxion.cpp
@@ -127,11 +127,11 @@ public:
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 // Invisible Model
                 me->SetDisplayId(11686);
-                SummonAdds(me->GetVictim());
-                SummonAdds(me->GetVictim());
-                SummonAdds(me->GetVictim());
-                SummonAdds(me->GetVictim());
-                SummonAdds(me->GetVictim());
+                SummonAdds(me->GetAutoAttackVictim());
+                SummonAdds(me->GetAutoAttackVictim());
+                SummonAdds(me->GetAutoAttackVictim());
+                SummonAdds(me->GetAutoAttackVictim());
+                SummonAdds(me->GetAutoAttackVictim());
                 Invisible = true;
                 InvisibleTimer = 15000;
 

--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -332,12 +332,12 @@ public:
                 {
                     if (HealthBelowPct(65))
                     {
-                        if (Unit* target = me->GetVictim())
+                        if (Unit* target = me->GetAutoAttackVictim())
                             tankGUID = target->GetGUID();
                         SetCombatMovement(false);
                         Phase = PHASE_BREATH;
                         me->SetReactState(REACT_PASSIVE);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->GetMotionMaster()->MovePoint(10, Phase2Location);
                         return;
                     }

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ayamiss.cpp
@@ -165,9 +165,9 @@ class boss_ayamiss : public CreatureScript
                     _phase = PHASE_GROUND;
                     SetCombatMovement(true);
                     me->SetCanFly(false);
-                    if (me->GetVictim())
+                    if (me->GetAutoAttackVictim())
                     {
-                        Position VictimPos = me->EnsureVictim()->GetPosition();
+                        Position VictimPos = me->GetAutoAttackVictim()->GetPosition();
                         me->GetMotionMaster()->MovePoint(POINT_GROUND, VictimPos);
                     }
                     ResetThreatList();

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_kurinnaxx.cpp
@@ -109,7 +109,7 @@ class boss_kurinnaxx : public CreatureScript
                         case EVENT_SANDTRAP:
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true))
                                 target->CastSpell(target, SPELL_SANDTRAP, true);
-                            else if (Unit* victim = me->GetVictim())
+                            else if (Unit* victim = me->GetAutoAttackVictim())
                                 victim->CastSpell(victim, SPELL_SANDTRAP, true);
                             events.ScheduleEvent(EVENT_SANDTRAP, 5s, 15s);
                             break;

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
@@ -149,8 +149,8 @@ class boss_moam : public CreatureScript
                             std::list<Unit*> targetList;
                             {
                                 for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                                    if (ref->GetAutoAttackVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetAutoAttackVictim()->GetPowerType() == POWER_MANA)
-                                        targetList.push_back(ref->GetAutoAttackVictim());
+                                    if (ref->GetVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetVictim()->GetPowerType() == POWER_MANA)
+                                        targetList.push_back(ref->GetVictim());
                             }
 
                             Trinity::Containers::RandomResize(targetList, 5);

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_moam.cpp
@@ -149,8 +149,8 @@ class boss_moam : public CreatureScript
                             std::list<Unit*> targetList;
                             {
                                 for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                                    if (ref->GetVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetVictim()->GetPowerType() == POWER_MANA)
-                                        targetList.push_back(ref->GetVictim());
+                                    if (ref->GetAutoAttackVictim()->GetTypeId() == TYPEID_PLAYER && ref->GetAutoAttackVictim()->GetPowerType() == POWER_MANA)
+                                        targetList.push_back(ref->GetAutoAttackVictim());
                             }
 
                             Trinity::Containers::RandomResize(targetList, 5);

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -225,7 +225,7 @@ class boss_ossirian : public CreatureScript
                 events.Update(diff);
 
                 // No kiting!
-                if (me->GetDistance(me->GetVictim()) > 60.00f && me->GetDistance(me->GetVictim()) < 120.00f)
+                if (me->GetDistance(me->GetAutoAttackVictim()) > 60.00f && me->GetDistance(me->GetAutoAttackVictim()) < 120.00f)
                     DoCastVictim(SPELL_SUMMON);
 
                 bool ApplySupreme = true;

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_bug_trio.cpp
@@ -218,8 +218,8 @@ public:
             if (KnockBack_Timer <= diff)
             {
                 DoCastVictim(SPELL_KNOCKBACK);
-                if (GetThreat(me->GetVictim()))
-                    ModifyThreatByPercent(me->GetVictim(), -80);
+                if (GetThreat(me->GetAutoAttackVictim()))
+                    ModifyThreatByPercent(me->GetAutoAttackVictim(), -80);
                 KnockBack_Timer = urand(15000, 25000);
             } else KnockBack_Timer -= diff;
 

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -651,7 +651,7 @@ public:
                         Stomach_Map.clear();
 
                         for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                            Stomach_Map[ref->GetAutoAttackVictim()->GetGUID()] = false;   //Outside stomach
+                            Stomach_Map[ref->GetVictim()->GetGUID()] = false;   //Outside stomach
 
                         //Spawn 2 flesh tentacles
                         FleshTentaclesKilled = 0;

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -276,7 +276,7 @@ public:
                             DoCast(target, SPELL_GREEN_BEAM);
 
                             //Correctly update our target
-                            me->SetTarget(target->GetGUID());
+                            me->SetPrimaryTarget(target->GetGUID());
                         }
 
                         //Beam every 3 seconds
@@ -311,7 +311,7 @@ public:
                         me->SetReactState(REACT_PASSIVE);
 
                         //Remove any target
-                        me->SetTarget(ObjectGuid::Empty);
+                        me->SetPrimaryTarget(ObjectGuid::Empty);
 
                         //Select random target for dark beam to start on
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
@@ -388,7 +388,7 @@ public:
                 //Transition phase
                 case PHASE_CTHUN_TRANSITION:
                     //Remove any target
-                    me->SetTarget(ObjectGuid::Empty);
+                    me->SetPrimaryTarget(ObjectGuid::Empty);
                     me->SetHealth(0);
                     me->SetVisible(false);
                     break;
@@ -424,7 +424,7 @@ public:
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);
 
                     //Remove Target field
-                    me->SetTarget(ObjectGuid::Empty);
+                    me->SetPrimaryTarget(ObjectGuid::Empty);
 
                     //Death animation/respawning;
                     instance->SetData(DATA_CTHUN_PHASE, PHASE_CTHUN_TRANSITION);
@@ -602,7 +602,7 @@ public:
                 return;
             }
 
-            me->SetTarget(ObjectGuid::Empty);
+            me->SetPrimaryTarget(ObjectGuid::Empty);
 
             uint32 currentPhase = instance->GetData(DATA_CTHUN_PHASE);
             if (currentPhase == PHASE_CTHUN_STOMACH || currentPhase == PHASE_CTHUN_WEAK)
@@ -651,7 +651,7 @@ public:
                         Stomach_Map.clear();
 
                         for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                            Stomach_Map[ref->GetVictim()->GetGUID()] = false;   //Outside stomach
+                            Stomach_Map[ref->GetAutoAttackVictim()->GetGUID()] = false;   //Outside stomach
 
                         //Spawn 2 flesh tentacles
                         FleshTentaclesKilled = 0;
@@ -672,7 +672,7 @@ public:
                 //Body Phase
                 case PHASE_CTHUN_STOMACH:
                     //Remove Target field
-                    me->SetTarget(ObjectGuid::Empty);
+                    me->SetPrimaryTarget(ObjectGuid::Empty);
 
                     //Weaken
                     if (FleshTentaclesKilled > 1)
@@ -1024,7 +1024,7 @@ public:
                 return;
 
             //EvadeTimer
-            if (!me->IsWithinMeleeRange(me->GetVictim()))
+            if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
             {
                 if (EvadeTimer <= diff)
                 {
@@ -1141,7 +1141,7 @@ public:
                 return;
 
             //EvadeTimer
-            if (!me->IsWithinMeleeRange(me->GetVictim()))
+            if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
             {
                 if (EvadeTimer <= diff)
                 {

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -191,7 +191,7 @@ class boss_skeram : public CreatureScript
                     events.RescheduleEvent(EVENT_BLINK, 2000);
                 }
 
-                if (me->IsWithinMeleeRange(me->GetVictim()))
+                if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                 {
                     events.RescheduleEvent(EVENT_EARTH_SHOCK, 2000);
                     DoMeleeAttackIfReady();

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_twinemperors.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_twinemperors.cpp
@@ -300,7 +300,7 @@ struct boss_twinemperorsAI : public ScriptedAI
     void MoveInLineOfSight(Unit* who) override
 
     {
-        if (!who || me->GetVictim())
+        if (!who || me->GetAutoAttackVictim())
             return;
 
         if (me->CanCreatureAttack(who))
@@ -548,8 +548,8 @@ public:
             //ShadowBolt_Timer
             if (ShadowBolt_Timer <= diff)
             {
-                if (!me->IsWithinDist(me->GetVictim(), 45.0f))
-                    me->GetMotionMaster()->MoveChase(me->GetVictim(), VEKLOR_DIST);
+                if (!me->IsWithinDist(me->GetAutoAttackVictim(), 45.0f))
+                    me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim(), VEKLOR_DIST);
                 else
                     DoCastVictim(SPELL_SHADOWBOLT);
                 ShadowBolt_Timer = 2000;
@@ -597,7 +597,7 @@ public:
             if (who->isTargetableForAttack())
             {
                 // VL doesn't melee
-                if (me->Attack(who, false))
+                if (me->AutoAttackStart(who, false))
                 {
                     me->GetMotionMaster()->MoveChase(who, VEKLOR_DIST);
                     AddThreat(who, 0.0f);

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_viscidus.cpp
@@ -284,8 +284,8 @@ class npc_glob_of_viscidus : public CreatureScript
                     if (Viscidus->IsAlive() && Viscidus->GetHealthPct() < 5.0f)
                     {
                         Viscidus->SetVisible(true);
-                        if (Viscidus->GetVictim())
-                            Unit::Kill(Viscidus->EnsureVictim(), Viscidus);
+                        if (Viscidus->GetAutoAttackVictim())
+                            Unit::Kill(Viscidus->GetAutoAttackVictim(), Viscidus);
                     }
                     else
                     {

--- a/src/server/scripts/Kalimdor/ZulFarrak/zulfarrak.cpp
+++ b/src/server/scripts/Kalimdor/ZulFarrak/zulfarrak.cpp
@@ -83,7 +83,7 @@ public:
         uint32 postGossipStep;
         uint32 Text_Timer;
         uint32 ShieldBash_Timer;
-        uint32 Revenge_Timer;                                   //this is wrong, spell should never be used unless me->GetVictim() dodge, parry or block attack. Trinity support required.
+        uint32 Revenge_Timer;                                   //this is wrong, spell should never be used unless me->GetAutoAttackVictim() dodge, parry or block attack. Trinity support required.
         ObjectGuid PlayerGUID;
 
         void Reset() override
@@ -311,7 +311,7 @@ public:
             else
                 Bomb_Timer -= diff;
 
-            if (me->isAttackReady() && !me->IsWithinMeleeRange(me->GetVictim()))
+            if (me->isAttackReady() && !me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
             {
                 DoCastVictim(SPELL_SHOOT);
                 me->SetSheath(SHEATH_STATE_RANGED);

--- a/src/server/scripts/Kalimdor/zone_ashenvale.cpp
+++ b/src/server/scripts/Kalimdor/zone_ashenvale.cpp
@@ -307,7 +307,7 @@ public:
             {
                 EscortAI::UpdateAI(diff);
 
-                if (!me->GetVictim())
+                if (!me->GetAutoAttackVictim())
                 {
                     if (HasEscortState(STATE_ESCORT_PAUSED) && _isBrazierExtinguished)
                     {

--- a/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
@@ -236,7 +236,7 @@ public:
         {
             CloseGossipMenuFor(player);
             me->SetFaction(FACTION_MONSTER);
-            me->Attack(player, true);
+            me->AutoAttackStart(player, true);
             return false;
         }
 

--- a/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
@@ -680,7 +680,7 @@ public:
                                     target = me;
 
                                 AddThreat(sironas, 0.001f, target);
-                                sironas->Attack(target, true);
+                                sironas->AutoAttackStart(target, true);
                                 sironas->GetMotionMaster()->MoveChase(target);
                             }
                             _moveTimer = 10 * IN_MILLISECONDS;

--- a/src/server/scripts/Kalimdor/zone_darkshore.cpp
+++ b/src/server/scripts/Kalimdor/zone_darkshore.cpp
@@ -87,7 +87,7 @@ public:
         {
             FollowerAI::MoveInLineOfSight(who);
 
-            if (!me->GetVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE) && who->GetEntry() == NPC_LILADRIS)
+            if (!me->GetAutoAttackVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE) && who->GetEntry() == NPC_LILADRIS)
             {
                 if (me->IsWithinDistInMap(who, INTERACTION_DISTANCE*5))
                 {
@@ -335,7 +335,7 @@ public:
         {
             FollowerAI::MoveInLineOfSight(who);
 
-            if (!me->GetVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE) && who->GetEntry() == NPC_GELKAK)
+            if (!me->GetAutoAttackVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE) && who->GetEntry() == NPC_GELKAK)
             {
                 if (me->IsWithinDistInMap(who, 10.0f))
                 {

--- a/src/server/scripts/Kalimdor/zone_moonglade.cpp
+++ b/src/server/scripts/Kalimdor/zone_moonglade.cpp
@@ -184,9 +184,9 @@ public:
         void EnterEvadeMode(EvadeReason why) override
         {
             Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID);
-            if (player && player->IsInCombat() && player->getAttackerForHelper())
+            if (player && player->IsInCombat() && player->GetAttackerForHelper())
             {
-                AttackStart(player->getAttackerForHelper());
+                AttackStart(player->GetAttackerForHelper());
                 return;
             }
             EscortAI::EnterEvadeMode(why);
@@ -223,8 +223,8 @@ public:
                 if (checkPlayerTimer <= diff)
                 {
                     Player* player = ObjectAccessor::GetPlayer(*me, PlayerGUID);
-                    if (player && player->IsInCombat() && player->getAttackerForHelper())
-                        AttackStart(player->getAttackerForHelper());
+                    if (player && player->IsInCombat() && player->GetAttackerForHelper())
+                        AttackStart(player->GetAttackerForHelper());
                     checkPlayerTimer = 1000;
                 } else checkPlayerTimer -= diff;
             }

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -386,11 +386,11 @@ public:
                         Talk(ANACHRONOS_SAY_1, Fandral);
                         break;
                     case 1:
-                        Fandral->SetTarget(me->GetGUID());
+                        Fandral->SetPrimaryTarget(me->GetGUID());
                         Fandral->AI()->Talk(FANDRAL_SAY_1, me);
                         break;
                     case 2:
-                        Fandral->SetTarget(ObjectGuid::Empty);
+                        Fandral->SetPrimaryTarget(ObjectGuid::Empty);
                         Merithra->AI()->Talk(MERITHRA_EMOTE_1);
                         break;
                     case 3:
@@ -400,14 +400,14 @@ public:
                         Arygos->AI()->Talk(ARYGOS_EMOTE_1);
                         break;
                     case 5:
-                        Caelestrasz->SetTarget(Fandral->GetGUID());
+                        Caelestrasz->SetPrimaryTarget(Fandral->GetGUID());
                         Caelestrasz->AI()->Talk(CAELESTRASZ_SAY_1);
                         break;
                     case 6:
                         Merithra->AI()->Talk(MERITHRA_SAY_2);
                         break;
                     case 7:
-                        Caelestrasz->SetTarget(ObjectGuid::Empty);
+                        Caelestrasz->SetPrimaryTarget(ObjectGuid::Empty);
                         Merithra->GetMotionMaster()->MoveCharge(-8065, 1530, 2.61f, 10);
                         break;
                     case 8:
@@ -737,8 +737,8 @@ public:
             {
                 if (SpellTimer4 <= diff)
                 {
-                    me->RemoveAllAttackers();
-                    me->AttackStop();
+                    me->StopAutoAttackingMe();
+                    me->AutoAttackStop();
                     DoCast(me, SPELL_STONED_CHANNEL_CAST_VISUAL);
                     SpellTimer4 = SpawnCast[0].Timer2;
                 } else SpellTimer4 -= diff;

--- a/src/server/scripts/Kalimdor/zone_tanaris.cpp
+++ b/src/server/scripts/Kalimdor/zone_tanaris.cpp
@@ -322,7 +322,7 @@ public:
         {
             FollowerAI::MoveInLineOfSight(who);
 
-            if (!me->GetVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE | STATE_FOLLOW_POSTEVENT) && who->GetEntry() == NPC_TORTA)
+            if (!me->GetAutoAttackVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE | STATE_FOLLOW_POSTEVENT) && who->GetEntry() == NPC_TORTA)
             {
                 if (me->IsWithinDistInMap(who, INTERACTION_DISTANCE))
                 {

--- a/src/server/scripts/Kalimdor/zone_ungoro_crater.cpp
+++ b/src/server/scripts/Kalimdor/zone_ungoro_crater.cpp
@@ -211,7 +211,7 @@ public:
         {
             FollowerAI::MoveInLineOfSight(who);
 
-            if (!me->GetVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE) && who->GetEntry() == NPC_SPRAGGLE)
+            if (!me->GetAutoAttackVictim() && !HasFollowState(STATE_FOLLOW_COMPLETE) && who->GetEntry() == NPC_SPRAGGLE)
             {
                 if (me->IsWithinDistInMap(who, INTERACTION_DISTANCE))
                 {

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_jedoga_shadowseeker.cpp
@@ -323,7 +323,7 @@ struct boss_jedoga_shadowseeker : public BossAI
                     break;
                 case EVENT_START_PHASE_TWO:
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->InterruptNonMeleeSpells(true);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                     me->GetMotionMaster()->MovePoint(POINT_PHASE_TWO, JedogaGroundPosition);

--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
@@ -181,7 +181,7 @@ class boss_prince_taldaram : public CreatureScript
                             break;
                         case EVENT_CONJURE_FLAME_SPHERES:
                             // random target?
-                            if (Unit* victim = me->GetVictim())
+                            if (Unit* victim = me->GetAutoAttackVictim())
                             {
                                 _flameSphereTargetGUID = victim->GetGUID();
                                 DoCast(victim, SPELL_CONJURE_FLAME_SPHERE);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -512,7 +512,7 @@ class npc_anubarak_anub_ar_assassin : public CreatureScript
 
                 if (diff >= _backstabTimer)
                 {
-                    if (me->GetVictim() && me->GetVictim()->isInBack(me))
+                    if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->isInBack(me))
                         DoCastVictim(SPELL_BACKSTAB);
                     _backstabTimer = 6 * IN_MILLISECONDS;
                 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -178,7 +178,7 @@ public:
             me->SetReactState(REACT_PASSIVE);
             me->SetHomePosition(hadronoxStep[step]);
             me->GetMotionMaster()->Clear();
-            me->AttackStop();
+            me->AutoAttackStop();
             me->GetMotionMaster()->MovePoint(0, hadronoxStep[step]);
         }
 
@@ -340,7 +340,7 @@ public:
                                 {
                                     me->GetMotionMaster()->Clear();
                                     SetCombatMovement(true);
-                                    AttackStart(me->GetVictim());
+                                    AttackStart(me->GetAutoAttackVictim());
                                 }
                             }
                             else // we are no longer in combat with players - reset the encounter

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
@@ -737,7 +737,7 @@ class npc_anub_ar_skirmisher : public CreatureScript
                             _events.Repeat(randtime(Seconds(20), Seconds(25)));
                             break;
                         case EVENT_BACKSTAB:
-                            if (me->GetVictim() && me->GetVictim()->isInBack(me))
+                            if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->isInBack(me))
                                 DoCastVictim(SPELL_BACKSTAB);
                             _events.Repeat(randtime(Seconds(10), Seconds(13)));
                             break;
@@ -840,7 +840,7 @@ class npc_skittering_swarmer : public CreatureScript
                 ScriptedAI::InitializeAI();
                 if (Creature* gatewatcher = me->GetInstanceScript()->GetCreature(DATA_KRIKTHIR))
                 {
-                    if (Unit* target = gatewatcher->getAttackerForHelper())
+                    if (Unit* target = gatewatcher->GetAttackerForHelper())
                         AttackStart(target);
                     gatewatcher->AI()->JustSummoned(me);
                 }
@@ -867,7 +867,7 @@ class npc_skittering_infector : public CreatureScript
                 ScriptedAI::InitializeAI();
                 if (Creature* gatewatcher = me->GetInstanceScript()->GetCreature(DATA_KRIKTHIR))
                 {
-                    if (Unit* target = gatewatcher->getAttackerForHelper())
+                    if (Unit* target = gatewatcher->GetAttackerForHelper())
                         AttackStart(target);
                     gatewatcher->AI()->JustSummoned(me);
                 }

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -290,7 +290,7 @@ public:
 
             if (Creature* fetchTene = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_TENEBRON)))
             {
-                if (fetchTene->IsAlive() && !fetchTene->GetVictim())
+                if (fetchTene->IsAlive() && !fetchTene->GetAutoAttackVictim())
                 {
                     _canUseWill = true;
                     if (!fetchTene->IsInCombat())
@@ -308,7 +308,7 @@ public:
 
             if (Creature* fetchShad = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_SHADRON)))
             {
-                if (fetchShad->IsAlive() && !fetchShad->GetVictim())
+                if (fetchShad->IsAlive() && !fetchShad->GetAutoAttackVictim())
                 {
                     _canUseWill = true;
                     if (!fetchShad->IsInCombat())
@@ -326,7 +326,7 @@ public:
 
             if (Creature* fetchVesp = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_VESPERON)))
             {
-                if (fetchVesp->IsAlive() && !fetchVesp->GetVictim())
+                if (fetchVesp->IsAlive() && !fetchVesp->GetAutoAttackVictim())
                 {
                     _canUseWill = true;
                     if (!fetchVesp->IsInCombat())
@@ -350,7 +350,7 @@ public:
         {
             if (Creature* temp = ObjectAccessor::GetCreature(*me, instance->GetGuidData(dataId)))
             {
-                if (temp->IsAlive() && !temp->GetVictim())
+                if (temp->IsAlive() && !temp->GetAutoAttackVictim())
                 {
                     temp->SetWalk(false);
 

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/obsidian_sanctum.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/obsidian_sanctum.cpp
@@ -221,7 +221,7 @@ struct dummy_dragonAI : public ScriptedAI
             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0, true))
             {
                 AddThreat(target, 1.0f);
-                me->Attack(target, true);
+                me->AutoAttackStart(target, true);
                 me->GetMotionMaster()->MoveChase(target);
             }
 
@@ -661,7 +661,7 @@ class npc_acolyte_of_shadron : public CreatureScript
 
                 for (Map::PlayerList::const_iterator i = PlayerList.begin(); i != PlayerList.end(); ++i)
                 {
-                    if (i->GetSource()->IsAlive() && i->GetSource()->HasAura(SPELL_TWILIGHT_SHIFT) && !i->GetSource()->GetVictim())
+                    if (i->GetSource()->IsAlive() && i->GetSource()->HasAura(SPELL_TWILIGHT_SHIFT) && !i->GetSource()->GetAutoAttackVictim())
                     {
                         i->GetSource()->CastSpell(i->GetSource(), SPELL_TWILIGHT_SHIFT_REMOVAL_ALL, true);
                         i->GetSource()->CastSpell(i->GetSource(), SPELL_TWILIGHT_RESIDUE, true);
@@ -745,14 +745,14 @@ class npc_acolyte_of_vesperon : public CreatureScript
 
                 for (Map::PlayerList::const_iterator i = PlayerList.begin(); i != PlayerList.end(); ++i)
                 {
-                    if (i->GetSource()->IsAlive() && i->GetSource()->HasAura(SPELL_TWILIGHT_SHIFT) && !i->GetSource()->GetVictim())
+                    if (i->GetSource()->IsAlive() && i->GetSource()->HasAura(SPELL_TWILIGHT_SHIFT) && !i->GetSource()->GetAutoAttackVictim())
                     {
                         i->GetSource()->CastSpell(i->GetSource(), SPELL_TWILIGHT_SHIFT_REMOVAL_ALL, true);
                         i->GetSource()->CastSpell(i->GetSource(), SPELL_TWILIGHT_RESIDUE, true);
                         i->GetSource()->RemoveAurasDueToSpell(SPELL_TWILIGHT_SHIFT);
                         i->GetSource()->RemoveAurasDueToSpell(SPELL_TWILIGHT_SHIFT_ENTER);
                     }
-                    if (i->GetSource()->IsAlive() && i->GetSource()->HasAura(SPELL_TWILIGHT_TORMENT_VESP) && !i->GetSource()->GetVictim())
+                    if (i->GetSource()->IsAlive() && i->GetSource()->HasAura(SPELL_TWILIGHT_TORMENT_VESP) && !i->GetSource()->GetAutoAttackVictim())
                         i->GetSource()->RemoveAurasDueToSpell(SPELL_TWILIGHT_TORMENT_VESP);
                 }
 

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
@@ -164,7 +164,7 @@ class boss_saviana_ragefire : public CreatureScript
                             me->SetDisableGravity(true);
                             me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->SetReactState(REACT_PASSIVE);
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             Position pos;
                             pos.Relocate(me);
                             pos.m_positionZ += 10.0f;

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_black_knight.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_black_knight.cpp
@@ -142,7 +142,7 @@ public:
         void JustSummoned(Creature* summon) override
         {
             summons.Summon(summon);
-            summon->AI()->AttackStart(me->GetVictim());
+            summon->AI()->AttackStart(me->GetAutoAttackVictim());
         }
 
         void SummonedCreatureDespawn(Creature* summon) override

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
@@ -540,7 +540,7 @@ public:
 
             if (uiFireBallTimer <= uiDiff)
             {
-                if (me->GetVictim())
+                if (me->GetAutoAttackVictim())
                     DoCastVictim(SPELL_FIREBALL);
                 uiFireBallTimer = 5000;
             } else uiFireBallTimer -= uiDiff;

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
@@ -610,7 +610,7 @@ struct boss_faction_championsAI : public BossAI
     void UpdateThreat()
     {
         for (ThreatReference* ref : me->GetThreatManager().GetModifiableThreatList())
-            if (Player* victim = ref->GetVictim()->ToPlayer())
+            if (Player* victim = ref->GetAutoAttackVictim()->ToPlayer())
             {
                 ref->ScaleThreat(0.0f);
                 ref->AddThreat(1000000.0f * CalculateThreat(me->GetDistance2d(victim), victim->GetArmor(), victim->GetHealth()));
@@ -687,7 +687,7 @@ struct boss_faction_championsAI : public BossAI
     {
         uint32 count = 0;
         for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-            if (me->GetDistance2d(ref->GetVictim()) < distance)
+            if (me->GetDistance2d(ref->GetAutoAttackVictim()) < distance)
                 ++count;
         return count;
     }
@@ -697,7 +697,7 @@ struct boss_faction_championsAI : public BossAI
         if (!who)
             return;
 
-        if (me->Attack(who, true))
+        if (me->AutoAttackStart(who, true))
         {
             AddThreat(who, 10.0f);
 
@@ -1484,7 +1484,7 @@ class npc_toc_hunter : public CreatureScript
                             events.ScheduleEvent(EVENT_STEADY_SHOT, 5s, 15s);
                             return;
                         case EVENT_WING_CLIP:
-                            if (Unit* target = me->GetVictim())
+                            if (Unit* target = me->GetAutoAttackVictim())
                             {
                                 if (me->GetDistance2d(target) < 6.0f)
                                     DoCast(target, SPELL_WING_CLIP);
@@ -1673,7 +1673,7 @@ class npc_toc_warrior : public CreatureScript
                             events.ScheduleEvent(EVENT_SUNDER_ARMOR, 2s, 5s);
                             return;
                         case EVENT_SHATTERING_THROW:
-                            if (Unit* target = me->GetVictim())
+                            if (Unit* target = me->GetAutoAttackVictim())
                             {
                                 if (target->HasAuraWithMechanic(1 << MECHANIC_IMMUNE_SHIELD))
                                 {
@@ -1752,7 +1752,7 @@ class npc_toc_dk : public CreatureScript
                             events.ScheduleEvent(EVENT_DEATH_COIL, 5s, 15s);
                             return;
                         case EVENT_DEATH_GRIP:
-                            if (Unit* target = me->GetVictim())
+                            if (Unit* target = me->GetAutoAttackVictim())
                             {
                                 if (me->IsInRange(target, 5.0f, 30.0f, false))
                                 {
@@ -1871,7 +1871,7 @@ class npc_toc_rogue : public CreatureScript
                                 events.RescheduleEvent(EVENT_BLADE_FLURRY, 5*IN_MILLISECONDS);
                             return;
                         case EVENT_SHADOWSTEP:
-                            if (Unit* target = me->GetVictim())
+                            if (Unit* target = me->GetAutoAttackVictim())
                             {
                                 if (me->IsInRange(target, 10.0f, 40.0f, false))
                                 {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
@@ -610,7 +610,7 @@ struct boss_faction_championsAI : public BossAI
     void UpdateThreat()
     {
         for (ThreatReference* ref : me->GetThreatManager().GetModifiableThreatList())
-            if (Player* victim = ref->GetAutoAttackVictim()->ToPlayer())
+            if (Player* victim = ref->GetVictim()->ToPlayer())
             {
                 ref->ScaleThreat(0.0f);
                 ref->AddThreat(1000000.0f * CalculateThreat(me->GetDistance2d(victim), victim->GetArmor(), victim->GetHealth()));
@@ -687,7 +687,7 @@ struct boss_faction_championsAI : public BossAI
     {
         uint32 count = 0;
         for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-            if (me->GetDistance2d(ref->GetAutoAttackVictim()) < distance)
+            if (me->GetDistance2d(ref->GetVictim()) < distance)
                 ++count;
         return count;
     }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_northrend_beasts.cpp
@@ -465,7 +465,7 @@ struct npc_snobold_vassal : public ScriptedAI
         Unit* gormok = _instance->GetCreature(DATA_GORMOK_THE_IMPALER);
         if (gormok && gormok->IsAlive())
         {
-            me->AttackStop();
+            me->AutoAttackStop();
             _targetGUID.Clear();
             _mountedOnPlayer = false;
             _events.CancelEvent(EVENT_BATTER);
@@ -485,7 +485,7 @@ struct npc_snobold_vassal : public ScriptedAI
         {
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
             _events.CancelEvent(EVENT_CHECK_MOUNT);
-            me->AttackStop();
+            me->AutoAttackStop();
             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0.0f, true))
                 AttackStart(target);
             SetCombatMovement(true);
@@ -710,7 +710,7 @@ struct boss_jormungarAI : public boss_northrend_beastsAI
     void Submerge()
     {
         me->SetReactState(REACT_PASSIVE);
-        me->AttackStop();
+        me->AutoAttackStop();
 
         if (wasMobile)
         {
@@ -760,7 +760,7 @@ struct boss_jormungarAI : public boss_northrend_beastsAI
         }
         else
         {
-            if (Unit* target = me->GetVictim())
+            if (Unit* target = me->GetAutoAttackVictim())
                 me->GetMotionMaster()->MoveChase(target);
             me->SetDisplayId(modelMobile);
             events.SetPhase(PHASE_MOBILE);
@@ -989,7 +989,7 @@ struct boss_icehowl : public boss_northrend_beastsAI
                 break;
             case EVENT_MASSIVE_CRASH:
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 events.SetPhase(PHASE_CHARGE);
                 me->GetMotionMaster()->MoveJump(ToCCommonLoc[1], 20.0f, 20.0f, POINT_MIDDLE);
                 break;
@@ -997,7 +997,7 @@ struct boss_icehowl : public boss_northrend_beastsAI
                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 0.0f, true))
                 {
                     DoCast(target, SPELL_FURIOUS_CHARGE_SUMMON, true);
-                    me->SetTarget(target->GetGUID());
+                    me->SetPrimaryTarget(target->GetGUID());
                     Talk(EMOTE_TRAMPLE_ROAR, target);
                     events.ScheduleEvent(EVENT_ICEHOWL_ROAR, 1s);
                 }
@@ -1015,7 +1015,7 @@ struct boss_icehowl : public boss_northrend_beastsAI
             case EVENT_TRAMPLE:
                 if (Creature* stalker = instance->GetCreature(DATA_FURIOUS_CHARGE))
                     me->GetMotionMaster()->MoveCharge(stalker->GetPositionX(), stalker->GetPositionY(), stalker->GetPositionZ(), 42.0f, POINT_ICEHOWL_CHARGE);
-                me->SetTarget(ObjectGuid::Empty);
+                me->SetPrimaryTarget(ObjectGuid::Empty);
                 break;
             case EVENT_FEROCIOUS_BUTT:
                 DoCastVictim(SPELL_FEROCIOUS_BUTT);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/trial_of_the_crusader.cpp
@@ -715,7 +715,7 @@ struct npc_fizzlebang_toc : public ScriptedAI
                     break;
                 case EVENT_SET_TARGET:
                     if (Creature* jaraxxus = _instance->GetCreature(DATA_JARAXXUS))
-                        me->SetTarget(jaraxxus->GetGUID());
+                        me->SetPrimaryTarget(jaraxxus->GetGUID());
                     _events.ScheduleEvent(EVENT_EMOTE_SHEATHE, 6s);
                     break;
                 case EVENT_EMOTE_SHEATHE:

--- a/src/server/scripts/Northrend/DraktharonKeep/boss_novos.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_novos.cpp
@@ -121,7 +121,7 @@ public:
             if (!target)
                 return;
 
-            if (me->Attack(target, true))
+            if (me->AutoAttackStart(target, true))
                 DoStartNoMovement(target);
         }
 

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
@@ -179,7 +179,7 @@ class boss_bronjahm : public CreatureScript
                             }
                             else
                             {
-                                if (!me->IsWithinMeleeRange(me->GetVictim()))
+                                if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                                     DoCastVictim(SPELL_SHADOW_BOLT);
                                 events.ScheduleEvent(EVENT_SHADOW_BOLT, 2s);
                             }

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
@@ -298,7 +298,7 @@ class boss_devourer_of_souls : public CreatureScript
                             me->SetReactState(REACT_PASSIVE);
 
                             //Remove any target
-                            me->SetTarget(ObjectGuid::Empty);
+                            me->SetPrimaryTarget(ObjectGuid::Empty);
 
                             me->GetMotionMaster()->Clear();
                             me->SetControlled(true, UNIT_STATE_ROOT);
@@ -322,7 +322,7 @@ class boss_devourer_of_souls : public CreatureScript
                                 me->SetReactState(REACT_AGGRESSIVE);
                                 me->SetDisplayId(DISPLAY_ANGER);
                                 me->SetControlled(false, UNIT_STATE_ROOT);
-                                me->GetMotionMaster()->MoveChase(me->GetVictim());
+                                me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                                 events.ScheduleEvent(EVENT_WAILING_SOULS, 60s, 70s);
                             }
                             break;

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -986,7 +986,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
             void DeleteAllFromThreatList(Unit* target, ObjectGuid except)
             {
                 for (ThreatReference* ref : target->GetThreatManager().GetModifiableThreatList())
-                  if (ref->GetVictim()->GetGUID() != except)
+                  if (ref->GetAutoAttackVictim()->GetGUID() != except)
                     ref->ClearThreat();
             }
 
@@ -1026,7 +1026,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                             }
                             break;
                         case EVENT_ESCAPE_2:
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             me->StopMoving();
                             me->SetReactState(REACT_PASSIVE);
 
@@ -1058,7 +1058,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                             if (Creature* lichking = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING_ESCAPE)))
                             {
                                 lichking->SetImmuneToPC(true);
-                                lichking->RemoveAllAttackers();
+                                lichking->StopAutoAttackingMe();
 
                                 DeleteAllFromThreatList(lichking, me->GetGUID());
                             }
@@ -1363,9 +1363,9 @@ class npc_the_lich_king_escape_hor : public CreatureScript
                 if (!me->HasReactState(REACT_PASSIVE))
                 {
                     if (Unit* victim = me->SelectVictim())
-                        if (!me->IsFocusing(nullptr, true) && victim != me->GetVictim())
+                        if (!me->HasSpellFocusTarget() && victim != me->GetAutoAttackVictim())
                             AttackStart(victim);
-                    return me->GetVictim() != nullptr;
+                    return me->GetAutoAttackVictim() != nullptr;
                 }
                 else if (me->GetCombatManager().GetPvECombatRefs().size() < 2 && me->HasAura(SPELL_REMORSELESS_WINTER))
                 {
@@ -2237,7 +2237,7 @@ class npc_raging_ghoul : public CreatureScript
                 switch (_events.ExecuteEvent())
                 {
                     case EVENT_RAGING_GHOUL_JUMP:
-                        if (Unit* victim = me->GetVictim())
+                        if (Unit* victim = me->GetAutoAttackVictim())
                         {
                             if (me->IsInRange(victim, 5.0f, 30.0f))
                             {

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -986,7 +986,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
             void DeleteAllFromThreatList(Unit* target, ObjectGuid except)
             {
                 for (ThreatReference* ref : target->GetThreatManager().GetModifiableThreatList())
-                  if (ref->GetAutoAttackVictim()->GetGUID() != except)
+                  if (ref->GetVictim()->GetGUID() != except)
                     ref->ClearThreat();
             }
 

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
@@ -220,7 +220,7 @@ class boss_garfrost : public CreatureScript
                             events.ScheduleEvent(EVENT_DEEP_FREEZE, 35s, 0, PHASE_THREE);
                             break;
                         case EVENT_FORGE_JUMP:
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             if (events.IsInPhase(PHASE_TWO))
                                 me->GetMotionMaster()->MoveJump(northForgePos, 25.0f, 15.0f, POINT_FORGE);
                             else if (events.IsInPhase(PHASE_THREE))
@@ -231,7 +231,7 @@ class boss_garfrost : public CreatureScript
                                 events.ScheduleEvent(EVENT_CHILLING_WAVE, 5s, 0, PHASE_TWO);
                             else if (events.IsInPhase(PHASE_THREE))
                                 events.ScheduleEvent(EVENT_DEEP_FREEZE, 10s, 0, PHASE_THREE);
-                            AttackStart(me->GetVictim());
+                            AttackStart(me->GetAutoAttackVictim());
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -198,7 +198,7 @@ class boss_ick : public CreatureScript
             {
                 if (actionId == ACTION_STORE_OLD_TARGET)
                 {
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         _oldTargetGUID = victim->GetGUID();
                         _tempThreat = GetThreat(victim);
@@ -208,7 +208,7 @@ class boss_ick : public CreatureScript
                 {
                     if (Unit* oldTarget = ObjectAccessor::GetUnit(*me, _oldTargetGUID))
                     {
-                        if (Unit* current = me->GetVictim())
+                        if (Unit* current = me->GetAutoAttackVictim())
                             ModifyThreatByPercent(current, -100);
 
                         AddThreat(oldTarget, _tempThreat);
@@ -581,7 +581,7 @@ class spell_ick_explosive_barrage : public SpellScriptLoader
                     if (caster->GetTypeId() == TYPEID_UNIT)
                     {
                         caster->GetMotionMaster()->Clear();
-                        caster->GetMotionMaster()->MoveChase(caster->GetVictim());
+                        caster->GetMotionMaster()->MoveChase(caster->GetAutoAttackVictim());
                     }
             }
 

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
@@ -171,7 +171,7 @@ class boss_tyrannus : public CreatureScript
                 if (me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE))
                     return;
 
-                if (victim && me->Attack(victim, true) && !events.IsInPhase(PHASE_INTRO))
+                if (victim && me->AutoAttackStart(victim, true) && !events.IsInPhase(PHASE_INTRO))
                     me->GetMotionMaster()->MoveChase(victim);
             }
 
@@ -403,7 +403,7 @@ class player_overlord_brandAI : public PlayerAI
         void DamageDealt(Unit* /*victim*/, uint32& damage, DamageEffectType /*damageType*/) override
         {
             if (Creature* tyrannus = ObjectAccessor::GetCreature(*me, _tyrannusGUID))
-                if (Unit* victim = tyrannus->GetVictim())
+                if (Unit* victim = tyrannus->GetAutoAttackVictim())
                 {
                     CastSpellExtraArgs args(tyrannus->GetGUID());
                     args.AddSpellBP0(damage);

--- a/src/server/scripts/Northrend/Gundrak/boss_slad_ran.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_slad_ran.cpp
@@ -235,7 +235,7 @@ public:
 
             if (uiGripOfSladRanTimer <= diff)
             {
-                Unit* target = me->GetVictim();
+                Unit* target = me->GetAutoAttackVictim();
 
                 DoCast(target, SPELL_GRIP_OF_SLAD_RAN);
                 uiGripOfSladRanTimer = urand(3, 6)*IN_MILLISECONDS;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_prince_council.cpp
@@ -1006,7 +1006,7 @@ class npc_ball_of_flame : public CreatureScript
                     {
                         // need to clear states now because this call is before AuraEffect is fully removed
                         me->ClearUnitState(UNIT_STATE_CASTING | UNIT_STATE_STUNNED);
-                        if (me->Attack(target, true))
+                        if (me->AutoAttackStart(target, true))
                             me->GetMotionMaster()->MoveChase(target, 1.0f);
                     }
             }
@@ -1128,12 +1128,12 @@ class npc_dark_nucleus : public CreatureScript
             {
                 _scheduler.Schedule(Seconds(1), [this](TaskContext targetAuraCheck)
                 {
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         if (me->GetDistance(victim) < 15.0f && !victim->HasAura(SPELL_SHADOW_RESONANCE_RESIST, me->GetGUID()))
                             DoCast(victim, SPELL_SHADOW_RESONANCE_RESIST);
                         else
-                            MoveInLineOfSight(me->GetVictim());
+                            MoveInLineOfSight(me->GetAutoAttackVictim());
                     }
                     targetAuraCheck.Repeat();
                 });

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -382,7 +382,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                         case EVENT_BLOOD_MIRROR:
                         {
                             // victim can be nullptr when this is processed in the same update tick as EVENT_AIR_PHASE
-                            if (me->GetVictim())
+                            if (me->GetAutoAttackVictim())
                             {
                                 Player* newOfftank = SelectRandomTarget(true);
                                 if (newOfftank)
@@ -392,8 +392,8 @@ class boss_blood_queen_lana_thel : public CreatureScript
                                         _offtankGUID = newOfftank->GetGUID();
 
                                         // both spells have SPELL_ATTR5_SINGLE_TARGET_SPELL, no manual removal needed
-                                        newOfftank->CastSpell(me->GetVictim(), SPELL_BLOOD_MIRROR_DAMAGE, true);
-                                        me->EnsureVictim()->CastSpell(newOfftank, SPELL_BLOOD_MIRROR_DUMMY, true);
+                                        newOfftank->CastSpell(me->GetAutoAttackVictim(), SPELL_BLOOD_MIRROR_DAMAGE, true);
+                                        me->GetAutoAttackVictim()->CastSpell(newOfftank, SPELL_BLOOD_MIRROR_DUMMY, true);
                                         DoCastVictim(SPELL_BLOOD_MIRROR_VISUAL);
                                         if (Is25ManRaid() && newOfftank->GetQuestStatus(QUEST_BLOOD_INFUSION) == QUEST_STATUS_INCOMPLETE &&
                                             newOfftank->HasAura(SPELL_UNSATED_CRAVING) && !newOfftank->HasAura(SPELL_THIRST_QUENCHED) &&
@@ -494,7 +494,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 std::list<Player*> tempTargets;
                 Unit* maintank = me->GetThreatManager().GetCurrentVictim();
                 for (ThreatReference const* ref : me->GetThreatManager().GetSortedThreatList())
-                    if (Player* refTarget = ref->GetVictim()->ToPlayer())
+                    if (Player* refTarget = ref->GetAutoAttackVictim()->ToPlayer())
                         if (refTarget != maintank && (includeOfftank || (refTarget->GetGUID() != _offtankGUID)))
                             tempTargets.push_back(refTarget->ToPlayer());
 
@@ -509,7 +509,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
 
                 if (includeOfftank)
                 {
-                    tempTargets.sort(Trinity::ObjectDistanceOrderPred(me->GetVictim()));
+                    tempTargets.sort(Trinity::ObjectDistanceOrderPred(me->GetAutoAttackVictim()));
                     return tempTargets.front();
                 }
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -494,7 +494,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 std::list<Player*> tempTargets;
                 Unit* maintank = me->GetThreatManager().GetCurrentVictim();
                 for (ThreatReference const* ref : me->GetThreatManager().GetSortedThreatList())
-                    if (Player* refTarget = ref->GetAutoAttackVictim()->ToPlayer())
+                    if (Player* refTarget = ref->GetVictim()->ToPlayer())
                         if (refTarget != maintank && (includeOfftank || (refTarget->GetGUID() != _offtankGUID)))
                             tempTargets.push_back(refTarget->ToPlayer());
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -1336,7 +1336,7 @@ class spell_deathbringer_boiling_blood : public SpellScriptLoader
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
-                targets.remove(GetCaster()->GetVictim());
+                targets.remove(GetCaster()->GetAutoAttackVictim());
                 if (targets.empty())
                     return;
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -630,10 +630,10 @@ protected:
         if (!me->HasReactState(REACT_PASSIVE))
         {
             if (Unit* victim = me->SelectVictim())
-                if (!me->IsFocusing(nullptr, true) && victim != me->GetVictim())
+                if (!me->HasSpellFocusTarget() && victim != me->GetAutoAttackVictim())
                     AttackStart(victim);
 
-            return me->GetVictim() != nullptr;
+            return me->GetAutoAttackVictim() != nullptr;
         }
         else if (me->GetThreatManager().IsThreatListEmpty())
         {
@@ -1074,7 +1074,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                     }
                 }
 
-                if (me->IsWithinMeleeRange(me->GetVictim()))
+                if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     DoMeleeAttackIfReady();
                 else if (me->isAttackReady())
                 {
@@ -1342,7 +1342,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                     }
                 }
 
-                if (me->IsWithinMeleeRange(me->GetVictim()))
+                if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     DoMeleeAttackIfReady();
                 else if (me->isAttackReady())
                 {
@@ -1635,7 +1635,7 @@ class npc_gunship_gunner : public CreatureScript
 
             void AttackStart(Unit* target) override
             {
-                me->Attack(target, false);
+                me->AutoAttackStart(target, false);
             }
 
             void MovementInform(uint32 type, uint32 pointId) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -277,7 +277,7 @@ class boss_lady_deathwhisper : public CreatureScript
                 if (me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE))
                     return;
 
-                if (victim && me->Attack(victim, true) && _phase != PHASE_ONE)
+                if (victim && me->AutoAttackStart(victim, true) && _phase != PHASE_ONE)
                     me->GetMotionMaster()->MoveChase(victim);
             }
 
@@ -414,7 +414,7 @@ class boss_lady_deathwhisper : public CreatureScript
                     _phase = PHASE_TWO;
                     Talk(SAY_PHASE_2);
                     Talk(EMOTE_PHASE_2);
-                    DoStartMovement(me->GetVictim());
+                    DoStartMovement(me->GetAutoAttackVictim());
                     ResetThreatList();
                     damage -= me->GetPower(POWER_MANA);
                     me->SetPower(POWER_MANA, 0);
@@ -434,8 +434,8 @@ class boss_lady_deathwhisper : public CreatureScript
                         })
                         .Schedule(Seconds(6), Seconds(9), GROUP_TWO, [this](TaskContext touch)
                         {
-                            if (me->GetVictim())
-                                me->AddAura(SPELL_TOUCH_OF_INSIGNIFICANCE, me->EnsureVictim());
+                            if (me->GetAutoAttackVictim())
+                                me->AddAura(SPELL_TOUCH_OF_INSIGNIFICANCE, me->GetAutoAttackVictim());
                             touch.Repeat();
                         })
                         .Schedule(Seconds(12), GROUP_TWO, [this](TaskContext summonShade)
@@ -644,7 +644,7 @@ class npc_cult_fanatic : public CreatureScript
                     case SPELL_DARK_MARTYRDOM_T:
                         me->SetReactState(REACT_PASSIVE);
                         me->InterruptNonMeleeSpells(true);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         DoCastSelf(SPELL_DARK_MARTYRDOM_FANATIC);
                         break;
                     case SPELL_DARK_MARTYRDOM_FANATIC:
@@ -746,7 +746,7 @@ class npc_cult_adherent : public CreatureScript
                     case SPELL_DARK_MARTYRDOM_T:
                         me->SetReactState(REACT_PASSIVE);
                         me->InterruptNonMeleeSpells(true);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         DoCastSelf(SPELL_DARK_MARTYRDOM_ADHERENT);
                         break;
                     case SPELL_DARK_MARTYRDOM_ADHERENT:
@@ -935,7 +935,7 @@ class npc_darnavan : public CreatureScript
                 if (me->HasUnitState(UNIT_STATE_CASTING))
                     return;
 
-                if (_canShatter && me->GetVictim() && me->EnsureVictim()->IsImmunedToDamage(SPELL_SCHOOL_MASK_NORMAL))
+                if (_canShatter && me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->IsImmunedToDamage(SPELL_SCHOOL_MASK_NORMAL))
                 {
                     DoCastVictim(SPELL_SHATTERING_THROW);
                     _canShatter = false;
@@ -943,7 +943,7 @@ class npc_darnavan : public CreatureScript
                     return;
                 }
 
-                if (_canCharge && !me->IsWithinMeleeRange(me->GetVictim()))
+                if (_canCharge && !me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                 {
                     DoCastVictim(SPELL_CHARGE);
                     _canCharge = false;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -253,7 +253,7 @@ class boss_lord_marrowgar : public CreatureScript
                                 return false;
                             }))
                                 me->GetMotionMaster()->Remove(movement);
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                             me->SetSpeedRate(MOVE_RUN, _baseSpeed);
                             events.CancelEvent(EVENT_BONE_STORM_MOVE);
                             events.ScheduleEvent(EVENT_ENABLE_BONE_SLICE, 10s);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -505,7 +505,7 @@ class boss_professor_putricide : public CreatureScript
                                 std::list<Unit*> targetList;
                                 {
                                     for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                                        if (Player* target = ref->GetAutoAttackVictim()->ToPlayer())
+                                        if (Player* target = ref->GetVictim()->ToPlayer())
                                             targetList.push_back(target);
                                 }
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -488,7 +488,7 @@ class boss_professor_putricide : public CreatureScript
                     case ACTION_CHANGE_PHASE:
                         me->SetSpeedRate(MOVE_RUN, _baseSpeed*2.0f);
                         events.DelayEvents(30000);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         if (!IsHeroic())
                         {
                             DoCast(me, SPELL_TEAR_GAS);
@@ -505,7 +505,7 @@ class boss_professor_putricide : public CreatureScript
                                 std::list<Unit*> targetList;
                                 {
                                     for (ThreatReference const* ref : me->GetThreatManager().GetUnsortedThreatList())
-                                        if (Player* target = ref->GetVictim()->ToPlayer())
+                                        if (Player* target = ref->GetAutoAttackVictim()->ToPlayer())
                                             targetList.push_back(target);
                                 }
 
@@ -623,7 +623,7 @@ class boss_professor_putricide : public CreatureScript
                             break;
                         case EVENT_RESUME_ATTACK:
                             me->SetReactState(REACT_AGGRESSIVE);
-                            AttackStart(me->GetVictim());
+                            AttackStart(me->GetAutoAttackVictim());
                             // remove Tear Gas
                             me->RemoveAurasDueToSpell(SPELL_TEAR_GAS_PERIODIC_TRIGGER);
                             instance->DoRemoveAurasDueToSpellOnPlayers(71615);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -499,7 +499,7 @@ class boss_sindragosa : public CreatureScript
                             me->SetDisableGravity(true);
                             me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->SetReactState(REACT_PASSIVE);
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             Position pos;
                             pos.Relocate(me);
                             pos.m_positionZ += 17.0f;
@@ -915,7 +915,7 @@ class npc_rimefang : public CreatureScript
                         {
                             _icyBlastCounter = RAID_MODE<uint8>(5, 7, 6, 8);
                             me->SetReactState(REACT_PASSIVE);
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             me->SetCanFly(true);
                             me->GetMotionMaster()->MovePoint(POINT_FROSTWYRM_FLY_IN, RimefangFlyPos);
                             float moveTime = me->GetExactDist(&RimefangFlyPos)/(me->GetSpeed(MOVE_FLIGHT)*0.001f);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -687,7 +687,7 @@ class boss_the_lich_king : public CreatureScript
                 {
                     events.SetPhase(PHASE_TRANSITION);
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->InterruptNonMeleeSpells(true);
                     me->GetMotionMaster()->MovePoint(POINT_CENTER_1, CenterPosition);
                     return;
@@ -697,7 +697,7 @@ class boss_the_lich_king : public CreatureScript
                 {
                     events.SetPhase(PHASE_TRANSITION);
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->InterruptNonMeleeSpells(true);
                     me->GetMotionMaster()->MovePoint(POINT_CENTER_2, CenterPosition);
                     return;
@@ -706,7 +706,7 @@ class boss_the_lich_king : public CreatureScript
                 if (events.IsInPhase(PHASE_THREE) && !HealthAbovePct(10))
                 {
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     events.Reset();
                     events.SetPhase(PHASE_OUTRO);
                     summons.DespawnAll();
@@ -1041,7 +1041,7 @@ class boss_the_lich_king : public CreatureScript
                             events.ScheduleEvent(EVENT_HARVEST_SOULS, urand(100000, 110000), 0, PHASE_THREE);
                             events.SetPhase(PHASE_FROSTMOURNE); // will stop running UpdateVictim (no evading)
                             me->SetReactState(REACT_PASSIVE);
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             events.DelayEvents(50000, EVENT_GROUP_VILE_SPIRITS);
                             events.RescheduleEvent(EVENT_DEFILE, 50000, 0, PHASE_THREE);
                             events.RescheduleEvent(EVENT_SOUL_REAPER, urand(57000, 62000), 0, PHASE_THREE);
@@ -1413,7 +1413,7 @@ class npc_raging_spirit : public CreatureScript
                     _events.SetPhase(PHASE_FROSTMOURNE);
                     _events.ScheduleEvent(EVENT_SET_AGRESSIVE, 52s);
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->InterruptNonMeleeSpells(true);
                 }
             }
@@ -2408,7 +2408,7 @@ class spell_the_lich_king_ice_burst_target_search : public SpellScriptLoader
                 if (GetCaster()->GetTypeId() == TYPEID_UNIT)
                 {
                     GetCaster()->ToCreature()->SetReactState(REACT_PASSIVE);
-                    GetCaster()->AttackStop();
+                    GetCaster()->AutoAttackStop();
                     GetCaster()->ToCreature()->DespawnOrUnsummon(500);
                 }
             }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -825,7 +825,7 @@ class npc_blazing_skeleton : public CreatureScript
                     switch (eventId)
                     {
                         case EVENT_FIREBALL:
-                            if (!me->IsWithinMeleeRange(me->GetVictim()))
+                            if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                                 DoCastVictim(SPELL_FIREBALL);
                             _events.ScheduleEvent(EVENT_FIREBALL, 2s, 4s);
                             break;
@@ -918,7 +918,7 @@ class npc_suppresser : public CreatureScript
                 }
 
                 // this creature has REACT_PASSIVE so it does not always have victim here
-                if (Unit* victim = me->GetVictim())
+                if (Unit* victim = me->GetAutoAttackVictim())
                     if (victim->GetEntry() != NPC_VALITHRIA_DREAMWALKER)
                         DoMeleeAttackIfReady();
             }

--- a/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
@@ -229,7 +229,7 @@ struct boss_four_horsemen_baseAI : public BossAI
                         return;
                     }
                     cBoss->SetReactState(REACT_PASSIVE);
-                    cBoss->AttackStop(); // clear initial target that was set on enter combat
+                    cBoss->AutoAttackStop(); // clear initial target that was set on enter combat
                     cBoss->setActive(true);
                     cBoss->SetFarVisible(true);
 

--- a/src/server/scripts/Northrend/Naxxramas/boss_gluth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gluth.cpp
@@ -210,11 +210,11 @@ public:
                             me->SetSpeed(MOVE_RUN, 36.0f);
 
                             me->SetReactState(ReactStates::REACT_PASSIVE);
-                            me->AttackStop();
+                            me->AutoAttackStop();
 
                             Talk(EMOTE_SPOTS_ONE);
 
-                            //me->SetTarget(ObjectGuid::Empty);
+                            //me->SetPrimaryTarget(ObjectGuid::Empty);
 
                             me->GetMotionMaster()->MoveCloserAndStop(1, zombie, 2.0f);
 
@@ -440,8 +440,8 @@ public:
                 if (value == STATE_ZOMBIE_DECIMATED)
                 {
                     me->SetReactState(ReactStates::REACT_PASSIVE);
-                    me->AttackStop();
-                    me->SetTarget(ObjectGuid::Empty);
+                    me->AutoAttackStop();
+                    me->SetPrimaryTarget(ObjectGuid::Empty);
                     // at this point, the zombie should be non attacking and non moving.
 
                     me->SetWalk(true); // it doesnt seem to work with MoveFollow() (but it does work with MovePoint()).
@@ -456,8 +456,8 @@ public:
 
                     // and loose aggro behavior
                     me->SetReactState(ReactStates::REACT_PASSIVE);
-                    me->AttackStop();
-                    me->SetTarget(ObjectGuid::Empty);
+                    me->AutoAttackStop();
+                    me->SetPrimaryTarget(ObjectGuid::Empty);
 
                     me->ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_GRIP, true); // not sure if this is blizz-like but this is very convenient
                 }

--- a/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_gothik.cpp
@@ -418,7 +418,7 @@ class boss_gothik : public CreatureScript
                 if (!UpdateVictim())
                     return;
 
-                if (me->HasReactState(REACT_AGGRESSIVE) && !_gateIsOpen && !IsOnSameSide(me, me->GetVictim()))
+                if (me->HasReactState(REACT_AGGRESSIVE) && !_gateIsOpen && !IsOnSameSide(me, me->GetAutoAttackVictim()))
                 {
                     // NBD: this should only happen in practice if there is nobody left alive on our side (we should open gate)
                     // thus we only do a cursory check to make sure (edge cases?)
@@ -514,7 +514,7 @@ class boss_gothik : public CreatureScript
                             if (!HealthBelowPct(30))
                             {
                                 me->CastStop();
-                                me->AttackStop();
+                                me->AutoAttackStop();
                                 me->StopMoving();
                                 me->SetReactState(REACT_PASSIVE);
                                 ResetThreatList();
@@ -621,7 +621,7 @@ struct npc_gothik_minion_baseAI : public ScriptedAI
             if (!UpdateVictim())
                 return;
 
-            if (!_gateIsOpen && !isOnSameSide(me->GetVictim()))
+            if (!_gateIsOpen && !isOnSameSide(me->GetAutoAttackVictim()))
             { // reset threat, then try to find someone on same side as us to attack
                 if (Player* newTarget = FindEligibleTarget(me, _gateIsOpen))
                 {

--- a/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_heigan.cpp
@@ -167,7 +167,7 @@ public:
                         Talk(EMOTE_DANCE);
                         _safeSection = 0;
                         me->SetReactState(REACT_PASSIVE);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->StopMoving();
                         DoCast(SPELL_TELEPORT_SELF);
                         DoCastAOE(SPELL_PLAGUE_CLOUD);

--- a/src/server/scripts/Northrend/Naxxramas/boss_maexxna.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_maexxna.cpp
@@ -79,7 +79,7 @@ struct WebTargetSelector : public std::unary_function<Unit*, bool>
     {
         if (target->GetTypeId() != TYPEID_PLAYER) // never web nonplayers (pets, guardians, etc.)
             return false;
-        if (_maexxna->GetVictim() == target) // never target tank
+        if (_maexxna->GetAutoAttackVictim() == target) // never target tank
             return false;
         if (target->HasAura(SPELL_WEB_WRAP)) // never target targets that are already webbed
             return false;

--- a/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
@@ -247,7 +247,7 @@ public:
                         me->SetReactState(REACT_PASSIVE);
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         me->SetImmuneToPC(true);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->StopMoving();
                         me->RemoveAllAuras();
 
@@ -316,10 +316,10 @@ public:
             {
                 /* workaround for movechase breaking after blinking
                    without this noth would just stand there unless his current target moves */
-                if (justBlinked && me->GetVictim() && !me->IsWithinMeleeRange(me->EnsureVictim()))
+                if (justBlinked && me->GetAutoAttackVictim() && !me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                 {
                     me->GetMotionMaster()->Clear();
-                    me->GetMotionMaster()->MoveChase(me->EnsureVictim());
+                    me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                     justBlinked = false;
                 }
                 else

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -132,11 +132,11 @@ public:
                             return;
                         }
 
-                        if ((*it)->GetVictim() != currentVictim)
+                        if ((*it)->GetAutoAttackVictim() != currentVictim)
                             secondThreat = *it;
                         if ((!secondThreat || Is25ManRaid()) && (++it != end && (*it)->IsAvailable()))
                         {
-                            if ((*it)->GetVictim() != currentVictim)
+                            if ((*it)->GetAutoAttackVictim() != currentVictim)
                                 (secondThreat ? thirdThreat : secondThreat) = *it;
                             if (!thirdThreat && Is25ManRaid() && (++it != end && (*it)->IsAvailable()))
                                 thirdThreat = *it;
@@ -146,9 +146,9 @@ public:
                         if (!secondThreat)
                             pHatefulTarget = currentVictim;
                         else if (!thirdThreat)
-                            pHatefulTarget = secondThreat->GetVictim();
+                            pHatefulTarget = secondThreat->GetAutoAttackVictim();
                         else
-                            pHatefulTarget = (secondThreat->GetVictim()->GetHealth() < thirdThreat->GetVictim()->GetHealth()) ? thirdThreat->GetVictim() : secondThreat->GetVictim();
+                            pHatefulTarget = (secondThreat->GetAutoAttackVictim()->GetHealth() < thirdThreat->GetAutoAttackVictim()->GetHealth()) ? thirdThreat->GetAutoAttackVictim() : secondThreat->GetAutoAttackVictim();
 
                         // add threat to highest threat targets
                         AddThreat(currentVictim, HATEFUL_THREAT_AMT);

--- a/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_patchwerk.cpp
@@ -132,11 +132,11 @@ public:
                             return;
                         }
 
-                        if ((*it)->GetAutoAttackVictim() != currentVictim)
+                        if ((*it)->GetVictim() != currentVictim)
                             secondThreat = *it;
                         if ((!secondThreat || Is25ManRaid()) && (++it != end && (*it)->IsAvailable()))
                         {
-                            if ((*it)->GetAutoAttackVictim() != currentVictim)
+                            if ((*it)->GetVictim() != currentVictim)
                                 (secondThreat ? thirdThreat : secondThreat) = *it;
                             if (!thirdThreat && Is25ManRaid() && (++it != end && (*it)->IsAvailable()))
                                 thirdThreat = *it;
@@ -146,9 +146,9 @@ public:
                         if (!secondThreat)
                             pHatefulTarget = currentVictim;
                         else if (!thirdThreat)
-                            pHatefulTarget = secondThreat->GetAutoAttackVictim();
+                            pHatefulTarget = secondThreat->GetVictim();
                         else
-                            pHatefulTarget = (secondThreat->GetAutoAttackVictim()->GetHealth() < thirdThreat->GetAutoAttackVictim()->GetHealth()) ? thirdThreat->GetAutoAttackVictim() : secondThreat->GetAutoAttackVictim();
+                            pHatefulTarget = (secondThreat->GetVictim()->GetHealth() < thirdThreat->GetVictim()->GetHealth()) ? thirdThreat->GetVictim() : secondThreat->GetVictim();
 
                         // add threat to highest threat targets
                         AddThreat(currentVictim, HATEFUL_THREAT_AMT);

--- a/src/server/scripts/Northrend/Naxxramas/boss_razuvious.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_razuvious.cpp
@@ -142,7 +142,7 @@ public:
                 {
                     case EVENT_ATTACK:
                         SetCombatMovement(true);
-                        if (Unit* victim = me->GetVictim())
+                        if (Unit* victim = me->GetAutoAttackVictim())
                             me->GetMotionMaster()->MoveChase(victim);
                         break;
                     case EVENT_STRIKE:

--- a/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_sapphiron.cpp
@@ -311,7 +311,7 @@ class boss_sapphiron : public CreatureScript
                                     _delayedDrain = false;
                                     events.SetPhase(PHASE_FLIGHT);
                                     me->SetReactState(REACT_PASSIVE);
-                                    me->AttackStop();
+                                    me->AutoAttackStop();
                                     float x, y, z, o;
                                     me->GetHomePosition(x, y, z, o);
                                     me->GetMotionMaster()->MovePoint(1, x, y, z);

--- a/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_thaddius.cpp
@@ -440,7 +440,7 @@ struct boss_thaddius : public BossAI
             }
             if (events.IsInPhase(PHASE_THADDIUS) && !me->HasUnitState(UNIT_STATE_CASTING) && me->isAttackReady())
             {
-                if (me->IsWithinMeleeRange(me->GetVictim()))
+                if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                 {
                     ballLightningEnabled = false;
                     DoMeleeAttackIfReady();
@@ -543,10 +543,10 @@ public:
                         refreshBeam = true; // force beam refresh
 
                         if (Creature* feugen = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_FEUGEN)))
-                            if (feugen->GetVictim())
+                            if (feugen->GetAutoAttackVictim())
                             {
-                                AddThreat(feugen->EnsureVictim(), 0.0f);
-                                me->SetInCombatWith(feugen->EnsureVictim());
+                                AddThreat(feugen->GetAutoAttackVictim(), 0.0f);
+                                me->SetInCombatWith(feugen->GetAutoAttackVictim());
                             }
                         break;
                     case ACTION_TRANSITION:
@@ -612,7 +612,7 @@ public:
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 me->RemoveAllAuras();
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->StopMoving();
                 me->SetStandState(UNIT_STAND_STATE_DEAD);
 
@@ -801,10 +801,10 @@ public:
                         refreshBeam = true; // force beam refresh
 
                         if (Creature* stalagg = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_STALAGG)))
-                            if (stalagg->GetVictim())
+                            if (stalagg->GetAutoAttackVictim())
                             {
-                                AddThreat(stalagg->EnsureVictim(), 0.0f);
-                                me->SetInCombatWith(stalagg->EnsureVictim());
+                                AddThreat(stalagg->GetAutoAttackVictim(), 0.0f);
+                                me->SetInCombatWith(stalagg->GetAutoAttackVictim());
                             }
                         staticFieldTimer = 6 * IN_MILLISECONDS;
                         magneticPullTimer = 30 * IN_MILLISECONDS;
@@ -870,7 +870,7 @@ public:
 
                 me->RemoveAllAuras();
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->StopMoving();
                 me->SetStandState(UNIT_STAND_STATE_DEAD);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -746,7 +746,7 @@ public:
             {
                 SetPhase(PHASE_TWO, true);
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 Talk(SAY_END_P_ONE);
             }
 
@@ -781,7 +781,7 @@ public:
                         break;
                     case EVENT_MOVE_TO_VORTEX_POINT:
                         me->SetReactState(REACT_PASSIVE);
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->GetMotionMaster()->MovePoint(POINT_VORTEX_P_ONE, MalygosPositions[1]);
                         break;
                     case EVENT_POWER_SPARKS:
@@ -795,7 +795,7 @@ public:
                             break;
                         }
 
-                        me->CastSpell(me->GetVictim(), SPELL_ARCANE_BREATH);
+                        me->CastSpell(me->GetAutoAttackVictim(), SPELL_ARCANE_BREATH);
                         events.ScheduleEvent(EVENT_ARCANE_BREATH, 20*IN_MILLISECONDS, 0, PHASE_ONE);
                         break;
                     case EVENT_ARCANE_STORM:
@@ -1803,7 +1803,7 @@ class spell_malygos_vortex_visual : public SpellScriptLoader
                 {
                     for (ThreatReference const* ref : caster->GetThreatManager().GetUnsortedThreatList())
                     {
-                        if (Player* targetPlayer = ref->GetVictim()->ToPlayer())
+                        if (Player* targetPlayer = ref->GetAutoAttackVictim()->ToPlayer())
                         {
                             if (targetPlayer->IsGameMaster())
                                 continue;
@@ -1903,7 +1903,7 @@ class spell_nexus_lord_align_disk_aggro : public SpellScriptLoader
             {
                 Creature* caster = GetCaster()->ToCreature();
                 if (Creature* target = GetHitCreature())
-                    target->GetMotionMaster()->MoveChase(caster->GetVictim());
+                    target->GetMotionMaster()->MoveChase(caster->GetAutoAttackVictim());
             }
 
             void Register() override

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -1803,7 +1803,7 @@ class spell_malygos_vortex_visual : public SpellScriptLoader
                 {
                     for (ThreatReference const* ref : caster->GetThreatManager().GetUnsortedThreatList())
                     {
-                        if (Player* targetPlayer = ref->GetAutoAttackVictim()->ToPlayer())
+                        if (Player* targetPlayer = ref->GetVictim()->ToPlayer())
                         {
                             if (targetPlayer->IsGameMaster())
                                 continue;

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
@@ -192,7 +192,7 @@ public:
                             if (counter >= 5)
                                 break;
 
-                            if (Player* player = ref->GetAutoAttackVictim()->ToPlayer())
+                            if (Player* player = ref->GetVictim()->ToPlayer())
                             {
                                 if (player->IsGameMaster() || player->HasAura(SPELL_VORTEX_4))
                                     continue;

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
@@ -192,7 +192,7 @@ public:
                             if (counter >= 5)
                                 break;
 
-                            if (Player* player = ref->GetVictim()->ToPlayer())
+                            if (Player* player = ref->GetAutoAttackVictim()->ToPlayer())
                             {
                                 if (player->IsGameMaster() || player->HasAura(SPELL_VORTEX_4))
                                     continue;

--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_magus_telestra.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_magus_telestra.cpp
@@ -245,7 +245,7 @@ public:
             if (bIsWaitingToAppear)
             {
                 me->StopMoving();
-                me->AttackStop();
+                me->AutoAttackStop();
                 if (uiIsWaitingToAppearTimer <= diff)
                 {
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
@@ -336,7 +336,7 @@ public:
 
             if (uiGravityWellTimer <= diff)
             {
-                if (Unit* target = me->GetVictim())
+                if (Unit* target = me->GetAutoAttackVictim())
                 {
                     DoCast(target, SPELL_GRAVITY_WELL);
                     uiCooldown = 6*IN_MILLISECONDS;

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -235,12 +235,12 @@ class boss_urom : public CreatureScript
                 {
                     if (arcaneExplosionTimer <= diff)
                     {
-                        if (me->GetVictim())
+                        if (me->GetAutoAttackVictim())
                         {
-                            Position pos = me->EnsureVictim()->GetPosition();
+                            Position pos = me->GetAutoAttackVictim()->GetPosition();
 
                             me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation());
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                         }
                         me->SetWalk(true);
 

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_bjarngrim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_bjarngrim.cpp
@@ -425,7 +425,7 @@ public:
         {
             if (Creature* pBjarngrim = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_BJARNGRIM)))
             {
-                if (pBjarngrim->IsAlive() && !pBjarngrim->GetVictim())
+                if (pBjarngrim->IsAlive() && !pBjarngrim->GetAutoAttackVictim())
                     pBjarngrim->AI()->AttackStart(who);
             }
         }

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
@@ -154,7 +154,7 @@ public:
                 for (uint8 i = 0; i < DATA_MAX_SPARKS; ++i)
                     me->CastSpell(me, SPELL_SUMMON_SPARK, true);
 
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetVisible(false);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 me->SetControlled(true, UNIT_STATE_ROOT);
@@ -249,8 +249,8 @@ public:
                         uiSplitTimer = 25*IN_MILLISECONDS;
                         bIsSplitPhase = true;
 
-                        if (me->GetVictim())
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                        if (me->GetAutoAttackVictim())
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                     }
                 }
                 else

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_volkhan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_volkhan.cpp
@@ -133,7 +133,7 @@ public:
 
         void AttackStart(Unit* who) override
         {
-            if (me->Attack(who, true))
+            if (me->AutoAttackStart(who, true))
             {
                 AddThreat(who, 0.0f);
                 me->SetInCombatWith(who);
@@ -245,8 +245,8 @@ public:
                         if (m_bIsStriking)
                         {
                             if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
-                                if (me->GetVictim())
-                                    me->GetMotionMaster()->MoveChase(me->GetVictim());
+                                if (me->GetAutoAttackVictim())
+                                    me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
 
                             m_bHasTemper = false;
                             m_bIsStriking = false;
@@ -408,7 +408,7 @@ public:
 
         void AttackStart(Unit* who) override
         {
-            if (me->Attack(who, true))
+            if (me->AutoAttackStart(who, true))
             {
                 AddThreat(who, 0.0f);
                 me->SetInCombatWith(who);
@@ -427,7 +427,7 @@ public:
                 me->SetHealth(1);
                 damage = 0;
                 me->RemoveAllAuras();
-                me->AttackStop();
+                me->AutoAttackStop();
                 // me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED); // Set in DB
                 // me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE); // Set in DB
                 if (me->IsNonMeleeSpellCast(false))

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -485,7 +485,7 @@ struct boss_algalon_the_observer : public BossAI
             damage = 0;
             events.SetPhase(PHASE_ROLE_PLAY);
             me->SetReactState(REACT_PASSIVE);
-            me->AttackStop();
+            me->AutoAttackStop();
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             DoCastSelf(SPELL_SELF_STUN);
             events.Reset();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -251,7 +251,7 @@ class boss_steelbreaker : public CreatureScript
                             events.CancelEvent(EVENT_BERSERK);
                             break;
                         case EVENT_FUSION_PUNCH:
-                            if (me->IsWithinMeleeRange(me->GetVictim()))
+                            if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                                 DoCastVictim(SPELL_FUSION_PUNCH);
                             events.ScheduleEvent(EVENT_FUSION_PUNCH, 13s, 22s);
                             break;
@@ -590,7 +590,7 @@ class boss_stormcaller_brundir : public CreatureScript
                             Talk(SAY_BRUNDIR_FLIGHT);
                             DoCast(me, SPELL_LIGHTNING_TENDRILS);
                             DoCast(me, SPELL_LIGHTNING_TENDRILS_VISUAL);
-                            me->AttackStop();
+                            me->AutoAttackStop();
                             me->SetHover(true);
                             events.DelayEvents(35000);
                             events.ScheduleEvent(EVENT_FLIGHT, 2500ms);
@@ -617,12 +617,12 @@ class boss_stormcaller_brundir : public CreatureScript
                         case EVENT_GROUND:
                             me->RemoveAurasDueToSpell(sSpellMgr->GetSpellIdForDifficulty(SPELL_LIGHTNING_TENDRILS, me));
                             me->RemoveAurasDueToSpell(SPELL_LIGHTNING_TENDRILS_VISUAL);
-                            DoStartMovement(me->GetVictim());
+                            DoStartMovement(me->GetAutoAttackVictim());
                             events.CancelEvent(EVENT_GROUND);
                             ResetThreatList();
                             break;
                         case EVENT_MOVE_POSITION:
-                            if (me->IsWithinMeleeRange(me->GetVictim()))
+                            if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                             {
                                 float x = float(irand(-25, 25));
                                 float y = float(irand(-25, 25));

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_auriaya.cpp
@@ -433,7 +433,7 @@ struct npc_feral_defender : public ScriptedAI
             if (!me->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
             {
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 DoCastSelf(SPELL_PERMANENT_FEIGN_DEATH, true);
                 DoCastSelf(SPELL_FERAL_ESSENCE_APPLICATION_REMOVAL, true);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -571,7 +571,7 @@ class boss_flame_leviathan : public CreatureScript
             }
 
             private:
-                //! Copypasta from DoSpellAttackIfReady, only difference is the target - it cannot be selected trough getVictim this way -
+                //! Copypasta from DoSpellAttackIfReady, only difference is the target - it cannot be selected trough GetAutoAttackVictim this way -
                 //! I also removed the spellInfo check
                 void DoBatteringRamIfReady()
                 {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -618,8 +618,8 @@ class boss_freya : public CreatureScript
 
                 me->SetReactState(REACT_PASSIVE);
                 me->InterruptNonMeleeSpells(true);
-                me->RemoveAllAttackers();
-                me->AttackStop();
+                me->StopAutoAttackingMe();
+                me->AutoAttackStop();
                 me->SetFaction(FACTION_FRIENDLY);
                 me->DespawnOrUnsummon(7500);
                 me->CastSpell(me, SPELL_KNOCK_ON_WOOD_CREDIT, true);
@@ -631,7 +631,7 @@ class boss_freya : public CreatureScript
                     if (Elder && Elder->IsAlive())
                     {
                         Elder->RemoveAllAuras();
-                        Elder->AttackStop();
+                        Elder->AutoAttackStop();
                         Elder->CombatStop(true);
                         Elder->GetThreatManager().ClearAllThreat();
                         Elder->AI()->DoAction(ACTION_ELDER_FREYA_KILLED);
@@ -1041,7 +1041,7 @@ class npc_detonating_lasher : public CreatureScript
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
                     {
                         // Switching to other target - modify aggro of new target by 20% from current target's aggro
-                        AddThreat(target, GetThreat(me->GetVictim()) * 1.2f);
+                        AddThreat(target, GetThreat(me->GetAutoAttackVictim()) * 1.2f);
                         AttackStart(target);
                     }
                     changeTargetTimer = urand(5000, 10000);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -210,12 +210,12 @@ class npc_flash_freeze : public CreatureScript
             void UpdateAI(uint32 diff) override
             {
                 if (!UpdateVictim()
-                 || !me->GetVictim()
-                 || me->EnsureVictim()->HasAura(SPELL_BLOCK_OF_ICE)
-                 || me->EnsureVictim()->HasAura(SPELL_FLASH_FREEZE_HELPER))
+                 || !me->GetAutoAttackVictim()
+                 || me->GetAutoAttackVictim()->HasAura(SPELL_BLOCK_OF_ICE)
+                 || me->GetAutoAttackVictim()->HasAura(SPELL_FLASH_FREEZE_HELPER))
                     return;
 
-                if (me->EnsureVictim()->GetGUID() != targetGUID || instance->GetBossState(BOSS_HODIR) != IN_PROGRESS)
+                if (me->GetAutoAttackVictim()->GetGUID() != targetGUID || instance->GetBossState(BOSS_HODIR) != IN_PROGRESS)
                     me->DespawnOrUnsummon();
 
                 if (checkDespawnTimer <= diff)
@@ -392,8 +392,8 @@ class boss_hodir : public CreatureScript
                         instance->SetData(DATA_HODIR_RARE_CACHE, 1);
 
                     me->RemoveAllAuras();
-                    me->RemoveAllAttackers();
-                    me->AttackStop();
+                    me->StopAutoAttackingMe();
+                    me->AutoAttackStop();
                     me->SetReactState(REACT_PASSIVE);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     me->SetControlled(true, UNIT_STATE_ROOT);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -186,7 +186,7 @@ class boss_ignis : public CreatureScript
                     summon->SetControlled(false, UNIT_STATE_ROOT);
                 }
 
-                summon->AI()->AttackStart(me->GetVictim());
+                summon->AI()->AttackStart(me->GetAutoAttackVictim());
                 summon->AI()->DoZoneInCombat();
                 summons.Summon(summon);
             }
@@ -262,7 +262,7 @@ class boss_ignis : public CreatureScript
                             break;
                         case EVENT_SCORCH:
                             Talk(SAY_SCORCH);
-                            if (Unit* target = me->GetVictim())
+                            if (Unit* target = me->GetAutoAttackVictim())
                                 me->SummonCreature(NPC_GROUND_SCORCH, target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN, 45000);
                             DoCast(SPELL_SCORCH);
                             events.ScheduleEvent(EVENT_SCORCH, 25000);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -235,7 +235,7 @@ class boss_kologarn : public CreatureScript
                 {
                     if (Unit* target = ObjectAccessor::GetUnit(*summon, eyebeamTarget))
                     {
-                        summon->Attack(target, false);
+                        summon->AutoAttackStart(target, false);
                         summon->GetMotionMaster()->MoveChase(target);
                     }
                 }
@@ -256,7 +256,7 @@ class boss_kologarn : public CreatureScript
                     switch (eventId)
                     {
                         case EVENT_MELEE_CHECK:
-                            if (!me->IsWithinMeleeRange(me->GetVictim()))
+                            if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                                 DoCast(SPELL_PETRIFY_BREATH);
                             events.ScheduleEvent(EVENT_MELEE_CHECK, 1s);
                             break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -699,7 +699,7 @@ class boss_leviathan_mk_ii : public CreatureScript
                     damage = me->GetHealth() - 1; // Let creature fall to 1 hp, but do not let it die or damage itself with SetHealth().
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     DoCast(me, SPELL_VEHICLE_DAMAGED, true);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->SetReactState(REACT_PASSIVE);
                     me->RemoveAllAurasExceptType(SPELL_AURA_CONTROL_VEHICLE, SPELL_AURA_MOD_INCREASE_HEALTH_PERCENT);
 
@@ -943,7 +943,7 @@ class boss_vx_001 : public CreatureScript
                 if (damage >= me->GetHealth())
                 {
                     damage = me->GetHealth() - 1; // Let creature fall to 1 hp, but do not let it die or damage itself with SetHealth().
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     DoCast(me, SPELL_VEHICLE_DAMAGED, true);
                     me->RemoveAllAurasExceptType(SPELL_AURA_CONTROL_VEHICLE, SPELL_AURA_MOD_INCREASE_HEALTH_PERCENT);
 
@@ -1126,7 +1126,7 @@ class boss_aerial_command_unit : public CreatureScript
                 {
                     damage = me->GetHealth() - 1; // Let creature fall to 1 hp, but do not let it die or damage itself with SetHealth().
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->SetReactState(REACT_PASSIVE);
                     DoCast(me, SPELL_VEHICLE_DAMAGED, true);
                     me->RemoveAllAurasExceptType(SPELL_AURA_CONTROL_VEHICLE, SPELL_AURA_MOD_INCREASE_HEALTH_PERCENT);
@@ -1174,7 +1174,7 @@ class boss_aerial_command_unit : public CreatureScript
                         break;
                     case DO_DISABLE_AERIAL:
                         me->CastStop();
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->SetReactState(REACT_PASSIVE);
                         me->GetMotionMaster()->MoveFall();
                         events.DelayEvents(23000);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -642,14 +642,14 @@ struct boss_razorscale : public BossAI
                     DoCastSelf(SPELL_FIREBOLT);
                     break;
                 case EVENT_FUSE_ARMOR:
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                         if (!victim->HasAura(SPELL_FUSED_ARMOR))
                             DoCast(victim, SPELL_FUSE_ARMOR);
                     events.Repeat(Seconds(10), Seconds(15));
                     break;
                 case EVENT_RESUME_MOVE_CHASE:
                     SetCombatMovement(true);
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                         me->GetMotionMaster()->MoveChase(victim);
                     break;
                 default:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -573,8 +573,8 @@ class boss_thorim : public CreatureScript
 
                 me->SetReactState(REACT_PASSIVE);
                 me->InterruptNonMeleeSpells(true);
-                me->RemoveAllAttackers();
-                me->AttackStop();
+                me->StopAutoAttackingMe();
+                me->AutoAttackStop();
                 me->SetFaction(FACTION_FRIENDLY);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_RENAME);
 
@@ -1069,7 +1069,7 @@ struct npc_thorim_trashAI : public ScriptedAI
         if (AIHelper::GetTotalHeal(spellInfo, me))
             target = AIHelper::GetHealTarget(spellInfo, me);
         else
-            target = me->GetVictim();
+            target = me->GetAutoAttackVictim();
 
         if (!target)
             return false;
@@ -1601,7 +1601,7 @@ class npc_sif : public CreatureScript
                 {
                     me->InterruptSpell(CURRENT_GENERIC_SPELL);
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                 }
             }
 
@@ -1812,7 +1812,7 @@ class spell_thorim_lightning_charge : public SpellScriptLoader
             {
                 /// @workaround: focus target is not working because spell is triggered and instant
                 if (Creature* creature = GetCaster()->ToCreature())
-                    creature->FocusTarget(GetSpell(), GetExplTargetWorldObject());
+                    creature->SetSpellFocus(GetExplTargetWorldObject(), GetSpell());
             }
 
             void HandleCharge()

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -218,7 +218,7 @@ struct boss_xt002 : public BossAI
     {
         events.SetPhase(PHASE_HEART);
         me->SetReactState(REACT_PASSIVE);
-        me->AttackStop();
+        me->AutoAttackStop();
         Talk(SAY_HEART_OPENED);
         events.CancelEvent(EVENT_TYMPANIC_TANTRUM);
         events.ScheduleEvent(EVENT_SUBMERGE, 6s, 0, PHASE_HEART);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
@@ -3142,7 +3142,7 @@ class spell_yogg_saron_hodirs_protective_gaze : public SpellScriptLoader     // 
                 if (dmgInfo.GetDamage() >= GetTarget()->GetHealth())
                 {
                     absorbAmount = dmgInfo.GetDamage();
-                    // or absorbAmount = dmgInfo.GetDamage() - GetTarget()->GetHealth() + 1
+                    // or absorbAmount = dmgInfo.GetDamage() - GetSelectedUnitGUID()->GetHealth() + 1
                     GetTarget()->CastSpell(GetTarget(), SPELL_FLASH_FREEZE, true);
                 }
                 else

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_keleseth.cpp
@@ -310,7 +310,7 @@ class npc_vrykul_skeleton : public CreatureScript
                             DoCastAOE(SPELL_BONE_ARMOR, true);
                             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                             me->SetStandState(UNIT_STAND_STATE_STAND);
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                             events.ScheduleEvent(EVENT_DECREPIFY, 4s, 6s);
                             break;
                         default:

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -570,7 +570,7 @@ class npc_scourge_hulk : public CreatureScript
 
                 if (mightyBlow <= diff)
                 {
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                         if (!victim->HasUnitState(UNIT_STATE_STUNNED))    // Prevent knocking back a ritual player
                             DoCast(victim, SPELL_MIGHTY_BLOW);
                     mightyBlow = urand(12000, 17000);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_ymiron.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_ymiron.cpp
@@ -215,7 +215,7 @@ public:
                 me->InterruptNonMeleeSpells(true);
                 DoCast(me, SPELL_SCREAMS_OF_THE_DEAD);
 
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetReactState(REACT_PASSIVE);
                 me->GetMotionMaster()->MovePoint(POINT_BOAT, ActiveBoat[ActiveOrder[Order]].MoveX, ActiveBoat[ActiveOrder[Order]].MoveY, ActiveBoat[ActiveOrder[Order]].MoveZ);
 

--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
@@ -96,7 +96,7 @@ class boss_emalon : public CreatureScript
 
                 // AttackStart has nullptr-check for victim
                 if (summoned->AI())
-                    summoned->AI()->AttackStart(me->GetVictim());
+                    summoned->AI()->AttackStart(me->GetAutoAttackVictim());
             }
 
             void JustEngagedWith(Unit* who) override
@@ -106,7 +106,7 @@ class boss_emalon : public CreatureScript
                     for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
                     {
                         Creature* minion = ObjectAccessor::GetCreature(*me, *itr);
-                        if (minion && minion->IsAlive() && !minion->GetVictim() && minion->AI())
+                        if (minion && minion->IsAlive() && !minion->GetAutoAttackVictim() && minion->AI())
                             minion->AI()->AttackStart(who);
                     }
                 }
@@ -223,7 +223,7 @@ class npc_tempest_minion : public CreatureScript
 
                 if (Creature* pEmalon = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_EMALON)))
                 {
-                    if (!pEmalon->GetVictim() && pEmalon->AI())
+                    if (!pEmalon->GetAutoAttackVictim() && pEmalon->AI())
                         pEmalon->AI()->AttackStart(who);
                 }
             }

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -415,7 +415,7 @@ public:
             {
                 tree->AI()->Talk(SAY_WALKER_ENEMY, player);
                 tree->SetFaction(FACTION_MONSTER);
-                tree->Attack(player, true);
+                tree->AutoAttackStart(player, true);
             }
         }
 

--- a/src/server/scripts/Northrend/zone_grizzly_hills.cpp
+++ b/src/server/scripts/Northrend/zone_grizzly_hills.cpp
@@ -73,7 +73,7 @@ public:
             if (Creature* Mrfloppy = GetClosestCreatureWithEntry(me, NPC_MRFLOPPY, 50.0f))
                 summoned->AI()->AttackStart(Mrfloppy);
             else
-                summoned->AI()->AttackStart(me->GetVictim());
+                summoned->AI()->AttackStart(me->GetAutoAttackVictim());
         }
 
         void WaypointReached(uint32 waypointId, uint32 /*pathId*/) override

--- a/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_nexusprince_shaffar.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_nexusprince_shaffar.cpp
@@ -222,7 +222,7 @@ class npc_ethereal_beacon : public CreatureScript
 
             void JustSummoned(Creature* summoned) override
             {
-                summoned->AI()->AttackStart(me->GetVictim());
+                summoned->AI()->AttackStart(me->GetAutoAttackVictim());
             }
 
             void UpdateAI(uint32 diff) override
@@ -362,7 +362,7 @@ public:
                 switch (eventId)
                 {
                     case EVENT_DOUBLE_BREATH:
-                        if (me->IsWithinDist(me->GetVictim(), ATTACK_DISTANCE))
+                        if (me->IsWithinDist(me->GetAutoAttackVictim(), ATTACK_DISTANCE))
                             DoCastVictim(SPELL_DOUBLE_BREATH);
                         _events.ScheduleEvent(EVENT_DOUBLE_BREATH, 6s, 9s);
                         break;

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
@@ -121,7 +121,7 @@ class boss_murmur : public CreatureScript
                             events.ScheduleEvent(EVENT_MURMURS_TOUCH, 25s, 35s);
                             break;
                         case EVENT_RESONANCE:
-                            if (!(me->IsWithinMeleeRange(me->GetVictim())))
+                            if (!(me->IsWithinMeleeRange(me->GetAutoAttackVictim())))
                             {
                                 DoCast(me, SPELL_RESONANCE);
                                 events.ScheduleEvent(EVENT_RESONANCE, 5s);
@@ -155,8 +155,8 @@ class boss_murmur : public CreatureScript
                 if (!me->isAttackReady())
                     return;
 
-                if (!me->IsWithinMeleeRange(me->GetVictim()))
-                    me->GetThreatManager().ResetThreat(me->GetVictim());
+                if (!me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
+                    me->GetThreatManager().ResetThreat(me->GetAutoAttackVictim());
 
                 DoMeleeAttackIfReady();
             }

--- a/src/server/scripts/Outland/BlackTemple/black_temple.cpp
+++ b/src/server/scripts/Outland/BlackTemple/black_temple.cpp
@@ -208,7 +208,7 @@ struct npc_angered_soul_fragment : public ScriptedAI
         _scheduler.CancelGroup(GROUP_OUT_OF_COMBAT);
         _scheduler.Schedule(Seconds(1), [this](TaskContext anger)
         {
-            Unit* target = me->GetVictim();
+            Unit* target = me->GetAutoAttackVictim();
             if (target && me->IsWithinMeleeRange(target))
                 DoCastSelf(SPELL_ANGER);
             else

--- a/src/server/scripts/Outland/BlackTemple/boss_gurtogg_bloodboil.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_gurtogg_bloodboil.cpp
@@ -211,7 +211,7 @@ struct boss_gurtogg_bloodboil : public BossAI
                 case EVENT_START_PHASE_2:
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1))
                     {
-                        if (Unit* oldTarget = me->GetVictim())
+                        if (Unit* oldTarget = me->GetAutoAttackVictim())
                         {
                             _oldTargetGUID = oldTarget->GetGUID();
                             _oldThreat = GetThreat(oldTarget);

--- a/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
@@ -593,7 +593,7 @@ struct boss_illidan_stormrage : public BossAI
             case ACTION_START_PHASE_2:
             {
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 me->HandleEmoteCommand(EMOTE_ONESHOT_LIFTOFF);
                 me->SetDisableGravity(true);
@@ -623,7 +623,7 @@ struct boss_illidan_stormrage : public BossAI
                 DoCastSelf(SPELL_SHADOW_PRISON, true);
                 summons.DoAction(ACTION_START_PHASE_4, EntryCheckPredicate(NPC_PARASITIC_SHADOWFIEND));
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 events.ScheduleEvent(EVENT_SHADOW_PRISON_TEXT, Milliseconds(500), GROUP_PHASE_ALL);
                 break;
@@ -633,7 +633,7 @@ struct boss_illidan_stormrage : public BossAI
                 DoCastSelf(SPELL_CAGE_TRAP, true);
                 break;
             case ACTION_START_OUTRO:
-                me->AttackStop();
+                me->AutoAttackStop();
                 events.Reset();
                 specialEvents.Reset();
                 DoCastSelf(SPELL_DEATH, true);
@@ -1140,7 +1140,7 @@ struct npc_akama_illidan : public ScriptedAI
                 break;
             case ACTION_START_OUTRO:
                 me->SetReactState(REACT_PASSIVE);
-                me->AttackStop();
+                me->AutoAttackStop();
                 _events.Reset();
                 _events.ScheduleEvent(EVENT_AKAMA_MOVE_BACK, 2s);
                 break;
@@ -1316,7 +1316,7 @@ struct npc_akama_illidan : public ScriptedAI
                     break;
                 case EVENT_AKAMA_MINIONS_EMOTE:
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->HandleEmoteCommand(EMOTE_ONESHOT_EXCLAMATION);
                     me->SetImmuneToNPC(true);
                     _events.ScheduleEvent(EVENT_AKAMA_MINIONS_MOVE, 4s);
@@ -1397,7 +1397,7 @@ struct npc_parasitic_shadowfiend : public ScriptedAI
         if (action == ACTION_START_PHASE_4)
         {
             me->SetReactState(REACT_PASSIVE);
-            me->AttackStop();
+            me->AutoAttackStop();
         }
         else if (action == ACTION_RESUME_COMBAT)
             _scheduler.Schedule(Seconds(2), [this](TaskContext /*context*/)
@@ -1648,7 +1648,7 @@ struct npc_maiev : public ScriptedAI
         {
             _events.Reset();
             me->SetReactState(REACT_PASSIVE);
-            me->AttackStop();
+            me->AutoAttackStop();
             if (Creature* illidan = _instance->GetCreature(DATA_ILLIDAN_STORMRAGE))
                 me->SetFacingToObject(illidan);
             Talk(SAY_MAIEV_SHADOWSONG_FINISHED);
@@ -1718,7 +1718,7 @@ struct npc_maiev : public ScriptedAI
                     _events.Repeat(Seconds(50));
                     break;
                 case EVENT_THROW_DAGGER:
-                    if (Unit* target = me->GetVictim())
+                    if (Unit* target = me->GetAutoAttackVictim())
                         if (!me->IsWithinMeleeRange(target))
                         {
                             DoCastVictim(SPELL_THROW_DAGGER);

--- a/src/server/scripts/Outland/BlackTemple/boss_reliquary_of_souls.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_reliquary_of_souls.cpp
@@ -330,7 +330,7 @@ struct boss_essence_of_suffering : public BossAI
             {
                 _dead = true;
                 Talk(SUFF_SAY_RECAP);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetReactState(REACT_PASSIVE);
                 events.Reset();
                 me->InterruptNonMeleeSpells(false);
@@ -449,7 +449,7 @@ struct boss_essence_of_desire : public BossAI
             {
                 _dead = true;
                 Talk(DESI_SAY_RECAP);
-                me->AttackStop();
+                me->AutoAttackStop();
                 me->SetReactState(REACT_PASSIVE);
                 events.Reset();
                 me->InterruptNonMeleeSpells(false);
@@ -562,7 +562,7 @@ struct boss_essence_of_anger : public BossAI
             {
                 case EVENT_CHECK_TANKER:
                 {
-                    Unit* target = me->GetVictim();
+                    Unit* target = me->GetAutoAttackVictim();
                     if (!_targetGUID || !target)
                         return;
 
@@ -585,7 +585,7 @@ struct boss_essence_of_anger : public BossAI
                     events.Repeat(Seconds(20));
                     break;
                 case EVENT_START_CHECK_TANKER:
-                    if (Unit* target = me->GetVictim())
+                    if (Unit* target = me->GetAutoAttackVictim())
                     {
                         _targetGUID = target->GetGUID();
                         events.ScheduleEvent(EVENT_CHECK_TANKER, 1s);

--- a/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
@@ -122,7 +122,7 @@ struct boss_supremus : public BossAI
 
         for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
         {
-            Unit* unit = ref->GetVictim();
+            Unit* unit = ref->GetAutoAttackVictim();
             if (me->IsWithinMeleeRange(unit))
             {
                 if (unit->GetHealth() > health)

--- a/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
@@ -122,7 +122,7 @@ struct boss_supremus : public BossAI
 
         for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
         {
-            Unit* unit = ref->GetAutoAttackVictim();
+            Unit* unit = ref->GetVictim();
             if (me->IsWithinMeleeRange(unit))
             {
                 if (unit->GetHealth() > health)

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_fathomlord_karathress.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_fathomlord_karathress.cpp
@@ -248,7 +248,7 @@ public:
 
                 //if there aren't other units, cast on the tank
                 if (!target)
-                    target = me->GetVictim();
+                    target = me->GetAutoAttackVictim();
 
                 if (target)
                     DoCast(target, SPELL_CATACLYSMIC_BOLT);
@@ -533,7 +533,7 @@ public:
             {
                 DoCast(me, SPELL_SPITFIRE_TOTEM);
                 if (Unit* SpitfireTotem = me->FindNearestCreature(CREATURE_SPITFIRE_TOTEM, 100.0f))
-                    SpitfireTotem->ToCreature()->AI()->AttackStart(me->GetVictim());
+                    SpitfireTotem->ToCreature()->AI()->AttackStart(me->GetAutoAttackVictim());
 
                 Spitfire_Timer = 60000;
             }
@@ -649,8 +649,8 @@ public:
             {
                 DoCastVictim(SPELL_TIDAL_SURGE);
                 // Hacky way to do it - won't trigger elseways
-                if (me->GetVictim())
-                    me->EnsureVictim()->CastSpell(me->GetVictim(), SPELL_TIDAL_SURGE_FREEZE, true);
+                if (me->GetAutoAttackVictim())
+                    me->GetAutoAttackVictim()->CastSpell(me->GetAutoAttackVictim(), SPELL_TIDAL_SURGE_FREEZE, true);
                 TidalSurge_Timer = 15000 + rand32() % 5000;
             } else TidalSurge_Timer -= diff;
 

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
@@ -283,7 +283,7 @@ public:
             }
             if (!CanAttack)
                 return;
-            if (!who || me->GetVictim())
+            if (!who || me->GetAutoAttackVictim())
                 return;
 
             if (me->CanCreatureAttack(who))
@@ -338,7 +338,7 @@ public:
                 }
             }
             // to prevent abuses during phase 2
-            if (Phase == 2 && !me->GetVictim() && me->IsInCombat())
+            if (Phase == 2 && !me->GetAutoAttackVictim() && me->IsInCombat())
             {
                 EnterEvadeMode();
                 return;
@@ -440,7 +440,7 @@ public:
                     bool inMeleeRange = false;
                     for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                     {
-                        Unit* target = ref->GetVictim();
+                        Unit* target = ref->GetAutoAttackVictim();
                         if (target->IsWithinMeleeRange(me)) // if in melee range
                         {
                             inMeleeRange = true;
@@ -466,7 +466,7 @@ public:
                     Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0);
 
                     if (!target)
-                        target = me->GetVictim();
+                        target = me->GetAutoAttackVictim();
 
                     DoCast(target, SPELL_FORKED_LIGHTNING);
 
@@ -504,8 +504,8 @@ public:
                     {
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                             coilfangElite->AI()->AttackStart(target);
-                        else if (me->GetVictim())
-                            coilfangElite->AI()->AttackStart(me->GetVictim());
+                        else if (me->GetAutoAttackVictim())
+                            coilfangElite->AI()->AttackStart(me->GetAutoAttackVictim());
                     }
                     CoilfangEliteTimer = 45000 + rand32() % 5000;
                 } else CoilfangEliteTimer -= diff;
@@ -518,8 +518,8 @@ public:
                     {
                         if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                             CoilfangStrider->AI()->AttackStart(target);
-                        else if (me->GetVictim())
-                            CoilfangStrider->AI()->AttackStart(me->GetVictim());
+                        else if (me->GetAutoAttackVictim())
+                            CoilfangStrider->AI()->AttackStart(me->GetAutoAttackVictim());
                     }
                     CoilfangStriderTimer = 60000 + rand32() % 10000;
                 } else CoilfangStriderTimer -= diff;
@@ -540,7 +540,7 @@ public:
                         Phase = 3;
 
                         // return to the tank
-                        me->GetMotionMaster()->MoveChase(me->GetVictim());
+                        me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                     }
                     CheckTimer = 1000;
                 } else CheckTimer -= diff;

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lady_vashj.cpp
@@ -440,7 +440,7 @@ public:
                     bool inMeleeRange = false;
                     for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                     {
-                        Unit* target = ref->GetAutoAttackVictim();
+                        Unit* target = ref->GetVictim();
                         if (target->IsWithinMeleeRange(me)) // if in melee range
                         {
                             inMeleeRange = true;

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
@@ -528,7 +528,7 @@ public:
                     Unit* currentVictim = mgr.GetCurrentVictim();
                     for (ThreatReference const* ref : mgr.GetSortedThreatList())
                     {
-                        if (Player* tempTarget = ref->GetAutoAttackVictim()->ToPlayer())
+                        if (Player* tempTarget = ref->GetVictim()->ToPlayer())
                             if (tempTarget != currentVictim && TargetList.size()<5)
                                 TargetList.push_back(tempTarget);
                     }

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_leotheras_the_blind.cpp
@@ -145,12 +145,12 @@ public:
         void UpdateAI(uint32 diff) override
         {
             //Return since we have no target
-            if (!UpdateVictim() || !me->GetVictim())
+            if (!UpdateVictim() || !me->GetAutoAttackVictim())
                 return;
 
-            if (me->EnsureVictim()->GetGUID() != victimGUID)
+            if (me->GetAutoAttackVictim()->GetGUID() != victimGUID)
             {
-                ModifyThreatByPercent(me->GetVictim(), -100);
+                ModifyThreatByPercent(me->GetAutoAttackVictim(), -100);
                 Unit* owner = ObjectAccessor::GetUnit(*me, victimGUID);
                 if (owner && owner->IsAlive())
                 {
@@ -282,7 +282,7 @@ public:
             if (me->HasAura(AURA_BANISH))
                 return;
 
-            if (!me->GetVictim() && me->CanCreatureAttack(who))
+            if (!me->GetAutoAttackVictim() && me->CanCreatureAttack(who))
             {
                 if (me->GetDistanceZ(who) > CREATURE_Z_ATTACK_RANGE)
                     return;
@@ -460,7 +460,7 @@ public:
                 NeedThreatReset = false;
                 ResetThreatList();
                 me->GetMotionMaster()->Clear();
-                me->GetMotionMaster()->MoveChase(me->GetVictim());
+                me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
             }
 
             //Enrage_Timer (10 min)
@@ -506,17 +506,17 @@ public:
             else
             {
                 //ChaosBlast_Timer
-                if (!me->GetVictim())
+                if (!me->GetAutoAttackVictim())
                     return;
-                if (me->IsWithinDist(me->GetVictim(), 30))
+                if (me->IsWithinDist(me->GetAutoAttackVictim(), 30))
                     me->StopMoving();
                 if (ChaosBlast_Timer <= diff)
                 {
                     // will cast only when in range of spell
-                    if (me->IsWithinDist(me->GetVictim(), 30))
+                    if (me->IsWithinDist(me->GetAutoAttackVictim(), 30))
                     {
                         //DoCastVictim(SPELL_CHAOS_BLAST, true);
-                        me->CastSpell(me->GetVictim(), SPELL_CHAOS_BLAST, CastSpellExtraArgs().SetOriginalCaster(me->GetGUID()).AddSpellBP0(100));
+                        me->CastSpell(me->GetAutoAttackVictim(), SPELL_CHAOS_BLAST, CastSpellExtraArgs().SetOriginalCaster(me->GetGUID()).AddSpellBP0(100));
                     }
                     ChaosBlast_Timer = 3000;
                 } else ChaosBlast_Timer -= diff;
@@ -528,7 +528,7 @@ public:
                     Unit* currentVictim = mgr.GetCurrentVictim();
                     for (ThreatReference const* ref : mgr.GetSortedThreatList())
                     {
-                        if (Player* tempTarget = ref->GetVictim()->ToPlayer())
+                        if (Player* tempTarget = ref->GetAutoAttackVictim()->ToPlayer())
                             if (tempTarget != currentVictim && TargetList.size()<5)
                                 TargetList.push_back(tempTarget);
                     }
@@ -586,8 +586,8 @@ public:
                 if (Creature* Copy = DoSpawnCreature(DEMON_FORM, 0, 0, 0, 0, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 6000))
                 {
                     Demon = Copy->GetGUID();
-                    if (me->GetVictim())
-                        Copy->AI()->AttackStart(me->GetVictim());
+                    if (me->GetAutoAttackVictim())
+                        Copy->AI()->AttackStart(me->GetAutoAttackVictim());
                 }
                 //set nightelf final form
                 IsFinalForm = true;
@@ -663,16 +663,16 @@ public:
             if (!UpdateVictim())
                 return;
             //ChaosBlast_Timer
-            if (me->IsWithinDist(me->GetVictim(), 30))
+            if (me->IsWithinDist(me->GetAutoAttackVictim(), 30))
                 me->StopMoving();
 
             if (ChaosBlast_Timer <= diff)
              {
                 // will cast only when in range od spell
-                if (me->IsWithinDist(me->GetVictim(), 30))
+                if (me->IsWithinDist(me->GetAutoAttackVictim(), 30))
                 {
                     //DoCastVictim(SPELL_CHAOS_BLAST, true);
-                    me->CastSpell(me->GetVictim(), SPELL_CHAOS_BLAST, CastSpellExtraArgs().SetOriginalCaster(me->GetGUID()).AddSpellBP0(100));
+                    me->CastSpell(me->GetAutoAttackVictim(), SPELL_CHAOS_BLAST, CastSpellExtraArgs().SetOriginalCaster(me->GetGUID()).AddSpellBP0(100));
                     ChaosBlast_Timer = 3000;
                 }
              } else ChaosBlast_Timer -= diff;

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lurker_below.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_lurker_below.cpp
@@ -178,7 +178,7 @@ public:
         {
             if (!CanStartEvent) // boss is invisible, don't attack
                 return;
-            if (!me->GetVictim() && who->IsValidAttackTarget(me))
+            if (!me->GetAutoAttackVictim() && who->IsValidAttackTarget(me))
             {
                 float attackRadius = me->GetAttackDistance(who);
                 if (me->IsWithinDistInMap(who, attackRadius))
@@ -312,8 +312,8 @@ public:
                 if (GeyserTimer <= diff)
                 {
                     Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1);
-                    if (!target && me->GetVictim())
-                        target = me->GetVictim();
+                    if (!target && me->GetAutoAttackVictim())
+                        target = me->GetAutoAttackVictim();
                     if (target)
                         DoCast(target, SPELL_GEYSER, true);
                     GeyserTimer = rand32() % 5000 + 15000;
@@ -326,8 +326,8 @@ public:
                     if (WaterboltTimer <= diff)
                     {
                         Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0);
-                        if (!target && me->GetVictim())
-                            target = me->GetVictim();
+                        if (!target && me->GetAutoAttackVictim())
+                            target = me->GetAutoAttackVictim();
                         if (target)
                             DoCast(target, SPELL_WATERBOLT, true);
                         WaterboltTimer = 3000;
@@ -418,7 +418,7 @@ public:
         void MoveInLineOfSight(Unit* who) override
 
         {
-            if (!who || me->GetVictim())
+            if (!who || me->GetAutoAttackVictim())
                 return;
 
             if (who->isInAccessiblePlaceFor(me) && me->IsValidAttackTarget(who) && me->IsWithinDistInMap(who, 45))
@@ -429,7 +429,7 @@ public:
         {
             if (MultiShotTimer <= diff)
             {
-                if (me->GetVictim())
+                if (me->GetAutoAttackVictim())
                     DoCastVictim(SPELL_SPREAD_SHOT, true);
 
                 MultiShotTimer = 10000 + rand32() % 10000;

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_morogrim_tidewalker.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_morogrim_tidewalker.cpp
@@ -330,7 +330,7 @@ public:
         void MoveInLineOfSight(Unit* who) override
 
         {
-            if (!who || me->GetVictim())
+            if (!who || me->GetAutoAttackVictim())
                 return;
 
             if (me->CanCreatureAttack(who))
@@ -349,7 +349,7 @@ public:
 
             if (Check_Timer <= diff)
             {
-                if (me->IsWithinDistInMap(me->GetVictim(), 5))
+                if (me->IsWithinDistInMap(me->GetAutoAttackVictim(), 5))
                 {
                     DoCastVictim(SPELL_GLOBULE_EXPLOSION);
 

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/instance_serpent_shrine.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/instance_serpent_shrine.cpp
@@ -155,7 +155,7 @@ class instance_serpent_shrine : public InstanceMapScript
                                     {
                                         if (Creature* frenzy = player->SummonCreature(NPC_COILFANG_FRENZY, player->GetPositionX(), player->GetPositionY(), player->GetPositionZ(), player->GetOrientation(), TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 2000))
                                         {
-                                            frenzy->Attack(player, false);
+                                            frenzy->AutoAttackStart(player, false);
                                             frenzy->SetSwim(true);
                                             frenzy->SetDisableGravity(true);
                                         }

--- a/src/server/scripts/Outland/CoilfangReservoir/TheUnderbog/boss_the_black_stalker.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/TheUnderbog/boss_the_black_stalker.cpp
@@ -99,8 +99,8 @@ public:
                 if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 1))
                     summon->AI()->AttackStart(target);
                 else
-                    if (me->GetVictim())
-                        summon->AI()->AttackStart(me->GetVictim());
+                    if (me->GetAutoAttackVictim())
+                        summon->AI()->AttackStart(me->GetAutoAttackVictim());
             }
         }
 

--- a/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_gruul.cpp
@@ -156,8 +156,8 @@ class boss_gruul : public CreatureScript
                         //and correct movement, if not already
                         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
                         {
-                            if (me->GetVictim())
-                                me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            if (me->GetAutoAttackVictim())
+                                me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                         }
                     }
                 }
@@ -208,7 +208,7 @@ class boss_gruul : public CreatureScript
                     {
                         Unit* target = SelectTarget(SELECT_TARGET_MAXTHREAT, 1);
 
-                        if (target && me->IsWithinMeleeRange(me->GetVictim()))
+                        if (target && me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                             DoCast(target, SPELL_HURTFUL_STRIKE);
                         else
                             DoCastVictim(SPELL_HURTFUL_STRIKE);

--- a/src/server/scripts/Outland/GruulsLair/boss_high_king_maulgar.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_high_king_maulgar.cpp
@@ -245,7 +245,7 @@ public:
             if (!who)
                 return;
 
-            if (me->Attack(who, true))
+            if (me->AutoAttackStart(who, true))
             {
                 AddThreat(who, 0.0f);
                 me->SetInCombatWith(who);
@@ -537,7 +537,7 @@ public:
                 return;
 
             //GreaterFireball_Timer
-            if (GreaterFireball_Timer < diff || me->IsWithinDist(me->GetVictim(), 30))
+            if (GreaterFireball_Timer < diff || me->IsWithinDist(me->GetAutoAttackVictim(), 30))
             {
                 DoCastVictim(SPELL_GREATER_FIREBALL);
                 GreaterFireball_Timer = 2000;
@@ -557,7 +557,7 @@ public:
                 std::vector<Unit*> target_list;
                 for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                 {
-                    Unit* target = ref->GetVictim();
+                    Unit* target = ref->GetAutoAttackVictim();
                     if (target && target->IsWithinDist(me, 15, false)) // 15 yard radius minimum
                         target_list.push_back(target);
                 }

--- a/src/server/scripts/Outland/GruulsLair/boss_high_king_maulgar.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_high_king_maulgar.cpp
@@ -557,7 +557,7 @@ public:
                 std::vector<Unit*> target_list;
                 for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                 {
-                    Unit* target = ref->GetAutoAttackVictim();
+                    Unit* target = ref->GetVictim();
                     if (target && target->IsWithinDist(me, 15, false)) // 15 yard radius minimum
                         target_list.push_back(target);
                 }

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_omor_the_unscarred.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_omor_the_unscarred.cpp
@@ -159,8 +159,8 @@ class boss_omor_the_unscarred : public CreatureScript
                     if (OrbitalStrike_Timer <= diff)
                     {
                         Unit* temp = nullptr;
-                        if (me->IsWithinMeleeRange(me->GetVictim()))
-                            temp = me->GetVictim();
+                        if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
+                            temp = me->GetAutoAttackVictim();
                         else temp = SelectTarget(SELECT_TARGET_RANDOM, 0);
 
                         if (temp && temp->GetTypeId() == TYPEID_PLAYER)
@@ -204,7 +204,7 @@ class boss_omor_the_unscarred : public CreatureScript
                 {
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                     {
-                        target = me->GetVictim();
+                        target = me->GetAutoAttackVictim();
 
                         DoCast(target, SPELL_SHADOW_BOLT);
                         Shadowbolt_Timer = 4000 + rand32() % 2500;

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -144,7 +144,7 @@ class boss_nazan : public CreatureScript
                         me->GetMotionMaster()->Clear();
                         if (Unit* victim = SelectTarget(SELECT_TARGET_MINDISTANCE, 0))
                             AttackStart(victim);
-                        DoStartMovement(me->GetVictim());
+                        DoStartMovement(me->GetAutoAttackVictim());
                         Talk(EMOTE);
                         return;
                     }
@@ -267,7 +267,7 @@ class boss_vazruden : public CreatureScript
 
                 if (Revenge_Timer <= diff)
                 {
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                         DoCast(victim, DUNGEON_MODE(SPELL_REVENGE, SPELL_REVENGE_H));
                     Revenge_Timer = 5000;
                 }
@@ -371,7 +371,7 @@ class boss_vazruden_the_herald : public CreatureScript
             {
                 if (!summon)
                     return;
-                Unit* victim = me->GetVictim();
+                Unit* victim = me->GetAutoAttackVictim();
                 if (summon->GetEntry() == NPC_NAZAN)
                 {
                     summon->SetDisableGravity(true);
@@ -428,7 +428,7 @@ class boss_vazruden_the_herald : public CreatureScript
                         Creature* Vazruden = ObjectAccessor::GetCreature(*me, VazrudenGUID);
                         if ((Nazan && Nazan->IsAlive()) || (Vazruden && Vazruden->IsAlive()))
                         {
-                            if ((Nazan && Nazan->GetVictim()) || (Vazruden && Vazruden->GetVictim()))
+                            if ((Nazan && Nazan->GetAutoAttackVictim()) || (Vazruden && Vazruden->GetAutoAttackVictim()))
                                 return;
                             else
                             {
@@ -501,7 +501,7 @@ class npc_hellfire_sentry : public CreatureScript
 
                 if (KidneyShot_Timer <= diff)
                 {
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                         DoCast(victim, SPELL_KIDNEY_SHOT);
                     KidneyShot_Timer = 20000;
                 }

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_watchkeeper_gargolmar.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_watchkeeper_gargolmar.cpp
@@ -86,7 +86,7 @@ class boss_watchkeeper_gargolmar : public CreatureScript
 
             void MoveInLineOfSight(Unit* who) override
             {
-                if (!me->GetVictim() && me->CanCreatureAttack(who))
+                if (!me->GetAutoAttackVictim() && me->CanCreatureAttack(who))
                 {
                     if (!me->CanFly() && me->GetDistanceZ(who) > CREATURE_Z_ATTACK_RANGE)
                         return;

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -196,7 +196,7 @@ class boss_magtheridon : public CreatureScript
                 {
                     events.SetPhase(PHASE_3);
                     me->SetReactState(REACT_PASSIVE);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     Talk(SAY_COLLAPSE);
                     instance->SetData(DATA_COLLAPSE, ACTION_ENABLE);
                     DoCastAOE(SPELL_CAMERA_SHAKE);

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
@@ -172,7 +172,7 @@ class boss_grand_warlock_nethekurse : public CreatureScript
                 if (IsIntroEvent || !IsMainEvent)
                     return;
 
-                if (me->Attack(who, true))
+                if (me->AutoAttackStart(who, true))
                 {
                     if (Phase)
                         DoStartNoMovement(who);

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_warchief_kargath_bladefist.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_warchief_kargath_bladefist.cpp
@@ -227,7 +227,7 @@ class boss_warchief_kargath_bladefist : public CreatureScript
                                 // stop bladedance
                                 InBlade = false;
                                 me->SetSpeedRate(MOVE_RUN, 2);
-                                me->GetMotionMaster()->MoveChase(me->GetVictim());
+                                me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                                 Blade_Dance_Timer = 30000;
                                 Wait_Timer = 0;
                                 if (IsHeroic())

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_alar.cpp
@@ -209,8 +209,8 @@ class boss_alar : public CreatureScript
                         me->InterruptNonMeleeSpells(true);
                         me->RemoveAllAuras();
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                        me->AttackStop();
-                        me->SetTarget(ObjectGuid::Empty);
+                        me->AutoAttackStop();
+                        me->SetPrimaryTarget(ObjectGuid::Empty);
                         me->SetSpeedRate(MOVE_RUN, 5.0f);
                         me->GetMotionMaster()->Clear();
                         me->GetMotionMaster()->MovePoint(0, waypoint[5][0], waypoint[5][1], waypoint[5][2]);
@@ -418,7 +418,7 @@ class boss_alar : public CreatureScript
 
                     if (DiveBomb_Timer <= diff)
                     {
-                        me->AttackStop();
+                        me->AutoAttackStop();
                         me->GetMotionMaster()->MovePoint(6, waypoint[4][0], waypoint[4][1], waypoint[4][2]);
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         me->SetFloatValue(UNIT_FIELD_BOUNDINGRADIUS, 50);
@@ -458,9 +458,9 @@ class boss_alar : public CreatureScript
             {
                 if (me->isAttackReady() && !me->IsNonMeleeSpellCast(false))
                 {
-                    if (me->IsWithinMeleeRange(me->GetVictim()))
+                    if (me->IsWithinMeleeRange(me->GetAutoAttackVictim()))
                     {
-                        me->AttackerStateUpdate(me->GetVictim());
+                        me->AttackerStateUpdate(me->GetAutoAttackVictim());
                         me->resetAttackTimer();
                     }
                     else

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_astromancer.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_astromancer.cpp
@@ -210,7 +210,7 @@ class boss_high_astromancer_solarian : public CreatureScript
                 if (AppearDelay)
                 {
                     me->StopMoving();
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     if (AppearDelay_Timer <= diff)
                     {
                         AppearDelay = false;
@@ -256,7 +256,7 @@ class boss_high_astromancer_solarian : public CreatureScript
                             if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                             {
                                 if (!me->HasInArc(2.5f, target))
-                                    target = me->GetVictim();
+                                    target = me->GetAutoAttackVictim();
 
                                 DoCast(target, SPELL_ARCANE_MISSILES);
                             }
@@ -331,7 +331,7 @@ class boss_high_astromancer_solarian : public CreatureScript
                 else if (Phase == 2)
                 {
                     //10 seconds after Solarian disappears, 12 mobs spawn out of the three portals.
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->StopMoving();
                     if (Phase2_Timer <= diff)
                     {
@@ -348,7 +348,7 @@ class boss_high_astromancer_solarian : public CreatureScript
                 }
                 else if (Phase == 3)
                 {
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->StopMoving();
                     //Check Phase3_Timer
                     if (Phase3_Timer <= diff)

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -385,7 +385,7 @@ struct advisorbase_ai : public ScriptedAI
             me->ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, false);
             me->ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, false);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_STUNNED);
-            me->SetTarget(ObjectGuid::Empty);
+            me->SetPrimaryTarget(ObjectGuid::Empty);
             me->SetStandState(UNIT_STAND_STATE_DEAD);
             me->GetMotionMaster()->Clear();
             JustDied(killer);
@@ -411,7 +411,7 @@ struct advisorbase_ai : public ScriptedAI
 
                 Unit* Target = ObjectAccessor::GetUnit(*me, DelayRes_Target);
                 if (!Target)
-                    Target = me->GetVictim();
+                    Target = me->GetAutoAttackVictim();
 
                 ResetThreatList();
                 AttackStart(Target);
@@ -459,7 +459,7 @@ class boss_kaelthas : public CreatureScript
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
                 me->SetDisableGravity(false);
-                me->SetTarget(ObjectGuid::Empty);
+                me->SetPrimaryTarget(ObjectGuid::Empty);
                 me->SetObjectScale(1.0f);
                 BossAI::Reset();
             }
@@ -564,7 +564,7 @@ class boss_kaelthas : public CreatureScript
                     DoAction(ACTION_START_ENCOUNTER);
                     who->SetInCombatWith(me);
                     AddThreat(who, 0.0f);
-                    me->SetTarget(who->GetGUID());
+                    me->SetPrimaryTarget(who->GetGUID());
                 }
             }
 
@@ -575,13 +575,13 @@ class boss_kaelthas : public CreatureScript
                     DoAction(ACTION_START_ENCOUNTER);
 
                     if (attacker)
-                        me->SetTarget(attacker->GetGUID());
+                        me->SetPrimaryTarget(attacker->GetGUID());
                 }
 
                 if (!_hasFullPower && me->HealthBelowPctDamaged(50, damage))
                 {
                     _hasFullPower = true;
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     me->InterruptNonMeleeSpells(false);
                     events.CancelEventGroup(EVENT_GROUP_COMBAT);
                     events.CancelEventGroup(EVENT_GROUP_SPECIAL);
@@ -1092,7 +1092,7 @@ class boss_grand_astromancer_capernian : public CreatureScript
                 if (!who || me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE))
                     return;
 
-                if (me->Attack(who, true))
+                if (me->AutoAttackStart(who, true))
                 {
                     AddThreat(who, 0.0f);
                     me->SetInCombatWith(who);
@@ -1145,7 +1145,7 @@ class boss_grand_astromancer_capernian : public CreatureScript
                     Unit* target = nullptr;
                     for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                     {
-                        Unit* unit = ref->GetVictim();
+                        Unit* unit = ref->GetAutoAttackVictim();
                         if (unit->IsWithinMeleeRange(me))
                         {
                             InMeleeRange = true;
@@ -1410,7 +1410,7 @@ class npc_phoenix_egg_tk : public CreatureScript
 
             void AttackStart(Unit* who) override
             {
-                if (me->Attack(who, false))
+                if (me->AutoAttackStart(who, false))
                 {
                     me->SetInCombatWith(who);
                     who->SetInCombatWith(me);
@@ -1421,7 +1421,7 @@ class npc_phoenix_egg_tk : public CreatureScript
 
             void JustSummoned(Creature* summoned) override
             {
-                AddThreat(me->GetVictim(), 0.0f, summoned);
+                AddThreat(me->GetAutoAttackVictim(), 0.0f, summoned);
                 summoned->CastSpell(summoned, SPELL_REBIRTH, false);
             }
 

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -1145,7 +1145,7 @@ class boss_grand_astromancer_capernian : public CreatureScript
                     Unit* target = nullptr;
                     for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                     {
-                        Unit* unit = ref->GetAutoAttackVictim();
+                        Unit* unit = ref->GetVictim();
                         if (unit->IsWithinMeleeRange(me))
                         {
                             InMeleeRange = true;

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
@@ -114,7 +114,7 @@ class boss_void_reaver : public CreatureScript
                             std::vector<Unit*> target_list;
                             for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                             {
-                                Unit* target = ref->GetAutoAttackVictim();
+                                Unit* target = ref->GetVictim();
                                 if (target->GetTypeId() == TYPEID_PLAYER && target->IsAlive() && !target->IsWithinDist(me, 18, false))
                                     target_list.push_back(target);
                             }

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
@@ -114,7 +114,7 @@ class boss_void_reaver : public CreatureScript
                             std::vector<Unit*> target_list;
                             for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
                             {
-                                Unit* target = ref->GetVictim();
+                                Unit* target = ref->GetAutoAttackVictim();
                                 if (target->GetTypeId() == TYPEID_PLAYER && target->IsAlive() && !target->IsWithinDist(me, 18, false))
                                     target_list.push_back(target);
                             }
@@ -123,7 +123,7 @@ class boss_void_reaver : public CreatureScript
                             if (!target_list.empty())
                                 target = *(target_list.begin() + rand32() % target_list.size());
                             else
-                                target = me->GetVictim();
+                                target = me->GetAutoAttackVictim();
 
                             if (target)
                                 me->CastSpell(target, SPELL_ARCANE_ORB);
@@ -134,8 +134,8 @@ class boss_void_reaver : public CreatureScript
                         case EVENT_KNOCK_AWAY:
                             DoCastVictim(SPELL_KNOCK_AWAY);
                             // Drop 25% aggro
-                            if (GetThreat(me->GetVictim()))
-                                ModifyThreatByPercent(me->GetVictim(), -25);
+                            if (GetThreat(me->GetAutoAttackVictim()))
+                                ModifyThreatByPercent(me->GetAutoAttackVictim(), -25);
 
                             events.ScheduleEvent(EVENT_KNOCK_AWAY, 30s);
                             break;

--- a/src/server/scripts/Outland/TempestKeep/Eye/the_eye.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/the_eye.cpp
@@ -79,7 +79,7 @@ class npc_crystalcore_devastator : public CreatureScript
                 //Knockaway_Timer
                 if (Knockaway_Timer <= diff)
                 {
-                    if (Unit* victim = me->GetVictim())
+                    if (Unit* victim = me->GetAutoAttackVictim())
                     {
                         DoCastVictim(SPELL_KNOCKAWAY, true);
                         me->GetThreatManager().ResetThreat(victim);

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/arcatraz.cpp
@@ -117,7 +117,7 @@ class npc_millhouse_manastorm : public CreatureScript
 
             void AttackStart(Unit* who) override
             {
-                if (me->Attack(who, true))
+                if (me->AutoAttackStart(who, true))
                 {
                     AddThreat(who, 0.0f);
                     me->SetInCombatWith(who);
@@ -320,7 +320,7 @@ class npc_warden_mellichar : public CreatureScript
                 if (IsRunning)
                     return;
 
-                if (!me->GetVictim() && me->CanCreatureAttack(who))
+                if (!me->GetAutoAttackVictim() && me->CanCreatureAttack(who))
                 {
                     if (!me->CanFly() && me->GetDistanceZ(who) > CREATURE_Z_ATTACK_RANGE)
                         return;

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/boss_harbinger_skyriss.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/boss_harbinger_skyriss.cpp
@@ -129,7 +129,7 @@ class boss_harbinger_skyriss : public CreatureScript
                     summon->SetHealth(summon->CountPctFromMaxHealth(33));
                 else
                     summon->SetHealth(summon->CountPctFromMaxHealth(66));
-                if (me->GetVictim())
+                if (me->GetAutoAttackVictim())
                     if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0))
                         summon->AI()->AttackStart(target);
 

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_high_botanist_freywinn.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_high_botanist_freywinn.cpp
@@ -183,7 +183,7 @@ class boss_high_botanist_freywinn : public CreatureScript
 
                             me->InterruptNonMeleeSpells(true);
                             me->RemoveAllAuras();
-                            me->GetMotionMaster()->MoveChase(me->GetVictim());
+                            me->GetMotionMaster()->MoveChase(me->GetAutoAttackVictim());
                             MoveFree = true;
                         }
                         MoveCheck_Timer = 500;

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_laj.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_laj.cpp
@@ -171,7 +171,7 @@ class boss_laj : public CreatureScript
 
             void JustSummoned(Creature* summon) override
             {
-                if (summon && me->GetVictim())
+                if (summon && me->GetAutoAttackVictim())
                     summon->AI()->AttackStart(SelectTarget(SELECT_TARGET_RANDOM, 0));
             }
 

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_warp_splinter.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_warp_splinter.cpp
@@ -99,7 +99,7 @@ class npc_warp_splinter_treant : public CreatureScript
 
             void UpdateAI(uint32 diff) override
             {
-                if (!UpdateVictim() || !me->GetVictim())
+                if (!UpdateVictim() || !me->GetAutoAttackVictim())
                 {
                     if (WarpGuid && check_Timer <= diff)
                     {
@@ -121,7 +121,7 @@ class npc_warp_splinter_treant : public CreatureScript
                     return;
                 }
 
-                if (me->EnsureVictim()->GetGUID() != WarpGuid)
+                if (me->GetAutoAttackVictim()->GetGUID() != WarpGuid)
                     DoMeleeAttackIfReady();
             }
         };

--- a/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
+++ b/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
@@ -208,7 +208,7 @@ public:
 
             if (ManaBurn_Timer <= diff)
             {
-                Unit* target = me->GetVictim();
+                Unit* target = me->GetAutoAttackVictim();
                 if (target && target->GetPowerType() == POWER_MANA)
                     DoCast(target, SPELL_MANA_BURN);
                 ManaBurn_Timer = 8000 + rand32() % 8000;

--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -730,14 +730,14 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (!UpdateVictim() || !me->GetVictim())
+            if (!UpdateVictim() || !me->GetAutoAttackVictim())
                 return;
 
             interrupt_cooldown += diff;
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;
 
-            if (me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING) && interrupt_cooldown > 25000)
+            if (me->GetAutoAttackVictim()->HasUnitState(UNIT_STATE_CASTING) && interrupt_cooldown > 25000)
             {
                 DoCastVictim(SPELL_COUNTERSPELL);
                 interrupt_cooldown = 0;

--- a/src/server/scripts/Outland/zone_netherstorm.cpp
+++ b/src/server/scripts/Outland/zone_netherstorm.cpp
@@ -433,8 +433,8 @@ public:
             {
                 std::list<Unit*> UnitsWithMana;
                 for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
-                    if (ref->GetVictim()->GetPower(POWER_MANA))
-                        UnitsWithMana.push_back(ref->GetVictim());
+                    if (ref->GetAutoAttackVictim()->GetPower(POWER_MANA))
+                        UnitsWithMana.push_back(ref->GetAutoAttackVictim());
                 if (!UnitsWithMana.empty())
                 {
                     DoCast(Trinity::Containers::SelectRandomContainerElement(UnitsWithMana), SPELL_MANA_BURN);

--- a/src/server/scripts/Outland/zone_netherstorm.cpp
+++ b/src/server/scripts/Outland/zone_netherstorm.cpp
@@ -433,8 +433,8 @@ public:
             {
                 std::list<Unit*> UnitsWithMana;
                 for (auto* ref : me->GetThreatManager().GetUnsortedThreatList())
-                    if (ref->GetAutoAttackVictim()->GetPower(POWER_MANA))
-                        UnitsWithMana.push_back(ref->GetAutoAttackVictim());
+                    if (ref->GetVictim()->GetPower(POWER_MANA))
+                        UnitsWithMana.push_back(ref->GetVictim());
                 if (!UnitsWithMana.empty())
                 {
                     DoCast(Trinity::Containers::SelectRandomContainerElement(UnitsWithMana), SPELL_MANA_BURN);

--- a/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
+++ b/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
@@ -875,7 +875,7 @@ public:
 
             me->AddUnitState(UNIT_STATE_ROOT);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-            me->SetTarget(ObjectGuid::Empty);
+            me->SetPrimaryTarget(ObjectGuid::Empty);
         }
 
         void JustEngagedWith(Unit* /*who*/) override { }
@@ -905,7 +905,7 @@ public:
             case 5:
                 if (Player* AggroTarget = ObjectAccessor::GetPlayer(*me, AggroTargetGUID))
                 {
-                    me->SetTarget(AggroTarget->GetGUID());
+                    me->SetPrimaryTarget(AggroTarget->GetGUID());
                     AddThreat(AggroTarget, 1);
                     me->HandleEmoteCommand(EMOTE_ONESHOT_POINT);
                 }

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -59,7 +59,7 @@ class npc_pet_dk_ebon_gargoyle : public CreatureScript
                 for (std::list<Unit*>::const_iterator iter = targets.begin(); iter != targets.end(); ++iter)
                     if ((*iter)->HasAura(SPELL_DK_SUMMON_GARGOYLE_1, ownerGuid))
                     {
-                        me->Attack((*iter), false);
+                        me->AutoAttackStart((*iter), false);
                         break;
                     }
             }

--- a/src/server/scripts/Pet/pet_hunter.cpp
+++ b/src/server/scripts/Pet/pet_hunter.cpp
@@ -82,11 +82,11 @@ class npc_pet_hunter_snake_trap : public CreatureScript
 
             void UpdateAI(uint32 diff) override
             {
-                if (me->GetVictim() && me->GetVictim()->HasBreakableByDamageCrowdControlAura())
+                if (me->GetAutoAttackVictim() && me->GetAutoAttackVictim()->HasBreakableByDamageCrowdControlAura())
                 { // don't break cc
                     me->GetThreatManager().ClearFixate();
                     me->InterruptNonMeleeSpells(false);
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     return;
                 }
 

--- a/src/server/scripts/Pet/pet_mage.cpp
+++ b/src/server/scripts/Pet/pet_mage.cpp
@@ -76,11 +76,11 @@ class npc_pet_mage_mirror_image : public CreatureScript
                 if (!me->HasUnitState(UNIT_STATE_CASTING) && !me->IsInCombat() && !owner->IsInCombat())
                     return false;
 
-                Unit* currentTarget = me->GetVictim();
+                Unit* currentTarget = me->GetAutoAttackVictim();
                 if (currentTarget && !CanAIAttack(currentTarget))
                 {
                     me->InterruptNonMeleeSpells(true); // do not finish casting on invalid targets
-                    me->AttackStop();
+                    me->AutoAttackStop();
                     currentTarget = nullptr;
                 }
 
@@ -134,7 +134,7 @@ class npc_pet_mage_mirror_image : public CreatureScript
                     return false;
                 }
 
-                if (selectedTarget != me->GetVictim())
+                if (selectedTarget != me->GetAutoAttackVictim())
                     AttackStartCaster(selectedTarget, CHASE_DISTANCE);
                 return true;
             }

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -768,7 +768,7 @@ class spell_dk_dancing_rune_weapon : public SpellScriptLoader
                     }
                 }
 
-                if (!drw || !drw->GetVictim())
+                if (!drw || !drw->GetAutoAttackVictim())
                     return;
 
                 SpellInfo const* spellInfo = eventInfo.GetSpellInfo();
@@ -780,8 +780,8 @@ class spell_dk_dancing_rune_weapon : public SpellScriptLoader
                     return;
 
                 int32 amount = static_cast<int32>(damageInfo->GetDamage()) / 2;
-                drw->SendSpellNonMeleeDamageLog(drw->GetVictim(), spellInfo->Id, amount, spellInfo->GetSchoolMask(), 0, 0, false, 0, false);
-                Unit::DealDamage(drw, drw->GetVictim(), amount, nullptr, SPELL_DIRECT_DAMAGE, spellInfo->GetSchoolMask(), spellInfo, true);
+                drw->SendSpellNonMeleeDamageLog(drw->GetAutoAttackVictim(), spellInfo->Id, amount, spellInfo->GetSchoolMask(), 0, 0, false, 0, false);
+                Unit::DealDamage(drw, drw->GetAutoAttackVictim(), amount, nullptr, SPELL_DIRECT_DAMAGE, spellInfo->GetSchoolMask(), spellInfo, true);
             }
 
             void Register() override

--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -539,7 +539,7 @@ class spell_hun_feeding_frenzy : public AuraScript
         uint8 rank = GetSpellInfo()->GetRank();
         uint32 spellId = triggerSpells[rank - 1];
 
-        if (GetTarget()->GetVictim() && GetTarget()->EnsureVictim()->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
+        if (GetTarget()->GetAutoAttackVictim() && GetTarget()->GetAutoAttackVictim()->HasAuraState(AURA_STATE_HEALTHLESS_35_PERCENT))
             GetTarget()->CastSpell(nullptr, spellId, aurEff);
         else
             GetTarget()->RemoveAurasDueToSpell(spellId);
@@ -1324,7 +1324,7 @@ class spell_hun_scatter_shot : public SpellScriptLoader
                 Player* caster = GetCaster()->ToPlayer();
                 // break Auto Shot and autohit
                 caster->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
-                caster->AttackStop();
+                caster->AutoAttackStop();
                 caster->SendAttackSwingCancelAttack();
             }
 

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1822,7 +1822,7 @@ class spell_pal_righteous_defense : public SpellScript
 
         if (Unit* target = GetExplTargetUnit())
         {
-            if (!target->IsFriendlyTo(caster) || target == caster || target->getAttackers().empty())
+            if (!target->IsFriendlyTo(caster) || target == caster || target->GetAutoAttackingMe().empty())
                 return SPELL_FAILED_BAD_TARGETS;
         }
         else
@@ -1835,7 +1835,7 @@ class spell_pal_righteous_defense : public SpellScript
     {
         if (Unit* target = GetHitUnit())
         {
-            auto const& attackers = target->getAttackers();
+            auto const& attackers = target->GetAutoAttackingMe();
 
             std::vector<Unit*> list(attackers.cbegin(), attackers.cend());
             Trinity::Containers::RandomResize(list, 3);

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -588,7 +588,7 @@ class spell_rog_prey_on_the_weak : public SpellScriptLoader
             void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
             {
                 Unit* target = GetTarget();
-                Unit* victim = target->GetVictim();
+                Unit* victim = target->GetAutoAttackVictim();
                 if (victim && (target->GetHealthPct() > victim->GetHealthPct()))
                 {
                     if (!target->HasAura(SPELL_ROGUE_PREY_ON_THE_WEAK))

--- a/src/server/scripts/World/npc_guard.cpp
+++ b/src/server/scripts/World/npc_guard.cpp
@@ -117,7 +117,7 @@ struct npc_guard_generic : public GuardAI
 
         _combatScheduler.Schedule(Seconds(1), [this](TaskContext meleeContext)
         {
-            Unit* victim = me->GetVictim();
+            Unit* victim = me->GetAutoAttackVictim();
             if (!me->isAttackReady() || !me->IsWithinMeleeRange(victim))
             {
                 meleeContext.Repeat();
@@ -125,7 +125,7 @@ struct npc_guard_generic : public GuardAI
             }
             if (roll_chance_i(20))
             {
-                if (SpellInfo const* spellInfo = SelectSpell(me->GetVictim(), 0, 0, SELECT_TARGET_ANY_ENEMY, 0, 0, 0, NOMINAL_MELEE_RANGE, SELECT_EFFECT_DONTCARE))
+                if (SpellInfo const* spellInfo = SelectSpell(me->GetAutoAttackVictim(), 0, 0, SELECT_TARGET_ANY_ENEMY, 0, 0, 0, NOMINAL_MELEE_RANGE, SELECT_EFFECT_DONTCARE))
                 {
                     me->resetAttackTimer();
                     DoCastVictim(spellInfo->Id);
@@ -152,7 +152,7 @@ struct npc_guard_generic : public GuardAI
             if (spellInfo)
                 healing = true;
             else
-                spellInfo = SelectSpell(me->GetVictim(), 0, 0, SELECT_TARGET_ANY_ENEMY, 0, 0, NOMINAL_MELEE_RANGE, 0, SELECT_EFFECT_DONTCARE);
+                spellInfo = SelectSpell(me->GetAutoAttackVictim(), 0, 0, SELECT_TARGET_ANY_ENEMY, 0, 0, NOMINAL_MELEE_RANGE, 0, SELECT_EFFECT_DONTCARE);
 
             // Found a spell
             if (spellInfo)
@@ -215,7 +215,7 @@ struct npc_guard_shattrath_faction : public GuardAI
     {
         _scheduler.Schedule(Seconds(5), [this](TaskContext banishContext)
         {
-            Unit* temp = me->GetVictim();
+            Unit* temp = me->GetAutoAttackVictim();
             if (temp && temp->GetTypeId() == TYPEID_PLAYER)
             {
                 DoCast(temp, me->GetEntry() == NPC_ALDOR_VINDICATOR ? SPELL_BANISHED_SHATTRATH_S : SPELL_BANISHED_SHATTRATH_A);

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -204,7 +204,7 @@ public:
                             }
 
                             if (markAura->GetDuration() < AURA_DURATION_TIME_LEFT)
-                                if (!lastSpawnedGuard->GetVictim())
+                                if (!lastSpawnedGuard->GetAutoAttackVictim())
                                     lastSpawnedGuard->AI()->AttackStart(who);
                         }
                         else
@@ -231,7 +231,7 @@ public:
                             return;
 
                         // ROOFTOP only triggers if the player is on the ground
-                        if (!playerTarget->IsFlying() && !lastSpawnedGuard->GetVictim())
+                        if (!playerTarget->IsFlying() && !lastSpawnedGuard->GetAutoAttackVictim())
                             lastSpawnedGuard->AI()->AttackStart(who);
 
                         break;


### PR DESCRIPTION
The first batch of refactors to keep #22461 manageable.

At its core, we split the current targeting apart somewhat - from two targets (auto-attack victim and currently selected unit) to three (auto-attack victim, primary target, and currently selected unit).

As a consequence, I also cleaned up function signatures, and made spell focusing less ugly.

## Selected unit 
* `GetTarget` -> `GetSelectedUnitGUID`
* MOVED `GetSelectedUnit` (from `Player` to `Unit`)
* MOVED `GetSelectedPlayer` (from `Player` to `Unit`)
* `SetTarget` REMOVED
* ADDED `UpdateSelectedUnit`

## Primary target
* ADDED `SetPrimaryTarget`
* ADDED `StopTargetingMe`
* ADDED `GetPrimaryTarget`

## Auto-attack victim
* getAttackerForHelper -> GetAttackerForHelper
* `Attack` -> `AutoAttackStart`
* `AttackStop` -> `AutoAttackStop`
* `GetVictim` -> `GetAutoAttackVictim`
* `EnsureVictim` REMOVED
* `RemoveAllAttackers` -> `StopAutoAttackingMe`
* `ValidateAttackersAndOwnTarget` -> `ValidateAutoAttackStates`

## Spell focus system
* `IsFocusing` -> `HasSpellFocusTarget`
* ADDED `GetSpellFocusTarget`
* `FocusTarget` -> `SetSpellFocus`
* `ReleaseFocus` -> `ReleaseSpellFocus`
* ADDED `ClearSpellFocus`
* REMOVED `MustReacquireTarget`
* REMOVED `DoNotReacquireTarget`