### PR TITLE
Scripts/ChamberOfAspects: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -178,7 +178,7 @@ public:
             events.ScheduleEvent(EVENT_FLAME_TSUNAMI, 30s);
             events.ScheduleEvent(EVENT_CALL_TENEBRON, 30s);
             events.ScheduleEvent(EVENT_CALL_SHADRON, 75s);
-            events.ScheduleEvent(EVENT_CALL_VESPERON, 120000);
+            events.ScheduleEvent(EVENT_CALL_VESPERON, 120s);
         }
 
         void JustDied(Unit* /*killer*/) override
@@ -469,7 +469,10 @@ public:
                             if (urand(0, 5) == 0)
                                 Talk(SAY_SARTHARION_SPECIAL);
                         }
-                        events.ScheduleEvent(EVENT_LAVA_STRIKE, (_isSoftEnraged ? urand(1400, 2000) : urand(5000, 20000)));
+                        if (_isSoftEnraged)
+                            events.ScheduleEvent(EVENT_LAVA_STRIKE, 1400ms, 2s);
+                        else
+                            events.ScheduleEvent(EVENT_LAVA_STRIKE, 5s, 20s);
                         break;
                     case EVENT_CALL_TENEBRON:
                         CallDragon(DATA_TENEBRON);

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/obsidian_sanctum.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/obsidian_sanctum.cpp
@@ -387,12 +387,12 @@ struct dummy_dragonAI : public ScriptedAI
             case EVENT_SHADOW_FISSURE:
                 if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                     DoCast(target, SPELL_SHADOW_FISSURE);
-                events.ScheduleEvent(eventId, urand(15000, 20000));
+                events.ScheduleEvent(eventId, 15s, 20s);
                 break;
             case EVENT_SHADOW_BREATH:
                 Talk(SAY_BREATH);
                 DoCastVictim(SPELL_SHADOW_BREATH);
-                events.ScheduleEvent(eventId, urand(20000, 25000));
+                events.ScheduleEvent(eventId, 20s, 25s);
                 break;
             default:
                 break;

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/ruby_sanctum.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/ruby_sanctum.cpp
@@ -86,13 +86,13 @@ class npc_xerestrasza : public CreatureScript
                     me->SetWalk(true);
                     me->GetMotionMaster()->MovePoint(0, xerestraszaMovePos);
 
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_1, 16000);
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_2, 25000);
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_3, 32000);
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_4, 42000);
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_5, 51000);
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_6, 61000);
-                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_7, 69000);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_1, 16s);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_2, 25s);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_3, 32s);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_4, 42s);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_5, 51s);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_6, 61s);
+                    _events.ScheduleEvent(EVENT_XERESTRASZA_EVENT_7, 69s);
                 }
                 else if (action == ACTION_INTRO_BALTHARUS && !_introDone)
                 {


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/ChamberOfAspects: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build