### PR TITLE
Scripts/Northrend: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -185,7 +185,7 @@ class npc_commander_eligor_dawnbringer : public CreatureScript
                                 switch (urand (0, 1))
                                 {
                                     case 0: ChangeImage(NPC_IMAGE_OF_KELTHUZAD, MODEL_IMAGE_OF_KELTHUZAD, SAY_KELTHUZAD_1);
-                                            _events.ScheduleEvent(EVENT_KELTHUZAD_2, 8000); break;
+                                            _events.ScheduleEvent(EVENT_KELTHUZAD_2, 8s); break;
                                     case 1: ChangeImage(NPC_IMAGE_OF_SAPPHIRON, MODEL_IMAGE_OF_SAPPHIRON, SAY_SAPPHIRON); break;
                                 }
                             }
@@ -197,7 +197,7 @@ class npc_commander_eligor_dawnbringer : public CreatureScript
                                     case 0: ChangeImage(NPC_IMAGE_OF_RAZUVIOUS, MODEL_IMAGE_OF_RAZUVIOUS, SAY_RAZUVIOUS); break;
                                     case 1: ChangeImage(NPC_IMAGE_OF_GOTHIK, MODEL_IMAGE_OF_GOTHIK, SAY_GOTHIK); break;
                                     case 2: ChangeImage(NPC_IMAGE_OF_THANE, MODEL_IMAGE_OF_THANE, SAY_DEATH_KNIGHTS_1);
-                                            _events.ScheduleEvent(EVENT_DEATH_KNIGHTS_2, 10000); break;
+                                            _events.ScheduleEvent(EVENT_DEATH_KNIGHTS_2, 10s); break;
                                 }
                             }
                             break;
@@ -228,7 +228,7 @@ class npc_commander_eligor_dawnbringer : public CreatureScript
                                 {
                                     case 0: ChangeImage(NPC_IMAGE_OF_NOTH, MODEL_IMAGE_OF_NOTH, SAY_NOTH); break;
                                     case 1: ChangeImage(NPC_IMAGE_OF_HEIGAN, MODEL_IMAGE_OF_HEIGAN, SAY_HEIGAN_1);
-                                            _events.ScheduleEvent(EVENT_HEIGAN_2, 8000); break;
+                                            _events.ScheduleEvent(EVENT_HEIGAN_2, 8s); break;
                                     case 2: ChangeImage(NPC_IMAGE_OF_LOATHEB, MODEL_IMAGE_OF_LOATHEB, SAY_LOATHEB); break;
                                 }
                             }
@@ -319,7 +319,7 @@ class npc_commander_eligor_dawnbringer : public CreatureScript
                             break;
                         case EVENT_KELTHUZAD_2:
                             Talk(SAY_KELTHUZAD_2);
-                            _events.ScheduleEvent(EVENT_KELTHUZAD_3, 8000);
+                            _events.ScheduleEvent(EVENT_KELTHUZAD_3, 8s);
                             break;
                         case EVENT_KELTHUZAD_3:
                             Talk(SAY_KELTHUZAD_3);
@@ -331,7 +331,7 @@ class npc_commander_eligor_dawnbringer : public CreatureScript
                                 creature->SetEntry(NPC_IMAGE_OF_BLAUMEUX);
                                 creature->SetDisplayId(MODEL_IMAGE_OF_BLAUMEUX);
                             }
-                            _events.ScheduleEvent(EVENT_DEATH_KNIGHTS_3, 10000);
+                            _events.ScheduleEvent(EVENT_DEATH_KNIGHTS_3, 10s);
                             break;
                         case EVENT_DEATH_KNIGHTS_3:
                             Talk(SAY_DEATH_KNIGHTS_3);
@@ -340,7 +340,7 @@ class npc_commander_eligor_dawnbringer : public CreatureScript
                                 creature->SetEntry(NPC_IMAGE_OF_ZELIEK);
                                 creature->SetDisplayId(MODEL_IMAGE_OF_ZELIEK);
                             }
-                            _events.ScheduleEvent(EVENT_DEATH_KNIGHTS_4, 10000);
+                            _events.ScheduleEvent(EVENT_DEATH_KNIGHTS_4, 10s);
                             break;
                         case EVENT_DEATH_KNIGHTS_4:
                             Talk(SAY_DEATH_KNIGHTS_4);
