### PR TITLE
Scripts/Auchindoun: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_nexusprince_shaffar.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_nexusprince_shaffar.cpp
@@ -113,7 +113,7 @@ class boss_nexusprince_shaffar : public CreatureScript
                 events.ScheduleEvent(EVENT_BEACON, 10s);
                 events.ScheduleEvent(EVENT_FIREBALL, 8s);
                 events.ScheduleEvent(EVENT_FROSTBOLT, 4s);
-                events.ScheduleEvent(EVENT_FROST_NOVA, 15000);
+                events.ScheduleEvent(EVENT_FROST_NOVA, 15s);
             }
 
             void JustSummoned(Creature* summoned) override
@@ -172,7 +172,7 @@ class boss_nexusprince_shaffar : public CreatureScript
                         break;
                     case EVENT_FROST_NOVA:
                         DoCast(me, SPELL_FROSTNOVA);
-                        events.ScheduleEvent(EVENT_FROST_NOVA, urand(17500, 25000));
+                        events.ScheduleEvent(EVENT_FROST_NOVA, 17500ms, 25s);
                         events.ScheduleEvent(EVENT_BLINK, 1500ms);
                         break;
                     default:
@@ -216,7 +216,7 @@ class npc_ethereal_beacon : public CreatureScript
                     if (!shaffar->IsInCombat())
                         shaffar->AI()->AttackStart(who);
 
-                _events.ScheduleEvent(EVENT_APPRENTICE, DUNGEON_MODE(20000, 10000));
+                _events.ScheduleEvent(EVENT_APPRENTICE, DUNGEON_MODE(20s, 10s));
                 _events.ScheduleEvent(EVENT_ARCANE_BOLT, 1s);
             }
 

--- a/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_pandemonius.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ManaTombs/boss_pandemonius.cpp
@@ -94,7 +94,7 @@ public:
                     else
                     {
                         events.ScheduleEvent(EVENT_VOID_BLAST, 500ms);
-                        events.DelayEvents(EVENT_DARK_SHELL, 500);
+                        events.DelayEvents(500ms, EVENT_DARK_SHELL);
                     }
                     break;
                 case EVENT_DARK_SHELL:

--- a/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_darkweaver_syth.cpp
+++ b/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_darkweaver_syth.cpp
@@ -101,7 +101,7 @@ public:
             events.ScheduleEvent(EVENT_ARCANE_SHOCK, 4s);
             events.ScheduleEvent(EVENT_FROST_SHOCK, 6s);
             events.ScheduleEvent(EVENT_SHADOW_SHOCK, 8s);
-            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 15000);
+            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 15s);
 
             Talk(SAY_AGGRO);
         }
@@ -190,7 +190,7 @@ public:
                 case EVENT_CHAIN_LIGHTNING:
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                         DoCast(target, SPELL_CHAIN_LIGHTNING);
-                    events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 25000);
+                    events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 25s);
                     break;
                 default:
                     break;

--- a/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_talon_king_ikiss.cpp
+++ b/src/server/scripts/Outland/Auchindoun/SethekkHalls/boss_talon_king_ikiss.cpp
@@ -87,7 +87,7 @@ public:
             Talk(SAY_AGGRO);
             events.ScheduleEvent(EVENT_ARCANE_VOLLEY, 5s);
             events.ScheduleEvent(EVENT_POLYMORPH, 8s);
-            events.ScheduleEvent(EVENT_BLINK, 35000);
+            events.ScheduleEvent(EVENT_BLINK, 35s);
             if (IsHeroic())
                 events.ScheduleEvent(EVENT_SLOW, 15s, 30s);
         }
@@ -102,7 +102,7 @@ public:
                         DoCast(SelectTarget(SelectTargetMethod::Random, 0), SPELL_POLYMORPH);
                     else
                         DoCast(SelectTarget(SelectTargetMethod::MaxThreat, 1), SPELL_POLYMORPH);
-                    events.ScheduleEvent(EVENT_POLYMORPH, urand(15000, 17500));
+                    events.ScheduleEvent(EVENT_POLYMORPH, 15s, 17500ms);
                     break;
                 case EVENT_ARCANE_VOLLEY:
                     DoCast(me, SPELL_ARCANE_VOLLEY);

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_blackheart_the_inciter.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_blackheart_the_inciter.cpp
@@ -84,7 +84,7 @@ struct boss_blackheart_the_inciter : public BossAI
         BossAI::JustEngagedWith(who);
         events.ScheduleEvent(EVENT_INCITE_CHAOS, 20s);
         events.ScheduleEvent(EVENT_CHARGE_ATTACK, 5s);
-        events.ScheduleEvent(EVENT_WAR_STOMP, 15000);
+        events.ScheduleEvent(EVENT_WAR_STOMP, 15s);
 
         Talk(SAY_AGGRO);
     }

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_grandmaster_vorpil.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_grandmaster_vorpil.cpp
@@ -143,7 +143,7 @@ class boss_grandmaster_vorpil : public CreatureScript
                 events.ScheduleEvent(EVENT_SHADOWBOLT_VOLLEY, 7s, 14s);
                 if (IsHeroic())
                     events.ScheduleEvent(EVENT_BANISH, 15s);
-                events.ScheduleEvent(EVENT_DRAW_SHADOWS, 45000);
+                events.ScheduleEvent(EVENT_DRAW_SHADOWS, 45s);
                 events.ScheduleEvent(EVENT_SUMMON_TRAVELER, 90s);
 
                 Talk(SAY_AGGRO);

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_murmur.cpp
@@ -73,7 +73,7 @@ class boss_murmur : public CreatureScript
                 events.ScheduleEvent(EVENT_MAGNETIC_PULL, 15s, 30s);
                 if (IsHeroic())
                 {
-                    events.ScheduleEvent(EVENT_THUNDERING_STORM, 15000);
+                    events.ScheduleEvent(EVENT_THUNDERING_STORM, 15s);
                     events.ScheduleEvent(EVENT_SONIC_SHOCK, 10s);
                 }
 
@@ -127,7 +127,7 @@ class boss_murmur : public CreatureScript
                             break;
                         case EVENT_THUNDERING_STORM:
                             DoCastAOE(SPELL_THUNDERING_STORM, true);
-                            events.ScheduleEvent(EVENT_THUNDERING_STORM, 15000);
+                            events.ScheduleEvent(EVENT_THUNDERING_STORM, 15s);
                             break;
                         case EVENT_SONIC_SHOCK:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 20.0f, false))


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Auchindoun: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build