### PR TITLE
Script/Quest: As the Crow Flies

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,22 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`="spell_crow_whisper_aura";
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(31774, "spell_crow_whisper_aura"),
+(31775, "spell_crow_whisper_aura"),
+(31776, "spell_crow_whisper_aura"),
+(31777, "spell_crow_whisper_aura");
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` IN (31746, -31773, -31774, -31775, -31776, -31777);
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(31746, 31773, 0, "As the Crow Flies - Whisper Aura 0"),
+(-31773, 31774, 0, "As the Crow Flies - Whisper Aura 1"),
+(-31774, 31775, 0, "As the Crow Flies - Whisper Aura 2"),
+(-31775, 31776, 0, "As the Crow Flies - Whisper Aura 3"),
+(-31776, 31777, 0, "As the Crow Flies - Whisper Aura 4"),
+(-31777, -31746, 0, "As the Crow Flies - Remove Stormcrow Shape");
+
+DELETE FROM `creature_text` WHERE `CreatureID`=17841;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(17841, 0, 0, "It's just like the structure you described at Umbrafen Lake.  Does this mean the naga are pumping water out of all the lakes in Zangarmarsh?", 15, 0, 100, 0, 0, 0, 14706, 0, "Ysiel Windsinger"),
+(17841, 1, 0, "The naga are even pumping the water out of their own lake!  What purpose could that possibly serve?", 15, 0, 100, 0, 0, 0, 14712, 0, "Ysiel Windsinger"),
+(17841, 2, 0, "There!  Those pipes all appear to be connected to that structure.  It can't possibly fit all the water they've been stealing.  Where are they keeping it?", 15, 0, 100, 0, 0, 0, 14713, 0, "Ysiel Windsinger"),
+(17841, 3, 0, "What we saw explains what happened in the Dead Mire.  There was a lake here once.  If we don't stop the naga, all of the marsh will soon look like this!", 15, 0, 100, 0, 0, 0, 14714, 0, "Ysiel Windsinger");

--- a/src/server/scripts/Outland/zone_zangarmarsh.cpp
+++ b/src/server/scripts/Outland/zone_zangarmarsh.cpp
@@ -229,6 +229,46 @@ public:
     }
 };
 
+enum AsTheCrowFlies
+{
+    SPELL_WHISPER_AURA_1 = 31774,
+    NPC_YSIEL_WINDSINGER = 17841
+};
+
+class spell_crow_whisper_aura : public SpellScriptLoader
+{
+    public:
+        spell_crow_whisper_aura() : SpellScriptLoader("spell_crow_whisper_aura") { }
+
+        class spell_crow_whisper_aura_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_crow_whisper_aura_SpellScript);
+
+            void HandleEffect(SpellEffIndex effIndex)
+            {
+                SpellInfo const* spellInfo = GetSpellInfo();
+                uint32 talkId = spellInfo->Id - SPELL_WHISPER_AURA_1;
+                Unit* caster = GetCaster();
+
+                if (Creature* questgiver = GetHitUnit()->SummonCreature(NPC_YSIEL_WINDSINGER, caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ(), caster->GetOrientation(), TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 2000))
+                {
+                    questgiver->SetVisible(false);
+                    questgiver->AI()->Talk(talkId, GetHitUnit());
+                }
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_crow_whisper_aura_SpellScript::HandleEffect, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_crow_whisper_aura_SpellScript();
+        }
+};
+
 /*######
 ## AddSC
 ######*/
@@ -237,4 +277,5 @@ void AddSC_zangarmarsh()
 {
     new npcs_ashyen_and_keleth();
     new npc_kayra_longmane();
+    new spell_crow_whisper_aura();
 }

--- a/src/server/scripts/Outland/zone_zangarmarsh.cpp
+++ b/src/server/scripts/Outland/zone_zangarmarsh.cpp
@@ -244,7 +244,7 @@ class spell_crow_whisper_aura : public SpellScriptLoader
         {
             PrepareSpellScript(spell_crow_whisper_aura_SpellScript);
 
-            void HandleEffect(SpellEffIndex effIndex)
+            void HandleEffect(SpellEffIndex /*effIndex*/)
             {
                 SpellInfo const* spellInfo = GetSpellInfo();
                 uint32 talkId = spellInfo->Id - SPELL_WHISPER_AURA_1;


### PR DESCRIPTION
**Changes proposed:**

Script the event that happens during the quest [As the Crow Flies](https://www.wowhead.com/quest=9718) (the questgiver whispers text to the player).

Because the player goes in different grids, grid searchers can't be used to obtain a handle to the questgiver. There also aren't other spawns or creature templates, so the script summons and despawns an invisible copy of the quest giver. Suggestions on a better handling of that behavior are welcome, if the current one isn't appropriate.

[Reference video](https://www.youtube.com/watch?v=eh1pN25cqAw).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Fixes the remaining issue in #5723 (already closed).


**Tests performed:** it works.