### PR TITLE
Core/Loot: make Loot::AddItem() honor LootItem::AllowedForPlayer()

### DIFF
--- a/src/server/game/Loot/Loot.cpp
+++ b/src/server/game/Loot/Loot.cpp
@@ -144,6 +144,24 @@ void Loot::AddItem(LootStoreItem const& item)
         lootItems.push_back(generatedLoot);
         count -= proto->GetMaxStackSize();
 
+        // In some cases, a dropped item should be visible/lootable only for some players in group
+        bool canSeeItemInLootWindow = false;
+        if (Player* player = ObjectAccessor::FindPlayer(lootOwnerGUID))
+        {
+            if (Group* group = player->GetGroup())
+            {
+                for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+                    if (Player* member = itr->GetSource())
+                        if (generatedLoot.AllowedForPlayer(member))
+                            canSeeItemInLootWindow = true;
+            }
+            else if (generatedLoot.AllowedForPlayer(player))
+                canSeeItemInLootWindow = true;
+        }
+
+        if (!canSeeItemInLootWindow)
+            continue;
+
         // non-conditional one-player only items are counted here,
         // free for all items are counted in FillFFALoot(),
         // non-ffa conditionals are counted in FillNonQuestNonFFAConditionalLoot()
@@ -158,6 +176,8 @@ bool Loot::FillLoot(uint32 lootId, LootStore const& store, Player* lootOwner, bo
     // Must be provided
     if (!lootOwner)
         return false;
+
+    lootOwnerGUID = lootOwner->GetGUID();
 
     LootTemplate const* tab = store.GetLootFor(lootId);
 

--- a/src/server/game/Loot/Loot.h
+++ b/src/server/game/Loot/Loot.h
@@ -213,6 +213,7 @@ struct TC_GAME_API Loot
     uint32 gold;
     uint8 unlootedCount;
     ObjectGuid roundRobinPlayer;                            // GUID of the player having the Round-Robin ownership for the loot. If 0, round robin owner has released.
+    ObjectGuid lootOwnerGUID;
     LootType loot_type;                                     // required for achievement system
     uint8 maxDuplicates;                                    // Max amount of items with the same entry that can drop (default is 1; on 25 man raid mode 3)
 


### PR DESCRIPTION
**Changes proposed:**

Currently Loot::AddItem() will increase unlootedCount without checking LootItem::AllowedForPlayer's result first. This means that items that cannot be looted by any player can be added to the loot. Because nobody can loot them, they're never removed and the creature will show an empty loot window and can't be skinned as a result.

However, in some cases the dropped item is not visible by some players (because they're not allowed to loot it) but should start a roll if any other player in party/raid can loot it. This case is also fixed in this PR.

Fixes #13940.

**Easy test case:**
WARNING: this empties the loot table of one creature. Don't run it if you care about your world db
```sql
DELETE FROM `creature_loot_template` WHERE `Entry`=2958;
INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
(2958, 44564, 0, 100, 0, 1, 0, 1, 1, "");
```
The creature (Prairie Wolf - 2958) will drop an Alchemy-only recipe that will prevent skinning without this PR.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.

**Known issues**: if a player without Alchemy 400+ (in the example case) exits the loot window before the player with Alchemy 400+, the creature will not be lootable again and the recipe will be unlootable. I don't know what's the best way to fix this, and it's a global issue with the loot system and not only with the part changed by this PR.