### PR TITLE
Script/Spell: properly round damage of Seal of Righteousness (on-hit proc)

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -2054,7 +2054,7 @@ class spell_pal_seal_of_righteousness : public SpellScriptLoader
                 float mws = GetTarget()->GetAttackTime(BASE_ATTACK);
                 mws /= 1000.0f;
 
-                int32 bp = int32(mws * (0.022f * ap + 0.044f * sph));
+                int32 bp = std::lroundf(mws * (0.022f * ap + 0.044f * sph));
                 CastSpellExtraArgs args(aurEff);
                 args.AddSpellBP0(bp);
                 GetTarget()->CastSpell(victim, SPELL_PALADIN_SEAL_OF_RIGHTEOUSNESS, args);


### PR DESCRIPTION
**Changes proposed:**

Currently, Seal of Righteousness' damage for the on-hit proc doesn't match the tooltip.
Example: human paladins, with their _massive_ 27 attack power, should deal 2 damage of SoR proc at level 1. Instead it deals 1 damage.
This is because the spell script truncates the calculated value, instead of rounding.

Video of human paladin [here](https://www.youtube.com/watch?v=oLy8hMW-e48). Sometimes it deals less damage, but that's because of the creature resisting some of the spell damage.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** tested, works. Damage done (when not partially resisted) matches tooltip.