### PR TITLE
Script/ZulGurub: allow Hakkar to cast Mind Control only if more than one unit is currently fighting him

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_hakkar.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_hakkar.cpp
@@ -132,9 +132,16 @@ class boss_hakkar : public CreatureScript
                             // events.ScheduleEvent(EVENT_CAUSE_INSANITY, 35s, 45s);
                             break;
                         case EVENT_WILL_OF_HAKKAR:
-                            DoCast(SelectTarget(SELECT_TARGET_RANDOM, 0, 100, true), SPELL_WILL_OF_HAKKAR);
+                        {
+                            // Mind Control is only triggered when there is more than one unit currently fighting Hakkar, including pets/guardians
+                            // But it is only actually cast on the player with the highest threat
+                            std::list<Unit*> unitList;
+                            SelectTargetList(unitList, 2, SELECT_TARGET_MAXTHREAT, 0, 0.0f, false);
+                            if (unitList.size() > 1)
+                                DoCast(SelectTarget(SELECT_TARGET_MAXTHREAT, 0, 100, true), SPELL_WILL_OF_HAKKAR);
                             events.ScheduleEvent(EVENT_WILL_OF_HAKKAR, 25s, 35s);
                             break;
+                        }
                         case EVENT_ENRAGE:
                             if (!me->HasAura(SPELL_ENRAGE))
                                 DoCast(me, SPELL_ENRAGE);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Hakkar should cast Mind Control on the current tank (examples [1](https://youtu.be/GXVmEUOS1ng?t=44), [2](https://youtu.be/GXVmEUOS1ng?t=82), [3](https://youtu.be/GXVmEUOS1ng?t=103), notice how it's always the current highest aggro player that gets targeted by it).

Also it should not be cast if there is only one player engaging him. Having a pet out will allow him to cast it, though. [Here](https://www.mmo-champion.com/threads/755450-Zul-Gurub-soloable)'s a discussion between people that soloed him in WotLK.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.