### PR TITLE
Core/EscortAI: set maximum distance allowed between player and escortee to default vision range

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
@@ -23,7 +23,7 @@
 
 class Quest;
 
-#define DEFAULT_MAX_PLAYER_DISTANCE 50
+#define DEFAULT_MAX_PLAYER_DISTANCE 100
 
 enum EscortState : uint32
 {


### PR DESCRIPTION
**Changes proposed:**

When an escort NPC gets further than 100 yards from the player that started the escort, it despawns. The current distance for that behaviour in TC is 50 yards.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:** tested, works.