### PR TITLE
Script/Creature: calculate Traveler's Tundra Mammoth's NPCs' exit position based on current player's position

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2964,7 +2964,7 @@ class npc_traveler_tundra_mammoth_exit_pos : public UnitScript
 public:
     npc_traveler_tundra_mammoth_exit_pos() : UnitScript("npc_traveler_tundra_mammoth_exit_pos") { }
 
-    void ModifyVehiclePassengerExitPos(Unit* passenger, Vehicle* vehicle, Position& pos)
+    void ModifyVehiclePassengerExitPos(Unit* passenger, Vehicle* /*vehicle*/, Position& pos)
     {
         if (passenger->GetTypeId() == TYPEID_UNIT)
         {

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2951,6 +2951,40 @@ public:
     }
 };
 
+enum TravelerTundraMammothNPCs
+{
+    NPC_HAKMUD_OF_ARGUS  = 32638,
+    NPC_GNIMO            = 32639,
+    NPC_DRIX_BLACKWRENCH = 32641,
+    NPC_MOJODISHU        = 32642
+};
+
+class npc_traveler_tundra_mammoth_exit_pos : public UnitScript
+{
+public:
+    npc_traveler_tundra_mammoth_exit_pos() : UnitScript("npc_traveler_tundra_mammoth_exit_pos") { }
+
+    void ModifyVehiclePassengerExitPos(Unit* passenger, Vehicle* vehicle, Position& pos)
+    {
+        if (passenger->GetTypeId() == TYPEID_UNIT)
+        {
+            switch (passenger->GetEntry())
+            {
+                // Right side
+                case NPC_DRIX_BLACKWRENCH:
+                case NPC_GNIMO:
+                    pos.RelocateOffset({ -2.0f, -2.0f, 0.0f, 0.0f });
+                    break;
+                // Left side
+                case NPC_MOJODISHU:
+                case NPC_HAKMUD_OF_ARGUS:
+                    pos.RelocateOffset({ -2.0f, 2.0f, 0.0f, 0.0f });
+                    break;
+            }
+        }
+    }
+};
+
 void AddSC_npcs_special()
 {
     new npc_air_force_bots();
@@ -2978,4 +3012,5 @@ void AddSC_npcs_special()
     new npc_train_wrecker();
     new npc_argent_squire_gruntling();
     new npc_bountiful_table();
+    new npc_traveler_tundra_mammoth_exit_pos();
 }


### PR DESCRIPTION
**Changes proposed:**

When a player dismounts from the [Traveler's Tundra Mammoth](https://wow.gamepedia.com/Reins_of_the_Traveler%27s_Tundra_Mammoth), the vendor/repair NPCs are supposed to dismount at a position based on the player's current position (south-east and south-west respectively).

[Example](https://youtu.be/IWxQLen9Hp8?t=171).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.