### PR TITLE
Core/Units: Only update height in SetHover if unit is bellow HoverHeight

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13152,7 +13152,7 @@ bool Unit::SetHover(bool enable, bool /*packetOnly = false*/)
     {
         //! No need to check height on ascent
         AddUnitMovementFlag(MOVEMENTFLAG_HOVER);
-        if (hoverHeight)
+        if (hoverHeight && GetPositionZ() - GetFloorZ() < hoverHeight)
             UpdateHeight(GetPositionZ() + hoverHeight);
     }
     else


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Only update height in SetHover if unit is bellow HoverHeight, this is needed when unit already is above hoverHeight, and SetHover is turned on later, then it's supposed to stay at the same position, take Miniron's Aerial unit for example.

No idea if GetFloorZ() is the correct option here, it worked as intended testing in Mimiron's fight.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [x] master