### PR TITLE
Fix movement map generation

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -1084,21 +1084,21 @@ namespace MMAP
         sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileY, tileX);
         FILE* file = fopen(fileName, "rb");
         if (!file)
-            return false;
+            return true;
 
         MmapTileHeader header;
         int count = fread(&header, sizeof(MmapTileHeader), 1, file);
         fclose(file);
         if (count != 1)
-            return false;
+            return true;
 
         if (header.mmapMagic != MMAP_MAGIC || header.dtVersion != uint32(DT_NAVMESH_VERSION))
-            return false;
+            return true;
 
         if (header.mmapVersion != MMAP_VERSION)
-            return false;
+            return true;
 
-        return true;
+        return false;
     }
 
     /**************************************************************************/


### PR DESCRIPTION
**Changes proposed:**
Fixes movement map generation.

I ran mmaps with `--debugOutput true` to examine the navmesh generated using Recast. However I noticed that none of the navmeshes were actually being generated. After some debugging I found this culprit - skipping tiles that were perfectly valid, and trying to run on invalid tiles.

**Target branch(es):** 3.3.5/master
- [ ] 3.3.5
- [ ] master

**Tests performed:** (Does it build, tested in-game, etc.)
- Builds and tested in game.

**Known issues and TODO list:** (add/remove lines as needed)

