### PR TITLE
Core/GameObject: Remove summoned game objects from the map after call…

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -793,11 +793,10 @@ void GameObject::Update(uint32 diff)
             if (!m_respawnDelayTime)
                 return;
 
-            // ToDo: Decide if we should properly despawn these. Maybe they expect to be able to manually respawn from script?
             if (!m_spawnedByDefault)
             {
                 m_respawnTime = 0;
-                DestroyForNearbyPlayers(); // old UpdateObjectVisibility()
+                Delete();
                 return;
             }
 


### PR DESCRIPTION
…ing  SetSpawnedByDefault(false)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Summoned game objects must be removed from the map once despawned.

**Target branch(es):** 3.3.5

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes #23115


**Tests performed:** build and tested IG

