### PR TITLE
Core/ZoneScript: Add "invoker" param to ProcessEvent

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldTB.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldTB.cpp
@@ -683,7 +683,7 @@ void BattlefieldTB::OnGameObjectCreate(GameObject* go)
     }
 };
 
-void BattlefieldTB::ProcessEvent(WorldObject* obj, uint32 eventId)
+void BattlefieldTB::ProcessEvent(WorldObject* obj, uint32 eventId, WorldObject* /*invoker*/)
 {
     if (!IsWarTime())
         return;
@@ -868,5 +868,5 @@ void TolBaradCapturePoint::ChangeTeam(TeamId /*oldTeam*/)
     }
 
     // Update counter
-    m_Bf->ProcessEvent(nullptr, EVENT_COUNT_CAPTURED_BASE);
+    m_Bf->ProcessEvent(nullptr, EVENT_COUNT_CAPTURED_BASE, nullptr);
 }

--- a/src/server/game/Battlefield/Zones/BattlefieldTB.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldTB.h
@@ -671,7 +671,7 @@ class TC_GAME_API BattlefieldTB : public Battlefield
         void PromotePlayer(Player* killer);
         void RemoveAurasFromPlayer(Player* player);
 
-        void ProcessEvent(WorldObject* obj, uint32 eventId) override;
+        void ProcessEvent(WorldObject* obj, uint32 eventId, WorldObject* invoker) override;
 
         void TowerDamaged(TBTowerId tbTowerId);
         void TowerDestroyed(TBTowerId tbTowerId);

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -1251,7 +1251,7 @@ void BattlefieldWG::UpdatedDestroyedTowerCount(TeamId team)
     }
 }
 
-void BattlefieldWG::ProcessEvent(WorldObject* obj, uint32 eventId)
+void BattlefieldWG::ProcessEvent(WorldObject* obj, uint32 eventId, WorldObject* /*invoker*/)
 {
     if (!obj || !IsWarTime())
         return;

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -373,7 +373,7 @@ class TC_GAME_API BattlefieldWG : public Battlefield
         void PromotePlayer(Player* killer);
 
         void UpdateTenacity();
-        void ProcessEvent(WorldObject* obj, uint32 eventId) override;
+        void ProcessEvent(WorldObject* obj, uint32 eventId, WorldObject* invoker) override;
 
         bool FindAndRemoveVehicleFromList(Unit* vehicle);
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2344,7 +2344,7 @@ void GameObject::EventInform(uint32 eventId, WorldObject* invoker /*= nullptr*/)
         AI()->EventInform(eventId);
 
     if (GetZoneScript())
-        GetZoneScript()->ProcessEvent(this, eventId);
+        GetZoneScript()->ProcessEvent(this, eventId, invoker);
 
     if (BattlegroundMap* bgMap = GetMap()->ToBattlegroundMap())
         if (bgMap->GetBG())

--- a/src/server/game/Maps/ZoneScript.h
+++ b/src/server/game/Maps/ZoneScript.h
@@ -56,7 +56,7 @@ class TC_GAME_API ZoneScript
         virtual uint32 GetData(uint32 /*DataId*/) const { return 0; }
         virtual void SetData(uint32 /*DataId*/, uint32 /*Value*/) { }
 
-        virtual void ProcessEvent(WorldObject* /*obj*/, uint32 /*eventId*/) { }
+        virtual void ProcessEvent(WorldObject* /*obj*/, uint32 /*eventId*/, WorldObject* /*invoker*/) { }
 };
 
 #endif

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1055,9 +1055,9 @@ void Spell::EffectSendEvent()
     TC_LOG_DEBUG("spells", "Spell ScriptStart %u for spellid %u in EffectSendEvent ", effectInfo->MiscValue, m_spellInfo->Id);
 
     if (ZoneScript* zoneScript = m_caster->GetZoneScript())
-        zoneScript->ProcessEvent(target, effectInfo->MiscValue);
+        zoneScript->ProcessEvent(target, effectInfo->MiscValue, m_caster);
     else if (InstanceScript* instanceScript = m_caster->GetInstanceScript())    // needed in case Player is the caster
-        instanceScript->ProcessEvent(target, effectInfo->MiscValue);
+        instanceScript->ProcessEvent(target, effectInfo->MiscValue, m_caster);
 
     m_caster->GetMap()->ScriptsStart(sEventScripts, effectInfo->MiscValue, m_caster, target);
 }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -261,7 +261,7 @@ public:
              return true;
         }
 
-        void ProcessEvent(WorldObject* /*obj*/, uint32 eventId) override
+        void ProcessEvent(WorldObject* /*obj*/, uint32 eventId, WorldObject* /*invoker*/) override
         {
             switch (eventId)
             {

--- a/src/server/scripts/EasternKingdoms/MagistersTerrace/instance_magisters_terrace.cpp
+++ b/src/server/scripts/EasternKingdoms/MagistersTerrace/instance_magisters_terrace.cpp
@@ -172,7 +172,7 @@ class instance_magisters_terrace : public InstanceMapScript
                 }
             }
 
-            void ProcessEvent(WorldObject* /*obj*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*obj*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 if (eventId == EVENT_SPAWN_KALECGOS)
                     if (!GetCreature(DATA_KALECGOS) && _events.Empty())

--- a/src/server/scripts/EasternKingdoms/Uldaman/instance_uldaman.cpp
+++ b/src/server/scripts/EasternKingdoms/Uldaman/instance_uldaman.cpp
@@ -507,7 +507,7 @@ class instance_uldaman : public InstanceMapScript
                 return ObjectGuid::Empty;
             } // end GetGuidData
 
-            void ProcessEvent(WorldObject* /*gameObject*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*gameObject*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 switch (eventId)
                 {

--- a/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/instance_zulaman.cpp
@@ -219,7 +219,7 @@ class instance_zulaman : public InstanceMapScript
                 return true;
             }
 
-            void ProcessEvent(WorldObject* /*obj*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*obj*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 switch (eventId)
                 {

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/boss_horAI.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/boss_horAI.cpp
@@ -30,7 +30,7 @@ void boss_horAI::Reset()
     me->SetImmuneToAll(true);
     me->SetReactState(REACT_PASSIVE);
     if (instance->GetData(DATA_WAVE_COUNT) != NOT_STARTED)
-        instance->ProcessEvent(nullptr, EVENT_DO_WIPE);
+        instance->ProcessEvent(nullptr, EVENT_DO_WIPE, nullptr);
 }
 
 void boss_horAI::DoAction(int32 actionId)

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -712,7 +712,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                     case EVENT_INTRO_LK_9:
                         if (Creature* falric = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_FALRIC)))
                             falric->AI()->Talk(SAY_FALRIC_INTRO_2);
-                        _instance->ProcessEvent(nullptr, EVENT_SPAWN_WAVES);
+                        _instance->ProcessEvent(nullptr, EVENT_SPAWN_WAVES, nullptr);
                         _events.ScheduleEvent(EVENT_INTRO_LK_10, 4000);
                         break;
                     case EVENT_INTRO_LK_10:
@@ -2076,7 +2076,7 @@ class at_hor_waves_restarter : public AreaTriggerScript
 
             if (_instance->GetData(DATA_INTRO_EVENT) == DONE && _instance->GetBossState(DATA_MARWYN) != DONE)
             {
-                _instance->ProcessEvent(nullptr, EVENT_SPAWN_WAVES);
+                _instance->ProcessEvent(nullptr, EVENT_SPAWN_WAVES, nullptr);
 
                 if (Creature* falric = ObjectAccessor::GetCreature(*player, _instance->GetGuidData(DATA_FALRIC)))
                 {

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/instance_halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/instance_halls_of_reflection.cpp
@@ -444,7 +444,7 @@ class instance_halls_of_reflection : public InstanceMapScript
                         break;
                     case DATA_WAVE_COUNT:
                         if (_waveCount && data == NOT_STARTED)
-                            ProcessEvent(nullptr, EVENT_DO_WIPE);
+                            ProcessEvent(nullptr, EVENT_DO_WIPE, nullptr);
                         break;
                     case DATA_FROSTSWORN_GENERAL:
                         if (data == DONE)
@@ -522,7 +522,7 @@ class instance_halls_of_reflection : public InstanceMapScript
                 switch (events.ExecuteEvent())
                 {
                     case EVENT_NEXT_WAVE:
-                        ProcessEvent(nullptr, EVENT_ADD_WAVE);
+                        ProcessEvent(nullptr, EVENT_ADD_WAVE, nullptr);
                         break;
                     case EVENT_SPAWN_ESCAPE_EVENT:
                         SpawnEscapeEvent();
@@ -533,7 +533,7 @@ class instance_halls_of_reflection : public InstanceMapScript
                 }
             }
 
-            void ProcessEvent(WorldObject* /*obj*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*obj*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 switch (eventId)
                 {

--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -1409,7 +1409,7 @@ class instance_icecrown_citadel : public InstanceMapScript
                 }
             }
 
-            void ProcessEvent(WorldObject* source, uint32 eventId) override
+            void ProcessEvent(WorldObject* source, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 switch (eventId)
                 {

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/instance_eye_of_eternity.cpp
@@ -153,7 +153,7 @@ public:
             unit->SetControlled(true, UNIT_STATE_ROOT);
         }
 
-        void ProcessEvent(WorldObject* /*obj*/, uint32 eventId) override
+        void ProcessEvent(WorldObject* /*obj*/, uint32 eventId, WorldObject* /*invoker*/) override
         {
             if (eventId == EVENT_FOCUSING_IRIS)
             {

--- a/src/server/scripts/Northrend/Nexus/Oculus/instance_oculus.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/instance_oculus.cpp
@@ -165,7 +165,7 @@ class instance_oculus : public InstanceMapScript
                 }
             }
 
-            void ProcessEvent(WorldObject* /*unit*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*unit*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 if (eventId != EVENT_CALL_DRAGON)
                     return;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -1310,21 +1310,21 @@ class go_ulduar_tower : public GameObjectScript
 
             InstanceScript* instance;
 
-            void Destroyed(WorldObject* /*attacker*/, uint32 /*eventId*/) override
+            void Destroyed(WorldObject* attacker, uint32 /*eventId*/) override
             {
                 switch (me->GetEntry())
                 {
                     case GO_TOWER_OF_STORMS:
-                        instance->ProcessEvent(me, EVENT_TOWER_OF_STORM_DESTROYED);
+                        instance->ProcessEvent(me, EVENT_TOWER_OF_STORM_DESTROYED, attacker);
                         break;
                     case GO_TOWER_OF_FLAMES:
-                        instance->ProcessEvent(me, EVENT_TOWER_OF_FLAMES_DESTROYED);
+                        instance->ProcessEvent(me, EVENT_TOWER_OF_FLAMES_DESTROYED, attacker);
                         break;
                     case GO_TOWER_OF_FROST:
-                        instance->ProcessEvent(me, EVENT_TOWER_OF_FROST_DESTROYED);
+                        instance->ProcessEvent(me, EVENT_TOWER_OF_FROST_DESTROYED, attacker);
                         break;
                     case GO_TOWER_OF_LIFE:
-                        instance->ProcessEvent(me, EVENT_TOWER_OF_LIFE_DESTROYED);
+                        instance->ProcessEvent(me, EVENT_TOWER_OF_LIFE_DESTROYED, attacker);
                         break;
                 }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -577,7 +577,7 @@ class instance_ulduar : public InstanceMapScript
                 }
             }
 
-            void ProcessEvent(WorldObject* /*gameObject*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*gameObject*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 switch (eventId)
                 {

--- a/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
+++ b/src/server/scripts/Northrend/VioletHold/instance_violet_hold.cpp
@@ -928,7 +928,7 @@ class instance_violet_hold : public InstanceMapScript
                 });
             }
 
-            void ProcessEvent(WorldObject* /*go*/, uint32 eventId) override
+            void ProcessEvent(WorldObject* /*go*/, uint32 eventId, WorldObject* /*invoker*/) override
             {
                 if (eventId == EVENT_ACTIVATE_CRYSTAL)
                 {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->
The Battleground class has a process event with this third param. This might be useful when working with battleground scripts (will make a draft PR for that one soonish)

**Changes proposed:**

-  Add extra param "invoker" to ZoneScript::ProcessEvent

**Target branch(es):**

- master

**Issues addressed:** none


**Tests performed:**
- Builds


**Known issues and TODO list:**
- none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
