### PR TITLE
Local-only mode fix

### DIFF
--- a/src/common/Asio/Resolver.h
+++ b/src/common/Asio/Resolver.h
@@ -31,13 +31,15 @@ namespace Trinity
         {
             boost::system::error_code ec;
 #if BOOST_VERSION >= 106600
-            boost::asio::ip::tcp::resolver::results_type results = resolver.resolve(protocol, host, service, ec);
+            boost::asio::ip::resolver_base::flags flagsResolver = boost::asio::ip::resolver_base::all_matching;
+            boost::asio::ip::tcp::resolver::results_type results = resolver.resolve(protocol, host, service, flagsResolver, ec);
             if (results.begin() == results.end() || ec)
                 return {};
 
             return results.begin()->endpoint();
 #else
-            boost::asio::ip::tcp::resolver::query query(std::move(protocol), std::move(host), std::move(service), boost::asio::ip::tcp::resolver::query::canonical_name);
+            boost::asio::ip::resolver_query_base::flags flagsQuery = boost::asio::ip::tcp::resolver::query::all_matching;
+            boost::asio::ip::tcp::resolver::query query(std::move(protocol), std::move(host), std::move(service), flagsQuery);
             boost::asio::ip::tcp::resolver::iterator itr = resolver.resolve(query, ec);
             boost::asio::ip::tcp::resolver::iterator end;
             if (itr == end || ec)

--- a/src/common/Asio/Resolver.h
+++ b/src/common/Asio/Resolver.h
@@ -37,7 +37,7 @@ namespace Trinity
 
             return results.begin()->endpoint();
 #else
-            boost::asio::ip::tcp::resolver::query query(std::move(protocol), std::move(host), std::move(service));
+            boost::asio::ip::tcp::resolver::query query(std::move(protocol), std::move(host), std::move(service), boost::asio::ip::tcp::resolver::query::canonical_name);
             boost::asio::ip::tcp::resolver::iterator itr = resolver.resolve(query, ec);
             boost::asio::ip::tcp::resolver::iterator end;
             if (itr == end || ec)


### PR DESCRIPTION
In response to issue #21309

**Changes proposed:**

Add flags to resolver to work in local-only cases.

**Target branch(es):**

- [v ] 3.3.5
- [v ] master  
Made for 3.3.5 but master seems the same.

**Issues addressed:** Closes  #21309  (in case of boost 1.65 or older)

**Tests performed:** Yes. Works flawlessly.
