### PR TITLE
Core/Movement: MoveSmoothPath will now insert the mover's current position before the spline waypoints to avoid losing the first spline point

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -830,6 +830,10 @@ void MotionMaster::MoveSmoothPath(uint32 pointId, Position const* pathPoints, si
     {
         return G3D::Vector3(point.GetPositionX(), point.GetPositionY(), point.GetPositionZ());
     });
+    
+    // The spline movement uses will use the first vertex as starting position
+    // We are going to add the owner's position first so we wont lose any waypoint provided in the position array
+    path.insert(path.begin(), G3D::Vector3(_owner->GetPositionX(), _owner->GetPositionY(), _owner->GetPositionZ()));
 
     init.MovebyPath(path);
     init.SetSmooth();


### PR DESCRIPTION
The spline movement system will use the first path vertex as the current position and since we are only passing over the path of the npc we need to add the first vertex manually to prevent the loss of the first spline waypoint. This will ensure that we will always have nice and complete results.

-  add a additional path point at the beginning of the path since the spline system uses the first point as starting position of the moving unit

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame via several scripts
