### PR TITLE
Core/Loot: fix some issues with master loot and don't allow players to see soulbound recipes that they already learned in the loot window

### DIFF
--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -453,7 +453,7 @@ void WorldSession::HandleLootMasterGiveOpcode(WorldPacket& recvData)
 
     ItemPosCountVec dest;
     InventoryResult msg = target->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, item.itemid, item.count);
-    if (item.follow_loot_rules && !item.AllowedForPlayer(target))
+    if (!item.AllowedForPlayer(target, true))
         msg = EQUIP_ERR_YOU_CAN_NEVER_USE_THAT_ITEM;
     if (msg != EQUIP_ERR_OK)
     {
@@ -463,8 +463,6 @@ void WorldSession::HandleLootMasterGiveOpcode(WorldPacket& recvData)
             _player->SendLootError(lootguid, LOOT_ERROR_MASTER_INV_FULL);
         else
             _player->SendLootError(lootguid, LOOT_ERROR_MASTER_OTHER);
-
-        target->SendEquipError(msg, nullptr, nullptr, item.itemid);
         return;
     }
 

--- a/src/server/game/Loot/Loot.h
+++ b/src/server/game/Loot/Loot.h
@@ -149,7 +149,7 @@ struct TC_GAME_API LootItem
                  { };
 
     // Basic checks for player/item compatibility - if false no chance to see the item in the loot
-    bool AllowedForPlayer(Player const* player) const;
+    bool AllowedForPlayer(Player const* player, bool isGivenByMasterLooter = false) const;
     void AddAllowedLooter(Player const* player);
     GuidSet const& GetAllowedLooters() const { return allowedGUIDs; }
 };


### PR DESCRIPTION
**Changes proposed:**

This PR implements the following changes:

- Allow the master looter to see quest items and recipes regardless of quest status/profession/skill level. Giving the item to any player is still subjected to the usual restrictions.

- Don't send an error message to the player receiving the loot - only the master looter should see an error if the target player can't receive the item.

- Soulbound recipes that the player already learned should not show in loot windows anymore.
Affects items like [Manual: Heavy Frostweave Bandage](https://www.wowhead.com/item=39152) and [A Guide to Northern Cloth Scavenging](https://www.wowhead.com/item=43876).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** fixes #16653, updates #12004.

**Tests performed:** it works.