### PR TITLE
DB/Spells: Fix Borrowed Time (Priest) for all Ranks

### DIFF
--- a/sql/updates/world/3.3.5/2019_07_27_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_07_27_00_world.sql
@@ -1,0 +1,9 @@
+-- Borrowed Time
+DELETE FROM `spell_ranks` WHERE `first_spell_id`=59887;
+INSERT INTO `spell_ranks` (`first_spell_id`, `spell_id`, `rank`) VALUES
+(59887,59887,1),
+(59887,59888,2),
+(59887,59889,3),
+(59887,59890,4),
+(59887,59891,5);
+UPDATE `spell_proc` SET `SpellId`=-59891 WHERE `SpellId`=59891;


### PR DESCRIPTION
folloup: https://github.com/TrinityCore/TrinityCore/commit/34f83c68e3d880da79b637390b4a8e2e357c5c45

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Update Borrowed Time fix for all ranks (https://github.com/TrinityCore/TrinityCore/commit/34f83c68e3d880da79b637390b4a8e2e357c5c45#commitcomment-34468896)
-  I know, it's only sql fix, @Keader guilty 😄 

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Tests performed:** tested in-game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
