### PR TITLE
Core/RDF: fix counting issue with the achievement Looking for More (and similar)

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -834,7 +834,6 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
             case ACHIEVEMENT_CRITERIA_TYPE_FLIGHT_PATHS_TAKEN:
             case ACHIEVEMENT_CRITERIA_TYPE_CAST_SPELL2:
             case ACHIEVEMENT_CRITERIA_TYPE_ACCEPTED_SUMMONINGS:
-            case ACHIEVEMENT_CRITERIA_TYPE_USE_LFD_TO_GROUP_WITH_PLAYERS:
                 SetCriteriaProgress(achievementCriteria, 1, PROGRESS_ACCUMULATE);
                 break;
             // std case: increment at miscvalue1
@@ -850,6 +849,7 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
             case ACHIEVEMENT_CRITERIA_TYPE_GOLD_EARNED_BY_AUCTIONS: /* FIXME: for online player only currently */
             case ACHIEVEMENT_CRITERIA_TYPE_TOTAL_DAMAGE_RECEIVED:
             case ACHIEVEMENT_CRITERIA_TYPE_TOTAL_HEALING_RECEIVED:
+            case ACHIEVEMENT_CRITERIA_TYPE_USE_LFD_TO_GROUP_WITH_PLAYERS:
                 SetCriteriaProgress(achievementCriteria, miscValue1, PROGRESS_ACCUMULATE);
                 break;
             // std case: increment at miscvalue2

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -1085,6 +1085,11 @@ void LFGMgr::UpdateProposal(uint32 proposalId, ObjectGuid guid, bool accept)
                 break;
         }
 
+        // Store the number of players that were present in group when joining RFD, used for achievement purposes
+        if (Player* player = ObjectAccessor::FindConnectedPlayer(pguid))
+            if (Group* group = player->GetGroup())
+                PlayersStore[pguid].numberOfPartyMembersAtJoin = group->GetMembersCount();
+
         SetState(pguid, LFG_STATE_DUNGEON);
     }
 
@@ -1454,7 +1459,14 @@ void LFGMgr::FinishDungeon(ObjectGuid gguid, const uint32 dungeonId, Map const* 
 
         // Update achievements
         if (dungeon->difficulty == DUNGEON_DIFFICULTY_HEROIC)
-            player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_USE_LFD_TO_GROUP_WITH_PLAYERS, 1);
+        {
+            uint8 lfdRandomPlayers = 0;
+            if (uint8 numParty = PlayersStore[guid].numberOfPartyMembersAtJoin)
+                lfdRandomPlayers = 5 - numParty;
+            else
+                lfdRandomPlayers = 4;
+            player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_USE_LFD_TO_GROUP_WITH_PLAYERS, lfdRandomPlayers);
+        }
 
         LfgReward const* reward = GetRandomDungeonReward(rDungeonId, player->getLevel());
         if (!reward)

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -1088,7 +1088,7 @@ void LFGMgr::UpdateProposal(uint32 proposalId, ObjectGuid guid, bool accept)
         // Store the number of players that were present in group when joining RFD, used for achievement purposes
         if (Player* player = ObjectAccessor::FindConnectedPlayer(pguid))
             if (Group* group = player->GetGroup())
-                PlayersStore[pguid].numberOfPartyMembersAtJoin = group->GetMembersCount();
+                PlayersStore[pguid].SetNumberOfPartyMembersAtJoin(group->GetMembersCount());
 
         SetState(pguid, LFG_STATE_DUNGEON);
     }