@@ -663,7 +663,7 @@ class npc_torturer_lecraft : public CreatureScript
                     {
                         case EVENT_HEMORRHAGE:
                             DoCastVictim(SPELL_HEMORRHAGE);
-                            _events.ScheduleEvent(EVENT_HEMORRHAGE, urand(12000, 168000));
+                            _events.ScheduleEvent(EVENT_HEMORRHAGE, 12s, 168s);
                             break;
                         case EVENT_KIDNEY_SHOT:
                             DoCastVictim(SPELL_KIDNEY_SHOT);

--- a/src/server/scripts/Northrend/zone_grizzly_hills.cpp
+++ b/src/server/scripts/Northrend/zone_grizzly_hills.cpp
@@ -422,7 +422,7 @@ public:
                 me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_USE_STANDING);
             }
             else
-                _events.ScheduleEvent(EVENT_WOODSMAN_1, 0);
+                _events.ScheduleEvent(EVENT_WOODSMAN_1, 0s);
         }
 
         void UpdateAI(uint32 diff) override
@@ -435,11 +435,11 @@ public:
                 {
                     case EVENT_WOODSMAN_1:
                         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_LOOT);
-                        _events.ScheduleEvent(EVENT_WOODSMAN_2, 3000);
+                        _events.ScheduleEvent(EVENT_WOODSMAN_2, 3s);
                         break;
                     case EVENT_WOODSMAN_2:
                         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_ATTACK1H);
-                        _events.ScheduleEvent(EVENT_WOODSMAN_1, 4000);
+                        _events.ScheduleEvent(EVENT_WOODSMAN_1, 4s);
                         break;
                     default:
                         break;
@@ -595,16 +595,16 @@ public:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, _playerGUID))
                              DoCast(player, SPELL_VENTURE_STRAGGLER_CREDIT);
                          me->GetMotionMaster()->MovePoint(0, me->GetPositionX()-7, me->GetPositionY()+7, me->GetPositionZ());
-                         _events.ScheduleEvent(EVENT_STRAGGLER_2, 2500);
+                         _events.ScheduleEvent(EVENT_STRAGGLER_2, 2500ms);
                          break;
                     case EVENT_STRAGGLER_2:
                          Talk(SAY_SEO);
                          me->GetMotionMaster()->MovePoint(0, me->GetPositionX()-7, me->GetPositionY()-5, me->GetPositionZ());
-                         _events.ScheduleEvent(EVENT_STRAGGLER_3, 2500);
+                         _events.ScheduleEvent(EVENT_STRAGGLER_3, 2500ms);
                          break;
                     case EVENT_STRAGGLER_3:
                         me->GetMotionMaster()->MovePoint(0, me->GetPositionX()-5, me->GetPositionY()-5, me->GetPositionZ());
-                        _events.ScheduleEvent(EVENT_STRAGGLER_4, 2500);
+                        _events.ScheduleEvent(EVENT_STRAGGLER_4, 2500ms);
                         break;
                     case EVENT_STRAGGLER_4:
                         me->DisappearAndDie();
@@ -633,7 +633,7 @@ public:
                 me->SetReactState(REACT_PASSIVE);
                 me->CombatStop(false);
                 _playerGUID = caster->GetGUID();
-                _events.ScheduleEvent(EVENT_STRAGGLER_1, 3500);
+                _events.ScheduleEvent(EVENT_STRAGGLER_1, 3500ms);
             }
         }
 
@@ -721,19 +721,19 @@ public:
                         case EVENT_LAKEFROG_1:
                             DoCast(me, SPELL_MAIDEN_OF_ASHWOOD_LAKE_TRANSFORM);
                             me->SetEntry(NPC_MAIDEN_OF_ASHWOOD_LAKE);
-                            _events.ScheduleEvent(EVENT_LAKEFROG_2, 2000);
+                            _events.ScheduleEvent(EVENT_LAKEFROG_2, 2s);
                             break;
                         case EVENT_LAKEFROG_2:
                             Talk(SAY_MAIDEN_0);
