### PR TITLE
core/Pet - pet health regen bug

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -59,6 +59,9 @@ void PetAI::UpdateAI(uint32 diff)
 
     Unit* owner = me->GetCharmerOrOwner();
 
+    if (IsEngaged() && !owner->IsEngaged())
+        EngagementOver();
+
     if (_updateAlliesTimer <= diff)
         // UpdateAllies self set update timer
         UpdateAllies();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Fixed a flaw in Pet ai that prevented pet to regenerate health
  after each combat. Player was forced to either :
  - dismiss the pet, then call it or summon it
  - get out of range of his pet to force it to disappear then call it or
    summon it
  - logout/login
- Only tested with hunter pets, though I suspect the fix is working for
  other pets whose AI is managed by the PetAI class

**Target branch(es):** 3.3.5

- [√] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.)
- tested with hunter pets

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
