### PR TITLE
Core/Misc: Handle timezones for hour-specific events specifieds in worldserver.conf

### DIFF
--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -86,6 +86,23 @@ time_t LocalTimeToUTCTime(time_t time)
 #endif
 }
 
+TC_COMMON_API time_t LocalTimeHourToUnixTime(time_t day, uint32 hour, bool mustBeAfterDay)
+{
+    tm todayLocal;
+    localtime_r(&day, &todayLocal);
+    todayLocal.tm_hour = 0;
+    todayLocal.tm_min = 0;
+    todayLocal.tm_sec = 0;
+    time_t midnightLocal = mktime(&todayLocal);
+    time_t hourLocal = midnightLocal + hour * HOUR;
+
+    // In timezones west of GMT (so GMT-1, etc) the / DAY * DAY math will return the day before. In this cases we just add 1 day to the time
+    if (mustBeAfterDay && hourLocal < day)
+        hourLocal += DAY;
+
+    return hourLocal;
+}
+
 std::string secsToTimeString(uint64 timeInSecs, bool shortText, bool hoursOnly)
 {
     uint64 secs    = timeInSecs % MINUTE;

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -77,7 +77,7 @@ struct tm* localtime_r(time_t const* time, struct tm *result)
 }
 #endif
 
-TC_COMMON_API tm TimeBreakdown(time_t time)
+tm TimeBreakdown(time_t time)
 {
     tm timeLocal;
     localtime_r(&time, &timeLocal);
@@ -93,7 +93,7 @@ time_t LocalTimeToUTCTime(time_t time)
 #endif
 }
 
-TC_COMMON_API time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAfterTime)
+time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAfterTime)
 {
     tm timeLocal = TimeBreakdown(time);
     timeLocal.tm_hour = 0;
@@ -102,7 +102,6 @@ TC_COMMON_API time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAft
     time_t midnightLocal = mktime(&timeLocal);
     time_t hourLocal = midnightLocal + hour * HOUR;
 
-    // In timezones west of GMT (so GMT-1, etc) the / DAY * DAY math will return the day before. In this cases we just add 1 day to the time
     if (onlyAfterTime && hourLocal < time)
         hourLocal += DAY;
 

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -77,6 +77,13 @@ struct tm* localtime_r(time_t const* time, struct tm *result)
 }
 #endif
 
+TC_COMMON_API tm TimeBreakdown(time_t time)
+{
+    tm timeLocal;
+    localtime_r(&time, &timeLocal);
+    return timeLocal;
+}
+
 time_t LocalTimeToUTCTime(time_t time)
 {
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
@@ -86,18 +93,17 @@ time_t LocalTimeToUTCTime(time_t time)
 #endif
 }
 
-TC_COMMON_API time_t LocalTimeHourToUnixTime(time_t day, uint32 hour, bool mustBeAfterDay)
+TC_COMMON_API time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAfterTime)
 {
-    tm todayLocal;
-    localtime_r(&day, &todayLocal);
-    todayLocal.tm_hour = 0;
-    todayLocal.tm_min = 0;
-    todayLocal.tm_sec = 0;
-    time_t midnightLocal = mktime(&todayLocal);
+    tm timeLocal = TimeBreakdown(time);
+    timeLocal.tm_hour = 0;
+    timeLocal.tm_min = 0;
+    timeLocal.tm_sec = 0;
+    time_t midnightLocal = mktime(&timeLocal);
     time_t hourLocal = midnightLocal + hour * HOUR;
 
     // In timezones west of GMT (so GMT-1, etc) the / DAY * DAY math will return the day before. In this cases we just add 1 day to the time
-    if (mustBeAfterDay && hourLocal < day)
+    if (onlyAfterTime && hourLocal < time)
         hourLocal += DAY;
 
     return hourLocal;

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -59,7 +59,8 @@ TC_COMMON_API int32 MoneyStringToMoney(std::string const& moneyString);
 
 TC_COMMON_API struct tm* localtime_r(time_t const* time, struct tm *result);
 TC_COMMON_API time_t LocalTimeToUTCTime(time_t time);
-TC_COMMON_API time_t LocalTimeHourToUnixTime(time_t day, uint32 hour, bool mustBeAfterDay = true);
+TC_COMMON_API time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAfterTime = true);
+TC_COMMON_API tm TimeBreakdown(time_t t);
 
 TC_COMMON_API std::string secsToTimeString(uint64 timeInSecs, bool shortText = false, bool hoursOnly = false);
 TC_COMMON_API uint32 TimeStringToSecs(std::string const& timestring);

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -59,6 +59,7 @@ TC_COMMON_API int32 MoneyStringToMoney(std::string const& moneyString);
 
 TC_COMMON_API struct tm* localtime_r(time_t const* time, struct tm *result);
 TC_COMMON_API time_t LocalTimeToUTCTime(time_t time);