-                            _events.ScheduleEvent(EVENT_LAKEFROG_3, 3000);
+                            _events.ScheduleEvent(EVENT_LAKEFROG_3, 3s);
                             break;
                         case EVENT_LAKEFROG_3:
                             me->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                            _events.ScheduleEvent(EVENT_LAKEFROG_4, 25000);
+                            _events.ScheduleEvent(EVENT_LAKEFROG_4, 25s);
                             break;
                         case EVENT_LAKEFROG_4:
                             me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                            _events.ScheduleEvent(EVENT_LAKEFROG_5, 2000);
+                            _events.ScheduleEvent(EVENT_LAKEFROG_5, 2s);
                             break;
                         case EVENT_LAKEFROG_5:
                             Talk(SAY_MAIDEN_1);
@@ -769,7 +769,7 @@ public:
                             me->GetMotionMaster()->MoveIdle();
                             me->SetFacingToObject(player);
                             _runningScript = true;
-                            _events.ScheduleEvent(EVENT_LAKEFROG_1, 2000);
+                            _events.ScheduleEvent(EVENT_LAKEFROG_1, 2s);
                         }
                     }
                 }

--- a/src/server/scripts/Northrend/zone_howling_fjord.cpp
+++ b/src/server/scripts/Northrend/zone_howling_fjord.cpp
@@ -212,14 +212,14 @@ public:
                     events.ScheduleEvent(EVENT_TALK_3, Seconds(3));
                     break;
                 case 20:
-                    events.ScheduleEvent(EVENT_BURN_CRATES, 0);
+                    events.ScheduleEvent(EVENT_BURN_CRATES, 0s);
                     break;
                 case 21:
-                    events.ScheduleEvent(EVENT_BURN_CRATES, 0);
+                    events.ScheduleEvent(EVENT_BURN_CRATES, 0s);
                     events.ScheduleEvent(EVENT_TALK_4, Seconds(3));
                     break;
                 case 28:
-                    events.ScheduleEvent(EVENT_BURN_CRATES, 0);
+                    events.ScheduleEvent(EVENT_BURN_CRATES, 0s);
                     events.ScheduleEvent(EVENT_LAUGH, 7s);
                     events.ScheduleEvent(EVENT_TALK_5, Seconds(9));
                     events.ScheduleEvent(EVENT_TALK_6, Seconds(17));

--- a/src/server/scripts/Northrend/zone_icecrown.cpp
+++ b/src/server/scripts/Northrend/zone_icecrown.cpp
@@ -231,7 +231,7 @@ class npc_tournament_training_dummy : public CreatureScript
             void DamageTaken(Unit* /*attacker*/, uint32& damage) override
             {
                 damage = 0;
-                events.RescheduleEvent(EVENT_DUMMY_RESET, 10000);
+                events.RescheduleEvent(EVENT_DUMMY_RESET, 10s);
             }
 
             void SpellHit(WorldObject* caster, SpellInfo const* spellInfo) override
@@ -501,14 +501,14 @@ public:
                             guidMason[2] = Mason3->GetGUID();
                             Mason3->GetMotionMaster()->MovePoint(0, Mason3Pos[1]);
                         }
-                        events.ScheduleEvent(EVENT_INTRO_1, 15000);
+                        events.ScheduleEvent(EVENT_INTRO_1, 15s);
                     }
                     break;
                 case EVENT_INTRO_1:
                     {
                         if (Creature* Dalfors = ObjectAccessor::GetCreature(*me, guidDalfors))
                             Dalfors->AI()->Talk(DALFORS_SAY_PRE_1);
-                        events.ScheduleEvent(EVENT_INTRO_2, 5000);
+                        events.ScheduleEvent(EVENT_INTRO_2, 5s);
                     }
                     break;
                 case EVENT_INTRO_2:
@@ -518,7 +518,7 @@ public:
                             Dalfors->SetFacingTo(6.215f);
                             Dalfors->AI()->Talk(DALFORS_SAY_PRE_2);
                         }
-                    events.ScheduleEvent(EVENT_INTRO_3, 5000);
+                    events.ScheduleEvent(EVENT_INTRO_3, 5s);
                     }
                     break;
                 case EVENT_INTRO_3:

