### PR TITLE
Scripts/DraktharonKeep: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/DraktharonKeep/boss_king_dred.cpp
+++ b/src/server/scripts/Northrend/DraktharonKeep/boss_king_dred.cpp
@@ -82,7 +82,7 @@ class boss_king_dred : public CreatureScript
 
                 events.ScheduleEvent(EVENT_BELLOWING_ROAR, 33s);
                 events.ScheduleEvent(EVENT_GRIEVOUS_BITE, 20s);
-                events.ScheduleEvent(EVENT_MANGLING_SLASH, 18500);
+                events.ScheduleEvent(EVENT_MANGLING_SLASH, 18500ms);
                 events.ScheduleEvent(EVENT_FEARSOME_ROAR, 10s, 20s);
                 events.ScheduleEvent(EVENT_PIERCING_SLASH, 15s);
                 events.ScheduleEvent(EVENT_RAPTOR_CALL, 20s, 25s);
@@ -131,7 +131,7 @@ class boss_king_dred : public CreatureScript
                             break;
                         case EVENT_MANGLING_SLASH:
                             DoCastVictim(SPELL_MANGLING_SLASH);
-                            events.ScheduleEvent(EVENT_MANGLING_SLASH, 18500);
+                            events.ScheduleEvent(EVENT_MANGLING_SLASH, 18500ms);
                             break;
                         case EVENT_FEARSOME_ROAR:
                             DoCastAOE(SPELL_FEARSOME_ROAR);


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/DraktharonKeep: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build