### PR TITLE
Scripts/Outland: Change auto to TempSummon* in npc_ancestral_wolf

### DIFF
--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -165,7 +165,7 @@ public:
 
                 me->SetSpeedRate(MOVE_WALK, 1.5f);
 
-                if (auto tempSummon = me->ToTempSummon())
+                if (TempSummon* tempSummon = me->ToTempSummon())
                     tempSummon->SetCanFollowOwner(false);
             }
             else


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Change auto to TempSummon* in npc_ancestral_wolf

Shauren: > Do not use `auto` for anything except container iterators (or other super long deep nested types)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5