### PR TITLE
Core/Spells: Fixed Ice Block / Divine Shield cast in Cyclone

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6110,6 +6110,8 @@ SpellCastResult Spell::CheckCasterAuras(uint32* param1) const
         }
         else if (!CheckSpellCancelsStun(param1))
             result = SPELL_FAILED_STUNNED;
+        else if ((m_spellInfo->Mechanic & MECHANIC_IMMUNE_SHIELD) && m_caster->ToUnit() && m_caster->ToUnit()->HasAuraWithMechanic(1 << MECHANIC_BANISH))
+            result = SPELL_FAILED_STUNNED;
     }
     else if (unitflag & UNIT_FLAG_SILENCED && m_spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && !CheckSpellCancelsSilence(param1))
         result = SPELL_FAILED_SILENCED;


### PR DESCRIPTION
**Changes proposed:**

-  Old fix about it: https://github.com/TrinityCore/TrinityCore/pull/7285
-  Players should cant cast ice block and divine shield while in cyclone.

**Target branch(es):** 3.3.5

**Tests performed:** Builded and tested in game


