### PR TITLE
Scripts/EasternKingdoms: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/EasternKingdoms/AlteracValley/boss_drekthar.cpp
+++ b/src/server/scripts/EasternKingdoms/AlteracValley/boss_drekthar.cpp
@@ -65,10 +65,10 @@ public:
         {
             Talk(SAY_AGGRO);
             events.ScheduleEvent(EVENT_WHIRLWIND, 1s, 20s);
-            events.ScheduleEvent(EVENT_WHIRLWIND2, urand(1 * IN_MILLISECONDS, 20 * IN_MILLISECONDS));
+            events.ScheduleEvent(EVENT_WHIRLWIND2, 1s, 20s);
             events.ScheduleEvent(EVENT_KNOCKDOWN, 12s);
             events.ScheduleEvent(EVENT_FRENZY, 6s);
-            events.ScheduleEvent(EVENT_RANDOM_YELL, 20s, 30s); //20 to 30 seconds
+            events.ScheduleEvent(EVENT_RANDOM_YELL, 20s, 30s);
         }
 
         void JustAppeared() override
@@ -109,7 +109,7 @@ public:
                         break;
                     case EVENT_WHIRLWIND2:
                         DoCastVictim(SPELL_WHIRLWIND2);
-                        events.ScheduleEvent(EVENT_WHIRLWIND2, urand(7 * IN_MILLISECONDS, 25 * IN_MILLISECONDS));
+                        events.ScheduleEvent(EVENT_WHIRLWIND2, 7s, 25s);
                         break;
                     case EVENT_KNOCKDOWN:
                         DoCastVictim(SPELL_KNOCKDOWN);

--- a/src/server/scripts/EasternKingdoms/AlteracValley/boss_galvangar.cpp
+++ b/src/server/scripts/EasternKingdoms/AlteracValley/boss_galvangar.cpp
@@ -67,8 +67,8 @@ public:
             Talk(SAY_AGGRO);
             events.ScheduleEvent(EVENT_CLEAVE, 1s, 9s);
             events.ScheduleEvent(EVENT_FRIGHTENING_SHOUT, 2s, 19s);
-            events.ScheduleEvent(EVENT_WHIRLWIND1, urand(1 * IN_MILLISECONDS, 13 * IN_MILLISECONDS));
-            events.ScheduleEvent(EVENT_WHIRLWIND2, urand(5 * IN_MILLISECONDS, 20 * IN_MILLISECONDS));
+            events.ScheduleEvent(EVENT_WHIRLWIND1, 1s, 13s);
+            events.ScheduleEvent(EVENT_WHIRLWIND2, 5s, 20s);
             events.ScheduleEvent(EVENT_MORTAL_STRIKE, 5s, 20s);
         }
 
@@ -114,11 +114,11 @@ public:
                         break;
                     case EVENT_WHIRLWIND1:
                         DoCastVictim(SPELL_WHIRLWIND1);
-                        events.ScheduleEvent(EVENT_WHIRLWIND1, urand(6 * IN_MILLISECONDS, 10 * IN_MILLISECONDS));
+                        events.ScheduleEvent(EVENT_WHIRLWIND1, 6s, 10s);
                         break;
                     case EVENT_WHIRLWIND2:
                         DoCastVictim(SPELL_WHIRLWIND2);
