### PR TITLE
Scripts/Icecrown Citadel: Ensure Deathbringer Saurfang cast Frenzy

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -360,7 +360,7 @@ class boss_deathbringer_saurfang : public CreatureScript
                 if (!_frenzied && HealthBelowPct(31)) // AT 30%, not below
                 {
                     _frenzied = true;
-                    DoCast(me, SPELL_FRENZY);
+                    DoCast(me, SPELL_FRENZY, true);
                     Talk(SAY_FRENZY);
                 }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Ensure Deathbringer Saurfang cast Frenzy (ID - 72737 Frenzy)
- If saurfang is casting and below 31% health, Frenzy doesn't cast, text is displayed and ```_frenzied``` set true, so, never get Frenzy in the encounter.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
