### PR TITLE
Core/Spells: implement GetHitCorpse helper for spell scripts

### DIFF
--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -552,6 +552,16 @@ GameObject* SpellScript::GetHitGObj() const
     return m_spell->gameObjTarget;
 }
 
+Corpse* SpellScript::GetHitCorpse() const
+{
+    if (!IsInTargetHook())
+    {
+        TC_LOG_ERROR("scripts", "Script: `%s` Spell: `%u`: function SpellScript::GetHitCorpse was called, but function has no effect in current hook!", m_scriptName->c_str(), m_scriptSpellId);
+        return nullptr;
+    }
+    return m_spell->corpseTarget;
+}
+
 WorldLocation* SpellScript::GetHitDest() const
 {
     if (!IsInEffectHook())

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -29,6 +29,7 @@ class Aura;
 class AuraApplication;
 class AuraEffect;
 class Creature;
+class Corpse;
 class DamageInfo;
 class DispelInfo;
 class DynamicObject;
@@ -453,6 +454,8 @@ class TC_GAME_API SpellScript : public _SpellScript
         Item* GetHitItem() const;
         // returns: target of current effect if it was GameObject otherwise NULL
         GameObject* GetHitGObj() const;
+        // returns: target of current effect if it was Corpse otherwise nullptr
+        Corpse* GetHitCorpse() const;
         // returns: destination of current effect
         WorldLocation* GetHitDest() const;
         // setter/getter for for damage done by spell to target of spell hit


### PR DESCRIPTION
**Changes proposed:**

-  implements a helper to access corpses hit by spells via spell scripts

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)
closes #24945

**Tests performed:** (Does it build, tested in-game, etc.)
builds, tested in 4.x
