### PR TITLE
Scripts/FrozenHalls: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
@@ -86,7 +86,7 @@ class boss_bronjahm : public CreatureScript
                 events.SetPhase(PHASE_1);
                 events.ScheduleEvent(EVENT_SHADOW_BOLT, 2s);
                 events.ScheduleEvent(EVENT_MAGIC_BANE, 8s, 20s);
-                events.ScheduleEvent(EVENT_CORRUPT_SOUL, urand(25000, 35000), 0, PHASE_1);
+                events.ScheduleEvent(EVENT_CORRUPT_SOUL, 25s, 35s, 0, PHASE_1);
             }
 
             void JustReachedHome() override
@@ -120,8 +120,8 @@ class boss_bronjahm : public CreatureScript
                 {
                     events.SetPhase(PHASE_2);
                     DoCast(me, SPELL_TELEPORT);
-                    events.ScheduleEvent(EVENT_FEAR, urand(12000, 16000), 0, PHASE_2);
-                    events.ScheduleEvent(EVENT_SOULSTORM, 100, 0, PHASE_2);
+                    events.ScheduleEvent(EVENT_FEAR, 12s, 16s, 0, PHASE_2);
+                    events.ScheduleEvent(EVENT_SOULSTORM, 100ms, 0, PHASE_2);
                 }
             }
 
@@ -190,7 +190,7 @@ class boss_bronjahm : public CreatureScript
                                 Talk(SAY_CORRUPT_SOUL);
                                 DoCast(target, SPELL_CORRUPT_SOUL);
                             }
-                            events.ScheduleEvent(EVENT_CORRUPT_SOUL, urand(25000, 35000), 0, PHASE_1);
+                            events.ScheduleEvent(EVENT_CORRUPT_SOUL, 25s, 35s, 0, PHASE_1);
                             break;
                         case EVENT_SOULSTORM:
                             Talk(SAY_SOUL_STORM);
@@ -199,7 +199,7 @@ class boss_bronjahm : public CreatureScript
                             break;
                         case EVENT_FEAR:
                             me->CastSpell(nullptr, SPELL_FEAR, { SPELLVALUE_MAX_TARGETS, 1 });
-                            events.ScheduleEvent(EVENT_FEAR, urand(8000, 12000), 0, PHASE_2);
+                            events.ScheduleEvent(EVENT_FEAR, 8s, 12s, 0, PHASE_2);
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_devourer_of_souls.cpp
@@ -305,7 +305,7 @@ class boss_devourer_of_souls : public CreatureScript
                             me->SetControlled(true, UNIT_STATE_ROOT);
 
                             wailingSoulTick = 15;
-                            events.DelayEvents(18000); // no other events during wailing souls
+                            events.DelayEvents(18s); // no other events during wailing souls
                             events.ScheduleEvent(EVENT_WAILING_SOULS_TICK, 3s); // first one after 3 secs.
                             break;
 

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/forge_of_souls.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/forge_of_souls.cpp
@@ -114,7 +114,7 @@ public:
                 phase = PHASE_INTRO;
                 me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 events.Reset();
-                events.ScheduleEvent(EVENT_INTRO_1, 1000);
+                events.ScheduleEvent(EVENT_INTRO_1, 1s);
             }
             return false;
         }
@@ -128,27 +128,27 @@ public:
                 {
                     case EVENT_INTRO_1:
                         Talk(SAY_SYLVANAS_INTRO_1);
-                        events.ScheduleEvent(EVENT_INTRO_2, 11500);
+                        events.ScheduleEvent(EVENT_INTRO_2, 11500ms);
                         break;
 
                     case EVENT_INTRO_2:
                         Talk(SAY_SYLVANAS_INTRO_2);
-                        events.ScheduleEvent(EVENT_INTRO_3, 10500);
+                        events.ScheduleEvent(EVENT_INTRO_3, 10500ms);
                         break;
 
                     case EVENT_INTRO_3:
                         Talk(SAY_SYLVANAS_INTRO_3);
-                        events.ScheduleEvent(EVENT_INTRO_4, 9500);
+                        events.ScheduleEvent(EVENT_INTRO_4, 9500ms);
                         break;
 
                     case EVENT_INTRO_4:
                         Talk(SAY_SYLVANAS_INTRO_4);
-                        events.ScheduleEvent(EVENT_INTRO_5, 10500);
+                        events.ScheduleEvent(EVENT_INTRO_5, 10500ms);
                         break;
 
                     case EVENT_INTRO_5:
                         Talk(SAY_SYLVANAS_INTRO_5);
-                        events.ScheduleEvent(EVENT_INTRO_6, 9500);
+                        events.ScheduleEvent(EVENT_INTRO_6, 9500ms);
                         break;
 
                     case EVENT_INTRO_6:
@@ -212,7 +212,7 @@ public:
                 phase = PHASE_INTRO;
                 me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 events.Reset();
-                events.ScheduleEvent(EVENT_INTRO_1, 1000);
+                events.ScheduleEvent(EVENT_INTRO_1, 1s);
             }
             return false;
         }
