### PR TITLE
Travis/CI: Upgrade to xenial image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: xenial
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 
 language: cpp
 compiler:
@@ -10,11 +10,7 @@ git:
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - sourceline: 'ppa:kzemek/boost'
     packages:
-      - g++-6
       - libboost1.58-dev
       - libboost-filesystem1.58-dev
       - libboost-iostreams1.58-dev


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Upgrade Travis CI from Ubuntu 14.04 to 16.04, recently added by Travis CI team. Added some comments to the pull request to explain the changes.
- Remove old unused setting to use Virtualized environment instead of Docker container as Travis CI migrated linux jobs to Docker anyway
- Reference blog post about xenial https://blog.travis-ci.com/2018-11-08-xenial-release
- Reference documentation about xenial https://docs.travis-ci.com/user/reference/xenial/
- Reference blog post about Docker forced migration https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
None

**Tests performed:** (Does it build, tested in-game, etc.)
It builds and it takes just as long as 14.04

![image](https://user-images.githubusercontent.com/1153754/51617233-1a31bc80-1f2c-11e9-89b4-22968f9ca4a2.png)


**Known issues and TODO list:** (add/remove lines as needed)
- None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
