### PR TITLE
Core/GameObject: don't allow non-consumable goobers to despawn on use

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -767,11 +767,12 @@ void GameObject::Update(uint32 diff)
 
             loot.clear();
 
-            // Do not delete goobers that are not consumed on loot, while still allowing them to despawn when they expire if summoned
+            // Do not delete gameobjects that are not consumed on loot, while still allowing them to despawn when they expire if summoned
             bool isSummonedAndExpired = (GetOwner() || GetSpellId()) && m_respawnTime == 0;
             bool isPermanentSpawn = m_respawnDelayTime == 0;
-            if (GetGoType() == GAMEOBJECT_TYPE_GOOBER && // ToDo: allow it to work with chests too
-                !GetGOInfo()->IsDespawnAtAction() && (!isSummonedAndExpired || isPermanentSpawn))
+            if (!GetGOInfo()->IsDespawnAtAction() &&
+                ((GetGoType() == GAMEOBJECT_TYPE_GOOBER && (!isSummonedAndExpired || isPermanentSpawn)) ||
+                (GetGoType() == GAMEOBJECT_TYPE_CHEST && !isSummonedAndExpired))) // ToDo: chests with data2 (chestRestockTime) > 0 and data3 (consumable) = 0 should not despawn on loot
             {
                 SetLootState(GO_READY);
                 UpdateObjectVisibility();


### PR DESCRIPTION
**Changes proposed:**

This PR fixes an issue where goober gameobjects ([Romantic Picnic Basket](https://www.wowhead.com/item=34480), the Naxxramas portals) would despawn after a player right-clicked on them.

They are goobers flagged as non-consumable (data3 == 0) so they should not despawn in any case unless they were summoned by a spell and they expired.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #15730, updates #23451.

**Tests performed:** it works.