### PR TITLE
Scripts/Ulduar: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_loken.cpp
@@ -106,7 +106,7 @@ public:
             BossAI::JustEngagedWith(who);
             Talk(SAY_AGGRO);
             events.SetPhase(PHASE_NORMAL);
-            events.ScheduleEvent(EVENT_ARC_LIGHTNING, 15000);
+            events.ScheduleEvent(EVENT_ARC_LIGHTNING, 15s);
             events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 20s);
             events.ScheduleEvent(EVENT_RESUME_PULSING_SHOCKWAVE, 1s);
             instance->DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMELY_DEATH_START_EVENT);
@@ -157,7 +157,7 @@ public:
                         Talk(EMOTE_NOVA);
                         DoCastAOE(SPELL_LIGHTNING_NOVA);
                         me->RemoveAurasDueToSpell(sSpellMgr->GetSpellIdForDifficulty(SPELL_PULSING_SHOCKWAVE, me));
-                        events.ScheduleEvent(EVENT_RESUME_PULSING_SHOCKWAVE, DUNGEON_MODE(5000, 4000)); // Pause Pulsing Shockwave aura
+                        events.ScheduleEvent(EVENT_RESUME_PULSING_SHOCKWAVE, DUNGEON_MODE(5s, 4s)); // Pause Pulsing Shockwave aura
                         events.ScheduleEvent(EVENT_LIGHTNING_NOVA, 20s, 21s);
                         break;
                     case EVENT_RESUME_PULSING_SHOCKWAVE:

--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_volkhan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_volkhan.cpp
@@ -117,16 +117,16 @@ public:
             DespawnGolem();
             m_lGolemGUIDList.clear();
             events.SetPhase(PHASE_INTRO);
-            events.ScheduleEvent(EVENT_FORGE_CAST, 2 * IN_MILLISECONDS, 0, PHASE_INTRO);
+            events.ScheduleEvent(EVENT_FORGE_CAST, 2s, 0, PHASE_INTRO);
         }
 
         void JustEngagedWith(Unit* who) override
         {
             Talk(SAY_AGGRO);
             events.SetPhase(PHASE_NORMAL);
-            events.ScheduleEvent(EVENT_PAUSE,            3.5 * IN_MILLISECONDS, 0, PHASE_NORMAL);
-            events.ScheduleEvent(EVENT_SHATTERING_STOMP,   0 * IN_MILLISECONDS, 0, PHASE_NORMAL);
-            events.ScheduleEvent(EVENT_SHATTER,            5 * IN_MILLISECONDS, 0, PHASE_NORMAL);
+            events.ScheduleEvent(EVENT_PAUSE, 3500ms, 0, PHASE_NORMAL);
+            events.ScheduleEvent(EVENT_SHATTERING_STOMP, 0s, 0, PHASE_NORMAL);
+            events.ScheduleEvent(EVENT_SHATTER, 5s, 0, PHASE_NORMAL);
             BossAI::JustEngagedWith(who);
         }
 
@@ -249,7 +249,7 @@ public:
 
                             m_bHasTemper = false;
                             m_bIsStriking = false;
-                            events.ScheduleEvent(EVENT_PAUSE, 3.5 * IN_MILLISECONDS, 0, PHASE_NORMAL);
+                            events.ScheduleEvent(EVENT_PAUSE, 3500ms, 0, PHASE_NORMAL);
                         }
                         break;
                     case EVENT_SHATTERING_STOMP:
@@ -263,19 +263,19 @@ public:
                             Talk(EMOTE_SHATTER);
                             m_bCanShatterGolem = true;
                         }
-                        events.ScheduleEvent(EVENT_SHATTERING_STOMP, 30 * IN_MILLISECONDS, 0, PHASE_NORMAL);
+                        events.ScheduleEvent(EVENT_SHATTERING_STOMP, 30s, 0, PHASE_NORMAL);
                         break;
                     case EVENT_SHATTER:
                         if (m_bCanShatterGolem)
                         {
                             ShatterGolem();
-                            events.ScheduleEvent(EVENT_SHATTER, 3 * IN_MILLISECONDS, 0, PHASE_NORMAL);
+                            events.ScheduleEvent(EVENT_SHATTER, 3s, 0, PHASE_NORMAL);
                             m_bCanShatterGolem = false;
                         }
                         break;
                     case EVENT_FORGE_CAST:
                         DoCast(me, SPELL_FORGE_VISUAL);
-                        events.ScheduleEvent(EVENT_FORGE_CAST, 15 * IN_MILLISECONDS, 0, PHASE_INTRO);
+                        events.ScheduleEvent(EVENT_FORGE_CAST, 15s, 0, PHASE_INTRO);
                         break;
                     default:
                         break;
@@ -398,8 +398,8 @@ public:
         void Initialize()
         {
             m_bIsFrozen = false;
-            events.ScheduleEvent(EVENT_BLAST,      20 * IN_MILLISECONDS);
-            events.ScheduleEvent(EVENT_IMMOLATION,  5 * IN_MILLISECONDS);
+            events.ScheduleEvent(EVENT_BLAST, 20s);
+            events.ScheduleEvent(EVENT_IMMOLATION, 5s);
         }
 
         bool m_bIsFrozen;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -337,7 +337,7 @@ struct boss_algalon_the_observer : public BossAI
                 events.Reset();
                 events.SetPhase(PHASE_ROLE_PLAY);
                 if (me->IsInCombat())
-                    events.ScheduleEvent(EVENT_ASCEND_TO_THE_HEAVENS, 1);
+                    events.ScheduleEvent(EVENT_ASCEND_TO_THE_HEAVENS, 1ms);
                 events.ScheduleEvent(EVENT_DESPAWN_ALGALON_1, 5s);
                 events.ScheduleEvent(EVENT_DESPAWN_ALGALON_2, 17s);
                 events.ScheduleEvent(EVENT_DESPAWN_ALGALON_3, 26s);
@@ -361,7 +361,7 @@ struct boss_algalon_the_observer : public BossAI
 
     void JustEngagedWith(Unit* who) override
     {
-        uint32 introDelay = 0;
+        Milliseconds introDelay = 0ms;
         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
         me->SetImmuneToNPC(true);
         events.Reset();
@@ -372,7 +372,7 @@ struct boss_algalon_the_observer : public BossAI
             Talk(SAY_ALGALON_AGGRO);
             me->PlayDirectMusic(ENGAGE_MUSIC_ID);
             BossAI::JustEngagedWith(who);
-            introDelay = 8000;
+            introDelay = 8s;
         }
         else
         {
@@ -382,19 +382,19 @@ struct boss_algalon_the_observer : public BossAI
             me->setActive(true);
             me->SetFarVisible(true);
             DoZoneInCombat();
-            introDelay = 26500;
+            introDelay = 26500ms;
             summons.DespawnEntry(NPC_AZEROTH);
             instance->SetData(EVENT_DESPAWN_ALGALON, 0);
             events.ScheduleEvent(EVENT_START_COMBAT, 16s);
         }
 
         events.ScheduleEvent(EVENT_INTRO_TIMER_DONE, introDelay);
-        events.ScheduleEvent(EVENT_QUANTUM_STRIKE, 3500 + introDelay);
-        events.ScheduleEvent(EVENT_PHASE_PUNCH, 15500 + introDelay);
-        events.ScheduleEvent(EVENT_SUMMON_COLLAPSING_STAR, 18000 + introDelay);
-        events.ScheduleEvent(EVENT_BIG_BANG, 90000 + introDelay);
-        events.ScheduleEvent(EVENT_ASCEND_TO_THE_HEAVENS, 360000 + introDelay);
-        events.ScheduleEvent(EVENT_COSMIC_SMASH, 25000 + introDelay);
+        events.ScheduleEvent(EVENT_QUANTUM_STRIKE, 3500ms + introDelay);
+        events.ScheduleEvent(EVENT_PHASE_PUNCH, 15500ms + introDelay);
+        events.ScheduleEvent(EVENT_SUMMON_COLLAPSING_STAR, 18s + introDelay);
+        events.ScheduleEvent(EVENT_BIG_BANG, 90s + introDelay);
+        events.ScheduleEvent(EVENT_ASCEND_TO_THE_HEAVENS, 360s + introDelay);
+        events.ScheduleEvent(EVENT_COSMIC_SMASH, 25s + introDelay);
 
         std::list<Creature*> stalkers;
         me->GetCreatureListWithEntryInGrid(stalkers, NPC_ALGALON_STALKER, 200.0f);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_assembly_of_iron.cpp
@@ -185,9 +185,9 @@ class boss_steelbreaker : public CreatureScript
                         me->SetFullHealth();
                         me->AddAura(SPELL_SUPERCHARGE, me);
                         events.SetPhase(++phase);
-                        events.RescheduleEvent(EVENT_FUSION_PUNCH, 15000);
+                        events.RescheduleEvent(EVENT_FUSION_PUNCH, 15s);
                         if (phase >= 2)
-                            events.RescheduleEvent(EVENT_STATIC_DISRUPTION, 30000);
+                            events.RescheduleEvent(EVENT_STATIC_DISRUPTION, 30s);
                         if (phase >= 3)
                             events.RescheduleEvent(EVENT_OVERWHELMING_POWER, 2s, 5s);
                         break;
@@ -263,7 +263,7 @@ class boss_steelbreaker : public CreatureScript
                         case EVENT_OVERWHELMING_POWER:
                             Talk(SAY_STEELBREAKER_POWER);
                             DoCastVictim(SPELL_OVERWHELMING_POWER);
-                            events.ScheduleEvent(EVENT_OVERWHELMING_POWER, RAID_MODE(60000, 35000));
+                            events.ScheduleEvent(EVENT_OVERWHELMING_POWER, RAID_MODE(60s, 35s));
                             break;
                     }
 
@@ -334,12 +334,12 @@ class boss_runemaster_molgeim : public CreatureScript
                         me->SetFullHealth();
                         me->AddAura(SPELL_SUPERCHARGE, me);
                         events.SetPhase(++phase);
