### PR TITLE
Core/Spells: Fix Sacred Shield (Paladin) absorb amount with ICC buff

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -138,8 +138,8 @@ enum PaladinSpellIcons
 
 enum MiscSpellIcons
 {
-    SPELL_ICON_ID_STRENGTH_OF_WRYNN                 = 1704,
-    SPELL_ICON_ID_HELLSCREAM_WARSONG                = 937
+    SPELL_ICON_ID_STRENGTH_OF_WRYNN              = 1704,
+    SPELL_ICON_ID_HELLSCREAM_WARSONG             = 937
 };
 
 // 31850 - Ardent Defender

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -136,6 +136,12 @@ enum PaladinSpellIcons
     PALADIN_ICON_ID_HAMMER_OF_THE_RIGHTEOUS      = 3023
 };
 
+enum MiscSpellIcons
+{
+    SPELL_ICON_ID_STRENGTH_OF_WRYNN                 = 1704,
+    SPELL_ICON_ID_HELLSCREAM_WARSONG                = 937
+};
+
 // 31850 - Ardent Defender
 class spell_pal_ardent_defender : public SpellScriptLoader
 {
@@ -1938,6 +1944,12 @@ class spell_pal_sacred_shield : public SpellScriptLoader
                     // Battleground - Dampening
                     else if (AuraEffect const* auraEffBattlegroudDampening = caster->GetAuraEffect(SPELL_GENERIC_BATTLEGROUND_DAMPENING, EFFECT_0))
                         AddPct(amount, auraEffBattlegroudDampening->GetAmount());
+
+                    // ICC buff
+                    if (AuraEffect const* auraStrengthOfWrynn = caster->GetAuraEffect(SPELL_AURA_MOD_HEALING_DONE_PERCENT, SPELLFAMILY_GENERIC, SPELL_ICON_ID_STRENGTH_OF_WRYNN, EFFECT_2))
+                        AddPct(amount, auraStrengthOfWrynn->GetAmount());
+                    else if (AuraEffect const* auraHellscreamsWarsong = caster->GetAuraEffect(SPELL_AURA_MOD_HEALING_DONE_PERCENT, SPELLFAMILY_GENERIC, SPELL_ICON_ID_HELLSCREAM_WARSONG, EFFECT_2))
+                        AddPct(amount, auraHellscreamsWarsong->GetAmount());
                 }
             }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Modify absorb amount in Sacred Shield script, should be modified by Strength of Wrynn / Hellscream's Warsong (ICC buff)

Patch Notes 3.3.3:
```
Hellscream's Warsong and Strength of Wrynn now provide their bonuses to player pet health and damage, as well as the absorption amounts of Power Word: Shield and Sacred Shield.
```
https://wowwiki.fandom.com/wiki/Strength_of_Wrynn
https://wow.gamepedia.com/Hellscream%27s_Warsong
https://www.mmo-champion.com/threads/701956-Patch-3-3-3-PTR-Notes-Update-Blue-posts
https://www.wowhead.com/patchnotes=3.3.3

Seems PW:Shield and Sacred Shield should be modified by ICC buff, I can't find any info about another spell with absorb effect that should be modified by ICC buff, so I decide do this PR like @Keader suggestion for PW:shield (https://github.com/TrinityCore/TrinityCore/pull/23985#issuecomment-569548802)

in case nobody find info about another spell, maybe the (3) point of this issue can be updated: https://github.com/TrinityCore/TrinityCore/issues/21415

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
