### PR TITLE
Scripts/AzjolNerub: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/Ahnkahet/boss_prince_taldaram.cpp
@@ -186,7 +186,7 @@ class boss_prince_taldaram : public CreatureScript
                                 _flameSphereTargetGUID = victim->GetGUID();
                                 DoCast(victim, SPELL_CONJURE_FLAME_SPHERE);
                             }
-                            events.ScheduleEvent(EVENT_CONJURE_FLAME_SPHERES, 15000);
+                            events.ScheduleEvent(EVENT_CONJURE_FLAME_SPHERES, 15s);
                             break;
                         case EVENT_VANISH:
                         {
@@ -196,7 +196,7 @@ class boss_prince_taldaram : public CreatureScript
                                     _embraceTargetGUID = embraceTarget->GetGUID();
                                 Talk(SAY_VANISH);
                                 DoCast(me, SPELL_VANISH);
-                                events.DelayEvents(500);
+                                events.DelayEvents(500ms);
                                 events.ScheduleEvent(EVENT_START_FEEDING, 2s);
                             }
                             events.ScheduleEvent(EVENT_VANISH, 25s, 35s);

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -356,7 +356,7 @@ public:
                 if (_nextSubmerge && me->HealthBelowPctDamaged(_nextSubmerge, damage))
                 {
                     events.CancelEvent(EVENT_SUBMERGE);
-                    events.ScheduleEvent(EVENT_SUBMERGE, 0, 0, PHASE_EMERGE);
+                    events.ScheduleEvent(EVENT_SUBMERGE, 0s, 0, PHASE_EMERGE);
                     _nextSubmerge = _nextSubmerge-25;
                 }
         }


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/AzjolNerub: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build