--- a/src/server/scripts/Northrend/zone_storm_peaks.cpp
+++ b/src/server/scripts/Northrend/zone_storm_peaks.cpp
@@ -497,7 +497,7 @@ public:
         {
             CloseGossipMenuFor(player);
             playerGUID = player->GetGUID();
-            events.ScheduleEvent(EVENT_SCRIPT_1, 100);
+            events.ScheduleEvent(EVENT_SCRIPT_1, 100ms);
             return false;
         }
 
@@ -515,16 +515,16 @@ public:
                         me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP | UNIT_NPC_FLAG_QUESTGIVER);
                         if (Creature* voice = me->SummonCreature(NPC_A_DISTANT_VOICE, 7863.43f, -1396.585f, 1538.076f, 2.949606f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 49000))
                             voiceGUID = voice->GetGUID();
-                        events.ScheduleEvent(EVENT_SCRIPT_2, 4000);
+                        events.ScheduleEvent(EVENT_SCRIPT_2, 4s);
                         break;
                     case EVENT_SCRIPT_2:
                         me->SetWalk(true);
                         me->GetMotionMaster()->MovePoint(0, 7861.488f, -1396.376f, 1534.059f, false);
-                        events.ScheduleEvent(EVENT_SCRIPT_3, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_3, 6s);
                         break;
                     case EVENT_SCRIPT_3:
                         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_WORK_MINING);
-                        events.ScheduleEvent(EVENT_SCRIPT_4, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_4, 6s);
                         break;
                     case EVENT_SCRIPT_4:
                         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
@@ -536,7 +536,7 @@ public:
                         }
                         if (GameObject* go = me->SummonGameObject(OBJECT_TOL_SIGNAL_1, 7860.273f, -1383.622f, 1538.302f, -1.658062f, QuaternionData(0.f, 0.f, -0.737277f, 0.6755905f), 0))
                             objectGUID[objectCounter++] = go->GetGUID();
-                        events.ScheduleEvent(EVENT_SCRIPT_5, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_5, 6s);
                         break;
                     case EVENT_SCRIPT_5:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, playerGUID))
@@ -544,7 +544,7 @@ public:
                                 voice->AI()->Talk(SAY_VOICE_2, player);
                         if (GameObject* go = me->SummonGameObject(OBJECT_TOL_SIGNAL_2, 7875.67f, -1387.266f, 1538.323f, -2.373644f, QuaternionData(0.f, 0.f, -0.9271832f, 0.3746083f), 0))
                             objectGUID[objectCounter++] = go->GetGUID();
-                        events.ScheduleEvent(EVENT_SCRIPT_6, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_6, 6s);
                         break;
                     case EVENT_SCRIPT_6:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, playerGUID))
@@ -552,7 +552,7 @@ public:
                                 voice->AI()->Talk(SAY_VOICE_3, player);
                         if (GameObject* go = me->SummonGameObject(OBJECT_TOL_SIGNAL_3, 7879.212f, -1401.175f, 1538.279f, 2.967041f, QuaternionData(0.f, 0.f, 0.9961939f, 0.08716504f), 0))
                             objectGUID[objectCounter++] = go->GetGUID();
-                        events.ScheduleEvent(EVENT_SCRIPT_7, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_7, 6s);
                         break;
                     case EVENT_SCRIPT_7:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, playerGUID))
@@ -560,7 +560,7 @@ public:
                                 voice->AI()->Talk(SAY_VOICE_4, player);
                         if (GameObject* go = me->SummonGameObject(OBJECT_TOL_SIGNAL_4, 7868.944f, -1411.18f, 1538.213f, 2.111848f, QuaternionData(0.f, 0.f, 0.8703556f, 0.4924237f), 0))
                             objectGUID[objectCounter++] = go->GetGUID();
-                        events.ScheduleEvent(EVENT_SCRIPT_8, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_8, 6s);
                         break;
                     case EVENT_SCRIPT_8:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, playerGUID))
@@ -568,12 +568,12 @@ public:
                                 voice->AI()->Talk(SAY_VOICE_5, player);
                         if (GameObject* go = me->SummonGameObject(OBJECT_TOL_SIGNAL_5, 7855.11f, -1406.839f, 1538.42f, 1.151916f, QuaternionData(0.f, 0.f, 0.5446386f, 0.8386708f), 0))
                             objectGUID[objectCounter] = go->GetGUID();
