### PR TITLE
Scripts/OnyxiasLair: Fix Onyxia Eruption spell

### DIFF
--- a/src/server/scripts/Kalimdor/OnyxiasLair/instance_onyxias_lair.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/instance_onyxias_lair.cpp
@@ -111,7 +111,9 @@ public:
                 //THIS GOB IS A TRAP - What shall i do? =(
                 //Cast it spell? Copyed Heigan method
                 floorEruption->SendCustomAnim(floorEruption->GetGoAnimProgress());
-                floorEruption->CastSpell(nullptr, Difficulty(instance->GetSpawnMode()) == RAID_DIFFICULTY_10MAN_NORMAL ? 17731 : 69294); //pFloorEruption->GetGOInfo()->trap.spellId
+                CastSpellExtraArgs args;
+                args.OriginalCaster = onyxiaGUID;
+                floorEruption->CastSpell(floorEruption, floorEruption->GetGOInfo()->trap.spellId, args);
 
                 //Get all immediatly nearby floors
                 std::list<GameObject*> nearFloorList;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Set boss as originalCaster for proper spellcast
-  Ternary Operator for spell difficulty isn't needed, spell have spell difficulty and works properly

For some reason, spell hit onyxia too, but this is another issue, explained here: #22824


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** Update #22824 (don't close)


**Tests performed:** Tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
