### PR TITLE
Scripts/Pet: Fix npc_pet_gen_soul_trader not following owner

### DIFF
--- a/src/server/scripts/Pet/pet_generic.cpp
+++ b/src/server/scripts/Pet/pet_generic.cpp
@@ -343,6 +343,8 @@ struct npc_pet_gen_soul_trader : public ScriptedAI
         Talk(SAY_SOUL_TRADER_INTRO);
         if (Unit* owner = me->GetOwner())
             DoCast(owner, SPELL_ETHEREAL_ONSUMMON);
+
+        CreatureAI::JustAppeared();
     }
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  npc_pet_gen_soul_trader is overriding CreatureAI::JustAppeared, making the creature never following the owner, so adding CreatureAI::JustAppeared will make it so it follows owner.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #23771

**Tests performed:** (Does it build, tested in-game, etc.)
Builds and tested ingame.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
