### PR TITLE
Core/Script: add script hook to allow overriding of a vehicle passenger's exit position

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12579,13 +12579,6 @@ void Unit::_ExitVehicle(Position const* exitPosition)
 
     SetControlled(false, UNIT_STATE_ROOT);      // SMSG_MOVE_FORCE_UNROOT, ~MOVEMENTFLAG_ROOT
 
-    Position pos;
-    if (!exitPosition)                          // Exit position not specified
-        pos = vehicle->GetBase()->GetPosition();  // This should use passenger's current position, leaving it as it is now
-                                                // because we calculate positions incorrect (sometimes under map)
-    else
-        pos = *exitPosition;
-
     AddUnitState(UNIT_STATE_MOVE);
 
     if (player)
@@ -12596,6 +12589,14 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         data << GetPackGUID();
         SendMessageToSet(&data, false);
     }
+
+    // Default exit position to vehicle position
+    Position pos = vehicle->GetBase()->GetPosition();
+    // If we ask for a specific exit position, use that one. Otherwise allow scripts to modify it
+    if (exitPosition)
+        pos = *exitPosition;
+    else
+        sScriptMgr->ModifyVehiclePassengerExitPos(this, vehicle, pos);
 
     float height = pos.GetPositionZ() + vehicle->GetBase()->GetCollisionHeight();
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12590,8 +12590,9 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         SendMessageToSet(&data, false);
     }
 
-    // Default exit position to vehicle position
+    // Default exit position to vehicle position and use the current orientation
     Position pos = vehicle->GetBase()->GetPosition();
+    pos.SetOrientation(GetOrientation());
     // If we ask for a specific exit position, use that one. Otherwise allow scripts to modify it
     if (exitPosition)
         pos = *exitPosition;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12607,7 +12607,7 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         init.SetFall();
 
     init.MoveTo(pos.GetPositionX(), pos.GetPositionY(), height, false);
-    init.SetFacing(GetOrientation());
+    init.SetFacing(pos.GetOrientation());
     init.SetTransportExit();
     GetMotionMaster()->LaunchMoveSpline(std::move(init), EVENT_VEHICLE_EXIT, MOTION_PRIORITY_HIGHEST);
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12590,13 +12590,13 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         SendMessageToSet(&data, false);
     }
 
-    // Default exit position to vehicle position and use the current orientation
     Position pos;
     // If we ask for a specific exit position, use that one. Otherwise allow scripts to modify it
     if (exitPosition)
         pos = *exitPosition;
     else
     {
+        // Set exit position to vehicle position and use the current orientation
         pos = vehicle->GetBase()->GetPosition();
         pos.SetOrientation(GetOrientation());
         sScriptMgr->ModifyVehiclePassengerExitPos(this, vehicle, pos);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12591,13 +12591,16 @@ void Unit::_ExitVehicle(Position const* exitPosition)
     }
 
     // Default exit position to vehicle position and use the current orientation
-    Position pos = vehicle->GetBase()->GetPosition();
-    pos.SetOrientation(GetOrientation());
+    Position pos;
     // If we ask for a specific exit position, use that one. Otherwise allow scripts to modify it
     if (exitPosition)
         pos = *exitPosition;
     else
+    {
+        pos = vehicle->GetBase()->GetPosition();
+        pos.SetOrientation(GetOrientation());
         sScriptMgr->ModifyVehiclePassengerExitPos(this, vehicle, pos);
+    }
 
     float height = pos.GetPositionZ() + vehicle->GetBase()->GetCollisionHeight();
 

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2111,6 +2111,11 @@ void ScriptMgr::ModifySpellDamageTaken(Unit* target, Unit* attacker, int32& dama
     FOREACH_SCRIPT(UnitScript)->ModifySpellDamageTaken(target, attacker, damage);
 }
 
+void ScriptMgr::ModifyVehiclePassengerExitPos(Unit* passenger, Vehicle* vehicle, Position& pos)
+{
+    FOREACH_SCRIPT(UnitScript)->ModifyVehiclePassengerExitPos(passenger, vehicle, pos);
+}
+
 SpellScriptLoader::SpellScriptLoader(char const* name)
     : ScriptObject(name)
 {

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -70,6 +70,7 @@ struct CreatureTemplate;
 struct CreatureData;
 struct ItemTemplate;
 struct MapEntry;
+struct Position;
 
 enum BattlegroundTypeId : uint32;
 enum ContentLevels : uint8;

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -407,6 +407,9 @@ class TC_GAME_API UnitScript : public ScriptObject
 
         // Called when Spell Damage is being Dealt
         virtual void ModifySpellDamageTaken(Unit* /*target*/, Unit* /*attacker*/, int32& /*damage*/) { }
+
+        // Called when an unit exits a vehicle
+        virtual void ModifyVehiclePassengerExitPos(Unit* /*passenger*/, Vehicle* /*vehicle*/, Position& /*pos*/) { }
 };
 
 class TC_GAME_API CreatureScript : public ScriptObject
@@ -1057,6 +1060,7 @@ class TC_GAME_API ScriptMgr
         void ModifyPeriodicDamageAurasTick(Unit* target, Unit* attacker, uint32& damage);
         void ModifyMeleeDamage(Unit* target, Unit* attacker, uint32& damage);
         void ModifySpellDamageTaken(Unit* target, Unit* attacker, int32& damage);
+        void ModifyVehiclePassengerExitPos(Unit* passenger, Vehicle* vehicle, Position& pos);
 
     private:
         uint32 _scriptCount;


### PR DESCRIPTION
**Changes proposed:**

Allow an UnitScript to override/modify the exit position of a vehicle's passenger when it exits a vehicle.

Some vehicles have a fixed exit position (#20447), others have an exit position relative to the vehicle's position ([Traveler's Tundra Mammoth](https://youtu.be/IWxQLen9Hp8?t=172)) and most vehicles eject the player to a nearby position (maybe it has something to do with bounding radius in that case?). DBC data doesn't seem to be enough to calculate a position, so I think this is the best alternative (being an UnitScript it works for both player and creature passengers and does not interfere with AI scripts).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** builds, works.