### PR TITLE
Core/GameObject: Remove linked traps when the main GameObject is remo…

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -241,6 +241,10 @@ void GameObject::RemoveFromWorld()
             if (GetMap()->ContainsGameObjectModel(*m_model))
                 GetMap()->RemoveGameObjectModel(*m_model);
 
+        // If linked trap exists, despawn it
+        if (GameObject* linkedTrap = GetLinkedTrap())
+        linkedTrap->DespawnOrUnsummon();
+
         WorldObject::RemoveFromWorld();
 
         if (m_spawnId)
@@ -907,10 +911,6 @@ void GameObject::DespawnOrUnsummon(Milliseconds delay, Seconds forceRespawnTime)
 
 void GameObject::Delete()
 {
-    // If nearby linked trap exists, despawn it
-    if (GameObject* linkedTrap = GetLinkedTrap())
-        linkedTrap->DespawnOrUnsummon();
-
     SetLootState(GO_NOT_READY);
     RemoveFromOwner();
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -243,7 +243,7 @@ void GameObject::RemoveFromWorld()
 
         // If linked trap exists, despawn it
         if (GameObject* linkedTrap = GetLinkedTrap())
-        linkedTrap->DespawnOrUnsummon();
+            linkedTrap->DespawnOrUnsummon();
 
         WorldObject::RemoveFromWorld();
 


### PR DESCRIPTION
…ved from the world

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Move the part of the code https://github.com/TrinityCore/TrinityCore/commit/750be73b9963ebcd4b823ec88b20af7cd819529b  that remove the linked trap from void GameObject::Delete() to void GameObject::RemoveFromWorld()

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #24183


**Tests performed:** it build, tested in-game


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Review

