### PR TITLE
[3.3.5] Core/PetAI - Imp behavior fix

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -459,14 +459,19 @@ void PetAI::MovementInform(uint32 type, uint32 id)
             // otherwise we're probably chasing a creature
             if (me->GetCharmerOrOwner() && me->GetCharmInfo() && id == me->GetCharmerOrOwner()->GetGUID().GetCounter() && me->GetCharmInfo()->IsReturning())
             {
-                ClearCharmInfoFlags();
-                me->GetCharmInfo()->SetIsFollowing(true);
+                Follow();
             }
             break;
         }
         default:
             break;
     }
+}
+
+void PetAI::Follow()
+{
+    ClearCharmInfoFlags();
+    me->GetCharmInfo()->SetIsFollowing(true);
 }
 
 bool PetAI::CanAttack(Unit* target)

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -55,6 +55,7 @@ class TC_GAME_API PetAI : public CreatureAI
         void MoveInLineOfSight_Safe(Unit* /*who*/) { } // CreatureAI interferes with returning pets
         void JustAppeared() override { } // we will control following manually
         void EnterEvadeMode(EvadeReason /*why*/) override { } // For fleeing, pets don't use this type of Evade mechanic
+        void Follow();
 
     private:
         bool NeedToStop();

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1994,3 +1994,22 @@ std::string Pet::GetDebugInfo() const
         << "PetType: " << std::to_string(getPetType());
     return sstr.str();
 }
+
+bool Pet::IsMovementPreventedByCasting() const
+{
+    // first check if currently a movement allowed channel is active and we're not casting
+    if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
+    {
+        if (spell->getState() != SPELL_STATE_FINISHED && spell->IsChannelActive())
+            if (spell->GetSpellInfo()->IsMoveAllowedChannel())
+                return false;
+    }
+
+    if (const_cast<Pet*>(this)->IsFocusing(nullptr, true))
+        return true;
+
+    if (HasUnitState(UNIT_STATE_CASTING))
+        return true;
+
+    return false;
+}

--- a/src/server/game/Entities/Pet/Pet.h
+++ b/src/server/game/Entities/Pet/Pet.h
@@ -149,6 +149,8 @@ class TC_GAME_API Pet : public Guardian
 
         std::string GetDebugInfo() const override;
 
+		bool IsMovementPreventedByCasting() const override;
+
     protected:
         uint32  m_happinessTimer;
         PetType m_petType;


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

Currently the Warlocks Imp tries to reposition himself after every cast
 At a certain point he runs random across the area and stop doing anything. He also tries to meele after he ran out of Mana. This leads to Imps pulling creatures in dungeons and breaks playing with Imps in general.

**Changes proposed:**

-  Imp now only tries to go on max range to target
-  Imp doesn`t run off randomly anymore
-  Imp stays on spot and idles when he runs out of mana as intended

**Target branch(es):** 3.3.5/master

- [X ] 3.3.5
- [ ] master

**Issues addressed:** Closes #22857


**Tests performed:** Builds and works as intended


**Known issues and TODO list:** 

- [ ] Imp has really weird problems with [Phase Shift](https://wotlk-twinhead.twinstar.cz/?spell=4511)
In some situations he starts spamming it like a retard. From my view this is a separate Issue and not related to this PR.

Please note that this is not my code - im just doing the PR since the original author stopped working on Trinity as seen in #22857 
So anyone should feel free to take other this PR if he thinks he can enhance it further.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