@@ -226,37 +226,37 @@ public:
                 {
                     case EVENT_INTRO_1:
                         Talk(SAY_JAINA_INTRO_1);
-                        events.ScheduleEvent(EVENT_INTRO_2, 8000);
+                        events.ScheduleEvent(EVENT_INTRO_2, 8s);
                         break;
 
                     case EVENT_INTRO_2:
                         Talk(SAY_JAINA_INTRO_2);
-                        events.ScheduleEvent(EVENT_INTRO_3, 8500);
+                        events.ScheduleEvent(EVENT_INTRO_3, 8500ms);
                         break;
 
                     case EVENT_INTRO_3:
                         Talk(SAY_JAINA_INTRO_3);
-                        events.ScheduleEvent(EVENT_INTRO_4, 8000);
+                        events.ScheduleEvent(EVENT_INTRO_4, 8s);
                         break;
 
                     case EVENT_INTRO_4:
                         Talk(SAY_JAINA_INTRO_4);
-                        events.ScheduleEvent(EVENT_INTRO_5, 10000);
+                        events.ScheduleEvent(EVENT_INTRO_5, 10s);
                         break;
 
                     case EVENT_INTRO_5:
                         Talk(SAY_JAINA_INTRO_5);
-                        events.ScheduleEvent(EVENT_INTRO_6, 8000);
+                        events.ScheduleEvent(EVENT_INTRO_6, 8s);
                         break;
 
                     case EVENT_INTRO_6:
                         Talk(SAY_JAINA_INTRO_6);
-                        events.ScheduleEvent(EVENT_INTRO_7, 12000);
+                        events.ScheduleEvent(EVENT_INTRO_7, 12s);
                         break;
 
                     case EVENT_INTRO_7:
                         Talk(SAY_JAINA_INTRO_7);
-                        events.ScheduleEvent(EVENT_INTRO_8, 8000);
+                        events.ScheduleEvent(EVENT_INTRO_8, 8s);
                         break;
 
                     case EVENT_INTRO_8:

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -404,7 +404,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
 
                 me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP | UNIT_NPC_FLAG_QUESTGIVER);
                 me->SetStandState(UNIT_STAND_STATE_STAND);
-                _events.ScheduleEvent(EVENT_WALK_INTRO1, 3000);
+                _events.ScheduleEvent(EVENT_WALK_INTRO1, 3s);
             }
 
             void UpdateAI(uint32 diff) override
@@ -421,13 +421,13 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                         {
                             me->GetMotionMaster()->MovePoint(0, JainaIntroPosition[1]);
                             Talk(SAY_JAINA_INTRO_1);
-                            _events.ScheduleEvent(EVENT_WALK_INTRO2, 7000);
+                            _events.ScheduleEvent(EVENT_WALK_INTRO2, 7s);
                         }
                         else
                         {
                             me->GetMotionMaster()->MovePoint(0, SylvanasIntroPosition[1]);
                             Talk(SAY_SYLVANAS_INTRO_1);
-                            _events.ScheduleEvent(EVENT_WALK_INTRO2, 9000);
+                            _events.ScheduleEvent(EVENT_WALK_INTRO2, 9s);
                         }
                         break;
                     case EVENT_WALK_INTRO2:
@@ -444,92 +444,92 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                         if (_instance->GetData(DATA_TEAM_IN_INSTANCE) == ALLIANCE)
                         {
                             me->GetMotionMaster()->MovePoint(0, JainaIntroPosition[2]);
-                            _events.ScheduleEvent(EVENT_INTRO_A2_1, 0);
+                            _events.ScheduleEvent(EVENT_INTRO_A2_1, 0s);
                         }
                         else
                         {
                             me->GetMotionMaster()->MovePoint(0, SylvanasIntroPosition[2]);
-                            _events.ScheduleEvent(EVENT_INTRO_H2_1, 0);
+                            _events.ScheduleEvent(EVENT_INTRO_H2_1, 0s);
                         }
                         break;
                     // A2 Intro Events
                     case EVENT_INTRO_A2_1:
                         Talk(SAY_JAINA_INTRO_3);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_2, 7000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_2, 7s);
                         break;
                     case EVENT_INTRO_A2_2:
                         Talk(SAY_JAINA_INTRO_4);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_3, 10000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_3, 10s);
                         break;
                     case EVENT_INTRO_A2_3:
                         me->CastSpell(me, SPELL_CAST_VISUAL, false);
                         me->CastSpell(me, SPELL_FROSTMOURNE_SOUNDS, true);
                         _instance->HandleGameObject(_instance->GetGuidData(DATA_FROSTMOURNE), true);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_4, 10000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_4, 10s);
                         break;
                     case EVENT_INTRO_A2_4:
                         if (Creature* uther = me->SummonCreature(NPC_UTHER, UtherSpawnPos, TEMPSUMMON_MANUAL_DESPAWN))
                             _utherGUID = uther->GetGUID();