@@ -1461,7 +1461,7 @@ void LFGMgr::FinishDungeon(ObjectGuid gguid, const uint32 dungeonId, Map const* 
         if (dungeon->difficulty == DUNGEON_DIFFICULTY_HEROIC)
         {
             uint8 lfdRandomPlayers = 0;
-            if (uint8 numParty = PlayersStore[guid].numberOfPartyMembersAtJoin)
+            if (uint8 numParty = PlayersStore[guid].GetNumberOfPartyMembersAtJoin())
                 lfdRandomPlayers = 5 - numParty;
             else
                 lfdRandomPlayers = 4;

--- a/src/server/game/DungeonFinding/LFGPlayerData.cpp
+++ b/src/server/game/DungeonFinding/LFGPlayerData.cpp
@@ -21,7 +21,7 @@ namespace lfg
 {
 
 LfgPlayerData::LfgPlayerData(): m_State(LFG_STATE_NONE), m_OldState(LFG_STATE_NONE),
-    m_Team(0), m_Group(), m_Roles(0), m_Comment("")
+    m_Team(0), m_Group(), m_Roles(0), m_Comment(""), numberOfPartyMembersAtJoin(0)
 { }
 
 LfgPlayerData::~LfgPlayerData() { }

--- a/src/server/game/DungeonFinding/LFGPlayerData.cpp
+++ b/src/server/game/DungeonFinding/LFGPlayerData.cpp
@@ -21,7 +21,7 @@ namespace lfg
 {
 
 LfgPlayerData::LfgPlayerData(): m_State(LFG_STATE_NONE), m_OldState(LFG_STATE_NONE),
-    m_Team(0), m_Group(), m_Roles(0), m_Comment(""), numberOfPartyMembersAtJoin(0)
+    m_Team(0), m_Group(), m_Roles(0), m_Comment(""), m_NumberOfPartyMembersAtJoin(0)
 { }
 
 LfgPlayerData::~LfgPlayerData() { }
@@ -112,6 +112,16 @@ std::string const& LfgPlayerData::GetComment() const
 LfgDungeonSet const& LfgPlayerData::GetSelectedDungeons() const
 {
     return m_SelectedDungeons;
+}
+
+void LfgPlayerData::SetNumberOfPartyMembersAtJoin(uint8 count)
+{
+    m_NumberOfPartyMembersAtJoin = count;
+}
+
+uint8 LfgPlayerData::GetNumberOfPartyMembersAtJoin()
+{
+    return m_NumberOfPartyMembersAtJoin;
 }
 
 } // namespace lfg

--- a/src/server/game/DungeonFinding/LFGPlayerData.h
+++ b/src/server/game/DungeonFinding/LFGPlayerData.h
@@ -55,7 +55,8 @@ class TC_GAME_API LfgPlayerData
         LfgDungeonSet const& GetSelectedDungeons() const;
 
         // Achievement-related
-        uint8 numberOfPartyMembersAtJoin;
+        void SetNumberOfPartyMembersAtJoin(uint8 count);
+        uint8 GetNumberOfPartyMembersAtJoin();
 
     private:
         // General
@@ -69,6 +70,9 @@ class TC_GAME_API LfgPlayerData
         uint8 m_Roles;                                     ///< Roles the player selected when joined LFG
         std::string m_Comment;                             ///< Player comment used when joined LFG
         LfgDungeonSet m_SelectedDungeons;                  ///< Selected Dungeons when joined LFG
+
+        // Achievement-related
+        uint8 m_NumberOfPartyMembersAtJoin;
 };
 
 } // namespace lfg

--- a/src/server/game/DungeonFinding/LFGPlayerData.h
+++ b/src/server/game/DungeonFinding/LFGPlayerData.h
@@ -54,6 +54,9 @@ class TC_GAME_API LfgPlayerData
         std::string const& GetComment() const;
         LfgDungeonSet const& GetSelectedDungeons() const;
 
+        // Achievement-related
+        uint8 numberOfPartyMembersAtJoin;
+
     private:
         // General
         LfgState m_State;                                  ///< State if group in LFG


### PR DESCRIPTION
**Changes proposed:**

Currently the achievements [Looking For More](https://wowwiki.fandom.com/wiki/Looking_For_More) and similar will increase their count by 1 for every completed RDF. They should instead increase it by the amount of random players that were picked for that run.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #12187.

**Tests performed:** it works.