### PR TITLE
Handle different slopes in mmaps

### DIFF
--- a/dep/recastnavigation/Recast/Include/Recast.h
+++ b/dep/recastnavigation/Recast/Include/Recast.h
@@ -224,6 +224,9 @@ struct rcConfig
 	/// The maximum slope that is considered walkable. [Limits: 0 <= value < 90] [Units: Degrees] 
 	float walkableSlopeAngle;
 
+	/// The maximum slope that is considered walkable but not steep. It should be lower/equal than walkableSlopeAngle. [Limits: 0 <= value < 90] [Units: Degrees] 
+	float walkableSlopeAngleNotSteep;
+
 	/// Minimum floor to 'ceiling' height that will still allow the floor area to 
 	/// be considered walkable. [Limit: >= 3] [Units: vx] 
 	int walkableHeight;
@@ -586,7 +589,8 @@ static const unsigned char RC_NULL_AREA = 0;
 /// The default area id used to indicate a walkable polygon. 
 /// This is also the maximum allowed area id, and the only non-null area id 
 /// recognized by some steps in the build process. 
-static const unsigned char RC_WALKABLE_AREA = 63;
+static const unsigned char RC_WALKABLE_AREA = 62;
+static const unsigned char RC_WALKABLE_AREA_STEEP = 63;
 
 /// The value returned by #rcGetCon if the specified direction is not connected
 /// to another span. (Has no neighbor.)

--- a/dep/recastnavigation/Recast/Include/Recast.h
+++ b/dep/recastnavigation/Recast/Include/Recast.h
@@ -589,8 +589,7 @@ static const unsigned char RC_NULL_AREA = 0;
 /// The default area id used to indicate a walkable polygon. 
 /// This is also the maximum allowed area id, and the only non-null area id 
 /// recognized by some steps in the build process. 
-static const unsigned char RC_WALKABLE_AREA = 62;
-static const unsigned char RC_WALKABLE_AREA_STEEP = 63;
+static const unsigned char RC_WALKABLE_AREA = 63;
 
 /// The value returned by #rcGetCon if the specified direction is not connected
 /// to another span. (Has no neighbor.)
@@ -814,7 +813,7 @@ bool rcCreateHeightfield(rcContext* ctx, rcHeightfield& hf, int width, int heigh
 ///  @param[in]		nt					The number of triangles.
 ///  @param[out]	areas				The triangle area ids. [Length: >= @p nt]
 void rcMarkWalkableTriangles(rcContext* ctx, const float walkableSlopeAngle, const float* verts, int nv,
-							 const int* tris, int nt, unsigned char* areas); 
+							 const int* tris, int nt, unsigned char* areas, unsigned char areaType = RC_WALKABLE_AREA);
 
 /// Sets the area id of all triangles with a slope greater than or equal to the specified value to #RC_NULL_AREA.
 ///  @ingroup recast

--- a/dep/recastnavigation/Recast/Source/Recast.cpp
+++ b/dep/recastnavigation/Recast/Source/Recast.cpp
@@ -334,7 +334,7 @@ static void calcTriNormal(const float* v0, const float* v1, const float* v2, flo
 void rcMarkWalkableTriangles(rcContext* ctx, const float walkableSlopeAngle,
 							 const float* verts, int nv,
 							 const int* tris, int nt,
-							 unsigned char* areas)
+							 unsigned char* areas, unsigned char areaType)
 {
 	rcIgnoreUnused(ctx);
 	rcIgnoreUnused(nv);
@@ -349,7 +349,7 @@ void rcMarkWalkableTriangles(rcContext* ctx, const float walkableSlopeAngle,
 		calcTriNormal(&verts[tri[0]*3], &verts[tri[1]*3], &verts[tri[2]*3], norm);
 		// Check if the face is walkable.
 		if (norm[1] > walkableThr)
-			areas[i] = RC_WALKABLE_AREA;
+			areas[i] = areaType;
 	}
 }
 

--- a/src/common/Collision/Maps/MapDefines.h
+++ b/src/common/Collision/Maps/MapDefines.h
@@ -22,7 +22,7 @@
 #include "DetourNavMesh.h"
 
 const uint32 MMAP_MAGIC = 0x4d4d4150; // 'MMAP'
