### PR TITLE
Scripts/RuinsOfAhnQiraj: Crystal handling

### DIFF
--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_ossirian.cpp
@@ -42,13 +42,19 @@ enum Texts
 
 enum Spells
 {
-    SPELL_SILENCE           = 25195,
+    SPELL_CURSE_OF_TONGUES  = 25195,
     SPELL_CYCLONE           = 25189,
+    SPELL_SAND_STORM        = 25160,
     SPELL_STOMP             = 25188,
     SPELL_SUPREME           = 25176,
     SPELL_SUMMON            = 20477,
-    SPELL_SAND_STORM        = 25160,
-    SPELL_SUMMON_CRYSTAL    = 25192
+    SPELL_SUMMON_CRYSTAL    = 25192,
+
+    SPELL_WEAKNESS_FIRE     = 25177,
+    SPELL_WEAKNESS_FROST    = 25178,
+    SPELL_WEAKNESS_NATURE   = 25180,
+    SPELL_WEAKNESS_ARCANE   = 25181,
+    SPELL_WEAKNESS_SHADOW   = 25183
 };
 
 enum Actions
@@ -63,28 +69,28 @@ enum Events
     EVENT_STOMP             = 3
 };
 
-uint8 const NUM_CRYSTALS = 9;
+uint8 const NUM_CRYSTALS = 12;
 
-// You spin me right round, baby
-// right round like a record, baby
-// right round round round
 Position CrystalCoordinates[NUM_CRYSTALS] =
 {
-    { -9394.230469f, 1951.808594f, 85.97733f, 0.0f },
-    { -9357.931641f, 1930.596802f, 85.556198f, 0.0f },
-    { -9383.113281f, 2011.042725f, 85.556389f, 0.0f },
-    { -9243.36f, 1979.04f, 85.556f, 0.0f },
-    { -9281.68f, 1886.66f, 85.5558f, 0.0f },
-    { -9241.8f, 1806.39f, 85.5557f, 0.0f },
-    { -9366.78f, 1781.76f, 85.5561f, 0.0f },
-    { -9430.37f, 1786.86f, 85.557f, 0.0f },
-    { -9406.73f, 1863.13f, 85.5558f, 0.0f }
+    { -9188.4404296875f, 1940.2099609375f, 85.6390991210937f, 3.17650008201599f },
+    { -9244.41015625f, 1808.97998046875f, 85.6390991210937f, 5.63741016387939f },
+    { -9248.41015625f, 1974.82995605469f, 85.6390991210937f, 5.89920997619629f },
+    { -9282.080078125f, 1887.33996582031f, 85.6390991210937f, 2.00712990760803f },
+    { -9299.73046875f, 1748.44995117187f, 85.6390991210937f, 1.44861996173859f },
+    { -9357.8603515625f, 1929.07995605469f, 85.6390991210937f, 1.06465005874634f },
+    { -9367.169921875f, 1780.89001464844f, 85.6390991210937f, 1.90241003036499f },
+    { -9383.2900390625f, 2012.68005371094f, 85.6511001586914f, 2.93214988708496f },
+    { -9406.099609375f, 1862.38000488281f, 85.6390991210937f, 6.2308201789856f },
+    { -9407.7197265625f, 1960.2099609375f, 85.6390991210937f, 1.11700999736786f },
+    { -9432.400390625f, 1782.53002929687f, 85.6390991210937f, 5.86430978775024f },
+    { -9506.1904296875f, 1865.56994628906f, 85.6390991210937f, 4.27606010437012f }
 };
 
 float RoomRadius = 165.0f;
 uint8 const NUM_TORNADOS = 5; /// @todo This number is completly random!
 uint8 const NUM_WEAKNESS = 5;
-uint32 const SpellWeakness[NUM_WEAKNESS] = { 25177, 25178, 25180, 25181, 25183 };
+uint32 const SpellWeakness[NUM_WEAKNESS] = { SPELL_WEAKNESS_FIRE, SPELL_WEAKNESS_FROST, SPELL_WEAKNESS_NATURE, SPELL_WEAKNESS_ARCANE, SPELL_WEAKNESS_SHADOW };
 Position const RoomCenter = { -9343.041992f, 1923.278198f, 85.555984f, 0.0 };
 
 class boss_ossirian : public CreatureScript
