### PR TITLE
Core/Scripts: Change PlayerScript and CreatureScript inheritance

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2084,31 +2084,26 @@ void ScriptMgr::OnGroupDisband(Group* group)
 void ScriptMgr::OnHeal(Unit* healer, Unit* reciever, uint32& gain)
 {
     FOREACH_SCRIPT(UnitScript)->OnHeal(healer, reciever, gain);
-    FOREACH_SCRIPT(PlayerScript)->OnHeal(healer, reciever, gain);
 }
 
 void ScriptMgr::OnDamage(Unit* attacker, Unit* victim, uint32& damage)
 {
     FOREACH_SCRIPT(UnitScript)->OnDamage(attacker, victim, damage);
-    FOREACH_SCRIPT(PlayerScript)->OnDamage(attacker, victim, damage);
 }
 
 void ScriptMgr::ModifyPeriodicDamageAurasTick(Unit* target, Unit* attacker, uint32& damage)
 {
     FOREACH_SCRIPT(UnitScript)->ModifyPeriodicDamageAurasTick(target, attacker, damage);
-    FOREACH_SCRIPT(PlayerScript)->ModifyPeriodicDamageAurasTick(target, attacker, damage);
 }
 
 void ScriptMgr::ModifyMeleeDamage(Unit* target, Unit* attacker, uint32& damage)
 {
     FOREACH_SCRIPT(UnitScript)->ModifyMeleeDamage(target, attacker, damage);
-    FOREACH_SCRIPT(PlayerScript)->ModifyMeleeDamage(target, attacker, damage);
 }
 
 void ScriptMgr::ModifySpellDamageTaken(Unit* target, Unit* attacker, int32& damage)
 {
     FOREACH_SCRIPT(UnitScript)->ModifySpellDamageTaken(target, attacker, damage);
-    FOREACH_SCRIPT(PlayerScript)->ModifySpellDamageTaken(target, attacker, damage);
 }
 
 SpellScriptLoader::SpellScriptLoader(char const* name)
@@ -2135,11 +2130,10 @@ FormulaScript::FormulaScript(char const* name)
     ScriptRegistry<FormulaScript>::Instance()->AddScript(this);
 }
 
-UnitScript::UnitScript(char const* name, bool addToScripts)
+UnitScript::UnitScript(char const* name)
     : ScriptObject(name)
 {
-    if (addToScripts)
-        ScriptRegistry<UnitScript>::Instance()->AddScript(this);
+    ScriptRegistry<UnitScript>::Instance()->AddScript(this);
 }
 
 WorldMapScript::WorldMapScript(char const* name, uint32 mapId)
@@ -2185,7 +2179,7 @@ ItemScript::ItemScript(char const* name)
 }
 
 CreatureScript::CreatureScript(char const* name)
-    : UnitScript(name, false)
+    : ScriptObject(name)
 {
     ScriptRegistry<CreatureScript>::Instance()->AddScript(this);
 }
@@ -2278,7 +2272,7 @@ AchievementCriteriaScript::AchievementCriteriaScript(char const* name)
 }
 
 PlayerScript::PlayerScript(char const* name)
-    : UnitScript(name, false)
+    : ScriptObject(name)
 {
     ScriptRegistry<PlayerScript>::Instance()->AddScript(this);
 }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -390,7 +390,7 @@ class TC_GAME_API UnitScript : public ScriptObject
 {
     protected:
 
-        UnitScript(char const* name, bool addToScripts = true);
+        UnitScript(char const* name);
 
     public:
         // Called when a unit deals healing to another unit
@@ -409,7 +409,7 @@ class TC_GAME_API UnitScript : public ScriptObject
         virtual void ModifySpellDamageTaken(Unit* /*target*/, Unit* /*attacker*/, int32& /*damage*/) { }
 };
 
-class TC_GAME_API CreatureScript : public UnitScript
+class TC_GAME_API CreatureScript : public ScriptObject
 {
     protected:
 
@@ -606,7 +606,7 @@ class TC_GAME_API AchievementCriteriaScript : public ScriptObject
         virtual bool OnCheck(Player* source, Unit* target) = 0;
 };
 
-class TC_GAME_API PlayerScript : public UnitScript
+class TC_GAME_API PlayerScript : public ScriptObject
 {
     protected:
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Remove UnitScript from PlayerScript and CreatureScript classes as that's how the original system that was PR'd worked, see https://github.com/TrinityCore/TrinityCore/pull/7867 for reference.
Please note these are used as global hooks and should really just invoke stateless functions.
If you need to hook methods from PlayerScript/CreatureScript and UnitScript, just define 2 different scripts (this is how the original system worked and how it was designed to work)

See https://github.com/TrinityCore/TrinityCore/pull/7867#issuecomment-8854396 for more info as why this change was applied in the first place

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
- https://github.com/TrinityCore/TrinityCore/issues/23047
- It also fixes PlayerScript overridden methods defined in UnitScript not being called (as now those don't exist anymore and will give a build error to existing scripts IF the use properly used the override keyword)

**Tests performed:** (Does it build, tested in-game, etc.)
```cpp
#include "ScriptMgr.h"
#include <cstdio>

class TestPlayerScript : PlayerScript
{
public:
    TestPlayerScript() : PlayerScript("TestPlayerScript")
    {
        printf("TestPlayerScript ctor\n");
    }

    void OnLogin(Player* /*player*/, bool /*firstLogin*/) override
    {
        printf("Logged in\n");
    }

    virtual ~TestPlayerScript()
    {
        printf("TestPlayerScript dtor\n");
    }
};

class TestCreatureScript : CreatureScript
{
public:
    TestCreatureScript() : CreatureScript("TestCreatureScript")
    {
        printf("TestCreatureScript ctor\n");
    }

    CreatureAI* GetAI(Creature* /*creature*/) const override
    {
        printf("GetAI\n");
        return nullptr;
    }

    virtual ~TestCreatureScript()
    {
        printf("TestCreatureScript dtor\n");
    }
};

class TestUnitScript : UnitScript
{
public:
    TestUnitScript() : UnitScript("TestUnitScript")
    {
        printf("TestUnitScript ctor\n");
    }

    void OnHeal(Unit* /*healer*/, Unit* /*reciever*/, uint32& /*gain*/) override
    {
        printf("Heal\n");
    }

    virtual ~TestUnitScript()
    {
        printf("TestUnitScript dtor\n");
    }
};

void AddCustomScripts()
{
    new TestPlayerScript();
    new TestCreatureScript();
    new TestUnitScript();
}
```

**Known issues and TODO list:** (add/remove lines as needed)
- It would be nice to just call functions instead of create class instances that are not thread-safe and that get half the methods called with nothing overriding the default base empty method.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
