### PR TITLE
Core/AI: Fix Guardians not following the owner after finishing combat

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -243,8 +243,11 @@ class TC_GAME_API CreatureAI : public UnitAI
 
     private:
         void OnOwnerCombatInteraction(Unit* target);
+        // Returns the value of IsEngaged() from the previous tick
+        bool SetWasEngaged(bool value);
 
         bool _moveInLOSLocked;
+        bool _wasEngaged;
 };
 
 #endif


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

CreatureAI::UpdateVictim() was not triggering EnterEvadeMode() after the Creature ended combat because IsEngaged() would return false.
These changes save the value of IsEngaged() to be used next tick to check if the Creature was in combat, is not anymore now and needs to evade (or select another enemy).
EnterEvadeMode() sets the stored previous value to false to ensure the Creature will not try to evade while already evading.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #17981


**Tests performed:** (Does it build, tested in-game, etc.)
- .cast 46657
- attack a mob
- after the mob dies, notice how the guardian now follows you again

**Known issues and TODO list:** (add/remove lines as needed)
None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
