### PR TITLE
Script/ZulGurub: fix the RP texts triggered when players reach certain areas

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,10 @@
+UPDATE `creature_text` SET `TextRange`=3 WHERE `CreatureID`=14834 AND `GroupId` IN (2, 3);
+DELETE FROM `creature_text` WHERE `CreatureID`=14834 AND `GroupId`=4;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(14834, 4, 0, "Your callous disregard for the sovereign might of the Gurubashi Empire has been noted. The inhabitants of Zul'Gurub have been alerted to your presence.", 16, 0, 100, 0, 0, 0, 10550, 3, "hakkar SAY_ENTRANCE");
+
+DELETE FROM `areatrigger_scripts` WHERE `entry` IN (3957, 3958, 3960);
+INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`) VALUES
+(3957, 'at_zulgurub_entrance'),
+(3958, 'at_zulgurub_entrance'),
+(3960, 'at_zulgurub_entrance');

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_hakkar.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_hakkar.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "zulgurub.h"
+#include "DBCStructure.h"
 #include "InstanceScript.h"
+#include "Player.h"
 #include "ScriptedCreature.h"
 #include "ScriptMgr.h"
 
@@ -24,8 +26,9 @@ enum Says
 {
     SAY_AGGRO                   = 0,
     SAY_FLEEING                 = 1,
-    SAY_MINION_DESTROY          = 2,     // Where does it belong?
-    SAY_PROTECT_ALTAR           = 3      // Where does it belong?
+    SAY_MINION_DESTROY          = 2,
+    SAY_PROTECT_ALTAR           = 3,
+    SAY_ENTRANCE                = 4
 };
 
 enum Spells
@@ -180,7 +183,41 @@ class boss_hakkar : public CreatureScript
         }
 };
 
+class at_zulgurub_entrance : public OnlyOnceAreaTriggerScript
+{
+public:
+    at_zulgurub_entrance() : OnlyOnceAreaTriggerScript("at_zulgurub_entrance") { }
+
+    bool _OnTrigger(Player* player, AreaTriggerEntry const* areaTrigger) override
+    {
+        InstanceScript* instance = player->GetInstanceScript();
+        if (!instance || instance->GetBossState(DATA_HAKKAR) == DONE)
+            return true;
+
+        if (Creature* hakkar = instance->GetCreature(DATA_HAKKAR))
+        {
+            switch (areaTrigger->id)
+            {
+                case AREA_TRIGGER_1:
+                    hakkar->AI()->Talk(SAY_ENTRANCE);
+                    break;
+                case AREA_TRIGGER_2:
+                    hakkar->AI()->Talk(SAY_PROTECT_ALTAR);
+                    break;
+                case AREA_TRIGGER_3:
+                    hakkar->AI()->Talk(SAY_MINION_DESTROY);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return true;
+    }
+};
+
 void AddSC_boss_hakkar()
 {
     new boss_hakkar();
+    new at_zulgurub_entrance();
 }

--- a/src/server/scripts/EasternKingdoms/ZulGurub/instance_zulgurub.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/instance_zulgurub.cpp
@@ -36,7 +36,8 @@ ObjectData const creatureData[] =
     { NPC_JINDO_THE_HEXXER,   DATA_JINDO },
     { NPC_ARLOKK,             DATA_ARLOKK },
     { NPC_PRIESTESS_MARLI,    DATA_MARLI },
-    { NPC_VILEBRANCH_SPEAKER, DATA_VILEBRANCH_SPEAKER }
+    { NPC_VILEBRANCH_SPEAKER, DATA_VILEBRANCH_SPEAKER },
+    { NPC_HAKKAR,             DATA_HAKKAR }
 };
 
 ObjectData const gameobjectData[] =

--- a/src/server/scripts/EasternKingdoms/ZulGurub/zulgurub.h
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/zulgurub.h
@@ -60,14 +60,21 @@ enum ZGCreatureIds
     NPC_MANDOKIR            = 11382, // Mandokir Event
     NPC_OHGAN               = 14988, // Mandokir Event
     NPC_VILEBRANCH_SPEAKER  = 11391, // Mandokir Event
-    NPC_CHAINED_SPIRT       = 15117  // Mandokir Event
-
+    NPC_CHAINED_SPIRT       = 15117, // Mandokir Event
+    NPC_HAKKAR              = 14834
 };
 
 enum ZGGameObjectIds
 {
     GO_FORCEFIELD           = 180497, // Arlokk Event
     GO_GONG_OF_BETHEKK      = 180526  // Arlokk Event
+};
+
+enum ZulGurubAreaTriggers
+{
+    AREA_TRIGGER_1          = 3957,
+    AREA_TRIGGER_2          = 3958,
+    AREA_TRIGGER_3          = 3960
 };
 
 template <class AI, class T>


### PR DESCRIPTION
**Changes proposed:**

Implement the emotes sent when a player first steps inside certain areatriggers, and save their status in the DB so they can only be triggered once for every raid reset, persisting across server restarts/grid unloads.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #17572

**Tests performed:** it works.