### PR TITLE
Core: Restore reset in EscortAI::InitializeAI

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -84,6 +84,8 @@ void EscortAI::InitializeAI()
 
     if (me->GetFaction() != me->GetCreatureTemplate()->faction)
         me->RestoreFaction();
+    
+    Reset();
 }
 
 void EscortAI::ReturnToLastPoint()


### PR DESCRIPTION
The reset on EscortAI::InitializeAI was removed on https://github.com/TrinityCore/TrinityCore/commit/e4e6e2209c8ad6cc534460a4ec9f6da469761d15#diff-2270235252e23698c6d2c9a49eb35bb1L88
It's used in many escort scripts.
Closes  #23008

**Target branch(es):** 3.3.5

- [x] 3.3.5
- [ ] master
