### PR TITLE
Core/Movement: Implement stack with priority in MotionMaster

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -594,7 +594,7 @@ void SmartAI::AttackStart(Unit* who)
 
     if (who && me->Attack(who, mCanAutoAttack))
     {
-        me->GetMotionMaster()->Clear(MOTION_PRIORITY_NORMAL);
+        //me->GetMotionMaster()->Clear(MOTION_PRIORITY_NORMAL);
         me->PauseMovement();
 
         if (mCanCombatMove)

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -1027,7 +1027,7 @@ void MotionMaster::LaunchMoveSpline(Movement::MoveSplineInit&& init, uint32 id/*
 void MotionMaster::Pop(bool active, bool movementInform)
 {
     MovementGenerator* pointer = *_generators.begin();
-    _generators.erase(pointer);
+    _generators.erase(_generators.begin());
     Delete(pointer, active, movementInform);
 }
 
@@ -1121,18 +1121,15 @@ void MotionMaster::DirectAdd(MovementGenerator* movement, MovementSlot slot/* = 
                 AddFlag(MOTIONMASTER_FLAG_STATIC_INITIALIZATION_PENDING);
             break;
         case MOTION_SLOT_ACTIVE:
+        {
+            auto insertPosition = _generators.begin();
+
             if (!_generators.empty())
             {
                 if (movement->Priority >= (*_generators.begin())->Priority)
                 {
                     MovementGenerator* pointer = *_generators.begin();
-                    if (movement->Priority == pointer->Priority)
-                    {
-                        _generators.erase(pointer);
-                        Delete(pointer, true, false);
-                    }
-                    else
-                        pointer->Deactivate(_owner);
+                    pointer->Deactivate(_owner);
                 }
                 else
                 {
@@ -1141,20 +1138,16 @@ void MotionMaster::DirectAdd(MovementGenerator* movement, MovementSlot slot/* = 
                         return a->Priority == movement->Priority;
                     });
 
-                    if (itr != _generators.end())
-                    {
-                        MovementGenerator* pointer = *itr;
-                        _generators.erase(pointer);
-                        Delete(pointer, false, false);
-                    }
+                    insertPosition = itr;
                 }
             }
             else
                 _defaultGenerator->Deactivate(_owner);
 
-            _generators.emplace(movement);
+            _generators.emplace_hint(insertPosition, movement);
             AddBaseUnitState(movement);
             break;
+        }
         default:
             break;
     }

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -90,7 +90,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
 
     // our target might have gone away
     Unit* const target = GetTarget();
-    if (!target || !target->IsInWorld())
+    if (!target || !target->IsInWorld() || !target->IsAlive())
         return false;
 
     // the owner might be unable to move (rooted or casting), pause movement


### PR DESCRIPTION
Handle movement generators as stack with priority, deactivating current one when adding a new movement generator instead of deleting current one.
Fixes #17981

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Handle movement generators as stack with priority, deactivating current one when adding a new movement generator instead of deleting current one.
-  ChaseMovementGenerator now doesn't wait for the target to be removed from world to be deactivated anymore but does that as soon as the target dies.

**Target branch(es):** 3.3.5/master

- 3.3.5

**Issues addressed:**
Closes #17981

**Tests performed:** (Does it build, tested in-game, etc.)
- .cast 46657
- attack a mob
- after the mob dies, notice how the guardian now follows you again

**Known issues and TODO list:** (add/remove lines as needed)

- As this is a quite big change, it requires testing is other cases. Some thoughts:
  - How big is _generators going to grow if every time a npc attacks a creature pushes a new ChaseMovementGenerator ?
  - Should all the calls of MotionMaster::Add() be modified not to create a new generator everytime but maybe use an existing one already in _generators ?
- SmartAI::AttackStart() calls me->PauseMovement() that in case of an active generator does nothing to it. Should it deactivate it ? Or is mCanCombatMove always true anyway for creatures that have a movement generator other than the idle one anyway ?


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