-                        _events.ScheduleEvent(EVENT_INTRO_A2_5, 2000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_5, 2s);
                         break;
                     case EVENT_INTRO_A2_5:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_1);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_6, 3000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_6, 3s);
                         break;
                     case EVENT_INTRO_A2_6:
                         Talk(SAY_JAINA_INTRO_5);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_7, 7000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_7, 7s);
                         break;
                     case EVENT_INTRO_A2_7:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_2);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_8, 7000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_8, 7s);
                         break;
                     case EVENT_INTRO_A2_8:
                         Talk(SAY_JAINA_INTRO_6);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_9, 1200);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_9, 1200ms);
                         break;
                     case EVENT_INTRO_A2_9:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_3);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_10, 11000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_10, 11s);
                         break;
                     case EVENT_INTRO_A2_10:
                         Talk(SAY_JAINA_INTRO_7);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_11, 6000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_11, 6s);
                         break;
                     case EVENT_INTRO_A2_11:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_4);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_12, 12000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_12, 12s);
                         break;
                     case EVENT_INTRO_A2_12:
                         Talk(SAY_JAINA_INTRO_8);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_13, 6000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_13, 6s);
                         break;
                     case EVENT_INTRO_A2_13:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_5);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_14, 13000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_14, 13s);
                         break;
                     case EVENT_INTRO_A2_14:
                         Talk(SAY_JAINA_INTRO_9);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_15, 12000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_15, 12s);
                         break;
                     case EVENT_INTRO_A2_15:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_6);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_16, 25000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_16, 25s);
                         break;
                     case EVENT_INTRO_A2_16:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_7);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_17, 6000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_17, 6s);
                         break;
                     case EVENT_INTRO_A2_17:
                         Talk(SAY_JAINA_INTRO_10);
-                        _events.ScheduleEvent(EVENT_INTRO_A2_18, 5000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_18, 5s);
                         break;
                     case EVENT_INTRO_A2_18:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
@@ -537,69 +537,69 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             uther->HandleEmoteCommand(EMOTE_ONESHOT_NO);
                             uther->AI()->Talk(SAY_UTHER_INTRO_A2_8);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_A2_19, 12000);
+                        _events.ScheduleEvent(EVENT_INTRO_A2_19, 12s);
                         break;
                     case EVENT_INTRO_A2_19:
                         Talk(SAY_JAINA_INTRO_11);
-                        _events.ScheduleEvent(EVENT_INTRO_LK_1, 3000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_1, 3s);
                         break;
                     // H2 Intro Events
                     case EVENT_INTRO_H2_1:
                         Talk(SAY_SYLVANAS_INTRO_1);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_2, 8000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_2, 8s);
                         break;
                     case EVENT_INTRO_H2_2:
                         Talk(SAY_SYLVANAS_INTRO_2);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_3, 6000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_3, 6s);
                         break;
                     case EVENT_INTRO_H2_3:
                         Talk(SAY_SYLVANAS_INTRO_3);
                         me->CastSpell(me, SPELL_CAST_VISUAL, false);
                         me->CastSpell(me, SPELL_FROSTMOURNE_SOUNDS, true);
                         _instance->HandleGameObject(_instance->GetGuidData(DATA_FROSTMOURNE), true);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_4, 6000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_4, 6s);
                         break;
                     case EVENT_INTRO_H2_4:
                         // spawn UTHER during speach 2
                         if (Creature* uther = me->SummonCreature(NPC_UTHER, UtherSpawnPos, TEMPSUMMON_MANUAL_DESPAWN))
                             _utherGUID = uther->GetGUID();
-                        _events.ScheduleEvent(EVENT_INTRO_H2_5, 2000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_5, 2s);
                         break;
                     case EVENT_INTRO_H2_5:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_H2_1);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_6, 11000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_6, 11s);
                         break;
                     case EVENT_INTRO_H2_6:
                         Talk(SAY_SYLVANAS_INTRO_4);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_7, 3000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_7, 3s);
                         break;
                     case EVENT_INTRO_H2_7:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_H2_2);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_8, 6000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_8, 6s);
                         break;
                     case EVENT_INTRO_H2_8:
                         Talk(SAY_SYLVANAS_INTRO_5);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_9, 5000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_9, 5s);
                         break;
                     case EVENT_INTRO_H2_9:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_H2_3);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_10, 19000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_10, 19s);
                         break;
                     case EVENT_INTRO_H2_10:
                         Talk(SAY_SYLVANAS_INTRO_6);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_11, 1500);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_11, 1500ms);
                         break;
                     case EVENT_INTRO_H2_11:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_H2_4);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_12, 19500);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_12, 19500ms);
                         break;
                     case EVENT_INTRO_H2_12:
                         Talk(SAY_SYLVANAS_INTRO_7);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_13, 2000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_13, 2s);
                         break;
                     case EVENT_INTRO_H2_13:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
@@ -607,16 +607,16 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             uther->HandleEmoteCommand(EMOTE_ONESHOT_NO);
                             uther->AI()->Talk(SAY_UTHER_INTRO_H2_5);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_H2_14, 12000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_14, 12s);
                         break;
                     case EVENT_INTRO_H2_14:
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
                             uther->AI()->Talk(SAY_UTHER_INTRO_H2_6);
-                        _events.ScheduleEvent(EVENT_INTRO_H2_15, 8000);
+                        _events.ScheduleEvent(EVENT_INTRO_H2_15, 8s);
                         break;
                     case EVENT_INTRO_H2_15:
                         Talk(SAY_SYLVANAS_INTRO_8);
-                        _events.ScheduleEvent(EVENT_INTRO_LK_1, 2000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_1, 2s);
                         break;
                     // Remaining Intro Events common for both faction
                     case EVENT_INTRO_LK_1:
@@ -626,7 +626,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             lichking->SetWalk(true);
                             lichking->GetMotionMaster()->MovePoint(0, LichKingIntroPosition[2]);
                             _lichkingGUID = lichking->GetGUID();
