### PR TITLE
Core/Movement: Respect walk state when chasing

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -65,7 +65,7 @@ ChaseMovementGenerator::ChaseMovementGenerator(Unit* target, Optional<ChaseRange
 }
 ChaseMovementGenerator::~ChaseMovementGenerator() = default;
 
-void ChaseMovementGenerator::Initialize(Unit* owner)
+void ChaseMovementGenerator::Initialize(Unit* /*owner*/)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -70,7 +70,6 @@ void ChaseMovementGenerator::Initialize(Unit* owner)
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
-    owner->SetWalk(false);
     _path = nullptr;
     _lastTargetPosition.reset();
 }
@@ -203,7 +202,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
 
             Movement::MoveSplineInit init(owner);
             init.MovebyPath(_path->GetPath());
-            init.SetWalk(false);
+            init.SetWalk(owner->IsWalking());
             init.SetFacing(target);
 
             init.Launch();

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter2.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter2.cpp
@@ -443,6 +443,7 @@ public:
                         }
                         break;
                     case 2:
+                        me->SetWalk(false);
                         if (GameObject* tree = me->FindNearestGameObject(GO_INCONSPICUOUS_TREE, 40.0f))
                             if (Unit* unit = tree->GetOwner())
                                 AttackStart(unit);

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_kirtonos_the_herald.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_kirtonos_the_herald.cpp
@@ -180,6 +180,7 @@ class boss_kirtonos_the_herald : public CreatureScript
                                 me->HandleEmoteCommand(EMOTE_ONESHOT_ROAR);
                                 me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 0, uint32(WEAPON_KIRTONOS_STAFF));
                                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);
+                                me->SetWalk(false);
                                 me->SetReactState(REACT_AGGRESSIVE);
                                 events.ScheduleEvent(INTRO_6, 5000);
                                 break;

--- a/src/server/scripts/EasternKingdoms/Stratholme/instance_stratholme.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/instance_stratholme.cpp
@@ -282,6 +282,7 @@ class instance_stratholme : public InstanceMapScript
                                     ysida->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
                                     ysida->GetClosePoint(x, y, z, ysida->GetObjectScale() / 3, 4.0f);
                                     ysida->GetMotionMaster()->MovePoint(1, x, y, z);
+                                    ysida->SetWalk(false);
 
                                     Map::PlayerList const& players = instance->GetPlayers();
 

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -187,6 +187,7 @@ public:
                     SetEscortPaused(true);
                     if (Creature* pMarzon = me->SummonCreature(NPC_MARZON_BLADE, -8411.360352f, 480.069733f, 123.760895f, 4.941504f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 1000))
                     {
+                        pMarzon->SetWalk(true);
                         pMarzon->GetMotionMaster()->MovePoint(0, -8408.000977f, 468.611450f, 123.759903f);
                         MarzonGUID = pMarzon->GetGUID();
                     }
@@ -256,7 +257,10 @@ public:
                             if (Creature* pTyrion = me->FindNearestCreature(NPC_TYRION, 20.0f, true))
                                 pTyrion->AI()->Talk(SAY_TYRION_2);
                             if (Creature* pMarzon = ObjectAccessor::GetCreature(*me, MarzonGUID))
+                            {
+                                pMarzon->SetWalk(false);
                                 pMarzon->SetFaction(FACTION_MONSTER);
+                            }
                             me->SetFaction(FACTION_MONSTER);
                             uiTimer = 0;
                             uiPhase = 0;
@@ -290,10 +294,7 @@ public:
 
     struct npc_marzon_silent_bladeAI : public ScriptedAI
     {
-        npc_marzon_silent_bladeAI(Creature* creature) : ScriptedAI(creature)
-        {
-            me->SetWalk(true);
-        }
+        npc_marzon_silent_bladeAI(Creature* creature) : ScriptedAI(creature) { }
 
         void Reset() override
         {

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/culling_of_stratholme.cpp
@@ -702,6 +702,7 @@ public:
                                 cityman->SetTarget(me->GetGUID());
                                 cityman->SetWalk(true);
                                 cityman->GetMotionMaster()->MovePoint(0, 2088.625f, 1279.191f, 140.743f);
+                                cityman->SetWalk(false);
                             }
                             JumpToNextStep(2000);
                             break;
@@ -882,6 +883,7 @@ public:
                                     bossGUID = pBoss->GetGUID();
                                     pBoss->SetWalk(true);
                                     pBoss->GetMotionMaster()->MovePoint(0, 2194.110f, 1332.00f, 130.00f);
+                                    pBoss->SetWalk(false);
                                 }
                             }
                             JumpToNextStep(30000);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