-                        events.RescheduleEvent(EVENT_SHIELD_OF_RUNES, 27000);
-                        events.RescheduleEvent(EVENT_RUNE_OF_POWER, 25000);
+                        events.RescheduleEvent(EVENT_SHIELD_OF_RUNES, 27s);
+                        events.RescheduleEvent(EVENT_RUNE_OF_POWER, 25s);
                         if (phase >= 2)
-                            events.RescheduleEvent(EVENT_RUNE_OF_DEATH, 30000);
+                            events.RescheduleEvent(EVENT_RUNE_OF_DEATH, 30s);
                         if (phase >= 3)
-                            events.RescheduleEvent(EVENT_RUNE_OF_SUMMONING, urand(20000, 30000));
+                            events.RescheduleEvent(EVENT_RUNE_OF_SUMMONING, 20s, 30s);
                         break;
                     }
                 }
@@ -494,7 +494,7 @@ class boss_stormcaller_brundir : public CreatureScript
                 events.ScheduleEvent(EVENT_MOVE_POSITION, 1s);
                 events.ScheduleEvent(EVENT_BERSERK, 15min);
                 events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 4s);
-                events.ScheduleEvent(EVENT_OVERLOAD, urand(60000, 120000));
+                events.ScheduleEvent(EVENT_OVERLOAD, 60s, 120s);
 
                 if (Creature* trigger = me->FindNearestCreature(NPC_WORLD_TRIGGER, 100.0f))
                     m_TriggerGUID = trigger->GetGUID();
@@ -510,13 +510,13 @@ class boss_stormcaller_brundir : public CreatureScript
                         me->AddAura(SPELL_SUPERCHARGE, me);
                         events.SetPhase(++phase);
                         events.RescheduleEvent(EVENT_CHAIN_LIGHTNING, 7s, 12s);
-                        events.RescheduleEvent(EVENT_OVERLOAD, urand(40000, 50000));
+                        events.RescheduleEvent(EVENT_OVERLOAD, 40s, 50s);
                         if (phase >= 2)
-                            events.RescheduleEvent(EVENT_LIGHTNING_WHIRL, urand(15000, 250000));
+                            events.RescheduleEvent(EVENT_LIGHTNING_WHIRL, 15s, 250s);
                         if (phase >= 3)
                         {
                             DoCast(me, SPELL_STORMSHIELD);
-                            events.RescheduleEvent(EVENT_LIGHTNING_TENDRILS, urand(50000, 60000));
+                            events.RescheduleEvent(EVENT_LIGHTNING_TENDRILS, 50s, 60s);
                             me->ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_STUN, true); // Apply immumity to stuns
                         }
                         break;
@@ -583,7 +583,7 @@ class boss_stormcaller_brundir : public CreatureScript
                             Talk(EMOTE_BRUNDIR_OVERLOAD);
                             Talk(SAY_BRUNDIR_SPECIAL);
                             DoCast(SPELL_OVERLOAD);
-                            events.ScheduleEvent(EVENT_OVERLOAD, urand(60000, 120000));
+                            events.ScheduleEvent(EVENT_OVERLOAD, 60s, 120s);
                             break;
                         case EVENT_LIGHTNING_WHIRL:
                             DoCast(SPELL_LIGHTNING_WHIRL);
@@ -595,9 +595,9 @@ class boss_stormcaller_brundir : public CreatureScript
                             DoCast(me, SPELL_LIGHTNING_TENDRILS_VISUAL);
                             me->AttackStop();
                             me->SetHover(true);
-                            events.DelayEvents(35000);
+                            events.DelayEvents(35s);
                             events.ScheduleEvent(EVENT_FLIGHT, 2500ms);
-                            events.ScheduleEvent(EVENT_ENDFLIGHT, 32500);
+                            events.ScheduleEvent(EVENT_ENDFLIGHT, 32500ms);
                             events.ScheduleEvent(EVENT_LIGHTNING_TENDRILS, 90s);
                             break;
                         case EVENT_FLIGHT:
@@ -644,7 +644,7 @@ class boss_stormcaller_brundir : public CreatureScript
                                         me->GetMotionMaster()->MovePoint(0, pos);
                                 }
                             }
-                            events.ScheduleEvent(EVENT_MOVE_POSITION, urand(7500, 10000));
+                            events.ScheduleEvent(EVENT_MOVE_POSITION, 7500ms, 10s);
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -276,8 +276,8 @@ class boss_flame_leviathan : public CreatureScript
             {
                 BossAI::JustEngagedWith(who);
                 me->SetReactState(REACT_PASSIVE);
-                events.ScheduleEvent(EVENT_PURSUE, 1);
-                events.ScheduleEvent(EVENT_MISSILE, urand(1500, 4*IN_MILLISECONDS));
+                events.ScheduleEvent(EVENT_PURSUE, 1ms);
+                events.ScheduleEvent(EVENT_MISSILE, 1500ms, 4s);
                 events.ScheduleEvent(EVENT_VENT, 20s);
                 events.ScheduleEvent(EVENT_SHUTDOWN, 150s);
                 events.ScheduleEvent(EVENT_SPEED, 15s);
@@ -427,7 +427,7 @@ class boss_flame_leviathan : public CreatureScript
                             if (Shutout)
                                 Shutout = false;
                             events.ScheduleEvent(EVENT_REPAIR, 4s);
-                            events.DelayEvents(20 * IN_MILLISECONDS, 0);
+                            events.DelayEvents(20s, 0);
                             break;
                         case EVENT_REPAIR:
                             Talk(EMOTE_REPAIR);
@@ -584,7 +584,7 @@ class boss_flame_leviathan : public CreatureScript
 
                         if (!target)
                         {
-                            events.RescheduleEvent(EVENT_PURSUE, 0);
+                            events.RescheduleEvent(EVENT_PURSUE, 0s);
                             return;
                         }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -206,11 +206,12 @@ enum FreyaEvents
 
 enum Misc
 {
-    WAVE_TIME                                   = 60000, // Normal wave is one minute
     TIME_DIFFERENCE                             = 10000, // If difference between waveTime and WAVE_TIME is bigger then TIME_DIFFERENCE, schedule EVENT_WAVE in 10 seconds
     DATA_GETTING_BACK_TO_NATURE                 = 1,
     DATA_KNOCK_ON_WOOD                          = 2
 };
+
+constexpr Seconds FREYA_WAVE_TIME = 60s; // Normal wave is one minute
 
 class npc_iron_roots : public CreatureScript
 {
@@ -385,7 +386,7 @@ class boss_freya : public CreatureScript
                 me->CastSpell(me, SPELL_ATTUNED_TO_NATURE, args);
 
                 events.ScheduleEvent(EVENT_WAVE, 10s);
-                events.ScheduleEvent(EVENT_EONAR_GIFT, 25000);
+                events.ScheduleEvent(EVENT_EONAR_GIFT, 25s);
                 events.ScheduleEvent(EVENT_ENRAGE, 10min);
                 events.ScheduleEvent(EVENT_SUNBEAM, 5s, 15s);
             }
@@ -438,7 +439,7 @@ class boss_freya : public CreatureScript
                         case EVENT_WAVE:
                             SpawnWave();
                             if (waveCount <= 6) // If set to 6 The Bombs appear during the Final Add wave
-                                events.ScheduleEvent(EVENT_WAVE, WAVE_TIME);
+                                events.ScheduleEvent(EVENT_WAVE, FREYA_WAVE_TIME);
                             else
                                 events.ScheduleEvent(EVENT_NATURE_BOMB, 10s, 20s);
                             break;
@@ -815,7 +816,7 @@ class boss_elder_stonebark : public CreatureScript
                     me->RemoveAurasDueToSpell(SPELL_DRAINED_OF_POWER);
                 events.ScheduleEvent(EVENT_TREMOR, 10s, 12s);
                 events.ScheduleEvent(EVENT_FISTS, 25s, 35s);
-                events.ScheduleEvent(EVENT_BARK, urand(37500, 40000));
+                events.ScheduleEvent(EVENT_BARK, 37500ms, 40s);
             }
 
             void KilledUnit(Unit* who) override
@@ -924,7 +925,7 @@ class boss_elder_ironbranch : public CreatureScript
                     me->RemoveAurasDueToSpell(SPELL_DRAINED_OF_POWER);
                 events.ScheduleEvent(EVENT_IMPALE, 18s, 22s);
                 events.ScheduleEvent(EVENT_IRON_ROOTS, 12s, 17s);
-                events.ScheduleEvent(EVENT_THORN_SWARM, urand(7500, 12500));
+                events.ScheduleEvent(EVENT_THORN_SWARM, 7500ms, 12500ms);
             }
 
             void KilledUnit(Unit* who) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -173,7 +173,7 @@ class boss_general_vezax : public CreatureScript
                         }
                         case EVENT_SEARING_FLAMES:
                             DoCastAOE(SPELL_SEARING_FLAMES);
-                            events.ScheduleEvent(EVENT_SEARING_FLAMES, urand(14000, 17500));
+                            events.ScheduleEvent(EVENT_SEARING_FLAMES, 14s, 17500ms);
                             break;
                         case EVENT_MARK_OF_THE_FACELESS:
                         {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -448,7 +448,7 @@ class boss_hodir : public CreatureScript
                         case EVENT_ICICLE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
                                 DoCast(target, SPELL_ICICLE);
-                            events.ScheduleEvent(EVENT_ICICLE, RAID_MODE(5500, 3500));
+                            events.ScheduleEvent(EVENT_ICICLE, RAID_MODE(5500ms, 3500ms));
                             break;
                         case EVENT_FLASH_FREEZE:
                             Talk(SAY_FLASH_FREEZE);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_ignis.cpp
@@ -146,11 +146,11 @@ class boss_ignis : public CreatureScript
                 BossAI::JustEngagedWith(who);
                 Talk(SAY_AGGRO);
                 events.ScheduleEvent(EVENT_JET, 30s);
-                events.ScheduleEvent(EVENT_SCORCH, 25000);
-                events.ScheduleEvent(EVENT_SLAG_POT, 35000);
-                events.ScheduleEvent(EVENT_CONSTRUCT, 15000);
+                events.ScheduleEvent(EVENT_SCORCH, 25s);
+                events.ScheduleEvent(EVENT_SLAG_POT, 35s);
+                events.ScheduleEvent(EVENT_CONSTRUCT, 15s);
                 events.ScheduleEvent(EVENT_END_POT, 40s);
-                events.ScheduleEvent(EVENT_BERSERK, 480000);
+                events.ScheduleEvent(EVENT_BERSERK, 480s);
                 Initialize();
                 instance->DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEVEMENT_IGNIS_START_EVENT);
             }
