### PR TITLE
Scripts/IoC: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/IsleOfConquest/boss_ioc_horde_alliance.cpp
+++ b/src/server/scripts/Northrend/IsleOfConquest/boss_ioc_horde_alliance.cpp
@@ -63,8 +63,8 @@ public:
         void JustEngagedWith(Unit* /*who*/) override
         {
             _events.ScheduleEvent(EVENT_BRUTAL_STRIKE, 5s);
-            _events.ScheduleEvent(EVENT_DAGGER_THROW,  7 * IN_MILLISECONDS);
-            _events.ScheduleEvent(EVENT_CHECK_RANGE,   1 * IN_MILLISECONDS);
+            _events.ScheduleEvent(EVENT_DAGGER_THROW, 7s);
+            _events.ScheduleEvent(EVENT_CHECK_RANGE, 1s);
             _events.ScheduleEvent(EVENT_CRUSHING_LEAP, 15s);
         }
 


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/IoC: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build