### PR TITLE
Scripts/BlackrockMountain: Use std::chrono::duration overloads of Eve…

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_general_angerforge.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_general_angerforge.cpp
@@ -68,8 +68,8 @@ class boss_general_angerforge : public CreatureScript
                 if (me->HealthBelowPctDamaged(20, damage) && _events.IsInPhase(PHASE_ONE))
                 {
                     _events.SetPhase(PHASE_TWO);
-                    _events.ScheduleEvent(EVENT_MEDIC, 0, 0, PHASE_TWO);
-                    _events.ScheduleEvent(EVENT_ADDS, 0, 0, PHASE_TWO);
+                    _events.ScheduleEvent(EVENT_MEDIC, 0s, 0, PHASE_TWO);
+                    _events.ScheduleEvent(EVENT_ADDS, 0s, 0, PHASE_TWO);
                 }
             }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_magmus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_magmus.cpp
@@ -65,7 +65,7 @@ class boss_magmus : public CreatureScript
                 if (me->HealthBelowPctDamaged(50, damage) && _events.IsInPhase(PHASE_ONE))
                 {
                     _events.SetPhase(PHASE_TWO);
-                    _events.ScheduleEvent(EVENT_WARSTOMP, 0, 0, PHASE_TWO);
+                    _events.ScheduleEvent(EVENT_WARSTOMP, 0s, 0, PHASE_TWO);
                 }
             }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_drakkisath.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_drakkisath.cpp
@@ -53,9 +53,9 @@ public:
         {
             BossAI::JustEngagedWith(who);
             events.ScheduleEvent(EVENT_FIRE_NOVA, 6s);
-            events.ScheduleEvent(EVENT_CLEAVE,    8000);
+            events.ScheduleEvent(EVENT_CLEAVE, 8s);
             events.ScheduleEvent(EVENT_CONFLIGURATION, 15s);
-            events.ScheduleEvent(EVENT_THUNDERCLAP,    17000);
+            events.ScheduleEvent(EVENT_THUNDERCLAP, 17s);
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_highlord_omokk.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_highlord_omokk.cpp
@@ -53,8 +53,8 @@ public:
         void JustEngagedWith(Unit* who) override
         {
             BossAI::JustEngagedWith(who);
-            events.ScheduleEvent(EVENT_FRENZY,      20000);
-            events.ScheduleEvent(EVENT_KNOCK_AWAY,  18000);
+            events.ScheduleEvent(EVENT_FRENZY, 20s);
+            events.ScheduleEvent(EVENT_KNOCK_AWAY, 18s);
         }
 
         void JustDied(Unit* /*killer*/) override

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_mother_smolderweb.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_mother_smolderweb.cpp
@@ -54,7 +54,7 @@ public:
         void JustEngagedWith(Unit* who) override
         {
             BossAI::JustEngagedWith(who);
-            events.ScheduleEvent(EVENT_CRYSTALIZE,   20 * IN_MILLISECONDS);
+            events.ScheduleEvent(EVENT_CRYSTALIZE, 20s);
             events.ScheduleEvent(EVENT_MOTHERS_MILK, 10s);
         }
 
@@ -89,7 +89,7 @@ public:
                         break;
                     case EVENT_MOTHERS_MILK:
                         DoCast(me, SPELL_MOTHERSMILK);
-                        events.ScheduleEvent(EVENT_MOTHERS_MILK, urand(5 * IN_MILLISECONDS, 12500));
+                        events.ScheduleEvent(EVENT_MOTHERS_MILK, 5s, 12500ms);
                         break;
                 }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_pyroguard_emberseer.cpp
@@ -110,9 +110,9 @@ public:
         void JustEngagedWith(Unit* /*who*/) override
         {
             // ### TODO Check combat timing ###
-            events.ScheduleEvent(EVENT_FIRENOVA,    6000);
+            events.ScheduleEvent(EVENT_FIRENOVA, 6s);
             events.ScheduleEvent(EVENT_FLAMEBUFFET, 3s);
-            events.ScheduleEvent(EVENT_PYROBLAST,  14000);
+            events.ScheduleEvent(EVENT_PYROBLAST, 14s);
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -202,7 +202,7 @@ public:
                                 }
                             }
                             me->RemoveAura(SPELL_ENCAGED_EMBERSEER);