+TC_COMMON_API time_t LocalTimeHourToUnixTime(time_t day, uint32 hour, bool mustBeAfterDay = true);
 
 TC_COMMON_API std::string secsToTimeString(uint64 timeInSecs, bool shortText = false, bool hoursOnly = false);
 TC_COMMON_API uint32 TimeStringToSecs(std::string const& timestring);

--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -369,7 +369,7 @@ void InstanceSaveManager::LoadResetTimes()
             }
 
             // update the reset time if the hour in the configs changes
-            uint64 newresettime = LocalTimeHourToUnixTime(oldresettime, resetHour, false);
+            uint64 newresettime = GetLocalHourTimestamp(oldresettime, resetHour, false);
             if (oldresettime != newresettime)
             {
                 PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_GLOBAL_INSTANCE_RESETTIME);
@@ -403,7 +403,7 @@ void InstanceSaveManager::LoadResetTimes()
         if (!t)
         {
             // initialize the reset time
-            t = LocalTimeHourToUnixTime(today + period, resetHour);
+            t = GetLocalHourTimestamp(today + period, resetHour);
 
             PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_GLOBAL_INSTANCE_RESETTIME);
             stmt->setUInt16(0, uint16(mapid));
@@ -417,7 +417,7 @@ void InstanceSaveManager::LoadResetTimes()
             // assume that expired instances have already been cleaned
             // calculate the next reset time
             time_t day = (t / DAY) * DAY;
-            t = LocalTimeHourToUnixTime(day + ((today - day) / period + 1) * period, resetHour);
+            t = GetLocalHourTimestamp(day + ((today - day) / period + 1) * period, resetHour);
 
             PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_GLOBAL_INSTANCE_RESETTIME);
             stmt->setUInt64(0, uint64(t));
@@ -456,7 +456,7 @@ time_t InstanceSaveManager::GetSubsequentResetTime(uint32 mapid, Difficulty diff
     if (period < DAY)
         period = DAY;
 
-    return LocalTimeHourToUnixTime(((resetTime + MINUTE) / DAY * DAY) + period, resetHour);
+    return GetLocalHourTimestamp(((resetTime + MINUTE) / DAY * DAY) + period, resetHour);
 }
 
 void InstanceSaveManager::SetResetTimeFor(uint32 mapid, Difficulty d, time_t t)

--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -346,7 +346,7 @@ void InstanceSaveManager::LoadResetTimes()
     }
 
     // load the global respawn times for raid/heroic instances
-    uint32 diff = sWorld->getIntConfig(CONFIG_INSTANCE_RESET_TIME_HOUR) * HOUR;
+    uint32 resetHour = sWorld->getIntConfig(CONFIG_INSTANCE_RESET_TIME_HOUR);
     if (QueryResult result = CharacterDatabase.Query("SELECT mapid, difficulty, resettime FROM instance_reset"))
     {
         do
@@ -369,7 +369,7 @@ void InstanceSaveManager::LoadResetTimes()
             }
 
             // update the reset time if the hour in the configs changes
-            uint64 newresettime = (oldresettime / DAY) * DAY + diff;
+            uint64 newresettime = LocalTimeHourToUnixTime(oldresettime, resetHour, false);
             if (oldresettime != newresettime)
             {
                 PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_GLOBAL_INSTANCE_RESETTIME);
@@ -403,7 +403,7 @@ void InstanceSaveManager::LoadResetTimes()
         if (!t)
         {
             // initialize the reset time
-            t = today + period + diff;
+            t = LocalTimeHourToUnixTime(today + period, resetHour);
 
             PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_GLOBAL_INSTANCE_RESETTIME);
             stmt->setUInt16(0, uint16(mapid));
@@ -416,8 +416,8 @@ void InstanceSaveManager::LoadResetTimes()
         {
             // assume that expired instances have already been cleaned
             // calculate the next reset time
-            t = (t / DAY) * DAY;
-            t += ((today - t) / period + 1) * period + diff;
+            time_t day = (t / DAY) * DAY;
+            t = LocalTimeHourToUnixTime(day + ((today - day) / period + 1) * period, resetHour);
 
             PreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_GLOBAL_INSTANCE_RESETTIME);
             stmt->setUInt64(0, uint64(t));
@@ -451,12 +451,12 @@ time_t InstanceSaveManager::GetSubsequentResetTime(uint32 mapid, Difficulty diff
         return 0;
     }
 
