### PR TITLE
Core/SmartAI: Allow setting orientation for SMART_ACTION_MOVE_TO_POS

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1476,7 +1476,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     if (TransportBase* trans = me->GetDirectTransport())
                         trans->CalculatePassengerPosition(dest.x, dest.y, dest.z);
 
-                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, dest.x, dest.y, dest.z, e.action.MoveToPos.disablePathfinding == 0);
+                me->GetMotionMaster()->MovePoint(e.action.MoveToPos.pointId, dest.x, dest.y, dest.z, e.action.MoveToPos.disablePathfinding == 0, e.target.o);
             }
             else
             {


### PR DESCRIPTION
**Changes proposed:**
Pass orientation to MotionMaster when raw coordinates in SMART_ACTION_MOVE_TO_POS are given.

**Target branch(es):** 3.3.5

**Issues addressed:** Ref #22975

**Tests performed:** Does build, tested with custom SQL


~**Known issues and TODO list:**~

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
