### PR TITLE
Core: added aarch64 definition for jemalloc

### DIFF
--- a/dep/jemalloc/CMakeLists.txt
+++ b/dep/jemalloc/CMakeLists.txt
@@ -28,6 +28,14 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT NOJEM)
     set(JEM_MADFREE_DEF "#undef")
   endif()
 
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(JEM_CPU_SPINWAIT "")
+    set(JEM_HAVE_CPU_SPINWAIT 0)
+  else()
+    set(JEM_CPU_SPINWAIT "__asm__ volatile\(\"pause\"\)")
+    set(JEM_HAVE_CPU_SPINWAIT 1)
+  endif()
+
   # Create the header, so we can use it
   configure_file(
     "${CMAKE_SOURCE_DIR}/dep/jemalloc/jemalloc_internal_defs.h.in.cmake"

--- a/dep/jemalloc/jemalloc_internal_defs.h.in.cmake
+++ b/dep/jemalloc/jemalloc_internal_defs.h.in.cmake
@@ -33,9 +33,9 @@
  * Hyper-threaded CPUs may need a special instruction inside spin loops in
  * order to yield to another virtual CPU.
  */
-#define CPU_SPINWAIT __asm__ volatile("pause")
+#define CPU_SPINWAIT @JEM_CPU_SPINWAIT@
 /* 1 if CPU_SPINWAIT is defined, 0 otherwise. */
-#define HAVE_CPU_SPINWAIT 1
+#define HAVE_CPU_SPINWAIT @JEM_HAVE_CPU_SPINWAIT@
 
 /*
  * Number of significant bits in virtual addresses.  This may be less than the


### PR DESCRIPTION
Not really sure what happened but somehow i killed everything i worked on, so onwards with a new PR for this branch.

**Changes proposed:**

-  aarch64 definition for jemalloc
    - as defined by jemalloc on raspberry pi

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)

- [x] build
- [x] in game (on raspberry pi 4)

**Known issues and TODO list:** (add/remove lines as needed)