-                            _events.ScheduleEvent(EVENT_OPEN_IMPENETRABLE_DOOR, 0);
+                            _events.ScheduleEvent(EVENT_OPEN_IMPENETRABLE_DOOR, 0s);
                             _events.ScheduleEvent(EVENT_CLOSE_IMPENETRABLE_DOOR, 4s);
                         }
                         if (Creature* uther = ObjectAccessor::GetCreature(*me, _utherGUID))
@@ -637,12 +637,12 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             else
                                 uther->AI()->Talk(SAY_UTHER_INTRO_H2_7);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_2, 10000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_2, 10s);
                         break;
                     case EVENT_INTRO_LK_2:
                         if (Creature* lichking = ObjectAccessor::GetCreature(*me, _lichkingGUID))
                             lichking->AI()->Talk(SAY_LK_INTRO_1);
-                        _events.ScheduleEvent(EVENT_INTRO_LK_3, 1000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_3, 1s);
                         break;
                     case EVENT_INTRO_LK_3:
                         // The Lich King banishes Uther to the abyss.
@@ -652,7 +652,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             uther->DespawnOrUnsummon(5000);
                             _utherGUID.Clear();
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_4, 9000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_4, 9s);
                         break;
                     case EVENT_INTRO_LK_4:
                         // He steps forward and removes the runeblade from the heap of skulls.
@@ -663,12 +663,12 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             lichking->CastSpell(lichking, SPELL_TAKE_FROSTMOURNE, true);
                             lichking->CastSpell(lichking, SPELL_FROSTMOURNE_VISUAL, true);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_5, 8000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_5, 8s);
                         break;
                     case EVENT_INTRO_LK_5:
                         if (Creature* lichking = ObjectAccessor::GetCreature(*me, _lichkingGUID))
                             lichking->AI()->Talk(SAY_LK_INTRO_2);
-                        _events.ScheduleEvent(EVENT_INTRO_LK_6, 10000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_6, 10s);
                         break;
                     case EVENT_INTRO_LK_6:
                         // summon Falric and Marwyn. then go back to the door
@@ -688,7 +688,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             lichking->SetWalk(true);
                             lichking->GetMotionMaster()->MovePoint(0, LichKingMoveAwayPos);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_7, 10000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_7, 10s);
                         _events.ScheduleEvent(EVENT_OPEN_IMPENETRABLE_DOOR, 5s);
                         break;
                     case EVENT_INTRO_LK_7:
@@ -698,7 +698,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             marwyn->SetWalk(true);
                             marwyn->GetMotionMaster()->MovePoint(0, MarwynPosition[1]);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_8, 1000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_8, 1s);
                         break;
                     case EVENT_INTRO_LK_8:
                         if (Creature* falric = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_FALRIC)))
@@ -707,13 +707,13 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             falric->SetWalk(true);
                             falric->GetMotionMaster()->MovePoint(0, FalricPosition[1]);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_9, 5000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_9, 5s);
                         break;
                     case EVENT_INTRO_LK_9:
                         if (Creature* falric = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_FALRIC)))
                             falric->AI()->Talk(SAY_FALRIC_INTRO_2);
                         _instance->ProcessEvent(0, EVENT_SPAWN_WAVES);
-                        _events.ScheduleEvent(EVENT_INTRO_LK_10, 4000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_10, 4s);
                         break;
                     case EVENT_INTRO_LK_10:
                         if (_instance->GetData(DATA_TEAM_IN_INSTANCE) == ALLIANCE)
@@ -724,7 +724,7 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                         /// @todo: needs some improvements
                         if (Creature* korelnOrLoralen = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_KORELN_LORALEN)))
                             korelnOrLoralen->GetMotionMaster()->MovePoint(1, KorelnOrLoralenPos[2]);
-                        _events.ScheduleEvent(EVENT_INTRO_LK_11, 5000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_11, 5s);
                         break;
                     case EVENT_INTRO_LK_11:
                         if (Creature* lichking = ObjectAccessor::GetCreature(*me, _lichkingGUID))
@@ -762,10 +762,10 @@ class npc_jaina_or_sylvanas_intro_hor : public CreatureScript
                             lichking->GetMotionMaster()->MovePoint(0, LichKingIntroPosition[2]);
                             lichking->SetReactState(REACT_PASSIVE);
                             _lichkingGUID = lichking->GetGUID();
-                            _events.ScheduleEvent(EVENT_OPEN_IMPENETRABLE_DOOR, 0);
+                            _events.ScheduleEvent(EVENT_OPEN_IMPENETRABLE_DOOR, 0s);
                             _events.ScheduleEvent(EVENT_CLOSE_IMPENETRABLE_DOOR, 4s);
                         }
-                        _events.ScheduleEvent(EVENT_INTRO_LK_4, 15000);
+                        _events.ScheduleEvent(EVENT_INTRO_LK_4, 15s);
                         break;
                     case EVENT_OPEN_IMPENETRABLE_DOOR:
                         _instance->HandleGameObject(_instance->GetGuidData(DATA_IMPENETRABLE_DOOR), true);
@@ -860,20 +860,20 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                         if (_prefight)
                             return;
                         _prefight = true;
-                        _events.ScheduleEvent(EVENT_ESCAPE_1, 1000);
+                        _events.ScheduleEvent(EVENT_ESCAPE_1, 1s);
                         break;
                     case ACTION_WALL_BROKEN:
                         ++_icewall;
                         if (_icewall < 4)
-                            _events.ScheduleEvent(EVENT_ESCAPE_13, 3000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_13, 3s);
                         else
