### PR TITLE
Core/Spells: Crystallize should not use DIMINISHING

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2270,6 +2270,9 @@ void SpellInfo::_LoadSpellDiminishInfo()
                 // Screams of the Dead (King Ymiron)
                 else if (Id == 51750)
                     return DIMINISHING_NONE;
+                // Crystallize (Keristrasza heroic)
+                else if (Id == 48179)
+                    return DIMINISHING_NONE;
                 break;
             }
             // Event spells

--- a/src/server/scripts/Northrend/Nexus/Nexus/boss_keristrasza.cpp
+++ b/src/server/scripts/Northrend/Nexus/Nexus/boss_keristrasza.cpp
@@ -34,7 +34,7 @@ enum Spells
     SPELL_CRYSTAL_CHAINS                          = 50997,
     SPELL_ENRAGE                                  = 8599,
     SPELL_CRYSTALFIRE_BREATH                      = 48096,
-    SPELL_CRYSTALIZE                              = 48179,
+    SPELL_CRYSTALLIZE                             = 48179,
     SPELL_INTENSE_COLD                            = 48094,
     SPELL_INTENSE_COLD_TRIGGERED                  = 48095
 };
@@ -42,7 +42,7 @@ enum Spells
 enum Events
 {
     EVENT_CRYSTAL_FIRE_BREATH                     = 1,
-    EVENT_CRYSTAL_CHAINS_CRYSTALIZE,
+    EVENT_CRYSTAL_CHAINS_CRYSTALLIZE,
     EVENT_TAIL_SWEEP
 };
 
@@ -99,7 +99,7 @@ class boss_keristrasza : public CreatureScript
                 BossAI::JustEngagedWith(who);
 
                 events.ScheduleEvent(EVENT_CRYSTAL_FIRE_BREATH, 14s);
-                events.ScheduleEvent(EVENT_CRYSTAL_CHAINS_CRYSTALIZE, DUNGEON_MODE(30000, 11000));
+                events.ScheduleEvent(EVENT_CRYSTAL_CHAINS_CRYSTALLIZE, DUNGEON_MODE(30000, 11000));
                 events.ScheduleEvent(EVENT_TAIL_SWEEP, 5s);
             }
 
@@ -186,14 +186,14 @@ class boss_keristrasza : public CreatureScript
                             DoCastVictim(SPELL_CRYSTALFIRE_BREATH);
                             events.ScheduleEvent(EVENT_CRYSTAL_FIRE_BREATH, 14s);
                             break;
-                        case EVENT_CRYSTAL_CHAINS_CRYSTALIZE:
+                        case EVENT_CRYSTAL_CHAINS_CRYSTALLIZE:
                             DoCast(me, SPELL_TAIL_SWEEP);
-                            events.ScheduleEvent(EVENT_CRYSTAL_CHAINS_CRYSTALIZE, 5s);
+                            events.ScheduleEvent(EVENT_CRYSTAL_CHAINS_CRYSTALLIZE, 5s);
                             break;
                         case EVENT_TAIL_SWEEP:
                             Talk(SAY_CRYSTAL_NOVA);
                             if (IsHeroic())
-                                DoCast(me, SPELL_CRYSTALIZE);
+                                DoCast(me, SPELL_CRYSTALLIZE);
                             else if (Unit* target = SelectTarget(SELECT_TARGET_RANDOM, 0, 100.0f, true))
                                 DoCast(target, SPELL_CRYSTAL_CHAINS);
                             events.ScheduleEvent(EVENT_TAIL_SWEEP, DUNGEON_MODE(30000, 11000));


### PR DESCRIPTION
and also correcting mistake in spell name

by Rushor and wotlk-enthusiast

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Crystallize should not use DIMINISHING;
-  correcting mistake in spell name for script of [keristrasza](https://www.wowhead.com/npc=26723/keristrasza#abilities:mode=heroic)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #24360

**Tests performed:** (Does it build, tested in-game, etc.)
Compiles, tested in heroic mode before and after PR was applied.
+also tested by wotlk-enthusiast (author of issue ticket)
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