@@ -229,10 +229,10 @@ class boss_ignis : public CreatureScript
                                 Talk(SAY_SLAG_POT);
                                 _slagPotGUID = target->GetGUID();
                                 DoCast(target, SPELL_GRAB);
-                                events.DelayEvents(3000);
+                                events.DelayEvents(3s);
                                 events.ScheduleEvent(EVENT_GRAB_POT, 500ms);
                             }
-                            events.ScheduleEvent(EVENT_SLAG_POT, RAID_MODE(30000, 15000));
+                            events.ScheduleEvent(EVENT_SLAG_POT, RAID_MODE(30s, 15s));
                             break;
                         case EVENT_GRAB_POT:
                             if (Unit* slagPotTarget = ObjectAccessor::GetUnit(*me, _slagPotGUID))
@@ -265,14 +265,14 @@ class boss_ignis : public CreatureScript
                             if (Unit* target = me->GetVictim())
                                 me->SummonCreature(NPC_GROUND_SCORCH, target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), 0, TEMPSUMMON_TIMED_DESPAWN, 45000);
                             DoCast(SPELL_SCORCH);
-                            events.ScheduleEvent(EVENT_SCORCH, 25000);
+                            events.ScheduleEvent(EVENT_SCORCH, 25s);
                             break;
                         case EVENT_CONSTRUCT:
                             Talk(SAY_SUMMON);
                             DoSummon(NPC_IRON_CONSTRUCT, ConstructSpawnPosition[urand(0, CONSTRUCT_SPAWN_POINTS - 1)], 30000, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT);
                             DoCast(SPELL_STRENGHT);
                             DoCast(me, SPELL_ACTIVATE_CONSTRUCT);
-                            events.ScheduleEvent(EVENT_CONSTRUCT, RAID_MODE(40000, 30000));
+                            events.ScheduleEvent(EVENT_CONSTRUCT, RAID_MODE(40s, 30s));
                             break;
                         case EVENT_BERSERK:
                             DoCast(me, SPELL_BERSERK, true);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_kologarn.cpp
@@ -125,7 +125,7 @@ class boss_kologarn : public CreatureScript
                 events.ScheduleEvent(EVENT_MELEE_CHECK, 6s);
                 events.ScheduleEvent(EVENT_SMASH, 5s);
                 events.ScheduleEvent(EVENT_SWEEP, 19s);
-                events.ScheduleEvent(EVENT_STONE_GRIP, 25000);
+                events.ScheduleEvent(EVENT_STONE_GRIP, 25s);
                 events.ScheduleEvent(EVENT_FOCUSED_EYEBEAM, 21s);
                 events.ScheduleEvent(EVENT_ENRAGE, 10min);
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -399,10 +399,10 @@ class boss_mimiron : public CreatureScript
                 switch (action)
                 {
                     case DO_ACTIVATE_VX001:
-                        events.ScheduleEvent(EVENT_VX001_ACTIVATION_1, 1000);
+                        events.ScheduleEvent(EVENT_VX001_ACTIVATION_1, 1s);
                         break;
                     case DO_ACTIVATE_AERIAL:
-                        events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_1, 5000);
+                        events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_1, 5s);
                         break;
                     case DO_ACTIVATE_V0L7R0N_1:
                         Talk(SAY_AERIAL_DEATH);
@@ -410,7 +410,7 @@ class boss_mimiron : public CreatureScript
                             mkii->GetMotionMaster()->MovePoint(WP_MKII_P4_POS_1, VehicleRelocation[WP_MKII_P4_POS_1]);
                         break;
                     case DO_ACTIVATE_V0L7R0N_2:
-                        events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_1, 1000);
+                        events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_1, 1s);
                         break;
                     case DO_ACTIVATE_HARD_MODE:
                         _fireFighter = true;
@@ -436,7 +436,7 @@ class boss_mimiron : public CreatureScript
 
                 if (_fireFighter)
                     events.ScheduleEvent(EVENT_SUMMON_FLAMES, 3s);
-                events.ScheduleEvent(EVENT_INTRO_1, 1500);
+                events.ScheduleEvent(EVENT_INTRO_1, 1500ms);
             }
 
             void JustDied(Unit* /*killer*/) override
@@ -450,7 +450,7 @@ class boss_mimiron : public CreatureScript
                 me->ExitVehicle();
                 // ExitVehicle() offset position is not implemented, so we make up for that with MoveJump()...
                 me->GetMotionMaster()->MoveJump(me->GetPositionX() + (10.f * std::cos(me->GetOrientation())), me->GetPositionY() + (10.f * std::sin(me->GetOrientation())), me->GetPositionZ(), me->GetOrientation(), 10.f, 5.f);
-                events.ScheduleEvent(EVENT_OUTTRO_1, 7000);
+                events.ScheduleEvent(EVENT_OUTTRO_1, 7s);
             }
 
             void Reset() override
@@ -501,11 +501,11 @@ class boss_mimiron : public CreatureScript
                         case EVENT_SUMMON_FLAMES:
                             if (Creature* worldtrigger = instance->GetCreature(DATA_MIMIRON_WORLD_TRIGGER))
                                 worldtrigger->CastSpell(nullptr, SPELL_SCRIPT_EFFECT_SUMMON_FLAMES_INITIAL, CastSpellExtraArgs(me->GetGUID()).AddSpellMod(SPELLVALUE_MAX_TARGETS, 3));
-                            events.RescheduleEvent(EVENT_SUMMON_FLAMES, 28000);
+                            events.RescheduleEvent(EVENT_SUMMON_FLAMES, 28s);
                             break;
                         case EVENT_INTRO_1:
                             Talk(_fireFighter ? SAY_HARDMODE_ON : SAY_MKII_ACTIVATE);
-                            events.ScheduleEvent(EVENT_INTRO_2, 5000);
+                            events.ScheduleEvent(EVENT_INTRO_2, 5s);
                             break;
                         case EVENT_INTRO_2:
                             if (Unit* mkii = me->GetVehicleBase())
@@ -514,7 +514,7 @@ class boss_mimiron : public CreatureScript
                                 mkii->RemoveAurasDueToSpell(SPELL_FREEZE_ANIM);
                                 mkii->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                             }
-                            events.ScheduleEvent(EVENT_INTRO_3, 2000);
+                            events.ScheduleEvent(EVENT_INTRO_3, 2s);
                             break;
                         case EVENT_INTRO_3:
                             if (Creature* mkii = me->GetVehicleCreatureBase())
@@ -523,44 +523,44 @@ class boss_mimiron : public CreatureScript
                         case EVENT_VX001_ACTIVATION_1:
                             if (Unit* mkii = me->GetVehicleBase())
                                 mkii->SetFacingTo(3.686f); // fix magic number
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_2, 1000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_2, 1s);
                             break;
                         case EVENT_VX001_ACTIVATION_2:
                             if (Unit* mkii = me->GetVehicleBase())
                                 DoCast(mkii, SPELL_SEAT_6);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_3, 1000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_3, 1s);
                             break;
                         case EVENT_VX001_ACTIVATION_3:
                             Talk(SAY_MKII_DEATH);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_4, 5000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_4, 5s);
                             break;
                         case EVENT_VX001_ACTIVATION_4:
                             if (GameObject* elevator = instance->GetGameObject(DATA_MIMIRON_ELEVATOR))
                                 elevator->SetGoState(GO_STATE_READY);
                             if (Creature* worldtrigger = instance->GetCreature(DATA_MIMIRON_WORLD_TRIGGER))
                                 worldtrigger->CastSpell(worldtrigger, SPELL_ELEVATOR_KNOCKBACK);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_5, 6000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_5, 6s);
                             break;
                         case EVENT_VX001_ACTIVATION_5:
                             if (GameObject* elevator = instance->GetGameObject(DATA_MIMIRON_ELEVATOR))
                                 elevator->SetGoState(GO_STATE_DESTROYED);
                             if (Creature* vx001 = me->SummonCreature(NPC_VX_001, VX001SummonPos, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 120000))
                                 vx001->CastSpell(vx001, SPELL_FREEZE_ANIM);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_6, 19000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_6, 19s);
                             break;
                         case EVENT_VX001_ACTIVATION_6:
                             if (Unit* vx001 = ObjectAccessor::GetUnit(*me, instance->GetGuidData(DATA_VX_001)))
                                 DoCast(vx001, SPELL_SEAT_1);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_7, 3500);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_7, 3500ms);
                             break;
                         case EVENT_VX001_ACTIVATION_7:
                             Talk(SAY_VX001_ACTIVATE);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_8, 4000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_8, 4s);
                             break;
                         case EVENT_VX001_ACTIVATION_8:
                             if (Unit* vx001 = me->GetVehicleBase())
                                 DoCast(vx001, SPELL_SEAT_2);
-                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_9, 3000);
+                            events.ScheduleEvent(EVENT_VX001_ACTIVATION_9, 3s);
                             break;
                         case EVENT_VX001_ACTIVATION_9:
                             if (Creature* vx001 = me->GetVehicleCreatureBase())
@@ -569,24 +569,24 @@ class boss_mimiron : public CreatureScript
                         case EVENT_AERIAL_ACTIVATION_1:
                             if (Unit* mkii = me->GetVehicleBase())
                                 DoCast(mkii, SPELL_SEAT_5);
-                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_2, 2500);
+                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_2, 2500ms);
                             break;
                         case EVENT_AERIAL_ACTIVATION_2:
                             Talk(SAY_VX001_DEATH);
-                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_3, 5000);
+                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_3, 5s);
                             break;
                         case EVENT_AERIAL_ACTIVATION_3:
                             me->SummonCreature(NPC_AERIAL_COMMAND_UNIT, ACUSummonPos, TEMPSUMMON_MANUAL_DESPAWN);
