### PR TITLE
Core/Spells: check inventory space when using SPELL_EFFECT_CREATE_ITEM

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6632,7 +6632,12 @@ SpellCastResult Spell::CheckItems(uint32* param1 /*= nullptr*/, uint32* param2 /
                     {
                         ItemPosCountVec dest;
                         InventoryResult msg = target->ToPlayer()->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, m_spellInfo->Effects[i].ItemType, 1);
-                        if (msg != EQUIP_ERR_OK)
+                        if (target->ToPlayer()->GetFreeInventorySpace() == 0)
+                        {
+                            player->SendEquipError(EQUIP_ERR_INVENTORY_FULL, nullptr, nullptr, m_spellInfo->Effects[i].ItemType);
+                            return SPELL_FAILED_DONT_REPORT;
+                        }
+                        else if (msg != EQUIP_ERR_OK)
                         {
                             ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(m_spellInfo->Effects[i].ItemType);
                             /// @todo Needs review


### PR DESCRIPTION
**Changes proposed:**
-  add check for free space in bags

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [? ] master

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #24182

**Tests performed:** (Does it build, tested in-game, etc.)
+ Compiles; 
+ Tested, with steps provided in #24182:
   1..add 37702 11
   2.transform 10 item=37702 into 1 Eternal Fire
   3.make sure you have no free slot in your bags
   4.Click the Eternal Fire
   5.You will en up with 10 Crystallized Fire instead of 11


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ]