### PR TITLE
Scripts/Kalimdor: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_chrono_lord_epoch.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_chrono_lord_epoch.cpp
@@ -83,7 +83,7 @@ class boss_epoch : public CreatureScript
                     case EVENT_CURSE_OF_EXERTION:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
                             DoCast(target, SPELL_CURSE_OF_EXERTION);
-                        events.ScheduleEvent(EVENT_CURSE_OF_EXERTION, 9300);
+                        events.ScheduleEvent(EVENT_CURSE_OF_EXERTION, 9300ms);
                         break;
                     case EVENT_TIME_WARP:
                         Talk(SAY_TIME_WARP);

--- a/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/TheBlackMorass/instance_the_black_morass.cpp
@@ -51,17 +51,17 @@ float PortalLocation[4][4]=
 struct Wave
 {
     uint32 PortalBoss;                                      //protector of current portal
-    uint32 NextPortalTime;                                  //time to next portal, or 0 if portal boss need to be killed
+    Milliseconds NextPortalTime;                            //time to next portal, or 0 if portal boss need to be killed
 };
 
 static Wave RiftWaves[]=
 {
-    { RIFT_BOSS,                0 },
-    { NPC_CRONO_LORD_DEJA,      0 },
-    { RIFT_BOSS,           120000 },
-    { NPC_TEMPORUS,        140000 },
-    { RIFT_BOSS,           120000 },
-    { NPC_AEONUS,               0 }
+    { RIFT_BOSS,             0s },
+    { NPC_CRONO_LORD_DEJA,   0s },
+    { RIFT_BOSS,           120s },
+    { NPC_TEMPORUS,        140s },
+    { RIFT_BOSS,           120s },
+    { NPC_AEONUS,            0s }
 };
 
 enum EventIds
@@ -195,7 +195,7 @@ public:
                         TC_LOG_DEBUG("scripts", "Instance The Black Morass: Starting event.");
                         InitWorldState();
                         m_auiEncounter[1] = IN_PROGRESS;
-                        ScheduleEventNextPortal(15000);
+                        ScheduleEventNextPortal(15s);
                     }
 
                     if (data == DONE)
@@ -227,7 +227,7 @@ public:
                 if (data == SPECIAL)
                 {
                     if (mRiftPortalCount < 7)
-                        ScheduleEventNextPortal(5000);
+                        ScheduleEventNextPortal(5s);
                 }
                 else
                     m_auiEncounter[1] = data;
@@ -338,9 +338,9 @@ public:
             }
         }
 
-        void ScheduleEventNextPortal(uint32 nextPortalTime)
+        void ScheduleEventNextPortal(Milliseconds nextPortalTime)
         {
-            if (nextPortalTime > 0)
+            if (nextPortalTime > 0s)
                 Events.RescheduleEvent(EVENT_NEXT_PORTAL, nextPortalTime);
         }
 

--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -257,8 +257,8 @@ public:
                         Talk(SAY_PHASE_2_TRANS);
                         instance->SetData(DATA_ONYXIA_PHASE, Phase);
                         events.ScheduleEvent(EVENT_WHELP_SPAWN, 5s);
-                        events.ScheduleEvent(EVENT_LAIR_GUARD, 15000);
-                        events.ScheduleEvent(EVENT_DEEP_BREATH, 75000);
+                        events.ScheduleEvent(EVENT_LAIR_GUARD, 15s);
+                        events.ScheduleEvent(EVENT_DEEP_BREATH, 75s);
                         events.ScheduleEvent(EVENT_MOVEMENT, 10s);
                         events.ScheduleEvent(EVENT_FIREBALL, 18s);
                         break;
@@ -427,7 +427,7 @@ public:
                                 Talk(EMOTE_BREATH);
                                 if (PointData) /// @todo: In what cases is this null? What should we do?
                                     DoCast(me, PointData->SpellId);
