### PR TITLE
Core/PacketIO: Handle CMSG_REQUEST_PET_INFO for more cases

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -904,5 +904,21 @@ void WorldSession::HandleLearnPreviewTalentsPet(WorldPacket& recvData)
 
 void WorldSession::HandleRequestPetInfoOpcode(WorldPacket& /*recvPacket*/)
 {
-    GetPlayer()->PetSpellInitialize();
+    // Handle the packet CMSG_REQUEST_PET_INFO - sent when player does ingame /reload command
+
+    // Packet sent when player has a pet
+    if (_player->GetPet())
+        _player->PetSpellInitialize();
+    else if (Unit* charm = _player->GetCharmed())
+    {
+        // Packet sent when player has a possessed unit
+        if (charm->HasUnitState(UNIT_STATE_POSSESSED))
+            _player->PossessSpellInitialize();
+        // Packet sent when player controlling a vehicle
+        else if (charm->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && charm->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_POSSESSED))
+            _player->VehicleSpellInitialize();
+        // Packet sent when player has a charmed unit
+        else
+            _player->CharmSpellInitialize();
+    }
 }


### PR DESCRIPTION
Handle CMSG_REQUEST_PET_INFO for more cases:
+ vehicle
+ charm
+ possession

from https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/87c6cc19e570623ab0d1d0ae569e0a51823d0200 slightly modified

ref https://github.com/TrinityCore/TrinityCore/commit/6ebe1afeeccb847702c12e522bddaa7b5694dc38#comments

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Extend CMSG_REQUEST_PET_INFO when player uses in-game /reload command while using:
+ vehicle
+ charm
+ possession

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [] master

**Issues addressed:** Closes #  (insert issue tracker number)
none found

**Tests performed:** (Does it build, tested in-game, etc.)
These cases:
+pet, with warlock imp
+vehicle, with .npc add temp 33109
+charm, with https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=61191 on https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=11937

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
