### PR TITLE
Core/Movement: inform owner of current walk/run state of waypoint movement

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -362,9 +362,11 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
             break;
         case WAYPOINT_MOVE_TYPE_RUN:
             init.SetWalk(false);
+            owner->SetWalk(false);
             break;
         case WAYPOINT_MOVE_TYPE_WALK:
             init.SetWalk(true);
+            owner->SetWalk(true);
             break;
         default:
             break;


### PR DESCRIPTION
**Changes proposed:**

Currently, when a creature uses the waypoint system (pathid in creature_addon, LOAD_PATH script command), the walk/run state is only set in the spline. The creature doesn't actually know it's walking (MOVEMENTFLAG_WALKING is never set), so pets and formation members default to always running after the pathing unit.

This PR adds calls to Creature::SetWalk() when the waypoint movegen decides if the creature should run (WAYPOINT_MOVE_TYPE_RUN) or walk (WAYPOINT_MOVE_TYPE_WALK), so that subsequent calls to Unit::IsWalking() will return the expected result.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #12817


**Tests performed:** tested with Backbiter (https://github.com/TrinityCore/TrinityCore/issues/12817#issuecomment-230668275) and the Mine Cars that follow [Scarlet Miners](https://www.wowhead.com/npc=28841) in the Death Knight starting area.