### PR TITLE
Core/Misc: don't allow FindNearestCreature() and FindNearestGameObject() searches to return the entity that called them

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -740,7 +740,7 @@ namespace Trinity
 
             bool operator()(GameObject* go)
             {
-                if (go->GetEntry() == i_entry && i_obj.IsWithinDistInMap(go, i_range))
+                if (go->GetEntry() == i_entry && go->GetGUID() != i_obj.GetGUID() && i_obj.IsWithinDistInMap(go, i_range))
                 {
                     i_range = i_obj.GetDistance(go);        // use found GO range as new range limit for next check
                     return true;
@@ -1278,7 +1278,7 @@ namespace Trinity
 
             bool operator()(Creature* u)
             {
-                if (u->getDeathState() != DEAD && u->GetEntry() == i_entry && u->IsAlive() == i_alive && i_obj.IsWithinDistInMap(u, i_range))
+                if (u->getDeathState() != DEAD && u->GetEntry() == i_entry && u->IsAlive() == i_alive && u->GetGUID() != i_obj.GetGUID() && i_obj.IsWithinDistInMap(u, i_range))
                 {
                     i_range = i_obj.GetDistance(u);         // use found unit range as new range limit for next check
                     return true;


### PR DESCRIPTION
**Changes proposed:**

When a creature/gameobject searches for a nearby creature/gameobject with a specific entry, it does not make sense to allow to return that same creature/gameobject in the search results.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #23334.

**Tests performed:** it works.