### PR TITLE
Core/Players: properly re-use skills when re-learning a skill

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5638,7 +5638,7 @@ void Player::SetSkill(uint16 id, uint16 step, uint16 newVal, uint16 maxVal)
                 SetUpdateFieldValue(m_values.ModifyValue(&Player::m_activePlayerData).ModifyValue(&UF::ActivePlayerData::ProfessionSkillLine, 1), 0);
         }
     }
-    else if (itr != mSkillStatus.end())                 //add
+    else                            //add
     {
         // Check if the player already has a skill, otherwise pick a empty skill slot if available
         uint8 skillSlot = itr != mSkillStatus.end() ? itr->second.pos : 0;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5707,8 +5707,8 @@ void Player::SetSkill(uint16 id, uint16 step, uint16 newVal, uint16 maxVal)
         SetSkillMaxRank(skillSlot, maxVal);
 
         // apply skill bonuses
-        SetSkillTempBonus(itr->second.pos, 0);
-        SetSkillPermBonus(itr->second.pos, 0);
+        SetSkillTempBonus(skillSlot, 0);
+        SetSkillPermBonus(skillSlot, 0);
 
         UpdateSkillEnchantments(id, 0, newVal);
 


### PR DESCRIPTION
**Changes proposed:**
cleaned up redundant code that was still using the old logic of expecting unused skill fields but since the update field rework a player already has set all skills that are available to him. This change is going to properly re-use them so we no longer store skills in new slots.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame on my 434 portover
