### PR TITLE
Core/Spells: Use correct SpellEntry field for Amplitude

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -332,7 +332,7 @@ SpellEffectInfo::SpellEffectInfo(SpellEntry const* spellEntry, SpellInfo const* 
     _effIndex = effIndex;
     Effect = spellEntry->Effect[effIndex];
     ApplyAuraName = spellEntry->EffectAura[effIndex];
-    Amplitude = spellEntry->EffectAmplitude[effIndex];
+    Amplitude = spellEntry->EffectAuraPeriod[effIndex];
     DieSides = spellEntry->EffectDieSides[effIndex];
     RealPointsPerLevel = spellEntry->EffectRealPointsPerLevel[effIndex];
     BasePoints = spellEntry->EffectBasePoints[effIndex];


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

EffectAmplitude is incorrectly used twice after c92950b3e1f6366d85d707365a8ad2caddafeecc in SpellInfo (for Amplitude and ValueMultiplier). This simply restores the behavior by correcting the field used for Amplitude to EffectAuraPeriod (as EffectAmplitude was the old name for EffectAuraPeriod).


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
