### PR TITLE
Core/AI: Fix reset and interruption of non melee spells

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -205,6 +205,11 @@ void CreatureAI::JustAppeared()
     }
 }
 
+void CreatureAI::JustReachedHome()
+{
+    Reset();
+}
+
 void CreatureAI::JustEnteredCombat(Unit* who)
 {
     if (!IsEngaged() && !me->CanHaveThreatList())
@@ -234,7 +239,6 @@ void CreatureAI::EnterEvadeMode(EvadeReason why)
         }
     }
 
-    Reset();
 }
 
 bool CreatureAI::UpdateVictim()
@@ -276,6 +280,7 @@ void CreatureAI::EngagementStart(Unit* who)
     }
     _isEngaged = true;
 
+    me->InterruptNonMeleeSpells(false);
     me->AtEngage(who);
 }
 

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -157,7 +157,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         void OnCharmed(bool isNew) override;
 
         // Called at reaching home after evade
-        virtual void JustReachedHome() { }
+        virtual void JustReachedHome();
 
         void DoZoneInCombat(Creature* creature = nullptr);
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Move the reset to JustReachedHome() instead of EnterEvadeMode()
-  Interrupt non melee spells in EngagementStart()
-  

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** It fixes issues encountered in this PR https://github.com/TrinityCore/TrinityCore/pull/24300

**Tests performed:** Does it build: Yes, tested in-game: Yes

**Known issues and TODO list:** (add/remove lines as needed)

- [ ]  Review

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
