### PR TITLE
Core/PathGenerator: Fix path generator returning shortcuts when start and end are on the same polygon

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -107,7 +107,9 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* owner, uint32 diff)
         }
 
         bool result = _path->CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-        if (!result || (_path->GetPathType() & PATHFIND_NOPATH) || (_path->GetPathType() & PATHFIND_SHORTCUT))
+        if (!result || (_path->GetPathType() & PATHFIND_NOPATH)
+                    || (_path->GetPathType() & PATHFIND_SHORTCUT)
+                    || (_path->GetPathType() & PATHFIND_FARFROMPOLY))
         {
             _timer.Reset(100);
             return true;

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -164,7 +164,9 @@ void FleeingMovementGenerator<T>::SetTargetLocation(T* owner)
     }
 
     bool result = _path->CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-    if (!result || (_path->GetPathType() & PATHFIND_NOPATH) || (_path->GetPathType() & PATHFIND_SHORTCUT))
+    if (!result || (_path->GetPathType() & PATHFIND_NOPATH)
+                || (_path->GetPathType() & PATHFIND_SHORTCUT)
+                || (_path->GetPathType() & PATHFIND_FARFROMPOLY))
     {
         _timer.Reset(100);
         return;

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -140,7 +140,9 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     }
 
     bool result = _path->CalculatePath(position.GetPositionX(), position.GetPositionY(), position.GetPositionZ());
-    if (!result || (_path->GetPathType() & PATHFIND_NOPATH) || (_path->GetPathType() & PATHFIND_SHORTCUT))
+    if (!result || (_path->GetPathType() & PATHFIND_NOPATH)
+                || (_path->GetPathType() & PATHFIND_SHORTCUT)
+                || (_path->GetPathType() & PATHFIND_FARFROMPOLY))
     {
         _timer.Reset(100);
         return;

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -249,14 +249,12 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
     if (startPoly == endPoly)
     {
         TC_LOG_DEBUG("maps.mmaps", "++ BuildPolyPath :: (startPoly == endPoly)");
-
-        BuildShortcut();
-
         _pathPolyRefs[0] = startPoly;
         _polyLength = 1;
 
         _type = farFromPoly ? PATHFIND_INCOMPLETE : PATHFIND_NORMAL;
-        TC_LOG_DEBUG("maps.mmaps", "++ BuildPolyPath :: path type %d", _type);
+
+        BuildPointPath(startPoint, endPoint);
         return;
     }
 
@@ -772,11 +770,22 @@ dtStatus PathGenerator::FindSmoothPath(float const* startPos, float const* endPo
     uint32 npolys = polyPathSize;
 
     float iterPos[VERTEX_SIZE], targetPos[VERTEX_SIZE];
-    if (dtStatusFailed(_navMeshQuery->closestPointOnPolyBoundary(polys[0], startPos, iterPos)))
-        return DT_FAILURE;
 
-    if (dtStatusFailed(_navMeshQuery->closestPointOnPolyBoundary(polys[npolys-1], endPos, targetPos)))
-        return DT_FAILURE;
+    if (polyPathSize > 1)
+    {
+        // Pick the closest poitns on poly border
+        if (dtStatusFailed(_navMeshQuery->closestPointOnPolyBoundary(polys[0], startPos, iterPos)))
+            return DT_FAILURE;
+
+        if (dtStatusFailed(_navMeshQuery->closestPointOnPolyBoundary(polys[npolys - 1], endPos, targetPos)))
+            return DT_FAILURE;
+    }
+    else
+    {
+        // Case where the path is on the same poly
+        dtVcopy(iterPos, startPos);
+        dtVcopy(targetPos, endPos);
+    }
 
     dtVcopy(&smoothPath[nsmoothPath*VERTEX_SIZE], iterPos);
     nsmoothPath++;

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -465,6 +465,9 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
     else
         _type = PATHFIND_INCOMPLETE;
 
+    if (farFromPoly)
+        _type = PathType(_type | PATHFIND_FARFROMPOLY);
+
     // generate the point-path out of our up-to-date poly-path
     BuildPointPath(startPoint, endPoint);
 }

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -225,7 +225,7 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
         if (buildShotrcut)
         {
             BuildShortcut();
-            _type = PathType(PATHFIND_NORMAL | PATHFIND_NOT_USING_PATH);
+            _type = PathType(PATHFIND_NORMAL | PATHFIND_NOT_USING_PATH | PATHFIND_FARFROMPOLY);
             return;
         }
         else
@@ -238,7 +238,7 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
                 SetActualEndPosition(G3D::Vector3(endPoint[2], endPoint[0], endPoint[1]));
             }
 
-            _type = PATHFIND_INCOMPLETE;
+            _type = PathType(PATHFIND_INCOMPLETE | PATHFIND_FARFROMPOLY);
         }
     }
 
@@ -252,7 +252,7 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
         _pathPolyRefs[0] = startPoly;
         _polyLength = 1;
 
-        _type = farFromPoly ? PATHFIND_INCOMPLETE : PATHFIND_NORMAL;
+        _type = farFromPoly ? PathType(PATHFIND_INCOMPLETE | PATHFIND_FARFROMPOLY) : PATHFIND_NORMAL;
 
         BuildPointPath(startPoint, endPoint);
         return;

--- a/src/server/game/Movement/PathGenerator.h
+++ b/src/server/game/Movement/PathGenerator.h
@@ -47,6 +47,7 @@ enum PathType
     PATHFIND_NOPATH         = 0x08,   // no valid path at all or error in generating one
     PATHFIND_NOT_USING_PATH = 0x10,   // used when we are either flying/swiming or on map w/o mmaps
     PATHFIND_SHORT          = 0x20,   // path is longer or equal to its limited path length
+    PATHFIND_FARFROMPOLY    = 0x40,   // start of end positions are far from the mmap poligon
 };
 
 class TC_GAME_API PathGenerator


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Second try of handling paths on same poly in a better way than just building a shortcut.
- Skip looking for closest point on polygon boundary when path is on same poly
- Add a new status PATHFIND_FARFROMPOLY for callers to decide what to do if the start or end positions are far from mmap polygon, i.e. player on unwalkable mesh reached with flying mount
- Skip paths that have PATHFIND_FARFROMPOLY in ConfusedMovementGenerator<T>, FleeingMovementGenerator<T> and RandomMovementGenerator<Creature> . The movement generator will have to either try again to look for another path if end position is far from the polygon, otherwise the Unit will not move at all and just stand still if start position is far from the polygon. This fixes Players falling under meshes when being on unwalkable meshes, i.e. pillars in Blade's Edge Arena in Outland map (not the actual Arena map).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
- [x] Charge from .go xyz -3268.020752 -2486.342529 20.014091 0 to .go xyz -3282.670654 -2478.257324 24.3308734 0
- [x] .go xyz 1291.276733, -4012.389648, 50.746246 1 and .aura 52061 you will go through the map
- [x]  .go xyz 1362.246704, -4174.677246, 95.796837 1 and .aura 52061 you will go through the map
- [x] .go xyz 2849.104004, 5943.180176, 11.228345 530 and .aura 52061 you will go through the map

**Known issues and TODO list:** (add/remove lines as needed)



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
