### PR TITLE
Scripts/Trial Of The Crusader: Fixed Anub'arak Pursuing Spikes movement

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -370,7 +370,6 @@ class boss_anubarak_trial : public CreatureScript
                             break;
                         }
                         case EVENT_EMERGE:
-                            events.ScheduleEvent(EVENT_SUBMERGE, 80*IN_MILLISECONDS, 0, PHASE_MELEE);
                             DoCast(SPELL_SPIKE_TELE);
                             summons.DespawnEntry(NPC_SPIKE);
                             me->RemoveAurasDueToSpell(SPELL_SUBMERGE_ANUBARAK);
@@ -825,8 +824,7 @@ class npc_anubarak_spike : public CreatureScript
                 me->GetThreatManager().ResetAllThreat();
                 DoZoneInCombat();
                 AddThreat(who, 1000000.0f);
-                me->GetMotionMaster()->Clear();
-                me->GetMotionMaster()->MoveChase(who);
+                AttackStart(who);
             }
 
             private:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Change MoveChase to AttackStart to allow movement
-  Remove duplicate EVENT_SUBMERGE (added here: https://github.com/TrinityCore/TrinityCore/commit/1f9db80b69379f3abc4b2f8bb5dbc26ec971cc92)

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes #23010


**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
