### PR TITLE
Remove forgotten leftover from the last ForceRespawn nuke

### DIFF
--- a/src/server/game/OutdoorPvP/OutdoorPvP.cpp
+++ b/src/server/game/OutdoorPvP/OutdoorPvP.cpp
@@ -184,7 +184,6 @@ bool OPvPCapturePoint::DelObject(uint32 type)
     if (!spawnId)
         return false;
     
-    sObjectMgr->DeleteGameObjectData(spawnId);
     m_ObjectTypes[m_Objects[type]] = 0;
     m_Objects[type] = 0;
     


### PR DESCRIPTION
This call is already done in the GameObject::DeleteFromDB just below

Related commit where it was forgotten:
https://github.com/TrinityCore/TrinityCore/commit/84b7b2e08ea55575cbe62d795383d4a5341ffd4d
The removal has already been done in the corresponding DelCreature function.