### PR TITLE
Core/Groups: do not allow lfg groups to change the loot mode

### DIFF
--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -447,6 +447,9 @@ void WorldSession::HandleLootMethodOpcode(WorldPacket& recvData)
     if (!group->IsLeader(GetPlayer()->GetGUID()))
         return;
 
+    if (group->isLFGGroup())
+        return;
+    
     if (lootMethod > NEED_BEFORE_GREED)
         return;
 


### PR DESCRIPTION
**Changes proposed:**

-  add a new check to the loot method opcode handler to block any attempt of changing the loot mode while inside a lfg group. The UI itself blocks the method setting but you can still run scripts that will trigger that opcode so we will block it from now on.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame by some mates, works fine so far.