### PR TITLE
Core/Conditions: fix mistake in CONDITION_QUEST_OBJECTIVE_PROGRESS

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -507,10 +507,9 @@ bool Condition::Meets(ConditionSourceInfo& sourceInfo) const
             {
                 const Quest* quest = sObjectMgr->GetQuestTemplate(ConditionValue1);
                 uint16 log_slot = player->FindQuestSlot(quest->GetQuestId());
-                uint32 progressCount = 0;
-                if (log_slot < MAX_QUEST_LOG_SIZE)
-                    progressCount = player->GetQuestSlotCounter(log_slot, ConditionValue2);
-                if (progressCount == ConditionValue3)
+                if (log_slot >= MAX_QUEST_LOG_SIZE)
+                    break;
+                if (player->GetQuestSlotCounter(log_slot, ConditionValue2) == ConditionValue3)
                     condMeets = true;
             }
             break;


### PR DESCRIPTION
**Changes proposed:**

Forgot to check if the player actually has the quest whose conditions are checked for, in #23438. It didn't cross my mind that this would be actually used with a progression value of 0, sorry :P

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.