### PR TITLE
force charset utf-8 compiling for unicode charset on VS

### DIFF
--- a/cmake/compiler/msvc/settings.cmake
+++ b/cmake/compiler/msvc/settings.cmake
@@ -21,6 +21,11 @@ target_compile_options(trinity-warning-interface
   INTERFACE
     /W3)
 
+# force charset utf-8 compiling for unicode charset on VS
+target_compile_options(trinity-compile-option-interface
+  INTERFACE
+    /utf-8)
+
 # set up output paths ofr static libraries etc (commented out - shown here as an example only)
 #set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 #set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/src/server/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/worldserver/CommandLine/CliRunnable.cpp
@@ -28,7 +28,9 @@
 #include "Log.h"
 #include "Util.h"
 
-#if TRINITY_PLATFORM != TRINITY_PLATFORM_WINDOWS
+#if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
+#include <Windows.h>
+#else
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "Chat.h"
@@ -91,7 +93,9 @@ void utf8print(void* /*arg*/, char const* str)
     if (!Utf8toWStr(str, strlen(str), wtemp_buf, wtemp_len))
         return;
 
-    wprintf(L"%s", wtemp_buf);
+    char temp_buf[6000];
+    CharToOemBuffW(&wtemp_buf[0], &temp_buf[0], wtemp_len+1);
+    printf(temp_buf);
 #else
 {
     printf("%s", str);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  cmake:force charset utf-8 compiling for unicode charset on VS
-  console:fix chinese message show ???

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
~~- [ ] master~~

**Issues addressed:** N/A


**Tests performed:** BUILD、CI、play in game


**Known issues and TODO list:** (add/remove lines as needed)

N/A

continued #24235 by @dxzhan

Note:
- When visual studio compiles, if the cpp file contains Chinese characters, an error will be reported after compile or the Chinese characters in the game will display `???`. The reproduction mode is as follows:

Add a custom script to output an system message and written in Chinese characters when onlogin(). Before PR, vs may not pass the compilation, or after compilation and enter the game. you will see the system message shows `???`

- second console fix:trinity_string.content_loc4 is Chinese(zhCN),you translate. if this message shows in console.before this pr it will show `???`


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