-                                events.ScheduleEvent(EVENT_DEEP_BREATH, 75000);
+                                events.ScheduleEvent(EVENT_DEEP_BREATH, 75s);
                             }
                             else
                                 events.ScheduleEvent(EVENT_DEEP_BREATH, 1s);
@@ -443,7 +443,7 @@ public:
 
                                 me->GetMotionMaster()->MovePoint(PointData->LocId, PointData->fX, PointData->fY, PointData->fZ);
                                 IsMoving = true;
-                                events.ScheduleEvent(EVENT_MOVEMENT, 25000);
+                                events.ScheduleEvent(EVENT_MOVEMENT, 25s);
                             }
                             else
                                 events.ScheduleEvent(EVENT_MOVEMENT, 500ms);

--- a/src/server/scripts/Kalimdor/RazorfenDowns/boss_mordresh_fire_eye.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/boss_mordresh_fire_eye.cpp
@@ -55,7 +55,7 @@ public:
         void Reset() override
         {
             _Reset();
-            events.ScheduleEvent(EVENT_OOC_1, 10000);
+            events.ScheduleEvent(EVENT_OOC_1, 10s);
         }
 
         void JustEngagedWith(Unit* who) override
@@ -84,19 +84,19 @@ public:
                     {
                         case EVENT_OOC_1:
                             Talk(SAY_OOC_1);
-                            events.ScheduleEvent(EVENT_OOC_2, 8000);
+                            events.ScheduleEvent(EVENT_OOC_2, 8s);
                             break;
                         case EVENT_OOC_2:
                             Talk(SAY_OOC_2);
-                            events.ScheduleEvent(EVENT_OOC_3, 3000);
+                            events.ScheduleEvent(EVENT_OOC_3, 3s);
                             break;
                         case EVENT_OOC_3:
                             me->HandleEmoteCommand(EMOTE_ONESHOT_EXCLAMATION);
-                            events.ScheduleEvent(EVENT_OOC_4, 6000);
+                            events.ScheduleEvent(EVENT_OOC_4, 6s);
                             break;
                         case EVENT_OOC_4:
                             Talk(SAY_OOC_3);
-                            events.ScheduleEvent(EVENT_OOC_1, 14000);
+                            events.ScheduleEvent(EVENT_OOC_1, 14s);
                             break;
                     }
                 }

--- a/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
@@ -164,7 +164,7 @@ public:
                         Talk(SAY_EVENT_START);
                         DoCastSelf(SPELL_IDOL_SHUTDOWN_VISUAL);
                         events.ScheduleEvent(EVENT_IDOL_ROOM_SPAWNER, 100ms);
-                        events.ScheduleEvent(EVENT_PROGRESS, 120000);
+                        events.ScheduleEvent(EVENT_PROGRESS, 120s);
                         break;
                     case EVENT_IDOL_ROOM_SPAWNER:
                         if (Creature* creature = me->SummonCreature(NPC_IDOL_ROOM_SPAWNER, PosSummonSpawner[urand(0,2)], TEMPSUMMON_TIMED_DESPAWN, 4000))

--- a/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
+++ b/src/server/scripts/Kalimdor/RuinsOfAhnQiraj/boss_buru.cpp
@@ -132,7 +132,7 @@ class boss_buru : public CreatureScript
             {
                 ChaseNewVictim();
                 Eggs.push_back(EggGUID);
-                events.ScheduleEvent(EVENT_RESPAWN_EGG, 100000);
+                events.ScheduleEvent(EVENT_RESPAWN_EGG, 100s);
             }
 
             void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -187,12 +187,12 @@ class boss_skeram : public CreatureScript
                     Talk(SAY_SPLIT);
                     _hpct -= 25.0f;
                     me->SetVisible(false);
-                    events.RescheduleEvent(EVENT_BLINK, 2000);
+                    events.RescheduleEvent(EVENT_BLINK, 2s);
                 }
 
                 if (me->IsWithinMeleeRange(me->GetVictim()))
                 {
-                    events.RescheduleEvent(EVENT_EARTH_SHOCK, 2000);
+                    events.RescheduleEvent(EVENT_EARTH_SHOCK, 2s);
                     DoMeleeAttackIfReady();
                 }
             }

