### PR TITLE
Core/Vehicles: implement vehicle seat addon table to specify seat ori…

### DIFF
--- a/sql/updates/world/3.3.5/2020_02_08_01_world.sql
+++ b/sql/updates/world/3.3.5/2020_02_08_01_world.sql
@@ -1,3 +1,4 @@
+--
 DROP TABLE IF EXISTS `vehicle_seat_addon`;
 CREATE TABLE `vehicle_seat_addon` (  
   `SeatEntry` INT(4) UNSIGNED NOT NULL COMMENT 'VehicleSeatEntry.dbc identifier',

--- a/sql/updates/world/3.3.5/2020_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/2020_99_99_99_world.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS `vehicle_seat_addon`;
+CREATE TABLE `vehicle_seat_addon` (  
+  `SeatEntry` INT(4) UNSIGNED NOT NULL COMMENT 'VehicleSeatEntry.dbc identifier',
+  `SeatOrientation` FLOAT(6) DEFAULT 0 COMMENT 'Seat Orientation override value',
+  `ExitParamX` FLOAT(10) DEFAULT 0,
+  `ExitParamY` FLOAT(10) DEFAULT 0,
+  `ExitParamZ` FLOAT(10) DEFAULT 0,
+  `ExitParamO` FLOAT(10) DEFAULT 0,
+  `ExitParamValue` TINYINT(1) DEFAULT 0,
+  PRIMARY KEY (`SeatEntry`)
+);
+
+INSERT INTO `vehicle_seat_addon` (`SeatEntry`, `SeatOrientation`, `ExitParamX`, `ExitParamY`, `ExitParamZ`, `ExitParamO`, `ExitParamValue`) VALUES
+(2764, 0, -2, 2, 0, 0, 1), -- Traveler's Tundra Mammoth Seat 2
+(2765, 0, -2, -2, 0, 0, 1), -- Traveler's Tundra Mammoth Seat 3
+(2767, 0, -2, 2, 0, 0, 1), -- Traveler's Tundra Mammoth Seat 2
+(2768, 0, -2, -2, 0, 0, 1); -- Traveler's Tundra Mammoth Seat 3

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12545,6 +12545,7 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         return;
 
     // This should be done before dismiss, because there may be some aura removal
+    VehicleSeatAddon const seatAddon = m_vehicle->GetSeatAddonForSeatOfPassenger(this);
     Vehicle* vehicle = m_vehicle->RemovePassenger(this);
 
     Player* player = ToPlayer();
@@ -12575,7 +12576,15 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         // Set exit position to vehicle position and use the current orientation
         pos = vehicle->GetBase()->GetPosition();
         pos.SetOrientation(GetOrientation());
+
+        // To-do: snap this hook out of existance
         sScriptMgr->ModifyVehiclePassengerExitPos(this, vehicle, pos);
+
+        // Change exit position based on seat entry addon data
+        if (seatAddon.ExitParameter == VehicleExitParameters::VehicleExitParamOffset)
+            pos.RelocateOffset({ seatAddon.ExitParameterX, seatAddon.ExitParameterY, seatAddon.ExitParameterZ, seatAddon.ExitParameterO });
+        else if (seatAddon.ExitParameter == VehicleExitParameters::VehicleExitParamDest)
+            pos.Relocate({ seatAddon.ExitParameterX, seatAddon.ExitParameterY, seatAddon.ExitParameterZ, seatAddon.ExitParameterO });
     }
 
     float height = pos.GetPositionZ() + vehicle->GetBase()->GetCollisionHeight();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12545,7 +12545,7 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         return;
 
     // This should be done before dismiss, because there may be some aura removal
-    VehicleSeatAddon const seatAddon = m_vehicle->GetSeatAddonForSeatOfPassenger(this);
+    VehicleSeatAddon const* seatAddon = m_vehicle->GetSeatAddonForSeatOfPassenger(this);
     Vehicle* vehicle = m_vehicle->RemovePassenger(this);
 
     Player* player = ToPlayer();
@@ -12581,10 +12581,13 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         sScriptMgr->ModifyVehiclePassengerExitPos(this, vehicle, pos);
 
         // Change exit position based on seat entry addon data
