### PR TITLE
Core/Creature: equipment_id field on creature table is not working co…

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -489,9 +489,11 @@ bool Creature::InitEntry(uint32 entry, CreatureData const* data /*= nullptr*/)
     SetNativeDisplayId(displayID);
 
     // Load creature equipment
-    if (!data || data->equipmentId == 0)
-        LoadEquipment(); // use default equipment (if available)
-    else                // override, 0 means no equipment
+    if (!data)
+        LoadEquipment();  // use default equipment (if available) for summons
+    else if (data->equipmentId == 0)
+        LoadEquipment(0); // 0 means no equipment for creature table
+    else                         
     {
         m_originalEquipmentId = data->equipmentId;
         LoadEquipment(data->equipmentId);


### PR DESCRIPTION
…rrectly, if it's set to 0 the npc still spawn with the equipement.

By Malcrom
Closes TrinityCore#16416