### PR TITLE
Core/Spells: Fix ammo consumption

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7484,13 +7484,14 @@ void Spell::HandleLaunchPhase()
 
     PrepareTargetProcessing();
 
+    bool ammoTaken = false;
+
     for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
         float multiplier = 1.0f;
         if (m_applyMultiplierMask & (1 << i))
             multiplier = m_spellInfo->Effects[i].CalcDamageMultiplier(m_originalCaster, this);
 
-        bool ammoTaken = false;
         for (TargetInfo& target : m_UniqueTargetInfo)
         {
             uint32 mask = target.EffectMask;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Improve logic when check ammoTaken (broke here: https://github.com/TrinityCore/TrinityCore/commit/080d2c6cd439acb2059adc4e24a279de98aa0db6#diff-952c711803610aa78110e4f92ff2516aR7266 ) now only take ammo one time, not for every effect of the spell.

You can test it with Hunter Spell Chimera Shot or Scatter Shot by example, use spells and see ammo consumption 

**Target branch(es):**

- [X] 3.3.5
- [ ] master

**Issues addressed:**


**Tests performed:**  tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
