### PR TITLE
CMake: removed unused code for LIBSDIR entry

### DIFF
--- a/cmake/platform/unix/settings.cmake
+++ b/cmake/platform/unix/settings.cmake
@@ -4,12 +4,6 @@ if( NOT CONF_DIR )
   message(STATUS "UNIX: Using default configuration directory")
 endif()
 
-# set default library directory
-if( NOT LIBSDIR )
-  set(LIBSDIR ${CMAKE_INSTALL_PREFIX}/lib)
-  message(STATUS "UNIX: Using default library directory")
-endif()
-
 # configure uninstaller
 configure_file(
   "${CMAKE_SOURCE_DIR}/cmake/platform/cmake_uninstall.in.cmake"

--- a/cmake/showoptions.cmake
+++ b/cmake/showoptions.cmake
@@ -10,7 +10,6 @@ message("")
 
 message("* Install core to        : ${CMAKE_INSTALL_PREFIX}")
 if( UNIX )
-  message("* Install libraries to   : ${LIBSDIR}")
   message("* Install configs to     : ${CONF_DIR}")
 endif()
 message("")

--- a/doc/UnixInstall.txt
+++ b/doc/UnixInstall.txt
@@ -42,7 +42,6 @@ CMakeLists.txt in the main folder and take a look at some of the flags like
     CMAKE_INSTALL_PREFIX    Set installation directory
     NOJEM                   Do not build with jemalloc (advanced users only)
     CONF_DIR                Set path as default configuration directory
-    LIBSDIR                 Set path as default library directory
     CMAKE_C_FLAGS           Set C_FLAGS for compile (advanced users only)
     CMAKE_CXX_FLAGS         Set CXX_FLAGS for compile (advanced users only)
     CMAKE_BUILD_TYPE        Set build type - the supported modes are:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

During the build, cmake informs that it is using a separate directory for libraries (as a default on *nix systems)

![image](https://user-images.githubusercontent.com/9049790/84675439-eac28c00-af34-11ea-84a8-e9b068402e33.png)

During the runtime we can see that new running server process is using shared libraries from the default system lib directory.

![image](https://user-images.githubusercontent.com/9049790/84676757-8d2f3f00-af36-11ea-99de-4e07714f16e9.png)

And that's because there is no code that creates a directory or links libs to the compiled binary. 

-  Remove legacy code related to LIBSDIR entry, so it won't confuse users during the build as it doesn't have an implementation.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)

Build works on *nix systems

<!---
**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


 Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