-                        events.ScheduleEvent(EVENT_WHIRLWIND2, urand(10 * IN_MILLISECONDS, 25 * IN_MILLISECONDS));
+                        events.ScheduleEvent(EVENT_WHIRLWIND2, 10s, 25s);
                         break;
                     case EVENT_MORTAL_STRIKE:
                         DoCastVictim(SPELL_MORTAL_STRIKE);

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -260,22 +260,22 @@ public:
                     {
                     case EVENT_ICY_TOUCH:
                         DoCastVictim(SPELL_ICY_TOUCH);
-                        events.DelayEvents(1000, GCD_CAST);
+                        events.DelayEvents(1s, GCD_CAST);
                         events.ScheduleEvent(EVENT_ICY_TOUCH, 5s, GCD_CAST);
                         break;
                     case EVENT_PLAGUE_STRIKE:
                         DoCastVictim(SPELL_PLAGUE_STRIKE);
-                        events.DelayEvents(1000, GCD_CAST);
+                        events.DelayEvents(1s, GCD_CAST);
                         events.ScheduleEvent(EVENT_PLAGUE_STRIKE, 5s, GCD_CAST);
                         break;
                     case EVENT_BLOOD_STRIKE:
                         DoCastVictim(SPELL_BLOOD_STRIKE);
-                        events.DelayEvents(1000, GCD_CAST);
+                        events.DelayEvents(1s, GCD_CAST);
                         events.ScheduleEvent(EVENT_BLOOD_STRIKE, 5s, GCD_CAST);
                         break;
                     case EVENT_DEATH_COIL:
                         DoCastVictim(SPELL_DEATH_COIL);
-                        events.DelayEvents(1000, GCD_CAST);
+                        events.DelayEvents(1s, GCD_CAST);
                         events.ScheduleEvent(EVENT_DEATH_COIL, 5s, GCD_CAST);
                         break;
                     }

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_doctor_theolen_krastinov.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_doctor_theolen_krastinov.cpp
@@ -86,7 +86,7 @@ class boss_doctor_theolen_krastinov : public CreatureScript
                         case EVENT_FRENZY:
                             DoCast(me, SPELL_FRENZY, true);
                             Talk(EMOTE_FRENZY_KILL);
-                            events.ScheduleEvent(EVENT_FRENZY, 120000);
+                            events.ScheduleEvent(EVENT_FRENZY, 120s);
                             break;
                         default:
                             break;

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_kirtonos_the_herald.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_kirtonos_the_herald.cpp
@@ -126,7 +126,7 @@ class boss_kirtonos_the_herald : public CreatureScript
 
             void IsSummonedBy(WorldObject* /*summoner*/) override
             {
-                events.ScheduleEvent(INTRO_1, 500);
+                events.ScheduleEvent(INTRO_1, 500ms);
                 me->SetDisableGravity(true);
                 me->SetReactState(REACT_PASSIVE);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);
@@ -141,7 +141,7 @@ class boss_kirtonos_the_herald : public CreatureScript
             void MovementInform(uint32 type, uint32 id) override
             {
                 if (type == WAYPOINT_MOTION_TYPE && id == POINT_KIRTONOS_LAND)
-                    events.ScheduleEvent(INTRO_2, 1500);
+                    events.ScheduleEvent(INTRO_2, 1500ms);
             }
 
             void UpdateAI(uint32 diff) override
@@ -159,13 +159,13 @@ class boss_kirtonos_the_herald : public CreatureScript
                                 break;
                             case INTRO_2:
                                 me->GetMotionMaster()->MovePoint(0, PosMove[0]);
-                                events.ScheduleEvent(INTRO_3, 1000);
+                                events.ScheduleEvent(INTRO_3, 1s);
                                 break;
                             case INTRO_3:
                                 if (GameObject* gate = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(GO_GATE_KIRTONOS)))
                                     gate->SetGoState(GO_STATE_READY);
                                 me->SetFacingTo(0.01745329f);
-                                events.ScheduleEvent(INTRO_4, 3000);
+                                events.ScheduleEvent(INTRO_4, 3s);
                                 break;
                             case INTRO_4:
                                 if (GameObject* brazier = ObjectAccessor::GetGameObject(*me, instance->GetGuidData(GO_BRAZIER_OF_THE_HERALD)))
@@ -174,14 +174,14 @@ class boss_kirtonos_the_herald : public CreatureScript
                                 me->SetDisableGravity(false);
                                 DoCast(me, SPELL_KIRTONOS_TRANSFORM);
                                 me->SetCanFly(false);
