### PR TITLE
Core/Gameobjects: Traps shouldn't activate in Sanctuary

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2950,6 +2950,13 @@ bool WorldObject::IsValidAttackTarget(WorldObject const* target, SpellInfo const
     if (unitTarget && unitTarget->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && unit && unit->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED) && (unitTarget->IsInSanctuary() || unit->IsInSanctuary()))
         return false;
 
+    // Traps shouldn't activate in Sanctuary
+    if (GameObject const* go = ToGameObject())
+        if (go->GetGoType() == GAMEOBJECT_TYPE_TRAP)
+            if (AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(go->GetAreaId()))
+                if (areaEntry->IsSanctuary())
+                    return false;
+
     // additional checks - only PvP case
     if (playerAffectingAttacker && playerAffectingTarget)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Traps shouldn't activate in Sanctuary
-  go to dalaran with a hunter, find a hostile npc with movement and put a trap or freezing arrow at this npc

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master


**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
