### PR TITLE
Core/Maps: fix respawn times for manual respawns

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3029,6 +3029,7 @@ bool Map::CheckRespawn(RespawnInfo* info)
 void Map::Respawn(RespawnInfo* info, CharacterDatabaseTransaction dbTrans)
 {
     info->respawnTime = GameTime::GetGameTime();
+    _respawnTimes.increase(info->handle);
     SaveRespawnInfoDB(*info, dbTrans);
 }
 


### PR DESCRIPTION
by joshwhedon

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->
In the spawn system, respawns are stored in two places, the list of spawns and the list of respawn times. When you respawn something manually (via script or command), the respawn time is updated on the list of spawns, but the list of respawn times remains the same. Therefore, your respawn will only be triggered once everything else before it in the spawn times list is respawned.

**Changes proposed:**

-  updating respawn times list

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:**
Closes #24421


**Tests performed:** (Does it build, tested in-game, etc.)
Compiles, tested by joshwhedon

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
