### PR TITLE
Core/GameObjects: goober gameobjects may reset only if they have a lock id or a reset time specified

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -755,8 +755,8 @@ void GameObject::Update(uint32 diff)
                     m_usetimes = 0;
                 }
 
-                // Only goobers with a lock id may reset their go state
-                if (GetGOInfo()->GetLockId())
+                // Only goobers with a lock id and a reset time may reset their go state
+                if (GetGOInfo()->GetLockId() && GetGOInfo()->GetAutoCloseTime())
                     SetGoState(GO_STATE_READY);
 
                 //any return here in case battleground traps

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -755,8 +755,8 @@ void GameObject::Update(uint32 diff)
                     m_usetimes = 0;
                 }
 
-                // Only goobers with a lock id and a reset time may reset their go state
-                if (GetGOInfo()->GetLockId() && GetGOInfo()->GetAutoCloseTime())
+                // Only goobers with a lock id or a reset time may reset their go state
+                if (GetGOInfo()->GetLockId() || GetGOInfo()->GetAutoCloseTime())
                     SetGoState(GO_STATE_READY);
 
                 //any return here in case battleground traps

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -755,7 +755,9 @@ void GameObject::Update(uint32 diff)
                     m_usetimes = 0;
                 }
 
-                SetGoState(GO_STATE_READY);
+                // Only goobers with a lock id may reset their go state
+                if (GetGOInfo()->GetLockId())
+                    SetGoState(GO_STATE_READY);
 
                 //any return here in case battleground traps
                 if (GameObjectOverride const* goOverride = GetGameObjectOverride())


### PR DESCRIPTION
Tests have shown that Goobers without a lock id (Data0=0) are not allowed to reset their go state such as the teleporters in Ulduar and Icecrown Citadel. The tests has been expanded by checking 4.x goobers as well and the perfect example that confirms that result is the Ancient Bell for Atramedes' intro which also is not suposed to reset after using it.

**Changes proposed:**
-  block the go state reset for goober gameobjects without a lock id and no reset time to prevent some ugly visual issues with them such as the icecrown citadel and ulduar teleporters. Apparently all gameobjects with a lock id are suposed to reset while gameobjects without a lock id and with no reset time are actually not meant to reset their visual state once activated.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame by me and Kilyana

