### PR TITLE
Core/Movement: Fix some undermap issues with random movement/fear/blink

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -3308,8 +3308,8 @@ void WorldObject::MovePositionToFirstCollision(Position &pos, float dist, float 
     {
         if (Unit const* unit = ToUnit())
         {
-            // flying, ignore.
-            if (unit->IsFlying())
+            // unit can fly, ignore.
+            if (unit->CanFly())
                 return;
 
             // fall back to gridHeight if any

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1422,40 +1422,29 @@ void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z) const
 
     if (Unit const* unit = ToUnit())
     {
-        if (!unit->CanFly())
-        {
-            bool canSwim = unit->CanSwim();
-            float ground_z = z;
-            float max_z;
-            if (canSwim)
-                max_z = GetMapWaterOrGroundLevel(x, y, z, &ground_z);
-            else
-                max_z = ground_z = GetMapHeight(x, y, z);
+        // Unit is flying, ignore.
+        if (unit->IsFlying())
+            return;
 
-            if (max_z > INVALID_HEIGHT)
-            {
-                // hovering units cannot go below their hover height
-                float hoverOffset = unit->GetHoverOffset();
-                max_z += hoverOffset;
-                ground_z += hoverOffset;
-
-                if (z > max_z)
-                    z = max_z;
-                else if (z < ground_z)
-                    z = ground_z;
-            }
-        }
+        bool canSwim = unit->CanSwim();
+        float ground_z = z;
+        float max_z;
+        if (canSwim)
+            max_z = GetMapWaterOrGroundLevel(x, y, z, &ground_z);
         else
+            max_z = ground_z = GetMapHeight(x, y, z);
+
+        if (max_z > INVALID_HEIGHT)
         {
-            float const gridHeight = GetMap()->GetGridHeight(x, y) + unit->GetHoverOffset();
-            float const vmapHeight = GetMap()->GetVmapDataFloorZ(x, y, z); // don't add hover offset here. if check might return unintended value
-            // Check if vmap under us
-            if (vmapHeight <= INVALID_HEIGHT)
-            {
-                // no vmap found, check if unit is under grid height
-                if (z < gridHeight)
-                    z = gridHeight;
-            }
+            // hovering units cannot go below their hover height
+            float hoverOffset = unit->GetHoverOffset();
+            max_z += hoverOffset;
+            ground_z += hoverOffset;
+
+            if (z > max_z && !unit->CanFly())
+                z = max_z;
+            else if (z < ground_z)
+                z = ground_z;
         }
     }
     else

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1418,7 +1418,12 @@ void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z, float* grou
 {
     // TODO: Allow transports to be part of dynamic vmap tree
     if (GetTransport())
+    {
+        if (groundZ)
+            *groundZ = z;
+
         return;
+    }
 
     if (Unit const* unit = ToUnit())
     {

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1414,7 +1414,7 @@ void WorldObject::UpdateGroundPositionZ(float x, float y, float &z) const
         z = new_z + (isType(TYPEMASK_UNIT) ? static_cast<Unit const*>(this)->GetHoverOffset() : 0.0f);
 }
 
-void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z) const
+void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z, float* groundZ) const
 {
     // TODO: Allow transports to be part of dynamic vmap tree
     if (GetTransport())
@@ -1422,29 +1422,40 @@ void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z) const
 
     if (Unit const* unit = ToUnit())
     {
-        // Unit is flying, ignore.
-        if (unit->IsFlying())
-            return;
-
-        bool canSwim = unit->CanSwim();
-        float ground_z = z;
-        float max_z;
-        if (canSwim)
-            max_z = GetMapWaterOrGroundLevel(x, y, z, &ground_z);
-        else
-            max_z = ground_z = GetMapHeight(x, y, z);
-
-        if (max_z > INVALID_HEIGHT)
+        if (!unit->CanFly())
         {
-            // hovering units cannot go below their hover height
-            float hoverOffset = unit->GetHoverOffset();
-            max_z += hoverOffset;
-            ground_z += hoverOffset;
+            bool canSwim = unit->CanSwim();
+            float ground_z = z;
+            float max_z;
+            if (canSwim)
+                max_z = GetMapWaterOrGroundLevel(x, y, z, &ground_z);
+            else
+                max_z = ground_z = GetMapHeight(x, y, z);
 
-            if (z > max_z && !unit->CanFly())
-                z = max_z;
-            else if (z < ground_z)
+            if (max_z > INVALID_HEIGHT)
+            {
+                // hovering units cannot go below their hover height
+                float hoverOffset = unit->GetHoverOffset();
+                max_z += hoverOffset;
+                ground_z += hoverOffset;
+
+                if (z > max_z)
+                    z = max_z;
+                else if (z < ground_z)
+                    z = ground_z;
+            }
+
+            if (groundZ)
+                *groundZ = ground_z;
+        }
+        else
+        {
+            float ground_z = GetMapHeight(x, y, z) + unit->GetHoverOffset();
+            if (z < ground_z)
                 z = ground_z;
+
+            if (groundZ)
+               *groundZ = ground_z;
         }
     }
     else
@@ -1452,6 +1463,9 @@ void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z) const
         float ground_z = GetMapHeight(x, y, z);
         if (ground_z > INVALID_HEIGHT)
             z = ground_z;
