### PR TITLE
Core/Movement: implement smooth waypoint transition

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -29,7 +29,7 @@
 #include "Transport.h"
 #include "WaypointManager.h"
 
-WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bool repeating) : _nextMoveTime(0), _transitionPointId(0), _pathId(pathId), _repeating(repeating), _loadedFromDB(true)
+WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bool repeating) : _nextMoveTime(0), _pathId(pathId), _transitionPointId(0), _repeating(repeating), _loadedFromDB(true)
 {
     Mode = MOTION_MODE_DEFAULT;
     Priority = MOTION_PRIORITY_NORMAL;
@@ -37,7 +37,7 @@ WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bo
     BaseUnitState = UNIT_STATE_ROAMING;
 }
 
-WaypointMovementGenerator<Creature>::WaypointMovementGenerator(WaypointPath& path, bool repeating) : _nextMoveTime(0), _transitionPointId(0), _pathId(0), _repeating(repeating), _loadedFromDB(false)
+WaypointMovementGenerator<Creature>::WaypointMovementGenerator(WaypointPath& path, bool repeating) : _nextMoveTime(0), _pathId(0), _transitionPointId(0), _repeating(repeating), _loadedFromDB(false)
 {
     _path = &path;
 

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
@@ -71,7 +71,7 @@ class WaypointMovementGenerator<Creature> : public MovementGeneratorMedium<Creat
 
         TimeTrackerSmall _nextMoveTime;
         uint32 _pathId;
-		uint32 _transitionPointId;
+        uint32 _transitionPointId;
         bool _repeating;
         bool _loadedFromDB;
 };

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
@@ -71,6 +71,7 @@ class WaypointMovementGenerator<Creature> : public MovementGeneratorMedium<Creat
 
         TimeTrackerSmall _nextMoveTime;
         uint32 _pathId;
+		uint32 _transitionPointId;
         bool _repeating;
         bool _loadedFromDB;
 };

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
@@ -71,7 +71,7 @@ class WaypointMovementGenerator<Creature> : public MovementGeneratorMedium<Creat
 
         TimeTrackerSmall _nextMoveTime;
         uint32 _pathId;
-        uint32 _transitionPointId;
+        int32 _transitionPointId;
         bool _repeating;
         bool _loadedFromDB;
 };


### PR DESCRIPTION
**Changes proposed:**
-  implement missing handling to make a creature smoothly transition from one waypoint path into another. Retails tends to use the first spline point of the following waypoint path in the prior path to make transitions smoother without appearing laggy. This PR is literally doing this by calculating the path of the next waypoint in advance and picking the first spline point from it for the current waypoint path.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame: https://www.youtube.com/watch?v=osnXEEXwUH4

The small hickup you can see at the npc Thomas Miller on the left side is not an issue of the smooth waypoint transition but a issue with the path generator that tends to occasionally return stupid spline points which is an issue outside of the scope of this PR.

