### PR TITLE
Game/SmartScripts: Reset counter in SAI only on Initialize.

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3760,7 +3760,7 @@ void SmartScript::OnInitialize(WorldObject* obj, AreaTriggerEntry const* at)
     ProcessEventsFor(SMART_EVENT_AI_INIT);
     InstallEvents();
     ProcessEventsFor(SMART_EVENT_JUST_CREATED);
-	mCounterList.clear();
+    mCounterList.clear();
 }
 
 void SmartScript::OnMoveInLineOfSight(Unit* who)

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -179,7 +179,6 @@ void SmartScript::OnReset()
     }
     ProcessEventsFor(SMART_EVENT_RESET);
     mLastInvoker.Clear();
-    mCounterList.clear();
 }
 
 void SmartScript::ResetBaseObject()
@@ -3761,6 +3760,7 @@ void SmartScript::OnInitialize(WorldObject* obj, AreaTriggerEntry const* at)
     ProcessEventsFor(SMART_EVENT_AI_INIT);
     InstallEvents();
     ProcessEventsFor(SMART_EVENT_JUST_CREATED);
+	mCounterList.clear();
 }
 
 void SmartScript::OnMoveInLineOfSight(Unit* who)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  This PR fix es the issue https://github.com/TrinityCore/TrinityCore/issues/24436. The counter in SAI will no longer be reset in Hook OnReset (which is called after each evade). The counter should only be handled to be resetted manually in SAI DB scripts itself.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5


**Issues addressed:** Closes #  (insert issue tracker number)
https://github.com/TrinityCore/TrinityCore/issues/24436

**Tests performed:** (Does it build, tested in-game, etc.)
yes

**Known issues and TODO list:** (add/remove lines as needed)

- [x] nothing



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
