### PR TITLE
Core/Movement: Allow using walk when chasing

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -585,14 +585,14 @@ void MotionMaster::MoveFollow(Unit* target, float dist, ChaseAngle angle, Moveme
     Add(new FollowMovementGenerator(target, dist, angle), slot);
 }
 
-void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle)
+void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle, bool walk)
 {
     // Ignore movement request if target not exist
     if (!target || target == _owner)
         return;
 
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveChase: '%s', starts chasing '%s'", _owner->GetGUID().ToString().c_str(), target->GetGUID().ToString().c_str());
-    Add(new ChaseMovementGenerator(target, dist, angle));
+    Add(new ChaseMovementGenerator(target, dist, angle, walk));
 }
 
 void MotionMaster::MoveConfused()

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -140,7 +140,7 @@ class TC_GAME_API MotionMaster
         void MoveTargetedHome();
         void MoveRandom(float spawndist = 0.0f);
         void MoveFollow(Unit* target, float dist, ChaseAngle angle, MovementSlot slot = MOTION_SLOT_ACTIVE);
-        void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
+        void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {}, bool walk = false);
         void MoveChase(Unit* target, float dist, float angle) { MoveChase(target, ChaseRange(dist), ChaseAngle(angle)); }
         void MoveChase(Unit* target, float dist) { MoveChase(target, ChaseRange(dist)); }
         void MoveConfused();

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -56,7 +56,9 @@ static void DoMovementInform(Unit* owner, Unit* target)
         AI->MovementInform(CHASE_MOTION_TYPE, target->GetGUID().GetCounter());
 }
 
-ChaseMovementGenerator::ChaseMovementGenerator(Unit* target, Optional<ChaseRange> range, Optional<ChaseAngle> angle) : AbstractFollower(ASSERT_NOTNULL(target)), _range(range), _angle(angle)
+ChaseMovementGenerator::ChaseMovementGenerator(Unit *target, Optional<ChaseRange> range, Optional<ChaseAngle> angle,
+                                               bool walk) : AbstractFollower(ASSERT_NOTNULL(target)), _range(range),
+                                                           _angle(angle), _walk(walk)
 {
     Mode = MOTION_MODE_DEFAULT;
     Priority = MOTION_PRIORITY_NORMAL;
@@ -70,7 +72,7 @@ void ChaseMovementGenerator::Initialize(Unit* owner)
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
-    owner->SetWalk(false);
+    owner->SetWalk(_walk);
     _path = nullptr;
     _lastTargetPosition.reset();
 }
@@ -203,7 +205,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
 
             Movement::MoveSplineInit init(owner);
             init.MovebyPath(_path->GetPath());
-            init.SetWalk(false);
+            init.SetWalk(_walk);
             init.SetFacing(target);
 
             init.Launch();

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.h
@@ -30,7 +30,7 @@ class Unit;
 class ChaseMovementGenerator : public MovementGenerator, public AbstractFollower
 {
     public:
-        explicit ChaseMovementGenerator(Unit* target, Optional<ChaseRange> range = {}, Optional<ChaseAngle> angle = {});
+        explicit ChaseMovementGenerator(Unit* target, Optional<ChaseRange> range = {}, Optional<ChaseAngle> angle = {}, bool walk = false);
         ~ChaseMovementGenerator();
 
         void Initialize(Unit*) override;
@@ -47,6 +47,7 @@ class ChaseMovementGenerator : public MovementGenerator, public AbstractFollower
 
         Optional<ChaseRange> const _range;
         Optional<ChaseAngle> const _angle;
+        bool _walk;
 
         std::unique_ptr<PathGenerator> _path;
         Optional<Position> _lastTargetPosition;

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -670,9 +670,8 @@ struct npc_dark_rider_of_acherus : public ScriptedAI
             {
                 case EVENT_START_MOVING:
                     me->SetTarget(_horseGUID);
-                    me->SetWalk(true);
                     if (Creature* horse = ObjectAccessor::GetCreature(*me, _horseGUID))
-                        me->GetMotionMaster()->MoveChase(horse);
+                        me->GetMotionMaster()->MoveChase(horse, {}, {}, true);
                     _events.ScheduleEvent(EVENT_DESPAWN_HORSE, 5s);
                     break;
                 case EVENT_DESPAWN_HORSE:

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -908,6 +908,15 @@ class boss_thaladred_the_darkener : public CreatureScript
                 advisorbase_ai::Reset();
             }
 
+            void AttackStart(Unit* who) override
+            {
+                if (!who || _inFakeDeath || me->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE))
+                    return;
+
+                if (me->Attack(who, true))
+                    me->GetMotionMaster()->MoveChase(who, {}, {}, true);
+            }
+
             void JustEngagedWith(Unit* who) override
             {
                 Talk(SAY_THALADRED_AGGRO);


### PR DESCRIPTION
**Changes proposed:**
Allow passing additional parameter to Chase Movement Generator in order to determine whether unit should walk. Currently it looks like that: 
```c
me->GetMotionMaster()->MoveChase(horse, {}, {}, true);
```

**Target branch(es):** 3.3.5

**Tests performed:** Does build, works-in-game