### PR TITLE
Core/Spells: Check a few aura effects for determining if should be negative

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3674,29 +3674,26 @@ bool _isPositiveEffectImpl(SpellInfo const* spellInfo, uint8 effIndex, std::unor
                 return true;
             case SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE:
             case SPELL_AURA_PERIODIC_TRIGGER_SPELL_FROM_CLIENT:
-            case SPELL_AURA_PERIODIC_TRIGGER_SPELL:
-                if (!_isPositiveTarget(spellInfo, effIndex))
+                if (SpellInfo const* spellTriggeredProto = sSpellMgr->GetSpellInfo(spellInfo->Effects[effIndex].TriggerSpell))
                 {
-                    if (SpellInfo const* spellTriggeredProto = sSpellMgr->GetSpellInfo(spellInfo->Effects[effIndex].TriggerSpell))
+                    // negative targets of main spell return early
+                    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
                     {
-                        // negative targets of main spell return early
-                        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-                        {
-                            // already seen this
-                            if (visited.count({ spellTriggeredProto->Id, i }) > 0)
-                                continue;
+                        // already seen this
+                        if (visited.count({ spellTriggeredProto->Id, i }) > 0)
+                            continue;
 
-                            if (!spellTriggeredProto->Effects[i].Effect)
-                                continue;
+                        if (!spellTriggeredProto->Effects[i].Effect)
+                            continue;
 
-                            // if non-positive trigger cast targeted to positive target this main cast is non-positive
-                            // this will place this spell auras as debuffs
-                            if (_isPositiveTarget(spellTriggeredProto, i) && !_isPositiveEffectImpl(spellTriggeredProto, i, visited))
-                                return false;
-                        }
+                        // if non-positive trigger cast targeted to positive target this main cast is non-positive
+                        // this will place this spell auras as debuffs
+                        if (_isPositiveTarget(spellTriggeredProto, i) && !_isPositiveEffectImpl(spellTriggeredProto, i, visited))
+                            return false;
                     }
                 }
                 break;
+            case SPELL_AURA_PERIODIC_TRIGGER_SPELL:
             case SPELL_AURA_MOD_STUN:
             case SPELL_AURA_TRANSFORM:
             case SPELL_AURA_MOD_DECREASE_SPEED:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- This check:https://github.com/TrinityCore/TrinityCore/blob/26ba4ecd5140fa13953ca7c3e1ab3f269a85ce71/src/server/game/Spells/SpellInfo.cpp#L3675-L3699
was added here: https://github.com/TrinityCore/TrinityCore/commit/29c228a80170e4264129d4e3bed4d2fc41aca5a7
but without check if target is positive or negative https://github.com/TrinityCore/TrinityCore/blob/29c228a80170e4264129d4e3bed4d2fc41aca5a7/src/server/game/Spells/SpellInfo.cpp#L1791-L1808
and this another check:https://github.com/TrinityCore/TrinityCore/blob/29c228a80170e4264129d4e3bed4d2fc41aca5a7/src/server/game/Spells/SpellInfo.cpp#L1896-L1898
made negative all enemy target

- after this commit https://github.com/TrinityCore/TrinityCore/commit/efeae33495c8b57ae04aeeb382ee85099ac0b600 was changed and only targets enemy were checked only if "if non-positive trigger cast targeted to positive target", is wrong, broke a lot of SPELL_AURA_PERIODIC_TRIGGER_SPELL debuffs

- SPELL_AURA_PERIODIC_TRIGGER_SPELL_WITH_VALUE and SPELL_AURA_PERIODIC_TRIGGER_SPELL_FROM_CLIENT should keep this check, but without taking into account if the target is an enemy

-  SPELL_AURA_PERIODIC_TRIGGER_SPELL should be negative if TargetType is enemy
by example:
ID - 9614 Rift Beacon https://www.wowhead.com/spell=9614
ID - 23015 Crystal Prison https://www.wowhead.com/spell=23015
ID - 27177 Defile https://www.wowhead.com/spell=27177
ID - 23410 Wild Magic https://www.wowhead.com/spell=23410
ID - 23418 Siphon Blessing https://www.wowhead.com/spell=23418
ID - 23425 Corrupted Totems https://www.wowhead.com/spell=23425
ID - 24210 Mark of Arlokk https://www.wowhead.com/spell=24210
ID - 24918 Stink Trap https://www.wowhead.com/spell=24918
ID - 27673 Five Fat Finger Exploding Heart Technique https://www.wowhead.com/spell=27673
ID - 27819 Detonate Mana https://www.wowhead.com/spell=27819
ID - 29768 Overload https://www.wowhead.com/spell=29768
ID - 31423 Spore Disease https://www.wowhead.com/spell=31423
ID - 31704 Levitate https://www.wowhead.com/spell=31704
ID - 33401 Possess https://www.wowhead.com/spell=33401
ID - 36414 Focused Bursts https://www.wowhead.com/spell=36414
ID - 36469 Parasite https://www.wowhead.com/spell=36469
ID - 37540 Fireball Barrage https://www.wowhead.com/spell=37540
ID - 37632 Toxic Barrage https://www.wowhead.com/spell=37632
ID - 37933 Consume Flesh https://www.wowhead.com/spell=37933
ID - 37986 Ancient Fire https://www.wowhead.com/spell=37986
ID - 41001 Fatal Attraction https://www.wowhead.com/spell=41001
ID - 41264 Energy Surge https://www.wowhead.com/spell=41264
ID - 42783 Wrath of the Astromancer https://www.wowhead.com/spell=42783
ID - 45587 Web Bolt https://www.wowhead.com/spell=45587
ID - 48599 Rune of Binding https://www.wowhead.com/spell=48599
ID - 49753 Rune of Destruction https://www.wowhead.com/spell=49753
ID - 60440 Mind Sear https://www.wowhead.com/spell=60440 
ID - 67892 Touch of the Val'kyr https://www.wowhead.com/spell=67892

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:** None, I think


**Tests performed:** tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