-        if (seatAddon.ExitParameter == VehicleExitParameters::VehicleExitParamOffset)
-            pos.RelocateOffset({ seatAddon.ExitParameterX, seatAddon.ExitParameterY, seatAddon.ExitParameterZ, seatAddon.ExitParameterO });
-        else if (seatAddon.ExitParameter == VehicleExitParameters::VehicleExitParamDest)
-            pos.Relocate({ seatAddon.ExitParameterX, seatAddon.ExitParameterY, seatAddon.ExitParameterZ, seatAddon.ExitParameterO });
+        if (seatAddon)
+        {
+            if (seatAddon->ExitParameter == VehicleExitParameters::VehicleExitParamOffset)
+                pos.RelocateOffset({ seatAddon->ExitParameterX, seatAddon->ExitParameterY, seatAddon->ExitParameterZ, seatAddon->ExitParameterO });
+            else if (seatAddon->ExitParameter == VehicleExitParameters::VehicleExitParamDest)
+                pos.Relocate({ seatAddon->ExitParameterX, seatAddon->ExitParameterY, seatAddon->ExitParameterZ, seatAddon->ExitParameterO });
+        }
     }
 
     float height = pos.GetPositionZ() + vehicle->GetBase()->GetCollisionHeight();

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -854,8 +854,13 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
         Passenger->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
 
 
+    float o = veSeatAddon.SeatOrientationOffset;
+    float x = veSeat->AttachmentOffset.X;
+    float y = veSeat->AttachmentOffset.Y;
+    float z = veSeat->AttachmentOffset.Z;
+
     Passenger->AddUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
-    Passenger->m_movementInfo.transport.pos.Relocate(veSeat->m_attachmentOffsetX, veSeat->m_attachmentOffsetY, veSeat->m_attachmentOffsetZ, veSeatAddon.SeatOrientationOffset);
+    Passenger->m_movementInfo.transport.pos.Relocate(x, y, z, o);
     Passenger->m_movementInfo.transport.time = 0;
     Passenger->m_movementInfo.transport.seat = Seat->first;
     Passenger->m_movementInfo.transport.guid = Target->GetBase()->GetGUID();
@@ -878,8 +883,8 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
 
     Movement::MoveSplineInit init(Passenger);
     init.DisableTransportPathTransformations();
-    init.MoveTo(veSeat->m_attachmentOffsetX, veSeat->m_attachmentOffsetY, veSeat->m_attachmentOffsetZ, false, true);
-    init.SetFacing(0.0f);
+    init.MoveTo(x, y, z, false, true);
+    init.SetFacing(o);
     init.SetTransportEnter();
     Passenger->GetMotionMaster()->LaunchMoveSpline(std::move(init), EVENT_VEHICLE_BOARD, MOTION_PRIORITY_HIGHEST);
 

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -41,7 +41,8 @@ UsableSeatNum(0), _me(unit), _vehicleInfo(vehInfo), _creatureEntry(creatureEntry
         if (uint32 seatId = _vehicleInfo->m_seatID[i])
             if (VehicleSeatEntry const* veSeat = sVehicleSeatStore.LookupEntry(seatId))
             {
-                Seats.insert(std::make_pair(i, VehicleSeat(veSeat)));
+                VehicleSeatAddon addon = sObjectMgr->GetVehicleSeatAddon(seatId);
+                Seats.insert(std::make_pair(i, VehicleSeat(veSeat, addon)));
                 if (veSeat->CanEnterOrExit())
                     ++UsableSeatNum;
             }
@@ -343,6 +344,30 @@ SeatMap::const_iterator Vehicle::GetNextEmptySeat(int8 seatId, bool next) const
     }
 
     return seat;
