### PR TITLE
Fix inconsistent NPC aggro on spell miss

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2673,18 +2673,6 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
                 case SPELL_AURA_MOD_STUN:
                     spellInfo->AttributesCu |= SPELL_ATTR0_CU_AURA_CC;
                     break;
-                case SPELL_AURA_PERIODIC_HEAL:
-                case SPELL_AURA_PERIODIC_DAMAGE:
-                case SPELL_AURA_PERIODIC_DAMAGE_PERCENT:
-                case SPELL_AURA_PERIODIC_LEECH:
-                case SPELL_AURA_PERIODIC_MANA_LEECH:
-                case SPELL_AURA_PERIODIC_HEALTH_FUNNEL:
-                case SPELL_AURA_PERIODIC_ENERGIZE:
-                case SPELL_AURA_OBS_MOD_HEALTH:
-                case SPELL_AURA_OBS_MOD_POWER:
-                case SPELL_AURA_POWER_BURN:
-                    spellInfo->AttributesCu |= SPELL_ATTR0_CU_NO_INITIAL_THREAT;
-                    break;
             }
 
             switch (spellInfo->Effects[j].Effect)


### PR DESCRIPTION
Details: https://github.com/TrinityCore/TrinityCore/issues/23804

**Changes proposed:**

-  Remove the statements in SpellMgr.cpp that apply the custom spell attribute SPELL_ATTR0_CU_NO_INITIAL_THREAT based generically on a number of spell aura types.

**Target branch(es):**

- [X] 3.3.5

**Issues addressed:** Closes #23804


**Tests performed:**
- Build: PASS
- Tests: observed consistent threat generation on mobs with all negative/damaging spells listed in the issue #23804.

**Known issues and TODO list:**