### PR TITLE
Core/Movement: Fix WaypointMovementGenerator ignoring EscortAI::SetEscortPaused() on Gossip Hello

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -56,6 +56,10 @@ void WaypointMovementGenerator<Creature>::Pause(uint32 timer/* = 0*/)
 {
     if (timer)
     {
+        // Don't try to paused an already paused generator
+        if (HasFlag(MOVEMENTGENERATOR_FLAG_PAUSED))
+            return;
+
         AddFlag(MOVEMENTGENERATOR_FLAG_TIMED_PAUSED);
         _nextMoveTime.Reset(timer);
         RemoveFlag(MOVEMENTGENERATOR_FLAG_PAUSED);


### PR DESCRIPTION
**Changes proposed:**

- Fix WaypointMovementGenerator ignoring EscortAI::SetEscortPaused() when talking to a NPC, scheduling a 3 minutes pause on the WaypointMovementGenerator even if it was already disabled with no timer, waiting for the player to select a gossip entry to resume the movement.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Ref #21190


**Tests performed:** (Does it build, tested in-game, etc.)
- tried the Thrall @ Old hillsbrad escort event. When Thrall stops after killing some kind of boss guard at the Keep gate (and before mounting up), he waits for the player to select a gossip. As soon as I selected the gossip, he started walking (and the WaypointMovementGenerator wasn't paused twice, I debugged the code)

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
