### PR TITLE
Core/Movement: inform owner of current walk/run state of movement and remove MOVEMENTFLAG_WALKING usage for creatures

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -249,7 +249,7 @@ Creature::Creature(bool isWorldObject): Unit(isWorldObject), MapObject(), m_grou
     m_corpseRemoveTime(0), m_respawnTime(0), m_respawnDelay(300), m_corpseDelay(60), m_wanderDistance(0.0f), m_boundaryCheckTime(2500), m_combatPulseTime(0), m_combatPulseDelay(0), m_reactState(REACT_AGGRESSIVE),
     m_defaultMovementType(IDLE_MOTION_TYPE), m_spawnId(0), m_equipmentId(0), m_originalEquipmentId(0), m_AlreadyCallAssistance(false), m_AlreadySearchedAssistance(false), m_cannotReachTarget(false), m_cannotReachTimer(0),
     m_meleeDamageSchoolMask(SPELL_SCHOOL_MASK_NORMAL), m_originalEntry(0), m_homePosition(), m_transportHomePosition(), m_creatureInfo(nullptr), m_creatureData(nullptr), _waypointPathId(0), _currentWaypointNodeInfo(0, 0),
-    m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), _lastDamagedTime(0),
+    m_isWalking(false), m_formation(nullptr), m_triggerJustAppeared(true), m_respawnCompatibilityMode(false), _lastDamagedTime(0),
     _regenerateHealth(true), _regenerateHealthLock(false)
 {
     m_regenTimer = CREATURE_REGEN_INTERVAL;
@@ -2873,9 +2873,7 @@ void Creature::SetCannotReachTarget(bool cannotReach)
 
 bool Creature::SetWalk(bool enable)
 {
-    if (!Unit::SetWalk(enable))
-        return false;
-
+    m_isWalking = enable;
     WorldPacket data(enable ? SMSG_SPLINE_MOVE_SET_WALK_MODE : SMSG_SPLINE_MOVE_SET_RUN_MODE, 9);
     data << GetPackGUID();
     SendMessageToSet(&data, false);

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -147,6 +147,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         CreatureAI* AI() const { return reinterpret_cast<CreatureAI*>(GetAI()); }
 
         bool SetWalk(bool enable) override;
+        bool IsWalking() const override { return m_isWalking; }
         bool SetDisableGravity(bool disable, bool packetOnly = false) override;
         bool SetSwim(bool enable) override;
         bool SetCanFly(bool enable, bool packetOnly = false) override;
@@ -418,6 +419,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         // Waypoint path
         uint32 _waypointPathId;
         std::pair<uint32/*nodeId*/, uint32/*pathId*/> _currentWaypointNodeInfo;
+        bool m_isWalking;
 
         // Formation var
         CreatureGroup* m_formation;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1119,7 +1119,7 @@ class TC_GAME_API Unit : public WorldObject
         void SendMovementFlagUpdate(bool self = false);
 
         bool IsGravityDisabled() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY); }
-        bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING); }
+        virtual bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING); }
         bool IsHovering() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_HOVER); }
         virtual bool SetWalk(bool enable);
         virtual bool SetDisableGravity(bool disable, bool packetOnly = false);

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -362,9 +362,11 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
             break;
         case WAYPOINT_MOVE_TYPE_RUN:
             init.SetWalk(false);
+            owner->SetWalk(false);
             break;
         case WAYPOINT_MOVE_TYPE_WALK:
             init.SetWalk(true);
+            owner->SetWalk(true);
             break;
         default:
             break;

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -194,7 +194,7 @@ namespace Movement
         args.TransformForTransport = unit->HasUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT) && unit->GetTransGUID();
         // mix existing state into new
         args.flags.canswim = unit->CanSwim();
-        args.walk = unit->HasUnitMovementFlag(MOVEMENTFLAG_WALKING);
+        args.walk = unit->IsWalking();
         args.flags.flying = unit->m_movementInfo.HasMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY);
     }
 


### PR DESCRIPTION
**Changes proposed:**

Currently, when a creature uses the waypoint system (pathid in creature_addon, LOAD_PATH script command), the walk/run state is only set in the spline. The creature doesn't actually know it's walking, so pets and formation members default to always running after the pathing unit.

This PR:
- Adds calls to Creature::SetWalk() when the waypoint movegen decides if the creature should run (WAYPOINT_MOVE_TYPE_RUN) or walk (WAYPOINT_MOVE_TYPE_WALK), so that subsequent calls to Unit::IsWalking() will return the expected result.
- Removes the Unit::SetWalk() call in Creature::SetWalk, because creatures shouldn't get MOVEMENTFLAG_WALKING (https://github.com/TrinityCore/TrinityCore/pull/24839#issuecomment-645955515).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #12817


**Tests performed:** tested with Backbiter (https://github.com/TrinityCore/TrinityCore/issues/12817#issuecomment-230668275) and the Mine Cars that follow [Scarlet Miners](https://www.wowhead.com/npc=28841) in the Death Knight starting area. Used .debug moveflags to make sure walking creatures don't get MOVEMENTFLAG_WALKING (0x100).