### PR TITLE
Scripts/Spells: Fixed Mages 2P T10 proc delay

### DIFF
--- a/sql/updates/world/3.3.5/2020_04_26_04_world.sql
+++ b/sql/updates/world/3.3.5/2020_04_26_04_world.sql
@@ -2,4 +2,4 @@ DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_mage_arcane_missiles'
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (-5143,'spell_mage_arcane_missiles');
 
-UPDATE `spell_script_names` SET `ScriptName` = 'spell_mage_missile_barrage_proc' WHERE `spell_id` = 44401;
+UPDATE `spell_script_names` SET `ScriptName`='spell_mage_missile_barrage_proc' WHERE `spell_id`=44401;

--- a/sql/updates/world/3.3.5/2020_77_40_98_world.sql
+++ b/sql/updates/world/3.3.5/2020_77_40_98_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_mage_arcane_missiles';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-5143,'spell_mage_arcane_missiles');
+
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_mage_missile_barrage_proc' WHERE `spell_id` = 44401;

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -68,7 +68,8 @@ enum MageSpells
     SPELL_MAGE_T8_4P_BONUS                       = 64869,
     SPELL_MAGE_MISSILE_BARRAGE                   = 44401,
     SPELL_MAGE_FINGERS_OF_FROST_AURASTATE_AURA   = 44544,
-    SPELL_MAGE_PERMAFROST_AURA                   = 68391
+    SPELL_MAGE_PERMAFROST_AURA                   = 68391,
+    SPELL_MAGE_ARCANE_MISSILES_R1                = 5143
 };
 
 enum MageSpellIcons
@@ -104,6 +105,38 @@ class spell_mage_incanters_absorbtion_base_AuraScript : public AuraScript
                 target->CastSpell(target, SPELL_MAGE_INCANTERS_ABSORBTION_TRIGGERED, args);
             }
         }
+};
+
+// -5143 - Arcane Missiles
+class spell_mage_arcane_missiles : public AuraScript
+{
+    PrepareAuraScript(spell_mage_arcane_missiles);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_MAGE_T10_2P_BONUS, SPELL_MAGE_T10_2P_BONUS_EFFECT });
+    }
+
+    void OnRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        if (target->HasAura(SPELL_MAGE_T10_2P_BONUS) && _canProcT10)
+            target->CastSpell(nullptr, SPELL_MAGE_T10_2P_BONUS_EFFECT, aurEff);
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_mage_arcane_missiles::OnRemove, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
+    }
+
+private:
+    bool _canProcT10 = false;
+
+public:
+    void AllowT10Proc()
+    {
+        _canProcT10 = true;
+    }
 };
 
 // -31571 - Arcane Potency
@@ -728,7 +761,6 @@ class spell_mage_focus_magic : public SpellScriptLoader
         }
 };
 
-// 44401 - Missile Barrage
 // 48108 - Hot Streak
 // 57761 - Fireball!
 class spell_mage_gen_extra_effects : public SpellScriptLoader
@@ -1301,6 +1333,51 @@ class spell_mage_missile_barrage : public SpellScriptLoader
         }
 };
 
+// 44401 - Missile Barrage
+class spell_mage_missile_barrage_proc : public AuraScript
+{
+    PrepareAuraScript(spell_mage_missile_barrage_proc);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_MAGE_T10_2P_BONUS, SPELL_MAGE_T8_4P_BONUS });
+    }
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        Unit* caster = eventInfo.GetActor();
+        // Prevent double proc for Arcane missiles
+        if (caster == eventInfo.GetProcTarget())
+            return false;
+
+        // Proc chance is unknown, we'll just use dummy aura amount
+        if (AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_MAGE_T8_4P_BONUS, EFFECT_0))
+            if (roll_chance_i(aurEff->GetAmount()))
+                return false;
+
+        return true;
+    }
+
+
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* caster = GetTarget();
+        if (caster->HasAura(SPELL_MAGE_T10_2P_BONUS))
+            if (Aura* aura = caster->GetAuraOfRankedSpell(SPELL_MAGE_ARCANE_MISSILES_R1))
+                if (spell_mage_arcane_missiles* missiles = aura->GetScript<spell_mage_arcane_missiles>(ScriptName))
+                    missiles->AllowT10Proc();
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_mage_missile_barrage_proc::CheckProc);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_mage_missile_barrage_proc::OnRemove, EFFECT_0, SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+    }
+
+public:
+    static char constexpr const ScriptName[] = "spell_mage_arcane_missiles";
+};
+
 enum SilvermoonPolymorph
 {
     NPC_AUROSALIA   = 18744,
@@ -1398,6 +1475,7 @@ class spell_mage_summon_water_elemental : public SpellScriptLoader
 void AddSC_mage_spell_scripts()
 {
     new spell_mage_arcane_potency();
+    RegisterAuraScript(spell_mage_arcane_missiles);
     new spell_mage_blast_wave();
     new spell_mage_blazing_speed();
     new spell_mage_burning_determination();
@@ -1427,6 +1505,7 @@ void AddSC_mage_spell_scripts()
     new spell_mage_master_of_elements();
     RegisterAuraScript(spell_mage_mirror_image);
     new spell_mage_missile_barrage();
+    RegisterAuraScript(spell_mage_missile_barrage_proc);
     new spell_mage_polymorph_cast_visual();
     new spell_mage_summon_water_elemental();
 }

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1358,7 +1358,6 @@ class spell_mage_missile_barrage_proc : public AuraScript
         return true;
     }
 
-
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* caster = GetTarget();


### PR DESCRIPTION
**Changes proposed:**

Ok kids, is a weird script, i know... but is needed.

Issue:
Mage 2P T10 (70753 - Pushing the Limit) should give you 12% of spell hast. It's working fine for good part of spells, but not when procced by Arcane Missiles.
Right now i's handled here: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Spells/spell_mage.cpp#L734
**Problem is:** Proc need be delayed until Arcane Missiles finish. Proof: https://youtu.be/jD4Ds6f_6wo?t=267
Current behavior (without fix): It proc when mage start cast Arcane Missiles, and he lose the whole time of arcane missiles channel (he lose aura time :/)

**Our current proc system dont allow delay it until a channel finish**, since PROC_SPELL_PHASE_FINISH is handled before channel finish.
Since i cant find any other spell with this behavior, not worth delay PROC_SPELL_PHASE_FINISH for a specific case only.
Since it looks like a exception, i'm fixing as exception (only with scripts).

**Target branch(es):** 3.3.5

**Issues addressed:** Has no open issue about it (i belive)


**Tests performed:** Builded and tested in game (using it in my server for 3 months now)

PS: Ty ElonSucker for all help 😍 