-    time_t diff = sWorld->getIntConfig(CONFIG_INSTANCE_RESET_TIME_HOUR) * HOUR;
+    time_t resetHour = sWorld->getIntConfig(CONFIG_INSTANCE_RESET_TIME_HOUR);
     time_t period = uint32(((mapDiff->resetTime * sWorld->getRate(RATE_INSTANCE_RESET_TIME)) / DAY) * DAY);
     if (period < DAY)
         period = DAY;
 
-    return ((resetTime + MINUTE) / DAY * DAY) + period + diff;
+    return LocalTimeHourToUnixTime(((resetTime + MINUTE) / DAY * DAY) + period, resetHour);
 }
 
 void InstanceSaveManager::SetResetTimeFor(uint32 mapid, Difficulty d, time_t t)

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -230,11 +230,11 @@ void World::TriggerGuidWarning()
     time_t today = (gameTime / DAY) * DAY;
 
     // Check if our window to restart today has passed. 5 mins until quiet time
-    while (gameTime >= LocalTimeHourToUnixTime(today, getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME)) - 1810)
+    while (gameTime >= GetLocalHourTimestamp(today, getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME)) - 1810)
         today += DAY;
 
     // Schedule restart for 30 minutes before quiet time, or as long as we have
-    _warnShutdownTime = LocalTimeHourToUnixTime(today, getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME)) - 1800;
+    _warnShutdownTime = GetLocalHourTimestamp(today, getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME)) - 1800;
 
     _guidWarn = true;
     SendGuidWarning();

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -230,11 +230,11 @@ void World::TriggerGuidWarning()
     time_t today = (gameTime / DAY) * DAY;
 
     // Check if our window to restart today has passed. 5 mins until quiet time
-    while (gameTime >= (today + (getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME) * HOUR) - 1810))
+    while (gameTime >= LocalTimeHourToUnixTime(today, getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME)) - 1810)
         today += DAY;
 
     // Schedule restart for 30 minutes before quiet time, or as long as we have
-    _warnShutdownTime = today + (getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME) * HOUR) - 1800;
+    _warnShutdownTime = LocalTimeHourToUnixTime(today, getIntConfig(CONFIG_RESPAWN_RESTARTQUIETTIME)) - 1800;
 
     _guidWarn = true;
     SendGuidWarning();

--- a/src/server/scripts/World/boosted_xp.cpp
+++ b/src/server/scripts/World/boosted_xp.cpp
@@ -24,8 +24,7 @@ namespace
     bool IsXPBoostActive()
     {
         time_t time = GameTime::GetGameTime();
-        tm localTm;
-        localtime_r(&time, &localTm);
+        tm localTm = TimeBreakdown(time);
         uint32 weekdayMaskBoosted = sWorld->getIntConfig(CONFIG_XP_BOOST_DAYMASK);
         uint32 weekdayMask = (1 << localTm.tm_wday);
         bool currentDayBoosted = (weekdayMask & weekdayMaskBoosted) != 0;

--- a/src/server/scripts/World/boosted_xp.cpp
+++ b/src/server/scripts/World/boosted_xp.cpp
@@ -17,6 +17,7 @@
 
 #include "GameTime.h"
 #include "ScriptMgr.h"
+#include "Util.h"
 #include "World.h"
 
 namespace

--- a/src/server/scripts/World/boosted_xp.cpp
+++ b/src/server/scripts/World/boosted_xp.cpp
@@ -19,15 +19,15 @@
 #include "ScriptMgr.h"
 #include "World.h"
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 namespace
 {
     bool IsXPBoostActive()
     {
-        auto now = boost::posix_time::to_tm(boost::posix_time::from_time_t(GameTime::GetGameTime()));
+        time_t time = GameTime::GetGameTime();
+        tm localTm;
+        localtime_r(&time, &localTm);
         uint32 weekdayMaskBoosted = sWorld->getIntConfig(CONFIG_XP_BOOST_DAYMASK);
-        uint32 weekdayMask = (1 << now.tm_wday);
+        uint32 weekdayMask = (1 << localTm.tm_wday);
         bool currentDayBoosted = (weekdayMask & weekdayMaskBoosted) != 0;
         return currentDayBoosted;
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->
**Changes proposed:**

-  Handle timezones for hour-specific events specifieds in worldserver.conf

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #22956


**Tests performed:** (Does it build, tested in-game, etc.)
Tried with timezone CEST (GMT+2) and GMT-6


**Known issues and TODO list:** (add/remove lines as needed)

- [x] Add support to Instance.ResetTimeHour
- [x] ~~Add support to Guild.ResetHour~~ this seems to work already fine
- [x]  ~~Add support to Battleground.Random.ResetHour~~ this seems to work already fine
- [ ] Add support to Quests.DailyResetTime
- [x] Add support to Respawn.RestartQuietTime
- [x] Add support to Weekend xp rate
- [ ] Add support to game events (i.e. Darkmoon Faire)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
