### PR TITLE
Core/Spells: Scrolls should not be consumed, when they fail to apply

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13336,43 +13336,46 @@ int32 Unit::GetHighestExclusiveSameEffectSpellGroupValue(AuraEffect const* aurEf
 bool Unit::IsHighestExclusiveAura(Aura const* aura, bool removeOtherAuraApplications /*= false*/)
 {
     for (uint32 i = 0 ; i < MAX_SPELL_EFFECTS; ++i)
-    {
         if (AuraEffect const* aurEff = aura->GetEffect(i))
+            if (!IsHighestExclusiveAuraEffect(aura->GetSpellInfo(), aurEff->GetAuraType(), aurEff->GetAmount(), aura->GetEffectMask(), removeOtherAuraApplications))
+                return false;
+
+    return true;
+}
+
+bool Unit::IsHighestExclusiveAuraEffect(SpellInfo const* spellInfo, AuraType auraType, int32 effectAmount, uint8 auraEffectMask, bool removeOtherAuraApplications /*= false*/)
+{
+    AuraEffectList const& auras = GetAuraEffectsByType(auraType);
+    for (Unit::AuraEffectList::const_iterator itr = auras.begin(); itr != auras.end();)
+    {
+        AuraEffect const* existingAurEff = (*itr);
+        ++itr;
+
+        if (sSpellMgr->CheckSpellGroupStackRules(spellInfo, existingAurEff->GetSpellInfo()) == SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST)
         {
-            AuraType const auraType = AuraType(aura->GetSpellInfo()->Effects[i].ApplyAuraName);
-            AuraEffectList const& auras = GetAuraEffectsByType(auraType);
-            for (Unit::AuraEffectList::const_iterator itr = auras.begin(); itr != auras.end();)
+            int32 diff = abs(effectAmount) - abs(existingAurEff->GetAmount());
+            if (!diff)
+                for (int32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+                    diff += int32((auraEffectMask & (1 << i)) >> i) - int32((existingAurEff->GetBase()->GetEffectMask() & (1 << i)) >> i);
+
+            if (diff > 0)
             {
-                AuraEffect const* existingAurEff = (*itr);
-                ++itr;
-
-                if (sSpellMgr->CheckSpellGroupStackRules(aura->GetSpellInfo(), existingAurEff->GetSpellInfo())
-                    == SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST)
+                Aura const* base = existingAurEff->GetBase();
+                // no removing of area auras from the original owner, as that completely cancels them
+                if (removeOtherAuraApplications && (!base->IsArea() || base->GetOwner() != this))
                 {
-                    int32 diff = abs(aurEff->GetAmount()) - abs(existingAurEff->GetAmount());
-                    if (!diff)
-                        diff = int32(aura->GetEffectMask()) - int32(existingAurEff->GetBase()->GetEffectMask());
-
-                    if (diff > 0)
+                    if (AuraApplication* aurApp = existingAurEff->GetBase()->GetApplicationOfTarget(GetGUID()))
                     {
-                        Aura const* base = existingAurEff->GetBase();
-                        // no removing of area auras from the original owner, as that completely cancels them
-                        if (removeOtherAuraApplications && (!base->IsArea() || base->GetOwner() != this))
-                        {
-                            if (AuraApplication* aurApp = existingAurEff->GetBase()->GetApplicationOfTarget(GetGUID()))
-                            {
-                                bool hasMoreThanOneEffect = base->HasMoreThanOneEffectForType(auraType);
-                                uint32 removedAuras = m_removedAurasCount;
-                                RemoveAura(aurApp);
-                                if (hasMoreThanOneEffect || m_removedAurasCount > removedAuras + 1)
-                                    itr = auras.begin();
-                            }
-                        }
+                        bool hasMoreThanOneEffect = base->HasMoreThanOneEffectForType(auraType);
+                        uint32 removedAuras = m_removedAurasCount;
+                        RemoveAura(aurApp);
+                        if (hasMoreThanOneEffect || m_removedAurasCount > removedAuras + 1)
+                            itr = auras.begin();
                     }
-                    else if (diff < 0)
-                        return false;
                 }
             }
+            else if (diff < 0)
+                return false;
         }
     }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1668,6 +1668,7 @@ class TC_GAME_API Unit : public WorldObject
 
         int32 GetHighestExclusiveSameEffectSpellGroupValue(AuraEffect const* aurEff, AuraType auraType, bool checkMiscValue = false, int32 miscValue = 0) const;
         bool IsHighestExclusiveAura(Aura const* aura, bool removeOtherAuraApplications = false);
+        bool IsHighestExclusiveAuraEffect(SpellInfo const* spellInfo, AuraType auraType, int32 effectAmount, uint8 auraEffectMask, bool removeOtherAuraApplications = false);
 
         virtual void Talk(std::string const& text, ChatMsg msgType, Language language, float textRange, WorldObject const* target);
         virtual void Say(std::string const& text, Language language, WorldObject const* target = nullptr);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3244,21 +3244,21 @@ void Spell::_cast(bool skipCheck)
 
     CallScriptBeforeCastHandlers();
 
-    auto cleanupSpell = [this, modOwner](SpellCastResult res, uint32* p1 = nullptr, uint32* p2 = nullptr)
-    {
-        SendCastResult(res, p1, p2);
-        SendInterrupted(0);
-
-        if (modOwner)
-            modOwner->SetSpellModTakingSpell(this, false);
-
-        finish(false);
-        SetExecutedCurrently(false);
-    };
-
     // skip check if done already (for instant cast spells for example)
     if (!skipCheck)
     {
+        auto cleanupSpell = [this, modOwner](SpellCastResult res, uint32* p1 = nullptr, uint32* p2 = nullptr)
+        {
+            SendCastResult(res, p1, p2);
+            SendInterrupted(0);
+
+            if (modOwner)
+                modOwner->SetSpellModTakingSpell(this, false);
+
+            finish(false);
+            SetExecutedCurrently(false);
+        };
+
         uint32 param1 = 0, param2 = 0;
         SpellCastResult castResult = CheckCast(false, &param1, &param2);
         if (castResult != SPELL_CAST_OK)
@@ -3313,40 +3313,6 @@ void Spell::_cast(bool skipCheck)
                     }
                 }
             }
-        }
-    }
-
-    // check if target already has the same type, but more powerful aura
-    if (modOwner)
-    {
-        for (uint32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-        {
-            if (!GetSpellInfo()->Effects[i].IsAura())
-                continue;
-
-                Unit::AuraEffectList const& auras = modOwner->GetAuraEffectsByType(SPELL_AURA_MOD_STAT);
-                for (Unit::AuraEffectList::const_iterator auraIt = auras.begin(); auraIt != auras.end(); ++auraIt)
-                {
-                    // check if both spells are in same SpellGroups
-                    if (sSpellMgr->CheckSpellGroupStackRules(GetSpellInfo(), (*auraIt)->GetSpellInfo()) == SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST)
-                    {
-                        // compare new aura vs existing aura
-                        if (abs(GetSpellInfo()->Effects[i].BasePoints) < abs((*auraIt)->GetSpellInfo()->Effects[i].BasePoints))
-                        {
-                            cleanupSpell(SPELL_FAILED_AURA_BOUNCED);
-                            return;
-                        }
-                        else if (abs(GetSpellInfo()->Effects[i].BasePoints) == abs((*auraIt)->GetSpellInfo()->Effects[i].BasePoints))
-                        {
-                            // in case when baseboints match and to avoid false positive, example, spell 8097 vs 8116
-                            if (abs(GetSpellInfo()->Effects[i].MiscValue) == abs((*auraIt)->GetSpellInfo()->Effects[i].MiscValue))
-                            {
-                                cleanupSpell(SPELL_FAILED_AURA_BOUNCED);
-                                return;
-                            }
-                        }
-                    }
-                }
         }
     }
 
@@ -5426,6 +5392,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
         }
     }
 
