### PR TITLE
Worldserver/CLI: console printf fix

### DIFF
--- a/src/server/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/worldserver/CommandLine/CliRunnable.cpp
@@ -32,7 +32,16 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "Chat.h"
+#endif
 
+static constexpr char const *CLI_PREFIX = "TC> ";
+
+static inline void print_cli_prefix()
+{
+    printf("%s", CLI_PREFIX);
+}
+
+#if TRINITY_PLATFORM != TRINITY_PLATFORM_WINDOWS
 char* command_finder(char const* text, int state)
 {
     static size_t idx, len;
@@ -102,7 +111,7 @@ void utf8print(void* /*arg*/, char const* str)
 
 void commandFinished(void*, bool /*success*/)
 {
-    printf("TC> ");
+    print_cli_prefix();
     fflush(stdout);
 }
 
@@ -124,19 +133,17 @@ int kb_hit_return()
 /// %Thread start
 void CliThread()
 {
-    ///- Display the list of available CLI functions then beep
-    //TC_LOG_INFO("server.worldserver", "");
-#if TRINITY_PLATFORM != TRINITY_PLATFORM_WINDOWS
+#if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
+    // print this here the first time
+    // later it will be printed after command queue updates
+    print_cli_prefix();
+#else
     rl_attempted_completion_function = cli_completion;
     rl_event_hook = cli_hook_func;
 #endif
 
     if (sConfigMgr->GetBoolDefault("BeepAtStart", true))
         printf("\a");                                       // \a = Alert
-
-    // print this here the first time
-    // later it will be printed after command queue updates
-    printf("TC>");
 
     ///- As long as the World is running (no World::m_stopEvent), get the command line and handle it
     while (!World::IsStopped())
@@ -151,12 +158,12 @@ void CliThread()
         {
             if (!WStrToUtf8(commandbuf, wcslen(commandbuf), command))
             {
-                printf("TC>");
+                print_cli_prefix();
                 continue;
             }
         }
 #else
-        char* command_str = readline("TC>");
+        char* command_str = readline(CLI_PREFIX);
         rl_bind_key('\t', rl_complete);
         if (command_str != nullptr)
         {
@@ -173,7 +180,7 @@ void CliThread()
                 if (nextLineIndex == 0)
                 {
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
-                    printf("TC>");
+                    print_cli_prefix();
 #endif
                     continue;
                 }

--- a/src/server/worldserver/CommandLine/CliRunnable.cpp
+++ b/src/server/worldserver/CommandLine/CliRunnable.cpp
@@ -34,9 +34,9 @@
 #include "Chat.h"
 #endif
 
-static constexpr char const *CLI_PREFIX = "TC> ";
+static constexpr char CLI_PREFIX[] = "TC> ";
 
-static inline void print_cli_prefix()
+static inline void PrintCliPrefix()
 {
     printf("%s", CLI_PREFIX);
 }
@@ -111,7 +111,7 @@ void utf8print(void* /*arg*/, char const* str)
 
 void commandFinished(void*, bool /*success*/)
 {
-    print_cli_prefix();
+    PrintCliPrefix();
     fflush(stdout);
 }
 
@@ -136,7 +136,7 @@ void CliThread()
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
     // print this here the first time
     // later it will be printed after command queue updates
-    print_cli_prefix();
+    PrintCliPrefix();
 #else
     rl_attempted_completion_function = cli_completion;
     rl_event_hook = cli_hook_func;
@@ -158,7 +158,7 @@ void CliThread()
         {
             if (!WStrToUtf8(commandbuf, wcslen(commandbuf), command))
             {
-                print_cli_prefix();
+                PrintCliPrefix();
                 continue;
             }
         }
@@ -180,7 +180,7 @@ void CliThread()
                 if (nextLineIndex == 0)
                 {
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
-                    print_cli_prefix();
+                    PrintCliPrefix();
 #endif
                     continue;
                 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Some CLI printf functions had different output because of a missing space.
-  Removed extra console printf for *nix systems
<img width="1204" alt="Screen Shot 2020-06-13 at 22 07 24" src="https://user-images.githubusercontent.com/9049790/84577163-8c759c00-adc2-11ea-95d2-021b403b47f9.png">

These issues only visible if Console is Enabled in the worldserver config. 


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master 

Cannot check master branch, but the CLI code is the same, so I assume this PR should also fix it.


**Tests performed:**  Compiled, manually tested in the console.



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