-                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_4, 5000);
+                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_4, 5s);
                             break;
                         case EVENT_AERIAL_ACTIVATION_4:
                             if (Unit* aerial = ObjectAccessor::GetUnit(*me, instance->GetGuidData(DATA_AERIAL_COMMAND_UNIT)))
                                 me->CastSpell(aerial, SPELL_SEAT_1);
-                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_5, 2000);
+                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_5, 2s);
                             break;
                         case EVENT_AERIAL_ACTIVATION_5:
                             Talk(SAY_AERIAL_ACTIVATE);
-                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_6, 8000);
+                            events.ScheduleEvent(EVENT_AERIAL_ACTIVATION_6, 8s);
                             break;
                         case EVENT_AERIAL_ACTIVATION_6:
                             if (Creature* acu = me->GetVehicleCreatureBase())
@@ -595,7 +595,7 @@ class boss_mimiron : public CreatureScript
                         case EVENT_VOL7RON_ACTIVATION_1:
                             if (Creature* mkii = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_LEVIATHAN_MK_II)))
                                 mkii->SetFacingTo(float(M_PI));
-                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_2, 1000);
+                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_2, 1s);
                             break;
                         case EVENT_VOL7RON_ACTIVATION_2:
                             if (Creature* mkii = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_LEVIATHAN_MK_II)))
@@ -606,12 +606,12 @@ class boss_mimiron : public CreatureScript
                                     vx001->CastSpell(mkii, SPELL_MOUNT_MKII);
                                 }
                             }
-                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_3, 4500);
+                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_3, 4500ms);
                             break;
                         case EVENT_VOL7RON_ACTIVATION_3:
                             if (Creature* mkii = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_LEVIATHAN_MK_II)))
                                 mkii->GetMotionMaster()->MovePoint(WP_MKII_P4_POS_4, VehicleRelocation[WP_MKII_P4_POS_4]);
-                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_4, 5000);
+                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_4, 5s);
                             break;
                         case EVENT_VOL7RON_ACTIVATION_4:
                             if (Creature* vx001 = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_VX_001)))
@@ -623,16 +623,16 @@ class boss_mimiron : public CreatureScript
                                     aerial->CastSpell(aerial, SPELL_HALF_HEAL);
                                 }
                             }
-                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_5, 4000);
+                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_5, 4s);
                             break;
                         case EVENT_VOL7RON_ACTIVATION_5:
                             Talk(SAY_V07TRON_ACTIVATE);
-                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_6, 3000);
+                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_6, 3s);
                             break;
                         case EVENT_VOL7RON_ACTIVATION_6:
                             if (Creature* vx001 = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_VX_001)))
                                 DoCast(vx001, SPELL_SEAT_2);
-                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_7, 5000);
+                            events.ScheduleEvent(EVENT_VOL7RON_ACTIVATION_7, 5s);
                             break;
                         case EVENT_VOL7RON_ACTIVATION_7:
                             for (uint8 data = DATA_LEVIATHAN_MK_II; data <= DATA_AERIAL_COMMAND_UNIT; ++data)
@@ -643,7 +643,7 @@ class boss_mimiron : public CreatureScript
                             me->RemoveAurasDueToSpell(SPELL_SLEEP_VISUAL_1);
                             DoCast(me, SPELL_SLEEP_VISUAL_2);
                             me->SetFaction(FACTION_FRIENDLY);
-                            events.ScheduleEvent(EVENT_OUTTRO_2, 3000);
+                            events.ScheduleEvent(EVENT_OUTTRO_2, 3s);
                             break;
                         case EVENT_OUTTRO_2:
                             Talk(SAY_V07TRON_DEATH);
@@ -655,7 +655,7 @@ class boss_mimiron : public CreatureScript
                             }
                             else
                                 me->SummonGameObject(RAID_MODE(GO_CACHE_OF_INNOVATION, GO_CACHE_OF_INNOVATION_HERO), 2744.040f, 2569.352f, 364.3135f, 3.124123f, QuaternionData(0.f, 0.f, 0.9999619f, 0.008734641f), 604800);
-                            events.ScheduleEvent(EVENT_OUTTRO_3, 11000);
+                            events.ScheduleEvent(EVENT_OUTTRO_3, 11s);
                             break;
                         case EVENT_OUTTRO_3:
                             DoCast(me, SPELL_TELEPORT_VISUAL);
@@ -756,8 +756,8 @@ class boss_leviathan_mk_ii : public CreatureScript
                         me->SetReactState(REACT_AGGRESSIVE);
 
                         events.SetPhase(PHASE_VOL7RON);
-                        events.ScheduleEvent(EVENT_PROXIMITY_MINE, 15000);
-                        events.ScheduleEvent(EVENT_SHOCK_BLAST, 45000);
+                        events.ScheduleEvent(EVENT_PROXIMITY_MINE, 15s);
+                        events.ScheduleEvent(EVENT_SHOCK_BLAST, 45s);
                         break;
                     default:
                         break;
@@ -808,17 +808,17 @@ class boss_leviathan_mk_ii : public CreatureScript
                             mimiron->AI()->DoAction(DO_ACTIVATE_VX001);
                         break;
                     case WP_MKII_P4_POS_1:
-                        events.ScheduleEvent(EVENT_MOVE_POINT_2, 1);
+                        events.ScheduleEvent(EVENT_MOVE_POINT_2, 1ms);
                         break;
                     case WP_MKII_P4_POS_2:
-                        events.ScheduleEvent(EVENT_MOVE_POINT_3, 1);
+                        events.ScheduleEvent(EVENT_MOVE_POINT_3, 1ms);
                         break;
                     case WP_MKII_P4_POS_3:
                         if (Creature* mimiron = instance->GetCreature(BOSS_MIMIRON))
                             mimiron->AI()->DoAction(DO_ACTIVATE_V0L7R0N_2);
                         break;
                     case WP_MKII_P4_POS_4:
-                        events.ScheduleEvent(EVENT_MOVE_POINT_5, 1);
+                        events.ScheduleEvent(EVENT_MOVE_POINT_5, 1ms);
                         break;
                     default:
                         break;
@@ -871,29 +871,29 @@ class boss_leviathan_mk_ii : public CreatureScript
                     {
                         case EVENT_PROXIMITY_MINE:
                             DoCastAOE(SPELL_PROXIMITY_MINES);
-                            events.RescheduleEvent(EVENT_PROXIMITY_MINE, 35000);
+                            events.RescheduleEvent(EVENT_PROXIMITY_MINE, 35s);
                             break;
                         case EVENT_PLASMA_BLAST:
                             DoCastVictim(SPELL_SCRIPT_EFFECT_PLASMA_BLAST);
-                            events.RescheduleEvent(EVENT_PLASMA_BLAST, urand(30000, 45000), 0, PHASE_LEVIATHAN_MK_II);
+                            events.RescheduleEvent(EVENT_PLASMA_BLAST, 30s, 45s, 0, PHASE_LEVIATHAN_MK_II);
 
                             if (events.GetTimeUntilEvent(EVENT_NAPALM_SHELL) < 9000)
-                                events.RescheduleEvent(EVENT_NAPALM_SHELL, 9000, 0, PHASE_LEVIATHAN_MK_II); // The actual spell is cast by the turret, we should not let it interrupt itself.
+                                events.RescheduleEvent(EVENT_NAPALM_SHELL, 9s, 0, PHASE_LEVIATHAN_MK_II); // The actual spell is cast by the turret, we should not let it interrupt itself.
                             break;
                         case EVENT_SHOCK_BLAST:
                             DoCastAOE(SPELL_SHOCK_BLAST);
-                            events.RescheduleEvent(EVENT_SHOCK_BLAST, urand(34000, 36000));
+                            events.RescheduleEvent(EVENT_SHOCK_BLAST, 34s, 36s);
                             break;
                         case EVENT_FLAME_SUPPRESSANT_MK:
                             DoCastAOE(SPELL_FLAME_SUPPRESSANT_MK);
-                            events.RescheduleEvent(EVENT_FLAME_SUPPRESSANT_MK, 60000, 0, PHASE_LEVIATHAN_MK_II);
+                            events.RescheduleEvent(EVENT_FLAME_SUPPRESSANT_MK, 60s, 0, PHASE_LEVIATHAN_MK_II);
                             break;
                         case EVENT_NAPALM_SHELL:
                             DoCastAOE(SPELL_FORCE_CAST_NAPALM_SHELL);
-                            events.RescheduleEvent(EVENT_NAPALM_SHELL, urand(6000, 15000), 0, PHASE_LEVIATHAN_MK_II);
+                            events.RescheduleEvent(EVENT_NAPALM_SHELL, 6s, 15s, 0, PHASE_LEVIATHAN_MK_II);
 
                             if (events.GetTimeUntilEvent(EVENT_PLASMA_BLAST) < 2000)
-                                events.RescheduleEvent(EVENT_PLASMA_BLAST, 2000, 0, PHASE_LEVIATHAN_MK_II);  // The actual spell is cast by the turret, we should not let it interrupt itself.
+                                events.RescheduleEvent(EVENT_PLASMA_BLAST, 2s, 0, PHASE_LEVIATHAN_MK_II);  // The actual spell is cast by the turret, we should not let it interrupt itself.
                             break;
                         case EVENT_MOVE_POINT_2:
                             me->GetMotionMaster()->MovePoint(WP_MKII_P4_POS_2, VehicleRelocation[WP_MKII_P4_POS_2]);
@@ -997,7 +997,7 @@ class boss_vx_001 : public CreatureScript
                         events.SetPhase(PHASE_VX_001);
                         events.ScheduleEvent(EVENT_ROCKET_STRIKE, 20s);
                         events.ScheduleEvent(EVENT_SPINNING_UP, 30s, 35s);
-                        events.ScheduleEvent(EVENT_RAPID_BURST, 500, 0, PHASE_VX_001);
+                        events.ScheduleEvent(EVENT_RAPID_BURST, 500ms, 0, PHASE_VX_001);
                         break;
                     case DO_ASSEMBLED_COMBAT:
                         me->SetStandState(UNIT_STAND_STATE_STAND);
@@ -1006,7 +1006,7 @@ class boss_vx_001 : public CreatureScript
                         events.SetPhase(PHASE_VOL7RON);
                         events.ScheduleEvent(EVENT_ROCKET_STRIKE, 20s);
                         events.ScheduleEvent(EVENT_SPINNING_UP, 30s, 35s);
-                        events.ScheduleEvent(EVENT_HAND_PULSE, 500, 0, PHASE_VOL7RON);
+                        events.ScheduleEvent(EVENT_HAND_PULSE, 500ms, 0, PHASE_VOL7RON);
                         if (_fireFighter)
                             events.ScheduleEvent(EVENT_FROST_BOMB, 1s);
                         break;
@@ -1062,12 +1062,12 @@ class boss_vx_001 : public CreatureScript
                         case EVENT_RAPID_BURST:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 120, true))
                                 DoCast(target, SPELL_SUMMON_BURST_TARGET);