+    uint8 approximateAuraEffectMask = 0;
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         // for effects of spells that have only one target
@@ -5844,6 +5811,9 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
             default:
                 break;
         }
+
+        if (m_spellInfo->Effects[i].IsAura())
+            approximateAuraEffectMask |= 1 << i;
     }
 
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
@@ -5968,6 +5938,12 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
             default:
                 break;
         }
+
+        // check if target already has the same type, but more powerful aura
+        if (!m_spellInfo->IsTargetingArea())
+            if (Unit* target = m_targets.GetUnitTarget())
+                if (!target->IsHighestExclusiveAuraEffect(m_spellInfo, AuraType(m_spellInfo->Effects[i].ApplyAuraName), m_spellInfo->Effects[i].CalcValue(), approximateAuraEffectMask, false))
+                    return SPELL_FAILED_AURA_BOUNCED;
     }
 
     // check trade slot case (last, for allow catch any another cast problems)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- add check if there is more powerful aura applied and only then delete item if there is none.
After chenges with "A more powerful spell is already active" item is not consumed/deleted.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #18429

**Tests performed:**
Tested in these cases:
A)
1. With 80lvl Mage.
2. .add item 17020 10 
3. .learn 43002 [Arcane Brilliance Rank3](https://woehead.way-of-elendil.fr/?spell=43002#spell-group-stack) & apply on self
4. .additem 2290 13  [Scroll of Intellect II](https://woehead.way-of-elendil.fr/?item=2290) and use it
5. **Result:** There will be error "A more powerful spell is already active", item wont be consumed

B) 
1. Disable aura [Arcane Brilliance Rank3](https://woehead.way-of-elendil.fr/?spell=43002#spell-group-stack)
2. use [Scroll of Intellect II](https://woehead.way-of-elendil.fr/?item=2290)
3. **Result:** Aura will be applied and item consumed

C) 
1. while active aura from [Scroll of Intellect II](https://woehead.way-of-elendil.fr/?item=2290)
2. use again [Scroll of Intellect II](https://woehead.way-of-elendil.fr/?item=2290)
3. **Result:** Aura timer renewed, item consumed

D) 
1. get a char with pet
2. .additem 1477 6 and apply a [Scroll of Agility II](https://woehead.way-of-elendil.fr/?item=1477) to you and pet
3. .additem 1180 6 and attempt to apply a [Scroll of Stamina](https://woehead.way-of-elendil.fr/?item=1180) while previous buff is active on self and then pet
4. **Result:** There will be error "A more powerful spell is already active" for both, item wont be consumed

E)
1. Before buff timer runs out on pet and you, reapply [Scroll of Agility II](https://woehead.way-of-elendil.fr/?item=1477)
2.  **Result:** Aura timer renewed for both, items consumed

F) 
1. While aura from [Scroll of Agility II](https://woehead.way-of-elendil.fr/?item=1477) active, use [Scroll of Intellect II](https://woehead.way-of-elendil.fr/?item=2290)
2. **Result:** [Scroll of Intellect II](https://woehead.way-of-elendil.fr/?item=2290) aura replaces [Scroll of Agility II](https://woehead.way-of-elendil.fr/?item=1477) 

G)
1. .additem 11566 3 [Crystal Charge](https://woehead.way-of-elendil.fr/?item=11566)
2. use item on target
3. **Result:** After items explosion effect, from 3 charges 1 consumed, 2 left.


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
