### PR TITLE
Core/CreatureAI: ICC/Shambling Horror re-cast Enrage as soon as it is not stun

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -190,6 +190,7 @@ enum Spells
 #define REMORSELESS_WINTER_2 RAID_MODE<uint32>(72259, 74273, 74274, 74275)
 #define SUMMON_VALKYR        RAID_MODE<uint32>(69037, 74361, 69037, 74361)
 #define HARVEST_SOUL         RAID_MODE<uint32>(68980, 74325, 74296, 74297)
+#define ENRAGE               RAID_MODE<uint32>(72143, 72146, 72147, 72148)
 
 enum Events
 {
@@ -1365,8 +1366,10 @@ class npc_shambling_horror_icc : public CreatureScript
                             _events.ScheduleEvent(EVENT_SHOCKWAVE, 20s, 25s);
                             break;
                         case EVENT_ENRAGE:
-                            DoCast(me, SPELL_ENRAGE);
-                            _events.ScheduleEvent(EVENT_ENRAGE, 20s, 25s);
+                            if (SPELL_CAST_OK != DoCast(me, SPELL_ENRAGE))
+                                _events.ScheduleEvent(EVENT_ENRAGE, 1s);
+                            else
+                                _events.ScheduleEvent(EVENT_ENRAGE, 20s, 25s);
                             break;
                         default:
                             break;
@@ -1374,6 +1377,15 @@ class npc_shambling_horror_icc : public CreatureScript
                 }
 
                 DoMeleeAttackIfReady();
+            }
+
+            void OnSpellCastInterrupt(SpellInfo const* spell) override
+            {
+                ScriptedAI::OnSpellCastInterrupt(spell);
+
+                // When enrage is interrupted, reschedule the event
+                if (spell->Id == ENRAGE)
+                    _events.RescheduleEvent(EVENT_ENRAGE, 1s);
             }
 
         private:


### PR DESCRIPTION
**Changes proposed:**

-  If you stun the Shambling Horror during the cast of Enrage, they will re-cast it as soon as the stun fades

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master (should probably apply too ?)

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
build, tested IG in 10 & 25

**Known issues and TODO list:** (add/remove lines as needed)
- I have no proof that the Shambling Horror's Shockwave work the same way, so it's not part of the changes.

**Sources**
https://www.wowhead.com/spell=72143/enrage#comments
If you stun the Shamblers they will re-cast it as soon as the stun fades. Even if stunned part way through the cast. Even though the spell data has a cooldown of 7s they never use it more than once every 20 on the Lich King 25 encounter