### PR TITLE
Fixed a logic mistake for ground detection in MovePositionToFirstCollision

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -3234,7 +3234,7 @@ void WorldObject::MovePositionToFirstCollision(Position &pos, float dist, float 
     UpdateAllowedPositionZ(destx, desty, destz);
     bool col = VMAP::VMapFactory::createOrGetVMapManager()->getObjectHitPos(GetMapId(),
         pos.m_positionX, pos.m_positionY, pos.m_positionZ + halfHeight,
-        destx, desty, destz + halfHeight,
+        destx, desty, destz,
         destx, desty, destz, -0.5f);
 
     // collision occured
@@ -3249,7 +3249,7 @@ void WorldObject::MovePositionToFirstCollision(Position &pos, float dist, float 
     // check dynamic collision
     col = GetMap()->getObjectHitPos(GetPhaseMask(),
         pos.m_positionX, pos.m_positionY, pos.m_positionZ + halfHeight,
-        destx, desty, destz + halfHeight,
+        destx, desty, destz,
         destx, desty, destz, -0.5f);
 
     // Collided with a gameobject


### PR DESCRIPTION
**Changes proposed:**
fixed an issue that was causing some units getting summoned in the air instead of the ground. We use the collision to find anything between z + halfheight and z. destZ has been normalized already so we don't have to add another halfheight to them as it already has the correct ground height.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame.

Summon behaivior prior to the change:
![wowscrnshot_021919_174348](https://user-images.githubusercontent.com/18347559/53031930-1e3ef480-346e-11e9-8c05-2c26d7bc3931.jpg)

Summon behaivior after the change:
![wowscrnshot_021919_174550](https://user-images.githubusercontent.com/18347559/53031976-36af0f00-346e-11e9-941d-f6d4b072c1bb.jpg)

