### PR TITLE
Core/Players: Fix logic in CanSeeSpellClickOn

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -25243,7 +25243,7 @@ bool Player::CanSeeSpellClickOn(Creature const* c) const
 
     auto clickBounds = sObjectMgr->GetSpellClickInfoMapBounds(c->GetEntry());
     if (clickBounds.begin() == clickBounds.end())
-        return true;
+        return false;
 
     for (auto const& clickPair : clickBounds)
     {


### PR DESCRIPTION
**Changes proposed:**

-  Block CanSeeSpellClickOn for the npc if there is no entry for it in SpellClick data.

**Isssues**:  Closes #22689

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master