### PR TITLE
Fixed possible desync issues caused by vehicles teleport

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12663,6 +12663,9 @@ void Unit::NearTeleportTo(Position const& pos, bool casting /*= false*/)
     }
     else
     {
+        if (!GetMap()->IsGridLoaded(pos.GetPositionX(), pos.GetPositionY()))
+            GetMap()->LoadGrid(pos.GetPositionX(), pos.GetPositionY());
+
         SendTeleportPacket(pos);
         UpdatePosition(pos, true);
         UpdateObjectVisibility();


### PR DESCRIPTION
**Changes proposed:**

-  Fixed desync issues when vehicle is teleported with seat acessories which are filled by players  

**Target branch(es):** 

- 3.3.5

**Issues addressed:** 

When vehicle is ported and if player uses any of its seats, both units are teleported but just visual, their real positions remains same. Best practise to reproduce this is by taking quest https://www.wowhead.com/quest=12521/where-in-the-world-is-hemet-nesingwary and by calling this quest vehicle event. 
This change will make sure that grid is loaded before units are teleported. Desync happened because units were attempting to have teleport before destination grid activates (if grid was not activated before)

**Tests performed:** 

build, tested in-game

Note: its my first PR on this project