-                                events.ScheduleEvent(INTRO_5, 1000);
+                                events.ScheduleEvent(INTRO_5, 1s);
                                 break;
                             case INTRO_5:
                                 me->HandleEmoteCommand(EMOTE_ONESHOT_ROAR);
                                 me->SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + 0, uint32(WEAPON_KIRTONOS_STAFF));
                                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE|UNIT_FLAG_NOT_SELECTABLE);
                                 me->SetReactState(REACT_AGGRESSIVE);
-                                events.ScheduleEvent(INTRO_6, 5000);
+                                events.ScheduleEvent(INTRO_6, 5s);
                                 break;
                             case INTRO_6:
                                 me->GetMotionMaster()->MovePoint(0, PosMove[1]);

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_kormok.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_kormok.cpp
@@ -69,7 +69,7 @@ public:
         {
             events.ScheduleEvent(EVENT_SHADOWBOLT_VOLLEY, 10s);
             events.ScheduleEvent(EVENT_BONE_SHIELD, 2s);
-            events.ScheduleEvent(EVENT_SUMMON_MINIONS, 15000);
+            events.ScheduleEvent(EVENT_SUMMON_MINIONS, 15s);
         }
 
         void JustSummoned(Creature* summoned) override
@@ -102,11 +102,11 @@ public:
                 {
                     case EVENT_SHADOWBOLT_VOLLEY:
                         DoCastVictim(SPELL_SHADOWBOLT_VOLLEY);
-                        events.ScheduleEvent(EVENT_SHADOWBOLT_VOLLEY, 15000);
+                        events.ScheduleEvent(EVENT_SHADOWBOLT_VOLLEY, 15s);
                         break;
                     case EVENT_BONE_SHIELD:
                         DoCastVictim(SPELL_BONE_SHIELD);
-                        events.ScheduleEvent(EVENT_BONE_SHIELD, 45000);
+                        events.ScheduleEvent(EVENT_BONE_SHIELD, 45s);
                         break;
                     case EVENT_SUMMON_MINIONS:
                         DoCast(SPELL_SUMMON_BONE_MINIONS);

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_ras_frostwhisper.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_ras_frostwhisper.cpp
@@ -60,7 +60,7 @@ public:
             events.ScheduleEvent(EVENT_FROSTBOLT, 8s);
             events.ScheduleEvent(EVENT_CHILL_NOVA, 12s);
             events.ScheduleEvent(EVENT_FREEZE, 18s);
-            events.ScheduleEvent(EVENT_FEAR, 45000);
+            events.ScheduleEvent(EVENT_FEAR, 45s);
         }
 
         void UpdateAI(uint32 diff) override
@@ -100,7 +100,7 @@ public:
                         break;
                     case EVENT_FROSTVOLLEY:
                         DoCastVictim(SPELL_FROSTVOLLEY);
-                        events.ScheduleEvent(EVENT_FROSTVOLLEY, 15000);
+                        events.ScheduleEvent(EVENT_FROSTVOLLEY, 15s);
                         break;
                     default:
                         break;

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_maleki_the_pallid.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_maleki_the_pallid.cpp
@@ -62,8 +62,8 @@ public:
 
         void JustEngagedWith(Unit* /*who*/) override
         {
-            _events.ScheduleEvent(EVENT_FROSTBOLT,  1 * IN_MILLISECONDS);
-            _events.ScheduleEvent(EVENT_ICETOMB,   16 * IN_MILLISECONDS);
+            _events.ScheduleEvent(EVENT_FROSTBOLT, 1s);
+            _events.ScheduleEvent(EVENT_ICETOMB, 16s);
             _events.ScheduleEvent(EVENT_DRAINLIFE, 31s);
         }
 
@@ -90,7 +90,7 @@ public:
                     case EVENT_FROSTBOLT:
                         if (rand32() % 90)
                             DoCastVictim(SPELL_FROSTBOLT);
-                        _events.ScheduleEvent(EVENT_FROSTBOLT, 3.5 * IN_MILLISECONDS);
+                        _events.ScheduleEvent(EVENT_FROSTBOLT, 3500ms);
                         break;
                     case EVENT_ICETOMB:
                         if (rand32() % 65)

