### PR TITLE
Core/Misc: Wisp Spirit minor edit

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4235,7 +4235,8 @@ void Player::BuildPlayerRepop()
     packet.PlayerGUID = GetGUID();
     GetSession()->SendPacket(packet.Write());
 
-    if (getRace() == RACE_NIGHTELF)
+    // If the player has the Wisp racial then cast the Wisp aura on them
+    if (HasSpell(20585))
         CastSpell(this, 20584, true);
     CastSpell(this, 8326, true);
 


### PR DESCRIPTION
Made a change to have the Wisp Spirit racial to work on anyone who has the spell. A convenience for custom projects and makes no difference on a blizzlike project.


**Changes proposed:**

-  Make the Wisp Spirit racial passive work for anyone who has the racial, not just Night Elves.
-  This is a convenience for custom projects who may want to use the racial on other races.
-  Has no affect on blizzlike projects.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
- N/A

**Tests performed:** (Does it build, tested in-game, etc.)
- Builds and works in-game.

**Known issues and TODO list:** (add/remove lines as needed)


