### PR TITLE
Scripts/CoilfangReservoir: Use std::chrono::duration overloads of Eve…

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SteamVault/boss_hydromancer_thespia.cpp
@@ -72,7 +72,7 @@ class boss_hydromancer_thespia : public CreatureScript
                 Talk(SAY_AGGRO);
                 BossAI::JustEngagedWith(who);
 
-                events.ScheduleEvent(EVENT_LIGHTNING_CLOUD, 15000);
+                events.ScheduleEvent(EVENT_LIGHTNING_CLOUD, 15s);
                 events.ScheduleEvent(EVENT_LUNG_BURST, 7s);
                 events.ScheduleEvent(EVENT_ENVELOPING_WINDS, 9s);
             }

--- a/src/server/scripts/Outland/CoilfangReservoir/TheSlavePens/boss_quagmirran.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/TheSlavePens/boss_quagmirran.cpp
@@ -64,7 +64,7 @@ class boss_quagmirran : public CreatureScript
             void JustEngagedWith(Unit* who) override
             {
                 BossAI::JustEngagedWith(who);
-                events.ScheduleEvent(EVENT_ACID_SPRAY, 25000);
+                events.ScheduleEvent(EVENT_ACID_SPRAY, 25s);
                 events.ScheduleEvent(EVENT_CLEAVE, 9s);
                 events.ScheduleEvent(EVENT_UPPERCUT, 20s);
                 events.ScheduleEvent(EVENT_POISON_BOLT_VOLLEY, 31s);


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/CoilfangReservoir: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build