### PR TITLE
Core/Movement: Fix a crash on login

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -83,7 +83,7 @@ bool MovementGeneratorComparator::operator()(MovementGenerator const* a, Movemen
 
 MovementGeneratorInformation::MovementGeneratorInformation(MovementGeneratorType type, ObjectGuid targetGUID, std::string const& targetName) : Type(type), TargetGUID(targetGUID), TargetName(targetName) { }
 
-MotionMaster::MotionMaster(Unit* unit) : _owner(unit), _defaultGenerator(nullptr), _flags(MOTIONMASTER_FLAG_NONE) { }
+MotionMaster::MotionMaster(Unit* unit) : _owner(unit), _defaultGenerator(nullptr), _flags(MOTIONMASTER_FLAG_NONE), _defaultInitialized(false) { }
 
 MotionMaster::~MotionMaster()
 {
@@ -110,6 +110,7 @@ void MotionMaster::Initialize()
 
 void MotionMaster::InitializeDefault()
 {
+    _defaultInitialized = true;
     Add(FactorySelector::SelectMovementGenerator(_owner), MOTION_SLOT_DEFAULT);
 }
 
@@ -322,7 +323,7 @@ void MotionMaster::Add(MovementGenerator* movement, MovementSlot slot/* = MOTION
         return;
     }
 
-    if (HasFlag(MOTIONMASTER_FLAG_UPDATE))
+    if (HasFlag(MOTIONMASTER_FLAG_UPDATE) || (!_owner->IsInWorld() && !_defaultInitialized))
     {
         DelayedActionDefine action = [this, movement, slot]()
         {

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -218,6 +218,7 @@ class TC_GAME_API MotionMaster
         MotionMasterUnitStatesContainer _baseUnitStatesMap;
         std::deque<DelayedAction> _delayedActions;
         uint8 _flags;
+        bool _defaultInitialized;
 };
 
 #endif // MOTIONMASTER_H


### PR DESCRIPTION
**Changes proposed:**

-  Fix a crash in MotionMaster happening when logging in with an aura of type SPELL_AURA_MOD_CONFUSE
-  This is an attempt to fix the crash

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23199 

**Tests performed:** 
- Tested ingame spell https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=9992 and relogging fast
- Logged in Stormwind


**Known issues and TODO list:** (add/remove lines as needed)

- There might be a better fix, especially for the Creatures in formation that don't call Initialize()


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
