### PR TITLE
Core/Arenas: Remove doors in RL, NA and BE when arena has begun

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBE.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBE.cpp
@@ -27,6 +27,27 @@ BattlegroundBE::BattlegroundBE()
     BgObjects.resize(BG_BE_OBJECT_MAX);
 }
 
+void BattlegroundBE::PostUpdateImpl(uint32 diff)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    _events.Update(diff);
+
+    while (uint32 eventId = _events.ExecuteEvent())
+    {
+        switch (eventId)
+        {
+            case BG_BE_EVENT_REMOVE_DOORS:
+                for (uint32 i = BG_BE_OBJECT_DOOR_1; i <= BG_BE_OBJECT_DOOR_2; ++i)
+                    DelObject(i);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
 void BattlegroundBE::StartingEventCloseDoors()
 {
     for (uint32 i = BG_BE_OBJECT_DOOR_1; i <= BG_BE_OBJECT_DOOR_4; ++i)
@@ -40,6 +61,7 @@ void BattlegroundBE::StartingEventOpenDoors()
 {
     for (uint32 i = BG_BE_OBJECT_DOOR_1; i <= BG_BE_OBJECT_DOOR_2; ++i)
         DoorOpen(i);
+    _events.ScheduleEvent(BG_BE_EVENT_REMOVE_DOORS, BG_BE_REMOVE_DOORS_TIMER);
 
     for (uint32 i = BG_BE_OBJECT_BUFF_1; i <= BG_BE_OBJECT_BUFF_2; ++i)
         SpawnBGObject(i, 60);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundBE.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBE.h
@@ -20,6 +20,7 @@
 #define __BATTLEGROUNDBE_H
 
 #include "Arena.h"
+#include "EventMap.h"
 
 enum BattlegroundBEObjectTypes
 {
@@ -42,6 +43,16 @@ enum BattlegroundBEGameObjects
     BG_BE_OBJECT_TYPE_BUFF_2    = 184664
 };
 
+enum BattlegroundBEData
+{
+    BG_BE_REMOVE_DOORS_TIMER    = 5000
+};
+
+enum BattlegroundBEEvents
+{
+    BG_BE_EVENT_REMOVE_DOORS    = 1
+};
+
 class BattlegroundBE : public Arena
 {
     public:
@@ -54,5 +65,10 @@ class BattlegroundBE : public Arena
         void HandleAreaTrigger(Player* Source, uint32 Trigger) override;
         bool SetupBattleground() override;
         void FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet) override;
+
+    private:
+        void PostUpdateImpl(uint32 diff) override;
+
+        EventMap _events;
 };
 #endif

--- a/src/server/game/Battlegrounds/Zones/BattlegroundNA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundNA.cpp
@@ -27,6 +27,27 @@ BattlegroundNA::BattlegroundNA()
     BgObjects.resize(BG_NA_OBJECT_MAX);
 }
 
+void BattlegroundNA::PostUpdateImpl(uint32 diff)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    _events.Update(diff);
+
+    while (uint32 eventId = _events.ExecuteEvent())
+    {
+        switch (eventId)
+        {
+            case BG_NA_EVENT_REMOVE_DOORS:
+                for (uint32 i = BG_NA_OBJECT_DOOR_1; i <= BG_NA_OBJECT_DOOR_2; ++i)
+                    DelObject(i);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
 void BattlegroundNA::StartingEventCloseDoors()
 {
     for (uint32 i = BG_NA_OBJECT_DOOR_1; i <= BG_NA_OBJECT_DOOR_4; ++i)
@@ -37,6 +58,7 @@ void BattlegroundNA::StartingEventOpenDoors()
 {
     for (uint32 i = BG_NA_OBJECT_DOOR_1; i <= BG_NA_OBJECT_DOOR_2; ++i)
         DoorOpen(i);
+    _events.ScheduleEvent(BG_NA_EVENT_REMOVE_DOORS, BG_NA_REMOVE_DOORS_TIMER);
 
     for (uint32 i = BG_NA_OBJECT_BUFF_1; i <= BG_NA_OBJECT_BUFF_2; ++i)
         SpawnBGObject(i, 60);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundNA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundNA.h
@@ -19,6 +19,7 @@
 #define __BATTLEGROUNDNA_H
 
 #include "Arena.h"
+#include "EventMap.h"
 
 enum BattlegroundNAObjectTypes
 {
@@ -41,6 +42,16 @@ enum BattlegroundNAGameObjects
     BG_NA_OBJECT_TYPE_BUFF_2    = 184664
 };
 
+enum BattlegroundNAData
+{
+    BG_NA_REMOVE_DOORS_TIMER    = 5000
+};
+
+enum BattlegroundNAEvents
+{
+    BG_NA_EVENT_REMOVE_DOORS    = 1
+};
+
 class BattlegroundNA : public Arena
 {
     public:
@@ -53,5 +64,10 @@ class BattlegroundNA : public Arena
         void HandleAreaTrigger(Player* Source, uint32 Trigger) override;
         bool SetupBattleground() override;
         void FillInitialWorldStates(WorldPackets::WorldState::InitWorldStates& packet) override;
+
+    private:
+        void PostUpdateImpl(uint32 diff) override;
+
+        EventMap _events;
 };
 #endif

--- a/src/server/game/Battlegrounds/Zones/BattlegroundRL.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundRL.cpp
@@ -27,6 +27,27 @@ BattlegroundRL::BattlegroundRL()
     BgObjects.resize(BG_RL_OBJECT_MAX);
 }
 
+void BattlegroundRL::PostUpdateImpl(uint32 diff)
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    _events.Update(diff);
+
+    while (uint32 eventId = _events.ExecuteEvent())
+    {
+        switch (eventId)
+        {
+            case BG_RL_EVENT_REMOVE_DOORS:
+                for (uint32 i = BG_RL_OBJECT_DOOR_1; i <= BG_RL_OBJECT_DOOR_2; ++i)
+                    DelObject(i);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
 void BattlegroundRL::StartingEventCloseDoors()
 {
     for (uint32 i = BG_RL_OBJECT_DOOR_1; i <= BG_RL_OBJECT_DOOR_2; ++i)
@@ -37,6 +58,7 @@ void BattlegroundRL::StartingEventOpenDoors()
 {
     for (uint32 i = BG_RL_OBJECT_DOOR_1; i <= BG_RL_OBJECT_DOOR_2; ++i)
         DoorOpen(i);
+    _events.ScheduleEvent(BG_RL_EVENT_REMOVE_DOORS, BG_RL_REMOVE_DOORS_TIMER);
 
     for (uint32 i = BG_RL_OBJECT_BUFF_1; i <= BG_RL_OBJECT_BUFF_2; ++i)
         SpawnBGObject(i, 60);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundRL.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundRL.h
@@ -19,6 +19,7 @@
 #define __BATTLEGROUNDRL_H
 
 #include "Arena.h"
+#include "EventMap.h"
 
 enum BattlegroundRLObjectTypes
 {
@@ -37,6 +38,16 @@ enum BattlegroundRLGameObjects
     BG_RL_OBJECT_TYPE_BUFF_2    = 184664
 };
 
+enum BattlegroundRLData
+{
+    BG_RL_REMOVE_DOORS_TIMER    = 5000
+};
+
+enum BattlegroundRLEvents
+{
+    BG_RL_EVENT_REMOVE_DOORS    = 1
+};
+
 class BattlegroundRL : public Arena
 {
     public:
@@ -49,5 +60,10 @@ class BattlegroundRL : public Arena
 
         void HandleAreaTrigger(Player* Source, uint32 Trigger) override;
         bool SetupBattleground() override;
+
+    private:
+        void PostUpdateImpl(uint32 diff) override;
+
+        EventMap _events;
 };
 #endif


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Remove doors in Ruins of Lordaeron Arena, Nagrand Arena and Blade's Edge Arena when arena has begun (5 secs after)
- https://www.youtube.com/watch?v=EwLOcI4h_kg&t=1205 <-- min 20:05 start arena and 5 secs after, the doors are removed
- https://www.warcraftmovies.com/movieview.php?id=163193 <-- min 17:23
- I don't see if should be the same in Dalaran Sewers Arena, but you can't abuse there
- Ring of Valor doesn't have doors

**Target branch(es):** 3.3.5/master

- [X] 3.3.5

**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