+
+        if (groundZ)
+            *groundZ = ground_z;
     }
 }
 
@@ -3278,10 +3292,27 @@ void WorldObject::MovePositionToFirstCollision(Position &pos, float dist, float 
         }
     }
 
+    float groundZ = VMAP_INVALID_HEIGHT_VALUE;
     Trinity::NormalizeMapCoord(pos.m_positionX);
     Trinity::NormalizeMapCoord(pos.m_positionY);
-    UpdateAllowedPositionZ(destx, desty, pos.m_positionZ);
+    UpdateAllowedPositionZ(destx, desty, pos.m_positionZ, &groundZ);
     pos.SetOrientation(GetOrientation());
+
+    // position has no ground under it (or is too far away)
+    if (groundZ <= INVALID_HEIGHT)
+    {
+        if (Unit const* unit = ToUnit())
+        {
+            // flying, ignore.
+            if (unit->IsFlying())
+                return;
+
+            // fall back to gridHeight if any
+            float gridHeight = GetMap()->GetGridHeight(pos.m_positionX, pos.m_positionY);
+            if (gridHeight > INVALID_HEIGHT)
+                pos.m_positionZ = gridHeight + unit->GetHoverOffset();
+        }
+    }
 }
 
 void WorldObject::SetPhaseMask(uint32 newPhaseMask, bool update)

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1447,9 +1447,15 @@ void WorldObject::UpdateAllowedPositionZ(float x, float y, float &z) const
         }
         else
         {
-            float ground_z = GetMapHeight(x, y, z) + unit->GetHoverOffset();
-            if (z < ground_z)
-                z = ground_z;
+            float const gridHeight = GetMap()->GetGridHeight(x, y) + unit->GetHoverOffset();
+            float const vmapHeight = GetMap()->GetVmapDataFloorZ(x, y, z); // don't add hover offset here. if check might return unintended value
+            // Check if vmap under us
+            if (vmapHeight <= INVALID_HEIGHT)
+            {
+                // no vmap found, check if unit is under grid height
+                if (z < gridHeight)
+                    z = gridHeight;
+            }
         }
     }
     else

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -288,7 +288,7 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
 
         virtual float GetCombatReach() const { return 0.0f; } // overridden (only) in Unit
         void UpdateGroundPositionZ(float x, float y, float &z) const;
