### PR TITLE
Core/GameObject: Set loot state to Not ready when a gob is deactivated

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -779,7 +779,7 @@ void GameObject::Update(uint32 diff)
                 return;
             }
 
-            SetLootState(GO_READY);
+            SetLootState(GO_NOT_READY);
 
             //burning flags in some battlegrounds, if you find better condition, just add it
             if (GetGOInfo()->IsDespawnAtAction() || GetGoAnimProgress() > 0)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:** Set loot state to Not ready when a gob is deactivated, this will fix the call of loot state ready when a gameobject despawns.

**Target branch(es):** 3.3.5

**Issues addressed:** Closes #22364

**Tests performed:**Yes
