### PR TITLE
Tools/vmap_extractor: Fixed typos reading MAIN and MAID chunks

### DIFF
--- a/src/tools/vmap4_extractor/wdtfile.cpp
+++ b/src/tools/vmap4_extractor/wdtfile.cpp
@@ -156,13 +156,13 @@ ADTFile* WDTFile::GetMap(int32 x, int32 y)
     if (_adtCache && _adtCache->file[x][y])
         return _adtCache->file[x][y].get();
 
-    if (!(_adtInfo.Data[x][y].Flag & 1))
+    if (!(_adtInfo.Data[y][x].Flag & 1))
         return nullptr;
 
     ADTFile* adt;
     std::string name = Trinity::StringFormat("World\\Maps\\%s\\%s_%d_%d_obj0.adt", _mapName.c_str(), _mapName.c_str(), x, y);
     if (_header.Flags & 0x200)
-        adt = new ADTFile(_adtFileDataIds->Data[x][y].Obj0ADT, name, _adtCache != nullptr);
+        adt = new ADTFile(_adtFileDataIds->Data[y][x].Obj0ADT, name, _adtCache != nullptr);
     else
         adt = new ADTFile(name, _adtCache != nullptr);
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  vmap_extractor is currently discarding many ADTs, due to reading the MAIN chunk array incorrectly. It is supposed to be read as [y][x], not [x][y]. 

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master


**Tests performed:** (Does it build, tested in-game, etc.)

- Tested by generating completely new vmaps and mmaps, fixes worldserver shutting down due too missing vmaps in the starting zone.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
