### PR TITLE
Core/SAI: add action_param3 to SMART_ACTION_REMOVEAURASFROMSPELL to allow it to remove only auras from spells that were cast by the entity itself

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -863,13 +863,21 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                 if (e.action.removeAura.spell)
                 {
+                    ObjectGuid casterGUID;
+                    if (e.action.removeAura.onlyOwnedAuras)
+                    {
+                        if (!me)
+                            break;
+                        casterGUID = me->GetGUID();
+                    }
+
                     if (e.action.removeAura.charges)
                     {
-                        if (Aura* aur = target->ToUnit()->GetAura(e.action.removeAura.spell))
+                        if (Aura* aur = target->ToUnit()->GetAura(e.action.removeAura.spell, casterGUID))
                             aur->ModCharges(-static_cast<int32>(e.action.removeAura.charges), AURA_REMOVE_BY_EXPIRE);
                     }
                     else
-                        target->ToUnit()->RemoveAurasDueToSpell(e.action.removeAura.spell);
+                        target->ToUnit()->RemoveAurasDueToSpell(e.action.removeAura.spell, casterGUID);
                 }
                 else
                     target->ToUnit()->RemoveAllAuras();

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -721,6 +721,7 @@ struct SmartAction
         {
             uint32 spell;
             uint32 charges;
+            uint32 onlyOwnedAuras;
         } removeAura;
 
         struct


### PR DESCRIPTION
**Changes proposed:**

There are cases where a script must remove an aura from a creature, but said creature has other copies of the same aura coming from different casters. In that case we might want to only remove the aura owned by the entity that is executing said script.

Setting action_param3 to 1 allows this behavior, while 0 (the default value) retains original behavior.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)

**Tests performed:** it works.