--- a/src/server/scripts/EasternKingdoms/Stratholme/boss_postmaster_malown.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/boss_postmaster_malown.cpp
@@ -69,7 +69,7 @@ class boss_postmaster_malown : public CreatureScript
                 events.ScheduleEvent(EVENT_BACKHAND, 8s);         // 2 sec stun
                 events.ScheduleEvent(EVENT_CURSEOFWEAKNESS, 20s); // lasts 2 mins
                 events.ScheduleEvent(EVENT_CURSEOFTONGUES, 22s);
-                events.ScheduleEvent(EVENT_CALLOFTHEGRAVE, 25000);
+                events.ScheduleEvent(EVENT_CALLOFTHEGRAVE, 25s);
             }
 
             void KilledUnit(Unit* /*victim*/) override
@@ -114,7 +114,7 @@ class boss_postmaster_malown : public CreatureScript
                         case EVENT_CALLOFTHEGRAVE:
                             if (rand32() % 100 < 5) //5% chance to cast
                                 DoCastVictim(SPELL_CALLOFTHEGRAVE, true);
-                            events.ScheduleEvent(EVENT_WAILINGDEAD, 25000);
+                            events.ScheduleEvent(EVENT_WAILINGDEAD, 25s);
                             break;
                         default:
                             break;

--- a/src/server/scripts/EasternKingdoms/Stratholme/instance_stratholme.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/instance_stratholme.cpp
@@ -256,7 +256,7 @@ class instance_stratholme : public InstanceMapScript
                                 if (EncounterState[0] == IN_PROGRESS || EncounterState[0] == FAIL)
                                     break;
                                 EncounterState[0] = data;
-                                events.ScheduleEvent(EVENT_BARON_RUN, 2700s);
+                                events.ScheduleEvent(EVENT_BARON_RUN, 45min);
                                 TC_LOG_DEBUG("scripts", "Instance Stratholme: Baron run in progress.");
                                 break;
                             case FAIL:

--- a/src/server/scripts/EasternKingdoms/Stratholme/instance_stratholme.cpp
+++ b/src/server/scripts/EasternKingdoms/Stratholme/instance_stratholme.cpp
@@ -256,7 +256,7 @@ class instance_stratholme : public InstanceMapScript
                                 if (EncounterState[0] == IN_PROGRESS || EncounterState[0] == FAIL)
                                     break;
                                 EncounterState[0] = data;
-                                events.ScheduleEvent(EVENT_BARON_RUN, 2700000);
+                                events.ScheduleEvent(EVENT_BARON_RUN, 2700s);
                                 TC_LOG_DEBUG("scripts", "Instance Stratholme: Baron run in progress.");
                                 break;
                             case FAIL:

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_felmyst.cpp
@@ -238,7 +238,7 @@ public:
         void MovementInform(uint32, uint32) override
         {
             if (phase == PHASE_FLIGHT)
-                events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1);
+                events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1ms);
         }
 
         void DamageTaken(Unit*, uint32 &damage) override
@@ -343,7 +343,7 @@ public:
                 }
                 case 4:
                     DespawnSummons(NPC_VAPOR_TRAIL);
-                    events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1);
+                    events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1ms);
                     break;
                 case 5:
                 {
@@ -377,14 +377,14 @@ public:
                     x = 2 * breathX - x;
                     y = 2 * breathY - y;
                     me->GetMotionMaster()->MovePoint(0, x, y, z);
-                    events.ScheduleEvent(EVENT_SUMMON_FOG, 1);
+                    events.ScheduleEvent(EVENT_SUMMON_FOG, 1ms);
                     break;
                 }
                 case 8:
                     me->CastStop(SPELL_FOG_BREATH);
                     me->RemoveAurasDueToSpell(SPELL_FOG_BREATH);
                     ++uiBreathCount;
