### PR TITLE
Core/SAI: allow creatures to handle gameobject spellhit SAI events

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -607,9 +607,19 @@ void SmartAI::SpellHit(Unit* unit, SpellInfo const* spellInfo)
     GetScript()->ProcessEventsFor(SMART_EVENT_SPELLHIT, unit, 0, 0, false, spellInfo);
 }
 
+void SmartAI::SpellHitByGameObject(GameObject* object, SpellInfo const* spellInfo)
+{
+    GetScript()->ProcessEventsFor(SMART_EVENT_SPELLHIT, nullptr, 0, 0, false, spellInfo, object);
+}
+
 void SmartAI::SpellHitTarget(Unit* target, SpellInfo const* spellInfo)
 {
     GetScript()->ProcessEventsFor(SMART_EVENT_SPELLHIT_TARGET, target, 0, 0, false, spellInfo);
+}
+
+void SmartAI::SpellHitTargetGameObject(GameObject* target, SpellInfo const* spellInfo)
+{
+    GetScript()->ProcessEventsFor(SMART_EVENT_SPELLHIT_TARGET, nullptr, 0, 0, false, spellInfo, target);
 }
 
 void SmartAI::DamageTaken(Unit* doneBy, uint32& damage)

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -99,9 +99,11 @@ class TC_GAME_API SmartAI : public CreatureAI
 
         // Called when hit by a spell
         void SpellHit(Unit* unit, SpellInfo const* spellInfo) override;
+        void SpellHitByGameObject(GameObject* object, SpellInfo const* spellInfo) override;
 
         // Called when spell hits a target
         void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override;
+        void SpellHitTargetGameObject(GameObject* object, SpellInfo const* spellInfo) override;
 
         // Called at any Damage from any attacker (before damage apply)
         void DamageTaken(Unit* doneBy, uint32& damage) override;


### PR DESCRIPTION
**Changes proposed:**

Spell::TargetInfo::DoDamageAndTriggers() was skipping AI hooks when the caster was a gameobject.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #22613, supersedes #22626.

**Tests performed:** it works.

**Known issues and TODO list:**

- Spells cast by gameobjects will not deal damage/heal. That issue is outside of the scope of this PR and it is not caused by it.