--- a/src/server/scripts/Kalimdor/boss_azuregos.cpp
+++ b/src/server/scripts/Kalimdor/boss_azuregos.cpp
@@ -105,7 +105,7 @@ class boss_azuregos : public CreatureScript
                         case EVENT_MANA_STORM:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 60.0f, true))
                                 DoCast(target, SPELL_MANA_STORM);
-                            events.ScheduleEvent(EVENT_MANA_STORM, urand(7500, 12500));
+                            events.ScheduleEvent(EVENT_MANA_STORM, 7500ms, 12500ms);
                             break;
                         case EVENT_CHILL:
                             DoCastVictim(SPELL_CHILL);

--- a/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
@@ -255,8 +255,8 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override
         {
-            _events.ScheduleEvent(EVENT_UPPERCUT,      15 * IN_MILLISECONDS);
-            _events.ScheduleEvent(EVENT_IMMOLATE,      10 * IN_MILLISECONDS);
+            _events.ScheduleEvent(EVENT_UPPERCUT, 15s);
+            _events.ScheduleEvent(EVENT_IMMOLATE, 10s);
             _events.ScheduleEvent(EVENT_CURSE_OF_BLOOD, 5s);
         }
 
@@ -431,18 +431,18 @@ public:
                     {
                         case EVENT_FROST_SHOCK:
                             DoCastVictim(SPELL_FROST_SHOCK);
-                            _events.DelayEvents(1 * IN_MILLISECONDS);
+                            _events.DelayEvents(1s);
                             _events.ScheduleEvent(EVENT_FROST_SHOCK, 10s, 15s);
                             break;
                         case EVENT_SEARING_TOTEM:
                             DoCast(me, SPELL_SEARING_TOTEM);
-                            _events.DelayEvents(1 * IN_MILLISECONDS);
-                            _events.ScheduleEvent(EVENT_SEARING_TOTEM, urand(110, 130) * IN_MILLISECONDS);
+                            _events.DelayEvents(1s);
+                            _events.ScheduleEvent(EVENT_SEARING_TOTEM, 110s, 130s);
                             break;
                         case EVENT_STRENGTH_OF_EARTH_TOTEM:
                             DoCast(me, SPELL_STRENGTH_OF_EARTH_TOTEM);
-                            _events.DelayEvents(1 * IN_MILLISECONDS);
-                            _events.ScheduleEvent(EVENT_STRENGTH_OF_EARTH_TOTEM, urand(110, 130) * IN_MILLISECONDS);
+                            _events.DelayEvents(1s);
+                            _events.ScheduleEvent(EVENT_STRENGTH_OF_EARTH_TOTEM, 110s, 130s);
                             break;
                         case EVENT_HEALING_SURGE:
                         {

--- a/src/server/scripts/Kalimdor/zone_moonglade.cpp
+++ b/src/server/scripts/Kalimdor/zone_moonglade.cpp
@@ -449,7 +449,7 @@ public:
                 if (me->HasAura(SPELL_OMEN_STARFALL))
                     me->RemoveAurasDueToSpell(SPELL_OMEN_STARFALL);
 
-                events.RescheduleEvent(EVENT_CAST_STARFALL, urand(14000, 16000));
+                events.RescheduleEvent(EVENT_CAST_STARFALL, 14s, 16s);
             }
         }
 
@@ -497,7 +497,7 @@ public:
         void Reset() override
         {
             events.Reset();
-            events.ScheduleEvent(EVENT_DESPAWN, 5*MINUTE*IN_MILLISECONDS);
+            events.ScheduleEvent(EVENT_DESPAWN, 5min);
         }
 
         void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -353,7 +353,7 @@ public:
             if (who->GetTypeId() == TYPEID_PLAYER && who->IsWithinDist(me, 20.0f) && !inProgress)
             {
                 inProgress = true;
-                events.ScheduleEvent(EVENT_SCENE_1, 2000);
+                events.ScheduleEvent(EVENT_SCENE_1, 2s);
             }
         }
 
