### PR TITLE
Scripts/Gundrak: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_eck.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_eck.cpp
@@ -78,7 +78,7 @@ class boss_eck : public CreatureScript
             {
                 if (!_berserk && me->HealthBelowPctDamaged(20, damage))
                 {
-                    events.RescheduleEvent(EVENT_BERSERK, 1000);
+                    events.RescheduleEvent(EVENT_BERSERK, 1s);
                     _berserk = true;
                 }
             }

--- a/src/server/scripts/Northrend/Gundrak/gundrak.h
+++ b/src/server/scripts/Northrend/Gundrak/gundrak.h
@@ -88,7 +88,7 @@ enum GDSpellIds
     SPELL_FIRE_BEAM_ELEMENTAL        = 57072
 };
 
-constexpr auto TIMER_STATUE_ACTIVATION = 3500ms;
+constexpr Milliseconds TIMER_STATUE_ACTIVATION = 3500ms;
 
 template <class AI, class T>
 inline AI* GetGundrakAI(T* obj)

--- a/src/server/scripts/Northrend/Gundrak/gundrak.h
+++ b/src/server/scripts/Northrend/Gundrak/gundrak.h
@@ -88,10 +88,7 @@ enum GDSpellIds
     SPELL_FIRE_BEAM_ELEMENTAL        = 57072
 };
 
-enum GDInstanceMisc
-{
-    TIMER_STATUE_ACTIVATION          = 3500
-};
+constexpr auto TIMER_STATUE_ACTIVATION = 3500ms;
 
 template <class AI, class T>
 inline AI* GetGundrakAI(T* obj)


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Gundrak: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build