### PR TITLE
Core/Creature: prevent dead creatures from setting a focus target.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3011,6 +3011,10 @@ void Creature::FocusTarget(Spell const* focusSpell, WorldObject const* target)
     if (m_focusSpell)
         return;
 
+    // Prevent dead creatures from setting a focus target, so they won't turn
+    if (!IsAlive())
+        return;
+
     // some spells shouldn't track targets
     if (focusSpell->IsFocusDisabled())
         return;


### PR DESCRIPTION
**Changes proposed:**

Apply the SQL script in #23366 and try to do the quest. You'll notice the dead creature will set a focus on the player and turn around when the player moves, after using the Forsaken Banner.

This PR prevents dead creatures from obtaining a focus target, as they aren't supposed to move around.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.