### PR TITLE
Core/DBC: Implement ServerMessage.dbc and generalize SMSG_SERVER_MESSAGE

### DIFF
--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -207,6 +207,7 @@ DBCStorage <WMOAreaTableEntry> sWMOAreaTableStore(WMOAreaTableEntryfmt);
 DBCStorage <WorldMapAreaEntry> sWorldMapAreaStore(WorldMapAreaEntryfmt);
 DBCStorage <WorldMapOverlayEntry> sWorldMapOverlayStore(WorldMapOverlayEntryfmt);
 DBCStorage <WorldSafeLocsEntry> sWorldSafeLocsStore(WorldSafeLocsEntryfmt);
+DBCStorage <ServerMessagesEntry> sServerMessagesStore(ServerMessagesEntryfmt);
 
 typedef std::list<std::string> StoreProblemList;
 
@@ -389,6 +390,7 @@ void LoadDBCStores(const std::string& dataPath)
     LOAD_DBC(sWorldMapAreaStore,                  "WorldMapArea.dbc");
     LOAD_DBC(sWorldMapOverlayStore,               "WorldMapOverlay.dbc");
     LOAD_DBC(sWorldSafeLocsStore,                 "WorldSafeLocs.dbc");
+    LOAD_DBC(sServerMessagesStore,                "ServerMessages.dbc");
 
 #undef LOAD_DBC
 

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -206,6 +206,7 @@ TC_GAME_API extern DBCStorage <WMOAreaTableEntry>            sWMOAreaTableStore;
 //TC_GAME_API extern DBCStorage <WorldMapAreaEntry>           sWorldMapAreaStore; -- use Zone2MapCoordinates and Map2ZoneCoordinates
 TC_GAME_API extern DBCStorage <WorldMapOverlayEntry>         sWorldMapOverlayStore;
 TC_GAME_API extern DBCStorage <WorldSafeLocsEntry>           sWorldSafeLocsStore;
+TC_GAME_API extern DBCStorage <ServerMessagesEntry>          sServerMessagesStore;
 
 TC_GAME_API void LoadDBCStores(const std::string& dataPath);
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -3000,8 +3000,12 @@ void World::SendServerMessage(ServerMessageType type, const char *text, Player* 
 {
     WorldPacket data(SMSG_SERVER_MESSAGE, 50);              // guess size
     data << uint32(type);
-    if (type <= SERVER_MSG_STRING)
+
+    if (sServerMessagesStore.AssertEntry(type)->IsFormattableMessage())
+    {
+        ASSERT_NOTNULL(text);
         data << text;
+    }
 
     if (player)
         player->SendDirectMessage(&data);

--- a/src/server/game/World/World.h
+++ b/src/server/game/World/World.h
@@ -659,7 +659,7 @@ class TC_GAME_API World
         void SendWorldText(uint32 string_id, ...);
         void SendGlobalText(char const* text, WorldSession* self);
         void SendGMText(uint32 string_id, ...);
-        void SendServerMessage(ServerMessageType type, const char *text = "", Player* player = nullptr);
+        void SendServerMessage(ServerMessageType type, const char *text = nullptr, Player* player = nullptr);
         void SendGlobalMessage(WorldPacket const* packet, WorldSession* self = nullptr, uint32 team = 0);
         void SendGlobalGMMessage(WorldPacket const* packet, WorldSession* self = nullptr, uint32 team = 0);
         bool SendZoneMessage(uint32 zone, WorldPacket const* packet, WorldSession* self = nullptr, uint32 team = 0);

--- a/src/server/shared/DataStores/DBCStructure.h
+++ b/src/server/shared/DataStores/DBCStructure.h
@@ -1904,7 +1904,7 @@ struct ServerMessagesEntry
     uint32 ID;                                              // 0
     char* Text;                                             // 1 Message, it's localized.
 
-    inline bool IsFormattableMessage() const { return std::strstr(Text, "%s") != nullptr; }
+    inline bool IsFormattableMessage() const { return strstr(Text, "%s") != nullptr; }
 };
 
 #pragma pack(pop)

--- a/src/server/shared/DataStores/DBCStructure.h
+++ b/src/server/shared/DataStores/DBCStructure.h
@@ -24,6 +24,7 @@
 #include "Util.h"
 #include <set>
 #include <map>
+#include <string.h>
 
 // Structures using to access raw DBC data and required packing to portability
 #pragma pack(push, 1)

--- a/src/server/shared/DataStores/DBCStructure.h
+++ b/src/server/shared/DataStores/DBCStructure.h
@@ -1897,6 +1897,15 @@ struct WorldStateUI
 };
 */
 
+//ServerMessages.dbc
+struct ServerMessagesEntry
+{
+    uint32 ID;                                              // 0
+    char* Text;                                             // 1 Message, it's localized.
+
+    inline bool IsFormattableMessage() const { return std::strstr(Text, "%s") != nullptr; }
+};
+
 #pragma pack(pop)
 
 // Structures not used for casting to loaded DBC data and not required then packing

--- a/src/server/shared/DataStores/DBCfmt.h
+++ b/src/server/shared/DataStores/DBCfmt.h
@@ -140,5 +140,6 @@ char constexpr WMOAreaTableEntryfmt[] = "niiixxxxxiixxxxxxxxxxxxxxxxx";
 char constexpr WorldMapAreaEntryfmt[] = "xinxffffixx";
 char constexpr WorldMapOverlayEntryfmt[] = "nxiiiixxxxxxxxxxx";
 char constexpr WorldSafeLocsEntryfmt[] = "nifffxxxxxxxxxxxxxxxxx";
+char constexpr ServerMessagesEntryfmt[] = "nsxxxxxxxxxxxxxxxx";
 
 #endif


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Load ServerMessages.dbc.
-  Generalize SMSG_SERVER_MESSAGE to not assume that a message is formattable based on known blizzlike DBC entry ids.

The intention of this commit, like my other recent ones, is to help TrinityCore be slightly more generalized as an MMORPG framework since I use it as such.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)

Broadcast messages still work, I tested them. I did not test with any non-blizzlike DBCs though.

**Known issues and TODO list:** (add/remove lines as needed)

This is my first time loading a DBC so maybe someone will find some issues.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
