### PR TITLE
3.3.5 game event respawn

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1263,6 +1263,7 @@ void GameEventMgr::GameEventSpawn(int16 event_id)
 
             // Spawn if necessary (loaded grids only)
             Map* map = sMapMgr->CreateBaseMap(data->spawnPoint.GetMapId());
+            map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
             // We use spawn coords to spawn
             if (!map->Instanceable() && map->IsGridLoaded(data->spawnPoint))
             {
@@ -1290,6 +1291,7 @@ void GameEventMgr::GameEventSpawn(int16 event_id)
             // Spawn if necessary (loaded grids only)
             // this base map checked as non-instanced and then only existed
             Map* map = sMapMgr->CreateBaseMap(data->spawnPoint.GetMapId());
+            map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
             // We use current coords to unspawn, not spawn coords since creature can have changed grid
             if (!map->Instanceable() && map->IsGridLoaded(data->spawnPoint))
             {
@@ -1341,6 +1343,7 @@ void GameEventMgr::GameEventUnspawn(int16 event_id)
 
             sMapMgr->DoForAllMapsWithMapId(data->spawnPoint.GetMapId(), [&itr](Map* map)
             {
+                map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
                 auto creatureBounds = map->GetCreatureBySpawnIdStore().equal_range(*itr);
                 for (auto itr2 = creatureBounds.first; itr2 != creatureBounds.second;)
                 {
@@ -1371,6 +1374,7 @@ void GameEventMgr::GameEventUnspawn(int16 event_id)
 
             sMapMgr->DoForAllMapsWithMapId(data->spawnPoint.GetMapId(), [&itr](Map* map)
             {
+                map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
                 auto gameobjectBounds = map->GetGameObjectBySpawnIdStore().equal_range(*itr);
                 for (auto itr2 = gameobjectBounds.first; itr2 != gameobjectBounds.second;)
                 {

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1263,7 +1263,8 @@ void GameEventMgr::GameEventSpawn(int16 event_id)
 
             // Spawn if necessary (loaded grids only)
             Map* map = sMapMgr->CreateBaseMap(data->spawnPoint.GetMapId());
-            map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
+            if (!sPoolMgr->IsPartOfAPool<Creature>(*itr))
+                map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
             // We use spawn coords to spawn
             if (!map->Instanceable() && map->IsGridLoaded(data->spawnPoint))
             {
@@ -1291,7 +1292,8 @@ void GameEventMgr::GameEventSpawn(int16 event_id)
             // Spawn if necessary (loaded grids only)
             // this base map checked as non-instanced and then only existed
             Map* map = sMapMgr->CreateBaseMap(data->spawnPoint.GetMapId());
-            map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
+            if (!sPoolMgr->IsPartOfAPool<GameObject>(*itr))
+                map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
             // We use current coords to unspawn, not spawn coords since creature can have changed grid
             if (!map->Instanceable() && map->IsGridLoaded(data->spawnPoint))
             {
@@ -1343,7 +1345,8 @@ void GameEventMgr::GameEventUnspawn(int16 event_id)
 
             sMapMgr->DoForAllMapsWithMapId(data->spawnPoint.GetMapId(), [&itr](Map* map)
             {
-                map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
+                if (!sPoolMgr->IsPartOfAPool<Creature>(*itr))
+                    map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
                 auto creatureBounds = map->GetCreatureBySpawnIdStore().equal_range(*itr);
                 for (auto itr2 = creatureBounds.first; itr2 != creatureBounds.second;)
                 {
@@ -1374,7 +1377,8 @@ void GameEventMgr::GameEventUnspawn(int16 event_id)
 
             sMapMgr->DoForAllMapsWithMapId(data->spawnPoint.GetMapId(), [&itr](Map* map)
             {
-                map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
+                if (!sPoolMgr->IsPartOfAPool<GameObject>(*itr))
+                    map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
                 auto gameobjectBounds = map->GetGameObjectBySpawnIdStore().equal_range(*itr);
                 for (auto itr2 = gameobjectBounds.first; itr2 != gameobjectBounds.second;)
                 {

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1263,8 +1263,7 @@ void GameEventMgr::GameEventSpawn(int16 event_id)
 
             // Spawn if necessary (loaded grids only)
             Map* map = sMapMgr->CreateBaseMap(data->spawnPoint.GetMapId());
-            if (!sPoolMgr->IsPartOfAPool<Creature>(*itr))
-                map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
+            map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
             // We use spawn coords to spawn
             if (!map->Instanceable() && map->IsGridLoaded(data->spawnPoint))
             {
@@ -1292,8 +1291,7 @@ void GameEventMgr::GameEventSpawn(int16 event_id)
             // Spawn if necessary (loaded grids only)
             // this base map checked as non-instanced and then only existed
             Map* map = sMapMgr->CreateBaseMap(data->spawnPoint.GetMapId());
-            if (!sPoolMgr->IsPartOfAPool<GameObject>(*itr))
-                map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
+            map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
             // We use current coords to unspawn, not spawn coords since creature can have changed grid
             if (!map->Instanceable() && map->IsGridLoaded(data->spawnPoint))
             {
@@ -1345,8 +1343,7 @@ void GameEventMgr::GameEventUnspawn(int16 event_id)
 
             sMapMgr->DoForAllMapsWithMapId(data->spawnPoint.GetMapId(), [&itr](Map* map)
             {
-                if (!sPoolMgr->IsPartOfAPool<Creature>(*itr))
-                    map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
+                map->RemoveRespawnTime(SPAWN_TYPE_CREATURE, *itr);
                 auto creatureBounds = map->GetCreatureBySpawnIdStore().equal_range(*itr);
                 for (auto itr2 = creatureBounds.first; itr2 != creatureBounds.second;)
                 {
@@ -1377,8 +1374,7 @@ void GameEventMgr::GameEventUnspawn(int16 event_id)
 
             sMapMgr->DoForAllMapsWithMapId(data->spawnPoint.GetMapId(), [&itr](Map* map)
             {
-                if (!sPoolMgr->IsPartOfAPool<GameObject>(*itr))
-                    map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
+                map->RemoveRespawnTime(SPAWN_TYPE_GAMEOBJECT, *itr);
                 auto gameobjectBounds = map->GetGameObjectBySpawnIdStore().equal_range(*itr);
                 for (auto itr2 = gameobjectBounds.first; itr2 != gameobjectBounds.second;)
                 {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  remove respawn times from creatures/gameobjects when starting/stopping a game event

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #21519


**Tests performed:** (Does it build, tested in-game, etc.)
- .go xyz -773.906067 -5010.133301 17.237411 1
- .event start 61
- /tar darkspear scout
- .damage 50000
- .event stop 61
- .event start 61

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] This handles only the issue described in #21519 , it doesn't attempt to fix whatever other issues game event, respawn times (and pools) might have together
- [ ] @r00ty-tc is working on a different solution that should fix some other issues too. This PR could be used in the time being (either merged in TC or even just merged locally by users)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
