### PR TITLE
Spells/DK: Fix wrong class name definition in Rime AuraScript

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -2104,9 +2104,9 @@ class spell_dk_rime : public SpellScriptLoader
     public:
         spell_dk_rime() : SpellScriptLoader("spell_dk_rime") { }
 
-        class spell_dk_blade_barrier_AuraScript : public AuraScript
+        class spell_dk_rime_AuraScript : public AuraScript
         {
-            PrepareAuraScript(spell_dk_blade_barrier_AuraScript);
+            PrepareAuraScript(spell_dk_rime_AuraScript);
 
             bool CheckProc(ProcEventInfo& /*eventInfo*/)
             {
@@ -2124,14 +2124,14 @@ class spell_dk_rime : public SpellScriptLoader
 
             void Register() override
             {
-                DoCheckProc += AuraCheckProcFn(spell_dk_blade_barrier_AuraScript::CheckProc);
-                OnEffectProc += AuraEffectProcFn(spell_dk_blade_barrier_AuraScript::HandleProc, EFFECT_1, SPELL_AURA_PROC_TRIGGER_SPELL);
+                DoCheckProc += AuraCheckProcFn(spell_dk_rime_AuraScript::CheckProc);
+                OnEffectProc += AuraEffectProcFn(spell_dk_rime_AuraScript::HandleProc, EFFECT_1, SPELL_AURA_PROC_TRIGGER_SPELL);
             }
         };
 
         AuraScript* GetAuraScript() const override
         {
-            return new spell_dk_blade_barrier_AuraScript();
+            return new spell_dk_rime_AuraScript();
         }
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix wrong class name definition in Rime AuraScript introduced in this commit: https://github.com/TrinityCore/TrinityCore/commit/2ff855054f52bf2dcf81aa7a7da7bab7f8a99686
- Nothing changes in-game

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Tests performed:** (Does it build)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
