### PR TITLE
Core/Packet: send SMSG_QUESTGIVER_STATUS_MULTIPLE when the player levels up

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2668,6 +2668,8 @@ void Player::GiveLevel(uint8 level)
                     SetByteFlag(PLAYER_FIELD_BYTES, PLAYER_FIELD_BYTES_OFFSET_RAF_GRANTABLE_LEVEL, 0x01);
             }
 
+    SendQuestGiverStatusMultiple();
+
     sScriptMgr->OnPlayerLevelChanged(this, oldLevel);
 }
 


### PR DESCRIPTION
**Changes proposed:**

Make sure nearby questgivers are updated at levelup, so players can accept new quests that became available from a nearby questgiver without having to leave the area and come back.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.

**How to reproduce:** (add/remove lines as needed)

- Create a Horde character
- .char level 77
- .npc add 31151 (will spawn a questgiver with gray !)
- .levelup (will bring you to 78, the minimum level required for this questgiver's quest)
- Notice that the ! is still gray and you can't obtain any quest, without this change
- .gm on
- .gm off
- The ! will become yellow because changing GM state will trigger an update on nearby questgivers, too.