### PR TITLE
Core/AI: fixed creatures occasionally interrupting their channeled spells

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -243,7 +243,7 @@ bool CreatureAI::UpdateVictim()
     if (!me->HasReactState(REACT_PASSIVE))
     {
         if (Unit* victim = me->SelectVictim())
-            if (!me->IsFocusing(nullptr, true) && victim != me->GetVictim())
+            if (!me->IsMovementPreventedByCasting() && victim != me->GetVictim())
                 AttackStart(victim);
 
         return me->GetVictim() != nullptr;


### PR DESCRIPTION
**Changes proposed:**
-  expand the focusing check in UpdateVictim() to casting related movement blockers in general to avoid channeled spells getting interrupted because of missing checks

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame, discovered places no longer have these issues.
