### PR TITLE
Core/SAI: Reimplement EVENT_FRIENDLY_HEALTH_PCT

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -925,21 +925,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                     TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u has pct value above 100, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
                     return false;
                 }
-
-                switch (e.GetTargetType())
-                {
-                    case SMART_TARGET_CREATURE_RANGE:
-                    case SMART_TARGET_CREATURE_GUID:
-                    case SMART_TARGET_CREATURE_DISTANCE:
-                    case SMART_TARGET_CLOSEST_CREATURE:
-                    case SMART_TARGET_CLOSEST_PLAYER:
-                    case SMART_TARGET_PLAYER_RANGE:
-                    case SMART_TARGET_PLAYER_DISTANCE:
-                        break;
-                    default:
-                        TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u uses invalid target_type %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.GetTargetType());
-                        return false;
-                }
                 break;
             case SMART_EVENT_DISTANCE_CREATURE:
                 if (e.event.distance.guid == 0 && e.event.distance.entry == 0)


### PR DESCRIPTION
This is the continuation of https://github.com/TrinityCore/TrinityCore/pull/20694 which cannot be modified anymore because the author deleted the branch in his fork.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

EVENT_FRIENDLY_HEALTH_PCT is fundamentally broken, as any ACTION that uses a target will not work with it. It attempts to implement an action into an event, which doesn't work.

This change will reimplement it to be consistent with other events (like EVENT_FRIENDLY_HEALTH) and will allow the use of TARGET_ACTION_INVOKER, which is also consistent with other events.
**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #20536

**Tests performed:** (Does it build, tested in-game, etc.)
None

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] All current SAI using this event is broken anway, but to fix it, all it needs is the target type changed to TARGET_ACTION_INVOKER, as the reimplementation is otherwise compatible with existing fields.
- [ ] The range should not be hardcoded but moved to SAI
- [ ] The existing scripts need to set a range
- [ ] DoSelectLowestHpFriendly(..) returns a single Unit with the lowest hp but then the health % is compared to minHpPct. This means if there is an event with minHpPct set to 50% and 2 allies, one with 20% and one with 60%, the event will not be triggered. 
- [x] --Same goes if there are 2 allies and the lowest hp one is not in combat due to the IsInCombat() check.-- The searcher already checks for IsInCombat()
- [ ] Another broken thing: the parameters were copied from EVENT_FRIENDLY_HEALTH_PCT with min/max but then the implementation of EVENT_FRIENDLY_HEALTH was left (which uses only 1 parameter validation as HP deficit). This means that DoSelectLowestHpFriendly() will always find the lowest hp unit around, even if we set max % to 10


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
