### PR TITLE
Add quick events for easier event handling

### DIFF
--- a/src/common/Utilities/EventProcessor.cpp
+++ b/src/common/Utilities/EventProcessor.cpp
@@ -78,6 +78,17 @@ void EventProcessor::Update(uint32 p_time)
         // the next update tick
         AddEvent(event, CalculateTime(1), false);
     }
+
+    auto itr = m_quickEvents.begin();
+    auto end = m_quickEvents.upper_bound(m_time);
+    while (itr != end && itr != m_quickEvents.end())
+    {
+        itr->second();
+        ++itr;
+    }
+
+    if (itr != end)
+        m_quickEvents.erase(m_quickEvents.begin(), end);
 }
 
 void EventProcessor::KillAllEvents(bool force)
@@ -109,6 +120,11 @@ void EventProcessor::KillAllEvents(bool force)
 
     if (force)
         m_events.clear();
+}
+
+void EventProcessor::AddEvent(const std::function<void()>& func, uint64 e_time)
+{
+    m_quickEvents.insert({ e_time, func });
 }
 
 void EventProcessor::AddEvent(BasicEvent* event, uint64 e_time, bool set_addtime)

--- a/src/common/Utilities/EventProcessor.h
+++ b/src/common/Utilities/EventProcessor.h
@@ -22,9 +22,8 @@
 #include "Define.h"
 #include "Duration.h"
 #include <map>
-#include "Random.h"
-
 #include <functional>
+#include "Random.h"
 
 class EventProcessor;
 

--- a/src/common/Utilities/EventProcessor.h
+++ b/src/common/Utilities/EventProcessor.h
@@ -24,6 +24,8 @@
 #include <map>
 #include "Random.h"
 
+#include <functional>
+
 class EventProcessor;
 
 // Note. All times are in milliseconds here.
@@ -79,6 +81,9 @@ class TC_COMMON_API EventProcessor
         void Update(uint32 p_time);
         void KillAllEvents(bool force);
         void AddEvent(BasicEvent* event, uint64 e_time, bool set_addtime = true);
+
+        void AddEvent(const std::function<void()>& func, uint64 e_time);
+
         void AddEventAtOffset(BasicEvent* event, Milliseconds offset) { AddEvent(event, CalculateTime(offset.count())); }
         void AddEventAtOffset(BasicEvent* event, Milliseconds offset, Milliseconds offset2) { AddEvent(event, CalculateTime(urand(offset.count(), offset2.count()))); }
         void ModifyEventTime(BasicEvent* event, uint64 newTime);
@@ -87,6 +92,7 @@ class TC_COMMON_API EventProcessor
     protected:
         uint64 m_time;
         std::multimap<uint64, BasicEvent*> m_events;
+        std::multimap< uint64, std::function<void()>> m_quickEvents;
 };
 
 #endif

--- a/src/common/Utilities/EventProcessor.h
+++ b/src/common/Utilities/EventProcessor.h
@@ -92,7 +92,7 @@ class TC_COMMON_API EventProcessor
     protected:
         uint64 m_time;
         std::multimap<uint64, BasicEvent*> m_events;
-        std::multimap< uint64, std::function<void()>> m_quickEvents;
+        std::multimap<uint64, std::function<void()>> m_quickEvents;
 };
 
 #endif


### PR DESCRIPTION
**Changes proposed:**
Add another container that plays nicely with lambdas to ease event development.

Instead of having to create a whole seperate class that derives from `BasicEvent` this addition will allow simple future actions to be added by just adding a lambda to the EventProcessor instead.

**Target branch(es):** 3.3.5

- [x] 3.3.5