### PR TITLE
Core/SAI: Allow to include/exclude EnterEvadeMode calls in SMART_EVENT_EVADE SAI event depending on EvadeReason value

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -94,7 +94,8 @@ class TC_GAME_API CreatureAI : public UnitAI
             EVADE_REASON_BOUNDARY,          // the creature has moved outside its evade boundary
             EVADE_REASON_NO_PATH,           // the creature was unable to reach its target for over 5 seconds
             EVADE_REASON_SEQUENCE_BREAK,    // this is a boss and the pre-requisite encounters for engaging it are not defeated yet
-            EVADE_REASON_OTHER
+            EVADE_REASON_OTHER,
+            EVADE_REASON_END
         };
 
         explicit CreatureAI(Creature* creature);

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -406,11 +406,11 @@ void SmartAI::MovementInform(uint32 type, uint32 id)
         _OOCReached = true;
 }
 
-void SmartAI::EnterEvadeMode(EvadeReason /*why*/)
+void SmartAI::EnterEvadeMode(EvadeReason why)
 {
     if (_evadeDisabled)
     {
-        GetScript()->ProcessEventsFor(SMART_EVENT_EVADE);
+        GetScript()->ProcessEventsFor(SMART_EVENT_EVADE, nullptr, why);
         return;
     }
 
@@ -425,7 +425,7 @@ void SmartAI::EnterEvadeMode(EvadeReason /*why*/)
 
     me->AddUnitState(UNIT_STATE_EVADE);
 
-    GetScript()->ProcessEventsFor(SMART_EVENT_EVADE); // must be after _EnterEvadeMode (spells, auras, ...)
+    GetScript()->ProcessEventsFor(SMART_EVENT_EVADE, nullptr, why); // must be after _EnterEvadeMode (spells, auras, ...)
 
     SetRun(_run);
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2980,7 +2980,6 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
         //no params
         case SMART_EVENT_AGGRO:
         case SMART_EVENT_DEATH:
-        case SMART_EVENT_EVADE:
         case SMART_EVENT_REACHED_HOME:
         case SMART_EVENT_CHARMED_TARGET:
         case SMART_EVENT_CORPSE_REMOVED:
@@ -3388,6 +3387,17 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
 
             ProcessTimedAction(e, e.event.counter.cooldownMin, e.event.counter.cooldownMax);
             break;
+        case SMART_EVENT_EVADE:
+        {
+            // Skip the action if includeReasonsMask is specified and this event does NOT match it
+            if (e.event.evade.includeReasonsMask != 0 && !(e.event.evade.includeReasonsMask & (1 << var0)))
+                return;
+            // Skip the action if excludeReasonsMask is specified and this event does match it
+            if (e.event.evade.excludeReasonsMask != 0 && (e.event.evade.excludeReasonsMask & (1 << var0)))
+                return;
+            ProcessAction(e, unit, var0, var1, bvar, spell, gob);
+            break;
+        }
         default:
             TC_LOG_ERROR("sql.sql", "SmartScript::ProcessEvent: Unhandled Event type %u", e.GetEventType());
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "SmartScriptMgr.h"
+#include "CreatureAI.h"
 #include "CreatureTextMgr.h"
 #include "DatabaseEnv.h"
 #include "DBCStores.h"
@@ -1010,6 +1011,19 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                     return false;
                 }
                 break;
+            case SMART_EVENT_EVADE:
+                // Check if the includeReasons and excludeReasons masks store any value equal/higher than EVADE_REASON_END (which is itself not allowed)
+                if ((e.event.evade.includeReasonsMask >> CreatureAI::EVADE_REASON_END) > 0)
+                {
+                    TC_LOG_ERROR("sql.sql", "SmartAIMgr: Event SMART_EVENT_EVADE using invalid includeReasonsMask mask %u, skipped.", e.event.evade.includeReasonsMask);
+                    return false;
+                }
+                if ((e.event.evade.excludeReasonsMask >> CreatureAI::EVADE_REASON_END) > 0)
+                {
+                    TC_LOG_ERROR("sql.sql", "SmartAIMgr: Event SMART_EVENT_EVADE using invalid excludeReasonsMask mask %u, skipped.", e.event.evade.excludeReasonsMask);
+                    return false;
+                }
+                break;
             case SMART_EVENT_LINK:
             case SMART_EVENT_GO_LOOT_STATE_CHANGED:
             case SMART_EVENT_GO_EVENT_INFORM:
@@ -1024,7 +1038,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             case SMART_EVENT_TRANSPORT_REMOVE_PLAYER:
             case SMART_EVENT_AGGRO:
             case SMART_EVENT_DEATH:
-            case SMART_EVENT_EVADE:
             case SMART_EVENT_REACHED_HOME:
             case SMART_EVENT_RESET:
             case SMART_EVENT_QUEST_ACCEPTED:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -103,7 +103,7 @@ enum SMART_EVENT
     SMART_EVENT_AGGRO                    = 4,       // NONE
     SMART_EVENT_KILL                     = 5,       // CooldownMin0, CooldownMax1, playerOnly2, else creature entry3
     SMART_EVENT_DEATH                    = 6,       // NONE
-    SMART_EVENT_EVADE                    = 7,       // NONE
+    SMART_EVENT_EVADE                    = 7,       // IncludeReasonsMask (0 all, < 1 << EVADE_REASON_END), ExcludeReasonsMask (0 none, < 1 << EVADE_REASON_END)
     SMART_EVENT_SPELLHIT                 = 8,       // SpellID, School, CooldownMin, CooldownMax
     SMART_EVENT_RANGE                    = 9,       // MinDist, MaxDist, RepeatMin, RepeatMax
     SMART_EVENT_OOC_LOS                  = 10,      // NoHostile, MaxRnage, CooldownMin, CooldownMax
@@ -428,6 +428,12 @@ struct SmartEvent
             uint32 cooldownMin;
             uint32 cooldownMax;
         } counter;
+
+        struct
+        {
+            uint32 includeReasonsMask;
+            uint32 excludeReasonsMask;
+        } evade;
 
         struct
         {


### PR DESCRIPTION
**Changes proposed:**

Core/SAI: Allow to include/exclude EnterEvadeMode calls in SMART_EVENT_EVADE SAI event depending on EvadeReason value

SMART_EVENT_EVADE now has 2 parameters:
- includeReasonsMask: 0 means "always execute", any value > 0 must be a mask of EvadeReason enumeration
- excludeReasonsMask: 0 means "always execute", any value > 0 must be a mask of EvadeReason enumeration

Accepted values:
- 0x00  (0) Always Execute
- 0x01  (1) EVADE_REASON_NO_HOSTILES
- 0x02  (2) EVADE_REASON_BOUNDARY
- 0x04  (4) EVADE_REASON_NO_PATH
- 0x08  (8) EVADE_REASON_SEQUENCE_BREAK
- 0x10 (16) EVADE_REASON_OTHER

The 2 conditions are applied in AND, i.e. to exclude EVADE_REASON_OTHER only set includeReasonsMask to 0, excludeReasonsMask to 16 .

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23270

**Tests performed:** (Does it build, tested in-game, etc.)
No tests performed at all, not even the build

**Known issues and TODO list:** (add/remove lines as needed)
Find them please


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