-                        events.ScheduleEvent(EVENT_SCRIPT_9, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_9, 6s);
                         break;
                     case EVENT_SCRIPT_9:
                         if (Creature* voice = ObjectAccessor::GetCreature(*me, voiceGUID))
                             voice->CastSpell(voice, SPELL_RESURRECTION);
-                        events.ScheduleEvent(EVENT_SCRIPT_10, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_10, 6s);
                         break;
                     case EVENT_SCRIPT_10:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, playerGUID))
@@ -581,7 +581,7 @@ public:
                             Talk(SAY_BRANN_2, player);
                             player->KilledMonsterCredit(me->GetEntry());
                         }
-                        events.ScheduleEvent(EVENT_SCRIPT_11, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_11, 6s);
                         break;
                     case EVENT_SCRIPT_11:
                         me->SetFacingTo(2.932153f);
@@ -592,13 +592,13 @@ public:
                             if (GameObject* go = ObjectAccessor::GetGameObject(*me, objectGUID[i]))
                                 go->Delete();
 
-                        events.ScheduleEvent(EVENT_SCRIPT_12, 6000);
+                        events.ScheduleEvent(EVENT_SCRIPT_12, 6s);
                         break;
                     case EVENT_SCRIPT_12:
                         me->GetMotionMaster()->Clear();
                         me->SetWalk(false);
                         me->GetMotionMaster()->MovePoint(0, 7799.908f, -1413.561f, 1534.829f, false);
-                        events.ScheduleEvent(EVENT_SCRIPT_13, 10000);
+                        events.ScheduleEvent(EVENT_SCRIPT_13, 10s);
                         break;
                     case EVENT_SCRIPT_13:
                         me->DisappearAndDie();

--- a/src/server/scripts/Northrend/zone_zuldrak.cpp
+++ b/src/server/scripts/Northrend/zone_zuldrak.cpp
@@ -252,7 +252,7 @@ public:
                         me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
                         Talk(SAY_RECRUIT);
-                        _events.ScheduleEvent(EVENT_RECRUIT_2, 3000);
+                        _events.ScheduleEvent(EVENT_RECRUIT_2, 3s);
                         break;
                     case EVENT_RECRUIT_2:
                         me->SetWalk(true);
@@ -270,7 +270,7 @@ public:
 
         bool GossipSelect(Player* player, uint32 /*menuId*/, uint32 /*gossipListId*/) override
         {
-            _events.ScheduleEvent(EVENT_RECRUIT_1, 100);
+            _events.ScheduleEvent(EVENT_RECRUIT_1, 100ms);
             CloseGossipMenuFor(player);
             me->CastSpell(player, SPELL_QUEST_CREDIT, true);
             me->SetFacingToObject(player);
@@ -491,16 +491,16 @@ public:
                    {
                         case 2:
                         case 3:
-                            _events.ScheduleEvent(EVENT_EASY_123, 100);
+                            _events.ScheduleEvent(EVENT_EASY_123, 100ms);
                             break;
                         case 4:
-                            _events.ScheduleEvent(EVENT_MEDIUM_4, 100);
+                            _events.ScheduleEvent(EVENT_MEDIUM_4, 100ms);
                             break;
                         case 5:
-                            _events.ScheduleEvent(EVENT_MEDIUM_5, 100);
+                            _events.ScheduleEvent(EVENT_MEDIUM_5, 100ms);
                             break;
                         case 6:
-                            _events.ScheduleEvent(EVENT_HARD_6, 100);
+                            _events.ScheduleEvent(EVENT_HARD_6, 100ms);
                             break;
                         default:
                             break;
@@ -569,7 +569,7 @@ public:
                 DoCast(player, SPELL_ALCHEMIST_APPRENTICE_INVISBUFF);
                 _playerGUID = player->GetGUID();
                 _getingredienttry = 1;
-                _events.ScheduleEvent(EVENT_EASY_123, 100);
+                _events.ScheduleEvent(EVENT_EASY_123, 100ms);
                 return false;
             }
 


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Northrend: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build