### PR TITLE
Core/Spells: fixed a edge case in spell focusing for channeled spells

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3162,7 +3162,7 @@ void Creature::ReacquireSpellFocusTarget()
 
     SetTarget(_spellFocusInfo.Target);
 
-    if (!HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_DISABLE_TURN))
+    if (!HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_DISABLE_TURN) && !IsMovementPreventedByCasting())
     {
         if (_spellFocusInfo.Target)
         {


### PR DESCRIPTION

**Changes proposed:**

-  Fixes channeled spells getting interrupted by the focus release when being cast within the focus release delay and if the channeled spell has no focus target on its own (self channeled casts)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame

