### PR TITLE
Core/Creatures: fix some other cases where a creature should not be able to set focus

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3011,8 +3011,12 @@ void Creature::FocusTarget(Spell const* focusSpell, WorldObject const* target)
     if (m_focusSpell)
         return;
 
-    // Prevent dead creatures from setting a focus target, so they won't turn
-    if (!IsAlive())
+    // Prevent dead/feigning death creatures from setting a focus target, so they won't turn
+    if (!IsAlive() || HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH) || HasAuraType(SPELL_AURA_FEIGN_DEATH))
+        return;
+
+    // Don't allow stunned creatures to set a focus target
+    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_STUNNED))
         return;
 
     // some spells shouldn't track targets


### PR DESCRIPTION
**Changes proposed:**

Creatures should not be able to set focus while dead, feigning death or if they're stunned, mostly in case of permanent cosmetic auras related to quests.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.