-#define MMAP_VERSION 10
+#define MMAP_VERSION 11
 
 struct MmapTileHeader
 {
@@ -51,17 +51,21 @@ enum NavArea
     NAV_AREA_EMPTY          = 0,
     // areas 1-60 will be used for destructible areas (currently skipped in vmaps, WMO with flag 1)
     // ground is the highest value to make recast choose ground over water when merging surfaces very close to each other (shallow water would be walkable)
-    NAV_AREA_GROUND         = 63,
-    NAV_AREA_WATER          = 62,
-    NAV_AREA_MAGMA_SLIME    = 61 // don't need to differentiate between them
+    NAV_AREA_GROUND_STEEP   = 63,
+    NAV_AREA_GROUND         = 62,
+    NAV_AREA_WATER          = 61,
+    NAV_AREA_MAGMA_SLIME    = 60, // don't need to differentiate between them
+    NAV_AREA_MAX_VALUE      = 63,
+    NAV_AREA_MIN_VALUE      = NAV_AREA_MAGMA_SLIME
 };
 
 enum NavTerrainFlag
 {
-    NAV_EMPTY       = 0x00,
-    NAV_GROUND      = 1 << (63 - NAV_AREA_GROUND),
-    NAV_WATER       = 1 << (63 - NAV_AREA_WATER),
-    NAV_MAGMA_SLIME = 1 << (63 - NAV_AREA_MAGMA_SLIME)
+    NAV_EMPTY        = 0x00,
+    NAV_GROUND_STEEP = 1 << (NAV_AREA_MAX_VALUE - NAV_AREA_GROUND_STEEP),
+    NAV_GROUND       = 1 << (NAV_AREA_MAX_VALUE - NAV_AREA_GROUND),
+    NAV_WATER        = 1 << (NAV_AREA_MAX_VALUE - NAV_AREA_WATER),
+    NAV_MAGMA_SLIME  = 1 << (NAV_AREA_MAX_VALUE - NAV_AREA_MAGMA_SLIME)
 };
 
 #endif /* _MAPDEFINES_H */

--- a/src/common/Collision/Maps/MapDefines.h
+++ b/src/common/Collision/Maps/MapDefines.h
@@ -51,12 +51,13 @@ enum NavArea
     NAV_AREA_EMPTY          = 0,
     // areas 1-60 will be used for destructible areas (currently skipped in vmaps, WMO with flag 1)
     // ground is the highest value to make recast choose ground over water when merging surfaces very close to each other (shallow water would be walkable)
-    NAV_AREA_GROUND_STEEP   = 63,
-    NAV_AREA_GROUND         = 62,
-    NAV_AREA_WATER          = 61,
-    NAV_AREA_MAGMA_SLIME    = 60, // don't need to differentiate between them
-    NAV_AREA_MAX_VALUE      = 63,
-    NAV_AREA_MIN_VALUE      = NAV_AREA_MAGMA_SLIME
+    NAV_AREA_GROUND_STEEP   = 11,
+    NAV_AREA_GROUND         = 10,
+    NAV_AREA_WATER          = 9,
+    NAV_AREA_MAGMA_SLIME    = 8, // don't need to differentiate between them
+    NAV_AREA_MAX_VALUE      = NAV_AREA_GROUND_STEEP,
+    NAV_AREA_MIN_VALUE      = NAV_AREA_MAGMA_SLIME,
+    NAV_AREA_ALL_MASK       = 0x3F // max allowed value
 };
 
 enum NavTerrainFlag

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -678,6 +678,7 @@ void PathGenerator::UpdateFilter()
     // allow creatures to cheat and use different movement types if they are moved
     // forcefully into terrain they can't normally move in
     if (Unit const* _sourceUnit = _source->ToUnit())