-                            _events.ScheduleEvent(EVENT_ESCAPE_15, 3000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_15, 3s);
                         break;
                     case ACTION_GUNSHIP_ARRIVAL:
-                        _events.ScheduleEvent(EVENT_ESCAPE_16, 5000);
+                        _events.ScheduleEvent(EVENT_ESCAPE_16, 5s);
                         break;
                     case ACTION_GUNSHIP_ARRIVAL_2:
-                        _events.ScheduleEvent(EVENT_ESCAPE_17, 5000);
+                        _events.ScheduleEvent(EVENT_ESCAPE_17, 5s);
                         break;
                     default:
                         break;
@@ -903,7 +903,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                     case 0:
                         player->PlayerTalkClass->SendCloseGossip();
                         me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                        _events.ScheduleEvent(EVENT_ESCAPE_6, 0);
+                        _events.ScheduleEvent(EVENT_ESCAPE_6, 0s);
                         break;
                     default:
                         break;
@@ -1022,7 +1022,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                                     lichking->AI()->Talk(SAY_LK_ESCAPE_1);
                                 else
                                     lichking->AI()->Talk(SAY_LK_ESCAPE_2);
-                                _events.ScheduleEvent(EVENT_ESCAPE_2, 8000);
+                                _events.ScheduleEvent(EVENT_ESCAPE_2, 8s);
                             }
                             break;
                         case EVENT_ESCAPE_2:
@@ -1041,12 +1041,12 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                                 lichking->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED);
                             }
 
-                            _events.ScheduleEvent(EVENT_ESCAPE_3, 1500);
+                            _events.ScheduleEvent(EVENT_ESCAPE_3, 1500ms);
                             break;
                         case EVENT_ESCAPE_3:
                             if (_instance->GetData(DATA_TEAM_IN_INSTANCE) == HORDE)
                                 DoCastAOE(SPELL_SYLVANAS_DARK_BINDING, true);
-                            _events.ScheduleEvent(EVENT_ESCAPE_4, 1000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_4, 1s);
                             break;
                         case EVENT_ESCAPE_4:
                             if (_instance->GetData(DATA_TEAM_IN_INSTANCE) == ALLIANCE)
@@ -1063,7 +1063,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                                 DeleteAllFromThreatList(lichking, me->GetGUID());
                             }
 
-                            _events.ScheduleEvent(EVENT_ESCAPE_5, 2000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_5, 2s);
                             break;
                         case EVENT_ESCAPE_5:
                             me->GetMotionMaster()->MovePoint(POINT_SHADOW_THRONE_DOOR, SylvanasShadowThroneDoorPosition);
@@ -1087,32 +1087,32 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
                             }
                             _invincibility = false;
                             _instance->DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_NOT_RETREATING_EVENT);
-                            _events.ScheduleEvent(EVENT_ESCAPE_7, 1000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_7, 1s);
                             break;
                         case EVENT_ESCAPE_7:
                             if (Creature* lichking = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING_ESCAPE)))
                                 lichking->HandleEmoteCommand(TEXT_EMOTE_ROAR);
                             me->GetMotionMaster()->MovePoint(0, NpcJainaOrSylvanasEscapeRoute[0]);
-                            _events.ScheduleEvent(EVENT_ESCAPE_8, 3000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_8, 3s);
                             break;
                         case EVENT_ESCAPE_8:
                             if (Creature* lichking = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING_ESCAPE)))
                                 lichking->GetMotionMaster()->MovePoint(0, NpcJainaOrSylvanasEscapeRoute[0]);
-                            _events.ScheduleEvent(EVENT_ESCAPE_9, 1000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_9, 1s);
                             break;
                         case EVENT_ESCAPE_9:
                             me->GetMotionMaster()->MovePoint(0, NpcJainaOrSylvanasEscapeRoute[1]);
-                            _events.ScheduleEvent(EVENT_ESCAPE_10, 5000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_10, 5s);
                             break;
                         case EVENT_ESCAPE_10:
                             me->GetMotionMaster()->MovePoint(0, NpcJainaOrSylvanasEscapeRoute[2]);
                             if (Creature* lichking = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING_ESCAPE)))
                                 lichking->GetMotionMaster()->MovePoint(1, LichKingFirstSummon);
-                            _events.ScheduleEvent(EVENT_ESCAPE_11, 6000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_11, 6s);
                             break;
                         case EVENT_ESCAPE_11:
                             SummonIceWall();
-                            _events.ScheduleEvent(EVENT_ESCAPE_12, 4000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_12, 4s);
                             break;
                         case EVENT_ESCAPE_12:
                             if (Creature* lichking = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING_ESCAPE)))
@@ -1125,7 +1125,7 @@ class npc_jaina_or_sylvanas_escape_hor : public CreatureScript
 
                             if (_icewall && _icewall < 4)
                                 me->GetMotionMaster()->MovePoint(POINT_ATTACK_ICEWALL, NpcJainaOrSylvanasEscapeRoute[_icewall + 3]);
-                            _events.ScheduleEvent(EVENT_ESCAPE_14, 8000);
+                            _events.ScheduleEvent(EVENT_ESCAPE_14, 8s);
                             break;
                         case EVENT_ESCAPE_14:
                             SummonIceWall();
