### PR TITLE
Scripts/ToC: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -306,14 +306,14 @@ class boss_anubarak_trial : public CreatureScript
                     {
                         case EVENT_FREEZE_SLASH:
                             DoCastVictim(SPELL_FREEZE_SLASH);
-                            events.ScheduleEvent(EVENT_FREEZE_SLASH, 15*IN_MILLISECONDS, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_FREEZE_SLASH, 15s, 0, PHASE_MELEE);
                             return;
                         case EVENT_PENETRATING_COLD:
                         {
                             CastSpellExtraArgs args;
                             args.AddSpellMod(SPELLVALUE_MAX_TARGETS, RAID_MODE(2, 5, 2, 5));
                             me->CastSpell(nullptr, SPELL_PENETRATING_COLD, args);
-                            events.ScheduleEvent(EVENT_PENETRATING_COLD, 20 * IN_MILLISECONDS, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_PENETRATING_COLD, 20s, 0, PHASE_MELEE);
                             return;
                         }
                         case EVENT_SUMMON_NERUBIAN:
@@ -323,13 +323,13 @@ class boss_anubarak_trial : public CreatureScript
                                 args.AddSpellMod(SPELLVALUE_MAX_TARGETS, RAID_MODE(1, 2, 2, 4));
                                 me->CastSpell(nullptr, SPELL_SUMMON_BURROWER, args);
                             }
-                            events.ScheduleEvent(EVENT_SUMMON_NERUBIAN, 45*IN_MILLISECONDS, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_SUMMON_NERUBIAN, 45s, 0, PHASE_MELEE);
                             return;
                         case EVENT_NERUBIAN_SHADOW_STRIKE:
                         {
                             EntryCheckPredicate pred(NPC_BURROWER);
                             summons.DoAction(ACTION_SHADOW_STRIKE, pred);
-                            events.ScheduleEvent(EVENT_NERUBIAN_SHADOW_STRIKE, 30*IN_MILLISECONDS, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_NERUBIAN_SHADOW_STRIKE, 30s, 0, PHASE_MELEE);
                             break;
                         }
                         case EVENT_SUBMERGE:
@@ -340,9 +340,9 @@ class boss_anubarak_trial : public CreatureScript
                                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                                 Talk(EMOTE_BURROWER);
                                 events.SetPhase(PHASE_SUBMERGED);
-                                events.ScheduleEvent(EVENT_PURSUING_SPIKE, 2*IN_MILLISECONDS, 0, PHASE_SUBMERGED);
-                                events.ScheduleEvent(EVENT_SUMMON_SCARAB, 4*IN_MILLISECONDS, 0, PHASE_SUBMERGED);
-                                events.ScheduleEvent(EVENT_EMERGE, 1*MINUTE*IN_MILLISECONDS, 0, PHASE_SUBMERGED);
+                                events.ScheduleEvent(EVENT_PURSUING_SPIKE, 2s, 0, PHASE_SUBMERGED);
+                                events.ScheduleEvent(EVENT_SUMMON_SCARAB, 4s, 0, PHASE_SUBMERGED);
+                                events.ScheduleEvent(EVENT_EMERGE, 60s, 0, PHASE_SUBMERGED);
                             }
                             break;
                         case EVENT_PURSUING_SPIKE:
@@ -360,7 +360,7 @@ class boss_anubarak_trial : public CreatureScript
                             if (Creature* pBurrow = ObjectAccessor::GetCreature(*me, *i))
                                 pBurrow->CastSpell(pBurrow, 66340, false);
 
