### PR TITLE
Scripts/Spells: Dimensional Ripper - Everlook

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_item_dimensional_ripper_everlook';
+INSERT INTO `spell_script_names` VALUES (23442,'spell_item_dimensional_ripper_everlook');

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1062,25 +1062,6 @@ void Spell::EffectTeleportUnits(SpellEffIndex /*effIndex*/)
         TC_LOG_ERROR("spells", "Spell::EffectTeleportUnits - spellId %u attempted to teleport creature to a different map.", m_spellInfo->Id);
         return;
     }
-
-    // post effects for TARGET_DEST_DB
-    /// @todo: awful hacks, move this to spellscripts
-    switch (m_spellInfo->Id)
-    {
-        // Dimensional Ripper - Everlook
-        case 23442:
-        {
-            int32 r = irand(0, 119);
-            if (r >= 70)                                  // 7/12 success
-            {
-                if (r < 100)                              // 4/12 evil twin
-                    m_caster->CastSpell(m_caster, 23445, true);
-                else                                        // 1/12 fire
-                    m_caster->CastSpell(m_caster, 23449, true);
-            }
-            return;
-        }
-    }
 }
 
 void Spell::EffectApplyAura(SpellEffIndex effIndex)

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -1724,6 +1724,7 @@ class spell_item_scroll_of_recall : public SpellScript
 enum TransporterSpells
 {
     SPELL_EVIL_TWIN                         = 23445,
+    SPELL_TRANSPORTER_MALFUNCTION_FIRE      = 23449,
     SPELL_TRANSPORTER_MALFUNCTION_SMALLER   = 36893,
     SPELL_TRANSPORTER_MALFUNCTION_BIGGER    = 36895,
     SPELL_TRANSPORTER_MALFUNCTION_CHICKEN   = 36940,
@@ -1731,6 +1732,41 @@ enum TransporterSpells
     SPELL_TRANSFORM_ALLIANCE                = 36899,
     SPELL_SOUL_SPLIT_EVIL                   = 36900,
     SPELL_SOUL_SPLIT_GOOD                   = 36901
+};
+
+// 23442 - Dimensional Ripper - Everlook
+class spell_item_dimensional_ripper_everlook : public SpellScript
+{
+    PrepareSpellScript(spell_item_dimensional_ripper_everlook);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_TRANSPORTER_MALFUNCTION_FIRE, SPELL_EVIL_TWIN });
+    }
+
+    bool Load() override
+    {
+        return GetCaster()->GetTypeId() == TYPEID_PLAYER;
+    }
+
+    void HandleScript(SpellEffIndex /* effIndex */)
+    {
+        int32 r = irand(0, 119);
+        if (r <= 70)                               // 7/12 success
+            return;
+
+        Unit* caster = GetCaster();
+
+        if (r < 100)                              // 4/12 evil twin
+            caster->CastSpell(caster, SPELL_EVIL_TWIN, true);
+        else                                      // 1/12 fire
+            caster->CastSpell(caster, SPELL_TRANSPORTER_MALFUNCTION_FIRE, true);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_item_dimensional_ripper_everlook::HandleScript, EFFECT_0, SPELL_EFFECT_TELEPORT_UNITS);
+    }
 };
 
 // 36941 - Ultrasafe Transporter: Toshley's Station
@@ -4214,6 +4250,7 @@ void AddSC_item_spell_scripts()
     RegisterAuraScript(spell_item_power_circle);
     RegisterSpellScript(spell_item_savory_deviate_delight);
     RegisterSpellScript(spell_item_scroll_of_recall);
+    RegisterSpellScript(spell_item_dimensional_ripper_everlook);
     RegisterSpellScript(spell_item_ultrasafe_transporter);
     RegisterSpellScript(spell_item_dimensional_ripper_area52);
     RegisterAuraScript(spell_item_unsated_craving);


### PR DESCRIPTION
**Changes proposed:**
Migrate spell `Dimensional Ripper - Everlook` to spell scripts system, therefore removing all hacks from teleporting post-effects.

**Target branch(es):** 3.3.5

**Tests performed:** Not tested in-game (**should** work)