+    {
         if (_sourceUnit->IsInWater() || _sourceUnit->IsUnderWater())
         {
             uint16 includedFlags = _filter.getIncludeFlags();
@@ -687,6 +688,11 @@ void PathGenerator::UpdateFilter()
 
             _filter.setIncludeFlags(includedFlags);
         }
+
+        if (Creature const* _sourceCreature = _source->ToCreature())
+            if (_sourceCreature->IsInCombat() || _sourceCreature->IsInEvadeMode())
+                _filter.setIncludeFlags(_filter.getIncludeFlags() | NAV_GROUND_STEEP);
+    }
 }
 
 NavTerrainFlag PathGenerator::GetNavTerrain(float x, float y, float z)

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -34,6 +34,7 @@ PathGenerator::PathGenerator(WorldObject const* owner) :
     _navMeshQuery(nullptr)
 {
     memset(_pathPolyRefs, 0, sizeof(_pathPolyRefs));
+    _filter.setAreaCost(NAV_AREA_GROUND_STEEP, 2.0f);
 
     TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::PathGenerator for %s", _source->GetGUID().ToString().c_str());
 

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -34,7 +34,6 @@ PathGenerator::PathGenerator(WorldObject const* owner) :
     _navMeshQuery(nullptr)
 {
     memset(_pathPolyRefs, 0, sizeof(_pathPolyRefs));
-    _filter.setAreaCost(NAV_AREA_GROUND_STEEP, 2.0f);
 
     TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::PathGenerator for %s", _source->GetGUID().ToString().c_str());
 

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -710,7 +710,7 @@ namespace MMAP
         // TODO: special flags for DYNAMIC polygons, ie surfaces that can be turned on and off
         for (int i = 0; i < iv.polyMesh->npolys; ++i)
         {
-            if (uint8 area = iv.polyMesh->areas[i] & RC_WALKABLE_AREA)
+            if (uint8 area = iv.polyMesh->areas[i] & NAV_AREA_MAX_VALUE)
             {
                 if (area >= NAV_AREA_MIN_VALUE)
                     iv.polyMesh->flags[i] = 1 << (NAV_AREA_MAX_VALUE - area);

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -1015,7 +1015,7 @@ namespace MMAP
         config.maxVertsPerPoly = DT_VERTS_PER_POLYGON;
         config.cs = tileConfig.BASE_UNIT_DIM;
         config.ch = tileConfig.BASE_UNIT_DIM;
-        config.walkableSlopeAngle = 70;
+        config.walkableSlopeAngle = 80;
         config.walkableSlopeAngleNotSteep = 55;
         config.tileSize = tileConfig.VERTEX_PER_TILE;
         config.walkableRadius = m_bigBaseUnit ? 1 : 2;

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -587,9 +587,17 @@ namespace MMAP
                 }
 
                 // mark all walkable tiles, both liquids and solids
+
+                /* we want to have triangles with slope less than walkableSlopeAngleNotSteep (<= 55) to have NAV_AREA_GROUND
+                 * and with slope between walkableSlopeAngleNotSteep and walkableSlopeAngle (55 < .. <= 70) to have NAV_AREA_GROUND_STEEP.
+                 * we achieve this using recast API: memset everything to NAV_AREA_GROUND_STEEP, call rcClearUnwalkableTriangles with 70 so
+                 * any area above that will get RC_NULL_AREA (unwalkable), then call rcMarkWalkableTriangles with 55 to set NAV_AREA_GROUND
+                 * on anything below 55 . Players and idle Creatures can use NAV_AREA_GROUND, while Creatures in combat can use NAV_AREA_GROUND_STEEP.
+                 */
                 unsigned char* triFlags = new unsigned char[tTriCount];
-                memset(triFlags, NAV_AREA_GROUND, tTriCount*sizeof(unsigned char));
+                memset(triFlags, NAV_AREA_GROUND_STEEP, tTriCount*sizeof(unsigned char));
                 rcClearUnwalkableTriangles(m_rcContext, tileCfg.walkableSlopeAngle, tVerts, tVertCount, tTris, tTriCount, triFlags);
+                rcMarkWalkableTriangles(m_rcContext, tileCfg.walkableSlopeAngleNotSteep, tVerts, tVertCount, tTris, tTriCount, triFlags);
                 rcRasterizeTriangles(m_rcContext, tVerts, tVertCount, tTris, triFlags, tTriCount, *tile.solid, config.walkableClimb);
                 delete[] triFlags;
 
@@ -597,6 +605,7 @@ namespace MMAP
                 rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
                 rcFilterWalkableLowHeightSpans(m_rcContext, tileCfg.walkableHeight, *tile.solid);
 
+                // add liquid triangles
                 rcRasterizeTriangles(m_rcContext, lVerts, lVertCount, lTris, lTriFlags, lTriCount, *tile.solid, config.walkableClimb);
 
                 // compact heightfield spans
@@ -703,8 +712,8 @@ namespace MMAP
         {
             if (uint8 area = iv.polyMesh->areas[i] & RC_WALKABLE_AREA)
             {
-                if (area >= NAV_AREA_MAGMA_SLIME)
-                    iv.polyMesh->flags[i] = 1 << (63 - area);
+                if (area >= NAV_AREA_MIN_VALUE)
+                    iv.polyMesh->flags[i] = 1 << (NAV_AREA_MAX_VALUE - area);
                 else
                     iv.polyMesh->flags[i] = NAV_GROUND; // TODO: these will be dynamic in future
             }
@@ -1007,6 +1016,7 @@ namespace MMAP
         config.cs = tileConfig.BASE_UNIT_DIM;
         config.ch = tileConfig.BASE_UNIT_DIM;
         config.walkableSlopeAngle = 70;
+        config.walkableSlopeAngleNotSteep = 55;
         config.tileSize = tileConfig.VERTEX_PER_TILE;
         config.walkableRadius = m_bigBaseUnit ? 1 : 2;
         config.borderSize = config.walkableRadius + 3;

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -597,7 +597,7 @@ namespace MMAP
                 unsigned char* triFlags = new unsigned char[tTriCount];
                 memset(triFlags, NAV_AREA_GROUND_STEEP, tTriCount*sizeof(unsigned char));
                 rcClearUnwalkableTriangles(m_rcContext, tileCfg.walkableSlopeAngle, tVerts, tVertCount, tTris, tTriCount, triFlags);
-                rcMarkWalkableTriangles(m_rcContext, tileCfg.walkableSlopeAngleNotSteep, tVerts, tVertCount, tTris, tTriCount, triFlags);
+                rcMarkWalkableTriangles(m_rcContext, tileCfg.walkableSlopeAngleNotSteep, tVerts, tVertCount, tTris, tTriCount, triFlags, NAV_AREA_GROUND);
                 rcRasterizeTriangles(m_rcContext, tVerts, tVertCount, tTris, triFlags, tTriCount, *tile.solid, config.walkableClimb);
                 delete[] triFlags;
 
@@ -710,7 +710,7 @@ namespace MMAP
         // TODO: special flags for DYNAMIC polygons, ie surfaces that can be turned on and off
         for (int i = 0; i < iv.polyMesh->npolys; ++i)
         {
-            if (uint8 area = iv.polyMesh->areas[i] & NAV_AREA_MAX_VALUE)
+            if (uint8 area = iv.polyMesh->areas[i] & NAV_AREA_ALL_MASK)
             {
                 if (area >= NAV_AREA_MIN_VALUE)
                     iv.polyMesh->flags[i] = 1 << (NAV_AREA_MAX_VALUE - area);

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -602,7 +602,8 @@ namespace MMAP
                 delete[] triFlags;
 
                 rcFilterLowHangingWalkableObstacles(m_rcContext, config.walkableClimb, *tile.solid);
-                rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
+                // disabled as it ignores walkableSlopeAngle settings
+                //rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
                 rcFilterWalkableLowHeightSpans(m_rcContext, tileCfg.walkableHeight, *tile.solid);
 
                 // add liquid triangles
@@ -1015,7 +1016,7 @@ namespace MMAP
         config.maxVertsPerPoly = DT_VERTS_PER_POLYGON;
         config.cs = tileConfig.BASE_UNIT_DIM;
         config.ch = tileConfig.BASE_UNIT_DIM;
-        config.walkableSlopeAngle = 80;
+        config.walkableSlopeAngle = 85;
         config.walkableSlopeAngleNotSteep = 55;
         config.tileSize = tileConfig.VERTEX_PER_TILE;
         config.walkableRadius = m_bigBaseUnit ? 1 : 2;

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -31,7 +31,7 @@
 
 namespace MMAP
 {
-    MapBuilder::MapBuilder(float maxWalkableAngle, bool skipLiquid,
+    MapBuilder::MapBuilder(bool skipLiquid,
         bool skipContinents, bool skipJunkMaps, bool skipBattlegrounds,
         bool debugOutput, bool bigBaseUnit, int mapid, char const* offMeshFilePath) :
         m_terrainBuilder     (nullptr),
@@ -40,7 +40,6 @@ namespace MMAP
         m_skipContinents     (skipContinents),
         m_skipJunkMaps       (skipJunkMaps),
         m_skipBattlegrounds  (skipBattlegrounds),
-        m_maxWalkableAngle   (maxWalkableAngle),
         m_bigBaseUnit        (bigBaseUnit),
         m_mapid              (mapid),
         m_totalTiles         (0u),
@@ -1007,7 +1006,7 @@ namespace MMAP
         config.maxVertsPerPoly = DT_VERTS_PER_POLYGON;
         config.cs = tileConfig.BASE_UNIT_DIM;
         config.ch = tileConfig.BASE_UNIT_DIM;
-        config.walkableSlopeAngle = m_maxWalkableAngle;
+        config.walkableSlopeAngle = 70;
         config.tileSize = tileConfig.VERTEX_PER_TILE;
         config.walkableRadius = m_bigBaseUnit ? 1 : 2;
         config.borderSize = config.walkableRadius + 3;

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -94,8 +94,7 @@ namespace MMAP
     class MapBuilder
     {
         public:
-            MapBuilder(float maxWalkableAngle   = 70.f,
-                bool skipLiquid          = false,
+            MapBuilder(bool skipLiquid   = false,
                 bool skipContinents      = false,
                 bool skipJunkMaps        = true,
                 bool skipBattlegrounds   = false,
@@ -160,7 +159,6 @@ namespace MMAP
             bool m_skipJunkMaps;
             bool m_skipBattlegrounds;
 
-            float m_maxWalkableAngle;
             bool m_bigBaseUnit;
 
             int32 m_mapid;

--- a/src/tools/mmaps_generator/PathGenerator.cpp
+++ b/src/tools/mmaps_generator/PathGenerator.cpp
@@ -75,7 +75,6 @@ bool handleArgs(int argc, char** argv,
                int &mapnum,
                int &tileX,
                int &tileY,
-               float &maxAngle,
                bool &skipLiquid,
                bool &skipContinents,
                bool &skipJunkMaps,
@@ -90,19 +89,7 @@ bool handleArgs(int argc, char** argv,
     char* param = nullptr;
     for (int i = 1; i < argc; ++i)
     {
-        if (strcmp(argv[i], "--maxAngle") == 0)
-        {
-            param = argv[++i];
-            if (!param)
-                return false;
-
-            float maxangle = atof(param);
-            if (maxangle <= 90.f && maxangle >= 45.f)
-                maxAngle = maxangle;
-            else
-                printf("invalid option for '--maxAngle', using default\n");
-        }
-        else if (strcmp(argv[i], "--threads") == 0)
+        if (strcmp(argv[i], "--threads") == 0)
         {
             param = argv[++i];
             if (!param)
@@ -274,7 +261,6 @@ int main(int argc, char** argv)
 
     unsigned int threads = std::thread::hardware_concurrency();
     int mapnum = -1;
-    float maxAngle = 70.0f;
     int tileX = -1, tileY = -1;
     bool skipLiquid = false,
          skipContinents = false,
@@ -287,7 +273,7 @@ int main(int argc, char** argv)
     char* file = nullptr;
 
     bool validParam = handleArgs(argc, argv, mapnum,
-                                 tileX, tileY, maxAngle,
+                                 tileX, tileY,
                                  skipLiquid, skipContinents, skipJunkMaps, skipBattlegrounds,
                                  debugOutput, silent, bigBaseUnit, offMeshInputPath, file, threads);
 
@@ -313,7 +299,7 @@ int main(int argc, char** argv)
     if (_liquidTypes.empty())
         return silent ? -5 : finish("Failed to load LiquidType.dbc", -5);
 
-    MapBuilder builder(maxAngle, skipLiquid, skipContinents, skipJunkMaps,
+    MapBuilder builder(skipLiquid, skipContinents, skipJunkMaps,
                        skipBattlegrounds, debugOutput, bigBaseUnit, mapnum, offMeshInputPath);
 
     uint32 start = getMSTime();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Handle different slopes in mmaps using different area flags that can be included/excluded when querying mmaps. 
- NAV_AREA_GROUND will be used for ground with slope in the range [0, 55] while NAV_AREA_GROUND_STEEP will be used for ground with slope in the range of (55, 70]. This allows to use the [0, 55] range for Players and idle Creatures and to use the (55, 70] range for Creatures in combat/evading (chasing Players in places usually not reachable)
- NAV_AREA_GROUND_STEEP takes priority over NAV_AREA_GROUND
- Remove --maxAngle parameter from mmaps_generator to keep all parameters hardcoded in MapBuilder::GetMapSpecificConfig() (one is not supposed to try random angles anyway)
- It's required to re-generate mmaps

This is how the tile looks in recastdemo. Light blue is NAV_AREA_GROUND, dark blue is NAV_AREA_GROUND_STEEP:
![image](https://user-images.githubusercontent.com/1153754/83970467-2aa2c700-a8d6-11ea-91a5-80a742beff9a.png)

Example path going up the hill using both area types:
![image](https://user-images.githubusercontent.com/1153754/83970488-3e4e2d80-a8d6-11ea-8caf-2d22f627503f.png)

Same path, this time excluding NAV_AREA_GROUND_STEEP:
![image](https://user-images.githubusercontent.com/1153754/83970504-4d34e000-a8d6-11ea-876a-06de1f06d1e3.png)

https://github.com/jackpoz/recastnavigation/tree/fixes/3.3.5-blink-55-degrees is the recastdemo branch that supports this

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #24644


**Tests performed:** (Does it build, tested in-game, etc.)
None


**Known issues and TODO list:** (add/remove lines as needed)

- [x] Implement the change in mmaps_generator
- [x] Implement the change in worldserver
- [x] Cleanup the code to reduce changes in recastnavigation
- [x] raise the steep angle from 70° to 85°


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
