### PR TITLE
Core/Movement: Add more LoS checks

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -93,6 +93,14 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* owner, uint32 diff)
         float angle = frand(0.0f, 1.0f) * float(M_PI) * 2.0f;
         owner->MovePositionToFirstCollision(destination, distance, angle);
 
+        // Check if the destination is in LOS
+        if (!owner->IsWithinLOS(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ()))
+        {
+            // Retry later on
+            _timer.Reset(200);
+            return true;
+        }
+
         if (!_path)
         {
             _path = std::make_unique<PathGenerator>(owner);

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -124,6 +124,14 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     float angle = frand(0.f, 1.f) * float(M_PI) * 2.f;
     owner->MovePositionToFirstCollision(position, distance, angle);
 
+    // Check if the destination is in LOS
+    if (!owner->IsWithinLOS(position.GetPositionX(), position.GetPositionY(), position.GetPositionZ()))
+    {
+        // Retry later on
+        _timer.Reset(200);
+        return;
+    }
+
     uint32 resetTimer = roll_chance_i(50) ? urand(5000, 10000) : urand(1000, 2000);
 
     if (!_path)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add more LoS checks to ensure Units don't cross trees/walls when fleeing/moving. I was able to reproduce only the Random movement one, with a Wolf attempting to walk into a tree, but I couldn't reproduce it with Confused one (polymorph). Still, some extra checks are better. MovePositionToFirstCollision() does some checks too but it doesn't seem to guarantee that the destination will be in LoS

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** None

**Tests performed:** (Does it build, tested in-game, etc.)
- Tested ingame with Polymorph with a breakpoint in the new code

**Known issues and TODO list:** (add/remove lines as needed)

- None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
