### PR TITLE
Core/DynamicInfo: rename some parameters according packet definitions

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2313,9 +2313,9 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             if (WorldObject* obj = GetBaseObject())
             {
-                obj->GetMap()->SetZoneOverrideLight(e.action.overrideLight.zoneId, e.action.overrideLight.lightId, e.action.overrideLight.fadeInTime);
-                TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_OVERRIDE_LIGHT: %s sets zone override light (zoneId: %u, lightId: %u, fadeInTime: %u)",
-                    obj->GetGUID().ToString().c_str(), e.action.overrideLight.zoneId, e.action.overrideLight.lightId, e.action.overrideLight.fadeInTime);
+                obj->GetMap()->SetZoneOverrideLight(e.action.overrideLight.zoneId, e.action.overrideLight.overrideLightId, e.action.overrideLight.transitionMilliseconds);
+                TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_OVERRIDE_LIGHT: %s sets zone override light (zoneId: %u, overrideLightId: %u, transitionMilliseconds: %u)",
+                    obj->GetGUID().ToString().c_str(), e.action.overrideLight.zoneId, e.action.overrideLight.overrideLightId, e.action.overrideLight.transitionMilliseconds);
             }
             break;
         }
@@ -2323,9 +2323,9 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             if (WorldObject* obj = GetBaseObject())
             {
-                obj->GetMap()->SetZoneWeather(e.action.overrideWeather.zoneId, (WeatherState)e.action.overrideWeather.weatherId, float(e.action.overrideWeather.weatherGrade));
-                TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_OVERRIDE_WEATHER: %s sets zone weather (zoneId: %u, weatherId: %u, weatherGrade: %u)",
-                    obj->GetGUID().ToString().c_str(), e.action.overrideWeather.zoneId, e.action.overrideWeather.weatherId, e.action.overrideWeather.weatherGrade);
+                obj->GetMap()->SetZoneWeather(e.action.overrideWeather.zoneId, (WeatherState)e.action.overrideWeather.weatherId, float(e.action.overrideWeather.intensity));
+                TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction: SMART_ACTION_OVERRIDE_WEATHER: %s sets zone weather (zoneId: %u, weatherId: %u, intensity: %u)",
+                    obj->GetGUID().ToString().c_str(), e.action.overrideWeather.zoneId, e.action.overrideWeather.weatherId, e.action.overrideWeather.intensity);
             }
             break;
         }

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1543,9 +1543,9 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                 return false;
             }
 
-            if (!sLightStore.LookupEntry(e.action.overrideLight.lightId))
+            if (!sLightStore.LookupEntry(e.action.overrideLight.overrideLightId))
             {
-                TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u uses non-existent lightId %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.overrideLight.lightId);
+                TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u uses non-existent overrideLightId %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.overrideLight.overrideLightId);
                 return false;
             }
 

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -587,8 +587,8 @@ enum SMART_ACTION
     SMART_ACTION_PLAY_CINEMATIC                     = 135,    // entry, cinematic
     SMART_ACTION_SET_MOVEMENT_SPEED                 = 136,    // movementType, speedInteger, speedFraction
     SMART_ACTION_PLAY_SPELL_VISUAL_KIT              = 137,    // spellVisualKitId (RESERVED, PENDING CHERRYPICK)
-    SMART_ACTION_OVERRIDE_LIGHT                     = 138,    // zoneId, lightId, fadeInTime
-    SMART_ACTION_OVERRIDE_WEATHER                   = 139,    // zoneId, weatherId, weatherGrade
+    SMART_ACTION_OVERRIDE_LIGHT                     = 138,    // zoneId, overrideLightID, transitionMilliseconds
+    SMART_ACTION_OVERRIDE_WEATHER                   = 139,    // zoneId, weatherId, intensity
 
     SMART_ACTION_END                                = 140
 };
@@ -1158,15 +1158,15 @@ struct SmartAction
         struct
         {
             uint32 zoneId;
-            uint32 lightId;
-            uint32 fadeInTime;
+            uint32 overrideLightId;
+            uint32 transitionMilliseconds;
         } overrideLight;
 
         struct
         {
             uint32 zoneId;
             uint32 weatherId;
-            uint32 weatherGrade;
+            uint32 intensity;
         } overrideWeather;
 
         //! Note for any new future actions

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -66,7 +66,7 @@ GridState* si_GridStates[MAX_GRID_STATE];
 
 
 ZoneDynamicInfo::ZoneDynamicInfo() : MusicId(0), DefaultWeather(nullptr), WeatherId(WEATHER_STATE_FINE),
