### PR TITLE
DB/Creature: ReActivate Creatures DeathState by using unit_flags3

### DIFF
--- a/sql/updates/world/master/2019_11_30_00_world.sql
+++ b/sql/updates/world/master/2019_11_30_00_world.sql
@@ -1,0 +1,1 @@
+UPDATE creature_template SET unit_flags3 = unit_flags | 8192 WHERE (unit_flags2 & 1) != 0;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [X] master

**Issues addressed:** Closes #  (insert issue tracker number)
- Creatures where was death was showing mana and life. This was incorrect and is now solved.
**Tests performed:** (Does it build, tested in-game, etc.)

Tests works fine and no problems with the death state anymore

**Known issues and TODO list:** (add/remove lines as needed)

Thanks to @Shauren who helped me ;)
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
