### PR TITLE
Core/Reputation: don't allow quests to reward Honor Hold/Alliance Vanguard reputation to Horde players or Thrallmar reputation to Alliance players

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6655,7 +6655,19 @@ void Player::RewardReputation(Quest const* quest)
 {
     for (uint8 i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
     {
-        if (!quest->RewardFactionId[i])
+        uint32 rewardFactionId = quest->RewardFactionId[i];
+
+        if (!rewardFactionId)
+            continue;
+
+        // @hack some quests give reputation to Alliance-only AND Horde-only factions, but DBC data does not allow to identify faction-only reputations
+        if (GetTeamId() == TEAM_HORDE && (
+            (rewardFactionId == 1037) || // Alliance Vanguard
+            (rewardFactionId == 946)))   // Honor Hold
+            continue;
+
+        if (GetTeamId() == TEAM_ALLIANCE &&
+            rewardFactionId == 947)     // Thrallmar
             continue;
 
         int32 rep = 0;
@@ -6680,17 +6692,17 @@ void Player::RewardReputation(Quest const* quest)
             continue;
 
         if (quest->IsDaily())
-            rep = CalculateReputationGain(REPUTATION_SOURCE_DAILY_QUEST, GetQuestLevel(quest), rep, quest->RewardFactionId[i], noQuestBonus);
+            rep = CalculateReputationGain(REPUTATION_SOURCE_DAILY_QUEST, GetQuestLevel(quest), rep, rewardFactionId, noQuestBonus);
         else if (quest->IsWeekly())
-            rep = CalculateReputationGain(REPUTATION_SOURCE_WEEKLY_QUEST, GetQuestLevel(quest), rep, quest->RewardFactionId[i], noQuestBonus);
+            rep = CalculateReputationGain(REPUTATION_SOURCE_WEEKLY_QUEST, GetQuestLevel(quest), rep, rewardFactionId, noQuestBonus);
         else if (quest->IsMonthly())
-            rep = CalculateReputationGain(REPUTATION_SOURCE_MONTHLY_QUEST, GetQuestLevel(quest), rep, quest->RewardFactionId[i], noQuestBonus);
+            rep = CalculateReputationGain(REPUTATION_SOURCE_MONTHLY_QUEST, GetQuestLevel(quest), rep, rewardFactionId, noQuestBonus);
         else if (quest->IsRepeatable())
-            rep = CalculateReputationGain(REPUTATION_SOURCE_REPEATABLE_QUEST, GetQuestLevel(quest), rep, quest->RewardFactionId[i], noQuestBonus);
+            rep = CalculateReputationGain(REPUTATION_SOURCE_REPEATABLE_QUEST, GetQuestLevel(quest), rep, rewardFactionId, noQuestBonus);
         else
-            rep = CalculateReputationGain(REPUTATION_SOURCE_QUEST, GetQuestLevel(quest), rep, quest->RewardFactionId[i], noQuestBonus);
+            rep = CalculateReputationGain(REPUTATION_SOURCE_QUEST, GetQuestLevel(quest), rep, rewardFactionId, noQuestBonus);
 
-        if (FactionEntry const* factionEntry = sFactionStore.LookupEntry(quest->RewardFactionId[i]))
+        if (FactionEntry const* factionEntry = sFactionStore.LookupEntry(rewardFactionId))
             GetReputationMgr().ModifyReputation(factionEntry, rep);
     }
 }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6662,12 +6662,12 @@ void Player::RewardReputation(Quest const* quest)
 
         // @hack some quests give reputation to Alliance-only AND Horde-only factions, but DBC data does not allow to identify faction-only reputations
         if (GetTeamId() == TEAM_HORDE && (
-            (rewardFactionId == 1037) || // Alliance Vanguard
-            (rewardFactionId == 946)))   // Honor Hold
+            rewardFactionId == 1037 || // Alliance Vanguard
+            rewardFactionId == 946))   // Honor Hold
             continue;
 
         if (GetTeamId() == TEAM_ALLIANCE &&
-            rewardFactionId == 947)     // Thrallmar
+            rewardFactionId == 947)    // Thrallmar
             continue;
 
         int32 rep = 0;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6660,14 +6660,7 @@ void Player::RewardReputation(Quest const* quest)
         if (!rewardFactionId)
             continue;
 
-        // @hack some quests give reputation to Alliance-only AND Horde-only factions, but DBC data does not allow to identify faction-only reputations
-        if (GetTeamId() == TEAM_HORDE && (
-            rewardFactionId == 1037 || // Alliance Vanguard
-            rewardFactionId == 946))   // Honor Hold
-            continue;
-
-        if (GetTeamId() == TEAM_ALLIANCE &&
-            rewardFactionId == 947)    // Thrallmar
+        if (!GetReputationMgr().IsReputationAllowedForTeam(GetTeamId(), rewardFactionId))
             continue;
 
         int32 rep = 0;

--- a/src/server/game/Reputation/ReputationMgr.cpp
+++ b/src/server/game/Reputation/ReputationMgr.cpp
@@ -67,6 +67,21 @@ bool ReputationMgr::IsAtWar(FactionEntry const* factionEntry) const
     return false;
 }
 
+bool ReputationMgr::IsReputationAllowedForTeam(TeamId team, uint32 factionId) const
+{
+    // @hack some quests give reputation to Alliance-only AND Horde-only factions, but DBC data does not allow to identify faction-only reputations
+    if (team == TEAM_HORDE && (
+        factionId == 1037 || // Alliance Vanguard
+        factionId == 946))   // Honor Hold
+        return false;
+
+    if (team == TEAM_ALLIANCE &&
+        factionId == 947)    // Thrallmar
+        return false;
+
+    return true;
+}
+
 int32 ReputationMgr::GetReputation(uint32 faction_id) const
 {
     FactionEntry const* factionEntry = sFactionStore.LookupEntry(faction_id);

--- a/src/server/game/Reputation/ReputationMgr.h
+++ b/src/server/game/Reputation/ReputationMgr.h
@@ -97,6 +97,7 @@ class TC_GAME_API ReputationMgr
 
         bool IsAtWar(uint32 faction_id) const;
         bool IsAtWar(FactionEntry const* factionEntry) const;
+        bool IsReputationAllowedForTeam(TeamId team, uint32 factionId) const;
 
         int32 GetReputation(uint32 faction_id) const;
         int32 GetReputation(FactionEntry const* factionEntry) const;


### PR DESCRIPTION
**Changes proposed:**

Haaaaaaack. I know. Put down your pitchforks.

As explained in issue #16582, Horde players can obtain reputation with Honor Hold/Alliance Vanguard and Alliance players can obtain reputation with Thrallmar.

This is because the quests (listed in said issue ticket) have both factions in their quest_template. However, on retail, the player doesn't receive the opposite faction's reputation.

DBC data does not contain usable data for this matter, as far as I can tell. There's nothing that says if a faction is Horde-only or Alliance-only.

Hence the hack. As this affects only those three reputations, I think it's a fair compromise.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** closes #16582.

**Tests performed:** it works.