### PR TITLE
Fix non pch

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/instance_steam_vault.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/instance_steam_vault.cpp
@@ -17,6 +17,7 @@
 
 #include "ScriptMgr.h"
 #include "Creature.h"
+#include "CreatureAI.h"
 #include "GameObject.h"
 #include "GameObjectAI.h"
 #include "InstanceScript.h"


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix https://travis-ci.org/Rochet2/TrinityCore3.3.5/jobs/476032902#L1970-L1977
```
/home/travis/build/Rochet2/TrinityCore3.3.5/server/src/server/scripts/Outland/CoilfangReservoir/SteamVault/instance_steam_vault.cpp:34:29: fatal error: member access into incomplete type 'CreatureAI'
            controller->AI()->Talk(CONTROLLER_TEXT_ACESS_USED);
                            ^
/home/travis/build/Rochet2/TrinityCore3.3.5/server/src/server/game/Scripting/ScriptMgr.h:35:7: note: forward declaration of 'CreatureAI'
class CreatureAI;
      ^
1 error generated.
make[2]: *** [src/server/scripts/CMakeFiles/scripts_outland.dir/Outland/CoilfangReservoir/SteamVault/instance_steam_vault.cpp.o] Error 1
```

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)
