### PR TITLE
Core/Movement: properly fix aura interrupts during movement

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -379,7 +379,6 @@ Unit::Unit(bool isWorldObject) :
     _oldFactionId = 0;
     _isWalkingBeforeCharm = false;
     _instantCast = false;
-	_positionUpdateInfo = PositionUpdateInfo();
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -379,6 +379,7 @@ Unit::Unit(bool isWorldObject) :
     _oldFactionId = 0;
     _isWalkingBeforeCharm = false;
     _instantCast = false;
+	_positionUpdateInfo = PositionUpdateInfo();
 }
 
 ////////////////////////////////////////////////////////////
@@ -526,10 +527,10 @@ void Unit::UpdateSplinePosition()
 void Unit::InterruptMovementBasedAuras()
 {
     // TODO: Check if orientation transport offset changed instead of only global orientation
-    if (m_positionUpdateInfo.Turned)
+    if (_positionUpdateInfo.Turned)
         RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TURNING);
 
-    if (m_positionUpdateInfo.Relocated && !GetVehicle())
+    if (_positionUpdateInfo.Relocated && !GetVehicle())
         RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_MOVE);
 }
 
@@ -12749,8 +12750,8 @@ bool Unit::UpdatePosition(float x, float y, float z, float orientation, bool tel
 
     UpdatePositionData();
 
-    m_positionUpdateInfo.Relocated = relocated;
-    m_positionUpdateInfo.Turned = turn;
+    _positionUpdateInfo.Relocated = relocated;
+    _positionUpdateInfo.Turned = turn;
 
     return (relocated || turn);
 }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -456,7 +456,9 @@ void Unit::Update(uint32 p_time)
     i_motionMaster->Update(p_time);
 
     // Wait with the aura interrupts until we have updated our movement generators and position
-    if (!movespline->Finalized() || isMoving() || isTurning())
+    if (GetTypeId() == TYPEID_PLAYER)
+        InterruptMovementBasedAuras();
+    else if (!movespline->Finalized())
         InterruptMovementBasedAuras();
 
     if (!GetAI() && (GetTypeId() != TYPEID_PLAYER || (IsCharmed() && GetCharmerGUID().IsCreature())))

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -714,6 +714,14 @@ enum ReactiveType
     MAX_REACTIVE
 };
 
+struct PositionUpdateInfo
+{
+    PositionUpdateInfo() : Relocated(false), Turned(false) { }
+
+    bool Relocated;
+    bool Turned;
+};
+
 // delay time next attack to prevent client attack animation problems
 #define ATTACK_DISPLAY_DELAY 200
 #define MAX_PLAYER_STEALTH_DETECT_RANGE 30.0f               // max distance for detection targets by player
@@ -1762,14 +1770,7 @@ class TC_GAME_API Unit : public WorldObject
 
         void UpdateSplineMovement(uint32 t_diff);
         void UpdateSplinePosition();
-
         void InterruptMovementBasedAuras();
-
-        struct
-        {
-            bool Relocated = false;
-            bool Turned = false;
-        } m_positionUpdateInfo;
 
         // player or player's pet
         float GetCombatRatingReduction(CombatRating cr) const;
@@ -1817,6 +1818,7 @@ class TC_GAME_API Unit : public WorldObject
         bool _isWalkingBeforeCharm;     ///< Are we walking before we were charmed?
 
         SpellHistory* m_spellHistory;
+		PositionUpdateInfo _positionUpdateInfo;
 };
 
 namespace Trinity

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1763,6 +1763,14 @@ class TC_GAME_API Unit : public WorldObject
         void UpdateSplineMovement(uint32 t_diff);
         void UpdateSplinePosition();
 
+         void InterruptMovementBasedAuras();
+
+        struct
+        {
+            bool Relocated = false;
+            bool Turned = false;
+        } m_positionUpdateInfo;
+
         // player or player's pet
         float GetCombatRatingReduction(CombatRating cr) const;
         uint32 GetCombatRatingDamageReduction(CombatRating cr, float rate, float cap, uint32 damage) const;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1763,7 +1763,7 @@ class TC_GAME_API Unit : public WorldObject
         void UpdateSplineMovement(uint32 t_diff);
         void UpdateSplinePosition();
 
-         void InterruptMovementBasedAuras();
+        void InterruptMovementBasedAuras();
 
         struct
         {

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -716,10 +716,8 @@ enum ReactiveType
 
 struct PositionUpdateInfo
 {
-    PositionUpdateInfo() : Relocated(false), Turned(false) { }
-
-    bool Relocated;
-    bool Turned;
+    bool Relocated = false;
+    bool Turned = false;
 };
 
 // delay time next attack to prevent client attack animation problems
@@ -1818,7 +1816,7 @@ class TC_GAME_API Unit : public WorldObject
         bool _isWalkingBeforeCharm;     ///< Are we walking before we were charmed?
 
         SpellHistory* m_spellHistory;
-		PositionUpdateInfo _positionUpdateInfo;
+        PositionUpdateInfo _positionUpdateInfo;
 };
 
 namespace Trinity


### PR DESCRIPTION
**Changes proposed:**
The current movement update logic is interrupting auras before movement generators had their turn with updating their movement state. This was leading to the edge case issue that auras that should get interrupted by movement were falsely removed because the unit was still considered as moving while it might have stopped in the same update tick.

The most prominent case is the interrupting of instant cast channeled spells during chase movement.

We now wait until the movement generators had their shot to update their movement so the nasty dictatorship of UpdatePosition comes to an end.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
fixes #22908 properly this time

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame on my 434 branch. Should be the same result on 335

