### PR TITLE
Core/Mail: include 100g in the mail sent after turning in the quest The Wrath of Neptulon

### DIFF
--- a/src/server/game/Mails/Mail.cpp
+++ b/src/server/game/Mails/Mail.cpp
@@ -100,7 +100,7 @@ void MailDraft::prepareItems(Player* receiver, SQLTransaction& trans)
 
     m_mailTemplateItemsNeed = false;
 
-    // The mail sent after turning in the quest The Wrath of Neptulon contains 100g
+    // The mail sent after turning in the quest The Good News and The Bad News contains 100g
     if (m_mailTemplateId == 123)
         m_money = 1000000;
 

--- a/src/server/game/Mails/Mail.cpp
+++ b/src/server/game/Mails/Mail.cpp
@@ -100,6 +100,10 @@ void MailDraft::prepareItems(Player* receiver, SQLTransaction& trans)
 
     m_mailTemplateItemsNeed = false;
 
+    // The mail sent after turning in the quest The Wrath of Neptulon contains 100g
+    if (m_mailTemplateId == 123)
+        m_money = 1000000;
+
     Loot mailLoot;
 
     // can be empty


### PR DESCRIPTION
**Changes proposed:**

After turning in the quest [The Wrath of Neptulon](https://www.wowhead.com/quest=8729), the player will receive a mail (after 24 hours) that should contain 100 gold. [Source](https://www.wowhead.com/quest=8729/the-wrath-of-neptulon#comments:id=83809).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** it works.