### PR TITLE
Core/Spells: fixed a possible client crash when casting pull towards dest spells with misc value 0

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4422,7 +4422,7 @@ void Spell::EffectPullTowardsDest(SpellEffIndex effIndex)
     float distXY = unitTarget->GetExactDist(pos);
     float distZ = pos->GetPositionZ() - unitTarget->GetPositionZ();
 
-    float speedXY = m_spellInfo->Effects[effIndex].MiscValue / 10.0f;
+    float speedXY = m_spellInfo->Effects[effIndex].MiscValue ? m_spellInfo->Effects[effIndex].MiscValue / 10.0f : 30.0f;
     float speedZ = (2 * speedXY * speedXY * distZ + Movement::gravity * distXY * distXY) / (2 * speedXY * distXY);
 
     unitTarget->JumpTo(speedXY, speedZ, true, *pos);


### PR DESCRIPTION
**Changes proposed:**

-  <Shauren> one does not simply divide by 0

The pull towards dest spell effect handler was not protected against potential 0 dividers when the misc value of the effects is 0. This means the packet will contain a infinite speedZ value which will ultimately cause a client crash. That's fixed now.

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- tested ingame on 434 which has plenty of such scenarios
