### PR TITLE
Scripts/Spells: Fixed Warlock Drain Soul issues

### DIFF
--- a/sql/updates/world/3.3.5/2020_11_87_87_world.sql
+++ b/sql/updates/world/3.3.5/2020_11_87_87_world.sql
@@ -1,0 +1,2 @@
+-- Disable proc of Drain Soul (will be handled by script)
+UPDATE `spell_proc` SET `AttributesMask`=0, `DisableEffectsMask`=7 WHERE `SpellId`=-1120;


### PR DESCRIPTION
**Changes proposed:**

Ok, time to try explain it.
In last approach (43c08b176115505b76c027667047f9a5bfcc4e11) i tried fixed some issues, including: "Drain soul was interrupted if someone in your group die. Caused by negative effects proccing in creature."

To fix it, i removed proc of Effect_0 and Effect_1, and allow only Effect_2 (positive one) proc.
But, effect_2 proc, cause a new issue, reported in #24368.
It happens because we dont check target, so it will proc for any creature that warlock kills.

So reverting disable of Effect_0 and Effect_1, and disabling effect_2, we back to original issue.
When you cast drain soul in a creature, and this creature kill anyone, drain soul is interrupted.

With debug, i tracked why it happens.

Everything start in
```
void Unit::Kill(Unit* attacker, Unit* victim, bool durabilityLoss /*= true*/)
```

We have this check there:

```cpp
 if (!victim->IsCritter())
        Unit::ProcSkillsAndAuras(attacker, victim, PROC_FLAG_KILL, PROC_FLAG_KILLED, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
```
In this case, we have attacker = creature and victim = your group mate.

Ignoring a little steps, we reach the method:

```cpp
void Unit::TriggerAurasProcOnEvent(Unit* actionTarget, uint32 typeMaskActor, uint32 typeMaskActionTarget, uint32 spellTypeMask, uint32 spellPhaseMask, uint32 hitMask, Spell* spell, DamageInfo* damageInfo, HealInfo* healInfo)
```

inside has this loop:

```cpp
for (auto itr = modOwner->GetAppliedAuras().begin(); itr != modOwner->GetAppliedAuras().end(); ++itr)
```
It means: i will get ALL applied auras on actor (in this case, actor = creature), and try proc it with PROC_FLAG_KILL.

**It works fine for good part of PROC_FLAG_KILL auras, since they only have positive effects, with target = UNIT_TARGET_CASTER.**

But... Drain Soul has negative effects too, so negative effects will be in creature, that will cause wrong proc of Drain Soul, since creature is not the caster of aura (and should not proc it lul)

I dont think that is the case of a generic fix, since drain soul is a exception.
And since it's a exception, is better fix it as a exception.

That's why i fixed it just using script.
I disabled the proc, it's not needed at all.
And handled like Cataclysm handle it (ty Elon-sucker <3), just using OnEffectRemove hook.
It fix all issues related with drain soul, and spell will work again :)


**Target branch(es):** 3.3.5

**Issues addressed:** Closes #24368 and replace #24368


**Tests performed:** Builded and tested fine. All issues are fixed.

