### PR TITLE
Scripts/ICC: Fixed Tear Gas not getting removed of Abomination in phase change of PP

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -1609,7 +1609,10 @@ class spell_putricide_clear_aura_effect_value : public SpellScriptLoader
                 uint32 auraId = sSpellMgr->GetSpellIdForDifficulty(uint32(GetEffectValue()), GetCaster());
                 target->RemoveAurasDueToSpell(auraId);
                 if (m_scriptSpellId == SPELL_TEAR_GAS_CANCEL)
-                    target->RemoveAurasDueToSpell(SPELL_TEAR_GAS_TRIGGER_MISSILE);
+                {
+                    uint32 auraId2 = GetSpellInfo()->Effects[EFFECT_1].CalcValue();
+                    target->RemoveAurasDueToSpell(auraId2);
+                }
             }
 
             void Register() override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -625,7 +625,6 @@ class boss_professor_putricide : public CreatureScript
                             AttackStart(me->GetVictim());
                             // remove Tear Gas
                             me->RemoveAurasDueToSpell(SPELL_TEAR_GAS_PERIODIC_TRIGGER);
-                            instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_TEAR_GAS_TRIGGER_MISSILE, true, true);
                             DoCastAOE(SPELL_TEAR_GAS_CANCEL);
                             instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_GAS_VARIABLE);
                             instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_OOZE_VARIABLE);
@@ -1606,8 +1605,11 @@ class spell_putricide_clear_aura_effect_value : public SpellScriptLoader
             void HandleScript(SpellEffIndex effIndex)
             {
                 PreventHitDefaultEffect(effIndex);
+                Unit* target = GetHitUnit();
                 uint32 auraId = sSpellMgr->GetSpellIdForDifficulty(uint32(GetEffectValue()), GetCaster());
-                GetHitUnit()->RemoveAurasDueToSpell(auraId);
+                target->RemoveAurasDueToSpell(auraId);
+                if (m_scriptSpellId == SPELL_TEAR_GAS_CANCEL)
+                    target->RemoveAurasDueToSpell(SPELL_TEAR_GAS_TRIGGER_MISSILE);
             }
 
             void Register() override


### PR DESCRIPTION
**Changes proposed:**

-  Tear Gas cancel  (71620) should remove Tear Gas (71615) too
-  It fix the issue of Abomination stay stunned by Tear Gas when phase change in Professor Putricide. 


**Target branch(es):** 3.3.5


**Issues addressed:** Has no open issues


**Tests performed:** Builded and tested in game
