### PR TITLE
Core/Quest: improve source item deletion logic for items that give quests

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15801,12 +15801,7 @@ bool Player::TakeQuestSourceItem(uint32 questId, bool msg)
             }
 
             ASSERT(item);
-            bool destroyItem = true;
-            for (uint8 n = 0; n < QUEST_ITEM_OBJECTIVES_COUNT; ++n)
-                if (item->StartQuest == questId)
-                    destroyItem = false;
-
-            if (destroyItem)
+            if (item->StartQuest != questId)
                 DestroyItemCount(srcItemId, count, true, true);
         }
     }


### PR DESCRIPTION
**Changes proposed:**

Items that give quests have some funky behaviors (thank you, Blizzard):

- Items that aren't Bind on Pickup are deleted when the quest is accepted if quest_template.StartItem is 0 (this already works fine before and after this PR).
- Items that start a quest whose StartItem field is the same id as said item are NOT deleted on quest accept/turn-in. This applies to [Demon Scarred Cloak](https://www.wowhead.com/item=4854) ([proof 1](https://www.wowhead.com/item=4854/demon-scarred-cloak#comments:id=234608), [proof 2](https://www.wowhead.com/quest=770/the-demon-scarred-cloak#comments:id=1056598)), [Cracked Silithid Carapace](https://www.wowhead.com/item=5877) ([proof](https://www.wowhead.com/item=5877/cracked-silithid-carapace#comments:id=883435)) and other equippable armor/weapon. This behavior leads to...
- Quests that have StartItem set to the same item id that started the quest must NOT be given to the player on quest accept, because the previous item was not deleted as per the precedent behavior. Examples: [Arena Master](https://www.wowhead.com/item=18706) ([video proof](https://youtu.be/gedm4B7Rgv8?t=230)), [Battered Hilt](https://www.wowhead.com/item=50379) ([video proof](https://youtu.be/4tEGvJvvXXk?t=4)). Notice the lack of "obtained item x" in the chat logs and how the item does not change place due to addnew+deleteold: there's no new item created, the old one is kept instead.

Long story short, this PR prevents the destruction of items that aren't supposed to be deleted ([Demon Scarred Cloak](https://www.wowhead.com/item=4854), [Pendant of Myzrael](https://www.wowhead.com/item=4614), [Noboru's Cudgel](https://www.wowhead.com/item=6196), [Cracked Silithid Carapace](https://www.wowhead.com/item=5877) and probably other useless white unique items Blizzard forgot about) and fixes a cosmetic detail on accepting two quests.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** builds and works.