### PR TITLE
Core/SAI: allow to start waypoint movement for a creature that is in combat

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -44,12 +44,6 @@ bool SmartAI::IsAIControlled() const
 
 void SmartAI::StartPath(bool run/* = false*/, uint32 pathId/* = 0*/, bool repeat/* = false*/, Unit* invoker/* = nullptr*/, uint32 nodeId/* = 1*/)
 {
-    if (me->IsEngaged()) // no wp movement in combat
-    {
-        TC_LOG_ERROR("scripts.ai.sai", "SmartAI::StartPath: Creature wanted to start waypoint movement (pathId: %u) while in combat, ignoring. (%s)", pathId, me->GetGUID().ToString().c_str());
-        return;
-    }
-
     if (HasEscortState(SMART_ESCORT_ESCORTING))
         StopPath();
 


### PR DESCRIPTION
**Changes proposed:**

Scripts should not care about the creature's combat status when starting waypoint. The AI will take care of stopping to fight enemies on its own, so scripts should always be able to setup a waypoint path.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.