### PR TITLE
Scripts/HellfireCitadel: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_the_maker.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/BloodFurnace/boss_the_maker.cpp
@@ -56,9 +56,9 @@ class boss_the_maker : public CreatureScript
                 BossAI::JustEngagedWith(who);
                 Talk(SAY_AGGRO);
 
-                events.ScheduleEvent(EVENT_ACID_SPRAY, 15000);
+                events.ScheduleEvent(EVENT_ACID_SPRAY, 15s);
                 events.ScheduleEvent(EVENT_EXPLODING_BREAKER, 6s);
-                events.ScheduleEvent(EVENT_DOMINATION, 120000);
+                events.ScheduleEvent(EVENT_DOMINATION, 120s);
                 events.ScheduleEvent(EVENT_KNOCKDOWN, 10s);
             }
 
@@ -90,7 +90,7 @@ class boss_the_maker : public CreatureScript
                     case EVENT_DOMINATION:
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                             DoCast(target, SPELL_DOMINATION);
-                        events.ScheduleEvent(EVENT_DOMINATION, 120000);
+                        events.ScheduleEvent(EVENT_DOMINATION, 120s);
                         break;
                     case EVENT_KNOCKDOWN:
                         DoCastVictim(SPELL_KNOCKDOWN);

--- a/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_watchkeeper_gargolmar.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/HellfireRamparts/boss_watchkeeper_gargolmar.cpp
@@ -128,13 +128,13 @@ class boss_watchkeeper_gargolmar : public CreatureScript
                     {
                         case EVENT_MORTAL_WOUND:
                             DoCastVictim(SPELL_MORTAL_WOUND);
-                            events.ScheduleEvent(EVENT_MORTAL_WOUND, urand (5000, 13000));
+                            events.ScheduleEvent(EVENT_MORTAL_WOUND, 5s, 13s);
                             break;
                         case EVENT_SURGE:
                             Talk(SAY_SURGE);
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                                 DoCast(target, SPELL_SURGE);
-                            events.ScheduleEvent(EVENT_SURGE, urand (5000, 13000));
+                            events.ScheduleEvent(EVENT_SURGE, 5s, 13s);
                             break;
                         case EVENT_RETALIATION:
                             DoCast(me, SPELL_RETALIATION);

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/boss_nethekurse.cpp
@@ -355,7 +355,7 @@ class npc_fel_orc_convert : public CreatureScript
                 if (events.ExecuteEvent() == EVENT_HEMORRHAGE)
                 {
                     DoCastVictim(SPELL_HEMORRHAGE);
-                    events.ScheduleEvent(EVENT_HEMORRHAGE, 15000);
+                    events.ScheduleEvent(EVENT_HEMORRHAGE, 15s);
                 }
 
                 DoMeleeAttackIfReady();


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/HellfireCitadel: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build