### PR TITLE
Core/Script: implement a PlayerScript hook called when a quest's objective receives progress

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16766,6 +16766,8 @@ void Player::SendQuestUpdateAddCreatureOrGo(Quest const* quest, ObjectGuid guid,
     uint16 log_slot = FindQuestSlot(quest->GetQuestId());
     if (log_slot < MAX_QUEST_LOG_SIZE)
         SetQuestSlotCounter(log_slot, creatureOrGO_idx, GetQuestSlotCounter(log_slot, creatureOrGO_idx) + add_count);
+
+    sScriptMgr->OnPlayerReachedQuestObjectiveCount(this, quest->GetQuestId(), creatureOrGO_idx, old_count + add_count);
 }
 
 void Player::SendQuestUpdateAddPlayer(Quest const* quest, uint16 old_count, uint16 add_count)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16767,7 +16767,7 @@ void Player::SendQuestUpdateAddCreatureOrGo(Quest const* quest, ObjectGuid guid,
     if (log_slot < MAX_QUEST_LOG_SIZE)
         SetQuestSlotCounter(log_slot, creatureOrGO_idx, GetQuestSlotCounter(log_slot, creatureOrGO_idx) + add_count);
 
-    sScriptMgr->OnPlayerReachedQuestObjectiveCount(this, quest->GetQuestId(), creatureOrGO_idx, old_count + add_count);
+    sScriptMgr->OnQuestObjectiveProgress(this, quest, creatureOrGO_idx, old_count + add_count);
 }
 
 void Player::SendQuestUpdateAddPlayer(Quest const* quest, uint16 old_count, uint16 add_count)

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1961,6 +1961,11 @@ void ScriptMgr::OnPlayerRepop(Player* player)
     FOREACH_SCRIPT(PlayerScript)->OnPlayerRepop(player);
 }
 
+void ScriptMgr::OnPlayerReachedQuestObjectiveCount(Player* player, uint32 questId, uint32 creatureOrGoEntry, uint8 count)
+{
+    FOREACH_SCRIPT(PlayerScript)->OnPlayerReachedQuestObjectiveCount(player, questId, creatureOrGoEntry, count);
+}
+
 // Account
 void ScriptMgr::OnAccountLogin(uint32 accountId)
 {

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1961,9 +1961,9 @@ void ScriptMgr::OnPlayerRepop(Player* player)
     FOREACH_SCRIPT(PlayerScript)->OnPlayerRepop(player);
 }
 
-void ScriptMgr::OnPlayerReachedQuestObjectiveCount(Player* player, uint32 questId, uint32 creatureOrGoEntry, uint8 count)
+void ScriptMgr::OnQuestObjectiveProgress(Player* player, Quest const* quest, uint32 objectiveIndex, uint16 progress)
 {
-    FOREACH_SCRIPT(PlayerScript)->OnPlayerReachedQuestObjectiveCount(player, questId, creatureOrGoEntry, count);
+    FOREACH_SCRIPT(PlayerScript)->OnQuestObjectiveProgress(player, quest, objectiveIndex, progress);
 }
 
 // Account

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -699,14 +699,14 @@ class TC_GAME_API PlayerScript : public ScriptObject
         // Called when a player changes to a new map (after moving to new map)
         virtual void OnMapChanged(Player* /*player*/) { }
 
+        // Called when a player obtains progress on a quest's objective
+        virtual void OnQuestObjectiveProgress(Player* /*player*/, Quest const* /*quest*/, uint32 /*objectiveIndex*/, uint16 /*progress*/) { }
+
         // Called after a player's quest status has been changed
         virtual void OnQuestStatusChange(Player* /*player*/, uint32 /*questId*/) { }
 
         // Called when a player presses release when he died
         virtual void OnPlayerRepop(Player* /*player*/) { }
-
-        // Called when a player obtains progress on a quest's objective
-        virtual void OnPlayerReachedQuestObjectiveCount(Player* /*player*/, uint32 /*questId*/, uint32 /*creatureOrGoEntry*/, uint8 /*count*/) { }
 };
 
 class TC_GAME_API AccountScript : public ScriptObject
@@ -1014,9 +1014,9 @@ class TC_GAME_API ScriptMgr
         void OnPlayerSave(Player* player);
         void OnPlayerBindToInstance(Player* player, Difficulty difficulty, uint32 mapid, bool permanent, uint8 extendState);
         void OnPlayerUpdateZone(Player* player, uint32 newZone, uint32 newArea);
+        void OnQuestObjectiveProgress(Player* player, Quest const* quest, uint32 objectiveIndex, uint16 progress);
         void OnQuestStatusChange(Player* player, uint32 questId);
         void OnPlayerRepop(Player* player);
-        void OnPlayerReachedQuestObjectiveCount(Player* player, uint32 questId, uint32 creatureOrGoEntry, uint8 count);
 
     public: /* AccountScript */
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -704,6 +704,9 @@ class TC_GAME_API PlayerScript : public ScriptObject
 
         // Called when a player presses release when he died
         virtual void OnPlayerRepop(Player* /*player*/) { }
+
+        // Called when a player obtains progress on a quest's objective
+        virtual void OnPlayerReachedQuestObjectiveCount(Player* player, uint32 questId, uint32 creatureOrGoEntry, uint8 count) { }
 };
 
 class TC_GAME_API AccountScript : public ScriptObject
@@ -1013,6 +1016,7 @@ class TC_GAME_API ScriptMgr
         void OnPlayerUpdateZone(Player* player, uint32 newZone, uint32 newArea);
         void OnQuestStatusChange(Player* player, uint32 questId);
         void OnPlayerRepop(Player* player);
+        void OnPlayerReachedQuestObjectiveCount(Player* player, uint32 questId, uint32 creatureOrGoEntry, uint8 count);
 
     public: /* AccountScript */
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -706,7 +706,7 @@ class TC_GAME_API PlayerScript : public ScriptObject
         virtual void OnPlayerRepop(Player* /*player*/) { }
 
         // Called when a player obtains progress on a quest's objective
-        virtual void OnPlayerReachedQuestObjectiveCount(Player* player, uint32 questId, uint32 creatureOrGoEntry, uint8 count) { }
+        virtual void OnPlayerReachedQuestObjectiveCount(Player* /*player*/, uint32 /*questId*/, uint32 /*creatureOrGoEntry*/, uint8 /*count*/) { }
 };
 
 class TC_GAME_API AccountScript : public ScriptObject


### PR DESCRIPTION
**Changes proposed:**

This implements a PlayerScript hook that's called whenever the player obtains progress in a quest that uses quest_template.RequiredNpcOrGoX fields.

It allows access to the player object, the id of the npc or gameobject target of the quest, and the new objective's count (if a quest requires to kill 25 of the same npc, the player is at 14/25 and kills one, the hook is called with count=15 and creatureOrGoEntry=whatever the npc entry is). 

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** adds core support to allow proper fixing of #23284 and #16037.


**Tests performed:** tested, works.