### PR TITLE
Core/Loot: don't allow to regenerate chest loot inside instances and raids

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8411,7 +8411,8 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
 
         // loot was generated and respawntime has passed since then, allow to recreate loot
         // to avoid bugs, this rule covers spawned gameobjects only
-        if (go->isSpawnedByDefault() && go->getLootState() == GO_ACTIVATED && !go->loot.isLooted() && go->GetLootGenerationTime() + go->GetRespawnDelay() < GameTime::GetGameTime())
+        // Don't allow to regenerate chest loot inside instances and raids, to avoid exploits with duplicate boss loot being given for some encounters
+        if (go->isSpawnedByDefault() && go->getLootState() == GO_ACTIVATED && !go->loot.isLooted() && !go->GetMap()->Instanceable() && go->GetLootGenerationTime() + go->GetRespawnDelay() < GameTime::GetGameTime())
             go->SetLootState(GO_READY);
 
         if (go->getLootState() == GO_READY)


### PR DESCRIPTION
**Changes proposed:**

Right now, loot regenerates inside any partially looted chest, based on spawntimesecs. This was implemented in 7011aabb56f061fc889ec42ce32b7605ceb35b53 and was supposed to help with chest behavior in the continent maps, but it also created an issue where loot regenerates inside chests that contain rewards from bosses.

The spawntimesecs is also the refill timer, however raids can be extended multiple times, so eventually those chests would refill.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.