-                            events.RescheduleEvent(EVENT_RAPID_BURST, 3000, 0, PHASE_VX_001);
+                            events.RescheduleEvent(EVENT_RAPID_BURST, 3s, 0, PHASE_VX_001);
                             break;
                         case EVENT_ROCKET_STRIKE:
                             DoCastAOE(events.IsInPhase(PHASE_VX_001) ? SPELL_ROCKET_STRIKE_SINGLE : SPELL_ROCKET_STRIKE_BOTH);
                             events.ScheduleEvent(EVENT_RELOAD, 10s);
-                            events.RescheduleEvent(EVENT_ROCKET_STRIKE, urand(20000, 25000));
+                            events.RescheduleEvent(EVENT_ROCKET_STRIKE, 20s, 25s);
                             break;
                         case EVENT_RELOAD:
                             for (int8 seat = ROCKET_SEAT_LEFT; seat <= ROCKET_SEAT_RIGHT; ++seat)
@@ -1077,20 +1077,20 @@ class boss_vx_001 : public CreatureScript
                         case EVENT_HAND_PULSE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 120, true))
                                 DoCast(target, RAND(SPELL_HAND_PULSE_LEFT, SPELL_HAND_PULSE_RIGHT));
-                            events.RescheduleEvent(EVENT_HAND_PULSE, urand(1500, 3000), 0, PHASE_VOL7RON);
+                            events.RescheduleEvent(EVENT_HAND_PULSE, 1500ms, 3s, 0, PHASE_VOL7RON);
                             break;
                         case EVENT_FROST_BOMB:
                             DoCastAOE(SPELL_SCRIPT_EFFECT_FROST_BOMB);
-                            events.RescheduleEvent(EVENT_FROST_BOMB, 45000);
+                            events.RescheduleEvent(EVENT_FROST_BOMB, 45s);
                             break;
                         case EVENT_SPINNING_UP:
                             DoCastAOE(SPELL_SPINNING_UP);
-                            events.DelayEvents(14000);
-                            events.RescheduleEvent(EVENT_SPINNING_UP, urand(55000, 65000));
+                            events.DelayEvents(14s);
+                            events.RescheduleEvent(EVENT_SPINNING_UP, 55s, 65s);
                             break;
                         case EVENT_FLAME_SUPPRESSANT_VX:
                             DoCastAOE(SPELL_FLAME_SUPPRESSANT_VX);
-                            events.RescheduleEvent(EVENT_FLAME_SUPPRESSANT_VX, urand(10000, 12000), 0, PHASE_VX_001);
+                            events.RescheduleEvent(EVENT_FLAME_SUPPRESSANT_VX, 10s, 12s, 0, PHASE_VX_001);
                             break;
                         default:
                             break;
@@ -1185,7 +1185,7 @@ class boss_aerial_command_unit : public CreatureScript
                         me->SetReactState(REACT_PASSIVE);
                         me->AttackStop();
                         me->GetMotionMaster()->MoveFall();
-                        events.DelayEvents(23000);
+                        events.DelayEvents(23s);
                         break;
                     case DO_ENABLE_AERIAL:
                         me->SetReactState(REACT_AGGRESSIVE);
@@ -1249,19 +1249,19 @@ class boss_aerial_command_unit : public CreatureScript
                     {
                         case EVENT_SUMMON_FIRE_BOTS:
                             DoCastAOE(SPELL_SUMMON_FIRE_BOT_TRIGGER, CastSpellExtraArgs(TRIGGERED_FULL_MASK).AddSpellMod(SPELLVALUE_MAX_TARGETS, 3));
-                            events.RescheduleEvent(EVENT_SUMMON_FIRE_BOTS, 45000, 0, PHASE_AERIAL_COMMAND_UNIT);
+                            events.RescheduleEvent(EVENT_SUMMON_FIRE_BOTS, 45s, 0, PHASE_AERIAL_COMMAND_UNIT);
                             break;
                         case EVENT_SUMMON_JUNK_BOT:
                             DoCastAOE(SPELL_SUMMON_JUNK_BOT_TRIGGER, CastSpellExtraArgs(TRIGGERED_FULL_MASK).AddSpellMod(SPELLVALUE_MAX_TARGETS, 1));
-                            events.RescheduleEvent(EVENT_SUMMON_JUNK_BOT, urand(11000, 12000), 0, PHASE_AERIAL_COMMAND_UNIT);
+                            events.RescheduleEvent(EVENT_SUMMON_JUNK_BOT, 11s, 12s, 0, PHASE_AERIAL_COMMAND_UNIT);
                             break;
                         case EVENT_SUMMON_ASSAULT_BOT:
                             DoCastAOE(SPELL_SUMMON_ASSAULT_BOT_TRIGGER, CastSpellExtraArgs(TRIGGERED_FULL_MASK).AddSpellMod(SPELLVALUE_MAX_TARGETS, 1));
-                            events.RescheduleEvent(EVENT_SUMMON_ASSAULT_BOT, 30000, 0, PHASE_AERIAL_COMMAND_UNIT);
+                            events.RescheduleEvent(EVENT_SUMMON_ASSAULT_BOT, 30s, 0, PHASE_AERIAL_COMMAND_UNIT);
                             break;
                         case EVENT_SUMMON_BOMB_BOT:
                             DoCast(me, SPELL_SUMMON_BOMB_BOT);
-                            events.RescheduleEvent(EVENT_SUMMON_BOMB_BOT, urand(15000, 20000), 0, PHASE_AERIAL_COMMAND_UNIT);
+                            events.RescheduleEvent(EVENT_SUMMON_BOMB_BOT, 15s, 20s, 0, PHASE_AERIAL_COMMAND_UNIT);
                             break;
                         default:
                             break;
@@ -1321,7 +1321,7 @@ class npc_mimiron_assault_bot : public CreatureScript
                     {
                         case EVENT_MAGNETIC_FIELD:
                             DoCastVictim(SPELL_MAGNETIC_FIELD);
-                            events.RescheduleEvent(EVENT_MAGNETIC_FIELD, 30000);
+                            events.RescheduleEvent(EVENT_MAGNETIC_FIELD, 30s);
                             break;
                         default:
                             break;
@@ -1429,7 +1429,7 @@ class npc_mimiron_computer : public CreatureScript
                 {
                     case DO_ACTIVATE_COMPUTER:
                         Talk(SAY_SELF_DESTRUCT_INITIATED);
-                        events.ScheduleEvent(EVENT_SELF_DESTRUCT_10, 3000);
+                        events.ScheduleEvent(EVENT_SELF_DESTRUCT_10, 3s);
                         break;
                     case DO_DEACTIVATE_COMPUTER:
                         Talk(SAY_SELF_DESTRUCT_TERMINATED);
@@ -1454,43 +1454,43 @@ class npc_mimiron_computer : public CreatureScript
                             Talk(SAY_SELF_DESTRUCT_10);
                             if (Creature* mimiron = instance->GetCreature(BOSS_MIMIRON))
                                 mimiron->AI()->DoAction(DO_ACTIVATE_HARD_MODE);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_9, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_9, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_9:
                             Talk(SAY_SELF_DESTRUCT_9);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_8, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_8, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_8:
                             Talk(SAY_SELF_DESTRUCT_8);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_7, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_7, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_7:
                             Talk(SAY_SELF_DESTRUCT_7);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_6, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_6, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_6:
                             Talk(SAY_SELF_DESTRUCT_6);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_5, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_5, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_5:
                             Talk(SAY_SELF_DESTRUCT_5);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_4, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_4, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_4:
                             Talk(SAY_SELF_DESTRUCT_4);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_3, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_3, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_3:
                             Talk(SAY_SELF_DESTRUCT_3);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_2, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_2, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_2:
                             Talk(SAY_SELF_DESTRUCT_2);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_1, 60000);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_1, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_1:
                             Talk(SAY_SELF_DESTRUCT_1);
-                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_FINALIZED, 1min);
+                            events.ScheduleEvent(EVENT_SELF_DESTRUCT_FINALIZED, 60s);
                             break;
                         case EVENT_SELF_DESTRUCT_FINALIZED:
                             Talk(SAY_SELF_DESTRUCT_FINALIZED);
@@ -1638,7 +1638,7 @@ class npc_mimiron_proximity_mine : public CreatureScript
                     {
                         case EVENT_PROXIMITY_MINE_ARM:
                             DoCast(me, SPELL_PROXIMITY_MINE_PERIODIC_TRIGGER);
-                            events.ScheduleEvent(EVENT_PROXIMITY_MINE_DETONATION, 33500);
+                            events.ScheduleEvent(EVENT_PROXIMITY_MINE_DETONATION, 33500ms);
                             break;
                         case EVENT_PROXIMITY_MINE_DETONATION:
                             if (me->HasAura(SPELL_PROXIMITY_MINE_PERIODIC_TRIGGER))

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -516,7 +516,7 @@ class boss_thorim : public CreatureScript
                     {
                         pillar->CastSpell(pillar, SPELL_LIGHTNING_ORB_CHARGED, true);
                         pillar->CastSpell(nullptr, SPELL_LIGHTNING_PILLAR_2);
-                        events.ScheduleEvent(EVENT_LIGHTNING_CHARGE, 8000, 0, PHASE_2);
+                        events.ScheduleEvent(EVENT_LIGHTNING_CHARGE, 8s, 0, PHASE_2);
                     }
                 }
             }
