### PR TITLE
Core/Movement: provide an extra spline path vertex for taxi pathings …

### DIFF
--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -75,7 +75,7 @@ void FlightPathMovementGenerator::DoReset(Player* owner)
     owner->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL | UNIT_FLAG_TAXI_FLIGHT);
 
     Movement::MoveSplineInit init(owner);
-    // Providing an starting vertex since the taxi paths do not provide such
+    // Providing a starting vertex since the taxi paths do not provide such
     init.Path().push_back(G3D::Vector3(owner->GetPositionX(), owner->GetPositionY(), owner->GetPositionZ()));
     uint32 end = GetPathAtMapEnd();
     for (uint32 i = GetCurrentNode(); i != end; ++i)

--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -75,6 +75,8 @@ void FlightPathMovementGenerator::DoReset(Player* owner)
     owner->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL | UNIT_FLAG_TAXI_FLIGHT);
 
     Movement::MoveSplineInit init(owner);
+    // Providing an starting vertex since the taxi paths do not provide such
+    init.Path().push_back(G3D::Vector3(owner->GetPositionX(), owner->GetPositionY(), owner->GetPositionZ()));
     uint32 end = GetPathAtMapEnd();
     for (uint32 i = GetCurrentNode(); i != end; ++i)
     {


### PR DESCRIPTION
**Changes proposed:**
-  added an additional spline path vertex for the spline system to use for calculating player start positions so we use correct pathings now and wont lose the first taxi path vertex for the player starting position. This effectively and correctly fixes the crash that was intended to be fixed by 680e1cbd6cf7c52abe104fb87d8fa6dba83fb633 which is only safeguarding the core from a mistake.

Oh, and on top of that taxi pathings such as the one starting at stormwing will no longer clip through walls because of that. You're welcome.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame, works for me (tm)
