### PR TITLE
Core/Spells: Implement a way for scripts to define spell corrections.

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -214,6 +214,22 @@ class TC_GAME_API SpellScriptLoader : public ScriptObject
         virtual AuraScript* GetAuraScript() const { return nullptr; }
 };
 
+class TC_GAME_API SpellCorrectionLoader : public ScriptObject
+{
+    protected:
+
+        SpellCorrectionLoader(char const* name);
+
+        void ApplySpellFix(std::initializer_list<uint32> spellIds, void(*fix)(SpellInfo*)) const;
+
+    public:
+        virtual void Execute() const = 0;
+
+        virtual bool ShouldLoad() const { return true; }
+
+        void ApplyCorrections() const;
+};
+
 class TC_GAME_API ServerScript : public ScriptObject
 {
     protected:
@@ -980,6 +996,10 @@ class TC_GAME_API ScriptMgr
         void CreateSpellScripts(uint32 spellId, std::vector<SpellScript*>& scriptVector, Spell* invoker) const;
         void CreateAuraScripts(uint32 spellId, std::vector<AuraScript*>& scriptVector, Aura* invoker) const;
         SpellScriptLoader* GetSpellScriptLoader(uint32 scriptId);
+
+    public: /* SpellCorrectionLoader */
+
+        void ApplySpellCorrections() const;
 
     public: /* ServerScript */
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2210,6 +2210,10 @@ void World::SetInitialWorldSettings()
     TC_LOG_INFO("server.loading", "Loading scenario poi data");
     sScenarioMgr->LoadScenarioPOI();
 
+    // We do it last to make sure everything a script might call in ShouldLoad() is initialized.
+    TC_LOG_INFO("server.loading", "Loading script-specific spell info corrections...");
+    sScriptMgr->ApplySpellCorrections();
+
     // Preload all cells, if required for the base maps
     if (sWorld->getBoolConfig(CONFIG_BASEMAP_LOAD_GRIDS))
     {


### PR DESCRIPTION
**Changes proposed:**

- Stop littering `SpellMgr` with hacks and litter scripts instead, to keep hacks contained.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

Will target 3.3.5 if this ships on master or passes validation.

**Issues addressed:** None

**Tests performed:** Builds and runs.

**TODO:**

- [ ] Hotswap ? Should work out of the box, but untested (I only build in static)
- [ ] Possible side effects if code executed during startup expects a modification to a spell to have been applied
- [ ] Migrate corrections out of `SpellMgr` to where they rightfully belong. 

`LoadSpellInfoCorrections` should **not** disappear, since not every spell is a script spell ; some are core mechanics (Hearthstone, Unstuck, Skinning, you name it)