### PR TITLE
Scripts/Outland: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Outland/boss_doomlord_kazzak.cpp
+++ b/src/server/scripts/Outland/boss_doomlord_kazzak.cpp
@@ -76,7 +76,7 @@ class boss_doomlord_kazzak : public CreatureScript
                 _events.ScheduleEvent(EVENT_CLEAVE, 7s);
                 _events.ScheduleEvent(EVENT_THUNDERCLAP, 14s, 18s);
                 _events.ScheduleEvent(EVENT_VOID_BOLT, 30s);
-                _events.ScheduleEvent(EVENT_MARK_OF_KAZZAK, 25000);
+                _events.ScheduleEvent(EVENT_MARK_OF_KAZZAK, 25s);
                 _events.ScheduleEvent(EVENT_ENRAGE, 1min);
                 _events.ScheduleEvent(EVENT_TWISTED_REFLECTION, 33s);
                 _events.ScheduleEvent(EVENT_BERSERK, 3min);
@@ -152,7 +152,7 @@ class boss_doomlord_kazzak : public CreatureScript
                         case EVENT_TWISTED_REFLECTION:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                                 DoCast(target, SPELL_TWISTED_REFLECTION);
-                            _events.ScheduleEvent(EVENT_TWISTED_REFLECTION, 15000);
+                            _events.ScheduleEvent(EVENT_TWISTED_REFLECTION, 15s);
                             break;
                         case EVENT_BERSERK:
                             DoCast(me, SPELL_BERSERK);

--- a/src/server/scripts/Outland/boss_doomwalker.cpp
+++ b/src/server/scripts/Outland/boss_doomwalker.cpp
@@ -67,7 +67,7 @@ class boss_doomwalker : public CreatureScript
             void Reset() override
             {
                 _events.Reset();
-                _events.ScheduleEvent(EVENT_ENRAGE, 0);
+                _events.ScheduleEvent(EVENT_ENRAGE, 0s);
                 _events.ScheduleEvent(EVENT_ARMOR, 5s, 13s);
                 _events.ScheduleEvent(EVENT_CHAIN, 10s, 30s);
                 _events.ScheduleEvent(EVENT_QUAKE, 25s, 35s);

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -891,7 +891,7 @@ public:
                     me->SetImmuneToPC(false);
                     me->SetFaction(FACTION_MONSTER_2);
                     me->EngageWithTarget(ObjectAccessor::GetPlayer(*me, _playerGUID));
-                    _events.ScheduleEvent(EVENT_FIREBALL, 1);
+                    _events.ScheduleEvent(EVENT_FIREBALL, 1ms);
                     _events.ScheduleEvent(EVENT_FROSTNOVA, 5s);
                     break;
                 case EVENT_FIREBALL:


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Outland: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build