### PR TITLE
Core/Spells: SPELL_AURA_PERIODIC_DUMMY should be negative if TargetType is enemy

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3714,6 +3714,7 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
             case SPELL_AURA_MOD_ATTACKER_RANGED_CRIT_DAMAGE:
             case SPELL_AURA_MOD_ATTACKER_SPELL_AND_WEAPON_CRIT_CHANCE:
             case SPELL_AURA_DUMMY:
+            case SPELL_AURA_PERIODIC_DUMMY:
             case SPELL_AURA_MOD_HEALING:
                 // check target for positive and negative spells
                 if (!_isPositiveTarget(spellInfo, effIndex))


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  SPELL_AURA_PERIODIC_DUMMY should be negative if TargetType is enemy
-  By example, when a DK cast ID - 49206 Summon Gargoyle on target, appear as buff and target can remove it with right click buff


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes none i think


**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
