### PR TITLE
Core/Creatures: Profession trainer fixes

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -48,10 +48,17 @@ namespace Trainer
             if (!player->IsSpellFitByClassAndRace(trainerSpell.SpellId))
                 continue;
 
+            SpellInfo const* trainerSpellInfo = sSpellMgr->AssertSpellInfo(trainerSpell.SpellId);
+            if (!trainerSpellInfo)
+                continue;
+
             bool primaryProfessionFirstRank = false;
-            for (int32 reqAbility : trainerSpell.ReqAbility)
+            for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             {
-                SpellInfo const* learnedSpellInfo = sSpellMgr->GetSpellInfo(reqAbility);
+                if (trainerSpellInfo->Effects[i].Effect != SPELL_EFFECT_LEARN_SPELL)
+                    continue;
+
+                SpellInfo const* learnedSpellInfo = sSpellMgr->GetSpellInfo(trainerSpellInfo->Effects[i].TriggerSpell);
                 if (learnedSpellInfo && learnedSpellInfo->IsPrimaryProfessionFirstRank())
                     primaryProfessionFirstRank = true;
             }
@@ -132,8 +139,18 @@ namespace Trainer
             return false;
 
         SpellInfo const* trainerSpellInfo = sSpellMgr->AssertSpellInfo(trainerSpell->SpellId);
-        if (trainerSpellInfo->IsPrimaryProfessionFirstRank() && !player->GetFreePrimaryProfessionPoints())
+        if (!trainerSpellInfo)
             return false;
+
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        {
+            if (trainerSpellInfo->Effects[i].Effect != SPELL_EFFECT_LEARN_SPELL)
+                continue;
+
+            SpellInfo const* learnedSpellInfo = sSpellMgr->GetSpellInfo(trainerSpellInfo->Effects[i].TriggerSpell);
+            if (learnedSpellInfo && learnedSpellInfo->IsPrimaryProfessionFirstRank() && !player->GetFreePrimaryProfessionPoints())
+                return false;
+        }
 
         return true;
     }

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -48,9 +48,7 @@ namespace Trainer
             if (!player->IsSpellFitByClassAndRace(trainerSpell.SpellId))
                 continue;
 
-            SpellInfo const* trainerSpellInfo = sSpellMgr->GetSpellInfo(trainerSpell.SpellId);
-            if (!trainerSpellInfo)
-                continue;
+            SpellInfo const* trainerSpellInfo = sSpellMgr->AssertSpellInfo(trainerSpell.SpellId);
 
             bool primaryProfessionFirstRank = false;
             for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -48,7 +48,7 @@ namespace Trainer
             if (!player->IsSpellFitByClassAndRace(trainerSpell.SpellId))
                 continue;
 
-            SpellInfo const* trainerSpellInfo = sSpellMgr->AssertSpellInfo(trainerSpell.SpellId);
+            SpellInfo const* trainerSpellInfo = sSpellMgr->GetSpellInfo(trainerSpell.SpellId);
             if (!trainerSpellInfo)
                 continue;
 
@@ -139,8 +139,6 @@ namespace Trainer
             return false;
 
         SpellInfo const* trainerSpellInfo = sSpellMgr->AssertSpellInfo(trainerSpell->SpellId);
-        if (!trainerSpellInfo)
-            return false;
 
         for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
         {


### PR DESCRIPTION
**Changes proposed:**

- Correctly check TriggerSpell for professions instead of ReqAbility.
- Fixed an issue, where profession ranks counted towards the max profession amount.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #22903 

**Tests performed:** Builds, tested by attempting to train more than two professions, along with training next rank of a profession.

**Known issues and TODO list:**
- Cleanup?
