### PR TITLE
Core/Console: start CliRunnable thread after all log messages have been printed

### DIFF
--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -307,17 +307,6 @@ extern int main(int argc, char** argv)
         ClearOnlineAccounts();
     });
 
-    // Launch CliRunnable thread
-    std::shared_ptr<std::thread> cliThread;
-#ifdef _WIN32
-    if (sConfigMgr->GetBoolDefault("Console.Enable", true) && (m_ServiceStatus == -1)/* need disable console in service mode*/)
-#else
-    if (sConfigMgr->GetBoolDefault("Console.Enable", true))
-#endif
-    {
-        cliThread.reset(new std::thread(CliThread), &ShutdownCLIThread);
-    }
-
     // Set server online (allow connecting now)
     LoginDatabase.DirectPExecute("UPDATE realmlist SET flag = flag & ~%u, population = 0 WHERE id = '%u'", REALM_FLAG_OFFLINE, realm.Id.Realm);
     realm.PopulationLevel = 0.0f;
@@ -335,6 +324,17 @@ extern int main(int argc, char** argv)
     TC_LOG_INFO("server.worldserver", "%s (worldserver-daemon) ready...", GitRevision::GetFullVersion());
 
     sScriptMgr->OnStartup();
+
+    // Launch CliRunnable thread
+    std::shared_ptr<std::thread> cliThread;
+#ifdef _WIN32
+    if (sConfigMgr->GetBoolDefault("Console.Enable", true) && (m_ServiceStatus == -1)/* need disable console in service mode*/)
+#else
+    if (sConfigMgr->GetBoolDefault("Console.Enable", true))
+#endif
+    {
+        cliThread.reset(new std::thread(CliThread), &ShutdownCLIThread);
+    }
 
     WorldUpdateLoop();
 


### PR DESCRIPTION
**Changes proposed:**

This is a very cosmetic change. The command line input thread was started (which outputs "TC>" and waits for input) before all log messages were printed, so the console would show "TC>[git revision] ready..." on the same line.

It makes more sense that the CLI input becomes available after the very last loading message has been printed to console.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** builds, launched worldserver a few times to make sure nothing breaks.