### PR TITLE
Core/Movement: Fix stunned falling units freezing the client

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -905,7 +905,7 @@ void MotionMaster::MoveFall(uint32 id/* = 0*/)
         return;
 
     // rooted units don't move (also setting falling+root flag causes client freezes)
-    if (_owner->HasUnitState(UNIT_STATE_ROOT))
+    if (_owner->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED))
         return;
 
     _owner->AddUnitMovementFlag(MOVEMENTFLAG_FALLING);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix stunned falling units freezing the client by excluding the falling movement if the unit has UNIT_STATE_STUNNED

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23320


**Tests performed:**
- Tested ingame the issue described in #23320


**Known issues and TODO list:** (add/remove lines as needed)
None, one might want to check if _owner->HasUnitMovementFlag(MOVEMENTFLAG_ROOT) is a better check but this PR fixes the issue with the least amount of changes and without having to check the previous fixed issues


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
