### PR TITLE
Core/BG: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundBE.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundBE.h
@@ -42,10 +42,7 @@ enum BattlegroundBEGameObjects
     BG_BE_OBJECT_TYPE_BUFF_2    = 184664
 };
 
-enum BattlegroundBEData
-{
-    BG_BE_REMOVE_DOORS_TIMER    = 5000
-};
+constexpr Seconds BG_BE_REMOVE_DOORS_TIMER = 5s;
 
 enum BattlegroundBEEvents
 {

--- a/src/server/game/Battlegrounds/Zones/BattlegroundDS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundDS.cpp
@@ -59,7 +59,7 @@ void BattlegroundDS::PostUpdateImpl(uint32 diff)
                 DoorOpen(BG_DS_OBJECT_WATER_1);
                 DoorOpen(BG_DS_OBJECT_WATER_2);
                 _events.CancelEvent(BG_DS_EVENT_WATERFALL_KNOCKBACK);
-                _events.ScheduleEvent(BG_DS_EVENT_WATERFALL_WARNING, urand(BG_DS_WATERFALL_TIMER_MIN, BG_DS_WATERFALL_TIMER_MAX));
+                _events.ScheduleEvent(BG_DS_EVENT_WATERFALL_WARNING, BG_DS_WATERFALL_TIMER_MIN, BG_DS_WATERFALL_TIMER_MAX);
                 break;
             case BG_DS_EVENT_WATERFALL_KNOCKBACK:
                 // Repeat knockback while the waterfall still active
@@ -105,7 +105,7 @@ void BattlegroundDS::StartingEventOpenDoors()
     for (uint32 i = BG_DS_OBJECT_BUFF_1; i <= BG_DS_OBJECT_BUFF_2; ++i)
         SpawnBGObject(i, 60);
 
-    _events.ScheduleEvent(BG_DS_EVENT_WATERFALL_WARNING, urand(BG_DS_WATERFALL_TIMER_MIN, BG_DS_WATERFALL_TIMER_MAX));
+    _events.ScheduleEvent(BG_DS_EVENT_WATERFALL_WARNING, BG_DS_WATERFALL_TIMER_MIN, BG_DS_WATERFALL_TIMER_MAX);
     //for (uint8 i = 0; i < BG_DS_PIPE_KNOCKBACK_TOTAL_COUNT; ++i)
     //    _events.ScheduleEvent(BG_DS_EVENT_PIPE_KNOCKBACK, BG_DS_PIPE_KNOCKBACK_FIRST_DELAY + i * BG_DS_PIPE_KNOCKBACK_DELAY);
 

--- a/src/server/game/Battlegrounds/Zones/BattlegroundDS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundDS.h
@@ -67,16 +67,17 @@ enum BattlegroundDSSpells
 enum BattlegroundDSData
 {
     // These values are NOT blizzlike... need the correct data!
-    BG_DS_WATERFALL_TIMER_MIN           = 30000,
-    BG_DS_WATERFALL_TIMER_MAX           = 60000,
-    BG_DS_WATERFALL_WARNING_DURATION    = 5000,
-    BG_DS_WATERFALL_DURATION            = 30000,
-    BG_DS_WATERFALL_KNOCKBACK_TIMER     = 1500,
-
     BG_DS_PIPE_KNOCKBACK_FIRST_DELAY    = 5000,
     BG_DS_PIPE_KNOCKBACK_DELAY          = 3000,
     BG_DS_PIPE_KNOCKBACK_TOTAL_COUNT    = 2,
 };
+
+// These values are NOT blizzlike... need the correct data!
+constexpr Seconds BG_DS_WATERFALL_TIMER_MIN = 30s;
+constexpr Seconds BG_DS_WATERFALL_TIMER_MAX = 60s;
+constexpr Seconds BG_DS_WATERFALL_WARNING_DURATION = 5s;
+constexpr Seconds BG_DS_WATERFALL_DURATION = 30s;
+constexpr Milliseconds BG_DS_WATERFALL_KNOCKBACK_TIMER = 1500ms;
 
 enum BattlegroundDSEvents
 {

--- a/src/server/game/Battlegrounds/Zones/BattlegroundNA.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundNA.h
@@ -41,10 +41,7 @@ enum BattlegroundNAGameObjects
     BG_NA_OBJECT_TYPE_BUFF_2    = 184664
 };
 
-enum BattlegroundNAData
-{
-    BG_NA_REMOVE_DOORS_TIMER    = 5000
-};
+constexpr Seconds BG_NA_REMOVE_DOORS_TIMER    = 5s;
 
 enum BattlegroundNAEvents
 {

--- a/src/server/game/Battlegrounds/Zones/BattlegroundRL.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundRL.h
@@ -37,10 +37,7 @@ enum BattlegroundRLGameObjects
     BG_RL_OBJECT_TYPE_BUFF_2    = 184664
 };
 
-enum BattlegroundRLData
-{
-    BG_RL_REMOVE_DOORS_TIMER    = 5000
-};
+constexpr Seconds BG_RL_REMOVE_DOORS_TIMER    = 5s;
 
 enum BattlegroundRLEvents
 {


### PR DESCRIPTION
**Changes proposed:**

-  Core/BG: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build