### PR TITLE
Cmake: fixed linking worldserver with boost 1.71

### DIFF
--- a/dep/boost/CMakeLists.txt
+++ b/dep/boost/CMakeLists.txt
@@ -45,9 +45,9 @@ else()
 endif()
 
 if (STD_HAS_WORKING_WREGEX)
-  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams)
+  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams serialization)
 else()
-  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams regex)
+  find_package(Boost ${BOOST_REQUIRED_VERSION} REQUIRED system filesystem thread program_options iostreams serialization regex)
 endif()
 
 # Find if Boost was compiled in C++03 mode because it requires -DBOOST_NO_CXX11_SCOPED_ENUMS


### PR DESCRIPTION
**Changes proposed:**

-  fixes build when using boost 1.71 binaries

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
compiled, works for me (tm)

**Known issues and TODO list:** (add/remove lines as needed)
- [ ] check if this is a 1.71 exclusive change or if it's backwards compatible
