### PR TITLE
[3.3.5] Core/Spells: spell hit from spells on stealthed targets

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3463,18 +3463,30 @@ void Spell::_cast(bool skipCheck)
 template <class Container>
 void Spell::DoProcessTargetContainer(Container& targetContainer)
 {
+    std::vector<TargetInfoBase*> hitTargets;
     for (TargetInfoBase& target : targetContainer)
     {
-        if (target.MissedTarget(this))
-            continue;
+        if (!target.MissedTarget(this))
+            hitTargets.push_back(&target);
+    }
 
-        target.PreprocessTarget(this);
+    for (TargetInfoBase* target : hitTargets)
+    {
+        target->PreprocessTarget(this);
+    }
 
-        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-            if (target.EffectMask & (1 << i))
-                target.DoTargetSpellHit(this, i);
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    {
+        for (TargetInfoBase* target : hitTargets)
+        {
+            if (target->EffectMask & (1 << i))
+                target->DoTargetSpellHit(this, i);
+        }
+    }
 
-        target.DoDamageAndTriggers(this);
+    for (TargetInfoBase* target : hitTargets)
+    {
+        target->DoDamageAndTriggers(this);
     }
 }
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2264,6 +2264,9 @@ void Spell::AddDestTarget(SpellDestination const& dest, uint32 effIndex)
 
 bool Spell::TargetInfo::MissedTarget(Spell *spell)
 {
+    if (spell->GetSpellInfo()->IsAffectingArea())
+        return false;
+
     Unit* unit = spell->m_caster->GetGUID() == TargetGUID ? spell->m_caster->ToUnit() : ObjectAccessor::GetUnit(*spell->m_caster, TargetGUID);
     if (!unit)
         return true;
@@ -3463,19 +3466,16 @@ void Spell::DoProcessTargetContainer(Container& targetContainer)
     for (TargetInfoBase& target : targetContainer)
     {
         if (target.MissedTarget(this))
-            return;
-    }
+            continue;
 
-    for (TargetInfoBase& target : targetContainer)
         target.PreprocessTarget(this);
 
-    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        for (TargetInfoBase& target : targetContainer)
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             if (target.EffectMask & (1 << i))
                 target.DoTargetSpellHit(this, i);
 
-    for (TargetInfoBase& target : targetContainer)
         target.DoDamageAndTriggers(this);
+    }
 }
 
 void Spell::handle_immediate()

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3779,7 +3779,7 @@ void Spell::update(uint32 difftime)
             {
                 // If the spell is channelled, and any stealthed then remove the aura,
                 // If there are no auras left then stop the channeled spell cast.
-                if (m_spellInfo->IsChanneled())
+                if (m_spellInfo->IsChanneled() && !m_spellInfo->IsAffectingArea())
                 {
                     bool stopChannel = true;
                     for (TargetInfo const& target : m_UniqueTargetInfo)

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -643,7 +643,7 @@ class TC_GAME_API Spell
         // Targets store structures and data
         struct TargetInfoBase
         {
-            virtual bool MissedTarget(Spell * spell) { return false; }
+            virtual bool MissedTarget(Spell* /*spell*/) { return false; }
             virtual void PreprocessTarget(Spell* /*spell*/) { }
             virtual void DoTargetSpellHit(Spell* spell, uint8 effIndex) = 0;
             virtual void DoDamageAndTriggers(Spell* /*spell*/) { }

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -643,6 +643,7 @@ class TC_GAME_API Spell
         // Targets store structures and data
         struct TargetInfoBase
         {
+            virtual bool MissedTarget(Spell * spell) { return false; }
             virtual void PreprocessTarget(Spell* /*spell*/) { }
             virtual void DoTargetSpellHit(Spell* spell, uint8 effIndex) = 0;
             virtual void DoDamageAndTriggers(Spell* /*spell*/) { }
@@ -656,6 +657,7 @@ class TC_GAME_API Spell
 
         struct TargetInfo : public TargetInfoBase
         {
+            bool MissedTarget(Spell * spell) override;
             void PreprocessTarget(Spell* spell) override;
             void DoTargetSpellHit(Spell* spell, uint8 effIndex) override;
             void DoDamageAndTriggers(Spell* spell) override;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -657,7 +657,7 @@ class TC_GAME_API Spell
 
         struct TargetInfo : public TargetInfoBase
         {
-            bool MissedTarget(Spell * spell) override;
+            bool MissedTarget(Spell* spell) override;
             void PreprocessTarget(Spell* spell) override;
             void DoTargetSpellHit(Spell* spell, uint8 effIndex) override;
             void DoDamageAndTriggers(Spell* spell) override;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  https://github.com/TrinityCore/TrinityCore/issues/11311
-  Has 3 Cases in which spell modifications is made:
-  Instant Cast then clear Unit cast called afterwards.
- Is a Channelled spell during which Stealth in entered during it's effect cancels effect in none targets.
- Is a Projectile and the Unit changes to stealth just before target is hit.
- Warptens - review taken into account and modified some code.
(original PR: https://github.com/TrinityCore/TrinityCore/pull/22971) 

**Target branch(es):** 3.3.5/master

- [*] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
https://github.com/TrinityCore/TrinityCore/issues/11311
Possibly a few others.

**Tests performed:** (Does it build, tested in-game, etc.)
Yes.
3 - Cases briefly tested in a one-on-one pvp combat scenario.

**Known issues and TODO list:** (add/remove lines as needed)
none yet - to add later