-                            events.ScheduleEvent(EVENT_PRE_FIGHT_2, 32000);
+                            events.ScheduleEvent(EVENT_PRE_FIGHT_2, 32s);
                             break;
                         }
                         case EVENT_PRE_FIGHT_2:
@@ -230,7 +230,7 @@ public:
 
                             if (_hasAura)
                             {
-                                events.ScheduleEvent(EVENT_PRE_FIGHT_1, 1000);
+                                events.ScheduleEvent(EVENT_PRE_FIGHT_1, 1s);
                                 instance->SetBossState(DATA_PYROGAURD_EMBERSEER, IN_PROGRESS);
                             }
                             break;

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
@@ -216,8 +216,8 @@ public:
                     if (GameObject* portcullis = me->FindNearestGameObject(GO_DR_PORTCULLIS, 50.0f))
                         portcullisGUID = portcullis->GetGUID();
 
-                    events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
-                    events.ScheduleEvent(EVENT_START_1, 1000);
+                    events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
+                    events.ScheduleEvent(EVENT_START_1, 1s);
                 }
             }
         }
@@ -229,7 +229,7 @@ public:
                 switch (id)
                 {
                     case 5:
-                        events.ScheduleEvent(EVENT_TELEPORT_1, 2000);
+                        events.ScheduleEvent(EVENT_TELEPORT_1, 2s);
                         break;
                     case 11:
                         if (Creature* gyth = me->FindNearestCreature(NPC_GYTH, 10.0f, true))
@@ -253,20 +253,20 @@ public:
                         case EVENT_START_1:
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_0);
-                            events.ScheduleEvent(EVENT_START_2, 4000);
+                            events.ScheduleEvent(EVENT_START_2, 4s);
                             break;
                         case EVENT_START_2:
-                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->HandleEmoteCommand(EMOTE_ONESHOT_POINT);
-                            events.ScheduleEvent(EVENT_START_3, 4000);
+                            events.ScheduleEvent(EVENT_START_3, 4s);
                             break;
                         case EVENT_START_3:
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_1);
-                            events.ScheduleEvent(EVENT_WAVE_1, 2000);
+                            events.ScheduleEvent(EVENT_WAVE_1, 2s);
                             events.ScheduleEvent(EVENT_TURN_TO_REND, 4s);
-                            events.ScheduleEvent(EVENT_WAVES_TEXT_1, 20000);
+                            events.ScheduleEvent(EVENT_WAVES_TEXT_1, 20s);
                             break;
                         case EVENT_TURN_TO_REND:
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
@@ -298,59 +298,59 @@ public:
                                 me->HandleEmoteCommand(EMOTE_ONESHOT_ROAR);
                             break;
                         case EVENT_WAVES_TEXT_1:
-                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                     victor->AI()->Talk(SAY_NEFARIUS_2);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_TALK);
-                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4000);
-                            events.ScheduleEvent(EVENT_WAVES_EMOTE_1, 5000);
-                            events.ScheduleEvent(EVENT_WAVE_2, 2000);
-                            events.ScheduleEvent(EVENT_WAVES_TEXT_2, 20000);
+                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4s);
+                            events.ScheduleEvent(EVENT_WAVES_EMOTE_1, 5s);
+                            events.ScheduleEvent(EVENT_WAVE_2, 2s);
+                            events.ScheduleEvent(EVENT_WAVES_TEXT_2, 20s);
                             break;
                         case EVENT_WAVES_TEXT_2:
-                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_3);
-                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4000);
-                            events.ScheduleEvent(EVENT_WAVE_3, 2000);
-                            events.ScheduleEvent(EVENT_WAVES_TEXT_3, 20000);
+                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4s);
+                            events.ScheduleEvent(EVENT_WAVE_3, 2s);
+                            events.ScheduleEvent(EVENT_WAVES_TEXT_3, 20s);
                             break;
                         case EVENT_WAVES_TEXT_3:
