### PR TITLE
Core/Movement: improved random movement pause handling to get closer to retail behaivior

### DIFF
--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -171,7 +171,7 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     init.SetWalk(walk);
     int32 splineDuration = init.Launch();
 
-    _wanderSteps--;
+    --_wanderSteps;
     if (_wanderSteps) // Creature has yet to do steps before pausing
         _timer.Reset(splineDuration);
     else

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -25,7 +25,7 @@
 #include "Random.h"
 
 template<class T>
-RandomMovementGenerator<T>::RandomMovementGenerator(float distance) : _timer(0), _reference(), _wanderDistance(distance)
+RandomMovementGenerator<T>::RandomMovementGenerator(float distance) : _timer(0), _reference(), _wanderDistance(distance), _wanderSteps(0)
 {
     this->Mode = MOTION_MODE_DEFAULT;
     this->Priority = MOTION_PRIORITY_NORMAL;
@@ -83,8 +83,11 @@ void RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
     _reference = owner->GetPosition();
     owner->StopMoving();
 
-    if (!_wanderDistance)
+    if (_wanderDistance == 0.f)
         _wanderDistance = owner->GetRespawnRadius();
+
+    // Retail seems to let a creature walk 2 up to 10 splines before triggering a pause
+    _wanderSteps = urand(2, 10);
 
     _timer.Reset(0);
     _path = nullptr;
@@ -119,8 +122,8 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     }
 
     Position position(_reference);
-    float distance = frand(0.f, 1.f) * _wanderDistance;
-    float angle = frand(0.f, 1.f) * float(M_PI) * 2.f;
+    float distance = frand(0.f, _wanderDistance);
+    float angle = frand(0.f, float(M_PI * 2));
     owner->MovePositionToFirstCollision(position, distance, angle);
 
     // Check if the destination is in LOS
@@ -130,8 +133,6 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
         _timer.Reset(200);
         return;
     }
-
-    uint32 resetTimer = roll_chance_i(50) ? urand(5000, 10000) : urand(1000, 2000);
 
     if (!_path)
     {
@@ -168,8 +169,17 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     Movement::MoveSplineInit init(owner);
     init.MovebyPath(_path->GetPath());
     init.SetWalk(walk);
-    time_t traveltime = init.Launch();
-    _timer.Reset(traveltime + resetTimer);
+    int32 splineDuration = init.Launch();
+
+    _wanderSteps--;
+    if (_wanderSteps) // Creature has yet to do steps before pausing
+        _timer.Reset(splineDuration);
+    else
+    {
+        // Creature has made all its steps, time for a little break
+        _timer.Reset(splineDuration + urand(4, 10) * IN_MILLISECONDS); // Retails seems to use rounded numbers so we do as well
+        _wanderSteps = urand(2, 10);
+    }
 
     // Call for creature group update
     owner->SignalFormationMovement(position);

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.h
@@ -50,6 +50,7 @@ class RandomMovementGenerator : public MovementGeneratorMedium<T, RandomMovement
         TimeTracker _timer;
         Position _reference;
         float _wanderDistance;
+        uint8 _wanderSteps;
 };
 
 #endif


### PR DESCRIPTION
**Changes proposed:**
-  tweaked the pause handling for random movements to get closer to retail behaivior. Instead of going with a plain 50% chance of triggering a waiting moment we will now pre-determine a number of splines that must be launched before a pause time window kicks in. While at it I also corrected the pause timer.
By the looks of it I would say I have pretty much nailed it so yeah. 110% blizzlike.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame on my 434 fork and of course compared it against retail