@@ -595,9 +595,9 @@ class boss_thorim : public CreatureScript
                 _JustDied();
 
                 Talk(SAY_DEATH);
-                events.ScheduleEvent(EVENT_OUTRO_1, 4000);
-                events.ScheduleEvent(EVENT_OUTRO_2, _hardMode ? 8000 : 11000);
-                events.ScheduleEvent(EVENT_OUTRO_3, _hardMode ? 19000 : 21000);
+                events.ScheduleEvent(EVENT_OUTRO_1, 4s);
+                events.ScheduleEvent(EVENT_OUTRO_2, _hardMode ? 8s : 11s);
+                events.ScheduleEvent(EVENT_OUTRO_3, _hardMode ? 19s : 21s);
 
                 me->m_Events.AddEvent(new UlduarKeeperDespawnEvent(me), me->m_Events.CalculateTime(35000));
             }
@@ -618,14 +618,14 @@ class boss_thorim : public CreatureScript
 
                 events.SetPhase(PHASE_1);
 
-                events.ScheduleEvent(EVENT_SAY_AGGRO_2, 9000, 0, PHASE_1);
-                events.ScheduleEvent(EVENT_SAY_SIF_START, 16500, 0, PHASE_1);
-                events.ScheduleEvent(EVENT_START_SIF_CHANNEL, 22500, 0, PHASE_1);
+                events.ScheduleEvent(EVENT_SAY_AGGRO_2, 9s, 0, PHASE_1);
+                events.ScheduleEvent(EVENT_SAY_SIF_START, 16500ms, 0, PHASE_1);
+                events.ScheduleEvent(EVENT_START_SIF_CHANNEL, 22500ms, 0, PHASE_1);
 
-                events.ScheduleEvent(EVENT_STORMHAMMER, 40000, 0, PHASE_1);
-                events.ScheduleEvent(EVENT_CHARGE_ORB, 30000, 0, PHASE_1);
-                events.ScheduleEvent(EVENT_SUMMON_ADDS, 15000, 0, PHASE_1);
-                events.ScheduleEvent(EVENT_BERSERK, 369000);
+                events.ScheduleEvent(EVENT_STORMHAMMER, 40s, 0, PHASE_1);
+                events.ScheduleEvent(EVENT_CHARGE_ORB, 30s, 0, PHASE_1);
+                events.ScheduleEvent(EVENT_SUMMON_ADDS, 15s, 0, PHASE_1);
+                events.ScheduleEvent(EVENT_BERSERK, 369s);
 
                 DoCast(me, SPELL_SHEATH_OF_LIGHTNING);
 
@@ -707,15 +707,15 @@ class boss_thorim : public CreatureScript
                             break;
                         case EVENT_STORMHAMMER:
                             DoCast(SPELL_STORMHAMMER);
-                            events.Repeat(15000, 20000);
+                            events.Repeat(15s, 20s);
                             break;
                         case EVENT_CHARGE_ORB:
                             DoCastAOE(SPELL_CHARGE_ORB);
-                            events.Repeat(15000, 20000);
+                            events.Repeat(15s, 20s);
                             break;
                         case EVENT_SUMMON_ADDS:
                             SummonWave();
-                            events.Repeat(_orbSummoned ? 3000 : 10000);
+                            events.Repeat(_orbSummoned ? 3s : 10s);
                             break;
                         case EVENT_JUMPDOWN:
                             if (_hardMode)
@@ -726,18 +726,18 @@ class boss_thorim : public CreatureScript
                             me->SetDisableGravity(false);
                             me->SetControlled(false, UNIT_STATE_ROOT);
                             me->GetMotionMaster()->MoveJump(2134.8f, -263.056f, 419.983f, me->GetOrientation(), 30.0f, 20.0f);
-                            events.ScheduleEvent(EVENT_START_PERIODIC_CHARGE, 2000, 0, PHASE_2);
-                            events.ScheduleEvent(EVENT_UNBALANCING_STRIKE, 15000, 0, PHASE_2);
-                            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 20000, 0, PHASE_2);
+                            events.ScheduleEvent(EVENT_START_PERIODIC_CHARGE, 2s, 0, PHASE_2);
+                            events.ScheduleEvent(EVENT_UNBALANCING_STRIKE, 15s, 0, PHASE_2);
+                            events.ScheduleEvent(EVENT_CHAIN_LIGHTNING, 20s, 0, PHASE_2);
                             break;
                         case EVENT_UNBALANCING_STRIKE:
                             DoCastVictim(SPELL_UNBALANCING_STRIKE);
-                            events.Repeat(15000, 20000);
+                            events.Repeat(15s, 20s);
                             break;
                         case EVENT_CHAIN_LIGHTNING:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
                                 DoCast(target, SPELL_CHAIN_LIGHTNING);
-                            events.Repeat(7000, 15000);
+                            events.Repeat(7s, 15s);
                             break;
                         case EVENT_START_PERIODIC_CHARGE:
                             if (Creature* controller = instance->GetCreature(DATA_THORIM_CONTROLLER))
@@ -829,7 +829,7 @@ class boss_thorim : public CreatureScript
                         if (!_orbSummoned)
                         {
                             _orbSummoned = true;
-                            events.RescheduleEvent(EVENT_BERSERK, 1000);
+                            events.RescheduleEvent(EVENT_BERSERK, 1s);
                         }
                         return;
                     case ACTION_INCREASE_PREADDS_COUNT:
@@ -925,8 +925,8 @@ class boss_thorim : public CreatureScript
                     Talk(SAY_JUMPDOWN);
                     events.SetPhase(PHASE_2);
                     events.ScheduleEvent(EVENT_JUMPDOWN, 8s);
-                    events.ScheduleEvent(EVENT_ACTIVATE_LIGHTNING_FIELD, 15000);
-                    events.RescheduleEvent(EVENT_BERSERK, 300000, 0, PHASE_2);
+                    events.ScheduleEvent(EVENT_ACTIVATE_LIGHTNING_FIELD, 15s);
+                    events.RescheduleEvent(EVENT_BERSERK, 300s, 0, PHASE_2);
 
                     if (Creature* sif = instance->GetCreature(DATA_SIF))
                         sif->InterruptNonMeleeSpells(false);
@@ -1149,7 +1149,12 @@ class npc_thorim_pre_phase : public CreatureScript
                 if (_info->PrimaryAbility)
                     _events.ScheduleEvent(EVENT_PRIMARY_ABILITY, 3s, 6s);
                 if (_info->SecondaryAbility)
-                    _events.ScheduleEvent(EVENT_SECONDARY_ABILITY, _info->SecondaryAbility == SPELL_SHOOT ? 2000 : urand(12000, 15000));
+                {
+                    if (_info->SecondaryAbility == SPELL_SHOOT)
+                        _events.ScheduleEvent(EVENT_SECONDARY_ABILITY, 2s);
+                    else
+                        _events.ScheduleEvent(EVENT_SECONDARY_ABILITY, 12s, 15s);
+                }
                 if (_info->ThirdAbility)
                     _events.ScheduleEvent(EVENT_THIRD_ABILITY, 6s, 8s);
                 if (_info->Type == MERCENARY_SOLDIER)
@@ -1180,13 +1185,18 @@ class npc_thorim_pre_phase : public CreatureScript
                 {
                     case EVENT_PRIMARY_ABILITY:
                         if (UseAbility(_info->PrimaryAbility))
-                            _events.ScheduleEvent(eventId, urand(15000, 20000));
+                            _events.ScheduleEvent(eventId, 15s, 20s);
                         else
                             _events.ScheduleEvent(eventId, 1s);
                         break;
                     case EVENT_SECONDARY_ABILITY:
                         if (UseAbility(_info->SecondaryAbility))
-                            _events.ScheduleEvent(eventId, _info->SecondaryAbility == SPELL_SHOOT ? 2000 : urand(4000, 8000));
+                        {
+                            if (_info->SecondaryAbility == SPELL_SHOOT)
+                                _events.ScheduleEvent(eventId, 2s);
+                            else
+                                _events.ScheduleEvent(eventId, 4s, 8s);
+                        }
                         else
                             _events.ScheduleEvent(eventId, 1s);
                         break;
@@ -1286,21 +1296,21 @@ class npc_thorim_arena_phase : public CreatureScript
                 {
                     case EVENT_PRIMARY_ABILITY:
                         if (UseAbility(_info->PrimaryAbility))
-                            _events.Repeat(3000, 6000);
+                            _events.Repeat(3s, 6s);
                         else
-                            _events.Repeat(1000);
+                            _events.Repeat(1s);
                         break;
                     case EVENT_SECONDARY_ABILITY:
                         if (UseAbility(_info->SecondaryAbility))
-                            _events.Repeat(12000, 16000);
+                            _events.Repeat(12s, 16s);
                         else
-                            _events.Repeat(1000);
+                            _events.Repeat(1s);
                         break;
                     case EVENT_THIRD_ABILITY:
                         if (UseAbility(_info->ThirdAbility))
-                            _events.Repeat(6000, 8000);
+                            _events.Repeat(6s, 8s);
                         else
-                            _events.Repeat(1000);
+                            _events.Repeat(1s);
                         break;
                     case EVENT_ABILITY_CHARGE:
                     {
@@ -1453,23 +1463,23 @@ class npc_runic_colossus : public CreatureScript
                         case EVENT_RUNIC_BARRIER:
                             Talk(EMOTE_RUNIC_BARRIER);
                             DoCastAOE(SPELL_RUNIC_BARRIER);
-                            _events.Repeat(35000, 45000);
+                            _events.Repeat(35s, 45s);
                             break;
                         case EVENT_SMASH:
                             DoCastAOE(SPELL_SMASH);
-                            _events.Repeat(15000, 18000);
+                            _events.Repeat(15s, 18s);
                             break;
                         case EVENT_RUNIC_CHARGE:
                         {
                             Unit* referer = me;
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, [referer](Unit* unit){ return unit->GetTypeId() == TYPEID_PLAYER && unit->IsInRange(referer, 8.0f, 40.0f); }))
                                 DoCast(target, SPELL_RUNIC_CHARGE);
-                            _events.Repeat(20000);
+                            _events.Repeat(20s);
                             break;
                         }
                         case EVENT_RUNIC_SMASH:
                             DoCast(me, RAND(SPELL_RUNIC_SMASH_LEFT, SPELL_RUNIC_SMASH_RIGHT));
-                            _events.Repeat(6000);
+                            _events.Repeat(6s);
                             break;
                         default:
                             break;
@@ -1521,9 +1531,9 @@ class npc_ancient_rune_giant : public CreatureScript
             {
                 DoZoneInCombat();
                 _events.Reset();
-                _events.ScheduleEvent(EVENT_RUNIC_FORTIFICATION, 1);
+                _events.ScheduleEvent(EVENT_RUNIC_FORTIFICATION, 1ms);
                 _events.ScheduleEvent(EVENT_STOMP, 10s, 12s);
-                _events.ScheduleEvent(EVENT_RUNE_DETONATION, 25000);
+                _events.ScheduleEvent(EVENT_RUNE_DETONATION, 25s);
             }
 
             void JustDied(Unit* /*killer*/) override
@@ -1552,12 +1562,12 @@ class npc_ancient_rune_giant : public CreatureScript
                             break;
                         case EVENT_STOMP:
                             DoCastAOE(SPELL_STOMP);
-                            _events.Repeat(10000, 12000);
+                            _events.Repeat(10s, 12s);
                             break;
                         case EVENT_RUNE_DETONATION:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 60.0f, true))
                                 DoCast(target, SPELL_RUNE_DETONATION);
