### PR TITLE
Core/SAI: Avoid calling EnterEvadeMode() on spawn with Guardians

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -94,7 +94,8 @@ class TC_GAME_API CreatureAI : public UnitAI
             EVADE_REASON_BOUNDARY,          // the creature has moved outside its evade boundary
             EVADE_REASON_NO_PATH,           // the creature was unable to reach its target for over 5 seconds
             EVADE_REASON_SEQUENCE_BREAK,    // this is a boss and the pre-requisite encounters for engaging it are not defeated yet
-            EVADE_REASON_OTHER
+            EVADE_REASON_OTHER,
+            EVADE_REASON_JUST_SPAWNED
         };
 
         explicit CreatureAI(Creature* creature);

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -197,6 +197,7 @@ class TC_GAME_API SmartAI : public CreatureAI
         void UpdatePath(uint32 diff);
         void UpdateFollow(uint32 diff);
         void UpdateDespawn(uint32 diff);
+        void FollowOrGoHome();
 
         SmartScript _script;
         bool _charmed;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2246,7 +2246,7 @@ void Spell::EffectSummonType(SpellEffIndex effIndex)
                     summon->SetUInt32Value(UNIT_NPC_FLAGS, summon->GetCreatureTemplate()->npcflag);
                     summon->SetImmuneToAll(true);
 
-                    summon->AI()->EnterEvadeMode();
+                    summon->AI()->EnterEvadeMode(CreatureAI::EVADE_REASON_JUST_SPAWNED);
                     break;
                 }
                 default:
@@ -5443,7 +5443,7 @@ void Spell::SummonGuardian(uint32 i, uint32 entry, SummonPropertiesEntry const* 
                 summon->SetDisplayId(1126); // modelid1
         }
 
-        summon->AI()->EnterEvadeMode();
+        summon->AI()->EnterEvadeMode(CreatureAI::EVADE_REASON_JUST_SPAWNED);
 
         ExecuteLogEffectSummonObject(i, summon);
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add a new EvadeReason EVADE_REASON_JUST_SPAWNED used by Spell::EffectSummonType() and Spell::SummonGuardian() when they call EnterEvadeMode() on spawn. This will not trigger all the SmartAI::EnterEvadeMode() methods but only the ones required to make the Guardian follow the owner.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23270 , replaces #23441


**Tests performed:** (Does it build, tested in-game, etc.)
Tested with https://github.com/TrinityCore/TrinityCore/pull/23441#issuecomment-504664076

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
