### PR TITLE
[DRAFT] Scripts/Scarlet Enclave: Gift Of The Harvester

### DIFF
--- a/sql/updates/world/3.3.5/2019_03_09_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_03_09_00_world.sql
@@ -1,2 +1,0 @@
--- 
-DELETE FROM `smart_scripts` WHERE `action_type`=11 AND `action_param1`=1604 AND `entryorguid` IN (6206,6218,6220,6219,6233,6222,6225,6234) AND `source_type`=0;

--- a/sql/updates/world/3.3.5/2019_03_09_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_03_09_00_world.sql
@@ -1,0 +1,2 @@
+-- 
+DELETE FROM `smart_scripts` WHERE `action_type`=11 AND `action_param1`=1604 AND `entryorguid` IN (6206,6218,6220,6219,6233,6222,6225,6234) AND `source_type`=0;

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+INSERT INTO `spell_script_names` VALUES
+(52479, 'spell_gift_of_the_harvester');
+UPDATE `gameobject_template` SET `Data3`=0,`AIName`='',`ScriptName`='gift_of_the_harvesterAI' WHERE `entry`=190769;

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,3 +1,4 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_gift_of_the_harvester';
 INSERT INTO `spell_script_names` VALUES
 (52479, 'spell_gift_of_the_harvester');
 UPDATE `gameobject_template` SET `Data3`=0,`AIName`='',`ScriptName`='gift_of_the_harvesterAI' WHERE `entry`=190769;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3736,10 +3736,6 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
                     if (unitTarget->GetTypeId() == TYPEID_UNIT && unitTarget->IsSummon())
                         unitTarget->ToTempSummon()->UnSummon();
                     return;
-                case 52479: // Gift of the Harvester
-                    if (unitTarget && unitCaster)
-                        unitCaster->CastSpell(unitTarget, urand(0, 1) ? damage : 52505, true);
-                    return;
                 case 53110: // Devour Humanoid
                     if (unitTarget)
                         unitTarget->CastSpell(m_caster, damage, true);

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -27,6 +27,7 @@
 #include "ObjectMgr.h"
 #include "PassiveAI.h"
 #include "Player.h"
+#include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
 #include "ScriptedGossip.h"
 #include "SpellInfo.h"

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -916,6 +916,15 @@ struct spell_gift_of_the_harvester : public SpellScript
 {
     PrepareSpellScript(spell_gift_of_the_harvester);
 
+    bool Validate(SpellInfo const* /*spell*/) override
+    {
+        return ValidateSpellInfo(
+                {
+                    SPELL_MINER_GHOUL_TRANSFORM,
+                    SPELL_MINER_GHOST_TRANSFORM
+                });
+    }
+
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
         uint32 spellId = urand(0, 1) ? SPELL_MINER_GHOUL_TRANSFORM : SPELL_MINER_GHOST_TRANSFORM;

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -929,7 +929,9 @@ struct spell_gift_of_the_harvester : public SpellScript
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
         uint32 spellId = RAND(SPELL_MINER_GHOUL_TRANSFORM, SPELL_MINER_GHOST_TRANSFORM);
-        GetCaster()->CastSpell(GetHitUnit(), spellId, true);
+
+        if (GameObject* caster = GetGObjCaster())
+            caster->CastSpell(GetHitUnit(), spellId, true);
     }
 
     void Register() override

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -894,15 +894,18 @@ struct gift_of_the_harvesterAI : public GameObjectAI
 {
     gift_of_the_harvesterAI(GameObject* go) : GameObjectAI(go) { }
 
-    void UpdateAI(uint32 diff) override
+    void Reset() override
     {
-        _scheduler.Update(diff);
-
         _scheduler.Schedule(2s, [this](TaskContext /*context*/)
         {
             me->SendCustomAnim(0);
             me->CastSpell(nullptr, SPELL_GIFT_OF_THE_HARVESTER, true);
         });
+    }
+    
+    void UpdateAI(uint32 diff) override
+    {
+        _scheduler.Update(diff);
     }
 
 private:
@@ -916,7 +919,7 @@ struct spell_gift_of_the_harvester : public SpellScript
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
         uint32 spellId = urand(0, 1) ? SPELL_MINER_GHOUL_TRANSFORM : SPELL_MINER_GHOST_TRANSFORM;
-        GetOriginalCaster()->CastSpell(GetHitUnit(), spellId, true);
+        GetCaster()->CastSpell(GetHitUnit(), spellId, true);
     }
 
     void Register() override

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -17,6 +17,7 @@
 
 #include "ScriptMgr.h"
 #include "CombatAI.h"