-        void UpdateAllowedPositionZ(float x, float y, float &z) const;
+        void UpdateAllowedPositionZ(float x, float y, float &z, float* groundZ = nullptr) const;
 
         void GetRandomPoint(Position const& srcPos, float distance, float& rand_x, float& rand_y, float& rand_z) const;
         Position GetRandomPoint(Position const& srcPos, float distance) const;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2442,7 +2442,11 @@ float Map::GetWaterOrGroundLevel(uint32 phasemask, float x, float y, float z, fl
 float Map::GetHeight(float x, float y, float z, bool checkVMap /*= true*/, float maxSearchDist /*= DEFAULT_HEIGHT_SEARCH*/) const
 {
     // find raw .map surface under Z coordinates
-    float const mapHeight = GetGridHeight(x, y);
+    float mapHeight = VMAP_INVALID_HEIGHT_VALUE;
+    float gridHeight = GetGridHeight(x, y);
+    if (G3D::fuzzyGe(z, gridHeight - GROUND_HEIGHT_TOLERANCE))
+        mapHeight = gridHeight;
+
     float vmapHeight = VMAP_INVALID_HEIGHT_VALUE;
     if (checkVMap)
     {

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -543,6 +543,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         float GetWaterOrGroundLevel(uint32 phasemask, float x, float y, float z, float* ground = nullptr, bool swim = false, float collisionHeight = 2.03128f) const; // DEFAULT_COLLISION_HEIGHT in Object.h
         float GetMinHeight(float x, float y) const;
         float GetHeight(float x, float y, float z, bool checkVMap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const;
+        float GetGridHeight(float x, float y) const;
+        float GetVmapDataFloorZ(float x, float y, float z) const;
         float GetHeight(Position const& pos, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const { return GetHeight(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), vmap, maxSearchDist); }
         float GetHeight(uint32 phasemask, float x, float y, float z, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const { return std::max<float>(GetHeight(x, y, z, vmap, maxSearchDist), GetGameObjectFloor(phasemask, x, y, z, maxSearchDist)); }
         float GetHeight(uint32 phasemask, Position const& pos, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const { return GetHeight(phasemask, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), vmap, maxSearchDist); }

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -544,7 +544,6 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         float GetMinHeight(float x, float y) const;
         float GetHeight(float x, float y, float z, bool checkVMap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const;
         float GetGridHeight(float x, float y) const;
-        float GetVmapDataFloorZ(float x, float y, float z) const;
         float GetHeight(Position const& pos, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const { return GetHeight(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), vmap, maxSearchDist); }
         float GetHeight(uint32 phasemask, float x, float y, float z, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const { return std::max<float>(GetHeight(x, y, z, vmap, maxSearchDist), GetGameObjectFloor(phasemask, x, y, z, maxSearchDist)); }
         float GetHeight(uint32 phasemask, Position const& pos, bool vmap = true, float maxSearchDist = DEFAULT_HEIGHT_SEARCH) const { return GetHeight(phasemask, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), vmap, maxSearchDist); }

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -100,7 +100,7 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* owner, uint32 diff)
         }
 
         bool result = _path->CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-        if (!result || (_path->GetPathType() & PATHFIND_NOPATH))
+        if (!result || (_path->GetPathType() & PATHFIND_NOPATH) || (_path->GetPathType() & PATHFIND_SHORTCUT))
         {
             _timer.Reset(100);
             return true;

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -165,7 +165,7 @@ void FleeingMovementGenerator<T>::SetTargetLocation(T* owner)
     }
 
     bool result = _path->CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-    if (!result || (_path->GetPathType() & PATHFIND_NOPATH))
+    if (!result || (_path->GetPathType() & PATHFIND_NOPATH) || (_path->GetPathType() & PATHFIND_SHORTCUT))
     {
         _timer.Reset(100);
         return;

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -108,7 +108,7 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     }
 
     bool result = _path->CalculatePath(position.GetPositionX(), position.GetPositionY(), position.GetPositionZ());
-    if (!result || (_path->GetPathType() & PATHFIND_NOPATH))
+    if (!result || (_path->GetPathType() & PATHFIND_NOPATH) || (_path->GetPathType() & PATHFIND_SHORTCUT))
     {
         _timer.Reset(100);
         return;

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -536,14 +536,14 @@ void PathGenerator::BuildPointPath(const float *startPoint, const float *endPoin
         /// @todo check the exact cases
         TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::BuildPointPath FAILED! path sized %d returned\n", pointCount);
         BuildShortcut();
-        _type = PATHFIND_NOPATH;
+        _type = PathType(_type | PATHFIND_NOPATH);
         return;
     }
     else if (pointCount == _pointPathLimit)
     {
         TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::BuildPointPath FAILED! path sized %d returned, lower than limit set to %d", pointCount, _pointPathLimit);
         BuildShortcut();
-        _type = PATHFIND_SHORT;
+        _type = PathType(_type | PATHFIND_SHORT);
         return;
     }
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1370,9 +1370,8 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
                 pos.m_positionX = m_preGeneratedPath->GetActualEndPosition().x;
                 pos.m_positionY = m_preGeneratedPath->GetActualEndPosition().y;
                 pos.m_positionZ = m_preGeneratedPath->GetActualEndPosition().z;
+                dest.Relocate(pos);
             }
-
-            dest.Relocate(pos);
             break;
         }
         default:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Only move to point if there is a path that is not a shortcut (which will make the unit move through terrain)
- ~Added new function to check if there is a vmap floor without search distance~
- Units that can fly, are underground but far above the vmap floor will stay underground (bronze drakes in tanaris)
- Don't remove PATHFIND_SHORTCUT from path type in some cases


**Target branch(es):**

- 3.3.5

**Issues addressed:** Updates #21255


**Tests performed:**
- Builds
- Blinking around in WSG
- Fearing in WSG
- Fearing in Icecrown (mountains in the centre)
- Blinking in Icecrown

**Known issues and TODO list:**

- ~Unsure about performance. I needed to check if there was a vmap way lower than the default search distance would let me for the drakes in tanaris/cot~


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
