### PR TITLE
Core/Spells: Pets need reset cooldown when summoned

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2889,8 +2889,8 @@ void Spell::EffectSummonPet(SpellEffIndex effIndex)
             if (OldSummon->getPetType() == SUMMON_PET)
             {
                 OldSummon->SetHealth(OldSummon->GetMaxHealth());
-                OldSummon->SetPower(OldSummon->GetPowerType(),
-                    OldSummon->GetMaxPower(OldSummon->GetPowerType()));
+                OldSummon->SetPower(OldSummon->GetPowerType(), OldSummon->GetMaxPower(OldSummon->GetPowerType()));
+                OldSummon->GetSpellHistory()->ResetAllCooldowns();
             }
 
             if (owner->GetTypeId() == TYPEID_PLAYER && OldSummon->isControlled())


### PR DESCRIPTION
**Changes proposed:**

-  It was discussed in https://github.com/TrinityCore/TrinityCore/pull/16551#issuecomment-220298203 and https://github.com/TrinityCore/TrinityCore/issues/4005, closed because "was not blizzlike".
-  But looks like it's blizzlike. As you can see [here](https://www.youtube.com/watch?v=szuiKxOEBJQ&feature=youtu.be&t=67) and [here](https://www.youtube.com/watch?v=szuiKxOEBJQ&feature=youtu.be&t=315).
Video was posted on youtube in 2016, but they're recorded in 2010, in Blizzards realms.
Original video was posted in warcraftmovies by [this](https://www.warcraftmovies.com/pv.php?l=glick5312) guy.
Check in part 1: warlock uses devour magic in rogue and resummon pet to try dispel again.
Check in part 2: Pet is dead with Spell Lock cooldown running. Warlock resummon pet and Spell lock get reset.

**Target branch(es):** 3.3.5

**Issues addressed:** Updates https://github.com/TrinityCore/TrinityCore/issues/4005


**Tests performed:** Builded and tested in game
