### PR TITLE
Core\GameObject: corrected check for IsWithinDistInMap

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2730,7 +2730,7 @@ bool GameObject::IsAtInteractDistance(Position const& pos, float radius) const
 
 bool GameObject::IsWithinDistInMap(Player const* player) const
 {
-    return IsInMap(this) && InSamePhase(this) && IsAtInteractDistance(player);
+    return IsInMap(player) && InSamePhase(player) && IsAtInteractDistance(player);
 }
 
 SpellInfo const* GameObject::GetSpellForLock(Player const* player) const


### PR DESCRIPTION
**Changes proposed:**

-  Before change checks IsInMap(this) && InSamePhase(this) are always return true, because we check, if gameObject is in same phase or map with himself

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Tests performed:** (Does it build, tested in-game, etc.)
Build

**Known issues and TODO list:** (add/remove lines as needed)
Don't know, just logical change