@@ -373,63 +373,63 @@ public:
                             me->SetFacingToObject(gryshka);
                             gryshka->AI()->Talk(SAY_GRYSHKA_1);
                         }
-                        events.ScheduleEvent(EVENT_SCENE_2, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_2, 4500ms);
                         break;
                     case EVENT_SCENE_2:
                         if (Creature* olvia = ObjectAccessor::GetCreature(*me, olviaGUID))
                             olvia->AI()->Talk(SAY_OLVIA_1);
-                        events.ScheduleEvent(EVENT_SCENE_3, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_3, 4500ms);
                         break;
                     case EVENT_SCENE_3:
                         if (Creature* felika = ObjectAccessor::GetCreature(*me, felikaGUID))
                             felika->AI()->Talk(SAY_FELIKA_1);
-                        events.ScheduleEvent(EVENT_SCENE_4, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_4, 4500ms);
                         break;
                     case EVENT_SCENE_4:
                         if (Creature* thathung = ObjectAccessor::GetCreature(*me, thungGUID))
                             thathung->AI()->Talk(SAY_THATHUNG);
-                        events.ScheduleEvent(EVENT_SCENE_5, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_5, 4500ms);
                         break;
                     case EVENT_SCENE_5:
                         if (Creature* sana = ObjectAccessor::GetCreature(*me, sanaGUID))
                             sana->AI()->Talk(SAY_SANA);
-                        events.ScheduleEvent(EVENT_SCENE_6, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_6, 4500ms);
                         break;
                     case EVENT_SCENE_6:
                         if (Creature* gryshka = ObjectAccessor::GetCreature(*me, gryshkaGUID))
                             gryshka->AI()->Talk(SAY_GRYSHKA_2);
-                        events.ScheduleEvent(EVENT_SCENE_7, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_7, 4500ms);
                         break;
                     case EVENT_SCENE_7:
                         if (Creature* kaja = ObjectAccessor::GetCreature(*me, kajaGUID))
                             kaja->AI()->Talk(SAY_KAJA);
-                        events.ScheduleEvent(EVENT_SCENE_8, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_8, 4500ms);
                         break;
                     case EVENT_SCENE_8:
                         if (Creature* felika = ObjectAccessor::GetCreature(*me, felikaGUID))
                             felika->AI()->Talk(SAY_FELIKA_2);
-                        events.ScheduleEvent(EVENT_SCENE_9, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_9, 4500ms);
                         break;
                     case EVENT_SCENE_9:
                         if (Creature* olvia = ObjectAccessor::GetCreature(*me, olviaGUID))
                             olvia->AI()->Talk(SAY_OLVIA_2);
-                        events.ScheduleEvent(EVENT_SCENE_10, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_10, 4500ms);
                         break;
                     case EVENT_SCENE_10:
                         Talk(SAY_RUNTHAK_1);
-                        events.ScheduleEvent(EVENT_SCENE_11, 1500);
+                        events.ScheduleEvent(EVENT_SCENE_11, 1500ms);
                         break;
                     case EVENT_SCENE_11:
                         Talk(SAY_RUNTHAK_2);
-                        events.ScheduleEvent(EVENT_SCENE_12, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_12, 4500ms);
                         break;
                     case EVENT_SCENE_12:
                         Talk(SAY_RUNTHAK_3);
-                        events.ScheduleEvent(EVENT_SCENE_13, 4500);
+                        events.ScheduleEvent(EVENT_SCENE_13, 4500ms);
                         break;
                     case EVENT_SCENE_13:
                         Talk(SAY_RUNTHAK_4);
-                        events.ScheduleEvent(EVENT_RESET, 25000);
+                        events.ScheduleEvent(EVENT_RESET, 25s);
                         break;
                     case EVENT_RESET:
                         Reset();
