### PR TITLE
Core/Players: added fixed 5 seconds interval for out of range group updates to match retail behaivior

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -401,6 +401,8 @@ Player::Player(WorldSession* session): Unit(true)
 
     m_achievementMgr = new AchievementMgr(this);
     m_reputationMgr = new ReputationMgr(this);
+
+    m_groupUpdateTimer.Reset(5000);
 }
 
 Player::~Player()
@@ -1329,7 +1331,12 @@ void Player::Update(uint32 p_time)
     }
 
     // group update
-    SendUpdateToOutOfRangeGroupMembers();
+    m_groupUpdateTimer.Update(p_time);
+    if (m_groupUpdateTimer.Passed())
+    {
+        SendUpdateToOutOfRangeGroupMembers();
+        m_groupUpdateTimer.Reset(5000);
+    }
 
     Pet* pet = GetPet();
     if (pet && !pet->IsWithinDistInMap(this, GetMap()->GetVisibilityRange()) && !pet->isPossessed())

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2399,6 +2399,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         bool m_needsZoneUpdate;
 
+        TimeTrackerSmall m_groupUpdateTimer;
+
     private:
         // internal common parts for CanStore/StoreItem functions
         InventoryResult CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemPosCountVec& dest, ItemTemplate const* pProto, uint32& count, bool swap, Item* pSrcItem) const;


### PR DESCRIPTION
**Changes proposed:**

-  changed the out of range group update handling to get updated every 5 seconds instead of with every update tick as soon as a flag gets added. This is what retail does as well according to 335 and 434 sniffs. On 4.x and above this fixes a nasty fps drop that is caused by spaming the client with group update packets because every single position update is causing the group update packet getting sent.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame, clear results
