### PR TITLE
Fixed pets repositioning themselves after every cast

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -425,8 +425,7 @@ void PetAI::DoAttack(Unit* target, bool chase)
             float chaseDistance = me->GetPetChaseDistance();
             float angle = chaseDistance == 0.f ? float(M_PI) : 0.f;
             float tolerance = chaseDistance == 0.f ? float(M_PI_4) : float(M_PI * 2);
-            ChaseAngle chaseAngle = ChaseAngle(angle, tolerance);
-            me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), chaseAngle);
+            me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), ChaseAngle(angle, tolerance));
         }
         else // (Stay && ((Aggressive || Defensive) && In Melee Range)))
         {

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -420,8 +420,11 @@ void PetAI::DoAttack(Unit* target, bool chase)
 
             if (me->HasUnitState(UNIT_STATE_FOLLOW))
                 me->GetMotionMaster()->Remove(FOLLOW_MOTION_TYPE);
-
-            me->GetMotionMaster()->MoveChase(target, me->GetPetChaseDistance(), float(M_PI));
+            
+            // Pets with ranged attacks should not care about the chase angles or tolerances at all.
+            float chaseDistance = me->GetPetChaseDistance();
+            ChaseAngle angle = ChaseAngle(chaseDistance == 0.f ? float(M_PI) : 0.f, chaseDistance == 0.f ? M_PI_4 : float(M_PI * 2));
+            me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), angle);
         }
         else // (Stay && ((Aggressive || Defensive) && In Melee Range)))
         {

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -423,7 +423,7 @@ void PetAI::DoAttack(Unit* target, bool chase)
             
             // Pets with ranged attacks should not care about the chase angles or tolerances at all.
             float chaseDistance = me->GetPetChaseDistance();
-            ChaseAngle angle = ChaseAngle(chaseDistance == 0.f ? float(M_PI) : 0.f, chaseDistance == 0.f ? M_PI_4 : float(M_PI * 2));
+            ChaseAngle angle = ChaseAngle(chaseDistance == 0.f ? float(M_PI) : 0.f, chaseDistance == 0.f ? float(M_PI_4) : float(M_PI * 2));
             me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), angle);
         }
         else // (Stay && ((Aggressive || Defensive) && In Melee Range)))

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -421,10 +421,12 @@ void PetAI::DoAttack(Unit* target, bool chase)
             if (me->HasUnitState(UNIT_STATE_FOLLOW))
                 me->GetMotionMaster()->Remove(FOLLOW_MOTION_TYPE);
             
-            // Pets with ranged attacks should not care about the chase angles or tolerances at all.
+            // Pets with ranged attacks should not care about the chase angle at all.
             float chaseDistance = me->GetPetChaseDistance();
-            ChaseAngle angle = ChaseAngle(chaseDistance == 0.f ? float(M_PI) : 0.f, chaseDistance == 0.f ? float(M_PI_4) : float(M_PI * 2));
-            me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), angle);
+            float angle = chaseDistance == 0.f ? float(M_PI) : 0.f;
+            float tolerance = chaseDistance == 0.f ? float(M_PI_4) : float(M_PI * 2);
+            ChaseAngle chaseAngle = ChaseAngle(angle, tolerance);
+            me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, chaseDistance), chaseAngle);
         }
         else // (Stay && ((Aggressive || Defensive) && In Melee Range)))
         {


### PR DESCRIPTION

**Changes proposed:**

-  ranged attacking pets, minions etc were also affected by the default chase behaivior which is positioning behind the chase target or at least to the tolerance angle. We have an exception for this now so melee pets will still do this while ranged attacking pets will no longer give a fuck about it.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
closes #22857

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame
