### PR TITLE
Fixes/3.3.5 fleeing speed attackstop

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5552,7 +5552,7 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     return true;
 }
 
-bool Unit::AttackStop()
+bool Unit::AttackStop(bool fleeing /* = false*/)
 {
     if (!m_attacking)
         return false;
@@ -5577,7 +5577,8 @@ bool Unit::AttackStop()
         if (creature->HasSearchedAssistance())
         {
             creature->SetNoSearchAssistance(false);
-            UpdateSpeed(MOVE_RUN);
+            if (!fleeing)
+                UpdateSpeed(MOVE_RUN);
         }
     }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -795,7 +795,7 @@ class TC_GAME_API Unit : public WorldObject
         Unit* getAttackerForHelper() const;                 // If someone wants to help, who to give them
         bool Attack(Unit* victim, bool meleeAttack);
         void CastStop(uint32 except_spellid = 0);
-        bool AttackStop();
+        bool AttackStop(bool fleeing = false);
         void RemoveAllAttackers();
         AttackerSet const& getAttackers() const { return m_attackers; }
         bool isAttackingPlayer() const;

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -932,7 +932,7 @@ void MotionMaster::MoveSeekAssistance(float x, float y, float z)
     if (_owner->GetTypeId() == TYPEID_UNIT)
     {
         TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveSeekAssistance: '%s', seeks assistance (X: %f, Y: %f, Z: %f)", _owner->GetGUID().ToString().c_str(), x, y, z);
-        _owner->AttackStop();
+        _owner->AttackStop(true);
         _owner->CastStop();
         _owner->ToCreature()->SetReactState(REACT_PASSIVE);
         Add(new AssistanceMovementGenerator(EVENT_ASSIST_MOVE, x, y, z));

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -192,6 +192,8 @@ void AssistanceMovementGenerator::Finalize(Unit* owner, bool active, bool moveme
         Creature* ownerCreature = owner->ToCreature();
         ownerCreature->SetNoCallAssistance(false);
         ownerCreature->CallAssistance();
+        // Re-calculate the speed after fleeing/seeking assistance
+        ownerCreature->UpdateSpeed(MOVE_RUN);
         if (ownerCreature->IsAlive())
             ownerCreature->GetMotionMaster()->MoveSeekAssistanceDistract(sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_ASSISTANCE_DELAY));
     }

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -185,15 +185,17 @@ void AssistanceMovementGenerator::Finalize(Unit* owner, bool active, bool moveme
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
     if (active)
+    {
         owner->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
+        // Re-calculate the speed after fleeing/seeking assistance
+        owner->UpdateSpeed(MOVE_RUN);
+    }
 
     if (movementInform && HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED))
     {
         Creature* ownerCreature = owner->ToCreature();
         ownerCreature->SetNoCallAssistance(false);
         ownerCreature->CallAssistance();
-        // Re-calculate the speed after fleeing/seeking assistance
-        ownerCreature->UpdateSpeed(MOVE_RUN);
         if (ownerCreature->IsAlive())
             ownerCreature->GetMotionMaster()->MoveSeekAssistanceDistract(sWorld->getIntConfig(CONFIG_CREATURE_FAMILY_ASSISTANCE_DELAY));
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Ensures Creatures seeking for assistance keep the 66% run speed, instead of 100%. The issue is described in detail at https://github.com/TrinityCore/TrinityCore/issues/21899#issuecomment-385968357

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #21899 , replaces #23990


**Tests performed:** (Does it build, tested in-game, etc.)
Tested ingame with the 2nd case described at https://github.com/TrinityCore/TrinityCore/issues/21899#issuecomment-568303556 . The npc has m_speed_rate[MOVE_RUN] set to 1.14286005 , when seeking assistance it becomes 0.754287660, when reaching the group of friendly mobs or dying or exiting combat because of .gm on the speed is reset to 1.14286005

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
