### PR TITLE
Core/GameObject: Move "Invalid faction ID 0" log to debug

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2564,7 +2564,12 @@ FactionTemplateEntry const* WorldObject::GetFactionTemplateEntry() const
         else if (Creature const* creature = ToCreature())
             TC_LOG_ERROR("entities", "Creature (template id: %u) has invalid faction (faction template id) #%u", creature->GetCreatureTemplate()->Entry, GetFaction());
         else if (GameObject const* go = ToGameObject())
-            TC_LOG_ERROR("entities", "GameObject (template id: %u) has invalid faction (faction template id) #%u", go->GetGOInfo()->entry, GetFaction());
+        {
+            if (GetFaction() == 0)
+                TC_LOG_DEBUG("entities", "GameObject (template id: %u) has empty faction (faction template id) #%u", go->GetGOInfo()->entry, GetFaction());
+            else
+                TC_LOG_ERROR("entities", "GameObject (template id: %u) has invalid faction (faction template id) #%u", go->GetGOInfo()->entry, GetFaction());
+        }
         else
             TC_LOG_ERROR("entities", "WorldObject (name: %s, type: %u) has invalid faction (faction template id) #%u", GetName().c_str(), uint32(GetTypeId()), GetFaction());
     }


### PR DESCRIPTION
Move "GameObject (template id: %u) has empty faction (faction template id) #%u" log from ERROR to DEBUG when the faction is 0 as this seems to be quite common even in sniffs.
If this is not supposed to happen, feel free to set the proper GameObject faction in the database.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Move "GameObject (template id: %u) has empty faction (faction template id) #%u" log from ERROR to DEBUG when the faction is 0 as this seems to be quite common even in sniffs.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
 None

**Tests performed:** (Does it build, tested in-game, etc.)
None

**Known issues and TODO list:** (add/remove lines as needed)
Not totally sure it's ok for GameObject to have faction 0 but none has been doing anything so far about that anyway so we can safely move the log to DEBUG


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
