### PR TITLE
Scripts/Kologarn: Fix "stuck in combat" issues

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -151,6 +151,7 @@ class boss_kologarn : public CreatureScript
                 me->GetMotionMaster()->MoveTargetedHome();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                 me->SetCorpseDelay(604800); // Prevent corpse from despawning.
+                ForceStopCombatForCreature(NPC_ARM_SWEEP_STALKER, 500.f);
                 _JustDied();
             }
 
@@ -211,6 +212,7 @@ class boss_kologarn : public CreatureScript
 
             void JustSummoned(Creature* summon) override
             {
+                BossAI::JustSummoned(summon);
                 switch (summon->GetEntry())
                 {
                     case NPC_FOCUSED_EYEBEAM:


### PR DESCRIPTION
**Changes proposed:**

-  Fix players stuck in combat with NPC_ARM_SWEEP_STALKER and/or both arms after killing the boss.
-  The arms are now tracked as summons so they respawn on evade

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23756 , replaces #23770 (it includes the same fix plus it fixes the arms)


**Tests performed:** (Does it build, tested in-game, etc.)
- started the fight
- waiting for EVENT_SWEEP to trigger
- killed the boss with .damage command while keeping the arms alive

**Known issues and TODO list:** (add/remove lines as needed)
- Not sure if the "summons" change breaks anything (achievements maybe ? did they work before ? )


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
