### PR TITLE
Script/Dalaran: don't allow Dalaran faction guards to teleport a player that has the Trespasser! debuff

### DIFF
--- a/src/server/scripts/Northrend/zone_dalaran.cpp
+++ b/src/server/scripts/Northrend/zone_dalaran.cpp
@@ -89,7 +89,9 @@ public:
             if (!player || player->IsGameMaster() || player->IsBeingTeleported() ||
                 // If player has Disguise aura for quest A Meeting With The Magister or An Audience With The Arcanist, do not teleport it away but let it pass
                 player->HasAura(SPELL_SUNREAVER_DISGUISE_FEMALE) || player->HasAura(SPELL_SUNREAVER_DISGUISE_MALE) ||
-                player->HasAura(SPELL_SILVER_COVENANT_DISGUISE_FEMALE) || player->HasAura(SPELL_SILVER_COVENANT_DISGUISE_MALE))
+                player->HasAura(SPELL_SILVER_COVENANT_DISGUISE_FEMALE) || player->HasAura(SPELL_SILVER_COVENANT_DISGUISE_MALE) ||
+                // If player has already been teleported, don't try to teleport again
+                player->HasAura(SPELL_TRESPASSER_A) || player->HasAura(SPELL_TRESPASSER_H))
                 return;
 
             switch (me->GetEntry())


### PR DESCRIPTION
**Changes proposed:**

The issue with the guards changing orientation is caused by the fact that the teleport spell cast is triggered two times for the same guard, it has nothing to do with spells being interrupted which was mentioned in #18373.

The spell focus system works by storing the original orientation, casting the spell, and restoring the orientation.

If the cast is triggered twice (possibly due to a delay in near teleport, in this case), the creature first casts the spell, stores the original orientation, but then before it can turn back to the original orientation it is already casting the second spell - which overrides the original orientation with the orientation it is facing right now (usually toward the area you tried to access).

Let's say the NPC has orientation=0. It turns to orientation=3 to cast a spell to a player, and saves the original orientation 0 somewhere to recover it later. But now it casts the spell again: orientation is still 3, but that stored 0 is overwritten by the new "original" orientation, a whopping 3.

Now, I believe this behavior is intended - it would be very ugly if a creature restored its original orientation every time before being allowed to cast a spell again.

Regardless of that, the issue is actually with the script - in no case a guard should teleport you when you already have the "teleported" aura.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Related to #18373, still have to check the other issues listed.

**Tests performed:** it works.