### PR TITLE
Core/Spells: Fix Spellsteal stealing Silence buff of Arcane Torrent

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3492,7 +3492,6 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
             case SPELL_EFFECT_LEARN_SPELL:
             case SPELL_EFFECT_SKILL_STEP:
             case SPELL_EFFECT_HEAL_PCT:
-            case SPELL_EFFECT_ENERGIZE_PCT:
                 return true;
             case SPELL_EFFECT_INSTAKILL:
                 if (i != effIndex && // for spells like 38044: instakill effect is negative but auras on target must count as buff


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't mark spells with at least 1 effect SPELL_EFFECT_ENERGIZE_PCT as Positive as Arcane Torrent has a negative silence effect on the target. Fix by @Riztazz

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #22515


**Tests performed:**
- Tested ingame with the steps described at #22515


**Known issues and TODO list:** (add/remove lines as needed)

- Other effects like SPELL_EFFECT_HEAL_PCT should be checked but that will be slightly out of scope of this PR. If anyone feels like to do that, please do :)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
