### PR TITLE
Scripts/Spells: prevent Drain Soul from cancelling prematurely

### DIFF
--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -516,6 +516,8 @@ class spell_warl_drain_soul : public SpellScriptLoader
 
             bool CheckProc(ProcEventInfo& eventInfo)
             {
+                // Drain Soul's proc tries to happen each time the warlock lands a killing blow on a unit while channeling.
+                // Make sure that dying unit is afflicted by the caster's Drain Soul debuff in order to avoid a false positive.
                 return eventInfo.GetProcTarget()->GetAuraApplicationOfRankedSpell(SPELL_WARLOCK_DRAIN_SOUL, GetCaster()->GetGUID()) != 0;
             }
 

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -519,8 +519,8 @@ class spell_warl_drain_soul : public SpellScriptLoader
                 // Drain Soul's proc tries to happen each time the warlock lands a killing blow on a unit while channeling.
                 // Make sure that dying unit is afflicted by the caster's Drain Soul debuff in order to avoid a false positive.
 
-                Unit * caster = GetCaster();
-                Unit * victim = eventInfo.GetProcTarget();
+                Unit* caster = GetCaster();
+                Unit* victim = eventInfo.GetProcTarget();
 
                 if (caster && victim)
                     return victim->GetAuraApplicationOfRankedSpell(SPELL_WARLOCK_DRAIN_SOUL, caster->GetGUID()) != 0;

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -518,7 +518,14 @@ class spell_warl_drain_soul : public SpellScriptLoader
             {
                 // Drain Soul's proc tries to happen each time the warlock lands a killing blow on a unit while channeling.
                 // Make sure that dying unit is afflicted by the caster's Drain Soul debuff in order to avoid a false positive.
-                return eventInfo.GetProcTarget()->GetAuraApplicationOfRankedSpell(SPELL_WARLOCK_DRAIN_SOUL, GetCaster()->GetGUID()) != 0;
+
+                Unit * caster = GetCaster();
+                Unit * victim = eventInfo.GetProcTarget();
+
+                if (caster && victim)
+                    return victim->GetAuraApplicationOfRankedSpell(SPELL_WARLOCK_DRAIN_SOUL, caster->GetGUID()) != 0;
+
+                return false;
             }
 
             void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -35,6 +35,7 @@
 
 enum WarlockSpells
 {
+    SPELL_WARLOCK_DRAIN_SOUL                        = 1120,
     SPELL_WARLOCK_CREATE_SOULSHARD                  = 43836,
     SPELL_WARLOCK_CURSE_OF_DOOM_EFFECT              = 18662,
     SPELL_WARLOCK_DEMONIC_CIRCLE_SUMMON             = 48018,
@@ -513,6 +514,11 @@ class spell_warl_drain_soul : public SpellScriptLoader
                 });
             }
 
+            bool CheckProc(ProcEventInfo& eventInfo)
+            {
+                return eventInfo.GetProcTarget()->GetAuraApplicationOfRankedSpell(SPELL_WARLOCK_DRAIN_SOUL, GetCaster()->GetGUID()) != 0;
+            }
+
             void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
             {
                 PreventDefaultAction();
@@ -548,9 +554,15 @@ class spell_warl_drain_soul : public SpellScriptLoader
 
             void Register() override
             {
+
+                // DoT Tick
                 OnEffectPeriodic += AuraEffectPeriodicFn(spell_warl_drain_soul_AuraScript::HandleTick, EFFECT_1, SPELL_AURA_PERIODIC_DAMAGE);
+
+                // Proc
+                DoCheckProc += AuraCheckProcFn(spell_warl_drain_soul_AuraScript::CheckProc);
                 OnEffectProc += AuraEffectProcFn(spell_warl_drain_soul_AuraScript::HandleProc, EFFECT_2, SPELL_AURA_PROC_TRIGGER_SPELL);
             }
+
         };
 
         AuraScript* GetAuraScript() const override


### PR DESCRIPTION
**Changes proposed:**

-  Prevent Drain Soul from proccing early when the warlock deals a killing blow to a unit other than the victim of drain soul.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Fixes #24368


**Tests performed:**

Two-target test:

1. Create a warlock.
2. Teach the warlock Drain Soul: `.learn 1120`
3. Give the warlock a high-rank of Corruption for convenient enemy killing: `.learn 11672`
4. Engage two experience-granting targets in combat.
5. Cast Corruption on target A.
6. Before target A dies, cast Drain Soul on target B.
7. When Target A dies, Drain Soul should still be casting on target B.
8. Kill Target A while channeling Drain Soul on it. A soul shard should be generated.

Continued proc test:

1. Level the same warlock to level 16: .level 15
2. Get Improved Drain Soul from the Affliction Tree
3. Have your "What happened to me?" view of the combat log ready.
4. Engage two experience-granting targets in combat.
5. Cast Corruption on target A.
6. Before target A dies, cast Drain Soul on target B.
7. When target A dies, observe that Drain Soul has not procced to give the caster mana back. As with the original test, Drain Soul should not be interrupted by the death of Target A.
8. Kill target B while channeling Drain Soul on it. A soul share should be generated, and the caster should receive mana back.
