### PR TITLE
Fix for the new version of MariaDB

### DIFF
--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -512,7 +512,9 @@ bool MySQLConnection::_HandleMySQLErrno(uint32 errNo, uint8 attempts /*= 5*/)
     {
         case CR_SERVER_GONE_ERROR:
         case CR_SERVER_LOST:
+#ifdef CR_INVALID_CONN_HANDLE
         case CR_INVALID_CONN_HANDLE:
+#endif
         case CR_SERVER_LOST_EXTENDED:
         {
             if (m_Mysql)


### PR DESCRIPTION
CR_INVALID_CONN_HANDLE was dropped since MariaDB 10.2

**Changes proposed:**

-  Checking definition of CR_INVALID_CONN_HANDLE

**Target branch(es):**

- [ ] 3.3.5
- [ ] master

**Issues addressed:**

- N/A

**Tests performed:** 

- Builds

**Known issues and TODO list:**
