### PR TITLE
Spell/Fishing: fix some Fishing bugs

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4898,15 +4898,15 @@ void Spell::EffectTransmitted(SpellEffIndex effIndex)
             // end time of range when possible catch fish (FISHING_BOBBER_READY_TIME..GetDuration(m_spellInfo))
             // start time == fish-FISHING_BOBBER_READY_TIME (0..GetDuration(m_spellInfo)-FISHING_BOBBER_READY_TIME)
             int32 lastSec = 0;
-            switch (urand(0, 3))
+            switch (urand(0, 2))
             {
                 case 0: lastSec =  3; break;
                 case 1: lastSec =  7; break;
                 case 2: lastSec = 13; break;
-                case 3: lastSec = 17; break;
             }
 
-            duration = duration - lastSec*IN_MILLISECONDS + FISHING_BOBBER_READY_TIME*IN_MILLISECONDS;
+            // Duration of the fishing bobber can't be higher than the Fishing channeling duration
+            duration = std::min(duration, duration - lastSec*IN_MILLISECONDS + FISHING_BOBBER_READY_TIME*IN_MILLISECONDS);
             break;
         }
         case GAMEOBJECT_TYPE_SUMMONING_RITUAL:


### PR DESCRIPTION
**Changes proposed:**

This PR fixes two issues with Fishing:

- Right now you can spam the fishing spell and eventually get an instantly lootable fishing bobber: this is because the duration to wait before looting is randomly picked between static timeframes (3/7/13/17 seconds of channeling remaining). Because 17 was a valid choice, and the channeling spell lasts exactly 17 seconds, it would cause an instantly lootable bobber (blizzlike times are 3/7/13).

- When the channeling of Fishing ends without the player clicking on the bobber (can happen if you get a hook four seconds before the channeling ends) , it should despawn. Right now it stays for one more second because FISHING_BOBBER_READY_TIME (five seconds) is always added to the duration and can result in a 18-second duration (channel time is 17).
Casting fishing again in that one second causes a desync where a new fishing bobber is spawned, becomes unlootable and gives a "fish got away" even after the player walked away.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.