### PR TITLE
Core/Dep: Rethrow the original exception object using an empty throw.…

### DIFF
--- a/dep/g3dlite/source/AnyTableReader.cpp
+++ b/dep/g3dlite/source/AnyTableReader.cpp
@@ -12,7 +12,7 @@ AnyTableReader::AnyTableReader(const std::string& name, const Any& a) : m_any(a)
         // invoked automatically.
         m_any.~Any();
         m_alreadyRead.~Set();
-        throw e;
+        throw;
     }
 }
 
@@ -25,7 +25,7 @@ AnyTableReader::AnyTableReader(const Any& a) : m_any(a) {
         // invoked automatically.
         m_any.~Any();
         m_alreadyRead.~Set();
-        throw e;
+        throw;
     }
 }
 

--- a/dep/g3dlite/source/BinaryInput.cpp
+++ b/dep/g3dlite/source/BinaryInput.cpp
@@ -297,9 +297,8 @@ void BinaryInput::loadIntoMemory(int64 startPosition, int64 minLength) {
 
 #   ifdef G3D_WINDOWS
         FILE* file = fopen(m_filename.c_str(), "rb");
-		if (!file) {
-			return;
-		}
+	    if (!file)
+		    return;
         debugAssert(file);
         size_t ret = fseek(file, (off_t)m_alreadyRead, SEEK_SET);
         debugAssert(ret == 0);

--- a/dep/g3dlite/source/BinaryInput.cpp
+++ b/dep/g3dlite/source/BinaryInput.cpp
@@ -297,6 +297,9 @@ void BinaryInput::loadIntoMemory(int64 startPosition, int64 minLength) {
 
 #   ifdef G3D_WINDOWS
         FILE* file = fopen(m_filename.c_str(), "rb");
+		if (!file) {
+			return;
+		}
         debugAssert(file);
         size_t ret = fseek(file, (off_t)m_alreadyRead, SEEK_SET);
         debugAssert(ret == 0);


### PR DESCRIPTION
… Otherwise a copy of e is created and the original exception type is lost and replaced by its (potential) super-type ParseError.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
