### PR TITLE
Scripts/PitOfSaron: Make sure ick stops moving when casting Explosive Barrage

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -572,7 +572,10 @@ class spell_ick_explosive_barrage : public SpellScriptLoader
             {
                 if (Unit* caster = GetCaster())
                     if (caster->GetTypeId() == TYPEID_UNIT)
+                    {
+                        caster->GetMotionMaster()->Clear();
                         caster->GetMotionMaster()->MoveIdle();
+                    }
             }
 
             void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Clear motionmaster of Ick so he stops chasing the victim while casting Explosive Barrage.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #23766


**Tests performed:** (Does it build, tested in-game, etc.)
Builds, and tested ingame

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
