### PR TITLE
Core/Movement: add a velocity argument for the spline chain meta table

### DIFF
--- a/sql/updates/world/3.3.5/2019_07_18_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_07_18_00_world.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `script_spline_chain_meta` ADD COLUMN `velocity` FLOAT(5) UNSIGNED DEFAULT 0 AFTER `msUntilNext`;

--- a/sql/updates/world/3.3.5/2019_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/2019_99_99_99_world.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `script_spline_chain_meta` ADD COLUMN `velocity` FLOAT(5) UNSIGNED DEFAULT 0 NULL AFTER `msUntilNext`;

--- a/sql/updates/world/3.3.5/2019_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/2019_99_99_99_world.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `script_spline_chain_meta` ADD COLUMN `velocity` FLOAT(5) UNSIGNED DEFAULT 0 NULL AFTER `msUntilNext`;

--- a/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
@@ -46,7 +46,7 @@ SplineChainMovementGenerator::SplineChainMovementGenerator(SplineChainResumeInfo
     BaseUnitState = UNIT_STATE_ROAMING;
 }
 
-uint32 SplineChainMovementGenerator::SendPathSpline(Unit* owner, Movement::PointsArray const& path) const
+uint32 SplineChainMovementGenerator::SendPathSpline(Unit* owner, float velocity, Movement::PointsArray const& path) const
 {
     uint32 nodeCount = path.size();
     ASSERT(nodeCount > 1, "SplineChainMovementGenerator::SendPathSpline: Every path must have source & destination (size > 1)! (%s)", owner->GetGUID().ToString().c_str());
@@ -56,6 +56,9 @@ uint32 SplineChainMovementGenerator::SendPathSpline(Unit* owner, Movement::Point
         init.MovebyPath(path);
     else
         init.MoveTo(path[1], false, true);
+
+    if (velocity > 0.f)
+        init.SetVelocity(velocity);
     init.SetWalk(_walk);
     return init.Launch();
 }
@@ -66,7 +69,7 @@ void SplineChainMovementGenerator::SendSplineFor(Unit* owner, uint32 index, uint
     TC_LOG_DEBUG("movement.splinechain", "SplineChainMovementGenerator::SendSplineFor: sending spline on index: %u. (%s)", index, owner->GetGUID().ToString().c_str());
 
     SplineChainLink const& thisLink = _chain[index];
-    uint32 actualDuration = SendPathSpline(owner, thisLink.Points);
+    uint32 actualDuration = SendPathSpline(owner, thisLink.Velocity, thisLink.Points);
     if (actualDuration != thisLink.ExpectedDuration)
     {
         TC_LOG_DEBUG("movement.splinechain", "SplineChainMovementGenerator::SendSplineFor: sent spline on index: %u, duration: %u ms. Expected duration: %u ms (delta %d ms). Adjusting. (%s)", index, actualDuration, thisLink.ExpectedDuration, int32(actualDuration) - int32(thisLink.ExpectedDuration), owner->GetGUID().ToString().c_str());
@@ -110,7 +113,7 @@ void SplineChainMovementGenerator::Initialize(Unit* owner)
 
         owner->AddUnitState(UNIT_STATE_ROAMING_MOVE);
         Movement::PointsArray partial(thisLink.Points.begin() + (_nextFirstWP-1), thisLink.Points.end());
-        SendPathSpline(owner, partial);
+        SendPathSpline(owner, thisLink.Velocity, partial);
 
         TC_LOG_DEBUG("movement.splinechain", "SplineChainMovementGenerator::Initialize: resumed spline chain generator from resume state. (%s)", owner->GetGUID().ToString().c_str());
 

--- a/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.h
@@ -47,7 +47,7 @@ class TC_GAME_API SplineChainMovementGenerator : public MovementGenerator
 
     private:
         void SendSplineFor(Unit* owner, uint32 index, uint32& duration);
-        uint32 SendPathSpline(Unit* owner, Movement::PointsArray const& path) const;
+        uint32 SendPathSpline(Unit* owner, float velocity, Movement::PointsArray const& path) const;
 
         uint32 const _id;
         std::vector<SplineChainLink> const& _chain;

--- a/src/server/game/Movement/Spline/SplineChain.h
+++ b/src/server/game/Movement/Spline/SplineChain.h
@@ -23,12 +23,13 @@
 
 struct TC_GAME_API SplineChainLink
 {
-    SplineChainLink(Movement::PointsArray const& points, uint32 expectedDuration, uint32 msToNext) : Points(points), ExpectedDuration(expectedDuration), TimeToNext(msToNext) { }
-    template <typename iteratorType> SplineChainLink(iteratorType begin, iteratorType end, uint32 expectedDuration, uint32 msToNext) : Points(begin, end), ExpectedDuration(expectedDuration), TimeToNext(msToNext) { }
-    SplineChainLink(uint32 expectedDuration, uint32 msToNext) : Points(), ExpectedDuration(expectedDuration), TimeToNext(msToNext) { }
+    SplineChainLink(Movement::PointsArray const& points, uint32 expectedDuration, uint32 msToNext, float velocity) : Points(points), ExpectedDuration(expectedDuration), TimeToNext(msToNext), Velocity(velocity) { }
+    template <typename iteratorType> SplineChainLink(iteratorType begin, iteratorType end, uint32 expectedDuration, uint32 msToNext, float velocity) : Points(begin, end), ExpectedDuration(expectedDuration), TimeToNext(msToNext), Velocity(velocity) { }
+    SplineChainLink(uint32 expectedDuration, uint32 msToNext, float velocity) : Points(), ExpectedDuration(expectedDuration), TimeToNext(msToNext), Velocity(velocity) { }
     Movement::PointsArray Points;
     uint32 ExpectedDuration;
     uint32 TimeToNext;
+    float Velocity;
 };
 
 struct TC_GAME_API SplineChainResumeInfo

--- a/src/server/game/Scripting/ScriptSystem.cpp
+++ b/src/server/game/Scripting/ScriptSystem.cpp
@@ -95,9 +95,9 @@ void SystemMgr::LoadScriptSplineChains()
 
     m_mSplineChainsMap.clear();
 
-    //                                                     0       1        2             3               4
-    QueryResult resultMeta = WorldDatabase.Query("SELECT entry, chainId, splineId, expectedDuration, msUntilNext FROM script_spline_chain_meta ORDER BY entry asc, chainId asc, splineId asc");
-    //                                                  0       1         2       3   4  5  6
+    //                                                   0      1        2         3                 4            5
+    QueryResult resultMeta = WorldDatabase.Query("SELECT entry, chainId, splineId, expectedDuration, msUntilNext, velocity FROM script_spline_chain_meta ORDER BY entry asc, chainId asc, splineId asc");
+    //                                                 0      1        2         3     4  5  6
     QueryResult resultWP = WorldDatabase.Query("SELECT entry, chainId, splineId, wpId, x, y, z FROM script_spline_chain_waypoints ORDER BY entry asc, chainId asc, splineId asc, wpId asc");
     if (!resultMeta || !resultWP)
     {
@@ -122,7 +122,8 @@ void SystemMgr::LoadScriptSplineChains()
 
             uint32 expectedDuration = fieldsMeta[3].GetUInt32();
             uint32 msUntilNext = fieldsMeta[4].GetUInt32();
-            chain.emplace_back(expectedDuration, msUntilNext);
+            float velocity = fieldsMeta[5].GetFloat();
+            chain.emplace_back(expectedDuration, msUntilNext, velocity);
 
             if (splineId == 0)
                 ++chainCount;


### PR DESCRIPTION
**Changes proposed:**

-  add a velocity argument for the spline chain meta table so we can now tell the creature at which speed it shall move instead of only using the default calculated speed values. This behaivior has been observed especially at flying creatures as they fly at many different speeds while their flight speed field remains unchanged.

For the wiki:
velocity = 0 - use default speeds
velocity > 0 - use the provided velocity for that spline path

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