-                    events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1);
+                    events.ScheduleEvent(EVENT_FLIGHT_SEQUENCE, 1ms);
                     if (uiBreathCount < 3)
                         uiFlightCount = 4;
                     break;

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_akilzon.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_akilzon.cpp
@@ -122,7 +122,7 @@ class boss_akilzon : public CreatureScript
                 events.ScheduleEvent(EVENT_CALL_LIGHTNING, 10s, 20s);    // totaly random timer. can't find any info on this
                 events.ScheduleEvent(EVENT_ELECTRICAL_STORM, 1min);                // 60 seconds(bosskillers)
                 events.ScheduleEvent(EVENT_RAIN, 47s, 52s);
-                events.ScheduleEvent(EVENT_ENRAGE, 10*MINUTE*IN_MILLISECONDS);      // 10 minutes till enrage(bosskillers)
+                events.ScheduleEvent(EVENT_ENRAGE, 10min);      // 10 minutes till enrage(bosskillers)
 
                 Talk(SAY_AGGRO);
             }

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
@@ -127,11 +127,11 @@ class boss_arlokk : public CreatureScript
             void JustEngagedWith(Unit* who) override
             {
                 BossAI::JustEngagedWith(who);
-                events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, urand(7000, 9000), 0, PHASE_ONE);
-                events.ScheduleEvent(EVENT_GOUGE, urand(12000, 15000), 0, PHASE_ONE);
+                events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, 7s, 9s, 0, PHASE_ONE);
+                events.ScheduleEvent(EVENT_GOUGE, 12s, 15s, 0, PHASE_ONE);
                 events.ScheduleEvent(EVENT_SUMMON_PROWLERS, 6s, 0, PHASE_ALL);
-                events.ScheduleEvent(EVENT_MARK_OF_ARLOKK, urand(9000, 11000), 0, PHASE_ALL);
-                events.ScheduleEvent(EVENT_TRANSFORM, urand(15000, 20000), 0, PHASE_ONE);
+                events.ScheduleEvent(EVENT_MARK_OF_ARLOKK, 9s, 11s, 0, PHASE_ALL);
+                events.ScheduleEvent(EVENT_TRANSFORM, 15s, 20s, 0, PHASE_ONE);
                 Talk(SAY_AGGRO);
 
                 // Sets up list of Panther spawners to cast on
@@ -192,7 +192,7 @@ class boss_arlokk : public CreatureScript
                     {
                         case EVENT_SHADOW_WORD_PAIN:
                             DoCastVictim(SPELL_SHADOW_WORD_PAIN, true);
-                            events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, urand(5000, 7000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, 5s, 7s, 0, PHASE_ONE);
                             break;
                         case EVENT_GOUGE:
                             DoCastVictim(SPELL_GOUGE, true);
@@ -226,7 +226,7 @@ class boss_arlokk : public CreatureScript
                                 DoCast(target, SPELL_MARK_OF_ARLOKK, true);
                                 Talk(SAY_FEAST_PROWLER, target);
                             }
-                            events.ScheduleEvent(EVENT_MARK_OF_ARLOKK, urand(120000, 130000));
+                            events.ScheduleEvent(EVENT_MARK_OF_ARLOKK, 120s , 130s);
                             break;
                         }
                         case EVENT_TRANSFORM:
@@ -253,12 +253,12 @@ class boss_arlokk : public CreatureScript
                             DoCast(me, SPELL_SUPER_INVIS);
                             me->SetWalk(false);
                             me->GetMotionMaster()->MovePoint(0, frand(-11551.0f, -11508.0f), frand(-1638.0f, -1617.0f), me->GetPositionZ());
-                            events.ScheduleEvent(EVENT_VANISH_2, 9000, 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_VANISH_2, 9s, 0, PHASE_ONE);
                             break;
                         case EVENT_VANISH_2:
                             DoCast(me, SPELL_VANISH);
                             DoCast(me, SPELL_SUPER_INVIS);
