### PR TITLE
Fix mob flee speed too fast, Fixes #21899

### DIFF
--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -181,6 +181,24 @@ template void PointMovementGenerator<Creature>::DoFinalize(Creature*, bool, bool
 
 //---- AssistanceMovementGenerator
 
+void AssistanceMovementGenerator::Initialize(Unit* owner)
+{
+    RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
+    AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
+
+    if (owner->HasUnitState(UNIT_STATE_LOST_CONTROL | UNIT_STATE_NOT_MOVE))
+        return;
+
+    if (!owner->IsStopped())
+        owner->StopMoving();
+
+    owner->AddUnitState(UNIT_STATE_ROAMING | UNIT_STATE_ROAMING_MOVE);
+    Movement::MoveSplineInit init(owner);
+    init.MoveTo(_x, _y, _z);
+    init.SetVelocity(owner->GetSpeed(MOVE_RUN) * 0.66);
+    init.Launch();
+}
+
 void AssistanceMovementGenerator::Finalize(Unit* owner, bool active, bool movementInform)
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
@@ -42,7 +42,7 @@ class PointMovementGenerator : public MovementGeneratorMedium<T, PointMovementGe
 
         uint32 GetId() const { return _movementId; }
 
-    private:
+    protected:
         void MovementInform(T*);
 
         uint32 _movementId;
@@ -58,6 +58,7 @@ class AssistanceMovementGenerator : public PointMovementGenerator<Creature>
     public:
         explicit AssistanceMovementGenerator(uint32 id, float x, float y, float z) : PointMovementGenerator<Creature>(id, x, y, z, true) { }
 
+        void Initialize(Unit* owner) override;
         void Finalize(Unit*, bool, bool) override;
         MovementGeneratorType GetMovementGeneratorType() const override;
 };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Creature flee speed should be 66% of its run speed.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
#21899

**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
