### PR TITLE
Core/Movement: Fix wrong orientation set when pausing movement

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10171,7 +10171,8 @@ void Unit::StopMoving()
         return;
 
     // Update position now since Stop does not start a new movement that can be updated later
-    UpdateSplinePosition();
+    if (movespline->Started())
+        UpdateSplinePosition();
     Movement::MoveSplineInit init(this);
     init.Stop();
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10171,7 +10171,7 @@ void Unit::StopMoving()
         return;
 
     // Update position now since Stop does not start a new movement that can be updated later
-    if (movespline->Started())
+    if (movespline->HasStarted())
         UpdateSplinePosition();
     Movement::MoveSplineInit init(this);
     init.Stop();

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -124,7 +124,7 @@ namespace Movement
 
         bool onTransport;
         std::string ToString() const;
-        bool Started() const
+        bool HasStarted() const
         {
             return time_passed > 0;
         }

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -124,6 +124,10 @@ namespace Movement
 
         bool onTransport;
         std::string ToString() const;
+        bool Started() const
+        {
+            return time_passed > 0;
+        }
     };
 }
 #endif // TRINITYSERVER_MOVEPLINE_H


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix wrong orientation set when pausing movement. The current Unit position is set as calculated from the spline if no time has passed since the spline was launched, i.e. time_passed == 0

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23272


**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame and debugged to see that the orientation of the npc of #23272 https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=16708 is correct
- Talked to the npc of #23272 https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=16708 while it's walking, the position got updated correctly (even if there is another issue that the old orientation is set when talking to the npc, relogging shows the correct orientation, it should be checked if 335 had this issue already).

**Known issues and TODO list:** (add/remove lines as needed)

-  None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
