### PR TITLE
Scripts: Fix crossfaction combat issue

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
@@ -210,8 +210,9 @@ class boss_devourer_of_souls : public CreatureScript
 
                 for (int8 i = 0; outroPositions[i].entry[entryIndex] != 0; ++i)
                 {
-                    if (Creature* summon = me->SummonCreature(outroPositions[i].entry[entryIndex], spawnPoint, TEMPSUMMON_DEAD_DESPAWN))
+                    if (TempSummon* summon = instance->instance->SummonCreature(outroPositions[i].entry[entryIndex], spawnPoint))
                     {
+                        summon->SetTempSummonType(TEMPSUMMON_DEAD_DESPAWN);
                         summon->GetMotionMaster()->MovePoint(0, outroPositions[i].movePosition);
                         if (summon->GetEntry() == NPC_JAINA_PART2)
                             summon->AI()->Talk(SAY_JAINA_OUTRO);

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/instance_pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/instance_pit_of_saron.cpp
@@ -21,6 +21,7 @@
 #include "Map.h"
 #include "pit_of_saron.h"
 #include "Player.h"
+#include "TemporarySummon.h"
 
 // positions for Martin Victus (37591) and Gorkun Ironskull (37592)
 Position const SlaveLeaderPos  = {689.7158f, -104.8736f, 513.7360f, 0.0f};

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/instance_pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/instance_pit_of_saron.cpp
@@ -157,9 +157,15 @@ class instance_pit_of_saron : public InstanceMapScript
                             if (Creature* summoner = instance->GetCreature(_garfrostGUID))
                             {
                                 if (_teamInInstance == ALLIANCE)
-                                    summoner->SummonCreature(NPC_MARTIN_VICTUS_1, SlaveLeaderPos, TEMPSUMMON_MANUAL_DESPAWN);
+                                {
+                                    if (TempSummon* summon = instance->SummonCreature(NPC_MARTIN_VICTUS_1, SlaveLeaderPos))
+                                        summon->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
+                                }
                                 else
-                                    summoner->SummonCreature(NPC_GORKUN_IRONSKULL_2, SlaveLeaderPos, TEMPSUMMON_MANUAL_DESPAWN);
+                                {
+                                    if (TempSummon* summon = instance->SummonCreature(NPC_GORKUN_IRONSKULL_2, SlaveLeaderPos))
+                                        summon->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
+                                }
                             }
                         }
                         break;
@@ -169,9 +175,15 @@ class instance_pit_of_saron : public InstanceMapScript
                             if (Creature* summoner = instance->GetCreature(_tyrannusGUID))
                             {
                                 if (_teamInInstance == ALLIANCE)
-                                    summoner->SummonCreature(NPC_JAINA_PART2, EventLeaderPos2, TEMPSUMMON_MANUAL_DESPAWN);
+                                {
+                                    if (TempSummon * summon = instance->SummonCreature(NPC_JAINA_PART2, EventLeaderPos2))
+                                        summon->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
+                                }
                                 else
-                                    summoner->SummonCreature(NPC_SYLVANAS_PART2, EventLeaderPos2, TEMPSUMMON_MANUAL_DESPAWN);
+                                {
+                                    if (TempSummon * summon = instance->SummonCreature(NPC_SYLVANAS_PART2, EventLeaderPos2))
+                                        summon->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Fix crossfaction combat issues in these cases:
- Fix Martin Victus attacking players in crossfaction groups because it was spawned as summon of the boss, triggering DoCombatInZone()
- Fix Devourer of Souls guardians attacking players in crossfaction groups because they were spawned as summons of the boss, triggering DoZoneInCombat()

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23795


**Tests performed:** (Does it build, tested in-game, etc.)
#23795 doesn't happen anymore

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Check other instances with the same issue


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
