### PR TITLE
Scripts/Spells: fix Turkey Timer duration

### DIFF
--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -3463,7 +3463,7 @@ class spell_gen_turkey_marker : public AuraScript
 
     void OnPeriodic(AuraEffect const* /*aurEff*/)
     {
-        int removeCount = 0;
+        int32 removeCount = 0;
 
         // pop expired times off of the stack
         while(!_applyTimes.empty() && _applyTimes.front() + GetMaxDuration() < GameTime::GetGameTimeMS())

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -3466,13 +3466,13 @@ class spell_gen_turkey_marker : public AuraScript
         int32 removeCount = 0;
 
         // pop expired times off of the stack
-        while(!_applyTimes.empty() && _applyTimes.front() + GetMaxDuration() < GameTime::GetGameTimeMS())
+        while (!_applyTimes.empty() && _applyTimes.front() + GetMaxDuration() < GameTime::GetGameTimeMS())
         {
             _applyTimes.pop_front();
             removeCount++;
         }
 
-        if(removeCount){
+        if (removeCount){
             ModStackAmount(-removeCount, AURA_REMOVE_BY_EXPIRE);
         }
     }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -3463,12 +3463,18 @@ class spell_gen_turkey_marker : public AuraScript
 
     void OnPeriodic(AuraEffect const* /*aurEff*/)
     {
-        if (_applyTimes.empty())
-            return;
+        int removeCount = 0;
 
-        // pop stack if it expired for us
-        if (_applyTimes.front() + GetMaxDuration() < GameTime::GetGameTimeMS())
-            ModStackAmount(-1, AURA_REMOVE_BY_EXPIRE);
+        // pop expired times off of the stack
+        while(!_applyTimes.empty() && _applyTimes.front() + GetMaxDuration() < GameTime::GetGameTimeMS())
+        {
+            _applyTimes.pop_front();
+            removeCount++;
+        }
+
+        if(removeCount){
+            ModStackAmount(-removeCount, AURA_REMOVE_BY_EXPIRE);
+        }
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -3472,9 +3472,8 @@ class spell_gen_turkey_marker : public AuraScript
             removeCount++;
         }
 
-        if (removeCount){
+        if (removeCount)
             ModStackAmount(-removeCount, AURA_REMOVE_BY_EXPIRE);
-        }
     }
 
     void Register() override


### PR DESCRIPTION
**Changes proposed:**

-  In `spell_gen_turkey_marker::OnPeriodic`, remove tracking timestamps from list as they expire. This prevents older applications from taking all stacks of the aura with them.

**Target branch(es):** 3.3.5

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #23387

**Tests performed:**

Builds successfully, Fedora 30.

Testing in-game:

1. Spawn as many turkeys as you need: `.npc add temp 24746`
2. Confirm that GM mode is off.
3. Kill 3 turkeys, start timer. Observe stack count, should be 3.
4. At 1:30, kill 7 more turkeys. Observe stack count, should be 10.
5. Wait until 3:00. Observe stack count, should fall to 7 and stay there.
6. Before 4:30, kill 7 more turkeys. Observe stack count, should be 14.
7. Kill 1 more turkey. This brings you to 15, spawning angry turkeys and granting the achievement.