-    WeatherGrade(0.0f), OverrideLightId(0), LightFadeInTime(0) { }
+    Intensity(0.0f), OverrideLightId(0), TransitionMilliseconds(0) { }
 
 Map::~Map()
 {
@@ -4570,7 +4570,7 @@ void Map::SendZoneDynamicInfo(uint32 zoneId, Player* player) const
         WorldPackets::Misc::OverrideLight overrideLight;
         overrideLight.AreaLightID = _defaultLight;
         overrideLight.OverrideLightID = overrideLightId;
-        overrideLight.TransitionMilliseconds = itr->second.LightFadeInTime;
+        overrideLight.TransitionMilliseconds = itr->second.TransitionMilliseconds;
         player->SendDirectMessage(overrideLight.Write());
     }
 }
@@ -4588,7 +4588,7 @@ void Map::SendZoneWeather(ZoneDynamicInfo const& zoneDynamicInfo, Player* player
 {
     if (WeatherState weatherId = zoneDynamicInfo.WeatherId)
     {
-        WorldPackets::Misc::Weather weather(weatherId, zoneDynamicInfo.WeatherGrade);
+        WorldPackets::Misc::Weather weather(weatherId, zoneDynamicInfo.Intensity);
         player->SendDirectMessage(weather.Write());
     }
     else if (zoneDynamicInfo.DefaultWeather)
@@ -4633,16 +4633,16 @@ Weather* Map::GetOrGenerateZoneDefaultWeather(uint32 zoneId)
     return info.DefaultWeather.get();
 }
 
-void Map::SetZoneWeather(uint32 zoneId, WeatherState weatherId, float weatherGrade)
+void Map::SetZoneWeather(uint32 zoneId, WeatherState weatherId, float intensity)
 {
     ZoneDynamicInfo& info = _zoneDynamicInfo[zoneId];
     info.WeatherId = weatherId;
-    info.WeatherGrade = weatherGrade;
+    info.Intensity = intensity;
 
     Map::PlayerList const& players = GetPlayers();
     if (!players.isEmpty())
     {
-        WorldPackets::Misc::Weather weather(weatherId, weatherGrade);
+        WorldPackets::Misc::Weather weather(weatherId, intensity);
         weather.Write();
 
         for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
@@ -4652,19 +4652,19 @@ void Map::SetZoneWeather(uint32 zoneId, WeatherState weatherId, float weatherGra
     }
 }
 
-void Map::SetZoneOverrideLight(uint32 zoneId, uint32 lightId, uint32 fadeInTime)
+void Map::SetZoneOverrideLight(uint32 zoneId, uint32 overrideLightId, uint32 transitionMilliseconds)
 {
     ZoneDynamicInfo& info = _zoneDynamicInfo[zoneId];
-    info.OverrideLightId = lightId;
-    info.LightFadeInTime = fadeInTime;
+    info.OverrideLightId = overrideLightId;
+    info.TransitionMilliseconds = transitionMilliseconds;
 
     Map::PlayerList const& players = GetPlayers();
     if (!players.isEmpty())
     {
         WorldPackets::Misc::OverrideLight overrideLight;
         overrideLight.AreaLightID = _defaultLight;
-        overrideLight.OverrideLightID = lightId;
-        overrideLight.TransitionMilliseconds = fadeInTime;
+        overrideLight.OverrideLightID = overrideLightId;
+        overrideLight.TransitionMilliseconds = transitionMilliseconds;
         overrideLight.Write();
 
         for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -264,11 +264,13 @@ struct ZoneDynamicInfo
     ZoneDynamicInfo();
 
     uint32 MusicId;
+
     std::unique_ptr<Weather> DefaultWeather;
     WeatherState WeatherId;
-    float WeatherGrade;
+    float Intensity;
+
     uint32 OverrideLightId;
-    uint32 LightFadeInTime;
+    uint32 TransitionMilliseconds;
 };
 
 #pragma pack(pop)
@@ -606,8 +608,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
 
         void SetZoneMusic(uint32 zoneId, uint32 musicId);
         Weather* GetOrGenerateZoneDefaultWeather(uint32 zoneId);
-        void SetZoneWeather(uint32 zoneId, WeatherState weatherId, float weatherGrade);
-        void SetZoneOverrideLight(uint32 zoneId, uint32 lightId, uint32 fadeInTime);
+        void SetZoneWeather(uint32 zoneId, WeatherState weatherId, float intensity);
+        void SetZoneOverrideLight(uint32 zoneId, uint32 overrideLightId, uint32 transitionMilliseconds);
 
         void UpdateAreaDependentAuras();
 

--- a/src/server/game/Weather/Weather.cpp
+++ b/src/server/game/Weather/Weather.cpp
@@ -30,12 +30,12 @@
 #include "World.h"
 
 /// Create the Weather object
-Weather::Weather(uint32 zone, WeatherData const* weatherChances)
-    : m_zone(zone), m_weatherChances(weatherChances)
+Weather::Weather(uint32 zoneId, WeatherData const* weatherChances)
+    : m_zone(zoneId), m_weatherChances(weatherChances)
 {
     m_timer.SetInterval(sWorld->getIntConfig(CONFIG_INTERVAL_CHANGEWEATHER));
     m_type = WEATHER_TYPE_FINE;
-    m_grade = 0;
+    m_intensity = 0;
 
     TC_LOG_INFO("misc", "WORLD: Starting weather system for zone %u (change every %u minutes).", m_zone, (uint32)(m_timer.GetInterval() / (MINUTE*IN_MILLISECONDS)));
 }
@@ -71,7 +71,7 @@ bool Weather::ReGenerate()
     if (!m_weatherChances)
     {
         m_type = WEATHER_TYPE_FINE;
-        m_grade = 0.0f;
+        m_intensity = 0.0f;
         return false;
     }
 
@@ -87,7 +87,7 @@ bool Weather::ReGenerate()
 
     // remember old values
     WeatherType old_type = m_type;
-    float old_grade = m_grade;
+    float old_intensity = m_intensity;
 
     //78 days between January 1st and March 20nd; 365/4=91 days by season
     // season source http://aa.usno.navy.mil/data/docs/EarthSeasons.html
@@ -100,21 +100,21 @@ bool Weather::ReGenerate()
 
     TC_LOG_INFO("misc", "Generating a change in %s weather for zone %u.", seasonName[season], m_zone);
 
-    if ((u < 60) && (m_grade < 0.33333334f))                // Get fair
+    if ((u < 60) && (m_intensity < 0.33333334f))                // Get fair
     {
         m_type = WEATHER_TYPE_FINE;
-        m_grade = 0.0f;
+        m_intensity = 0.0f;
     }
 
     if ((u < 60) && (m_type != WEATHER_TYPE_FINE))          // Get better
     {
-        m_grade -= 0.33333334f;
+        m_intensity -= 0.33333334f;
         return true;
     }
 
     if ((u < 90) && (m_type != WEATHER_TYPE_FINE))          // Get worse
     {
-        m_grade += 0.33333334f;
+        m_intensity += 0.33333334f;
         return true;
     }
 
@@ -125,25 +125,25 @@ bool Weather::ReGenerate()
         ///- if medium -> change weather type
         ///- if heavy -> 50% light, 50% change weather type
 
-        if (m_grade < 0.33333334f)
+        if (m_intensity < 0.33333334f)
         {
-            m_grade = 0.9999f;                              // go nuts
+            m_intensity = 0.9999f;                              // go nuts
             return true;
         }
         else
         {
-            if (m_grade > 0.6666667f)
+            if (m_intensity > 0.6666667f)
             {
                                                             // Severe change, but how severe?
                 uint32 rnd = urand(0, 99);
                 if (rnd < 50)
                 {
-                    m_grade -= 0.6666667f;
+                    m_intensity -= 0.6666667f;
                     return true;
                 }
             }
             m_type = WEATHER_TYPE_FINE;                     // clear up
-            m_grade = 0;
+            m_intensity = 0;
         }
     }
 
@@ -170,29 +170,29 @@ bool Weather::ReGenerate()
 
     if (m_type == WEATHER_TYPE_FINE)
     {
-        m_grade = 0.0f;
+        m_intensity = 0.0f;
     }
     else if (u < 90)
     {
-        m_grade = (float)rand_norm() * 0.3333f;
+        m_intensity = (float)rand_norm() * 0.3333f;
     }
     else
     {
         // Severe change, but how severe?
         rnd = urand(0, 99);
         if (rnd < 50)
-            m_grade = (float)rand_norm() * 0.3333f + 0.3334f;
+            m_intensity = (float)rand_norm() * 0.3333f + 0.3334f;
         else
-            m_grade = (float)rand_norm() * 0.3333f + 0.6667f;
+            m_intensity = (float)rand_norm() * 0.3333f + 0.6667f;
     }
 
     // return true only in case weather changes
-    return m_type != old_type || m_grade != old_grade;
+    return m_type != old_type || m_intensity != old_intensity;
 }
 
 void Weather::SendWeatherUpdateToPlayer(Player* player)
 {
-    WorldPackets::Misc::Weather weather(GetWeatherState(), m_grade);
+    WorldPackets::Misc::Weather weather(GetWeatherState(), m_intensity);
     player->SendDirectMessage(weather.Write());
 }
 
@@ -206,14 +206,14 @@ void Weather::SendFineWeatherUpdateToPlayer(Player* player)
 bool Weather::UpdateWeather()
 {
     ///- Send the weather packet to all players in this zone
-    if (m_grade >= 1)
-        m_grade = 0.9999f;
-    else if (m_grade < 0)
-        m_grade = 0.0001f;
+    if (m_intensity >= 1)
+        m_intensity = 0.9999f;
+    else if (m_intensity < 0)
+        m_intensity = 0.0001f;
 
     WeatherState state = GetWeatherState();
 
-    WorldPackets::Misc::Weather weather(state, m_grade);
+    WorldPackets::Misc::Weather weather(state, m_intensity);
 
     //- Returns false if there were no players found to update
     if (!sWorld->SendZoneMessage(m_zone, weather.Write()))
@@ -266,47 +266,47 @@ bool Weather::UpdateWeather()
     }
 
     TC_LOG_INFO("misc", "Change the weather of zone %u to %s.", m_zone, wthstr);
-    sScriptMgr->OnWeatherChange(this, state, m_grade);
+    sScriptMgr->OnWeatherChange(this, state, m_intensity);
     return true;
 }
 
 /// Set the weather
