### PR TITLE
Core/Session: don't remove players from party groups when they log out

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -548,11 +548,6 @@ void WorldSession::LogoutPlayer(bool save)
         ///- If the player is in a group (or invited), remove him. If the group if then only 1 person, disband the group.
         _player->UninviteFromGroup();
 
-        // remove player from the group if he is:
-        // a) in group; b) not in raid group; c) logging out normally (not being kicked or disconnected)
-        if (_player->GetGroup() && !_player->GetGroup()->isRaidGroup() && m_Socket)
-            _player->RemoveFromGroup();
-
         //! Send update to group and reset stored max enchanting level
         if (_player->GetGroup())
         {


### PR DESCRIPTION
**Changes proposed:**

From the 3.3.0 [undocumented changes](https://wowwiki.fandom.com/wiki/Patch_3.3.0_(undocumented_changes)):

- You no longer leave your party upon logging out.

I vaguely recall seeing this change in-game too back then, and I'm quite sure there was a timer that would give party leader to someone else if they logged out, but I don't have data to back that up.

**Target branch(es):** 3.3.5

- [x] 3.3.5

**Tests performed:** it works.