### PR TITLE
Core/Scripting: fixed hourly bell sounds

### DIFF
--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1941,29 +1941,41 @@ public:
     {
         go_bellsAI(GameObject* go) : GameObjectAI(go), _soundId(0) { }
 
-        uint32 zoneId = me->GetZoneId();
-
         void InitializeAI() override
         {
+            uint32 zoneId = me->GetZoneId();
+
             switch (me->GetEntry())
             {
                 case GO_HORDE_BELL:
                 {
-                if (zoneId == TIRISFAL_ZONE || zoneId == UNDERCITY_ZONE || zoneId == HILLSBARD_FOOTHILLS || zoneId == DUSKWOOD_ZONE)
-                    _soundId = BELLTOLLHORDE;  // undead bell sound 
-                else
-                    _soundId = BELLTOLLTRIBAL; // use drum sound as default for horde bell
-                break;
+                    switch (zoneId) {
+                    case TIRISFAL_ZONE:
+                    case UNDERCITY_ZONE:
+                    case HILLSBARD_FOOTHILLS:
+                    case DUSKWOOD_ZONE:
+                        _soundId = BELLTOLLHORDE;  // undead bell sound
+                        break;
+                    default:
+                        _soundId = BELLTOLLTRIBAL; // orc drum sound 
+                        break;
+                    }
                 }
                 case GO_ALLIANCE_BELL:
                 {
-                if (zoneId == IRONFORGE_ZONE || zoneId == DUN_MOROGH_ZONE)
-                    _soundId = BELLTOLLDWARFGNOME; // horn sound
-                else if (zoneId == DARNASSUS_ZONE || zoneId == TELDRASSIL_ZONE || zoneId == ASHENVALE_ZONE)
-                    _soundId = BELLTOLLNIGHTELF;   // nightelf bell sound 
-                else
-                    _soundId = BELLTOLLALLIANCE;   // use human bell sound as Alliance defalut
-                break;
+                    switch (zoneId) {
+                    case IRONFORGE_ZONE:
+                    case DUN_MOROGH_ZONE:
+                        _soundId = BELLTOLLDWARFGNOME; // horn sound
+                        break;
+                    case DARNASSUS_ZONE:
+                    case TELDRASSIL_ZONE:
+                    case ASHENVALE_ZONE:
+                        _soundId = BELLTOLLNIGHTELF;   // nightelf bell sound
+                        break;
+                    default:
+                        _soundId = BELLTOLLALLIANCE;   // human bell sound 
+                    }
                 }
                 case GO_KHARAZHAN_BELL:
                 {

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1898,22 +1898,25 @@ public:
 
 enum BellHourlySoundFX
 {
-    BELLTOLLHORDE          = 6595, // Horde
-    BELLTOLLTRIBAL         = 6675,
-    BELLTOLLALLIANCE       = 6594, // Alliance
-    BELLTOLLNIGHTELF       = 6674,
-    BELLTOLLDWARFGNOME     = 7234,
-    BELLTOLLKHARAZHAN      = 9154 // Kharazhan
+    BELLTOLLHORDE      = 6595, // Undercity
+    BELLTOLLTRIBAL     = 6675, // Orgrimma/Thunderbluff
+    BELLTOLLALLIANCE   = 6594, // Stormwind
+    BELLTOLLNIGHTELF   = 6674, // Darnassus
+    BELLTOLLDWARFGNOME = 7234, // Ironforge
+    BELLTOLLKHARAZHAN  = 9154  // Kharazhan
 };
 
-enum BellHourlySoundAreas
+enum BellHourlySoundZones
 {
-    UNDERCITY_AREA         = 1497,
-    IRONFORGE_1_AREA       = 809,
-    IRONFORGE_2_AREA       = 1,
-    DARNASSUS_AREA         = 1657,
-    TELDRASSIL_ZONE        = 141,
-    KHARAZHAN_MAPID        = 532
+    TIRISFAL_ZONE       = 85,
+    UNDERCITY_ZONE      = 1497,
+    DUN_MOROGH_ZONE     = 1,
+    IRONFORGE_ZONE      = 1537,
+    TELDRASSIL_ZONE     = 141,
+    DARNASSUS_ZONE      = 1657,
+    ASHENVALE_ZONE      = 331,
+    HILLSBARD_FOOTHILLS = 267,
+    DUSKWOOD_ZONE       = 42
 };
 
 enum BellHourlyObjects
@@ -1938,27 +1941,35 @@ public:
     {
         go_bellsAI(GameObject* go) : GameObjectAI(go), _soundId(0) { }
 
+        uint32 zoneId = me->GetZoneId();
+
         void InitializeAI() override
         {
             switch (me->GetEntry())
             {
                 case GO_HORDE_BELL:
-                    _soundId = me->GetAreaId() == UNDERCITY_AREA ? BELLTOLLHORDE : BELLTOLLTRIBAL;
-                    break;
+                {
+                if (zoneId == TIRISFAL_ZONE || zoneId == UNDERCITY_ZONE || zoneId == HILLSBARD_FOOTHILLS || zoneId == DUSKWOOD_ZONE)
+                    _soundId = BELLTOLLHORDE;  // undead bell sound 
+                else
+                    _soundId = BELLTOLLTRIBAL; // use drum sound as default for horde bell
+                break;
+                }
                 case GO_ALLIANCE_BELL:
                 {
-                    if (me->GetAreaId() == IRONFORGE_1_AREA || me->GetAreaId() == IRONFORGE_2_AREA)
-                        _soundId = BELLTOLLDWARFGNOME;
-                    else if (me->GetAreaId() == DARNASSUS_AREA || me->GetZoneId() == TELDRASSIL_ZONE)
-                        _soundId = BELLTOLLNIGHTELF;
-                    else
-                        _soundId = BELLTOLLALLIANCE;
-
-                    break;
+                if (zoneId == IRONFORGE_ZONE || zoneId == DUN_MOROGH_ZONE)
+                    _soundId = BELLTOLLDWARFGNOME; // horn sound
+                else if (zoneId == DARNASSUS_ZONE || zoneId == TELDRASSIL_ZONE || zoneId == ASHENVALE_ZONE)
+                    _soundId = BELLTOLLNIGHTELF;   // nightelf bell sound 
+                else
+                    _soundId = BELLTOLLALLIANCE;   // use human bell sound as Alliance defalut
+                break;
                 }
                 case GO_KHARAZHAN_BELL:
-                    _soundId = BELLTOLLKHARAZHAN;
-                    break;
+                {
+                _soundId = BELLTOLLKHARAZHAN;
+                break;
+                }
             }
         }
 

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1915,7 +1915,7 @@ enum BellHourlySoundZones
     TELDRASSIL_ZONE     = 141,
     DARNASSUS_ZONE      = 1657,
     ASHENVALE_ZONE      = 331,
-    HILLSBARD_FOOTHILLS = 267,
+    HILLSBRAD_FOOTHILLS = 267,
     DUSKWOOD_ZONE       = 42
 };
 
@@ -1952,7 +1952,7 @@ public:
                     switch (zoneId) {
                     case TIRISFAL_ZONE:
                     case UNDERCITY_ZONE:
-                    case HILLSBARD_FOOTHILLS:
+                    case HILLSBRAD_FOOTHILLS:
                     case DUSKWOOD_ZONE:
                         _soundId = BELLTOLLHORDE;  // undead bell sound
                         break;


### PR DESCRIPTION
**Changes proposed:**
- detection of bell gameobjects sound by zone instead of area
- fixes incorrect hourly sound beeing played in brill, tarren mill, ...

**Target branch(es):**
 3.3.5

**Tests performed:**
 go to area, where a bell gameobject is spawned
 .event start 73

**Note:**
You can find all current bell gameobject spawns in db:
gameobject ->filter by id:

HORDE_BELL          = 175885,
ALLIANCE_BELL      = 176573,
KHARAZHAN_BELL = 182064  

There might be a few spaws missing around the world (for example Undercity).