-                            events.ScheduleEvent(EVENT_VISIBLE, urand(7000, 10000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_VISIBLE, 7s, 10s, 0, PHASE_ONE);
                             break;
                         case EVENT_VISIBLE:
                             me->SetReactState(REACT_AGGRESSIVE);
@@ -267,14 +267,14 @@ class boss_arlokk : public CreatureScript
                                 AttackStart(target);
                             me->RemoveAura(SPELL_SUPER_INVIS);
                             me->RemoveAura(SPELL_VANISH);
-                            events.ScheduleEvent(EVENT_RAVAGE, urand(10000, 14000), 0, PHASE_TWO);
-                            events.ScheduleEvent(EVENT_TRANSFORM_BACK, urand(15000, 18000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_RAVAGE, 10s, 14s, 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_TRANSFORM_BACK, 15s, 18s, 0, PHASE_TWO);
                             events.SetPhase(PHASE_TWO);
                             me->ApplyStatPctModifier(UNIT_MOD_DAMAGE_MAINHAND, TOTAL_PCT, DamageIncrease); // hack
                             break;
                         case EVENT_RAVAGE:
                             DoCastVictim(SPELL_RAVAGE, true);
-                            events.ScheduleEvent(EVENT_RAVAGE, urand(10000, 14000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_RAVAGE, 10s, 14s, 0, PHASE_TWO);
                             break;
                         case EVENT_TRANSFORM_BACK:
                         {
@@ -289,9 +289,9 @@ class boss_arlokk : public CreatureScript
                             me->UpdateDamagePhysical(BASE_ATTACK);
                             */
                             me->ApplyStatPctModifier(UNIT_MOD_DAMAGE_MAINHAND, TOTAL_PCT, DamageDecrease); // hack
-                            events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, urand(4000, 7000), 0, PHASE_ONE);
-                            events.ScheduleEvent(EVENT_GOUGE, urand(12000, 15000), 0, PHASE_ONE);
-                            events.ScheduleEvent(EVENT_TRANSFORM, urand(16000, 20000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, 4s, 7s, 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_GOUGE, 12s, 15s, 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_TRANSFORM, 16s, 20s, 0, PHASE_ONE);
                             events.SetPhase(PHASE_ONE);
                             break;
                         }

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
@@ -226,7 +226,7 @@ class boss_arlokk : public CreatureScript
                                 DoCast(target, SPELL_MARK_OF_ARLOKK, true);
                                 Talk(SAY_FEAST_PROWLER, target);
                             }
-                            events.ScheduleEvent(EVENT_MARK_OF_ARLOKK, 120s , 130s);
+                            events.ScheduleEvent(EVENT_MARK_OF_ARLOKK, 120s, 130s);
                             break;
                         }
                         case EVENT_TRANSFORM:

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_jeklik.cpp
@@ -147,15 +147,15 @@ class boss_jeklik : public CreatureScript
                                 DoCast(target, SPELL_CHARGE);
                                 AttackStart(target);
                             }
-                            events.ScheduleEvent(EVENT_CHARGE_JEKLIK, urand(15000, 30000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_CHARGE_JEKLIK, 15s, 30s, 0, PHASE_ONE);
                             break;
                         case EVENT_SONIC_BURST:
                             DoCastVictim(SPELL_SONICBURST);
-                            events.ScheduleEvent(EVENT_SONIC_BURST, urand(8000, 13000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_SONIC_BURST, 8s, 13s, 0, PHASE_ONE);
                             break;
                         case EVENT_SCREECH:
                             DoCastVictim(SPELL_SCREECH);
-                            events.ScheduleEvent(EVENT_SCREECH, urand(18000, 26000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_SCREECH, 18s, 26s, 0, PHASE_ONE);
                             break;
                         case EVENT_SPAWN_BATS:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.f, true))
@@ -167,7 +167,7 @@ class boss_jeklik : public CreatureScript
                         case EVENT_SHADOW_WORD_PAIN:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.f, true))
                                 DoCast(target, SPELL_SHADOW_WORD_PAIN);
-                            events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, urand(12000, 18000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_SHADOW_WORD_PAIN, 12s, 18s, 0, PHASE_TWO);
                             break;
                         case EVENT_MIND_FLAY:
                             DoCastVictim(SPELL_MIND_FLAY);
