### PR TITLE
Fix #22948

### DIFF
--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -385,7 +385,6 @@ public:
             SetPhase(PHASE_NOT_STARTED, true);
             me->SetReactState(REACT_PASSIVE);
             instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMED_START_EVENT);
-            
             GameObject* iris = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(DATA_FOCUSING_IRIS_GUID));
             iris->SetPhaseMask(1, true); //1 = visible
         }

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -385,6 +385,9 @@ public:
             SetPhase(PHASE_NOT_STARTED, true);
             me->SetReactState(REACT_PASSIVE);
             instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMED_START_EVENT);
+            
+            GameObject* iris = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(DATA_FOCUSING_IRIS_GUID));
+            iris->SetPhaseMask(1, true); //1 = visible
         }
 
         uint32 GetData(uint32 data) const override
@@ -765,7 +768,7 @@ public:
                         if (GameObject* iris = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(DATA_FOCUSING_IRIS_GUID)))
                         {
                             me->SetFacingToObject(iris);
-                            iris->Delete(); // this is not the best way.
+                            iris->SetPhaseMask(2, true); //2 = Not visible
                         }
                         me->SetReactState(REACT_AGGRESSIVE);
                         SetPhase(PHASE_ONE, true);


### PR DESCRIPTION
**Changes proposed:**

-  Use phase mask instead of deleting iris.
-  When resetting the instance due to wipe, show the iris by calling SetPhaseMask again.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #22948

**Tests performed:** (Does it build, tested in-game, etc.)
Builds
Tested in-game before fix and confirmed it's still an issue
Tested in-game after fix and confirmed the orb disappears when encounter starts
Tested in-game after fix and confirmed the orb reappears after encounter wipes
Ensured that player can walk through the area where orb was after it disappears

**Known issues and TODO list:** (add/remove lines as needed)
N/A