+#include "CreatureAIImpl.h"
 #include "CreatureTextMgr.h"
 #include "GameObject.h"
 #include "GameObjectAI.h"
@@ -27,7 +28,6 @@
 #include "ObjectMgr.h"
 #include "PassiveAI.h"
 #include "Player.h"
-#include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
 #include "ScriptedGossip.h"
 #include "SpellInfo.h"

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -927,7 +927,7 @@ struct spell_gift_of_the_harvester : public SpellScript
 
     void HandleScriptEffect(SpellEffIndex /*effIndex*/)
     {
-        uint32 spellId = urand(0, 1) ? SPELL_MINER_GHOUL_TRANSFORM : SPELL_MINER_GHOST_TRANSFORM;
+        uint32 spellId = RAND(SPELL_MINER_GHOUL_TRANSFORM, SPELL_MINER_GHOST_TRANSFORM);
         GetCaster()->CastSpell(GetHitUnit(), spellId, true);
     }
 

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -883,6 +883,48 @@ public:
 
 };
 
+enum GiftOfTheHarvester
+{
+    SPELL_GIFT_OF_THE_HARVESTER = 52479,
+    SPELL_MINER_GHOUL_TRANSFORM = 52490,
+    SPELL_MINER_GHOST_TRANSFORM = 52505
+};
+
+struct gift_of_the_harvesterAI : public GameObjectAI
+{
+    gift_of_the_harvesterAI(GameObject* go) : GameObjectAI(go) { }
+
+    void UpdateAI(uint32 diff) override
+    {
+        _scheduler.Update(diff);
+
+        _scheduler.Schedule(2s, [this](TaskContext /*context*/)
+        {
+            me->SendCustomAnim(0);
+            me->CastSpell(nullptr, SPELL_GIFT_OF_THE_HARVESTER, true);
+        });
+    }
+
+private:
+    TaskScheduler _scheduler;
+};
+
+struct spell_gift_of_the_harvester : public SpellScript
+{
+    PrepareSpellScript(spell_gift_of_the_harvester);
+
+    void HandleScriptEffect(SpellEffIndex /*effIndex*/)
+    {
+        uint32 spellId = urand(0, 1) ? SPELL_MINER_GHOUL_TRANSFORM : SPELL_MINER_GHOST_TRANSFORM;
+        GetOriginalCaster()->CastSpell(GetHitUnit(), spellId, true);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_gift_of_the_harvester::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 // correct way: 52312 52314 52555 ...
 enum Creatures_SG
 {
@@ -1250,6 +1292,8 @@ void AddSC_the_scarlet_enclave_c1()
     RegisterAuraScript(spell_stable_master_repo);
     RegisterSpellScript(spell_deliver_stolen_horse);
     new npc_ros_dark_rider();
+    RegisterGameObjectAI(gift_of_the_harvesterAI);
+    RegisterSpellScript(spell_gift_of_the_harvester);
     new npc_dkc1_gothik();
     new npc_scarlet_ghoul();
     new npc_scarlet_miner();


### PR DESCRIPTION
**Changes proposed:**
- Move spell Gift of the Harvester out from hacks to a SpellScript.
- Implement GameObjectAI for item Gift of the Harvester (animation before cast), therefore dropping `Data3` value (spell casted in this case).

**Target branch(es):** 3.3.5

**Tests performed:** Does build. Could work-in-game.

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Crash happens when casting spell inside GameObjectAI because `this` (`WorldObject*`) becomes NULL-ed for some reason.
https://gist.github.com/Sorikoff/3d1ed6ee2e5573198fb99c8c1ebaf940
https://github.com/TrinityCore/TrinityCore/blob/a1dec9b38cfdab397801879ee12a326d0e7f148b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp#L904
- [ ] Neither ghoul nor ghost are summoned.