### PR TITLE
Core/Spell: allow damage from binary spells to go through elemental resistance's damage reduction

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1595,10 +1595,6 @@ void Unit::HandleEmoteCommand(uint32 anim_id)
     {
         if (spellInfo->HasAttribute(SPELL_ATTR4_IGNORE_RESISTANCES))
             return 0;
-
-        // Binary spells can't have damage part resisted
-        if (spellInfo->HasAttribute(SPELL_ATTR0_CU_BINARY_SPELL))
-            return 0;
     }
 
     float const averageResist = Unit::CalculateAverageResistReduction(attacker, schoolMask, victim, spellInfo);


### PR DESCRIPTION
**Changes proposed:**

The concept of binary spells is that the spell is either fully resisted (no spell effect applies) or it fully hits (all spell effects apply). For spells like Frost Nova, the damage part cannot apply without the root effect, and the other way around.

It should have no other impact: however, currently on TC, binary spells also bypass elemental resistance for damage calculations. I don't know where this came from, but it makes no sense, is wrong and there's a perfectly serviceable attribute (SPELL_ATTR4_IGNORE_RESISTANCES) to ignore resistances.

[In this video](https://youtu.be/PmQdi1_RrgA?t=68) you can see the Druid resisting part of Frost Nova's damage in PvP.
[In this other video](https://www.youtube.com/watch?v=V-qgBmWcEjg&feature=youtu.be&t=46) (from #19504) you can see the Druid resisting part of Frost Nova's damage in PvE.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** fixes issue described in #19504

**Tests performed:** it works.