### PR TITLE
Scripts/Spells: Fix infinite loop in Power Word Shield

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1029,6 +1029,10 @@ class spell_pri_power_word_shield : public SpellScriptLoader
                 if (dmgInfo.GetAttacker() == target)
                     return;
 
+                // Don't try to reflect the reflect spell
+                if (dmgInfo.GetSpellInfo() && dmgInfo.GetSpellInfo()->Id == SPELL_PRIEST_REFLECTIVE_SHIELD_TRIGGERED)
+                    return;
+
                 if (AuraEffect* talentAurEff = target->GetAuraEffectOfRankedSpell(SPELL_PRIEST_REFLECTIVE_SHIELD_R1, EFFECT_0))
                 {
                     CastSpellExtraArgs args(aurEff);


### PR DESCRIPTION
Fix infinite loop in Power Word Shield triggering back and forth the damage spell between 2 players, both with Power Word Shield and Reflective Shield talent https://wotlk.evowow.com/?spell=33201

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't try to reflect the reflecting spell  

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
Closes https://github.com/TrinityCore/TrinityCore/issues/22917

**Tests performed:** (Does it build, tested in-game, etc.)
None

**Known issues and TODO list:** (add/remove lines as needed)
- [x] Need to repro the issue to confirm the steps
- [x] Need to test ingame that the fix works

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
