### PR TITLE
Scripts/PitOfSaron: Fix Krick sometimes stuck in combat after finish kill Ick

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -374,6 +374,9 @@ class boss_krick : public CreatureScript
                 _phase = PHASE_OUTRO;
                 _events.Reset();
                 _events.ScheduleEvent(EVENT_OUTRO_1, 1000);
+
+                // Clear combat
+                me->CombatStop();
             }
 
             void UpdateAI(uint32 diff) override


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Clear combat on Kirck after kill Ick

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #23765


**Tests performed:** (Does it build, tested in-game, etc.)
Builds and tested ingame

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