-                            _events.Repeat(10000, 12000);
+                            _events.Repeat(10s, 12s);
                             break;
                         default:
                             break;
@@ -1614,7 +1624,7 @@ class npc_sif : public CreatureScript
                     Talk(SAY_SIF_EVENT);
                     _events.Reset();
                     _events.ScheduleEvent(EVENT_FROSTBOLT, 2s);
-                    _events.ScheduleEvent(EVENT_FROSTBOLT_VOLLEY, 15000);
+                    _events.ScheduleEvent(EVENT_FROSTBOLT_VOLLEY, 15s);
                     _events.ScheduleEvent(EVENT_BLINK, 20s, 25s);
                     _events.ScheduleEvent(EVENT_BLIZZARD, 30s);
                 }
@@ -1637,8 +1647,8 @@ class npc_sif : public CreatureScript
                         case EVENT_BLINK:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
                                 DoCast(target, SPELL_BLINK);
-                            _events.ScheduleEvent(EVENT_FROST_NOVA, 0);
-                            _events.Repeat(20000, 25000);
+                            _events.ScheduleEvent(EVENT_FROST_NOVA, 0s);
+                            _events.Repeat(20s, 25s);
                             return;
                         case EVENT_FROST_NOVA:
                             DoCastAOE(SPELL_FROSTNOVA);
@@ -1646,15 +1656,15 @@ class npc_sif : public CreatureScript
                         case EVENT_FROSTBOLT:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
                                 DoCast(target, SPELL_FROSTBOLT);
-                            _events.Repeat(2000);
+                            _events.Repeat(2s);
                             return;
                         case EVENT_FROSTBOLT_VOLLEY:
                             DoCastAOE(SPELL_FROSTBOLT_VOLLEY);
-                            _events.Repeat(15000, 20000);
+                            _events.Repeat(15s, 20s);
                             return;
                         case EVENT_BLIZZARD:
                             DoCastAOE(SPELL_BLIZZARD);
-                            _events.Repeat(35000, 45000);
+                            _events.Repeat(35s, 45s);
                             return;
                         default:
                             break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -198,7 +198,7 @@ struct boss_xt002 : public BossAI
     void DoAction(int32 action) override
     {
         if (action == ACTION_ENTER_HARD_MODE)
-            events.ScheduleEvent(EVENT_ENTER_HARD_MODE, 1);
+            events.ScheduleEvent(EVENT_ENTER_HARD_MODE, 1ms);
     }
 
     void KilledUnit(Unit* who) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
@@ -455,7 +455,7 @@ class boss_voice_of_yogg_saron : public CreatureScript
             void Initialize()
             {
                 _guardiansCount = 0;
-                _guardianTimer = 20000;
+                _guardianTimer = 20s;
                 _illusionShattered = false;
             }
 
@@ -522,7 +522,7 @@ class boss_voice_of_yogg_saron : public CreatureScript
                 DoCastAOE(SPELL_SUMMON_GUARDIAN_2, { SPELLVALUE_MAX_TARGETS, 1 });
                 DoCast(me, SPELL_SANITY_PERIODIC);
 
-                events.ScheduleEvent(EVENT_LOCK_DOOR, 15000);
+                events.ScheduleEvent(EVENT_LOCK_DOOR, 15s);
                 events.ScheduleEvent(EVENT_SUMMON_GUARDIAN_OF_YOGG_SARON, _guardianTimer, 0, PHASE_ONE);
                 events.ScheduleEvent(EVENT_EXTINGUISH_ALL_LIFE, 15min);    // 15 minutes
             }
@@ -547,7 +547,7 @@ class boss_voice_of_yogg_saron : public CreatureScript
                 events.Update(diff);
                 // don't summon tentacles when illusion is shattered, delay them
                 if (_illusionShattered)
-                    events.DelayEvents(diff, EVENT_GROUP_SUMMON_TENTACLES);
+                    events.DelayEvents(Milliseconds(diff), EVENT_GROUP_SUMMON_TENTACLES);
 
                 while (uint32 eventId = events.ExecuteEvent())
                 {
@@ -569,20 +569,20 @@ class boss_voice_of_yogg_saron : public CreatureScript
                             DoCastAOE(SPELL_SUMMON_GUARDIAN_2, { SPELLVALUE_MAX_TARGETS, 1 });
                             ++_guardiansCount;
                             if (_guardiansCount <= 6 && _guardiansCount % 3 == 0)
-                                _guardianTimer -= 5000;
+                                _guardianTimer -= 5s;
                             events.ScheduleEvent(EVENT_SUMMON_GUARDIAN_OF_YOGG_SARON, _guardianTimer, 0, PHASE_ONE);
                             break;
                         case EVENT_SUMMON_CORRUPTOR_TENTACLE:
                             DoCastAOE(SPELL_CORRUPTOR_TENTACLE_SUMMON);
-                            events.ScheduleEvent(EVENT_SUMMON_CORRUPTOR_TENTACLE, 30000, EVENT_GROUP_SUMMON_TENTACLES, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_SUMMON_CORRUPTOR_TENTACLE, 30s, EVENT_GROUP_SUMMON_TENTACLES, PHASE_TWO);
                             break;
                         case EVENT_SUMMON_CONSTRICTOR_TENTACLE:
                             DoCastAOE(SPELL_CONSTRICTOR_TENTACLE, { SPELLVALUE_MAX_TARGETS, 1 });
-                            events.ScheduleEvent(EVENT_SUMMON_CONSTRICTOR_TENTACLE, 25000, EVENT_GROUP_SUMMON_TENTACLES, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_SUMMON_CONSTRICTOR_TENTACLE, 25s, EVENT_GROUP_SUMMON_TENTACLES, PHASE_TWO);
                             break;
                         case EVENT_SUMMON_CRUSHER_TENTACLE:
                             DoCastAOE(SPELL_CRUSHER_TENTACLE_SUMMON);
-                            events.ScheduleEvent(EVENT_SUMMON_CRUSHER_TENTACLE, 60000, EVENT_GROUP_SUMMON_TENTACLES, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_SUMMON_CRUSHER_TENTACLE, 60s, EVENT_GROUP_SUMMON_TENTACLES, PHASE_TWO);
                             break;
                         case EVENT_ILLUSION:
                         {
@@ -676,7 +676,7 @@ class boss_voice_of_yogg_saron : public CreatureScript
 
         private:
             uint8 _guardiansCount;
-            uint32 _guardianTimer;
+            Milliseconds _guardianTimer;
             bool _illusionShattered;
         };
 
@@ -729,10 +729,10 @@ class boss_sara : public CreatureScript
 
                         Talk(SAY_SARA_TRANSFORM_1);
                         _events.SetPhase(PHASE_TRANSFORM);
-                        _events.ScheduleEvent(EVENT_TRANSFORM_1, 4700, 0, PHASE_TRANSFORM);
-                        _events.ScheduleEvent(EVENT_TRANSFORM_2, 9500, 0, PHASE_TRANSFORM);
-                        _events.ScheduleEvent(EVENT_TRANSFORM_3, 14300, 0, PHASE_TRANSFORM);
-                        _events.ScheduleEvent(EVENT_TRANSFORM_4, 14500, 0, PHASE_TRANSFORM);
+                        _events.ScheduleEvent(EVENT_TRANSFORM_1, 4700ms, 0, PHASE_TRANSFORM);
+                        _events.ScheduleEvent(EVENT_TRANSFORM_2, 9500ms, 0, PHASE_TRANSFORM);
+                        _events.ScheduleEvent(EVENT_TRANSFORM_3, 14300ms, 0, PHASE_TRANSFORM);
+                        _events.ScheduleEvent(EVENT_TRANSFORM_4, 14500ms, 0, PHASE_TRANSFORM);
                     }
                 }
             }
@@ -768,8 +768,8 @@ class boss_sara : public CreatureScript
             {
                 Talk(SAY_SARA_AGGRO);
                 _events.ScheduleEvent(EVENT_SARAS_FERVOR, 5s, 0, PHASE_ONE);
-                _events.ScheduleEvent(EVENT_SARAS_BLESSING, urand(10000, 30000), 0, PHASE_ONE);
-                _events.ScheduleEvent(EVENT_SARAS_ANGER, urand(15000, 25000), 0, PHASE_ONE);
+                _events.ScheduleEvent(EVENT_SARAS_BLESSING, 10s, 30s, 0, PHASE_ONE);
+                _events.ScheduleEvent(EVENT_SARAS_ANGER, 15s,  25s, 0, PHASE_ONE);
             }
 
             void JustEnteredCombat(Unit* who) override