@@ -1265,7 +1265,7 @@ class npc_the_lich_king_escape_hor : public CreatureScript
                 {
                     case 0: // 6 Ghouls, 1 Witch Doctor
                         DoZoneInCombat();
-                        _events.ScheduleEvent(EVENT_REMORSELESS_WINTER, 0);
+                        _events.ScheduleEvent(EVENT_REMORSELESS_WINTER, 0s);
                         _events.ScheduleEvent(EVENT_ESCAPE_SUMMON_GHOULS, 8s);
                         _events.ScheduleEvent(EVENT_ESCAPE_SUMMON_WITCH_DOCTOR, 14s);
                         Talk(SAY_LK_ESCAPE_ICEWALL_SUMMONED_1);
@@ -1804,7 +1804,7 @@ class npc_tortured_rifleman : public CreatureScript
 
             void JustEngagedWith(Unit* /*who*/) override
             {
-                _events.ScheduleEvent(EVENT_SHOOT, 1);
+                _events.ScheduleEvent(EVENT_SHOOT, 1ms);
                 _events.ScheduleEvent(EVENT_CURSED_ARROW, 7s);
                 _events.ScheduleEvent(EVENT_FROST_TRAP, 10s);
                 _events.ScheduleEvent(EVENT_ICE_SHOT, 15s);
@@ -2474,7 +2474,7 @@ class npc_uther_quel_delar : public CreatureScript
                     return;
 
                 _events.Reset();
-                _events.ScheduleEvent(EVENT_UTHER_1, 1);
+                _events.ScheduleEvent(EVENT_UTHER_1, 1ms);
             }
 
             void DamageTaken(Unit* /*attacker*/, uint32& damage) override
@@ -2489,10 +2489,10 @@ class npc_uther_quel_delar : public CreatureScript
                 {
                     case ACTION_UTHER_START_SCREAM:
                         _instance->SetData(DATA_QUEL_DELAR_EVENT, SPECIAL);
-                        _events.ScheduleEvent(EVENT_UTHER_2, 0);
+                        _events.ScheduleEvent(EVENT_UTHER_2, 0s);
                         break;
                     case ACTION_UTHER_OUTRO:
-                        _events.ScheduleEvent(EVENT_UTHER_6, 0);
+                        _events.ScheduleEvent(EVENT_UTHER_6, 0s);
                         break;
                     default:
                         break;
@@ -2530,15 +2530,15 @@ class npc_uther_quel_delar : public CreatureScript
                             if (Creature* bunny = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_FROSTMOURNE_ALTAR_BUNNY)))
                                 if (Unit* target = ObjectAccessor::GetPlayer(*me, _instance->GetGuidData(DATA_QUEL_DELAR_INVOKER)))
                                     bunny->CastSpell(target, SPELL_QUEL_DELAR_WILL, true);
-                            _events.ScheduleEvent(EVENT_UTHER_3, 2000);
+                            _events.ScheduleEvent(EVENT_UTHER_3, 2s);
                             break;
                         case EVENT_UTHER_3:
                             me->SummonCreature(NPC_QUEL_DELAR, QuelDelarSummonPos);
-                            _events.ScheduleEvent(EVENT_UTHER_4, 2000);
+                            _events.ScheduleEvent(EVENT_UTHER_4, 2s);
                             break;
                         case EVENT_UTHER_4:
                             Talk(SAY_UTHER_QUEL_DELAR_2);
-                            _events.ScheduleEvent(EVENT_UTHER_5, 8000);
+                            _events.ScheduleEvent(EVENT_UTHER_5, 8s);
                             break;
                         case EVENT_UTHER_5:
                             me->GetMotionMaster()->MovePoint(1, UtherQuelDelarMovement[0]);
@@ -2546,23 +2546,23 @@ class npc_uther_quel_delar : public CreatureScript
                         case EVENT_UTHER_6:
                             me->SetWalk(true);
                             me->GetMotionMaster()->MovePoint(0, UtherQuelDelarMovement[1]);
-                            _events.ScheduleEvent(EVENT_UTHER_7, 5000);
+                            _events.ScheduleEvent(EVENT_UTHER_7, 5s);
                             break;
                         case EVENT_UTHER_7:
                             Talk(SAY_UTHER_QUEL_DELAR_3);
-                            _events.ScheduleEvent(EVENT_UTHER_8, 12000);
+                            _events.ScheduleEvent(EVENT_UTHER_8, 12s);
                             break;
                         case EVENT_UTHER_8:
                             Talk(SAY_UTHER_QUEL_DELAR_4);
-                            _events.ScheduleEvent(EVENT_UTHER_9, 7000);
+                            _events.ScheduleEvent(EVENT_UTHER_9, 7s);
                             break;
                         case EVENT_UTHER_9:
                             Talk(SAY_UTHER_QUEL_DELAR_5);
-                            _events.ScheduleEvent(EVENT_UTHER_10, 10000);
+                            _events.ScheduleEvent(EVENT_UTHER_10, 10s);
                             break;
                         case EVENT_UTHER_10:
                             Talk(SAY_UTHER_QUEL_DELAR_6);
-                            _events.ScheduleEvent(EVENT_UTHER_11, 5000);
+                            _events.ScheduleEvent(EVENT_UTHER_11, 5s);
                             break;
                         case EVENT_UTHER_11:
                             DoCast(me, SPELL_ESSENCE_OF_CAPTURED_1, true);