-                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_4);
-                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4000);
-                            events.ScheduleEvent(EVENT_WAVE_4, 2000);
-                            events.ScheduleEvent(EVENT_WAVES_TEXT_4, 20000);
+                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4s);
+                            events.ScheduleEvent(EVENT_WAVE_4, 2s);
+                            events.ScheduleEvent(EVENT_WAVES_TEXT_4, 20s);
                             break;
                         case EVENT_WAVES_TEXT_4:
                             Talk(SAY_BLACKHAND_1);
-                            events.ScheduleEvent(EVENT_WAVES_EMOTE_2, 4000);
-                            events.ScheduleEvent(EVENT_TURN_TO_FACING_3, 8000);
-                            events.ScheduleEvent(EVENT_WAVE_5, 2000);
-                            events.ScheduleEvent(EVENT_WAVES_TEXT_5, 20000);
+                            events.ScheduleEvent(EVENT_WAVES_EMOTE_2, 4s);
+                            events.ScheduleEvent(EVENT_TURN_TO_FACING_3, 8s);
+                            events.ScheduleEvent(EVENT_WAVE_5, 2s);
+                            events.ScheduleEvent(EVENT_WAVES_TEXT_5, 20s);
                             break;
                         case EVENT_WAVES_TEXT_5:
-                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_5);
-                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4000);
-                            events.ScheduleEvent(EVENT_WAVE_6, 2000);
-                            events.ScheduleEvent(EVENT_WAVES_COMPLETE_TEXT_1, 20000);
+                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4s);
+                            events.ScheduleEvent(EVENT_WAVE_6, 2s);
+                            events.ScheduleEvent(EVENT_WAVES_COMPLETE_TEXT_1, 20s);
                             break;
                         case EVENT_WAVES_COMPLETE_TEXT_1:
-                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0);
+                            events.ScheduleEvent(EVENT_TURN_TO_PLAYER, 0s);
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_6);
-                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4000);
-                            events.ScheduleEvent(EVENT_WAVES_COMPLETE_TEXT_2, 13000);
+                            events.ScheduleEvent(EVENT_TURN_TO_FACING_1, 4s);
+                            events.ScheduleEvent(EVENT_WAVES_COMPLETE_TEXT_2, 13s);
                             break;
                         case EVENT_WAVES_COMPLETE_TEXT_2:
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
                                 victor->AI()->Talk(SAY_NEFARIUS_7);
                             Talk(SAY_BLACKHAND_2);
                             events.ScheduleEvent(EVENT_PATH_REND, 1s);
-                            events.ScheduleEvent(EVENT_WAVES_COMPLETE_TEXT_3, 4000);
+                            events.ScheduleEvent(EVENT_WAVES_COMPLETE_TEXT_3, 4s);
                             break;
                         case EVENT_WAVES_COMPLETE_TEXT_3:
                             if (Creature* victor = ObjectAccessor::GetCreature(*me, victorGUID))
@@ -367,7 +367,7 @@ public:
                             break;
                         case EVENT_TELEPORT_1:
                             me->NearTeleportTo(194.2993f, -474.0814f, 121.4505f, -0.01225555f);
-                            events.ScheduleEvent(EVENT_TELEPORT_2, 50000);
+                            events.ScheduleEvent(EVENT_TELEPORT_2, 50s);
                             break;
                         case EVENT_TELEPORT_2:
                             me->NearTeleportTo(216.485f, -434.93f, 110.888f, -0.01225555f);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_shadow_hunter_voshgajin.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_shadow_hunter_voshgajin.cpp
@@ -57,7 +57,7 @@ public:
         {
             BossAI::JustEngagedWith(who);
             events.ScheduleEvent(EVENT_CURSE_OF_BLOOD, 2s);
-            events.ScheduleEvent(EVENT_HEX,     8 * IN_MILLISECONDS);
+            events.ScheduleEvent(EVENT_HEX, 8s);
             events.ScheduleEvent(EVENT_CLEAVE, 14s);
         }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_warmaster_voone.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_warmaster_voone.cpp
