### PR TITLE
Scripts/Spells: Brittle Armor & Mercurial Shield

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_item_brittle_armor','spell_item_mercurial_shield');
+INSERT INTO `spell_script_names` VALUES
+(24590,'spell_item_brittle_armor'),
+(26465,'spell_item_mercurial_shield');

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3431,14 +3431,6 @@ void Spell::EffectScriptEffect(SpellEffIndex effIndex)
         {
             switch (m_spellInfo->Id)
             {
-                // Brittle Armor - need remove one 24575 Brittle Armor aura
-                case 24590:
-                    unitTarget->RemoveAuraFromStack(24575);
-                    return;
-                // Mercurial Shield - need remove one 26464 Mercurial Shield aura
-                case 26465:
-                    unitTarget->RemoveAuraFromStack(26464);
-                    return;
                 // Shadow Flame (All script effects, not just end ones to prevent player from dodging the last triggered spell)
                 case 22539:
                 case 22972:

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -404,6 +404,27 @@ class spell_item_dementia : public AuraScript
     }
 };
 
+// 24590 - Brittle Armor
+enum BrittleArmor
+{
+    SPELL_BRITTLE_ARMOR = 24575
+};
+
+class spell_item_brittle_armor : public SpellScript
+{
+    PrepareSpellScript(spell_item_brittle_armor);
+
+    void HandleScript(SpellEffIndex /* effIndex */)
+    {
+        GetHitUnit()->RemoveAuraFromStack(SPELL_BRITTLE_ARMOR);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_item_brittle_armor::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 // 64411 - Blessing of Ancient Kings (Val'anyr, Hammer of Ancient Kings)
 enum BlessingOfAncientKings
 {
@@ -1275,6 +1296,27 @@ class spell_item_mark_of_conquest : public AuraScript
     void Register() override
     {
         OnEffectProc += AuraEffectProcFn(spell_item_mark_of_conquest::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+    }
+};
+
+// 26465 - Mercurial Shield
+enum MercurialShield
+{
+    SPELL_MERCURIAL_SHIELD = 26464
+};
+
+class spell_item_mercurial_shield : public SpellScript
+{
+    PrepareSpellScript(spell_item_mercurial_shield);
+
+    void HandleScript(SpellEffIndex /* effIndex */)
+    {
+        GetHitUnit()->RemoveAuraFromStack(SPELL_MERCURIAL_SHIELD);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_item_mercurial_shield::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
     }
 };
 
@@ -4212,6 +4254,7 @@ void AddSC_item_spell_scripts()
     RegisterAuraScript(spell_item_arcane_shroud);
     RegisterAuraScript(spell_item_aura_of_madness);
     RegisterAuraScript(spell_item_dementia);
+    RegisterSpellScript(spell_item_brittle_armor);
     RegisterAuraScript(spell_item_blessing_of_ancient_kings);
     RegisterAuraScript(spell_item_valanyr_hammer_of_ancient_kings);
     RegisterAuraScript(spell_item_deadly_precision);
@@ -4239,6 +4282,7 @@ void AddSC_item_spell_scripts()
     RegisterAuraScript(spell_item_crystal_spire_of_karabor);
     RegisterSpellScript(spell_item_make_a_wish);
     RegisterAuraScript(spell_item_mark_of_conquest);
+    RegisterSpellScript(spell_item_mercurial_shield);
     RegisterSpellScript(spell_item_mingos_fortune_generator);
     RegisterAuraScript(spell_item_necrotic_touch);
     RegisterSpellScript(spell_item_net_o_matic);


### PR DESCRIPTION
**Changes proposed:**
Migrate spells `Brittle Armor` and `Mercurial Shield` (combined both in one PR due to them being basically one-lined) to spell scripts system.

**Target branch(es):** 3.3.5

**Tests performed:** Works in-game