### PR TITLE
[Core/Spell] Removing a duplicate item combat spell handling causing poisons (and …

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2482,10 +2482,6 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
             {
                 spellDamageInfo = std::make_unique<DamageInfo>(damageInfo, SPELL_DIRECT_DAMAGE, spell->m_attackType, hitMask);
                 procSpellType |= PROC_SPELL_TYPE_DAMAGE;
-
-                if (caster->GetTypeId() == TYPEID_PLAYER && !spell->m_spellInfo->HasAttribute(SPELL_ATTR0_STOP_ATTACK_TARGET) && !spell->m_spellInfo->HasAttribute(SPELL_ATTR4_CANT_TRIGGER_ITEM_SPELLS) &&
-                    (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MELEE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED))
-                    caster->ToPlayer()->CastItemCombatSpell(*spellDamageInfo);
             }
         }
 


### PR DESCRIPTION
…others) to proc twice.

https://github.com/TrinityCore/TrinityCore/issues/24608

**Changes proposed:**

-  Remove duplicate call to CastItemCombatSpell

**Target branch(es):** 3.3.5

**Issues addressed:** Closes # https://github.com/TrinityCore/TrinityCore/issues/24608

**Tests performed:**
Running for two days on a live server, no crash, no complaint