### PR TITLE
Core/PathGenerator: Fix path generator returning shortcuts when start and end are on the same polygon

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -245,19 +245,14 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
     // *** poly path generating logic ***
 
     // start and end are on same polygon
-    // just need to move in straight line
+    // handle this case like if they were 2 different polygons, building a line path split in few points
     if (startPoly == endPoly)
     {
         TC_LOG_DEBUG("maps.mmaps", "++ BuildPolyPath :: (startPoly == endPoly)");
 
-        BuildShortcut();
-
         _pathPolyRefs[0] = startPoly;
-        _polyLength = 1;
-
-        _type = farFromPoly ? PATHFIND_INCOMPLETE : PATHFIND_NORMAL;
-        TC_LOG_DEBUG("maps.mmaps", "++ BuildPolyPath :: path type %d", _type);
-        return;
+        _pathPolyRefs[1] = endPoly;
+        _polyLength = 2;
     }
 
     // look for startPoly/endPoly in current path

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -245,7 +245,7 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
     // *** poly path generating logic ***
 
     // start and end are on same polygon
-    // handle this case like if they were 2 different polygons, building a line path split in few points
+    // handle this case as if they were 2 different polygons, building a line path split in some few points
     if (startPoly == endPoly)
     {
         TC_LOG_DEBUG("maps.mmaps", "++ BuildPolyPath :: (startPoly == endPoly)");

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5509,7 +5509,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                     // first try with raycast, if it fails fall back to normal path
                     bool result = m_preGeneratedPath->CalculatePath(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), false, false);
                     if (m_preGeneratedPath->GetPathType() & PATHFIND_SHORT)
-                        return SPELL_FAILED_OUT_OF_RANGE;
+                        return SPELL_FAILED_NOPATH;
                     else if (!result || m_preGeneratedPath->GetPathType() & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE))
                         return SPELL_FAILED_NOPATH;
                     else if (m_preGeneratedPath->IsInvalidDestinationZ(target)) // Check position z, if not in a straight line

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -877,16 +877,8 @@ namespace MMAP
             return static_cast<uint32>(m_mapid) != mapID;
 
         if (m_skipContinents)
-            switch (mapID)
-            {
-                case 0:
-                case 1:
-                case 530:
-                case 571:
-                    return true;
-                default:
-                    break;
-            }
+            if (isContinentMap(mapID))
+                return true;
 
         if (m_skipJunkMaps)
             switch (mapID)
@@ -966,6 +958,20 @@ namespace MMAP
         }
     }
 
+    bool MapBuilder::isContinentMap(uint32 mapID)
+    {
+        switch (mapID)
+        {
+            case 0:
+            case 1:
+            case 530:
+            case 571:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     /**************************************************************************/
     bool MapBuilder::shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY)
     {
@@ -1015,6 +1021,12 @@ namespace MMAP
         config.maxSimplificationError = 1.8f;           // eliminates most jagged edges (tiny polygons)
         config.detailSampleDist = config.cs * 16;
         config.detailSampleMaxError = config.ch * 1;
+
+        if (isContinentMap(mapID))
+        {
+            config.walkableSlopeAngle = 55.f;
+            config.walkableClimb = m_bigBaseUnit ? 2 : 4;
+        }
 
         switch (mapID)
         {

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -1024,7 +1024,6 @@ namespace MMAP
 
         if (isContinentMap(mapID))
         {
-            config.walkableSlopeAngle = 55.f;
             config.walkableClimb = m_bigBaseUnit ? 2 : 4;
         }
 

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -1022,11 +1022,6 @@ namespace MMAP
         config.detailSampleDist = config.cs * 16;
         config.detailSampleMaxError = config.ch * 1;
 
-        if (isContinentMap(mapID))
-        {
-            config.walkableClimb = m_bigBaseUnit ? 2 : 4;
-        }
-
         switch (mapID)
         {
             // Blade's Edge Arena

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -143,6 +143,7 @@ namespace MMAP
 
             bool shouldSkipMap(uint32 mapID);
             bool isTransportMap(uint32 mapID);
+            bool isContinentMap(uint32 mapID);
             bool shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY);
 
             rcConfig GetMapSpecificConfig(uint32 mapID, float bmin[3], float bmax[3], const TileConfig &tileConfig);


### PR DESCRIPTION

**Changes proposed:**

-  Fix path generator returning shortcuts when start and end are on the same polygon by handling this case as if start and end were on 2 different polygons. This will ensure BuildPointPath() gets called which calls FindSmoothPath(), making sure each step is not longer than SMOOTH_PATH_STEP_SIZE (4 yards)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes the issue reported at https://github.com/TrinityCore/TrinityCore/commit/88a14251e2765880e90cb41be7919cd39e3308e2#commitcomment-36645636


**Tests performed:** (Does it build, tested in-game, etc.)
Checked the locations reported at https://github.com/TrinityCore/TrinityCore/commit/88a14251e2765880e90cb41be7919cd39e3308e2#commitcomment-36645636

**Known issues and TODO list:** (add/remove lines as needed)

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
