### PR TITLE
CMake: Prepare for target_precompile_headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,17 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 project(TrinityCore)
 
 # CMake policies (can not be handled elsewhere)
-cmake_policy(SET CMP0005 OLD)
+cmake_policy(SET CMP0005 NEW)
 if(POLICY CMP0043)
-  cmake_policy(SET CMP0043 OLD) # Disable 'Ignore COMPILE_DEFINITIONS_<Config> properties'
+  cmake_policy(SET CMP0043 NEW) # Disable 'Ignore COMPILE_DEFINITIONS_<Config> properties'
 endif()
 
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW) # Only interpret if() arguments as variables or keywords when unquoted - prevents intepreting if (SOME_STRING_VARIABLE MATCHES "MSVC") as if (SOME_STRING_VARIABLE MATCHES "1")
+endif()
+
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) # find_package() uses <PackageName>_ROOT variables
 endif()
 
 # Set RPATH-handing (CMake parameters)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,11 @@ project(TrinityCore)
 
 # CMake policies (can not be handled elsewhere)
 cmake_policy(SET CMP0005 NEW)
-cmake_policy(SET CMP0043 OLD) # Disable 'Ignore COMPILE_DEFINITIONS_<Config> properties'
+if (CMAKE_VERSION VERSION_LESS "3.16.0")
+  cmake_policy(SET CMP0043 OLD) # Disable 'Ignore COMPILE_DEFINITIONS_<Config> properties'
+else()
+  cmake_policy(SET CMP0043 NEW) # Cotire isn't used so set to NEW
+endif()
 cmake_policy(SET CMP0054 NEW) # Only interpret if() arguments as variables or keywords when unquoted - prevents intepreting if (SOME_STRING_VARIABLE MATCHES "MSVC") as if (SOME_STRING_VARIABLE MATCHES "1")
 
 if(POLICY CMP0074)
@@ -35,8 +39,12 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH 1)
 
 # set macro-directory
 list(APPEND CMAKE_MODULE_PATH
-  "${CMAKE_SOURCE_DIR}/cmake/macros"
-  "${CMAKE_SOURCE_DIR}/dep/cotire/CMake")
+  "${CMAKE_SOURCE_DIR}/cmake/macros")
+
+if (CMAKE_VERSION VERSION_LESS "3.16.0")
+  list(APPEND CMAKE_MODULE_PATH
+          "${CMAKE_SOURCE_DIR}/dep/cotire/CMake")
+endif()
 
 # build in Release-mode by default if not explicitly set
 if(CMAKE_GENERATOR STREQUAL "Ninja Multi-Config")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,8 @@ project(TrinityCore)
 
 # CMake policies (can not be handled elsewhere)
 cmake_policy(SET CMP0005 NEW)
-if(POLICY CMP0043)
-  cmake_policy(SET CMP0043 NEW) # Disable 'Ignore COMPILE_DEFINITIONS_<Config> properties'
-endif()
-
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW) # Only interpret if() arguments as variables or keywords when unquoted - prevents intepreting if (SOME_STRING_VARIABLE MATCHES "MSVC") as if (SOME_STRING_VARIABLE MATCHES "1")
-endif()
+cmake_policy(SET CMP0043 OLD) # Disable 'Ignore COMPILE_DEFINITIONS_<Config> properties'
+cmake_policy(SET CMP0054 NEW) # Only interpret if() arguments as variables or keywords when unquoted - prevents intepreting if (SOME_STRING_VARIABLE MATCHES "MSVC") as if (SOME_STRING_VARIABLE MATCHES "1")
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW) # find_package() uses <PackageName>_ROOT variables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 # We require CMake >= 3.2
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.8)
 
 # add this options before PROJECT keyword
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)

--- a/cmake/macros/FindPCHSupport.cmake
+++ b/cmake/macros/FindPCHSupport.cmake
@@ -1,27 +1,35 @@
-if (MSVC)
-  # Specify the maximum PreCompiled Header memory allocation limit
-  # Fixes a compiler-problem when using PCH - the /Ym flag is adjusted by the compiler in MSVC2012,
-  # hence we need to set an upper limit with /Zm to avoid discrepancies)
-  # (And yes, this is a verified, unresolved bug with MSVC... *sigh*)
-  #
-  # Note: This workaround was verified to be required on MSVC 2017 as well
-  set(COTIRE_PCH_MEMORY_SCALING_FACTOR 500)
+if (CMAKE_VERSION VERSION_LESS "3.16.0")
+  if (MSVC)
+    # Specify the maximum PreCompiled Header memory allocation limit
+    # Fixes a compiler-problem when using PCH - the /Ym flag is adjusted by the compiler in MSVC2012,
+    # hence we need to set an upper limit with /Zm to avoid discrepancies)
+    # (And yes, this is a verified, unresolved bug with MSVC... *sigh*)
+    #
+    # Note: This workaround was verified to be required on MSVC 2017 as well
+    set(COTIRE_PCH_MEMORY_SCALING_FACTOR 500)
+  endif ()
+
+  include(cotire)
+
+  function(ADD_CXX_PCH TARGET_NAME_LIST PCH_HEADER)
+    # Use the header for every target
+    foreach (TARGET_NAME ${TARGET_NAME_LIST})
+      # Disable unity builds
+      set_target_properties(${TARGET_NAME} PROPERTIES COTIRE_ADD_UNITY_BUILD OFF)
+
+      # Set the prefix header
+      set_target_properties(${TARGET_NAME} PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT ${PCH_HEADER})
+
+      # Workaround for cotire bug: https://github.com/sakra/cotire/issues/138
+      set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 14)
+    endforeach ()
+
+    cotire(${TARGET_NAME_LIST})
+  endfunction(ADD_CXX_PCH)
+else()
+  function(ADD_CXX_PCH TARGET_NAME_LIST PCH_HEADER)
+    foreach(TARGET_NAME ${TARGET_NAME_LIST})
+      target_precompile_headers(${TARGET_NAME} PRIVATE ${PCH_HEADER})
+    endforeach()
+  endfunction(ADD_CXX_PCH)
 endif()
-
-include(cotire)
-
-function(ADD_CXX_PCH TARGET_NAME_LIST PCH_HEADER)
-  # Use the header for every target
-  foreach(TARGET_NAME ${TARGET_NAME_LIST})
-    # Disable unity builds
-    set_target_properties(${TARGET_NAME} PROPERTIES COTIRE_ADD_UNITY_BUILD OFF)
-
-    # Set the prefix header
-    set_target_properties(${TARGET_NAME} PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT ${PCH_HEADER})
-
-    # Workaround for cotire bug: https://github.com/sakra/cotire/issues/138
-    set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 14)
-  endforeach()
-
-  cotire(${TARGET_NAME_LIST})
-endfunction(ADD_CXX_PCH)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Cleanup CMake policies
-  Use target_precompile_headers instead of cotire with CMake >= 3.16.0

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** compile
