### PR TITLE
Core/GameObject: implement restock mechanic for non-consumable gameobjects

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -797,7 +797,7 @@ void GameObject::Update(uint32 diff)
                 UpdateObjectVisibility();
                 return;
             }
-            else
+            else if (GetOwner() || GetSpellId())
             {
                 SetRespawnTime(0);
                 Delete();

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -510,6 +510,13 @@ void GameObject::Update(uint32 diff)
                     }
                     return;
                 }
+                case GAMEOBJECT_TYPE_CHEST:
+                    if (m_restockTime > GameTime::GetGameTime())
+                        return;
+                    // If there is no restock timer, or if the restock timer passed, the chest becomes ready to loot
+                    m_lootState = GO_READY;
+                    SendLootStateUpdateToNearbyPlayers();
+                    break;
                 default:
                     m_lootState = GO_READY;                         // for other GOis same switched without delay to GO_READY
                     break;
@@ -694,6 +701,13 @@ void GameObject::Update(uint32 diff)
                         }
                         else m_groupLootTimer -= diff;
                     }
+
+                    // Gameobject was partially looted and restock time passed, restock all loot now
+                    if (GameTime::GetGameTime() >= m_restockTime)
+                    {
+                        m_lootState = GO_READY;
+                        SendLootStateUpdateToNearbyPlayers();
+                    }
                     break;
                 case GAMEOBJECT_TYPE_TRAP:
                 {
@@ -769,12 +783,17 @@ void GameObject::Update(uint32 diff)
 
             // Do not delete gameobjects that are not consumed on loot, while still allowing them to despawn when they expire if summoned
             bool isSummonedAndExpired = (GetOwner() || GetSpellId()) && m_respawnTime == 0;
-            bool isPermanentSpawn = m_respawnDelayTime == 0;
-            if (!GetGOInfo()->IsDespawnAtAction() &&
-                ((GetGoType() == GAMEOBJECT_TYPE_GOOBER && (!isSummonedAndExpired || isPermanentSpawn)) ||
-                (GetGoType() == GAMEOBJECT_TYPE_CHEST && !isSummonedAndExpired && GetGOInfo()->chest.chestRestockTime == 0))) // ToDo: chests with data2 (chestRestockTime) > 0 and data3 (consumable) = 0 should not despawn on loot
+            if (!GetGOInfo()->IsDespawnAtAction() && !isSummonedAndExpired)
             {
-                SetLootState(GO_READY);
+                if (GetGoType() == GAMEOBJECT_TYPE_CHEST && GetGOInfo()->chest.chestRestockTime > 0)
+                {
+                    // Start restock timer when the chest is fully looted
+                    m_restockTime = GameTime::GetGameTime() + GetGOInfo()->chest.chestRestockTime;
+                    SetLootState(GO_NOT_READY);
+                    SendLootStateUpdateToNearbyPlayers();
+                }
+                else
+                    SetLootState(GO_READY);
                 UpdateObjectVisibility();
                 return;
             }
@@ -1308,6 +1327,10 @@ bool GameObject::ActivateToQuest(Player* target) const
         }
         case GAMEOBJECT_TYPE_CHEST:
         {
+            // Chests become inactive while not ready to be looted
+            if (getLootState() == GO_NOT_READY)
+                return false;
+
             // scan GO chest with loot including quest items
             if (LootTemplates_Gameobject.HaveQuestLootForPlayer(GetGOInfo()->GetLootId(), target))
             {
@@ -2307,6 +2330,10 @@ void GameObject::SetLootState(LootState state, Unit* unit)
 
     AI()->OnLootStateChanged(state, unit);
 
+    // Start restock timer if the chest is partially looted or not looted at all
+    if (GetGoType() == GAMEOBJECT_TYPE_CHEST && state == GO_ACTIVATED && GetGOInfo()->chest.chestRestockTime > 0 && m_restockTime == 0)
+        m_restockTime = GameTime::GetGameTime() + GetGOInfo()->chest.chestRestockTime;
+
     if (GetGoType() == GAMEOBJECT_TYPE_DOOR) // only set collision for doors on SetGoState
         return;
 
@@ -2318,6 +2345,27 @@ void GameObject::SetLootState(LootState state, Unit* unit)
             collision = !collision;
 
         EnableCollision(collision);
+    }
+}
+
+void GameObject::SendLootStateUpdateToNearbyPlayers()
+{
+    std::list<WorldObject*> targets;
+    Trinity::AllWorldObjectsInRange u_check(this, GetVisibilityRange());
+    Trinity::WorldObjectListSearcher<Trinity::AllWorldObjectsInRange> searcher(this, targets, u_check);
+    Cell::VisitAllObjects(this, searcher, GetVisibilityRange());
+
+    if (!targets.empty())
+    { 
+        for (WorldObject* target : targets)
+            if (target->GetTypeId() == TYPEID_PLAYER)
+            {
+                UpdateData udata;
+                WorldPacket packet;
+                BuildValuesUpdateBlockForPlayer(&udata, target->ToPlayer());
+                udata.BuildPacket(&packet);
+                target->ToPlayer()->SendDirectMessage(&packet);
+            }
     }
 }
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -515,7 +515,7 @@ void GameObject::Update(uint32 diff)
                         return;
                     // If there is no restock timer, or if the restock timer passed, the chest becomes ready to loot
                     m_lootState = GO_READY;
