### PR TITLE
Core/FlightPath: teleport players at destination on floor Z when the flight ends

### DIFF
--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -151,8 +151,9 @@ void FlightPathMovementGenerator::DoFinalize(Player* owner, bool active, bool/* 
         // when client side flight end early in comparison server side
         owner->StopMoving();
         owner->SetFallInformation(0, owner->GetPositionZ());
-        // When the player reaches the last flight point, teleport to destination at floor Z
-        owner->TeleportTo(_path[GetCurrentNode()]->MapID, _path[GetCurrentNode()]->LocX, _path[GetCurrentNode()]->LocY, owner->GetFloorZ(), owner->GetOrientation());
+        // When the player reaches the last flight point, teleport to destination at map height
+        float mapHeight = owner->GetMap()->GetHeight(_path[GetCurrentNode()]->LocX, _path[GetCurrentNode()]->LocY, _path[GetCurrentNode()]->LocZ);
+        owner->TeleportTo(_path[GetCurrentNode()]->MapID, _path[GetCurrentNode()]->LocX, _path[GetCurrentNode()]->LocY, mapHeight, owner->GetOrientation());
     }
 
     owner->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_TAXI_BENCHMARK);

--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -150,9 +150,9 @@ void FlightPathMovementGenerator::DoFinalize(Player* owner, bool active, bool/* 
         // this prevent cheating with landing  point at lags
         // when client side flight end early in comparison server side
         owner->StopMoving();
-        owner->SetFallInformation(0, owner->GetPositionZ());
-        // When the player reaches the last flight point, teleport to destination at map height
         float mapHeight = owner->GetMap()->GetHeight(_path[GetCurrentNode()]->LocX, _path[GetCurrentNode()]->LocY, _path[GetCurrentNode()]->LocZ);
+        owner->SetFallInformation(0, mapHeight);
+        // When the player reaches the last flight point, teleport to destination at map height
         owner->TeleportTo(_path[GetCurrentNode()]->MapID, _path[GetCurrentNode()]->LocX, _path[GetCurrentNode()]->LocY, mapHeight, owner->GetOrientation());
     }
 

--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -151,6 +151,8 @@ void FlightPathMovementGenerator::DoFinalize(Player* owner, bool active, bool/* 
         // when client side flight end early in comparison server side
         owner->StopMoving();
         owner->SetFallInformation(0, owner->GetPositionZ());
+        // When the player reaches the last flight point, teleport to destination at floor Z
+        owner->TeleportTo(_path[GetCurrentNode()]->MapID, _path[GetCurrentNode()]->LocX, _path[GetCurrentNode()]->LocY, owner->GetFloorZ(), owner->GetOrientation());
     }
 
     owner->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_TAXI_BENCHMARK);


### PR DESCRIPTION
**Changes proposed:**

Right now, when a player ends a flight path, they dismount in their actual position, which is usually a few yards above the ground. Instead they should be teleported to the destination position, which makes it look better cosmetically AND prevents cheating that could occur by creating high lag before the flight ends, since the player will be forcefully teleported back in any case.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #10051

**Tests performed:** it works.