### PR TITLE
Core/Spells: Fixed SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK stacking

### DIFF
--- a/sql/updates/world/3.3.5/2019_07_24_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_07_24_00_world.sql
@@ -3,7 +3,8 @@ DELETE FROM `spell_group` WHERE `id`=1122;
 INSERT INTO `spell_group` (`id`, `spell_id`) VALUES
 (1122,32182),
 (1122,2825),
-(1122,10060);
+(1122,10060),
+(1122,12472);
 
 DELETE FROM `spell_group_stack_rules` WHERE `group_id`=1122;
 INSERT INTO `spell_group_stack_rules` (`group_id`, `stack_rule`) VALUES

--- a/sql/updates/world/3.3.5/2019_07_24_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_07_24_00_world.sql
@@ -1,0 +1,10 @@
+-- Heroism/Bloodlust should not stack with Power Infusion
+DELETE FROM `spell_group` WHERE `id`=1122;
+INSERT INTO `spell_group` (`id`, `spell_id`) VALUES
+(1122,32182),
+(1122,2825),
+(1122,10060);
+
+DELETE FROM `spell_group_stack_rules` WHERE `group_id`=1122;
+INSERT INTO `spell_group_stack_rules` (`group_id`, `stack_rule`) VALUES
+(1122,4);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3901,37 +3901,13 @@ void AuraEffect::HandleModCastingSpeed(AuraApplication const* aurApp, uint8 mode
         return;
     }
 
-    if (GetAuraType() == SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK)
-    {
-        int32 schoolMask = GetMiscValue() ? GetMiscValue() : SPELL_SCHOOL_MASK_ALL;
-        Unit::AuraEffectList castingSpeedNotStack(target->GetAuraEffectsByType(SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK));
-        castingSpeedNotStack.remove_if([schoolMask, this](AuraEffect const* aurEff) -> bool
-        {
-            if (aurEff == this)
-                return true;
+    int32 spellGroupVal = target->GetHighestExclusiveSameEffectSpellGroupValue(this, GetAuraType());
+    if (abs(spellGroupVal) >= abs(GetAmount()))
+        return;
 
-            uint32 aurSpellMask = aurEff->GetMiscValue() ? aurEff->GetMiscValue() : SPELL_SCHOOL_MASK_ALL;
-            if (!(aurSpellMask & schoolMask) || aurEff->GetSpellInfo()->IsPassive())
-                return true;
-
-            return false;
-        });
-        
-        // Find stronger effect
-        int32 strongEffect = 0;
-        for (AuraEffect const* aurEff : castingSpeedNotStack)
-        {
-            if (abs(strongEffect) < abs(aurEff->GetAmount()))
-                strongEffect = aurEff->GetAmount();
-        }
-
-        if (abs(strongEffect) >= abs(GetAmount()))
-            return;
-
-        if (strongEffect)
-            target->ApplyCastTimePercentMod(float(strongEffect), !apply);
-    }
-
+    if (spellGroupVal)
+        target->ApplyCastTimePercentMod(float(spellGroupVal), !apply);
+    
     target->ApplyCastTimePercentMod((float)GetAmount(), apply);
 }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3168,7 +3168,7 @@ void AuraEffect::HandleAuraModSchoolImmunity(AuraApplication const* aurApp, uint
         target->GetThreatManager().EvaluateSuppressed();
     }
     else
-    { 
+    {
         // do not remove unit flag if there are more than this auraEffect of that kind on unit
         if (target->HasAuraType(GetAuraType()))
             return;
@@ -3899,6 +3899,24 @@ void AuraEffect::HandleModCastingSpeed(AuraApplication const* aurApp, uint8 mode
         }
 
         return;
+    }
+
+    if (GetAuraType() == SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK)
+    {
+        // Find stronger effect
+        int32 strongEffect = 0;
+        Unit::AuraEffectList const& castingSpeedNotStack = target->GetAuraEffectsByType(SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK);
+        for (AuraEffect const* aurEff : castingSpeedNotStack)
+        {
+            if (aurEff != this && abs(strongEffect) < abs(aurEff->GetAmount()))
+                strongEffect = aurEff->GetAmount();
+        }
+
+        if (abs(strongEffect) >= abs(GetAmount()))
+            return;
+
+        if (strongEffect)
+            target->ApplyCastTimePercentMod(float(strongEffect), !apply);
     }
 
     target->ApplyCastTimePercentMod((float)GetAmount(), apply);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3903,12 +3903,25 @@ void AuraEffect::HandleModCastingSpeed(AuraApplication const* aurApp, uint8 mode
 
     if (GetAuraType() == SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK)
     {
+        int32 schoolMask = GetMiscValue() ? GetMiscValue() : SPELL_SCHOOL_MASK_ALL;
+        Unit::AuraEffectList castingSpeedNotStack(target->GetAuraEffectsByType(SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK));
+        castingSpeedNotStack.remove_if([schoolMask, this](AuraEffect const* aurEff) -> bool
+        {
+            if (aurEff == this)
+                return true;
+
+            uint32 aurSpellMask = aurEff->GetMiscValue() ? aurEff->GetMiscValue() : SPELL_SCHOOL_MASK_ALL;
+            if (!(aurSpellMask & schoolMask) || aurEff->GetSpellInfo()->IsPassive())
+                return true;
+
+            return false;
+        });
+        
         // Find stronger effect
         int32 strongEffect = 0;
-        Unit::AuraEffectList const& castingSpeedNotStack = target->GetAuraEffectsByType(SPELL_AURA_MOD_CASTING_SPEED_NOT_STACK);
         for (AuraEffect const* aurEff : castingSpeedNotStack)
         {
-            if (aurEff != this && abs(strongEffect) < abs(aurEff->GetAmount()))
+            if (abs(strongEffect) < abs(aurEff->GetAmount()))
                 strongEffect = aurEff->GetAmount();
         }
 


### PR DESCRIPTION
**Changes proposed:**

-  Let only more powerful effect 

Change based in spell name + this 2.4.0 patch note:
```
Power Infusion: Infuses the target with power, increasing their spell haste by 20% and reducing the mana cost of all spells by 20%. Lasts for 15 seconds. This will not stack with other haste effects, such as Heroism, Bloodlust, or Icy Veins.
```
https://wowwiki.fandom.com/wiki/Patch_2.4.0

**Target branch(es):** 3.3.5

**Tests performed:** Builded and tested in game
