### PR TITLE
[Cherrypick] Core/Misc: Add console option to update databases only

### DIFF
--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -219,6 +219,9 @@ extern int main(int argc, char** argv)
     if (!StartDB())
         return 1;
 
+    if (vm.count("update-databases-only"))
+        return 0;
+
     std::shared_ptr<void> dbHandle(nullptr, [](void*) { StopDB(); });
 
     // Set server offline (not connectable)
@@ -603,6 +606,7 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, s
         ("version,v", "print version build info")
         ("config,c", value<fs::path>(&configFile)->default_value(fs::absolute(_TRINITY_CORE_CONFIG)),
                      "use <arg> as configuration file")
+        ("update-databases-only,u", "updates databases only")
         ;
 #ifdef _WIN32
     options_description win("Windows platform specific options");


### PR DESCRIPTION
Add "--update-databases-only" console argument to stop worldserver execution after having updated all databases (if specified in config file)

(cherry picked from commit 92bf5b1ba795303808c5f1b3bf82dd0204133ed8)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