@@ -662,7 +662,7 @@ public:
                 if (Creature* sylvanas = me->FindNearestCreature(NPC_BANSHEE_SYLVANAS, 25.0f))
                     sylvanasGUID = sylvanas->GetGUID();
 
-                events.ScheduleEvent(EVENT_HERALD_SCENE1, 4000);
+                events.ScheduleEvent(EVENT_HERALD_SCENE1, 4s);
             }
         }
 
@@ -691,18 +691,18 @@ public:
                                 guard->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_NONE);
                             }
                         }
-                        events.ScheduleEvent(EVENT_HERALD_SCENE2, 3000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE2, 3s);
                         break;
                     case EVENT_HERALD_SCENE2:
                         Talk(SAY_THRALL_1);
                         if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
                             me->SetFacingToObject(jaina);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE3, 3500);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE3, 3500ms);
                         break;
                     case EVENT_HERALD_SCENE3:
                         if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
                             jaina->AI()->Talk(SAY_JAINA_0);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE4, 5500);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE4, 5500ms);
                         break;
                     case EVENT_HERALD_SCENE4:
                         Talk(SAY_THRALL_2);
@@ -712,48 +712,48 @@ public:
                             sylvanas->SetWalk(true);
                             sylvanas->GetMotionMaster()->MovePoint(1, MiscMovePositions[2]);
                         }
-                        events.ScheduleEvent(EVENT_HERALD_SCENE5, 6500);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE5, 6500ms);
                         break;
                     case EVENT_HERALD_SCENE5:
                         if (Creature* sylvanas = ObjectAccessor::GetCreature(*me, sylvanasGUID))
                             sylvanas->AI()->Talk(SAY_SYLVANAS_0);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE6, 10000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE6, 10s);
                         break;
                     case EVENT_HERALD_SCENE6:
                         if (Creature* sylvanas = ObjectAccessor::GetCreature(*me, sylvanasGUID))
                             sylvanas->AI()->Talk(SAY_SYLVANAS_1);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE7, 20000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE7, 20s);
                         break;
                     case EVENT_HERALD_SCENE7:
                         Talk(SAY_THRALL_3);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE8, 4500);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE8, 4500ms);
                         break;
                     case EVENT_HERALD_SCENE8:
                         Talk(SAY_THRALL_4);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE9, 10000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE9, 10s);
                         break;
                     case EVENT_HERALD_SCENE9:
                         Talk(SAY_THRALL_5);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE10, 8000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE10, 8s);
                         break;
                     case EVENT_HERALD_SCENE10:
                         Talk(SAY_THRALL_6);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE11, 9000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE11, 9s);
                         break;
                     case EVENT_HERALD_SCENE11:
                         if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
                             jaina->AI()->Talk(SAY_JAINA_1);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE12, 6000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE12, 6s);
                         break;
                     case EVENT_HERALD_SCENE12:
                         if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
                             jaina->AI()->Talk(SAY_JAINA_2);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE13, 14000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE13, 14s);
                         break;
                     case EVENT_HERALD_SCENE13:
                         if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
                             jaina->AI()->Talk(SAY_JAINA_3);
-                        events.ScheduleEvent(EVENT_HERALD_SCENE14, 10000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE14, 10s);
                         break;
                     case EVENT_HERALD_SCENE14:
                         if (Creature* jaina = ObjectAccessor::GetCreature(*me, jainaGUID))
@@ -763,7 +763,7 @@ public:
                             jaina->GetMotionMaster()->MovePoint(2, jaina->GetHomePosition());
                             jaina->DespawnOrUnsummon(5000);
                         }
-                        events.ScheduleEvent(EVENT_HERALD_SCENE15, 7000);
+                        events.ScheduleEvent(EVENT_HERALD_SCENE15, 7s);
                         break;
                     case EVENT_HERALD_SCENE15:
                     {


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Kalimdor: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build