@@ -57,10 +57,10 @@ public:
         {
             BossAI::JustEngagedWith(who);
             events.ScheduleEvent(EVENT_SNAP_KICK, 8s);
-            events.ScheduleEvent(EVENT_CLEAVE,   14 * IN_MILLISECONDS);
+            events.ScheduleEvent(EVENT_CLEAVE, 14s);
             events.ScheduleEvent(EVENT_UPPERCUT, 20s);
             events.ScheduleEvent(EVENT_MORTAL_STRIKE, 12s);
-            events.ScheduleEvent(EVENT_PUMMEL,   32 * IN_MILLISECONDS);
+            events.ScheduleEvent(EVENT_PUMMEL, 32s);
             events.ScheduleEvent(EVENT_THROW_AXE, 1s);
         }
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_chromaggus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_chromaggus.cpp
@@ -198,9 +198,9 @@ public:
         {
             BossAI::JustEngagedWith(who);
 
-            events.ScheduleEvent(EVENT_SHIMMER, 0);
-            events.ScheduleEvent(EVENT_BREATH_1, 30000);
-            events.ScheduleEvent(EVENT_BREATH_2, 60000);
+            events.ScheduleEvent(EVENT_SHIMMER, 0s);
+            events.ScheduleEvent(EVENT_BREATH_1, 30s);
+            events.ScheduleEvent(EVENT_BREATH_2, 60s);
             events.ScheduleEvent(EVENT_AFFLICTION, 10s);
             events.ScheduleEvent(EVENT_FRENZY, 15s);
         }
@@ -235,11 +235,11 @@ public:
                         }
                     case EVENT_BREATH_1:
                             DoCastVictim(Breath1_Spell);
-                            events.ScheduleEvent(EVENT_BREATH_1, 60000);
+                            events.ScheduleEvent(EVENT_BREATH_1, 60s);
                             break;
                     case EVENT_BREATH_2:
                             DoCastVictim(Breath2_Spell);
-                            events.ScheduleEvent(EVENT_BREATH_2, 60000);
+                            events.ScheduleEvent(EVENT_BREATH_2, 60s);
                             break;
                     case EVENT_AFFLICTION:
                         {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -238,11 +238,11 @@ public:
             if ( type == 1 && data == 1)
             {
                 me->StopMoving();
-                events.ScheduleEvent(EVENT_PATH_2, 9000);
+                events.ScheduleEvent(EVENT_PATH_2, 9s);
             }
 
             if (type == 1 && data == 2)
-                events.ScheduleEvent(EVENT_SUCCESS_1, 5000);
+                events.ScheduleEvent(EVENT_SUCCESS_1, 5s);
         }
 
         void UpdateAI(uint32 diff) override
@@ -257,7 +257,7 @@ public:
                     {
                         case EVENT_PATH_2:
                             me->GetMotionMaster()->MovePath(NEFARIUS_PATH_2, false);
-                            events.ScheduleEvent(EVENT_CHAOS_1, 7000);
+                            events.ScheduleEvent(EVENT_CHAOS_1, 7s);
                             break;
                         case EVENT_CHAOS_1:
                             if (Creature* gyth = me->FindNearestCreature(NPC_GYTH, 75.0f, true))
@@ -265,7 +265,7 @@ public:
                                 me->SetFacingToObject(gyth);
                                 Talk(SAY_CHAOS_SPELL);
                             }
-                            events.ScheduleEvent(EVENT_CHAOS_2, 2000);
+                            events.ScheduleEvent(EVENT_CHAOS_2, 2s);
                             break;
                         case EVENT_CHAOS_2:
                             DoCast(SPELL_CHROMATIC_CHAOS);
@@ -281,7 +281,7 @@ public:
                                 if (GameObject* portcullis2 = me->FindNearestGameObject(GO_PORTCULLIS_TOBOSSROOMS, 80.0f))
                                     portcullis2->SetGoState(GO_STATE_ACTIVE);
                             }
-                            events.ScheduleEvent(EVENT_SUCCESS_2, 4000);
+                            events.ScheduleEvent(EVENT_SUCCESS_2, 4s);
                             break;
                         case EVENT_SUCCESS_2:
                             DoCast(me, SPELL_VAELASTRASZZ_SPAWN);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_vaelastrasz.cpp
