### PR TITLE
Core/Spell: allow Northrend Inscription Research to unlock three recipes the first time it is cast

### DIFF
--- a/src/server/game/Skills/SkillDiscovery.cpp
+++ b/src/server/game/Skills/SkillDiscovery.cpp
@@ -206,6 +206,19 @@ bool HasDiscoveredAllSpells(uint32 spellId, Player* player)
     return true;
 }
 
+bool HasDiscoveredAnySpell(uint32 spellId, Player* player)
+{
+    SkillDiscoveryMap::const_iterator tab = SkillDiscoveryStore.find(int32(spellId));
+    if (tab == SkillDiscoveryStore.end())
+        return false;
+
+    for (SkillDiscoveryList::const_iterator item_iter = tab->second.begin(); item_iter != tab->second.end(); ++item_iter)
+        if (player->HasSpell(item_iter->spellId))
+            return true;
+
+    return false;
+}
+
 uint32 GetSkillDiscoverySpell(uint32 skillId, uint32 spellId, Player* player)
 {
     uint32 skillvalue = skillId ? player->GetSkillValue(skillId) : uint32(0);

--- a/src/server/game/Skills/SkillDiscovery.h
+++ b/src/server/game/Skills/SkillDiscovery.h
@@ -26,6 +26,7 @@ class Player;
 TC_GAME_API void LoadSkillDiscoveryTable();
 TC_GAME_API uint32 GetSkillDiscoverySpell(uint32 skillId, uint32 spellId, Player* player);
 TC_GAME_API bool HasDiscoveredAllSpells(uint32 spellId, Player* player);
+TC_GAME_API bool HasDiscoveredAnySpell(uint32 spellId, Player* player);
 TC_GAME_API uint32 GetExplicitDiscoverySpell(uint32 spellId, Player* player);
 
 #endif

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2820,6 +2820,11 @@ class spell_gen_pet_summoned : public SpellScript
     }
 };
 
+enum ProfessionResearch
+{
+    SPELL_NORTHREND_INSCRIPTION_RESEARCH = 61177
+};
+
 class spell_gen_profession_research : public SpellScript
 {
     PrepareSpellScript(spell_gen_profession_research);
@@ -2831,7 +2836,9 @@ class spell_gen_profession_research : public SpellScript
 
     SpellCastResult CheckRequirement()
     {
-        if (HasDiscoveredAllSpells(GetSpellInfo()->Id, GetCaster()->ToPlayer()))
+        Player* player = GetCaster()->ToPlayer();
+
+        if (HasDiscoveredAllSpells(GetSpellInfo()->Id, player))
         {
             SetCustomCastResultMessage(SPELL_CUSTOM_ERROR_NOTHING_TO_DISCOVER);
             return SPELL_FAILED_CUSTOM_ERROR;
@@ -2845,11 +2852,15 @@ class spell_gen_profession_research : public SpellScript
         Player* caster = GetCaster()->ToPlayer();
         uint32 spellId = GetSpellInfo()->Id;
 
-        // learn random explicit discovery recipe (if any)
+        // Learn random explicit discovery recipe (if any)
+        // Players will now learn 3 recipes the very first time they perform Northrend Inscription Research (3.3.0 patch notes)
+        if (spellId == SPELL_NORTHREND_INSCRIPTION_RESEARCH && !HasDiscoveredAnySpell(spellId, caster))
+            for (int i = 0; i < 2; ++i)
+                if (uint32 discoveredSpellId = GetExplicitDiscoverySpell(spellId, caster))
+                    caster->LearnSpell(discoveredSpellId, false);
+
         if (uint32 discoveredSpellId = GetExplicitDiscoverySpell(spellId, caster))
             caster->LearnSpell(discoveredSpellId, false);
-
-        caster->UpdateCraftSkill(spellId);
     }
 
     void Register() override


### PR DESCRIPTION
**Changes proposed:**

From the [3.1.0 patch notes](https://wowwiki.fandom.com/wiki/Patch_3.1.0):

> Players will now learn 3 recipes the very first time they perform Northrend Inscription Research. This does not apply to players who have already discovered recipes from Northrend Inscription Research (sorry). 

Also don't call UpdateCraftSkill() in the script - it's already called elsewhere and results in double skill points awarded.

**Target branch(es):** 3.3.5

- [x] 3.3.5

**Tests performed:** it works.