### PR TITLE
Core/SAI: do not allow the waypoint pause timer to update while in combat

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -933,13 +933,13 @@ void SmartAI::UpdatePath(uint32 diff)
     // handle pause
     if (HasEscortState(SMART_ESCORT_PAUSED) && (_waypointReached || _waypointPauseForced))
     {
-        if (_waypointPauseTimer <= diff)
+        if (!me->IsInCombat() && !HasEscortState(SMART_ESCORT_RETURNING))
         {
-            if (!me->IsInCombat() && !HasEscortState(SMART_ESCORT_RETURNING))
+            if (_waypointPauseTimer <= diff)
                 ResumePath();
+            else
+                _waypointPauseTimer -= diff;
         }
-        else
-            _waypointPauseTimer -= diff;
     }
     else if (_waypointPathEnded) // end path
     {


### PR DESCRIPTION
**Changes proposed:**

Currently, the SAI waypoint pause timer keeps ticking down while the creature is in combat. If you pause the path right before the creature enters combat, it will start pathing straight away after combat ends.

In most escort quests, the creature summons hostile mobs, and after combat it stays paused, says/does something and then resumes pathing. If the pause timer keeps ticking in combat, this behavior requires various hacks to implement.

If a creature is in combat, it doesn't run any OOC/RP events. It makes sense that if we specify a pause timer, we want it to be paused for that amount even if the creature engages hostiles in the meantime.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** couldn't find a specific issue about this. It is mentioned in https://github.com/TrinityCore/TrinityCore/issues/21586#issuecomment-647054110


**Tests performed:** tested, works.