### PR TITLE
Core/Units: UNIT_FLAG_PACIFIED will no longer block victim updates

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5483,9 +5483,6 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (creature && creature->IsInEvadeMode())
         return false;
 
-    if (HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
-        return false;
-
     // nobody can attack GM in GM-mode
     if (victim->GetTypeId() == TYPEID_PLAYER)
     {

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2375,10 +2375,7 @@ void AuraEffect::HandleAuraModPacify(AuraApplication const* aurApp, uint8 mode, 
     Unit* target = aurApp->GetTarget();
 
     if (apply)
-    {
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED);
-        target->AttackStop();
-    }
     else
     {
         // do not remove unit flag if there are more than this auraEffect of that kind on unit on unit


### PR DESCRIPTION
**Changes proposed:**

After spending some time in reworking the Scarlet Monastry bosses, I stumbled accross this little thing while working on Arcanist Doan. If he bubbles himself he gets pacified which will block his melee attacks but according to classic gameplay footage and videos he should still chase, his victim.
This is not the only case as there are even Cataclysm bosses to this date that pacify themselves while still being fully capable of having victims, namely Siamat.

On TC the pacify flag also blocks victim checks on top of it because Unit::Attack will return false with the pacify flag. We now remove that check and only block melee attacks while pacified. in AttackerStateUpdate

So to sum things up, pacify seems to be the counterpart to silence which only blocks the corresponding mechanic rather than affecting AI behaivior.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame
