### PR TITLE
Core/DynamicObjects: Restore the ability of DynamicObjects to be world objects

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -336,7 +336,10 @@ template<>
 void Map::AddToGrid(DynamicObject* obj, Cell const& cell)
 {
     NGridType* grid = getNGrid(cell.GridX(), cell.GridY());
-    grid->GetGridType(cell.CellX(), cell.CellY()).AddGridObject(obj);
+    if (obj->IsWorldObject())
+        grid->GetGridType(cell.CellX(), cell.CellY()).AddWorldObject(obj);
+    else
+        grid->GetGridType(cell.CellX(), cell.CellY()).AddGridObject(obj);
 
     obj->SetCurrentCell(cell);
 }


### PR DESCRIPTION
… which was accidentally removed in f0f4a620fbeef9cc450d1294c1964fe98e45645d breaking Far Sight

**Changes proposed:**

-  Restore the code that allowed DynamicObjects to be added to world objects container, which is a necessity for them to be included in packet broadcast recipients. Before the aforementioned commit this was working as expected because `Map::AddToGrid` for DynamicObjects was using the generic template of the method which already implements this behavior.

**Target branch(es):**

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #17081


**Tests performed:** [Tested to be working](https://github.com/TrinityCore/TrinityCore/issues/17081#issuecomment-573047250) by @Keader at whose request this PR is made.

Albeit not tested, the code that creates this issue exists in master branch as well, so it makes sense to apply the fix there as well.
