### PR TITLE
Core/Spells: Fix Power Word: Shield (Priest) absorb amount

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -101,6 +101,12 @@ enum MiscSpells
     SPELL_GENERIC_BATTLEGROUND_DAMPENING            = 74411
 };
 
+enum MiscSpellIcons
+{
+    SPELL_ICON_ID_STRENGTH_OF_WRYNN                 = 1704,
+    SPELL_ICON_ID_HELLSCREAM_WARSONG                = 937
+};
+
 class PowerCheck
 {
     public:
@@ -1128,6 +1134,12 @@ class spell_pri_power_word_shield : public SpellScriptLoader
                     // Battleground - Dampening
                     else if (AuraEffect const* auraEffBattlegroudDampening = caster->GetAuraEffect(SPELL_GENERIC_BATTLEGROUND_DAMPENING, EFFECT_0))
                         AddPct(amount, auraEffBattlegroudDampening->GetAmount());
+
+                    // ICC buff
+                    if (AuraEffect const* auraStrengthOfWrynn = caster->GetAuraEffect(SPELL_AURA_MOD_HEALING_DONE_PERCENT, SPELLFAMILY_GENERIC, SPELL_ICON_ID_STRENGTH_OF_WRYNN, EFFECT_2))
+                        AddPct(amount, auraStrengthOfWrynn->GetAmount());
+                    else if (AuraEffect const* auraHellscreamsWarsong = caster->GetAuraEffect(SPELL_AURA_MOD_HEALING_DONE_PERCENT, SPELLFAMILY_GENERIC, SPELL_ICON_ID_HELLSCREAM_WARSONG, EFFECT_2))
+                        AddPct(amount, auraHellscreamsWarsong->GetAmount());
                 }
             }
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -78,6 +78,7 @@ enum PriestSpells
 
 enum PriestSpellIcons
 {
+    PRIEST_ICON_ID_FOCUSED_POWER                    = 2210,
     PRIEST_ICON_ID_BORROWED_TIME                    = 2899,
     PRIEST_ICON_ID_EMPOWERED_RENEW_TALENT           = 3021,
     PRIEST_ICON_ID_PAIN_AND_SUFFERING               = 2874,
@@ -95,7 +96,9 @@ enum PriestMisc
 
 enum MiscSpells
 {
-    SPELL_MAGE_ARCANE_POWER                         = 12042
+    SPELL_MAGE_ARCANE_POWER                         = 12042,
+    SPELL_GENERIC_ARENA_DAMPENING                   = 74410,
+    SPELL_GENERIC_BATTLEGROUND_DAMPENING            = 74411
 };
 
 class PowerCheck
@@ -1116,7 +1119,15 @@ class spell_pri_power_word_shield : public SpellScriptLoader
                         AddPct(amount, twinDisciplines->GetAmount());
 
                     // Focused Power
-                    amount *= caster->GetTotalAuraMultiplier(SPELL_AURA_MOD_HEALING_DONE_PERCENT);
+                    if (AuraEffect const* focusedPower = caster->GetAuraEffect(SPELL_AURA_MOD_HEALING_DONE_PERCENT, SPELLFAMILY_PRIEST, PRIEST_ICON_ID_FOCUSED_POWER, EFFECT_2))
+                        AddPct(amount, focusedPower->GetAmount());
+
+                    // Arena - Dampening
+                    if (AuraEffect const* auraEffArenaDampening = caster->GetAuraEffect(SPELL_GENERIC_ARENA_DAMPENING, EFFECT_0))
+                        AddPct(amount, auraEffArenaDampening->GetAmount());
+                    // Battleground - Dampening
+                    else if (AuraEffect const* auraEffBattlegroudDampening = caster->GetAuraEffect(SPELL_GENERIC_BATTLEGROUND_DAMPENING, EFFECT_0))
+                        AddPct(amount, auraEffBattlegroudDampening->GetAmount());
                 }
             }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Modify absorb amount in PW:Shield script, shouldn't be modified by all SPELL_AURA_MOD_HEALING_DONE_PERCENT auras (explained here: #22090)

PW:shield should be affected by Focused Power and Arena/Battleground - Dampening:
https://wowwiki.fandom.com/wiki/Power_Word:_Shield?oldid=2365404
```
Focused Power increases the amount absorbed by the shield.

Hotfix (2010-02-05): "The amount of damage being absorbed by Sacred Shield and Power Word: Shield is being reduced by 10% correctly in only battlegrounds, Arenas, and Wintergrasp."
```
But actually after this commit: https://github.com/TrinityCore/TrinityCore/commit/e672793a3cb6aae03cfea6cea68bbf0acb3cb4fc
Can be modified by spells like:
priest Blessed Resilience and it shouldn't:
https://www.wowhead.com/forums&topic=134352.2#p1658132

```
Effect = Heal
Spiritual Healing - Healing
Blessed Resilience - Healing
Test of Faith - Healing
NON OF THESE TALENTS INCREASE ABSORBTION OF POWER WORD: SHIELD, ONLY THE GLYPH
```
and others

Should be affected by ICC buff, but, as I explain in the issue: #22090
I don't know how want fix this @ariel- ( #21415 )

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes #22090


**Tests performed:** Tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