@@ -176,18 +176,18 @@ class boss_jeklik : public CreatureScript
                         case EVENT_CHAIN_MIND_FLAY:
                             me->InterruptNonMeleeSpells(false);
                             DoCastVictim(SPELL_CHAIN_MIND_FLAY);
-                            events.ScheduleEvent(EVENT_CHAIN_MIND_FLAY, urand(15000, 30000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_CHAIN_MIND_FLAY, 15s, 30s, 0, PHASE_TWO);
                             break;
                         case EVENT_GREATER_HEAL:
                             me->InterruptNonMeleeSpells(false);
                             DoCast(me, SPELL_GREATERHEAL);
-                            events.ScheduleEvent(EVENT_GREATER_HEAL, urand(25000, 35000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_GREATER_HEAL, 25s, 35s, 0, PHASE_TWO);
                             break;
                         case EVENT_SPAWN_FLYING_BATS:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.f, true))
                                 if (TempSummon* flyingBat = me->SummonCreature(NPC_FRENZIED_BAT, target->GetPositionX(), target->GetPositionY(), target->GetPositionZ() + 15.0f, 0.0f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 15000))
                                     flyingBat->AI()->AttackStart(target);
-                            events.ScheduleEvent(EVENT_SPAWN_FLYING_BATS, urand(10000, 15000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_SPAWN_FLYING_BATS, 10s, 15s, 0, PHASE_TWO);
                             break;
                         default:
                             break;

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_marli.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_marli.cpp
@@ -210,7 +210,7 @@ class boss_marli : public CreatureScript
                             events.ScheduleEvent(EVENT_TRANSFORM, 45s, 0, PHASE_TWO);
                             events.ScheduleEvent(EVENT_POISON_VOLLEY, 15s);
                             events.ScheduleEvent(EVENT_HATCH_SPIDER_EGG, 12s, 17s);
-                            events.ScheduleEvent(EVENT_TRANSFORM, urand(35000, 60000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_TRANSFORM, 35s, 60s, 0, PHASE_TWO);
                             events.SetPhase(PHASE_TWO);
                             break;
                         }

--- a/src/server/scripts/EasternKingdoms/zone_duskwood.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_duskwood.cpp
@@ -74,7 +74,7 @@ public:
         void JustEngagedWith(Unit* /*who*/) override
         {
             Talk(YELL_TWILIGHT_CORRUPTOR_AGGRO);
-            _events.ScheduleEvent(EVENT_SOUL_CORRUPTION, 15000);
+            _events.ScheduleEvent(EVENT_SOUL_CORRUPTION, 15s);
             _events.ScheduleEvent(EVENT_CREATURE_OF_NIGHTMARE, 30s);
         }
 
@@ -114,7 +114,7 @@ public:
                     case EVENT_CREATURE_OF_NIGHTMARE:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                             DoCast(target, SPELL_CREATURE_OF_NIGHTMARE);
-                        _events.ScheduleEvent(EVENT_CREATURE_OF_NIGHTMARE, 45000);
+                        _events.ScheduleEvent(EVENT_CREATURE_OF_NIGHTMARE, 45s);
                         break;
                     default:
                         break;

--- a/src/server/scripts/EasternKingdoms/zone_undercity.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_undercity.cpp
@@ -127,7 +127,7 @@ public:
             DoPlaySoundToSet(me, SOUND_AGGRO);
             _events.ScheduleEvent(EVENT_FADE, 30s);
             _events.ScheduleEvent(EVENT_SUMMON_SKELETON, 20s);
-            _events.ScheduleEvent(EVENT_BLACK_ARROW, 15000);
+            _events.ScheduleEvent(EVENT_BLACK_ARROW, 15s);
             _events.ScheduleEvent(EVENT_SHOOT, 8s);
             _events.ScheduleEvent(EVENT_MULTI_SHOT, 10s);
         }


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/EasternKingdoms: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build