@@ -2614,7 +2614,7 @@ class npc_quel_delar_sword : public CreatureScript
                 me->SetSpeedRate(MOVE_FLIGHT, 4.5f);
                 DoCast(SPELL_WHIRLWIND_VISUAL);
                 if (_intro)
-                    _events.ScheduleEvent(EVENT_QUEL_DELAR_INIT, 0);
+                    _events.ScheduleEvent(EVENT_QUEL_DELAR_INIT, 0s);
                 else
                     me->SetImmuneToAll(false);
             }
@@ -2640,7 +2640,7 @@ class npc_quel_delar_sword : public CreatureScript
                 switch (pointId)
                 {
                     case POINT_TAKE_OFF:
-                        _events.ScheduleEvent(EVENT_QUEL_DELAR_FLIGHT, 0);
+                        _events.ScheduleEvent(EVENT_QUEL_DELAR_FLIGHT, 0s);
                         break;
                     default:
                         break;

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_forgemaster_garfrost.cpp
@@ -135,7 +135,7 @@ class boss_garfrost : public CreatureScript
                 {
                     events.SetPhase(PHASE_TWO);
                     Talk(SAY_PHASE2);
-                    events.DelayEvents(8000);
+                    events.DelayEvents(8s);
                     DoCast(me, SPELL_THUNDERING_STOMP);
                     events.ScheduleEvent(EVENT_FORGE_JUMP, 1500ms);
                     return;
@@ -145,7 +145,7 @@ class boss_garfrost : public CreatureScript
                 {
                     events.SetPhase(PHASE_THREE);
                     Talk(SAY_PHASE3);
-                    events.DelayEvents(8000);
+                    events.DelayEvents(8s);
                     DoCast(me, SPELL_THUNDERING_STOMP);
                     events.ScheduleEvent(EVENT_FORGE_JUMP, 1500ms);
                     return;
@@ -209,7 +209,7 @@ class boss_garfrost : public CreatureScript
                                 Talk(SAY_THROW_SARONITE, target);
                                 DoCast(target, SPELL_THROW_SARONITE);
                             }
-                            events.ScheduleEvent(EVENT_THROW_SARONITE, urand(12500, 20000));
+                            events.ScheduleEvent(EVENT_THROW_SARONITE, 12500ms, 20s);
                             break;
                         case EVENT_CHILLING_WAVE:
                             DoCast(me, SPELL_CHILLING_WAVE);

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_krickandick.cpp
@@ -393,7 +393,7 @@ struct boss_krick : public ScriptedAI
                         jainaOrSylvanas->GetMotionMaster()->MovePoint(0, outroPos[3]);
                         _outroNpcGUID = jainaOrSylvanas->GetGUID();
                     }
-                    _events.ScheduleEvent(EVENT_OUTRO_2, 6000);
+                    _events.ScheduleEvent(EVENT_OUTRO_2, 6s);
                     break;
                 }
                 case EVENT_OUTRO_2:
@@ -406,11 +406,11 @@ struct boss_krick : public ScriptedAI
                         else
                             jainaOrSylvanas->AI()->Talk(SAY_SYLVANAS_OUTRO_2);
                     }
-                    _events.ScheduleEvent(EVENT_OUTRO_3, 5000);
+                    _events.ScheduleEvent(EVENT_OUTRO_3, 5s);
                     break;
                 case EVENT_OUTRO_3:
                     Talk(SAY_KRICK_OUTRO_3);
-                    _events.ScheduleEvent(EVENT_OUTRO_4, 18000);
+                    _events.ScheduleEvent(EVENT_OUTRO_4, 18s);
                     break;
                 case EVENT_OUTRO_4:
                     if (Creature* jainaOrSylvanas = ObjectAccessor::GetCreature(*me, _outroNpcGUID))
@@ -420,11 +420,11 @@ struct boss_krick : public ScriptedAI
                         else
                             jainaOrSylvanas->AI()->Talk(SAY_SYLVANAS_OUTRO_4);
                     }
-                    _events.ScheduleEvent(EVENT_OUTRO_5, 5000);
+                    _events.ScheduleEvent(EVENT_OUTRO_5, 5s);
                     break;
                 case EVENT_OUTRO_5:
                     Talk(SAY_KRICK_OUTRO_5);
-                    _events.ScheduleEvent(EVENT_OUTRO_6, 1000);
+                    _events.ScheduleEvent(EVENT_OUTRO_6, 1s);
                     break;
                 case EVENT_OUTRO_6:
                     if (Creature* tyrannus = ObjectAccessor::GetCreature(*me, _instanceScript->GetGuidData(DATA_TYRANNUS_EVENT)))
@@ -433,19 +433,19 @@ struct boss_krick : public ScriptedAI
                         tyrannus->GetMotionMaster()->MovePoint(1, outroPos[4]);
                         _tyrannusGUID = tyrannus->GetGUID();
                     }
-                    _events.ScheduleEvent(EVENT_OUTRO_7, 5000);
+                    _events.ScheduleEvent(EVENT_OUTRO_7, 5s);
                     break;
                 case EVENT_OUTRO_7:
                     if (Creature* tyrannus = ObjectAccessor::GetCreature(*me, _tyrannusGUID))
                         tyrannus->AI()->Talk(SAY_TYRANNUS_OUTRO_7);
