### PR TITLE
Scripts/World+Pet: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Pet/pet_shaman.cpp
+++ b/src/server/scripts/Pet/pet_shaman.cpp
@@ -54,7 +54,7 @@ class npc_pet_shaman_earth_elemental : public CreatureScript
             void Reset() override
             {
                 _events.Reset();
-                _events.ScheduleEvent(EVENT_SHAMAN_ANGEREDEARTH, 0);
+                _events.ScheduleEvent(EVENT_SHAMAN_ANGEREDEARTH, 0s);
                 me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_NATURE, true);
             }
 
@@ -98,7 +98,7 @@ class npc_pet_shaman_fire_elemental : public CreatureScript
                 _events.Reset();
                 _events.ScheduleEvent(EVENT_SHAMAN_FIRENOVA, 5s, 20s);
                 _events.ScheduleEvent(EVENT_SHAMAN_FIREBLAST, 5s, 20s);
-                _events.ScheduleEvent(EVENT_SHAMAN_FIRESHIELD, 0);
+                _events.ScheduleEvent(EVENT_SHAMAN_FIRESHIELD, 0s);
                 me->ApplySpellImmune(0, IMMUNITY_SCHOOL, SPELL_SCHOOL_MASK_FIRE, true);
             }
 

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -101,8 +101,8 @@ struct emerald_dragonAI : public WorldBossAI
         me->SetReactState(REACT_AGGRESSIVE);
         DoCast(me, SPELL_MARK_OF_NATURE_AURA, true);
         events.ScheduleEvent(EVENT_TAIL_SWEEP, 4s);
-        events.ScheduleEvent(EVENT_NOXIOUS_BREATH, urand(7500, 15000));
-        events.ScheduleEvent(EVENT_SEEPING_FOG, urand(12500, 20000));
+        events.ScheduleEvent(EVENT_NOXIOUS_BREATH, 7500ms, 15s);
+        events.ScheduleEvent(EVENT_SEEPING_FOG, 12500ms, 20s);
     }
 
     // Target killed during encounter, mark them as suspectible for Aura Of Nature
@@ -122,12 +122,12 @@ struct emerald_dragonAI : public WorldBossAI
                 // Despawntime is 2 minutes, so reschedule it for new cast after 2 minutes + a minor "random time" (30 seconds at max)
                 DoCast(me, SPELL_SEEPING_FOG_LEFT, true);
                 DoCast(me, SPELL_SEEPING_FOG_RIGHT, true);
-                events.ScheduleEvent(EVENT_SEEPING_FOG, urand(120000, 150000));
+                events.ScheduleEvent(EVENT_SEEPING_FOG, 120s, 150s);
                 break;
             case EVENT_NOXIOUS_BREATH:
                 // Noxious Breath is cast on random intervals, no less than 7.5 seconds between
                 DoCast(me, SPELL_NOXIOUS_BREATH);
-                events.ScheduleEvent(EVENT_NOXIOUS_BREATH, urand(7500, 15000));
+                events.ScheduleEvent(EVENT_NOXIOUS_BREATH, 7500ms, 15s);
                 break;
             case EVENT_TAIL_SWEEP:
                 // Tail Sweep is cast every two seconds, no matter what goes on in front of the dragon
@@ -528,7 +528,7 @@ class boss_emeriss : public CreatureScript
                 {
                     case EVENT_VOLATILE_INFECTION:
                         DoCastVictim(SPELL_VOLATILE_INFECTION);
-                        events.ScheduleEvent(EVENT_VOLATILE_INFECTION, 120000);
+                        events.ScheduleEvent(EVENT_VOLATILE_INFECTION, 120s);
                         break;
                     default:
                         emerald_dragonAI::ExecuteEvent(eventId);

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1101,16 +1101,12 @@ enum BrewfestMusic
     EVENT_BREWFESTGOBLIN03 = 11815 // 0.28 min
 };
 
-// These are in seconds
-enum BrewfestMusicTime
-{
-    EVENT_BREWFESTDWARF01_TIME = 95000,
-    EVENT_BREWFESTDWARF02_TIME = 155000,
-    EVENT_BREWFESTDWARF03_TIME = 23000,
-    EVENT_BREWFESTGOBLIN01_TIME = 68000,
-    EVENT_BREWFESTGOBLIN02_TIME = 93000,
-    EVENT_BREWFESTGOBLIN03_TIME = 28000
-};
+constexpr Seconds EVENT_BREWFESTDWARF01_TIME = 95s;
+constexpr Seconds EVENT_BREWFESTDWARF02_TIME = 155s;
+constexpr Seconds EVENT_BREWFESTDWARF03_TIME = 23s;
+constexpr Seconds EVENT_BREWFESTGOBLIN01_TIME = 68s;
+constexpr Seconds EVENT_BREWFESTGOBLIN02_TIME = 93s;
+constexpr Seconds EVENT_BREWFESTGOBLIN03_TIME = 28s;
 
 enum BrewfestMusicAreas
 {
@@ -1141,7 +1137,7 @@ public:
     struct go_brewfest_musicAI : public GameObjectAI
     {
         uint32 rnd = 0;
-        uint32 musicTime = 1000;
+        Milliseconds musicTime = 1s;
 
         go_brewfest_musicAI(GameObject* go) : GameObjectAI(go)
         {

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -487,7 +487,7 @@ public:
                 return;
 
             running = true;
-            events.ScheduleEvent(EVENT_CAST_RED_FIRE_RING, 1);
+            events.ScheduleEvent(EVENT_CAST_RED_FIRE_RING, 1ms);
         }
 
         bool checkNearbyPlayers()


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/World+Pet: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build