-                            events.ScheduleEvent(EVENT_SUMMON_SCARAB, 4*IN_MILLISECONDS, 0, PHASE_SUBMERGED);
+                            events.ScheduleEvent(EVENT_SUMMON_SCARAB, 4s, 0, PHASE_SUBMERGED);
 
                             /*It seems that this spell have something more that needs to be taken into account
                             //Need more sniff info
@@ -377,12 +377,12 @@ class boss_anubarak_trial : public CreatureScript
                             DoCast(me, SPELL_EMERGE_ANUBARAK);
                             Talk(EMOTE_EMERGE);
                             events.SetPhase(PHASE_MELEE);
-                            events.ScheduleEvent(EVENT_FREEZE_SLASH, 15*IN_MILLISECONDS, 0, PHASE_MELEE);
-                            events.ScheduleEvent(EVENT_PENETRATING_COLD, 20*IN_MILLISECONDS, PHASE_MELEE);
-                            events.ScheduleEvent(EVENT_SUMMON_NERUBIAN, 10*IN_MILLISECONDS, 0, PHASE_MELEE);
-                            events.ScheduleEvent(EVENT_SUBMERGE, 80*IN_MILLISECONDS, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_FREEZE_SLASH, 15s, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_PENETRATING_COLD, 20s, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_SUMMON_NERUBIAN, 10s, 0, PHASE_MELEE);
+                            events.ScheduleEvent(EVENT_SUBMERGE, 80s, 0, PHASE_MELEE);
                             if (IsHeroic())
-                                events.ScheduleEvent(EVENT_NERUBIAN_SHADOW_STRIKE, 30*IN_MILLISECONDS, 0, PHASE_MELEE);
+                                events.ScheduleEvent(EVENT_NERUBIAN_SHADOW_STRIKE, 30s, 0, PHASE_MELEE);
                             return;
                         case EVENT_SUMMON_FROST_SPHERE:
                         {

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_faction_champions.cpp
@@ -727,10 +727,10 @@ struct boss_faction_championsAI : public BossAI
                     if (me->HasBreakableByDamageCrowdControlAura())
                     {
                         RemoveCC();
-                        _events.RescheduleEvent(EVENT_REMOVE_CC, 2*MINUTE*IN_MILLISECONDS);
+                        _events.RescheduleEvent(EVENT_REMOVE_CC, 2min);
                     }
                     else
-                        _events.RescheduleEvent(EVENT_REMOVE_CC, 3*IN_MILLISECONDS);
+                        _events.RescheduleEvent(EVENT_REMOVE_CC, 3s);
                     return;
                 default:
                     return;
@@ -817,10 +817,10 @@ class npc_toc_druid : public CreatureScript
                             if (HealthBelowPct(30))
                             {
                                 DoCast(me, SPELL_BARKSKIN);
-                                events.RescheduleEvent(EVENT_HEAL_BARKSKIN, 60*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_HEAL_BARKSKIN, 60s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_HEAL_BARKSKIN, 3*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_HEAL_BARKSKIN, 3s);
                             return;
                         case EVENT_THORNS:
                             if (Creature* target = SelectRandomFriendlyMissingBuff(SPELL_THORNS))
@@ -907,7 +907,7 @@ class npc_toc_shaman : public CreatureScript
                                 if (!me->HasAura(AURA_SATED))
                                     DoCastAOE(SPELL_BLOODLUST);
                             }
-                            events.ScheduleEvent(EVENT_HEAL_BLOODLUST_HEROISM, 5*MINUTE*IN_MILLISECONDS);
+                            events.ScheduleEvent(EVENT_HEAL_BLOODLUST_HEROISM, 5min);
                             return;
                         case EVENT_HEX:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, NonTankTargetSelector(me)))
@@ -984,10 +984,10 @@ class npc_toc_paladin : public CreatureScript
                             if (HealthBelowPct(30) && !me->HasAura(SPELL_FORBEARANCE))
                             {
                                 DoCast(me, SPELL_DIVINE_SHIELD);
-                                events.RescheduleEvent(EVENT_HEAL_DIVINE_SHIELD, 5*MINUTE*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_HEAL_DIVINE_SHIELD, 5min);
                             }
                             else
-                                events.RescheduleEvent(EVENT_HEAL_DIVINE_SHIELD, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_HEAL_DIVINE_SHIELD, 5s);
                             return;
                         case EVENT_CLEANSE:
                             if (Unit* target = DoSelectLowestHpFriendly(40.0f))
@@ -1015,13 +1015,13 @@ class npc_toc_paladin : public CreatureScript
                                 if (!target->HasAura(SPELL_FORBEARANCE))
                                 {
                                     DoCast(target, SPELL_HAND_OF_PROTECTION);
-                                    events.RescheduleEvent(EVENT_HEAL_HAND_OF_PROTECTION, 5*MINUTE*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_HEAL_HAND_OF_PROTECTION, 5min);
                                 }
                                 else
-                                    events.RescheduleEvent(EVENT_HEAL_HAND_OF_PROTECTION, 3*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_HEAL_HAND_OF_PROTECTION, 3s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_HEAL_HAND_OF_PROTECTION, 10*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_HEAL_HAND_OF_PROTECTION, 10s);
                             return;
                         case EVENT_HAMMER_OF_JUSTICE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 15.0f, true))
@@ -1195,10 +1195,10 @@ class npc_toc_shadow_priest : public CreatureScript
                             if (HealthBelowPct(40))
                             {
                                 DoCast(me, SPELL_DISPERSION);
-                                events.RescheduleEvent(EVENT_DISPERSION, 180*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DISPERSION, 180s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_DISPERSION, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DISPERSION, 5s);
                             return;
                         case EVENT_DPS_DISPEL:
                             if (Unit* target = urand(0, 1) ? SelectTarget(SelectTargetMethod::Random, 0, 30.0f, true) : DoSelectLowestHpFriendly(40.0f))
@@ -1385,10 +1385,10 @@ class npc_toc_mage : public CreatureScript
                             if (HealthBelowPct(30))
                             {
                                 DoCast(SPELL_ICE_BLOCK);
-                                events.RescheduleEvent(EVENT_ICE_BLOCK, 5*MINUTE*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_ICE_BLOCK, 5min);
                             }
                             else
-                                events.RescheduleEvent(EVENT_ICE_BLOCK, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_ICE_BLOCK, 5s);
                             return;
                         case EVENT_POLYMORPH:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, NonTankTargetSelector(me)))
@@ -1461,10 +1461,10 @@ class npc_toc_hunter : public CreatureScript
                             if (HealthBelowPct(30))
                             {
                                 DoCast(SPELL_DETERRENCE);
-                                events.RescheduleEvent(EVENT_DETERRENCE, 150*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DETERRENCE, 150s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_DETERRENCE, 10*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DETERRENCE, 10s);
                             return;
                         case EVENT_DISENGAGE:
                             if (EnemiesInRange(10.0f) >= 2)
@@ -1584,10 +1584,10 @@ class npc_toc_boomkin : public CreatureScript
                             if (HealthBelowPct(30))
                             {
                                 DoCast(me, SPELL_BARKSKIN);
-                                events.RescheduleEvent(EVENT_DPS_BARKSKIN, 60*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DPS_BARKSKIN, 60s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_DPS_BARKSKIN, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DPS_BARKSKIN, 5s);
                             return;
                         default:
                             return;
@@ -1679,20 +1679,20 @@ class npc_toc_warrior : public CreatureScript
                                 if (target->HasAuraWithMechanic(1 << MECHANIC_IMMUNE_SHIELD))
                                 {
                                     DoCast(target, SPELL_SHATTERING_THROW);
-                                    events.RescheduleEvent(EVENT_SHATTERING_THROW, 5*MINUTE*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_SHATTERING_THROW, 5min);
                                     return;
                                 }
                             }
-                            events.RescheduleEvent(EVENT_SHATTERING_THROW, 3*IN_MILLISECONDS);
+                            events.RescheduleEvent(EVENT_SHATTERING_THROW, 3s);
                             return;
                         case EVENT_RETALIATION:
                             if (HealthBelowPct(50))
                             {
                                 DoCast(SPELL_RETALIATION);
-                                events.RescheduleEvent(EVENT_RETALIATION, 5*MINUTE*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_RETALIATION, 5min);
                             }
                             else
-                                events.RescheduleEvent(EVENT_RETALIATION, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_RETALIATION, 5s);
                             return;
                         default:
                             return;
@@ -1758,11 +1758,11 @@ class npc_toc_dk : public CreatureScript
                                 if (me->IsInRange(target, 5.0f, 30.0f, false))
                                 {
                                     DoCast(target, SPELL_DEATH_GRIP);
-                                    events.RescheduleEvent(EVENT_DEATH_GRIP, 35*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_DEATH_GRIP, 35s);
                                     return;
                                 }
                             }
-                            events.RescheduleEvent(EVENT_DEATH_GRIP, 3*IN_MILLISECONDS);
+                            events.RescheduleEvent(EVENT_DEATH_GRIP, 3s);
                             return;
                         case EVENT_FROST_STRIKE:
                             DoCastVictim(SPELL_FROST_STRIKE);
@@ -1772,10 +1772,10 @@ class npc_toc_dk : public CreatureScript
                             if (HealthBelowPct(50))
                             {
                                 DoCast(SPELL_ICEBOUND_FORTITUDE);
-                                events.RescheduleEvent(EVENT_ICEBOUND_FORTITUDE, 60*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_ICEBOUND_FORTITUDE, 60s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_ICEBOUND_FORTITUDE, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_ICEBOUND_FORTITUDE, 5s);
                             return;
                         case EVENT_ICY_TOUCH:
                             DoCastVictim(SPELL_ICY_TOUCH);
@@ -1785,10 +1785,10 @@ class npc_toc_dk : public CreatureScript
                             if (Unit* target = SelectEnemyCaster(false))
                             {
                                 DoCast(target, SPELL_STRANGULATE);
-                                events.RescheduleEvent(EVENT_STRANGULATE, 120*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_STRANGULATE, 120s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_STRANGULATE, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_STRANGULATE, 5s);
                             return;
                         default:
                             return;
@@ -1857,19 +1857,19 @@ class npc_toc_rogue : public CreatureScript
                             if (HealthBelowPct(50))
                             {
                                 DoCast(SPELL_CLOAK);
-                                events.RescheduleEvent(EVENT_CLOAK, 90*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_CLOAK, 90s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_CLOAK, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_CLOAK, 5s);
                             return;
                         case EVENT_BLADE_FLURRY:
                             if (EnemiesInRange(10.0f) >= 2)
                             {
                                 DoCast(SPELL_BLADE_FLURRY);
-                                events.RescheduleEvent(EVENT_BLADE_FLURRY, 120*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_BLADE_FLURRY, 120s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_BLADE_FLURRY, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_BLADE_FLURRY, 5s);
                             return;
                         case EVENT_SHADOWSTEP:
                             if (Unit* target = me->GetVictim())
@@ -1877,11 +1877,11 @@ class npc_toc_rogue : public CreatureScript
                                 if (me->IsInRange(target, 10.0f, 40.0f, false))
                                 {
                                     DoCast(target, SPELL_SHADOWSTEP);
-                                    events.RescheduleEvent(EVENT_SHADOWSTEP, 30*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_SHADOWSTEP, 30s);
                                     return;
                                 }
                             }
-                            events.RescheduleEvent(EVENT_SHADOWSTEP, 5*IN_MILLISECONDS);
+                            events.RescheduleEvent(EVENT_SHADOWSTEP, 5s);
                             return;
                         case EVENT_HEMORRHAGE:
                             DoCastVictim(SPELL_HEMORRHAGE);
@@ -2015,7 +2015,7 @@ class npc_toc_enh_shaman : public CreatureScript
                                 if (!me->HasAura(AURA_SATED))
                                     DoCastAOE(SPELL_BLOODLUST);
                             }
-                            events.ScheduleEvent(EVENT_DPS_BLOODLUST_HEROISM, 5*MINUTE*IN_MILLISECONDS);
+                            events.ScheduleEvent(EVENT_DPS_BLOODLUST_HEROISM, 5min);
                             return;
                         case EVENT_DEPLOY_TOTEM:
                             if (_totemCount < 4 || me->GetDistance2d(_totemOldCenterX, _totemOldCenterY) > 20.0f)
@@ -2118,22 +2118,22 @@ class npc_toc_retro_paladin : public CreatureScript
                                 if (!target->HasAura(SPELL_FORBEARANCE))
                                 {
                                     DoCast(target, SPELL_HAND_OF_PROTECTION);
-                                    events.RescheduleEvent(EVENT_DPS_HAND_OF_PROTECTION, 5*MINUTE*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_DPS_HAND_OF_PROTECTION, 5min);
                                 }
                                 else
-                                    events.RescheduleEvent(EVENT_DPS_HAND_OF_PROTECTION, 5*IN_MILLISECONDS);
+                                    events.RescheduleEvent(EVENT_DPS_HAND_OF_PROTECTION, 5s);
                             }
                             else
-                                events.RescheduleEvent(EVENT_DPS_HAND_OF_PROTECTION, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DPS_HAND_OF_PROTECTION, 5s);
                             return;
                         case EVENT_DPS_DIVINE_SHIELD:
                             if (HealthBelowPct(30) && !me->HasAura(SPELL_FORBEARANCE))
                             {
                                 DoCast(me, SPELL_DIVINE_SHIELD);
-                                events.RescheduleEvent(EVENT_DPS_DIVINE_SHIELD, 5*MINUTE*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DPS_DIVINE_SHIELD, 5min);
                             }
                             else
-                                events.RescheduleEvent(EVENT_DPS_DIVINE_SHIELD, 5*IN_MILLISECONDS);
+                                events.RescheduleEvent(EVENT_DPS_DIVINE_SHIELD, 5s);
                             return;
                         default:
                             return;


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/ToC: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build