-                    _events.ScheduleEvent(EVENT_OUTRO_8, 5000);
+                    _events.ScheduleEvent(EVENT_OUTRO_8, 5s);
                     break;
                 case EVENT_OUTRO_8:
                     //! HACK: Creature's can't have MOVEMENTFLAG_FLYING
                     me->AddUnitMovementFlag(MOVEMENTFLAG_FLYING);
                     me->GetMotionMaster()->MovePoint(0, outroPos[5]);
                     DoCast(me, SPELL_STRANGULATING);
-                    _events.ScheduleEvent(EVENT_OUTRO_9, 2000);
+                    _events.ScheduleEvent(EVENT_OUTRO_9, 2s);
                     break;
                 case EVENT_OUTRO_9:
                     Talk(SAY_KRICK_OUTRO_8);
@@ -453,25 +453,25 @@ struct boss_krick : public ScriptedAI
                     // there shall be some visual spell effect
                     if (Creature* tyrannus = ObjectAccessor::GetCreature(*me, _tyrannusGUID))
                         tyrannus->CastSpell(me, SPELL_NECROMANTIC_POWER, true);  //not sure if it's the right spell :/
-                    _events.ScheduleEvent(EVENT_OUTRO_10, 1000);
+                    _events.ScheduleEvent(EVENT_OUTRO_10, 1s);
                     break;
                 case EVENT_OUTRO_10:
                     //! HACK: Creature's can't have MOVEMENTFLAG_FLYING
                     me->RemoveUnitMovementFlag(MOVEMENTFLAG_FLYING);
                     me->AddUnitMovementFlag(MOVEMENTFLAG_FALLING_FAR);
                     me->GetMotionMaster()->MovePoint(0, outroPos[6]);
-                    _events.ScheduleEvent(EVENT_OUTRO_11, 2000);
+                    _events.ScheduleEvent(EVENT_OUTRO_11, 2s);
                     break;
                 case EVENT_OUTRO_11:
                     DoCast(me, SPELL_KRICK_KILL_CREDIT); // don't really know if we need it
                     me->SetStandState(UNIT_STAND_STATE_DEAD);
                     me->SetHealth(0);
-                    _events.ScheduleEvent(EVENT_OUTRO_12, 3000);
+                    _events.ScheduleEvent(EVENT_OUTRO_12, 3s);
                     break;
                 case EVENT_OUTRO_12:
                     if (Creature* tyrannus = ObjectAccessor::GetCreature(*me, _tyrannusGUID))
                         tyrannus->AI()->Talk(SAY_TYRANNUS_OUTRO_9);
-                    _events.ScheduleEvent(EVENT_OUTRO_13, 2000);
+                    _events.ScheduleEvent(EVENT_OUTRO_13, 2s);
                     break;
                 case EVENT_OUTRO_13:
                     if (Creature* jainaOrSylvanas = ObjectAccessor::GetCreature(*me, _outroNpcGUID))

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/boss_scourgelord_tyrannus.cpp
@@ -210,9 +210,9 @@ class boss_tyrannus : public CreatureScript
                 {
                     Talk(SAY_TYRANNUS_INTRO_1);
                     events.SetPhase(PHASE_INTRO);
-                    events.ScheduleEvent(EVENT_INTRO_1, 14000, 0, PHASE_INTRO);
-                    events.ScheduleEvent(EVENT_INTRO_2, 22000, 0, PHASE_INTRO);
-                    events.ScheduleEvent(EVENT_INTRO_3, 34000, 0, PHASE_INTRO);
+                    events.ScheduleEvent(EVENT_INTRO_1, 14s, 0, PHASE_INTRO);
+                    events.ScheduleEvent(EVENT_INTRO_2, 22s, 0, PHASE_INTRO);
+                    events.ScheduleEvent(EVENT_INTRO_3, 34s, 0, PHASE_INTRO);
                     events.ScheduleEvent(EVENT_COMBAT_START, 36s, 0, PHASE_INTRO);
                     instance->SetBossState(DATA_TYRANNUS, IN_PROGRESS);
                 }
@@ -331,7 +331,7 @@ class boss_rimefang : public CreatureScript
                 {
                     _events.SetPhase(PHASE_COMBAT);
                     DoZoneInCombat();
-                    _events.ScheduleEvent(EVENT_MOVE_NEXT, 500, 0, PHASE_COMBAT);
+                    _events.ScheduleEvent(EVENT_MOVE_NEXT, 500ms, 0, PHASE_COMBAT);
                     _events.ScheduleEvent(EVENT_ICY_BLAST, 15s, 0, PHASE_COMBAT);
                 }
                 else if (actionId == ACTION_END_COMBAT)

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
@@ -94,13 +94,13 @@ class npc_ymirjar_flamebearer : public CreatureScript
                         case EVENT_FIREBALL:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                                 DoCast(target, SPELL_FIREBALL);
-                            _events.RescheduleEvent(EVENT_FIREBALL, 5000);
+                            _events.RescheduleEvent(EVENT_FIREBALL, 5s);
                             break;
                         case EVENT_TACTICAL_BLINK:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                                 DoCast(target, SPELL_TACTICAL_BLINK);
                             DoCast(me, SPELL_HELLFIRE);
-                            _events.RescheduleEvent(EVENT_TACTICAL_BLINK, 12000);
+                            _events.RescheduleEvent(EVENT_TACTICAL_BLINK, 12s);
                             break;
                         default:
                             break;


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/FrozenHalls: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build