-void Weather::SetWeather(WeatherType type, float grade)
+void Weather::SetWeather(WeatherType type, float intensity)
 {
-    if (m_type == type && m_grade == grade)
+    if (m_type == type && m_intensity == intensity)
         return;
 
     m_type = type;
-    m_grade = grade;
+    m_intensity = intensity;
     UpdateWeather();
 }
 
 /// Get the sound number associated with the current weather
 WeatherState Weather::GetWeatherState() const
 {
-    if (m_grade<0.27f)
+    if (m_intensity < 0.27f)
         return WEATHER_STATE_FINE;
 
     switch (m_type)
     {
         case WEATHER_TYPE_RAIN:
-            if (m_grade<0.40f)
+            if (m_intensity < 0.40f)
                 return WEATHER_STATE_LIGHT_RAIN;
-            else if (m_grade<0.70f)
+            else if (m_intensity < 0.70f)
                 return WEATHER_STATE_MEDIUM_RAIN;
             else
                 return WEATHER_STATE_HEAVY_RAIN;
         case WEATHER_TYPE_SNOW:
-            if (m_grade<0.40f)
+            if (m_intensity < 0.40f)
                 return WEATHER_STATE_LIGHT_SNOW;
-            else if (m_grade<0.70f)
+            else if (m_intensity < 0.70f)
                 return WEATHER_STATE_MEDIUM_SNOW;
             else
                 return WEATHER_STATE_HEAVY_SNOW;
         case WEATHER_TYPE_STORM:
-            if (m_grade<0.40f)
+            if (m_intensity < 0.40f)
                 return WEATHER_STATE_LIGHT_SANDSTORM;
-            else if (m_grade<0.70f)
+            else if (m_intensity < 0.70f)
                 return WEATHER_STATE_MEDIUM_SANDSTORM;
             else
                 return WEATHER_STATE_HEAVY_SANDSTORM;

--- a/src/server/game/Weather/Weather.h
+++ b/src/server/game/Weather/Weather.h
@@ -66,7 +66,7 @@ class TC_GAME_API Weather
 {
     public:
 
-        Weather(uint32 zone, WeatherData const* weatherChances);
+        Weather(uint32 zoneId, WeatherData const* weatherChances);
         ~Weather() { };
 
         bool Update(uint32 diff);
@@ -75,7 +75,7 @@ class TC_GAME_API Weather
 
         void SendWeatherUpdateToPlayer(Player* player);
         static void SendFineWeatherUpdateToPlayer(Player* player);
-        void SetWeather(WeatherType type, float grade);
+        void SetWeather(WeatherType type, float intensity);
 
         /// For which zone is this weather?
         uint32 GetZone() const { return m_zone; };
@@ -86,7 +86,7 @@ class TC_GAME_API Weather
         WeatherState GetWeatherState() const;
         uint32 m_zone;
         WeatherType m_type;
-        float m_grade;
+        float m_intensity;
         IntervalTimer m_timer;
         WeatherData const* m_weatherChances;
 };


### PR DESCRIPTION
**Changes proposed:**

-  rename WeatherGrade -> Intensity
-  rename fadeInTime ->transitionMilliseconds
-  rename lightId -> overrideLightId 

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.) Build, tested
