### PR TITLE
Core/Spells - DK: Fix Icy Clutch dispel

### DIFF
--- a/sql/updates/world/3.3.5/2020_03_14_04_world.sql
+++ b/sql/updates/world/3.3.5/2020_03_14_04_world.sql
@@ -1,4 +1,4 @@
 -- 
-DELETE FROM `spell_script_names` WHERE `spell_id`=55095 AND `ScriptName`='spell_dk_frost_fever';
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_dk_frost_fever';
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
 (55095,'spell_dk_frost_fever');

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,4 @@
+-- 
+DELETE FROM `spell_script_names` WHERE `spell_id`=55095 AND `ScriptName`='spell_dk_frost_fever';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(55095,'spell_dk_frost_fever');

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1341,9 +1341,8 @@ class spell_dk_frost_fever : public AuraScript
     void HandleDispel(DispelInfo* /*dispelInfo*/)
     {
         if (Unit* caster = GetCaster())
-            if (Unit* target = GetUnitOwner())
-                if (AuraEffect* IcyClutch = target->GetAuraEffect(SPELL_AURA_MOD_DECREASE_SPEED, SPELLFAMILY_DEATHKNIGHT, 0, 0x00040000, 0, caster->GetGUID()))
-                    target->RemoveAurasDueToSpell(IcyClutch->GetId());
+            if (AuraEffect* IcyClutch = GetUnitOwner()->GetAuraEffect(SPELL_AURA_MOD_DECREASE_SPEED, SPELLFAMILY_DEATHKNIGHT, 0, 0x00040000, 0, caster->GetGUID()))
+                GetUnitOwner()->RemoveAurasDueToSpell(IcyClutch->GetId());
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1341,8 +1341,8 @@ class spell_dk_frost_fever : public AuraScript
     void HandleDispel(DispelInfo* /*dispelInfo*/)
     {
         if (Unit* caster = GetCaster())
-            if (AuraEffect* IcyClutch = GetUnitOwner()->GetAuraEffect(SPELL_AURA_MOD_DECREASE_SPEED, SPELLFAMILY_DEATHKNIGHT, 0, 0x00040000, 0, caster->GetGUID()))
-                GetUnitOwner()->RemoveAurasDueToSpell(IcyClutch->GetId());
+            if (AuraEffect* icyClutch = GetUnitOwner()->GetAuraEffect(SPELL_AURA_MOD_DECREASE_SPEED, SPELLFAMILY_DEATHKNIGHT, 0, 0x00040000, 0, caster->GetGUID()))
+                GetUnitOwner()->RemoveAurasDueToSpell(icyClutch->GetId());
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1333,6 +1333,25 @@ class spell_dk_hysteria : public AuraScript
     }
 };
 
+// 55095 - Frost Fever
+class spell_dk_frost_fever : public AuraScript
+{
+    PrepareAuraScript(spell_dk_frost_fever);
+
+    void HandleDispel(DispelInfo* /*dispelInfo*/)
+    {
+        if (Unit* caster = GetCaster())
+            if (Unit* target = GetUnitOwner())
+                if (AuraEffect* IcyClutch = target->GetAuraEffect(SPELL_AURA_MOD_DECREASE_SPEED, SPELLFAMILY_DEATHKNIGHT, 0, 0x00040000, 0, caster->GetGUID()))
+                    target->RemoveAurasDueToSpell(IcyClutch->GetId());
+    }
+
+    void Register() override
+    {
+        AfterDispel += AuraDispelFn(spell_dk_frost_fever::HandleDispel);
+    }
+};
+
 // 51209 - Hungering Cold
 class spell_dk_hungering_cold : public SpellScriptLoader
 {
@@ -3197,6 +3216,7 @@ void AddSC_deathknight_spell_scripts()
     new spell_dk_glyph_of_scourge_strike();
     RegisterSpellScript(spell_dk_glyph_of_scourge_strike_script);
     RegisterAuraScript(spell_dk_hysteria);
+    RegisterAuraScript(spell_dk_frost_fever);
     new spell_dk_hungering_cold();
     new spell_dk_icebound_fortitude();
     new spell_dk_improved_blood_presence();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Patch 3.2.0 (04-Aug-2009): Icy Clutch can no longer miss when Frost Fever hits, however, when Frost Fever is dispelled Icy Clutch will also be dispelled.


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes #24269


**Tests performed:** Tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
