### PR TITLE
spellHitFixOnStealth

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -643,6 +643,7 @@ class TC_GAME_API Spell
         // Targets store structures and data
         struct TargetInfoBase
         {
+            virtual bool MissedTarget(Spell * spell) { return false; }
             virtual void PreprocessTarget(Spell* /*spell*/) { }
             virtual void DoTargetSpellHit(Spell* spell, uint8 effIndex) = 0;
             virtual void DoDamageAndTriggers(Spell* /*spell*/) { }
@@ -656,6 +657,7 @@ class TC_GAME_API Spell
 
         struct TargetInfo : public TargetInfoBase
         {
+            bool MissedTarget(Spell * spell) override;
             void PreprocessTarget(Spell* spell) override;
             void DoTargetSpellHit(Spell* spell, uint8 effIndex) override;
             void DoDamageAndTriggers(Spell* spell) override;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  https://github.com/TrinityCore/TrinityCore/issues/11311
-  Has 3 Cases in which spell modifications is made:
-  Instant Cast then clear Unit cast called afterwards.
- Is a Channelled spell during which Stealth in entered during it's effect cancels effect in none targets.
- Is a Projectile and the Unit changes to stealth just before target is hit.

**Target branch(es):** 3.3.5/master

- [*] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
https://github.com/TrinityCore/TrinityCore/issues/11311
Possibly a few others.

**Tests performed:** (Does it build, tested in-game, etc.)
Yes.
3 - Cases briefly tested in a one-on-one pvp combat scenario.

**Known issues and TODO list:** (add/remove lines as needed)
none yet - to add later
