### PR TITLE
Core/Spell: honor IsStackableOnOneSlotWithDifferentCasters() when deciding if an aura should stack from different casters or not.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3170,7 +3170,7 @@ Aura* Unit::_TryStackingOrRefreshingExistingAura(AuraCreateInfo& createInfo)
         ObjectGuid castItemGUID = createInfo.CastItemGUID;
 
         // find current aura from spell and change it's stackamount, or refresh it's duration
-        if (Aura* foundAura = GetOwnedAura(createInfo.GetSpellInfo()->Id, createInfo.CasterGUID, createInfo.GetSpellInfo()->HasAttribute(SPELL_ATTR0_CU_ENCHANT_PROC) ? castItemGUID : ObjectGuid::Empty))
+        if (Aura* foundAura = GetOwnedAura(createInfo.GetSpellInfo()->Id, createInfo.GetSpellInfo()->IsStackableOnOneSlotWithDifferentCasters() ? ObjectGuid::Empty : createInfo.CasterGUID, createInfo.GetSpellInfo()->HasAttribute(SPELL_ATTR0_CU_ENCHANT_PROC) ? castItemGUID : ObjectGuid::Empty))
         {
             // effect masks do not match
             // extremely rare case


### PR DESCRIPTION
**Changes proposed:**

Currently, Unit::_TryStackingOrRefreshingExistingAura() always calls Unit::GetOwnedAura() supplying the caster as argument. This allows it to only return auras owned by the caster. This causes auras to never stack when they originate from different casters, IsStackableOnOneSlotWithDifferentCasters() is not taken into consideration.

**Target branch(es):**

- [x] 3.3.5

**Issues addressed:** Fixes #23387 and #22818.

**Tests performed:** it works, and assuming that IsStackableOnOneSlotWithDifferentCasters() is reliable it won't cause wrong behaviors in non-stackable-from-multiple-casters auras.