### PR TITLE
Core/Spells: SPELL_AURA_MOD_HEALING should be negative if TargetType is negative

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3714,6 +3714,7 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
             case SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE:
             case SPELL_AURA_MOD_ATTACKER_SPELL_AND_WEAPON_CRIT_CHANCE:
             case SPELL_AURA_DUMMY:
+            case SPELL_AURA_MOD_HEALING:
                 // check target for positive and negative spells
                 if (!_isPositiveTarget(spellInfo, effIndex))
                     return false;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  SPELL_AURA_MOD_HEALING should be negative if TargetType is negative
-  Mage Dampen/Amplify Magic specific check (https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Spells/SpellInfo.cpp#L3432-L3434) still be necessary because those spells have SPELL_AURA_MOD_DAMAGE_TAKEN and if have BP > 0 (https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Spells/SpellInfo.cpp#L3648) Amplify Magic will be negative and it shouldn't be


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes #24854


**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