+}
+
+/**
+ * @fn VehicleSeatAddon const Vehicle::GetSeatAddonForSeatOfPassenger(Unit const* passenger) const
+ *
+ * @brief Gets the vehicle seat addon data for the seat of a passenger
+ *
+ * @author Ovahlord
+ * @date 28-1-2020
+ *
+ * @param passenger Identifier for the current seat user
+ *
+ * @return The seat addon data for the currently used seat of a passenger
+ */
+
+VehicleSeatAddon const Vehicle::GetSeatAddonForSeatOfPassenger(Unit const* passenger) const
+{
+    for (SeatMap::const_iterator itr = Seats.begin(); itr != Seats.end(); itr++)
+    {
+        if (!itr->second.IsEmpty() && itr->second.Passenger.Guid == passenger->GetGUID())
+            return itr->second.SeatAddon;
+    }
+
+    return VehicleSeatAddon();
 }
 
 /**
@@ -809,6 +834,7 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
     Passenger->RemoveAurasByType(SPELL_AURA_MOUNTED);
 
     VehicleSeatEntry const* veSeat = Seat->second.SeatInfo;
+    VehicleSeatAddon const veSeatAddon = Seat->second.SeatAddon;
 
     Player* player = Passenger->ToPlayer();
     if (player)
@@ -827,8 +853,9 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
     if (veSeat->HasFlag(VEHICLE_SEAT_FLAG_PASSENGER_NOT_SELECTABLE))
         Passenger->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
 
+
     Passenger->AddUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
-    Passenger->m_movementInfo.transport.pos.Relocate(veSeat->m_attachmentOffsetX, veSeat->m_attachmentOffsetY, veSeat->m_attachmentOffsetZ);
+    Passenger->m_movementInfo.transport.pos.Relocate(veSeat->m_attachmentOffsetX, veSeat->m_attachmentOffsetY, veSeat->m_attachmentOffsetZ, veSeatAddon.SeatOrientationOffset);
     Passenger->m_movementInfo.transport.time = 0;
     Passenger->m_movementInfo.transport.seat = Seat->first;
     Passenger->m_movementInfo.transport.guid = Target->GetBase()->GetGUID();

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -855,9 +855,9 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
 
 
     float o = veSeatAddon.SeatOrientationOffset;
-    float x = veSeat->AttachmentOffset.X;
-    float y = veSeat->AttachmentOffset.Y;
-    float z = veSeat->AttachmentOffset.Z;
+    float x = veSeat->m_attachmentOffsetX;
+    float y = veSeat->m_attachmentOffsetY;
+    float z = veSeat->m_attachmentOffsetZ;
 
     Passenger->AddUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
     Passenger->m_movementInfo.transport.pos.Relocate(x, y, z, o);

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -41,7 +41,7 @@ UsableSeatNum(0), _me(unit), _vehicleInfo(vehInfo), _creatureEntry(creatureEntry
         if (uint32 seatId = _vehicleInfo->m_seatID[i])
             if (VehicleSeatEntry const* veSeat = sVehicleSeatStore.LookupEntry(seatId))
             {
-                VehicleSeatAddon addon = sObjectMgr->GetVehicleSeatAddon(seatId);
+                VehicleSeatAddon const* addon = sObjectMgr->GetVehicleSeatAddon(seatId);
                 Seats.insert(std::make_pair(i, VehicleSeat(veSeat, addon)));
                 if (veSeat->CanEnterOrExit())
                     ++UsableSeatNum;
@@ -347,7 +347,7 @@ SeatMap::const_iterator Vehicle::GetNextEmptySeat(int8 seatId, bool next) const
 }
 
 /**
- * @fn VehicleSeatAddon const Vehicle::GetSeatAddonForSeatOfPassenger(Unit const* passenger) const
+ * @fn VehicleSeatAddon const* Vehicle::GetSeatAddonForSeatOfPassenger(Unit const* passenger) const
  *
  * @brief Gets the vehicle seat addon data for the seat of a passenger
  *
@@ -359,15 +359,13 @@ SeatMap::const_iterator Vehicle::GetNextEmptySeat(int8 seatId, bool next) const
  * @return The seat addon data for the currently used seat of a passenger
  */
 
