### PR TITLE
Scripts/Spells: Fix implementation of #22332

### DIFF
--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_rajaxx.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_rajaxx.cpp
@@ -145,12 +145,12 @@ class spell_rajaxx_thundercrash : public SpellScript
         if (damage < 200)
             damage = 200;
 
-        SetHitDamage(damage);
+        SetEffectValue(damage);
     }
 
     void Register() override
     {
-        OnEffectHitTarget += SpellEffectFn(spell_rajaxx_thundercrash::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+        OnEffectLaunchTarget += SpellEffectFn(spell_rajaxx_thundercrash::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
     }
 };
 

--- a/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_four_horsemen.cpp
@@ -745,12 +745,12 @@ class boss_four_horsemen_sir : public CreatureScript
      void HandleDamageCalc(SpellEffIndex /*effIndex*/)
      {
          uint32 damage = GetCaster()->GetMap()->IsHeroic() ? 4250 : 2750;
-         SetHitDamage(damage);
+         SetEffectValue(damage);
      }
 
      void Register() override
      {
-         OnEffectHitTarget += SpellEffectFn(spell_four_horsemen_consumption::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+         OnEffectLaunchTarget += SpellEffectFn(spell_four_horsemen_consumption::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
      }
  };
 

--- a/src/server/scripts/Pet/pet_dk.cpp
+++ b/src/server/scripts/Pet/pet_dk.cpp
@@ -150,12 +150,12 @@ class spell_pet_dk_gargoyle_strike : public SpellScript
                 damage += (caster->getLevel() - 60) * 4;
         }
 
-        SetHitDamage(damage);
+        SetEffectValue(damage);
     }
 
     void Register() override
     {
-        OnEffectHitTarget += SpellEffectFn(spell_pet_dk_gargoyle_strike::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+        OnEffectLaunchTarget += SpellEffectFn(spell_pet_dk_gargoyle_strike::HandleDamageCalc, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
     }
 };
 


### PR DESCRIPTION
Change the way #22332 moved spell damage calculations from EffectSchoolDMG to scripts, using OnEffectLaunchTarget and SetEffectValue instead


**Changes proposed:**

-  use SetEffectValue() instead of SetHitDamage() since EffectSchoolDMG modifies "damage", not "m_damage"
-  use OnEffectLaunchTarget instead of OnEffectHitTarget, so the script is called right before SpellEffectDMG and all the bonus code in EffectSchoolDMG is called with the "damage" set in the script
-  this restores 100% the code flow of the old code before #22332 

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #21435


**Tests performed:** (Does it build, tested in-game, etc.)
I debugged spell_pet_dk_gargoyle_strike and checked that the code flow worked like intended. I don't know how much damage it's supposed to do, I got around 600 damage with a brand new level 80 character.
I didn't test the other spells, just applied the same changes.

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