-                    SendLootStateUpdateToNearbyPlayers();
+                    AddToObjectUpdateIfNeeded();
                     break;
                 default:
                     m_lootState = GO_READY;                         // for other GOis same switched without delay to GO_READY
@@ -706,7 +706,7 @@ void GameObject::Update(uint32 diff)
                     if (GameTime::GetGameTime() >= m_restockTime)
                     {
                         m_lootState = GO_READY;
-                        SendLootStateUpdateToNearbyPlayers();
+                        AddToObjectUpdateIfNeeded();
                     }
                     break;
                 case GAMEOBJECT_TYPE_TRAP:
@@ -790,7 +790,7 @@ void GameObject::Update(uint32 diff)
                     // Start restock timer when the chest is fully looted
                     m_restockTime = GameTime::GetGameTime() + GetGOInfo()->chest.chestRestockTime;
                     SetLootState(GO_NOT_READY);
-                    SendLootStateUpdateToNearbyPlayers();
+                    AddToObjectUpdateIfNeeded();
                 }
                 else
                     SetLootState(GO_READY);
@@ -2345,27 +2345,6 @@ void GameObject::SetLootState(LootState state, Unit* unit)
             collision = !collision;
 
         EnableCollision(collision);
-    }
-}
-
-void GameObject::SendLootStateUpdateToNearbyPlayers()
-{
-    std::list<WorldObject*> targets;
-    Trinity::AllWorldObjectsInRange u_check(this, GetVisibilityRange());
-    Trinity::WorldObjectListSearcher<Trinity::AllWorldObjectsInRange> searcher(this, targets, u_check);
-    Cell::VisitAllObjects(this, searcher, GetVisibilityRange());
-
-    if (!targets.empty())
-    { 
-        for (WorldObject* target : targets)
-            if (target->GetTypeId() == TYPEID_PLAYER)
-            {
-                UpdateData udata;
-                WorldPacket packet;
-                BuildValuesUpdateBlockForPlayer(&udata, target->ToPlayer());
-                udata.BuildPacket(&packet);
-                target->ToPlayer()->SendDirectMessage(&packet);
-            }
     }
 }
 

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -177,6 +177,7 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         LootState getLootState() const { return m_lootState; }
         // Note: unit is only used when s = GO_ACTIVATED
         void SetLootState(LootState s, Unit* unit = nullptr);
+        void SendLootStateUpdateToNearbyPlayers();
 
         uint16 GetLootMode() const { return m_LootMode; }
         bool HasLootMode(uint16 lootMode) const { return (m_LootMode & lootMode) != 0; }
@@ -308,6 +309,7 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         LootState   m_lootState;
         ObjectGuid  m_lootStateUnitGUID;                    // GUID of the unit passed with SetLootState(LootState, Unit*)
         bool        m_spawnedByDefault;
+        time_t      m_restockTime;
         time_t      m_cooldownTime;                         // used as internal reaction delay time store (not state change reaction).
                                                             // For traps this: spell casting cooldown, for doors/buttons: reset time.
         GOState     m_prevGoState;                          // What state to set whenever resetting

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -177,7 +177,6 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         LootState getLootState() const { return m_lootState; }
         // Note: unit is only used when s = GO_ACTIVATED
         void SetLootState(LootState s, Unit* unit = nullptr);
-        void SendLootStateUpdateToNearbyPlayers();
 
         uint16 GetLootMode() const { return m_LootMode; }
         bool HasLootMode(uint16 lootMode) const { return (m_LootMode & lootMode) != 0; }


### PR DESCRIPTION
**Changes proposed:**

Some gameobject chests should never despawn (data3 = 0) but instead they become inactive until their loot is restocked (data2 > 0).

This PR implements this behavior, and fixes the following cases:

-  Only one quest item inside the gameobject, it is looted: chest becomes inactive (not usable) until the restock time passes. Then it regens the loot and becomes activable.
-  Two quest items inside the gameobjects, one is looted: the other remains available and the gameobject remains active. When the restock timer elapses, the other item is regenerated.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #23451 by fixing the remaining issues listed there.

**Tests performed:** it works.