-VehicleSeatAddon const Vehicle::GetSeatAddonForSeatOfPassenger(Unit const* passenger) const
+VehicleSeatAddon const* Vehicle::GetSeatAddonForSeatOfPassenger(Unit const* passenger) const
 {
     for (SeatMap::const_iterator itr = Seats.begin(); itr != Seats.end(); itr++)
-    {
         if (!itr->second.IsEmpty() && itr->second.Passenger.Guid == passenger->GetGUID())
             return itr->second.SeatAddon;
-    }
 
-    return VehicleSeatAddon();
+    return nullptr;
 }
 
 /**
@@ -834,7 +832,7 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
     Passenger->RemoveAurasByType(SPELL_AURA_MOUNTED);
 
     VehicleSeatEntry const* veSeat = Seat->second.SeatInfo;
-    VehicleSeatAddon const veSeatAddon = Seat->second.SeatAddon;
+    VehicleSeatAddon const* veSeatAddon = Seat->second.SeatAddon;
 
     Player* player = Passenger->ToPlayer();
     if (player)
@@ -854,7 +852,7 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
         Passenger->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
 
 
-    float o = veSeatAddon.SeatOrientationOffset;
+    float o = veSeatAddon ? veSeatAddon->SeatOrientationOffset : 0.f;
     float x = veSeat->m_attachmentOffsetX;
     float y = veSeat->m_attachmentOffsetY;
     float z = veSeat->m_attachmentOffsetZ;

--- a/src/server/game/Entities/Vehicle/Vehicle.h
+++ b/src/server/game/Entities/Vehicle/Vehicle.h
@@ -52,7 +52,7 @@ class TC_GAME_API Vehicle : public TransportBase
         bool HasEmptySeat(int8 seatId) const;
         Unit* GetPassenger(int8 seatId) const;
         SeatMap::const_iterator GetNextEmptySeat(int8 seatId, bool next) const;
-        VehicleSeatAddon const GetSeatAddonForSeatOfPassenger(Unit const* passenger) const;
+        VehicleSeatAddon const* GetSeatAddonForSeatOfPassenger(Unit const* passenger) const;
         uint8 GetAvailableSeatCount() const;
 
         bool AddPassenger(Unit* passenger, int8 seatId = -1);

--- a/src/server/game/Entities/Vehicle/Vehicle.h
+++ b/src/server/game/Entities/Vehicle/Vehicle.h
@@ -52,6 +52,7 @@ class TC_GAME_API Vehicle : public TransportBase
         bool HasEmptySeat(int8 seatId) const;
         Unit* GetPassenger(int8 seatId) const;
         SeatMap::const_iterator GetNextEmptySeat(int8 seatId, bool next) const;
+        VehicleSeatAddon const GetSeatAddonForSeatOfPassenger(Unit const* passenger) const;
         uint8 GetAvailableSeatCount() const;
 
         bool AddPassenger(Unit* passenger, int8 seatId = -1);

--- a/src/server/game/Entities/Vehicle/VehicleDefines.h
+++ b/src/server/game/Entities/Vehicle/VehicleDefines.h
@@ -53,6 +53,14 @@ enum VehicleSpells
     VEHICLE_SPELL_PARACHUTE                      = 45472
 };
 
+enum class VehicleExitParameters
+{
+    VehicleExitParamNone,   // provided parameters will be ignored
+    VehicleExitParamOffset, // provided parameters will be used as offset values
+    VehicleExitParamDest,   // provided parameters will be used as absolute destination
+    VehicleExitParamMax
+};
+
 struct PassengerInfo
 {
     ObjectGuid Guid;
@@ -65,9 +73,24 @@ struct PassengerInfo
     }
 };
 
+struct VehicleSeatAddon
+{
+    VehicleSeatAddon() { }
+    VehicleSeatAddon(float orientatonOffset, float exitX, float exitY, float exitZ, float exitO, uint8 param) :
+        SeatOrientationOffset(orientatonOffset), ExitParameterX(exitX), ExitParameterY(exitY), ExitParameterZ(exitZ),
+        ExitParameterO(exitO), ExitParameter(VehicleExitParameters(param)) { }
+
+    float SeatOrientationOffset = 0.f;
+    float ExitParameterX = 0.f;
+    float ExitParameterY = 0.f;
+    float ExitParameterZ = 0.f;
+    float ExitParameterO = 0.f;
+    VehicleExitParameters ExitParameter = VehicleExitParameters::VehicleExitParamNone;
+};
+
 struct VehicleSeat
 {
-    explicit VehicleSeat(VehicleSeatEntry const* seatInfo) : SeatInfo(seatInfo)
+    explicit VehicleSeat(VehicleSeatEntry const* seatInfo, VehicleSeatAddon const seatAddon) : SeatInfo(seatInfo), SeatAddon(seatAddon)
     {
         Passenger.Reset();
     }
@@ -75,6 +98,7 @@ struct VehicleSeat
     bool IsEmpty() const { return Passenger.Guid.IsEmpty(); }
 
     VehicleSeatEntry const* SeatInfo;
+    VehicleSeatAddon const SeatAddon;
     PassengerInfo Passenger;
 };
 

--- a/src/server/game/Entities/Vehicle/VehicleDefines.h
+++ b/src/server/game/Entities/Vehicle/VehicleDefines.h
@@ -55,9 +55,9 @@ enum VehicleSpells
 
 enum class VehicleExitParameters
 {
-    VehicleExitParamNone,   // provided parameters will be ignored
-    VehicleExitParamOffset, // provided parameters will be used as offset values
-    VehicleExitParamDest,   // provided parameters will be used as absolute destination
+    VehicleExitParamNone    = 0, // provided parameters will be ignored
+    VehicleExitParamOffset  = 1, // provided parameters will be used as offset values
+    VehicleExitParamDest    = 2, // provided parameters will be used as absolute destination
     VehicleExitParamMax
 };
 
@@ -90,7 +90,7 @@ struct VehicleSeatAddon
 
 struct VehicleSeat
 {
-    explicit VehicleSeat(VehicleSeatEntry const* seatInfo, VehicleSeatAddon const seatAddon) : SeatInfo(seatInfo), SeatAddon(seatAddon)
+    explicit VehicleSeat(VehicleSeatEntry const* seatInfo, VehicleSeatAddon const* seatAddon) : SeatInfo(seatInfo), SeatAddon(seatAddon)
     {
         Passenger.Reset();
     }
@@ -98,7 +98,7 @@ struct VehicleSeat
     bool IsEmpty() const { return Passenger.Guid.IsEmpty(); }
 
     VehicleSeatEntry const* SeatInfo;
-    VehicleSeatAddon const SeatAddon;
+    VehicleSeatAddon const* SeatAddon;
     PassengerInfo Passenger;
 };
 

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -564,6 +564,7 @@ typedef std::unordered_map<uint32, QuestOfferRewardLocale> QuestOfferRewardLocal
 typedef std::unordered_map<uint32, QuestRequestItemsLocale> QuestRequestItemsLocaleContainer;
 typedef std::unordered_map<uint32, NpcTextLocale> NpcTextLocaleContainer;
 typedef std::unordered_map<uint32, PageTextLocale> PageTextLocaleContainer;
+typedef std::unordered_map<uint32, VehicleSeatAddon> VehicleSeatAddonContainer;
 
 struct GossipMenuItemsLocale
 {
@@ -1195,6 +1196,7 @@ class TC_GAME_API ObjectMgr
         void LoadMailLevelRewards();
         void LoadVehicleTemplateAccessories();
         void LoadVehicleAccessories();
+        void LoadVehicleSeatAddon();
 
         void LoadGossipText();
 
@@ -1541,6 +1543,15 @@ class TC_GAME_API ObjectMgr
 
         bool IsTransportMap(uint32 mapId) const { return _transportMaps.count(mapId) != 0; }
 
+        VehicleSeatAddon const GetVehicleSeatAddon(uint32 seatId) const
+        {
+            VehicleSeatAddonContainer::const_iterator itr = _vehicleSeatAddonStore.find(seatId);
+            if (itr == _vehicleSeatAddonStore.end())
+                return VehicleSeatAddon();
+
+            return itr->second;
+        }
+
     private:
         // first free id for selected id type
         uint32 _auctionId;
@@ -1702,6 +1713,7 @@ class TC_GAME_API ObjectMgr
         std::set<uint32> _transportMaps; // Helper container storing map ids that are for transports only, loaded from gameobject_template
 
         PlayerTotemModelMap _playerTotemModel;
+        VehicleSeatAddonContainer _vehicleSeatAddonStore;
 };
 
 #define sObjectMgr ObjectMgr::instance()

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1543,13 +1543,13 @@ class TC_GAME_API ObjectMgr
 
         bool IsTransportMap(uint32 mapId) const { return _transportMaps.count(mapId) != 0; }
 
-        VehicleSeatAddon const GetVehicleSeatAddon(uint32 seatId) const
+        VehicleSeatAddon const* GetVehicleSeatAddon(uint32 seatId) const
         {
             VehicleSeatAddonContainer::const_iterator itr = _vehicleSeatAddonStore.find(seatId);
             if (itr == _vehicleSeatAddonStore.end())
-                return VehicleSeatAddon();
+                return nullptr;
 
-            return itr->second;
+            return &itr->second;
         }
 
     private:

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1852,6 +1852,9 @@ void World::SetInitialWorldSettings()
     TC_LOG_INFO("server.loading", "Loading Vehicle Accessories...");
     sObjectMgr->LoadVehicleAccessories();                       // must be after LoadCreatureTemplates() and LoadNPCSpellClickSpells()
 
+    TC_LOG_INFO("server.loading", "Loading Vehicle Seat Addon Data...");
+    sObjectMgr->LoadVehicleSeatAddon();                         // must be after loading DBC
+
     TC_LOG_INFO("server.loading", "Loading SpellArea Data...");                // must be after quest load
     sSpellMgr->LoadSpellAreas();
 

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2880,40 +2880,6 @@ public:
     }
 };
 
-enum TravelerTundraMammothNPCs
-{
-    NPC_HAKMUD_OF_ARGUS  = 32638,
-    NPC_GNIMO            = 32639,
-    NPC_DRIX_BLACKWRENCH = 32641,
-    NPC_MOJODISHU        = 32642
-};
-
-class npc_traveler_tundra_mammoth_exit_pos : public UnitScript
-{
-public:
-    npc_traveler_tundra_mammoth_exit_pos() : UnitScript("npc_traveler_tundra_mammoth_exit_pos") { }
-
-    void ModifyVehiclePassengerExitPos(Unit* passenger, Vehicle* /*vehicle*/, Position& pos)
-    {
-        if (passenger->GetTypeId() == TYPEID_UNIT)
-        {
-            switch (passenger->GetEntry())
-            {
-                // Right side
-                case NPC_DRIX_BLACKWRENCH:
-                case NPC_GNIMO:
-                    pos.RelocateOffset({ -2.0f, -2.0f, 0.0f, 0.0f });
-                    break;
-                // Left side
-                case NPC_MOJODISHU:
-                case NPC_HAKMUD_OF_ARGUS:
-                    pos.RelocateOffset({ -2.0f, 2.0f, 0.0f, 0.0f });
-                    break;
-            }
-        }
-    }
-};
-
 void AddSC_npcs_special()
 {
     new npc_air_force_bots();
@@ -2941,5 +2907,4 @@ void AddSC_npcs_special()
     new npc_train_wrecker();
     new npc_argent_squire_gruntling();
     new npc_bountiful_table();
-    new npc_traveler_tundra_mammoth_exit_pos();
 }


### PR DESCRIPTION
**Changes proposed:**

-  implement a table to specify special vehicle seat behaivior
-  the current implementation comes with the following features:

1. a field to override vehicle seat attachment orientations. This allows people to change vehicle seat orientations by default to make them look into different directions. A commonly used feature, especially in Cataclysm

2. fields to handle passenger exit destinations properly. Instead of using a ugly ass scripting hook we can now specify either exit position offsets or entire coordinates which gives us full control over the vehicle exit destinations


**Target branch(es):**
- [x] 3.3.5


**Tests performed:**
- tested on my 434 fork in multiple occasions: Magmaw and his pincers, Traveler's Tundra Mammoth, Ozumat in Throne of the Tides and a Stormwind Charger Horse involved in the cata version of the quest 'Further Concerns'

**Known issues and TODO list:** 
- [ ] Snap ModifyVehiclePassengerExitPos out of existance. You don't want this hook.

