### PR TITLE
Core: build on aarch64 with gcc

### DIFF
--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -16,11 +16,13 @@ if(PLATFORM EQUAL 32)
       -msse2
       -mfpmath=sse)
 endif()
-target_compile_definitions(trinity-compile-option-interface
-  INTERFACE
-    -DHAVE_SSE2
-    -D__SSE2__)
-message(STATUS "GCC: SFMT enabled, SSE2 flags forced")
+if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  target_compile_definitions(trinity-compile-option-interface
+    INTERFACE
+      -DHAVE_SSE2
+      -D__SSE2__)
+  message(STATUS "GCC: SFMT enabled, SSE2 flags forced")
+endif()
 
 if( WITH_WARNINGS )
   target_compile_options(trinity-warning-interface

--- a/src/common/Utilities/SFMTRand.cpp
+++ b/src/common/Utilities/SFMTRand.cpp
@@ -20,34 +20,39 @@
 #include <array>
 #include <functional>
 #include <random>
-#if defined(__clang__) && defined(__aarch64__)
-#include <mm_malloc.h>
-#elif defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__)
-static __inline__ void *__attribute__((__always_inline__, __nodebug__, __malloc__))
-_mm_malloc(size_t __size, size_t __align) {
-    if (__align == 1) {
-        return malloc(__size);
-    }
-
-    if (!(__align & (__align - 1)) && __align < sizeof(void *))
-        __align = sizeof(void *);
-
-    void *__mallocedMemory;
-
-    if (posix_memalign(&__mallocedMemory, __align, __size))
-        return NULL;
-
-    return __mallocedMemory;
-}
-
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_mm_free(void *__p) {
-    free(__p);
-}
-#else
-#include <emmintrin.h>
-#endif
 #include <ctime>
+
+#if defined(__aarch64__)
+    #if defined(__clang__)
+        #include <mm_malloc.h>
+    #elif defined(__GNUC__)
+        static __inline__ void *__attribute__((__always_inline__, __nodebug__, __malloc__))
+        _mm_malloc(size_t __size, size_t __align) {
+            if (__align == 1) {
+                return malloc(__size);
+            }
+
+            if (!(__align & (__align - 1)) && __align < sizeof(void *))
+                __align = sizeof(void *);
+
+            void *__mallocedMemory;
+
+            if (posix_memalign(&__mallocedMemory, __align, __size))
+                return NULL;
+
+            return __mallocedMemory;
+        }
+
+        static __inline__ void __attribute__((__always_inline__, __nodebug__))
+        _mm_free(void *__p) {
+            free(__p);
+        }
+    #else
+        #error aarch64 only on clang and gcc
+    #endif
+#else
+    #include <emmintrin.h>
+#endif
 
 SFMTRand::SFMTRand()
 {

--- a/src/common/Utilities/SFMTRand.cpp
+++ b/src/common/Utilities/SFMTRand.cpp
@@ -20,8 +20,30 @@
 #include <array>
 #include <functional>
 #include <random>
-#if defined(__aarch64__)
+#if defined(__clang__) && defined(__aarch64__)
 #include <mm_malloc.h>
+#elif defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__)
+static __inline__ void *__attribute__((__always_inline__, __nodebug__, __malloc__))
+_mm_malloc(size_t __size, size_t __align) {
+    if (__align == 1) {
+        return malloc(__size);
+    }
+
+    if (!(__align & (__align - 1)) && __align < sizeof(void *))
+        __align = sizeof(void *);
+
+    void *__mallocedMemory;
+
+    if (posix_memalign(&__mallocedMemory, __align, __size))
+        return NULL;
+
+    return __mallocedMemory;
+}
+
+static __inline__ void __attribute__((__always_inline__, __nodebug__))
+_mm_free(void *__p) {
+    free(__p);
+}
 #else
 #include <emmintrin.h>
 #endif

--- a/src/common/Utilities/SFMTRand.cpp
+++ b/src/common/Utilities/SFMTRand.cpp
@@ -27,8 +27,10 @@
         #include <mm_malloc.h>
     #elif defined(__GNUC__)
         static __inline__ void *__attribute__((__always_inline__, __nodebug__, __malloc__))
-        _mm_malloc(size_t __size, size_t __align) {
-            if (__align == 1) {
+        _mm_malloc(size_t __size, size_t __align)
+        {
+            if (__align == 1)
+            {
                 return malloc(__size);
             }
 
@@ -44,7 +46,8 @@
         }
 
         static __inline__ void __attribute__((__always_inline__, __nodebug__))
-        _mm_free(void *__p) {
+        _mm_free(void *__p)
+        {
             free(__p);
         }
     #else


### PR DESCRIPTION
**Changes proposed:**

-  fixed GCC build on aarch64
    - missing `mm_malloc.h` on gcc for aarch64
        - added functions `_mm_malloc` and `_mm_free`
        - like https://clang.llvm.org/doxygen/mm__malloc_8h_source.html
    - don't force SSE2 flags for aarch64 with gcc

**Target branch(es):**

- [x] 3.3.5

**Tests performed:**
- [x] build on raspberry pi 4 4GB (ubuntu 19.10 64bit + GCC 9.2.1)
- [x] connected and played 5 min with 2 accounts in parallel
