### PR TITLE
Script/GunDrak: fix order for yell and altar texts on death for two bosses

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_moorabi.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_moorabi.cpp
@@ -121,8 +121,8 @@ class boss_moorabi : public CreatureScript
             void JustDied(Unit* /*killer*/) override
             {
                 _JustDied();
-                Talk(SAY_DEATH);
                 Talk(EMOTE_ACTIVATE_ALTAR);
+                Talk(SAY_DEATH);
             }
 
             void SpellHit(Unit* /*caster*/, SpellInfo const* spellInfo) override

--- a/src/server/scripts/Northrend/Gundrak/boss_slad_ran.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_slad_ran.cpp
@@ -170,8 +170,8 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             _JustDied();
-            Talk(SAY_DEATH);
             Talk(EMOTE_ACTIVATE_ALTAR);
+            Talk(SAY_DEATH);
         }
 
         void KilledUnit(Unit* who) override


### PR DESCRIPTION
**Changes proposed:**

Moorabi and Slad'Ran have the order of their on death texts reserved. They should first do the emote about the altars, then their own yell.

Videos: [Moorabi](https://youtu.be/6UG7G9pjUr4?t=27), [Slad'Ran](https://youtu.be/Xy4YXoao66o?t=104).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.