### PR TITLE
g3d: remove and gate some x86-specific code 

### DIFF
--- a/dep/g3dlite/include/G3D/platform.h
+++ b/dep/g3dlite/include/G3D/platform.h
@@ -273,7 +273,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) {\
 #           define __stdcall __attribute__((stdcall))
 #       endif
 
-#   elif defined(__x86_64__)
+#   elif defined(__x86_64__) || defined(__arm) || defined(__aarch64__)
 
 #       ifndef __cdecl
 #           define __cdecl

--- a/dep/g3dlite/source/System.cpp
+++ b/dep/g3dlite/source/System.cpp
@@ -78,9 +78,6 @@
     #include <CoreServices/CoreServices.h>
 #endif
 
-// SIMM include
-#include <xmmintrin.h>
-
 
 namespace G3D {
     

--- a/dep/g3dlite/source/System.cpp
+++ b/dep/g3dlite/source/System.cpp
@@ -548,8 +548,11 @@ static bool checkForCPUID() {
     // all known supported architectures have cpuid
     // add cases for incompatible architectures if they are added
     // e.g., if we ever support __powerpc__ being defined again
-
-    return true;
+#   if defined (__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
+        return true;
+#   else
+        return false;
+#   endif
 }
 
 

--- a/dep/g3dlite/source/System.cpp
+++ b/dep/g3dlite/source/System.cpp
@@ -1706,6 +1706,7 @@ void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, ui
 // for a discussion of why the second version saves ebx; it allows 32-bit code to compile with the -fPIC option.
 // On 64-bit x86, PIC code has a dedicated rip register for PIC so there is no ebx conflict.
 void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, uint32& edx) {
+#if defined (__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 #if ! defined(__PIC__) || defined(__x86_64__)
     // AT&T assembler syntax
     asm volatile(
@@ -1723,6 +1724,7 @@ void System::cpuid(CPUIDFunction func, uint32& eax, uint32& ebx, uint32& ecx, ui
                  "popl %%ebx       \n\t" /* restore the old ebx */
                  : "=a"(eax), "=r"(ebx), "=c"(ecx), "=d"(edx)
                  : "a"(func));
+#endif
 #endif
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  g3d: use compiler builtins for integer math on *all* platforms
-  g3d: build cpuid code only for x86

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #  (insert issue tracker number)

- Enhances #23231

**Tests performed:** (Does it build, tested in-game, etc.)

- master: built on Linux amd64, gcc
- master: login, create character, enter world
- 3.3.5: cherry-picked and built on Linux amd64, gcc

**Known issues and TODO list:** (add/remove lines as needed)

- needs testing on Windows and compilers other than gcc