### PR TITLE
Scripts/Ulduar: Fix Kologarn stuck in combat after death, when EVENT_SWEEP was used throughout encounter

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -572,7 +572,10 @@ class spell_ick_explosive_barrage : public SpellScriptLoader
             {
                 if (Unit* caster = GetCaster())
                     if (caster->GetTypeId() == TYPEID_UNIT)
+                    {
+                        caster->GetMotionMaster()->Clear();
                         caster->GetMotionMaster()->MoveIdle();
+                    }
             }
 
             void HandleEffectRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -152,6 +152,12 @@ class boss_kologarn : public CreatureScript
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 me->SetCorpseDelay(604800); // Prevent corpse from despawning.
                 _JustDied();
+
+                std::list<Creature*> armSweepStalkerList;
+                me->GetCreatureListWithEntryInGrid(armSweepStalkerList, NPC_ARM_SWEEP_STALKER, 500.0f);
+
+                for (Creature* armSweepStalker : armSweepStalkerList)
+                    armSweepStalker->CombatStop();
             }
 
             void KilledUnit(Unit* who) override


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix the arm sweep stalker triggers in combat after finish defeat kologarn
-  achievement criteria counting for The Antechamber of Ulduar seems to work now too

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #23756


**Tests performed:** (Does it build, tested in-game, etc.)
Builds, tested ingame

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
