### PR TITLE
Core/Unit: don't despawn summoned vehicles or vehicle accessories when player ejects

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12605,18 +12605,11 @@ void Unit::_ExitVehicle(Position const* exitPosition)
     if (player)
         player->ResummonPetTemporaryUnSummonedIfAny();
 
-    if (vehicle->GetBase()->HasUnitTypeMask(UNIT_MASK_MINION) && vehicle->GetBase()->GetTypeId() == TYPEID_UNIT)
-        if (((Minion*)vehicle->GetBase())->GetOwner() == this)
-            vehicle->GetBase()->ToCreature()->DespawnOrUnsummon(3000);
-
     if (HasUnitTypeMask(UNIT_MASK_ACCESSORY))
     {
         // Vehicle just died, we die too
         if (vehicle->GetBase()->getDeathState() == JUST_DIED)
             setDeathState(JUST_DIED);
-        // If for other reason we as minion are exiting the vehicle (ejected, master dismounted) - unsummon
-        else
-            ToTempSummon()->UnSummon(2000); // Approximation
     }
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12607,7 +12607,7 @@ void Unit::_ExitVehicle(Position const* exitPosition)
 
     if (vehicle->GetBase()->HasUnitTypeMask(UNIT_MASK_MINION) && vehicle->GetBase()->GetTypeId() == TYPEID_UNIT)
         if (((Minion*)vehicle->GetBase())->GetOwner() == this)
-            vehicle->GetBase()->ToCreature()->DespawnOrUnsummon(1);
+            vehicle->GetBase()->ToCreature()->DespawnOrUnsummon(3000);
 
     if (HasUnitTypeMask(UNIT_MASK_ACCESSORY))
     {


### PR DESCRIPTION
**Changes proposed:**

As visible [in this video](https://youtu.be/LQMLOThA2Js?t=63), a vehicle summoned via spellclick (related to the quest [Finding the Phylactery](https://www.wowhead.com/quest=11956)) dismounts the player but stays around a few seconds.

Right now the core despawns them in the next world tick, which makes any kind of event scripting impossible (that quest has the only one, as far as I know).

This is the best approach I can think of, as I do recall vehicles lingering for a few seconds before despawning - but maybe each script should handle its own vehicles' despawn instead on relying on this global despawn.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** works.