### PR TITLE
DB/Creature: Kurzen Commando

### DIFF
--- a/sql/updates/world/3.3.5/2019_08_26_00_world.sql
+++ b/sql/updates/world/3.3.5/2019_08_26_00_world.sql
@@ -1,0 +1,1 @@
+UPDATE `smart_scripts` SET `action_param1`='22766' WHERE `entryorguid`=938 AND `source_type`=0 AND `id`=0 AND `link`=0;


### PR DESCRIPTION
Fix spell id Kurzen Commando for hide, spell id 30831 is wrong and not work must 22766

https://www.wowhead.com/npc=938/kurzen-commando#abilities
