### PR TITLE
Core/Spell: Fix stutter step cast while moving exploit

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26895,3 +26895,10 @@ std::string Player::GetDebugInfo() const
     sstr << Unit::GetDebugInfo();
     return sstr.str();
 }
+
+void Player::InterruptSpellsByMovement()
+{
+    for (uint32 i = CURRENT_FIRST_NON_MELEE_SPELL; i < CURRENT_MAX_SPELL; i++)
+        if (m_currentSpells[i] && m_currentSpells[i]->IsInterruptedByMovement())
+            InterruptSpell(static_cast<CurrentSpellTypes>(i), false);
+}

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2171,6 +2171,8 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         std::string GetDebugInfo() const override;
 
+        void InterruptSpellsByMovement();
+
     protected:
         // Gamemaster whisper whitelist
         GuidList WhisperList;

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -35,6 +35,7 @@
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
+#include "Spell.h"
 
 void WorldSession::HandleMoveWorldportAckOpcode(WorldPacket & /*recvData*/)
 {
@@ -409,6 +410,12 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
 
     if (plrMover)                                            // nothing is charmed, or player charmed
     {
+        //We only really care if it's moving, other updates don't really matter for interruptions.
+        if (movementInfo.HasMovementFlag(MovementFlags::MOVEMENTFLAG_MASK_MOVING) && plrMover->HasUnitState(UnitState::UNIT_STATE_CASTING))
+            for (uint32 i = CURRENT_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
+                if (Spell* spell = plrMover->GetCurrentSpell(CurrentSpellTypes(i)))
+                    spell->AddMovementFlags(static_cast<MovementFlags>(movementInfo.flags));
+
         if (plrMover->IsSitState() && (movementInfo.flags & (MOVEMENTFLAG_MASK_MOVING | MOVEMENTFLAG_MASK_TURNING)))
             plrMover->SetStandState(UNIT_STAND_STATE_STAND);
 

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -35,7 +35,6 @@
 #include <boost/accumulators/statistics/variance.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics.hpp>
-#include "Spell.h"
 
 void WorldSession::HandleMoveWorldportAckOpcode(WorldPacket & /*recvData*/)
 {
@@ -410,12 +409,6 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
 
     if (plrMover)                                            // nothing is charmed, or player charmed
     {
-        //We only really care if it's moving, other updates don't really matter for interruptions.
-        if (movementInfo.HasMovementFlag(MovementFlags::MOVEMENTFLAG_MASK_MOVING) && plrMover->HasUnitState(UnitState::UNIT_STATE_CASTING))
-            for (uint32 i = CURRENT_MELEE_SPELL; i < CURRENT_MAX_SPELL; ++i)
-                if (Spell* spell = plrMover->GetCurrentSpell(CurrentSpellTypes(i)))
-                    spell->AddMovementFlags(static_cast<MovementFlags>(movementInfo.flags));
-
         if (plrMover->IsSitState() && (movementInfo.flags & (MOVEMENTFLAG_MASK_MOVING | MOVEMENTFLAG_MASK_TURNING)))
             plrMover->SetStandState(UNIT_STAND_STATE_STAND);
 

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -409,6 +409,8 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
 
     if (plrMover)                                            // nothing is charmed, or player charmed
     {
+        plrMover->InterruptSpellsByMovement();
+
         if (plrMover->IsSitState() && (movementInfo.flags & (MOVEMENTFLAG_MASK_MOVING | MOVEMENTFLAG_MASK_TURNING)))
             plrMover->SetStandState(UNIT_STAND_STATE_STAND);
 

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -522,7 +522,7 @@ class TC_GAME_API SpellEvent : public BasicEvent
 Spell::Spell(WorldObject* caster, SpellInfo const* info, TriggerCastFlags triggerFlags, ObjectGuid originalCasterGUID) :
 m_spellInfo(sSpellMgr->GetSpellForDifficultyFromSpell(info, caster)),
 m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerOrOwner()) ? caster->GetCharmerOrOwner() : caster)
-, m_spellValue(new SpellValue(m_spellInfo)), _spellEvent(nullptr), m_trackedCasterAggregatedMovementFlags(MovementFlags::MOVEMENTFLAG_NONE)
+, m_spellValue(new SpellValue(m_spellInfo)), _spellEvent(nullptr)
 {
     m_customError = SPELL_CUSTOM_ERROR_NONE;
     m_selfContainer = nullptr;
@@ -3708,7 +3708,7 @@ void Spell::update(uint32 difftime)
 
     // check if the player caster has moved before the spell finished
     if (m_caster->GetTypeId() == TYPEID_PLAYER && m_timer != 0 &&
-        (m_caster->ToPlayer()->isMoving() || GetAggregatedUnitMovementFlags() & MovementFlags::MOVEMENTFLAG_MASK_MOVING) && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT &&
+        m_caster->ToPlayer()->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT &&
         (m_spellInfo->Effects[EFFECT_0].Effect != SPELL_EFFECT_STUCK || !m_caster->ToPlayer()->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
     {
         // don't cancel for melee, autorepeat, triggered and instant spells

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -522,7 +522,7 @@ class TC_GAME_API SpellEvent : public BasicEvent
 Spell::Spell(WorldObject* caster, SpellInfo const* info, TriggerCastFlags triggerFlags, ObjectGuid originalCasterGUID) :
 m_spellInfo(sSpellMgr->GetSpellForDifficultyFromSpell(info, caster)),
 m_caster((info->HasAttribute(SPELL_ATTR6_CAST_BY_CHARMER) && caster->GetCharmerOrOwner()) ? caster->GetCharmerOrOwner() : caster)
-, m_spellValue(new SpellValue(m_spellInfo)), _spellEvent(nullptr)
+, m_spellValue(new SpellValue(m_spellInfo)), _spellEvent(nullptr), m_trackedCasterAggregatedMovementFlags(MovementFlags::MOVEMENTFLAG_NONE)
 {
     m_customError = SPELL_CUSTOM_ERROR_NONE;
     m_selfContainer = nullptr;
@@ -3708,7 +3708,7 @@ void Spell::update(uint32 difftime)
 
     // check if the player caster has moved before the spell finished
     if (m_caster->GetTypeId() == TYPEID_PLAYER && m_timer != 0 &&
-        m_caster->ToPlayer()->isMoving() && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT &&
+        (m_caster->ToPlayer()->isMoving() || GetAggregatedUnitMovementFlags() & MovementFlags::MOVEMENTFLAG_MASK_MOVING) && m_spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_MOVEMENT &&
         (m_spellInfo->Effects[EFFECT_0].Effect != SPELL_EFFECT_STUCK || !m_caster->ToPlayer()->HasUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR)))
     {
         // don't cancel for melee, autorepeat, triggered and instant spells

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -63,7 +63,6 @@ enum SpellTargetObjectTypes : uint8;
 enum SpellValueMod : uint8;
 enum TriggerCastFlags : uint32;
 enum WeaponAttackType : uint8;
-enum MovementFlags : uint32;
 
 #define SPELL_CHANNEL_UPDATE_INTERVAL (1 * IN_MILLISECONDS)
 #define MAX_SPELL_RANGE_TOLERANCE 3.0f
@@ -563,18 +562,6 @@ class TC_GAME_API Spell
 
         std::string GetDebugInfo() const;
 
-        //HelloKitty: I added these to address the issue of being able to move while casting. If we don't track the total movement flags being set new move packets can overwrite movement
-        //Before Spell::Update happens.
-        MovementFlags GetAggregatedUnitMovementFlags() const
-        {
-            return m_trackedCasterAggregatedMovementFlags;
-        }
-
-        void AddMovementFlags(MovementFlags flags)
-        {
-            m_trackedCasterAggregatedMovementFlags = static_cast<MovementFlags>(m_trackedCasterAggregatedMovementFlags | flags);
-        }
-
     protected:
         bool HasGlobalCooldown() const;
         void TriggerGlobalCooldown();
@@ -800,8 +787,6 @@ class TC_GAME_API Spell
         std::unique_ptr<PathGenerator> m_preGeneratedPath;
 
         ByteBuffer* m_effectExecuteData[MAX_SPELL_EFFECTS];
-
-        MovementFlags m_trackedCasterAggregatedMovementFlags;
 
         Spell(Spell const& right) = delete;
         Spell& operator=(Spell const& right) = delete;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -562,6 +562,8 @@ class TC_GAME_API Spell
 
         std::string GetDebugInfo() const;
 
+        bool IsInterruptedByMovement() const;
+
     protected:
         bool HasGlobalCooldown() const;
         void TriggerGlobalCooldown();

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -63,6 +63,7 @@ enum SpellTargetObjectTypes : uint8;
 enum SpellValueMod : uint8;
 enum TriggerCastFlags : uint32;
 enum WeaponAttackType : uint8;
+enum MovementFlags : uint32;
 
 #define SPELL_CHANNEL_UPDATE_INTERVAL (1 * IN_MILLISECONDS)
 #define MAX_SPELL_RANGE_TOLERANCE 3.0f
@@ -562,6 +563,18 @@ class TC_GAME_API Spell
 
         std::string GetDebugInfo() const;
 
+        //HelloKitty: I added these to address the issue of being able to move while casting. If we don't track the total movement flags being set new move packets can overwrite movement
+        //Before Spell::Update happens.
+        MovementFlags GetAggregatedUnitMovementFlags() const
+        {
+            return m_trackedCasterAggregatedMovementFlags;
+        }
+
+        void AddMovementFlags(MovementFlags flags)
+        {
+            m_trackedCasterAggregatedMovementFlags = static_cast<MovementFlags>(m_trackedCasterAggregatedMovementFlags | flags);
+        }
+
     protected:
         bool HasGlobalCooldown() const;
         void TriggerGlobalCooldown();
@@ -787,6 +800,8 @@ class TC_GAME_API Spell
         std::unique_ptr<PathGenerator> m_preGeneratedPath;
 
         ByteBuffer* m_effectExecuteData[MAX_SPELL_EFFECTS];
+
+        MovementFlags m_trackedCasterAggregatedMovementFlags;
 
         Spell(Spell const& right) = delete;
         Spell& operator=(Spell const& right) = delete;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Aggregate movement flags sent in movement packets in currently casted spells.
-  Check aggregated movement flags in Spell update and not rely exclusively on the snapshot of movement info in IsMoving() check

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)

https://github.com/TrinityCore/TrinityCore/issues/24490

**Tests performed:** (Does it build, tested in-game, etc.)

Tested locally, it fixes the ability to stutter step cast.

**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