@@ -125,6 +131,9 @@ class boss_ossirian : public CreatureScript
                     if (spell->Id == SpellWeakness[i])
                     {
                         me->RemoveAurasDueToSpell(SPELL_SUPREME);
+                        // Despawn used crystal
+                        if (GameObject* crystal = GetClosestGameObjectWithEntry(caster, GO_OSSIRIAN_CRYSTAL, 5.0f))
+                            crystal->Delete();
                         if (Creature* creatureCaster = caster->ToCreature())
                             creatureCaster->DespawnOrUnsummon();
                         SpawnNextCrystal();
@@ -148,7 +157,7 @@ class boss_ossirian : public CreatureScript
                 events.ScheduleEvent(EVENT_CYCLONE, 20s);
                 events.ScheduleEvent(EVENT_STOMP, 30s);
 
-                DoCast(me, SPELL_SUPREME);
+                DoCastSelf(SPELL_SUPREME);
                 Talk(SAY_AGGRO);
 
                 Map* map = me->GetMap();
@@ -198,7 +207,7 @@ class boss_ossirian : public CreatureScript
                 if (Creature* Trigger = me->SummonCreature(NPC_OSSIRIAN_TRIGGER, CrystalCoordinates[CrystalIterator]))
                 {
                     TriggerGUID = Trigger->GetGUID();
-                    if (GameObject* Crystal = Trigger->SummonGameObject(GO_OSSIRIAN_CRYSTAL, CrystalCoordinates[CrystalIterator], QuaternionData(), uint32(-1)))
+                    if (GameObject* Crystal = Trigger->SummonGameObject(GO_OSSIRIAN_CRYSTAL, CrystalCoordinates[CrystalIterator], QuaternionData(), uint32(-1), GO_SUMMON_TIMED_DESPAWN))
                     {
                         CrystalGUID = Crystal->GetGUID();
                         ++CrystalIterator;
@@ -246,7 +255,7 @@ class boss_ossirian : public CreatureScript
 
                 if (ApplySupreme)
                 {
-                    DoCast(me, SPELL_SUPREME);
+                    DoCastSelf(SPELL_SUPREME);
                     Talk(SAY_SUPREME);
                 }
 
@@ -255,7 +264,7 @@ class boss_ossirian : public CreatureScript
                     switch (eventId)
                     {
                         case EVENT_SILENCE:
-                            DoCast(me, SPELL_SILENCE);
+                            DoCastAOE(SPELL_CURSE_OF_TONGUES);
                             events.ScheduleEvent(EVENT_SILENCE, 20s, 30s);
                             break;
                         case EVENT_CYCLONE:
@@ -263,7 +272,7 @@ class boss_ossirian : public CreatureScript
                             events.ScheduleEvent(EVENT_CYCLONE, 20s);
                             break;
                         case EVENT_STOMP:
-                            DoCast(me, SPELL_STOMP);
+                            DoCastSelf(SPELL_STOMP);
                             events.ScheduleEvent(EVENT_STOMP, 30s);
                             break;
                         default:
@@ -294,6 +303,8 @@ class go_ossirian_crystal : public GameObjectScript
 
             bool GossipHello(Player* player) override
             {
+                // Crystal animation on use
+                me->SetLootState(GO_ACTIVATED);
                 Creature* ossirian = player->FindNearestCreature(NPC_OSSIRIAN, 30.0f);
                 if (!ossirian || instance->GetBossState(DATA_OSSIRIAN) != IN_PROGRESS)
                     return false;


### PR DESCRIPTION
https://wowwiki.fandom.com/wiki/Ossirian_the_Unscarred
https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=15339
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
+ make crystal usable with animation and despawn after use;
+ small code update;
+ spell rearrange;
+ define some magic numbers;
+ update crystal coordinates from sniffed data

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
Closes #17315 

**Tests performed:** (Does it build, tested in-game, etc.)
Compiled and tested by using crystals

todo:
[+] update crystal spawn coords from #24681
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
