### PR TITLE
Core/Combat: Fix crossfaction combat

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -23,6 +23,8 @@
 
 /*static*/ bool CombatManager::CanBeginCombat(Unit const* a, Unit const* b)
 {
+    // ToDo: add whatever is missing from WorldObject::IsValidAttackTarget() or use that function instead of copying everything here
+
     // Checks combat validity before initial reference creation.
     // For the combat to be valid...
     // ...the two units need to be different
@@ -44,6 +46,17 @@
         return false;
     if (a->HasUnitState(UNIT_STATE_IN_FLIGHT) || b->HasUnitState(UNIT_STATE_IN_FLIGHT))
         return false;
+
+    // check for immune to PC/NPC flags
+    if (!a->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && b->IsImmuneToNPC())
+        return false;
+    if (!b->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && a->IsImmuneToNPC())
+        return false;
+    if (a->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && b->IsImmuneToPC())
+        return false;
+    if (b->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && a->IsImmuneToPC())
+        return false;
+
     if (a->IsFriendlyTo(b) || b->IsFriendlyTo(a))
         return false;
     Player const* playerA = a->GetCharmerOrOwnerPlayerOrPlayerItself();


### PR DESCRIPTION
Fix an issue that would cause NPCs with UNIT_FLAG_IMMUNE_TO_PC flag to be in combat with players

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add UNIT_FLAG_IMMUNE_TO_PC checks to CombatManager

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23795


**Tests performed:** (Does it build, tested in-game, etc.)
See #23795

**Known issues and TODO list:** (add/remove lines as needed)

- It feels like CombatManager::CanBeginCombat() should simply use WorldObject::IsValidAttackTarget() instead, leaving that to future contributors


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
