### PR TITLE
Scripts/Scarlet Enclave: Unworthy Initiate

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -239,6 +239,7 @@ public:
                     {
                         me->SetFaction(FACTION_MONSTER);
                         me->SetImmuneToPC(false);
+                        me->SetReactState(REACT_AGGRESSIVE);
                         phase = PHASE_ATTACKING;
 
                         if (Player* target = ObjectAccessor::GetPlayer(*me, playerGUID))


### PR DESCRIPTION
**Changes proposed:** Set `REACT_AGGRESSIVE` state to Unworthy Initiate, so creature can attack correctly, when attack phase is active.

**Target branch(es):** 3.3.5

**Issues addressed:** None

**Tests performed:** Works!