@@ -114,7 +114,7 @@ public:
         {
             PlayerGUID = target->GetGUID();
             me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-            events.ScheduleEvent(EVENT_SPEECH_1, 1000);
+            events.ScheduleEvent(EVENT_SPEECH_1, 1s);
         }
 
         void KilledUnit(Unit* victim) override
@@ -140,17 +140,17 @@ public:
                             Talk(SAY_LINE1);
                             me->SetStandState(UNIT_STAND_STATE_STAND);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_TALK);
-                            events.ScheduleEvent(EVENT_SPEECH_2, 12000);
+                            events.ScheduleEvent(EVENT_SPEECH_2, 12s);
                             break;
                         case EVENT_SPEECH_2:
                             Talk(SAY_LINE2);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_TALK);
-                            events.ScheduleEvent(EVENT_SPEECH_3, 12000);
+                            events.ScheduleEvent(EVENT_SPEECH_3, 12s);
                             break;
                         case EVENT_SPEECH_3:
                             Talk(SAY_LINE3);
                             me->HandleEmoteCommand(EMOTE_ONESHOT_TALK);
-                            events.ScheduleEvent(EVENT_SPEECH_4, 16000);
+                            events.ScheduleEvent(EVENT_SPEECH_4, 16s);
                             break;
                         case EVENT_SPEECH_4:
                             me->SetFaction(FACTION_DRAGONFLIGHT_BLACK);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/instance_blackwing_lair.cpp
@@ -189,7 +189,7 @@ public:
                                 nefarian->DespawnOrUnsummon();
                             break;
                         case FAIL:
-                            _events.ScheduleEvent(EVENT_RESPAWN_NEFARIUS, 15 * IN_MILLISECONDS * MINUTE);
+                            _events.ScheduleEvent(EVENT_RESPAWN_NEFARIUS, 15min);
                             SetBossState(DATA_NEFARIAN, NOT_STARTED);
                             break;
                         default:

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_majordomo_executus.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_majordomo_executus.cpp
@@ -114,7 +114,7 @@ class boss_majordomo : public CreatureScript
                         EnterEvadeMode();
                         Talk(SAY_DEFEAT);
                         _JustDied();
-                        events.ScheduleEvent(EVENT_OUTRO_1, 32000);
+                        events.ScheduleEvent(EVENT_OUTRO_1, 32s);
                         return;
                     }
 
@@ -186,8 +186,8 @@ class boss_majordomo : public CreatureScript
                 {
                     me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                     Talk(SAY_SUMMON_MAJ);
-                    events.ScheduleEvent(EVENT_OUTRO_2, 8000);
-                    events.ScheduleEvent(EVENT_OUTRO_3, 24000);
+                    events.ScheduleEvent(EVENT_OUTRO_2, 8s);
+                    events.ScheduleEvent(EVENT_OUTRO_3, 24s);
                 }
                 else if (action == ACTION_START_RAGNAROS_ALT)
                 {

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
@@ -131,11 +131,11 @@ class boss_ragnaros : public CreatureScript
                     if (!_introState)
                     {
                         me->HandleEmoteCommand(EMOTE_ONESHOT_EMERGE);
-                        events.ScheduleEvent(EVENT_INTRO_1, 4000);
-                        events.ScheduleEvent(EVENT_INTRO_2, 23000);
-                        events.ScheduleEvent(EVENT_INTRO_3, 42000);
-                        events.ScheduleEvent(EVENT_INTRO_4, 43000);
-                        events.ScheduleEvent(EVENT_INTRO_5, 53000);
+                        events.ScheduleEvent(EVENT_INTRO_1, 4s);
+                        events.ScheduleEvent(EVENT_INTRO_2, 23s);
+                        events.ScheduleEvent(EVENT_INTRO_3, 42s);
+                        events.ScheduleEvent(EVENT_INTRO_4, 43s);
+                        events.ScheduleEvent(EVENT_INTRO_5, 53s);
                         _introState = 1;
                     }
 


### PR DESCRIPTION
**Changes proposed:**

- Scripts/BlackrockMountain: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build