### PR TITLE
Core/Movement: Implement move time skipped handler

### DIFF
--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -871,29 +871,6 @@ void WorldSession::HandleNextCinematicCamera(WorldPacket& /*recvData*/)
     GetPlayer()->GetCinematicMgr()->BeginCinematic();
 }
 
-void WorldSession::HandleMoveTimeSkippedOpcode(WorldPacket& recvData)
-{
-    /*  WorldSession::Update(getMSTime());*/
-    TC_LOG_DEBUG("network", "WORLD: Received CMSG_MOVE_TIME_SKIPPED");
-
-    ObjectGuid guid;
-    recvData >> guid.ReadAsPacked();
-    recvData.read_skip<uint32>();
-    /*
-        uint64 guid;
-        uint32 time_skipped;
-        recvData >> guid;
-        recvData >> time_skipped;
-        TC_LOG_DEBUG("network", "WORLD: CMSG_MOVE_TIME_SKIPPED");
-
-        //// @todo
-        must be need use in Trinity
-        We substract server Lags to move time (AntiLags)
-        for exmaple
-        GetPlayer()->ModifyLastMoveTime(-int32(time_skipped));
-    */
-}
-
 void WorldSession::HandleFeatherFallAck(WorldPacket& recvData)
 {
     TC_LOG_DEBUG("network", "WORLD: CMSG_MOVE_FEATHER_FALL_ACK");

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -619,11 +619,19 @@ void WorldSession::HandleMoveTimeSkippedOpcode(WorldPacket& recvData)
     recvData >> timeSkipped;
 
     Unit* mover = GetPlayer()->m_unitMovedByMe;
-    ASSERT(mover != nullptr);                      // there must always be a mover
+
+    if (mover == nullptr)
+    {
+        TC_LOG_WARN("entities.player", "WorldSession::HandleMoveTimeSkippedOpcode wrong mover state from the unit moved by the player %s", GetPlayer()->GetGUID().ToString().c_str());
+        return;
+    }
 
     // prevent tampered movement data
     if (guid != mover->GetGUID())
+    {
+        TC_LOG_WARN("entities.player", "WorldSession::HandleMoveTimeSkippedOpcode wrong guid from the unit moved by the player %s", GetPlayer()->GetGUID().ToString().c_str());
         return;
+    }
 
     mover->m_movementInfo.time += timeSkipped;
 

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -608,3 +608,27 @@ void WorldSession::HandleSummonResponseOpcode(WorldPacket& recvData)
 
     _player->SummonIfPossible(agree);
 }
+
+void WorldSession::HandleMoveTimeSkippedOpcode(WorldPacket& recvData)
+{
+    TC_LOG_DEBUG("network", "WORLD: Received CMSG_MOVE_TIME_SKIPPED");
+
+    ObjectGuid guid;
+    uint32 timeSkipped;
+    recvData >> guid.ReadAsPacked();
+    recvData >> timeSkipped;
+
+    Unit* mover = GetPlayer()->m_unitMovedByMe;
+    ASSERT(mover != nullptr);                      // there must always be a mover
+
+    // prevent tampered movement data
+    if (guid != mover->GetGUID())
+        return;
+
+    mover->m_movementInfo.time += timeSkipped;
+
+    WorldPacket data(MSG_MOVE_TIME_SKIPPED, recvData.size());
+    data << guid.WriteAsPacked();
+    data << timeSkipped;
+    GetPlayer()->SendMessageToSet(&data, false);
+}

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -620,7 +620,7 @@ void WorldSession::HandleMoveTimeSkippedOpcode(WorldPacket& recvData)
 
     Unit* mover = GetPlayer()->m_unitMovedByMe;
 
-    if (mover == nullptr)
+    if (!mover)
     {
         TC_LOG_WARN("entities.player", "WorldSession::HandleMoveTimeSkippedOpcode wrong mover state from the unit moved by the player %s", GetPlayer()->GetGUID().ToString().c_str());
         return;


### PR DESCRIPTION
Implement CMSG_MOVE_TIME_SKIPPED handler and move it to MovementHandler.cpp

**Changes proposed:**

The way the MOVE_TIME_SKIPPED packet works is as follow:
- The client sends it when the player [1] is moving but the client froze for a certain period of time.
- The packet only contains two information: the GUID of the moving unit. And the time elasped since the last movement packet has been sent.
- The meaning of the packet from the point of the view of the client that sends it is basically: I didn't run the physical simulation of the unit that I control for a certain period of time. Please, just play at a later time the last movement that was sent (new timestamp = previous timestamp + "time skipped").
- the server upon receiving that packet should 
	* retransmit the packet to the other clients that have a unit nearby.
	* update the movement timestamp of that unit (new timestamp = previous timestamp + "time skipped").
- the clients upon receiving also update the movement timestamp of that unit (new timestamp = previous timestamp + "time skipped") so that the previous move sent is "played" at a later time.

[1] or more generaly the unit currently moved by that client: it can be another player (in case of mind control for example), a vehicle, ...

More information on the packet exchange can be found in [this sniff extract](https://gist.github.com/chaodhib/e66010a8ecb77b406ff86f6bbe93a5e0#file-move-time-skipped-sniff). In it, we can see 3 packets sent by the client. The unit is moving between the first and third packet (and also before the first and after the third but that's not important here). The distance traveled between the first and third packet is only 500ms * run speed. Yet, the time difference between the 1st & 3rd packet is 500ms + 86ms. 86ms is the "time skipped". This confirms that the client didn't run the physical simulation during that duration.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** This is retail like. The implementation of that packet handler was missing. The movement should feel more smooth. Particularly when the [anti jitter buffer](https://trinitycore.atlassian.net/wiki/spaces/tc/pages/721256449/Movement) in the client will be utilized by TC, which is not the case at the moment.


**Tests performed:** (Does it build, tested in-game, etc.)
Tested in game.

**Known issues and TODO list:** 
The line `ASSERT(mover != nullptr);` could cause problems if mover control change (client A looses control of player B. Or client A gains control of Vehicle C, ...) is badly implemented. I didn't test these edge cases enough.