@@ -343,7 +343,7 @@ public:
                     break;
                 case 97:
                     Talk(SAY_TH_EPOCH_KILL_TARETHA);
-                    SetRun();
+                    me->SetWalk(false);
                     break;
                 case 98:
                     //trigger epoch Yell("Thrall! Come outside and face your fate! ....")

--- a/src/server/scripts/Kalimdor/ZulFarrak/instance_zulfarrak.cpp
+++ b/src/server/scripts/Kalimdor/ZulFarrak/instance_zulfarrak.cpp
@@ -320,6 +320,7 @@ public:
                     npc->SetWalk(true);
                     npc->GetMotionMaster()->MovePoint(1, x, y, z);
                     npc->SetHomePosition(x, y, z, o);
+                    npc->SetWalk(false);
                }
             }
         }

--- a/src/server/scripts/Kalimdor/ZulFarrak/zulfarrak.cpp
+++ b/src/server/scripts/Kalimdor/ZulFarrak/zulfarrak.cpp
@@ -233,6 +233,7 @@ public:
                 crew->SetHomePosition(x, y, z, 0);
                 crew->GetMotionMaster()->MovePoint(1, x, y, z);
                 crew->SetFaction(FACTION_ESCORTEE_N_NEUTRAL_ACTIVE);
+                crew->SetWalk(false);
             }
         }
     };

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -707,7 +707,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             falric->AI()->Talk(SAY_FALRIC_INTRO_1);
                             falric->SetWalk(true);
                             falric->GetMotionMaster()->MovePoint(0, FalricPosition[1]);
-                            marwyn->SetWalk(false);
+                            falric->SetWalk(false);
                         }
                         _events.ScheduleEvent(EVENT_INTRO_LK_9, 5000);
                         break;

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -697,6 +697,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             marwyn->AI()->Talk(SAY_MARWYN_INTRO_1);
                             marwyn->SetWalk(true);
                             marwyn->GetMotionMaster()->MovePoint(0, MarwynPosition[1]);
+                            marwyn->SetWalk(false);
                         }
                         _events.ScheduleEvent(EVENT_INTRO_LK_8, 1000);
                         break;
@@ -706,6 +707,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             falric->AI()->Talk(SAY_FALRIC_INTRO_1);
                             falric->SetWalk(true);
                             falric->GetMotionMaster()->MovePoint(0, FalricPosition[1]);
+                            marwyn->SetWalk(false);
                         }
                         _events.ScheduleEvent(EVENT_INTRO_LK_9, 5000);
                         break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -1235,6 +1235,7 @@ class npc_tirion_fordring_tft : public CreatureScript
                     me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                     me->SetWalk(true);
                     me->GetMotionMaster()->MovePoint(POINT_TIRION_INTRO, TirionIntro);
+                    me->SetWalk(false);
                 }
                 return false;
             }

--- a/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
@@ -463,6 +463,7 @@ struct npc_akama_shade : public ScriptedAI
                     me->RemoveAurasDueToSpell(SPELL_STEALTH);
                     me->SetWalk(true);
                     me->GetMotionMaster()->MovePoint(AKAMA_CHANNEL_WAYPOINT, AkamaWP[0], false);
+                    me->SetWalk(false);
                     break;
                 case EVENT_SHADE_CHANNEL:
                     me->SetFacingTo(FACE_THE_PLATFORM);

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_vazruden_the_herald.cpp
@@ -140,7 +140,6 @@ class boss_nazan : public CreatureScript
                         BellowingRoar_Timer = 6000;
                         ConeOfFire_Timer = 12000;
                         me->SetDisableGravity(false);
-                        me->SetWalk(true);
                         me->GetMotionMaster()->Clear();
                         if (Unit* victim = SelectTarget(SELECT_TARGET_MINDISTANCE, 0))
                             AttackStart(victim);

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -890,6 +890,7 @@ class boss_thaladred_the_darkener : public CreatureScript
 
             void Initialize()
             {
+                me->SetWalk(true);
                 Gaze_Timer = 100;
                 Silence_Timer = 20000;
                 Rend_Timer = 4000;

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -201,6 +201,7 @@ class npc_dream_fog : public CreatureScript
                     {
                         _roamTimer = urand(15000, 30000);
                         me->GetMotionMaster()->Clear();
+                        me->SetWalk(false);
                         me->GetMotionMaster()->MoveChase(target, 0.2f);
                     }
                     else


### PR DESCRIPTION
**Changes proposed:**
* Chase Movement Generator is modified to not to set walk mode to false on initialization.
* Chase Movement Generator is also modified to take into account current walk mode during each update tick, therefore allowing to chase in walking mode only when needed and set to do so.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #20938

**Tests performed:** Does build, works-in-game