### PR TITLE
Core/Movement: Fix a -Wclass-memaccess warning reported by GCC

### DIFF
--- a/src/server/game/Maps/TransportMgr.cpp
+++ b/src/server/game/Maps/TransportMgr.cpp
@@ -223,7 +223,7 @@ void TransportMgr::GeneratePath(GameObjectTemplate const* goInfo, TransportTempl
         {
             size_t extra = !keyFrames[i - 1].Teleport ? 1 : 0;
             std::shared_ptr<TransportSpline> spline = std::make_shared<TransportSpline>();
-            spline->init_spline(&splinePath[start], i - start + extra, Movement::SplineBase::ModeCatmullrom);
+            spline->init_spline({splinePath.cbegin() + start, splinePath.cbegin() + i + extra}, Movement::SplineBase::ModeCatmullrom);
             spline->initLengths();
             for (size_t j = start; j < i + extra; ++j)
             {

--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -124,10 +124,10 @@ void MoveSpline::init_spline(MoveSplineInitArgs const& args)
         uint32 cyclic_point = 0;
         if (splineflags.enter_cycle)
             cyclic_point = 1;   // shouldn't be modified, came from client
-        spline.init_cyclic_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()], cyclic_point, args.initialOrientation);
+        spline.init_cyclic_spline({args.path.cbegin(), args.path.cend()}, modes[args.flags.isSmooth()], cyclic_point, args.initialOrientation);
     }
     else
-        spline.init_spline(&args.path[0], args.path.size(), modes[args.flags.isSmooth()], args.initialOrientation);
+        spline.init_spline({args.path.cbegin(), args.path.cend()}, modes[args.flags.isSmooth()], args.initialOrientation);
 
     // init spline timestamps
     if (splineflags.falling)

--- a/src/server/game/Movement/Spline/Spline.h
+++ b/src/server/game/Movement/Spline/Spline.h
@@ -23,6 +23,7 @@
 #include <G3D/Vector3.h>
 #include <limits>
 #include <vector>
+#include <IteratorPair.h>
 
 namespace Movement {
 
@@ -78,15 +79,15 @@ protected:
     typedef float (SplineBase::*SegLenghtMethtod)(index_type) const;
     static SegLenghtMethtod seglengths[ModesEnd];
 
-    void InitLinear(Vector3 const*, index_type, index_type);
-    void InitCatmullRom(Vector3 const*, index_type, index_type);
-    void InitBezier3(Vector3 const*, index_type, index_type);
-    typedef void (SplineBase::*InitMethtod)(Vector3 const*, index_type, index_type);
+    void InitLinear(Trinity::IteratorPair<ControlArray::const_iterator> controls, index_type);
+    void InitCatmullRom(Trinity::IteratorPair<ControlArray::const_iterator> controls, index_type);
+    void InitBezier3(Trinity::IteratorPair<ControlArray::const_iterator> controls, index_type);
+    typedef void (SplineBase::*InitMethtod)(Trinity::IteratorPair<ControlArray::const_iterator> controls, index_type);
     static InitMethtod initializers[ModesEnd];
 
     void UninitializedSplineEvaluationMethod(index_type, float, Vector3&) const { ABORT(); }
     float UninitializedSplineSegLenghtMethod(index_type) const { ABORT(); return 0.0f; }
-    void UninitializedSplineInitMethod(Vector3 const*, index_type, index_type) { ABORT(); }
+    void UninitializedSplineInitMethod(Trinity::IteratorPair<ControlArray::const_iterator>, index_type) { ABORT(); }
 
 public:
 
@@ -117,8 +118,8 @@ public:
     Vector3 const& getPoint(index_type i) const { return points[i];}
 
     /** Initializes spline. Don't call other methods while spline not initialized. */
-    void init_spline(const Vector3 * controls, index_type count, EvaluationMode m, float orientation);
-    void init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point, float orientation);
+    void init_spline(Trinity::IteratorPair<ControlArray::const_iterator> controls, EvaluationMode m, float orientation);
+    void init_cyclic_spline(Trinity::IteratorPair<ControlArray::const_iterator> controls, EvaluationMode m, index_type cyclic_point, float orientation);
 
     /** As i can see there are a lot of ways how spline can be initialized
         would be no harm to have some custom initializers. */
@@ -173,8 +174,8 @@ public:
     void computeIndex(float t, index_type& out_idx, float& out_u) const;
 
     /** Initializes spline. Don't call other methods while spline not initialized. */
-    void init_spline(const Vector3 * controls, index_type count, EvaluationMode m, float orientation = 0) { SplineBase::init_spline(controls, count, m, orientation);}
-    void init_cyclic_spline(const Vector3 * controls, index_type count, EvaluationMode m, index_type cyclic_point, float orientation = 0) { SplineBase::init_cyclic_spline(controls, count, m, cyclic_point, orientation);}
+    void init_spline(Trinity::IteratorPair<ControlArray::const_iterator> controls, EvaluationMode m, float orientation = 0) { SplineBase::init_spline(controls, m, orientation);}
+    void init_cyclic_spline(Trinity::IteratorPair<ControlArray::const_iterator> controls, EvaluationMode m, index_type cyclic_point, float orientation = 0) { SplineBase::init_cyclic_spline(controls, m, cyclic_point, orientation);}
 
     /**  Initializes lengths with SplineBase::SegLength method. */
     void initLengths();


### PR DESCRIPTION
Warning:

```/home/peterke/DEV/TrinityCore/src/server/game/Movement/Spline/Spline.cpp: In member function ‘void Movement::SplineBase::InitLinear(const G3D::Vector3*, Movement::SplineBase::index_type, Movement::SplineBase::index_type)’:
/home/peterke/DEV/TrinityCore/src/server/game/Movement/Spline/Spline.cpp:226:57: warning: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘__gnu_cxx::__alloc_traits<std::allocator<G3D::Vector3>, G3D::Vector3>::value_type’ {aka ‘class G3D::Vector3’} with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
  226 |     memcpy(&points[0], controls, sizeof(Vector3) * count);
      |
```

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Rework passing of spline control points using iterators instead of raw pointers to std::vector contents
-  Fixes the above mentioned Wclass-memaccess warning

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:** tested in-game

* Observed guards in SW and IF
* Took transport from SW to Auberdine