### PR TITLE
Core/Achievement: fix mistake related to ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -11854,7 +11854,7 @@ Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update
     {
         ItemAddedQuestCheck(item, count);
         UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_RECEIVE_EPIC_ITEM, item, count);
-        UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM, item, 1);
+        UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM, item, count);
         if (randomPropertyId)
             pItem->SetItemRandomProperties(randomPropertyId);
         pItem = StoreItem(dest, pItem, update);


### PR DESCRIPTION
**Changes proposed:**

It's hardcoded to increase by 1, but it should increase by count.
This fixes item-related statistics (for example badges/emblems in the Character category) that always increased by one instead of the amount of emblems looted.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** works.