### PR TITLE
Core/GameObject: Fix the logic used to set the flag GO_FLAG_NODESPAWN…

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -769,7 +769,7 @@ void GameObject::Update(uint32 diff)
             if (GetSpellId() || GetOwnerGUID())
             {
                 //Don't delete spell spawned chests and goobers, which are not consumed on loot or on spell cast
-                if (m_respawnTime > 0 && GetGoType() == (GetGoType() == GAMEOBJECT_TYPE_CHEST || GetGoType() == GAMEOBJECT_TYPE_GOOBER) && !GetGOInfo()->IsDespawnAtAction())
+                if (m_respawnTime > 0 && (GetGoType() == GAMEOBJECT_TYPE_CHEST || GetGoType() == GAMEOBJECT_TYPE_GOOBER) && !GetGOInfo()->IsDespawnAtAction())
                 {
                     UpdateObjectVisibility();
                     SetLootState(GO_READY);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -764,23 +764,18 @@ void GameObject::Update(uint32 diff)
 
             loot.clear();
 
-            //! If this is summoned by a spell with ie. SPELL_EFFECT_SUMMON_OBJECT_WILD, with or without owner, we check respawn criteria based on spell
-            //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
-            if (GetSpellId() || GetOwnerGUID())
+            //Don't delete chests and goobers that have the flag consumable=0
+            if (GetGoType() == GAMEOBJECT_TYPE_CHEST && !GetGOInfo()->IsDespawnAtAction())
             {
-                //Don't delete spell spawned chests and goobers, which are not consumed on loot or on spell cast
-                if (m_respawnTime > 0 && (GetGoType() == GAMEOBJECT_TYPE_CHEST || GetGoType() == GAMEOBJECT_TYPE_GOOBER) && !GetGOInfo()->IsDespawnAtAction())
-                {
-                    UpdateObjectVisibility();
-                    SetLootState(GO_READY);
-                }
-                else
-                {
-                    SetRespawnTime(0);
-                    Delete();
-                }
-                return;
+                UpdateObjectVisibility();
+                SetLootState(GO_READY);
             }
+            else
+            {
+                SetRespawnTime(0);
+                Delete();
+            }
+            return;
 
             SetLootState(GO_NOT_READY);
 
@@ -1046,13 +1041,7 @@ bool GameObject::LoadFromDB(ObjectGuid::LowType spawnId, Map* map, bool addToMap
     {
         m_spawnedByDefault = true;
 
-        if (!GetGOInfo()->IsDespawnAtAction())
-        {
-            SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NODESPAWN);
-            m_respawnDelayTime = 0;
-            m_respawnTime = 0;
-        }
-        else
+        if (GetGOInfo()->IsDespawnAtAction())
         {
             m_respawnDelayTime = data->spawntimesecs;
             m_respawnTime = GetMap()->GetGORespawnTime(m_spawnId);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -765,7 +765,7 @@ void GameObject::Update(uint32 diff)
             loot.clear();
 
             //Don't delete chests and goobers that have the flag consumable=0
-            if (GetGoType() == GAMEOBJECT_TYPE_CHEST && !GetGOInfo()->IsDespawnAtAction())
+            if ((GetGoType() == GAMEOBJECT_TYPE_CHEST || GetGoType() == GAMEOBJECT_TYPE_GOOBER) && !GetGOInfo()->IsDespawnAtAction())
             {
                 UpdateObjectVisibility();
                 SetLootState(GO_READY);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1046,7 +1046,7 @@ bool GameObject::LoadFromDB(ObjectGuid::LowType spawnId, Map* map, bool addToMap
     {
         m_spawnedByDefault = true;
 
-        if (!GetGOInfo()->GetDespawnPossibility() || !GetGOInfo()->IsDespawnAtAction())
+        if (!GetGOInfo()->IsDespawnAtAction())
         {
             SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NODESPAWN);
             m_respawnDelayTime = 0;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -768,8 +768,8 @@ void GameObject::Update(uint32 diff)
             //! The GetOwnerGUID() check is mostly for compatibility with hacky scripts - 99% of the time summoning should be done trough spells.
             if (GetSpellId() || GetOwnerGUID())
             {
-                //Don't delete spell spawned chests, which are not consumed on loot
-                if (m_respawnTime > 0 && GetGoType() == GAMEOBJECT_TYPE_CHEST && !GetGOInfo()->IsDespawnAtAction())
+                //Don't delete spell spawned chests and goobers, which are not consumed on loot or on spell cast
+                if (m_respawnTime > 0 && GetGoType() == (GetGoType() == GAMEOBJECT_TYPE_CHEST || GetGoType() == GAMEOBJECT_TYPE_GOOBER) && !GetGOInfo()->IsDespawnAtAction())
                 {
                     UpdateObjectVisibility();
                     SetLootState(GO_READY);
@@ -1046,7 +1046,7 @@ bool GameObject::LoadFromDB(ObjectGuid::LowType spawnId, Map* map, bool addToMap
     {
         m_spawnedByDefault = true;
 
-        if (!GetGOInfo()->GetDespawnPossibility() && !GetGOInfo()->IsDespawnAtAction())
+        if (!GetGOInfo()->GetDespawnPossibility() || !GetGOInfo()->IsDespawnAtAction())
         {
             SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_NODESPAWN);
             m_respawnDelayTime = 0;

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -487,7 +487,8 @@ struct GameObjectTemplate
             case GAMEOBJECT_TYPE_GOOBER:     return goober.noDamageImmune != 0;
             case GAMEOBJECT_TYPE_FLAGSTAND:  return flagstand.noDamageImmune != 0;
             case GAMEOBJECT_TYPE_FLAGDROP:   return flagdrop.noDamageImmune != 0;
-            default: return true;
+            case GAMEOBJECT_TYPE_CHEST:      return true;
+            default: return false;
         }
     }
 

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -477,7 +477,7 @@ struct GameObjectTemplate
         }
     }
 
-    bool GetDespawnPossibility() const                      // despawn at targeting of cast?
+    bool CannotBeUsedUnderImmunity() const                      // The object cannot be use under Immunity like divine shield -- to be implemented
     {
         switch (type)
         {
@@ -487,7 +487,7 @@ struct GameObjectTemplate
             case GAMEOBJECT_TYPE_GOOBER:     return goober.noDamageImmune != 0;
             case GAMEOBJECT_TYPE_FLAGSTAND:  return flagstand.noDamageImmune != 0;
             case GAMEOBJECT_TYPE_FLAGDROP:   return flagdrop.noDamageImmune != 0;
-            default: return true;
+            default: return false;
         }
     }
 

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -487,7 +487,7 @@ struct GameObjectTemplate
             case GAMEOBJECT_TYPE_GOOBER:     return goober.noDamageImmune != 0;
             case GAMEOBJECT_TYPE_FLAGSTAND:  return flagstand.noDamageImmune != 0;
             case GAMEOBJECT_TYPE_FLAGDROP:   return flagdrop.noDamageImmune != 0;
-            default: return false;
+            default: return true;
         }
     }
 


### PR DESCRIPTION
… for gobs having !GetDespawnPossibility OR !IsDespawnAtAction

Keep Goobers that are summoned, spawned until the timer expire, like Romantic Basket case

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix the logic used to set the flag GO_FLAG_NODESPAWN for gobs having !GetDespawnPossibility OR !IsDespawnAtAction
-  Keep Goobers that are summoned spawned until the timer expire, like Romantic Basket case


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #15730


**Tests performed:** Yes


**Known issues and TODO list:** 

- [ ]  Require reviews


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
