### PR TITLE
Core/AI: Make charmed creatures follow their owner

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -631,6 +631,14 @@ void PetAI::UpdateAllies()
         _allySet.insert(owner->GetGUID());
 }
 
+void PetAI::OnCharmed(bool isNew)
+{
+    if (isNew)
+        me->GetMotionMaster()->MoveFollow(me->GetCharmer(), PET_FOLLOW_DIST, me->GetFollowAngle());
+
+    CreatureAI::OnCharmed(isNew);
+}
+
 void PetAI::ClearCharmInfoFlags()
 {
     CharmInfo* ci = me->GetCharmInfo();

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -633,7 +633,7 @@ void PetAI::UpdateAllies()
 
 void PetAI::OnCharmed(bool isNew)
 {
-    if (isNew)
+    if (me->IsCharmed())
         me->GetMotionMaster()->MoveFollow(me->GetCharmer(), PET_FOLLOW_DIST, me->GetFollowAngle());
 
     CreatureAI::OnCharmed(isNew);

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -46,6 +46,7 @@ class TC_GAME_API PetAI : public CreatureAI
         void ReceiveEmote(Player* player, uint32 textEmote) override;
         void JustEnteredCombat(Unit* who) override { EngagementStart(who); }
         void JustExitedCombat() override { EngagementOver(); }
+        void OnCharmed(bool isNew) override;
 
         // The following aren't used by the PetAI but need to be defined to override
         // default CreatureAI functions which interfere with the PetAI

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -690,6 +690,9 @@ void SmartAI::OnCharmed(bool /*isNew*/)
 
     _charmed = charmed;
 
+    if (charmed)
+        me->GetMotionMaster()->MoveFollow(me->GetCharmer(), PET_FOLLOW_DIST, me->GetFollowAngle());
+
     if (!charmed && !me->IsInEvadeMode())
     {
         if (_repeatWaypointPath)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Make charmed creatures follow their owner (it doesn't affect CHARM_TYPE_POSSESS and CHARM_TYPE_VEHICLE, not sure about CHARM_TYPE_CONVERT)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #24103


**Tests performed:** Tested #24103 casting spell 260 to a creature


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] test charming a creature into a pet

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
