### PR TITLE
Update CreatureTemplateModel to fit blizz logic

### DIFF
--- a/sql/updates/world/master/2019_06_16_01_world.sql
+++ b/sql/updates/world/master/2019_06_16_01_world.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `creature_template_model` DROP PRIMARY KEY;
+ALTER TABLE `creature_template_model` ADD PRIMARY KEY (`CreatureID`, `Idx`);

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `creature_template_model` DROP PRIMARY KEY, ADD PRIMARY KEY (`CreatureID`, `Idx`);

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `creature_template_model` DROP PRIMARY KEY, ADD PRIMARY KEY (`CreatureID`, `Idx`);

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -947,8 +947,6 @@ void ObjectMgr::CheckCreatureTemplate(CreatureTemplate const* cInfo)
 
     if (!cInfo->Models.size())
         TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) does not have any existing display id in creature_template_model.", cInfo->Entry);
-    else if (std::accumulate(cInfo->Models.begin(), cInfo->Models.end(), 0.0f, [](float sum, CreatureModel const& model) { return sum + model.Probability; }) <= 0.0f)
-        TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has zero total chance for all models in creature_template_model.", cInfo->Entry);
 
     if (!cInfo->unit_class || ((1 << (cInfo->unit_class-1)) & CLASSMASK_ALL_CREATURES) == 0)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  PrimaryKey removed for CreatureDisplay because Blizz sometimes has several times the same Display for 1 creature set in its model data
-  Added PrimaryKey for Idx, order never varies and is unique
-  Removed Error for 0 TotalProbability, since blizz also have several models with 0 probability for 1 creature -> random select with equal chance

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:** No explicit issue opened


**Tests performed:**


**Known issues and TODO list:**



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
