### PR TITLE
Core/Spells: Fixed SPELL_EFFECT_DISPEL when target has 2 spells with same ID

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2290,7 +2290,7 @@ void Spell::EffectDispel(SpellEffIndex effIndex)
         {
             auto successItr = std::find_if(successList.begin(), successList.end(), [&itr](DispelableAura& dispelAura) -> bool
             {
-                if (dispelAura.GetAura()->GetId() == itr->GetAura()->GetId())
+                if (dispelAura.GetAura()->GetId() == itr->GetAura()->GetId() && dispelAura.GetAura()->GetCaster() == itr->GetAura()->GetCaster())
                     return true;
 
                 return false;


### PR DESCRIPTION

**Changes proposed:**

-  Check Caster too, to determine if spell is already present on dispel list.

It fix a bug, that happens when 2 spells has same SpellId and you try dispel it (only 1 spell will be removed).

Reproduce case: Get 2 immolate from different casters and use dispel magic to dispel it.
Current Result: only 1 immolate will be removed.
Expected Result: 2 Immolates need be removed.

**Target branch(es):** 3.3.5

**Tests performed:** Builded and tested in game with Sirikfoll.