@@ -812,11 +812,11 @@ class boss_sara : public CreatureScript
                             break;
                         case EVENT_SARAS_ANGER:
                             DoCastAOE(SPELL_SARAS_ANGER_TARGET_SELECTOR, { SPELLVALUE_MAX_TARGETS, 1 });
-                            _events.ScheduleEvent(EVENT_SARAS_ANGER, urand(6000, 8000), 0, PHASE_ONE);
+                            _events.ScheduleEvent(EVENT_SARAS_ANGER, 6s, 8s, 0, PHASE_ONE);
                             break;
                         case EVENT_SARAS_BLESSING:
                             DoCastAOE(SPELL_SARAS_BLESSING_TARGET_SELECTOR, { SPELLVALUE_MAX_TARGETS, 1 });
-                            _events.ScheduleEvent(EVENT_SARAS_BLESSING, urand(6000, 30000), 0, PHASE_ONE);
+                            _events.ScheduleEvent(EVENT_SARAS_BLESSING, 6s, 30s, 0, PHASE_ONE);
                             break;
                         case EVENT_TRANSFORM_1:
                             Talk(SAY_SARA_TRANSFORM_2);
@@ -841,7 +841,7 @@ class boss_sara : public CreatureScript
                             _events.SetPhase(PHASE_TWO);
                             _events.ScheduleEvent(EVENT_DEATH_RAY, 20s, 0, PHASE_TWO);    // almost never cast at scheduled time, why?
                             _events.ScheduleEvent(EVENT_MALADY_OF_THE_MIND, 18s, 0, PHASE_TWO);
-                            _events.ScheduleEvent(EVENT_PSYCHOSIS, 1, 0, PHASE_TWO);
+                            _events.ScheduleEvent(EVENT_PSYCHOSIS, 1ms, 0, PHASE_TWO);
                             _events.ScheduleEvent(EVENT_BRAIN_LINK, 23s, 0, PHASE_TWO);
                             break;
                         case EVENT_DEATH_RAY:
@@ -850,7 +850,7 @@ class boss_sara : public CreatureScript
                             break;
                         case EVENT_MALADY_OF_THE_MIND:
                             DoCastAOE(SPELL_MALADY_OF_THE_MIND, { SPELLVALUE_MAX_TARGETS, 1 });
-                            _events.ScheduleEvent(EVENT_MALADY_OF_THE_MIND, urand(18000, 25000), 0, PHASE_TWO);
+                            _events.ScheduleEvent(EVENT_MALADY_OF_THE_MIND, 18s, 25s, 0, PHASE_TWO);
                             break;
                         case EVENT_PSYCHOSIS:
                             DoCastAOE(SPELL_PSYCHOSIS, { SPELLVALUE_MAX_TARGETS, 1 });
@@ -858,7 +858,7 @@ class boss_sara : public CreatureScript
                             break;
                         case EVENT_BRAIN_LINK:
                             DoCastAOE(SPELL_BRAIN_LINK, { SPELLVALUE_MAX_TARGETS, 2 });
-                            _events.ScheduleEvent(EVENT_BRAIN_LINK, urand(23000, 26000), 0, PHASE_TWO);
+                            _events.ScheduleEvent(EVENT_BRAIN_LINK, 23s, 26s, 0, PHASE_TWO);
                             break;
                         default:
                             break;
@@ -1007,7 +1007,7 @@ class boss_yogg_saron : public CreatureScript
                             DoCastAOE(SPELL_DEAFENING_ROAR);
                             Talk(SAY_YOGG_SARON_DEAFENING_ROAR);
                             Talk(EMOTE_YOGG_SARON_DEAFENING_ROAR);
-                            _events.ScheduleEvent(EVENT_DEAFENING_ROAR, urand(20000, 25000), 0, PHASE_THREE);    // timer guessed
+                            _events.ScheduleEvent(EVENT_DEAFENING_ROAR, 20s, 25s, 0, PHASE_THREE);    // timer guessed
                             break;
                         default:
                             break;
@@ -1024,7 +1024,7 @@ class boss_yogg_saron : public CreatureScript
                         _events.ScheduleEvent(EVENT_SHADOW_BEACON, 45s, 0, PHASE_THREE);
                         _events.ScheduleEvent(EVENT_LUNATIC_GAZE, 12s, 0, PHASE_THREE);
                         if (me->GetMap()->Is25ManRaid() && _instance->GetData(DATA_KEEPERS_COUNT) < 4)
-                            _events.ScheduleEvent(EVENT_DEAFENING_ROAR, urand(20000, 25000), 0, PHASE_THREE);    // timer guessed
+                            _events.ScheduleEvent(EVENT_DEAFENING_ROAR, 20s, 25s, 0, PHASE_THREE);    // timer guessed
                         Talk(SAY_YOGG_SARON_PHASE_3);
                         DoCast(me, SPELL_PHASE_3_TRANSFORM);
                         me->RemoveAurasDueToSpell(SPELL_SHADOWY_BARRIER_YOGG);
@@ -1261,7 +1261,7 @@ class npc_corruptor_tentacle : public CreatureScript
             {
                 DoCast(me, SPELL_TENTACLE_VOID_ZONE);
                 DoCastAOE(SPELL_ERUPT);
-                _events.ScheduleEvent(EVENT_CAST_RANDOM_SPELL, 1);
+                _events.ScheduleEvent(EVENT_CAST_RANDOM_SPELL, 1ms);
             }
 
             void UpdateAI(uint32 diff) override
@@ -1663,7 +1663,7 @@ class npc_yogg_saron_keeper : public CreatureScript
                     {
                         case EVENT_DESTABILIZATION_MATRIX:
                             DoCastAOE(SPELL_DESTABILIZATION_MATRIX, { SPELLVALUE_MAX_TARGETS, 1 });
-                            _events.ScheduleEvent(EVENT_DESTABILIZATION_MATRIX, urand(15000, 25000), 0, PHASE_TWO);
+                            _events.ScheduleEvent(EVENT_DESTABILIZATION_MATRIX, 15s, 25s, 0, PHASE_TWO);
                             break;
                         case EVENT_HODIRS_PROTECTIVE_GAZE:
                             DoCast(SPELL_HODIRS_PROTECTIVE_GAZE);
@@ -1679,7 +1679,7 @@ class npc_yogg_saron_keeper : public CreatureScript
                     // setting the phases is only for Thorim and Mimiron
                     case ACTION_PHASE_TWO:
                         _events.SetPhase(PHASE_TWO);
-                        _events.ScheduleEvent(EVENT_DESTABILIZATION_MATRIX, urand(5000, 15000), 0, PHASE_TWO);
+                        _events.ScheduleEvent(EVENT_DESTABILIZATION_MATRIX, 5s, 15s, 0, PHASE_TWO);
                         break;
                     case ACTION_PHASE_THREE:
                         _events.SetPhase(PHASE_THREE);
@@ -1733,24 +1733,24 @@ class npc_yogg_saron_illusions : public CreatureScript
                         if (Creature* neltharion = me->FindNearestCreature(NPC_NELTHARION, 50.0f))
                             neltharion->AI()->Talk(SAY_CHAMBER_ROLEPLAY_1);
 
-                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_1, 16000);
-                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_2, 22000);
-                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_3, 28000);
-                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_4, 36000);
+                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_1, 16s);
+                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_2, 22s);
+                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_3, 28s);
+                        _events.ScheduleEvent(EVENT_CHAMBER_ROLEPLAY_4, 36s);
                         break;
                     case ICECROWN_ILLUSION:
                         // same here
-                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_1, 1000);
-                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_2, 7500);
-                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_3, 19500);
-                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_4, 25500);
-                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_5, 33000);
-                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_6, 41300);
+                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_1, 1s);
+                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_2, 7500ms);
+                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_3, 19500ms);
+                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_4, 25500ms);
+                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_5, 33s);
+                        _events.ScheduleEvent(EVENT_ICECROWN_ROLEPLAY_6, 41300ms);
                         break;
                     case STORMWIND_ILLUSION:
-                        _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_4, 33800); // "A thousand deaths..."
-                        _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_5, 38850);
-                        _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_7, 58750);
+                        _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_4, 33800ms); // "A thousand deaths..."
+                        _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_5, 38850ms);
+                        _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_7, 58750ms);
                         // TODO: use "or one murder." sound and split the text in DB
                         break;
                 }
@@ -1851,10 +1851,10 @@ class npc_garona : public CreatureScript
                 me->SetWalk(true);
                 me->GetMotionMaster()->MovePoint(0, IllusionsMiscPos[0]);
 
-                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_1, 9250);
-                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_2, 16700);
-                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_3, 24150);
-                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_6, 52700);
+                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_1, 9250ms);
+                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_2, 16700ms);
+                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_3, 24150ms);
+                _events.ScheduleEvent(EVENT_STORMWIND_ROLEPLAY_6, 52700ms);
             }
 
             void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp
@@ -769,7 +769,7 @@ class boss_sara : public CreatureScript
                 Talk(SAY_SARA_AGGRO);
                 _events.ScheduleEvent(EVENT_SARAS_FERVOR, 5s, 0, PHASE_ONE);
                 _events.ScheduleEvent(EVENT_SARAS_BLESSING, 10s, 30s, 0, PHASE_ONE);
-                _events.ScheduleEvent(EVENT_SARAS_ANGER, 15s,  25s, 0, PHASE_ONE);
+                _events.ScheduleEvent(EVENT_SARAS_ANGER, 15s, 25s, 0, PHASE_ONE);
             }
 
             void JustEnteredCombat(Unit* who) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -771,7 +771,7 @@ class instance_ulduar : public InstanceMapScript
                         DoUpdateWorldState(WORLD_STATE_ALGALON_TIMER_ENABLED, 1);
                         DoUpdateWorldState(WORLD_STATE_ALGALON_DESPAWN_TIMER, 60);
                         _algalonTimer = 60;
-                        _events.ScheduleEvent(EVENT_DESPAWN_ALGALON, 3600000);
+                        _events.ScheduleEvent(EVENT_DESPAWN_ALGALON, 1h);
                         _events.ScheduleEvent(EVENT_UPDATE_ALGALON_TIMER, 1min);
                         break;
                     case DATA_ALGALON_SUMMON_STATE:


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Ulduar: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build