### PR TITLE
Fixed PvP Combat timer never getting refreshed

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8146,9 +8146,14 @@ void Unit::EngageWithTarget(Unit* enemy)
         return;
 
     if (CanHaveThreatList())
-        m_threatManager.AddThreat(enemy, 0.0f, nullptr, true, true);
+    {
+        if (!IsEngagedBy(enemy))
+            GetThreatManager().AddThreat(enemy, 0.0f, nullptr, true, true);
+    }
     else
+    {
         SetInCombatWith(enemy);
+    }
 }
 
 void Unit::SetImmuneToAll(bool apply, bool keepCombat)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8142,18 +8142,10 @@ void Unit::EngageWithTarget(Unit* enemy)
     if (!enemy)
         return;
 
-    if (IsEngagedBy(enemy))
-        return;
-
     if (CanHaveThreatList())
-    {
-        if (!IsEngagedBy(enemy))
-            GetThreatManager().AddThreat(enemy, 0.0f, nullptr, true, true);
-    }
+        m_threatManager.AddThreat(enemy, 0.0f, nullptr, true, true);
     else
-    {
         SetInCombatWith(enemy);
-    }
 }
 
 void Unit::SetImmuneToAll(bool apply, bool keepCombat)


### PR DESCRIPTION
**Changes proposed:**

-  Small tweak to allow combat timer to be refreshed in PvP.  

**Target branch(es):**

- [x] 3.3.5

**Issues addressed:** 
Closes #22851

**Tests performed:** (Does it build, tested in-game, etc.)
Code running on sunstrider core for about a year. (sunstrider being basically TC for TBC at this point).

**Known issues and TODO list:** 

/