### PR TITLE
Core/SAI: do not pass old creatureData to UpdateEntry() and keep current health when changing a NPC's entry

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1031,7 +1031,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             for (WorldObject* target : targets)
                 if (IsCreature(target))
-                    target->ToCreature()->UpdateEntry(e.action.updateTemplate.creature, target->ToCreature()->GetCreatureData(), e.action.updateTemplate.updateLevel != 0);
+                    target->ToCreature()->UpdateEntry(e.action.updateTemplate.creature, nullptr, e.action.updateTemplate.updateLevel != 0);
             break;
         }
         case SMART_ACTION_DIE:

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -568,7 +568,10 @@ bool Creature::UpdateEntry(uint32 entry, CreatureData const* data /*= nullptr*/,
     if (updateLevel)
         SelectLevel();
 
+    uint32 previousHealth = GetHealth();
     UpdateLevelDependantStats();
+    if (previousHealth > 0)
+        SetHealth(previousHealth);
 
     SetMeleeDamageSchool(SpellSchools(cInfo->dmgschool));
     SetStatFlatModifier(UNIT_MOD_RESISTANCE_HOLY,   BASE_VALUE, float(cInfo->resistance[SPELL_SCHOOL_HOLY]));


### PR DESCRIPTION
**Changes proposed:**

Currently we pass the old CreatureData to SMART_ACTION_UPDATE_TEMPLATE, before updating the entry. That causes some values (including modelid) to not update with the correct ones from the new creature entry.

Also the health should remain at the same percentage as it was before, instead of resetting (changing entry doesn't grant a creature a free Lay on Hands, it's the same creature with the same damage inflicted on it).

Test case: #23494. 

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.