### PR TITLE
Core/Database: Fix build with Maria DB on some distros

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -54,8 +54,8 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
     WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below 5.1");
-    WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s) does not match the version used to compile TrinityCore (%s). Search on forum for TCE00011.",
-        mysql_get_client_info(), MYSQL_SERVER_VERSION);
+    WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s id %lu) does not match the version id used to compile TrinityCore (id %u). Search on forum for TCE00011.",
+        mysql_get_client_info(), mysql_get_client_version(), MYSQL_VERSION_ID);
 }
 
 template <class T>

--- a/src/server/database/Database/MySQLThreading.cpp
+++ b/src/server/database/Database/MySQLThreading.cpp
@@ -28,7 +28,7 @@ void MySQL::Library_End()
     mysql_library_end();
 }
 
-char const* MySQL::GetLibraryVersion()
+uint32 MySQL::GetLibraryVersion()
 {
-    return MYSQL_SERVER_VERSION;
+    return MYSQL_VERSION_ID;
 }

--- a/src/server/database/Database/MySQLThreading.h
+++ b/src/server/database/Database/MySQLThreading.h
@@ -24,7 +24,7 @@ namespace MySQL
 {
     TC_DATABASE_API void Library_Init();
     TC_DATABASE_API void Library_End();
-    TC_DATABASE_API char const* GetLibraryVersion();
+    TC_DATABASE_API uint32 GetLibraryVersion();
 }
 
 #endif

--- a/src/server/scripts/Commands/cs_server.cpp
+++ b/src/server/scripts/Commands/cs_server.cpp
@@ -138,7 +138,7 @@ public:
         handler->PSendSysMessage("%s", GitRevision::GetFullVersion());
         handler->PSendSysMessage("Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
         handler->PSendSysMessage("Using Boost version: %i.%i.%i", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
-        handler->PSendSysMessage("Using MySQL version: %s", MySQL::GetLibraryVersion());
+        handler->PSendSysMessage("Using MySQL version: %u", MySQL::GetLibraryVersion());
         handler->PSendSysMessage("Using CMake version: %s", GitRevision::GetCMakeVersion());
 
         handler->PSendSysMessage("Compiled on: %s", GitRevision::GetHostOSVersion());


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix build with Maria DB on some distros / Maria DB versions that don't properly define MYSQL_SERVER_VERSION

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes some Fedora/CentOS build errors


**Tests performed:** (Does it build, tested in-game, etc.)
- Build on CentOS 8
- Built on Circle CI/Travis/AppVeyor
- Tested on Windows that the check still works and that the error is displayed

**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
