### PR TITLE
Core/Achievements: fixed bug with counting honorless units for achievement type ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL

### DIFF
--- a/src/server/game/Entities/Player/KillRewarder.cpp
+++ b/src/server/game/Entities/Player/KillRewarder.cpp
@@ -232,17 +232,9 @@ void KillRewarder::_RewardGroup()
 
             // 3.1.3. Reward each group member (even dead or corpse) within reward distance.
             for (GroupReference* itr = _group->GetFirstMember(); itr != nullptr; itr = itr->next())
-            {
                 if (Player* member = itr->GetSource())
-                {
-                    // Killer may not be at reward distance, check directly
-                    if (_killer == member || member->IsAtGroupRewardDistance(_victim))
-                    {
+                    if (_killer == member || member->IsAtGroupRewardDistance(_victim))  // Killer may not be at reward distance, check directly
                         _RewardPlayer(member, isDungeon);
-                        member->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL, 1, 0, _victim);
-                    }
-                }
-            }
         }
     }
 }

--- a/src/server/game/Entities/Player/KillRewarder.cpp
+++ b/src/server/game/Entities/Player/KillRewarder.cpp
@@ -232,9 +232,14 @@ void KillRewarder::_RewardGroup()
 
             // 3.1.3. Reward each group member (even dead or corpse) within reward distance.
             for (GroupReference* itr = _group->GetFirstMember(); itr != nullptr; itr = itr->next())
+            {
+                // Killer may not be at reward distance, check directly
                 if (Player* member = itr->GetSource())
-                    if (_killer == member || member->IsAtGroupRewardDistance(_victim))  // Killer may not be at reward distance, check directly
+                {
+                    if (_killer == member || member->IsAtGroupRewardDistance(_victim))
                         _RewardPlayer(member, isDungeon);
+                }
+            }
         }
     }
 }

--- a/src/server/game/Entities/Player/KillRewarder.cpp
+++ b/src/server/game/Entities/Player/KillRewarder.cpp
@@ -233,11 +233,13 @@ void KillRewarder::_RewardGroup()
             // 3.1.3. Reward each group member (even dead or corpse) within reward distance.
             for (GroupReference* itr = _group->GetFirstMember(); itr != nullptr; itr = itr->next())
             {
-                // Killer may not be at reward distance, check directly
                 if (Player* member = itr->GetSource())
                 {
+                    // Killer may not be at reward distance, check directly
                     if (_killer == member || member->IsAtGroupRewardDistance(_victim))
+                    {
                         _RewardPlayer(member, isDungeon);
+                    }
                 }
             }
         }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6819,6 +6819,7 @@ bool Player::RewardHonor(Unit* victim, uint32 groupsize, int32 honor, bool pvpto
             UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_RACE, victim->GetRace());
             UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA, GetAreaId());
             UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL, 1, 0, victim);
+            UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_SPECIAL_PVP_KILL, 1, 0, victim);
         }
         else
         {


### PR DESCRIPTION
**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #16075


**Tests performed:** (Does it build, tested in-game, etc.)
Build, tested