### PR TITLE
Core/LFG: Fix re-queueing while in a dungeon

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -619,13 +619,22 @@ void LFGMgr::LeaveLfg(ObjectGuid guid, bool disconnected)
         case LFG_STATE_QUEUED:
             if (gguid)
             {
+                LfgState newState = LFG_STATE_NONE;
+                LfgState oldState = GetOldState(gguid);
+
+                // Set the new state to LFG_STATE_DUNGEON/LFG_STATE_FINISHED_DUNGEON if the group is already in a dungeon
+                // This is required in case a LFG group vote-kicks a player in a dungeon, queues, then leaves the queue (maybe to queue later again)
+                if (Group* group = sGroupMgr->GetGroupByGUID(gguid.GetCounter()))
+                    if (group->isLFGGroup() && GetDungeon(gguid) && (oldState == LFG_STATE_DUNGEON || oldState == LFG_STATE_FINISHED_DUNGEON))
+                        newState = oldState;                
+
                 LFGQueue& queue = GetQueue(gguid);
                 queue.RemoveFromQueue(gguid);
-                SetState(gguid, LFG_STATE_NONE);
+                SetState(gguid, newState);
                 GuidSet const& players = GetPlayers(gguid);
                 for (GuidSet::const_iterator it = players.begin(); it != players.end(); ++it)
                 {
-                    SetState(*it, LFG_STATE_NONE);
+                    SetState(*it, newState);
                     SendLfgUpdateParty(*it, LfgUpdateData(LFG_UPDATETYPE_REMOVED_FROM_QUEUE));
                 }
             }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Fix an issue that wouldn't allow to re-queue after joining a dungeon, having 1 member leave/get kicked, queue, leave, queue.
In this case a message "One or more dungeons was not valid" would be displayed because LFG would try to queue the group as "continue dungeon" but the current group was not marked as "in dungeon" state anymore.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes https://github.com/TrinityCore/TrinityCore/issues/14331#issuecomment-529117790

**Tests performed:** (Does it build, tested in-game, etc.)
1. First test
  - Created a group of 4
  - Queue LFG with group
  - Joined LFG with a char alone
  - Accepted, entered dungeon
  - Kicked 1
  - Requeue LFG with group
  - Leave queue
  - Requeue LFG with group <-- now it works
2. Second test
  - Finish a LFG dungeon
  - 1 leaves (can't kick after dungeon is finished)
  - Requeue LFG with group
  - Leave queue
  - Requeue LFG with group <-- now it works

**Known issues and TODO list:** (add/remove lines as needed)
- None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
