### PR TITLE
Core/Spell: fix some issues with taunt spells

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2280,6 +2280,10 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
         _spellHitTarget = spell->m_caster->ToUnit();
 
+    // Ensure that a player target is put in combat by a taunt, even if they result immune clientside
+    if ((MissCondition == SPELL_MISS_IMMUNE || MissCondition == SPELL_MISS_IMMUNE2) && spell->m_caster->GetTypeId() == TYPEID_PLAYER && unit->GetTypeId() == TYPEID_PLAYER && spell->m_caster->IsValidAttackTarget(unit, spell->GetSpellInfo()))
+        unit->SetInCombatWith(spell->m_caster->ToPlayer());
+
     _enablePVP = false; // need to check PvP state before spell effects, but act on it afterwards
     if (_spellHitTarget)
     {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3069,8 +3069,8 @@ void Spell::EffectTaunt(SpellEffIndex /*effIndex*/)
         if (unitTarget->GetTypeId() != TYPEID_PLAYER && unitTarget->GetTarget() != unitCaster->GetGUID())
             unitCaster->CastSpell(unitTarget, 67485, true);
 
-    // Taunting player pets will force them to swap target
-    if (unitTarget->IsPet() && unitTarget->GetOwnerGUID().IsPlayer())
+    // Taunting player pets (that are aggressive or defensive) will force them to swap target
+    if (unitTarget->IsPet() && unitTarget->GetOwnerGUID().IsPlayer() && unitTarget->ToPet()->GetReactState() != REACT_PASSIVE)
     {
         if (Unit* owner = unitTarget->GetOwner())
             if (!owner->IsValidAttackTarget(unitCaster))

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -41,7 +41,6 @@
 #include "OutdoorPvPMgr.h"
 #include "PathGenerator.h"
 #include "Pet.h"
-#include "PetAI.h"
 #include "Player.h"
 #include "ReputationMgr.h"
 #include "ScriptMgr.h"

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3057,7 +3057,6 @@ void Spell::EffectTaunt(SpellEffIndex /*effIndex*/)
 
     // this effect use before aura Taunt apply for prevent taunt already attacking target
     // for spell as marked "non effective at already attacking target"
-
     if (!unitTarget || unitTarget->IsTotem())
     {
         SendCastResult(SPELL_FAILED_DONT_REPORT);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3069,29 +3069,6 @@ void Spell::EffectTaunt(SpellEffIndex /*effIndex*/)
         if (unitTarget->GetTypeId() != TYPEID_PLAYER && unitTarget->GetTarget() != unitCaster->GetGUID())
             unitCaster->CastSpell(unitTarget, 67485, true);
 
-    // Taunting player pets (that are aggressive or defensive) will force them to swap target
-    if (unitTarget->IsPet() && unitTarget->GetOwnerGUID().IsPlayer() && unitTarget->ToPet()->GetReactState() != REACT_PASSIVE)
-    {
-        if (Unit* owner = unitTarget->GetOwner())
-            if (!owner->IsValidAttackTarget(unitCaster))
-                return;
-
-        if (unitTarget->GetVictim() != unitCaster)
-        {
-            if (unitTarget->GetVictim())
-                unitTarget->AttackStop();
-
-            if (unitTarget->GetTypeId() != TYPEID_PLAYER && unitTarget->ToCreature()->IsAIEnabled())
-            {
-                CreatureAI* AI = unitTarget->ToCreature()->AI();
-                if (PetAI* petAI = dynamic_cast<PetAI*>(AI))
-                    petAI->_AttackStart(unitCaster); // force target switch
-                else
-                    AI->AttackStart(unitCaster);
-            }
-        }
-    }
-
     if (!unitTarget->CanHaveThreatList())
     {
         SendCastResult(SPELL_FAILED_DONT_REPORT);


### PR DESCRIPTION
**Changes proposed:**

- ~~Allow players to taunt player pets and guardiands/minions.~~
- Allow Hand of Reckoning to deal damage to player pets.
- Allow Hand of Reckoning to deal damage to fleeing targets.
- Put an enemy player in combat for 5 seconds after casting taunt effects.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #1315, supersedes #20239

**Tests performed:** it works.

**Known issues and TODO list:**

- [x] Pets should not be affected by taunt if they're passive.

- [x] ~~Taunted pets must return to their original target/stop attacking when taunt effect expires (not sure about this one, can't find enough research to prove or disprove it)~~ Don't have enough data on how it should work right now, and don't want this to stall the PR. Removed, will open a new PR once fixed.