### PR TITLE
Core/Player: do not consider FLAG_EXTRA_NO_XP_AT_KILL or pet status when deciding if a creature counts as a "gives experience or honor" target

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -23843,7 +23843,7 @@ bool Player::isHonorOrXPTarget(Unit* victim) const
 
     if (Creature const* creature = victim->ToCreature())
     {
-        if (!creature->CanGiveExperience())
+        if (creature->IsCritter() || creature->IsTotem())
             return false;
     }
     return true;


### PR DESCRIPTION
**Changes proposed:**

When a spell/talent/ability says "targets that grant experience or honor", the "experience" part is not to be taken literally. It simply means that the creature must be in the level range where it appears at green/yellow/red "difficulty" (ie: not trivial) for the player.

So it shouldn't take into consideration FLAG_EXTRA_NO_XP_AT_KILL, and those abilities should also work on pets.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:** Closes #23860


**Tests performed:** tested, works.