### PR TITLE
Core/SAI: don't allow to start a new SAI actionlist while the entity is already running one

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3801,6 +3801,10 @@ void SmartScript::SetTimedActionList(SmartScriptHolder& e, uint32 entry, Unit* i
         return;
     }
 
+    // Do NOT allow to start a new actionlist if a previous one is already running. We need to always finish the current actionlist
+    if (!mTimedActionList.empty())
+        return;
+
     mTimedActionList.clear();
     mTimedActionList = sSmartScriptMgr->GetScript(entry, SMART_SCRIPT_TYPE_TIMED_ACTIONLIST);
     if (mTimedActionList.empty())


### PR DESCRIPTION
**Changes proposed:**

When an actionlist is running, we assume that it will properly finish (unless the creature is killed mid-script). Right now, especially for events that happen when a quest is turned in, other players can turn in the same quest and cause the current actionlist to be dropped and start a new one.

For example, apply the SQL in #23419 (sorry, can't think of a good example with a reasonably long script right now) and have multiple players turn in the quest [On Brann's Trail](https://www.wowhead.com/quest=12854). The script will restart and the NPC will say the first lines of creature_text again.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.