### PR TITLE
Scripts/ICC: Use std::chrono::duration overloads of EventMap (Part 1)

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -162,14 +162,14 @@ class boss_blood_queen_lana_thel : public CreatureScript
             void Reset() override
             {
                 _Reset();
-                events.ScheduleEvent(EVENT_BERSERK, 330000);
+                events.ScheduleEvent(EVENT_BERSERK, 330s);
                 events.ScheduleEvent(EVENT_VAMPIRIC_BITE, 15s);
                 events.ScheduleEvent(EVENT_BLOOD_MIRROR, 2500ms, EVENT_GROUP_CANCELLABLE);
                 events.ScheduleEvent(EVENT_DELIRIOUS_SLASH, 20s, 24s, EVENT_GROUP_NORMAL);
                 events.ScheduleEvent(EVENT_PACT_OF_THE_DARKFALLEN, 15s, EVENT_GROUP_NORMAL);
-                events.ScheduleEvent(EVENT_SWARMING_SHADOWS, 30500, EVENT_GROUP_NORMAL);
+                events.ScheduleEvent(EVENT_SWARMING_SHADOWS, 30500ms, EVENT_GROUP_NORMAL);
                 events.ScheduleEvent(EVENT_TWILIGHT_BLOODBOLT, 20s, 25s, EVENT_GROUP_NORMAL);
-                events.ScheduleEvent(EVENT_AIR_PHASE, 124000 + uint32(Is25ManRaid() ? 3000 : 0));
+                events.ScheduleEvent(EVENT_AIR_PHASE, 124s + (Is25ManRaid() ? 3s : 0s));
                 CleanAuras();
                 _vampires.clear();
                 Initialize();
@@ -313,9 +313,9 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 {
                     case POINT_CENTER:
                         DoCast(me, SPELL_INCITE_TERROR);
-                        events.ScheduleEvent(EVENT_AIR_PHASE, 100000 + uint32(Is25ManRaid() ? 0 : 20000));
-                        events.RescheduleEvent(EVENT_SWARMING_SHADOWS, 30500, EVENT_GROUP_NORMAL);
-                        events.RescheduleEvent(EVENT_PACT_OF_THE_DARKFALLEN, 25500, EVENT_GROUP_NORMAL);
+                        events.ScheduleEvent(EVENT_AIR_PHASE, 100s + (Is25ManRaid() ? 0s : 20s));
+                        events.RescheduleEvent(EVENT_SWARMING_SHADOWS, 30500ms, EVENT_GROUP_NORMAL);
+                        events.RescheduleEvent(EVENT_PACT_OF_THE_DARKFALLEN, 25500ms, EVENT_GROUP_NORMAL);
                         events.ScheduleEvent(EVENT_AIR_START_FLYING, 5s);
                         break;
                     case POINT_AIR:
@@ -424,7 +424,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                                 for (std::list<Player*>::iterator itr = targets.begin(); itr != targets.end(); ++itr)
                                     DoCast(*itr, SPELL_PACT_OF_THE_DARKFALLEN);
                             }
-                            events.ScheduleEvent(EVENT_PACT_OF_THE_DARKFALLEN, 30500, EVENT_GROUP_NORMAL);
+                            events.ScheduleEvent(EVENT_PACT_OF_THE_DARKFALLEN, 30500ms, EVENT_GROUP_NORMAL);
                             break;
                         }
                         case EVENT_SWARMING_SHADOWS:
@@ -434,7 +434,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                                 Talk(SAY_SWARMING_SHADOWS);
                                 DoCast(target, SPELL_SWARMING_SHADOWS);
                             }
-                            events.ScheduleEvent(EVENT_SWARMING_SHADOWS, 30500, EVENT_GROUP_NORMAL);
+                            events.ScheduleEvent(EVENT_SWARMING_SHADOWS, 30500ms, EVENT_GROUP_NORMAL);
                             break;
                         case EVENT_TWILIGHT_BLOODBOLT:
                         {
@@ -450,7 +450,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                         case EVENT_AIR_PHASE:
                             DoStopAttack();
                             me->SetReactState(REACT_PASSIVE);
-                            events.DelayEvents(10000, EVENT_GROUP_NORMAL);
+                            events.DelayEvents(10s, EVENT_GROUP_NORMAL);
                             events.CancelEventGroup(EVENT_GROUP_CANCELLABLE);
                             me->GetMotionMaster()->MovePoint(POINT_CENTER, centerPos);
                             break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_deathbringer_saurfang.cpp
@@ -307,8 +307,8 @@ class boss_deathbringer_saurfang : public CreatureScript
 
                 Talk(SAY_AGGRO);
                 events.ScheduleEvent(EVENT_SUMMON_BLOOD_BEAST, 30s, 0, PHASE_COMBAT);
-                events.ScheduleEvent(EVENT_BERSERK, IsHeroic() ? 360000 : 480000, 0, PHASE_COMBAT);
-                events.ScheduleEvent(EVENT_BOILING_BLOOD, 15500, 0, PHASE_COMBAT);
+                events.ScheduleEvent(EVENT_BERSERK, IsHeroic() ? 360s : 480s, 0, PHASE_COMBAT);
+                events.ScheduleEvent(EVENT_BOILING_BLOOD, 15500ms, 0, PHASE_COMBAT);
                 events.ScheduleEvent(EVENT_BLOOD_NOVA, 17s, 0, PHASE_COMBAT);
                 events.ScheduleEvent(EVENT_RUNE_OF_BLOOD, 20s, 0, PHASE_COMBAT);
 
@@ -508,15 +508,15 @@ class boss_deathbringer_saurfang : public CreatureScript
                             break;
                         case EVENT_BLOOD_NOVA:
                             DoCastAOE(SPELL_BLOOD_NOVA_TRIGGER);
-                            events.ScheduleEvent(EVENT_BLOOD_NOVA, urand(20000, 25000), 0, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_BLOOD_NOVA, 20s, 25s, 0, PHASE_COMBAT);
                             break;
                         case EVENT_RUNE_OF_BLOOD:
                             DoCastVictim(SPELL_RUNE_OF_BLOOD);
-                            events.ScheduleEvent(EVENT_RUNE_OF_BLOOD, urand(20000, 25000), 0, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_RUNE_OF_BLOOD, 20s, 25s, 0, PHASE_COMBAT);
                             break;
                         case EVENT_BOILING_BLOOD:
                             DoCastSelf(SPELL_BOILING_BLOOD);
-                            events.ScheduleEvent(EVENT_BOILING_BLOOD, urand(15000, 20000), 0, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_BOILING_BLOOD, 15s, 20s, 0, PHASE_COMBAT);
                             break;
                         case EVENT_BERSERK:
                             DoCastSelf(SPELL_BERSERK);
@@ -563,10 +563,10 @@ class boss_deathbringer_saurfang : public CreatureScript
                         me->SetHomePosition(deathbringerPos.GetPositionX(), deathbringerPos.GetPositionY(), deathbringerPos.GetPositionZ(), me->GetOrientation());
                         me->GetMotionMaster()->MovePoint(POINT_SAURFANG, deathbringerPos.GetPositionX(), deathbringerPos.GetPositionY(), deathbringerPos.GetPositionZ());
 
-                        events.ScheduleEvent(EVENT_INTRO_ALLIANCE_2, 2500, 0, PHASE_INTRO_A);
-                        events.ScheduleEvent(EVENT_INTRO_ALLIANCE_3, 20000, 0, PHASE_INTRO_A);
+                        events.ScheduleEvent(EVENT_INTRO_ALLIANCE_2, 2500ms, 0, PHASE_INTRO_A);
+                        events.ScheduleEvent(EVENT_INTRO_ALLIANCE_3, 20s, 0, PHASE_INTRO_A);
 
-                        events.ScheduleEvent(EVENT_INTRO_HORDE_2, 5000, 0, PHASE_INTRO_H);
+                        events.ScheduleEvent(EVENT_INTRO_HORDE_2, 5s, 0, PHASE_INTRO_H);
                         break;
                     }
                     case ACTION_CONTINUE_INTRO:
@@ -574,12 +574,12 @@ class boss_deathbringer_saurfang : public CreatureScript
                         if (_introDone)
                             return;
 
-                        events.ScheduleEvent(EVENT_INTRO_ALLIANCE_6, 6500+500, 0, PHASE_INTRO_A);
+                        events.ScheduleEvent(EVENT_INTRO_ALLIANCE_6, 7s, 0, PHASE_INTRO_A);
                         events.ScheduleEvent(EVENT_INTRO_FINISH, 8s, 0, PHASE_INTRO_A);
 
-                        events.ScheduleEvent(EVENT_INTRO_HORDE_4, 6500, 0, PHASE_INTRO_H);
-                        events.ScheduleEvent(EVENT_INTRO_HORDE_9, 46700+1000+500, 0, PHASE_INTRO_H);
-                        events.ScheduleEvent(EVENT_INTRO_FINISH,  46700+1000+8000, 0, PHASE_INTRO_H);
+                        events.ScheduleEvent(EVENT_INTRO_HORDE_4, 6500ms, 0, PHASE_INTRO_H);
+                        events.ScheduleEvent(EVENT_INTRO_HORDE_9, 48200ms, 0, PHASE_INTRO_H);
+                        events.ScheduleEvent(EVENT_INTRO_FINISH,  55700ms, 0, PHASE_INTRO_H);
                         break;
                     }
                     case ACTION_MARK_OF_THE_FALLEN_CHAMPION:
@@ -680,7 +680,7 @@ class npc_high_overlord_saurfang_icc : public CreatureScript
                         me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                         Talk(SAY_INTRO_HORDE_1);
                         _events.SetPhase(PHASE_INTRO_H);
-                        _events.ScheduleEvent(EVENT_INTRO_HORDE_3, 18500, 0, PHASE_INTRO_H);
+                        _events.ScheduleEvent(EVENT_INTRO_HORDE_3, 18500ms, 0, PHASE_INTRO_H);
                         _instance->HandleGameObject(_instance->GetGuidData(GO_SAURFANG_S_DOOR), true);
                         if (Creature* deathbringer = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_DEATHBRINGER_SAURFANG)))
                             deathbringer->AI()->DoAction(PHASE_INTRO_H);
@@ -690,10 +690,10 @@ class npc_high_overlord_saurfang_icc : public CreatureScript
                     {
                         me->RemoveAurasDueToSpell(SPELL_GRIP_OF_AGONY);
                         Talk(SAY_OUTRO_HORDE_1);
-                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_2, 10000);   // say
-                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_3, 18000);   // say
-                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_4, 24000);   // cast
-                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_5, 30000);   // move
+                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_2, 10s);   // say
+                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_3, 18s);   // say
+                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_4, 24s);   // cast
+                        _events.ScheduleEvent(EVENT_OUTRO_HORDE_5, 30s);   // move
                         me->SetDisableGravity(false);
                         me->GetMotionMaster()->MoveFall();
                         GuardBroadcast([](Creature* guard)
@@ -734,10 +734,10 @@ class npc_high_overlord_saurfang_icc : public CreatureScript
                         case POINT_FIRST_STEP:
                             me->SetWalk(false);
                             Talk(SAY_INTRO_HORDE_3);
-                            _events.ScheduleEvent(EVENT_INTRO_HORDE_5, 15500, 0, PHASE_INTRO_H);
-                            _events.ScheduleEvent(EVENT_INTRO_HORDE_6, 29500, 0, PHASE_INTRO_H);
-                            _events.ScheduleEvent(EVENT_INTRO_HORDE_7, 43800, 0, PHASE_INTRO_H);
-                            _events.ScheduleEvent(EVENT_INTRO_HORDE_8, 47000, 0, PHASE_INTRO_H);
+                            _events.ScheduleEvent(EVENT_INTRO_HORDE_5, 15500ms, 0, PHASE_INTRO_H);
+                            _events.ScheduleEvent(EVENT_INTRO_HORDE_6, 29500ms, 0, PHASE_INTRO_H);
+                            _events.ScheduleEvent(EVENT_INTRO_HORDE_7, 43800ms, 0, PHASE_INTRO_H);
+                            _events.ScheduleEvent(EVENT_INTRO_HORDE_8, 47000ms, 0, PHASE_INTRO_H);
                             if (Creature* deathbringer = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_DEATHBRINGER_SAURFANG)))
                                 deathbringer->AI()->DoAction(ACTION_CONTINUE_INTRO);
                             break;
@@ -748,8 +748,8 @@ class npc_high_overlord_saurfang_icc : public CreatureScript
                                 deathbringer->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                                 deathbringer->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_DROWNED);
                             }
-                            _events.ScheduleEvent(EVENT_OUTRO_HORDE_5, 1000);    // move
-                            _events.ScheduleEvent(EVENT_OUTRO_HORDE_6, 4000);    // say
+                            _events.ScheduleEvent(EVENT_OUTRO_HORDE_5, 1s);    // move
+                            _events.ScheduleEvent(EVENT_OUTRO_HORDE_6, 4s);    // say
                             break;
                         case POINT_FINAL:
                             if (Creature* deathbringer = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_DEATHBRINGER_SAURFANG)))
@@ -891,7 +891,7 @@ class npc_muradin_bronzebeard_icc : public CreatureScript
 
                         me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                         Talk(SAY_INTRO_ALLIANCE_1);
-                        _events.ScheduleEvent(EVENT_INTRO_ALLIANCE_4, 2500+17500+9500, 0, PHASE_INTRO_A);
+                        _events.ScheduleEvent(EVENT_INTRO_ALLIANCE_4, 29500ms, 0, PHASE_INTRO_A);
                         _instance->HandleGameObject(_instance->GetGuidData(GO_SAURFANG_S_DOOR), true);
                         if (Creature* deathbringer = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_DEATHBRINGER_SAURFANG)))
                             deathbringer->AI()->DoAction(PHASE_INTRO_A);
@@ -938,7 +938,7 @@ class npc_muradin_bronzebeard_icc : public CreatureScript
                 {
                     me->SetWalk(false);
                     Talk(SAY_INTRO_ALLIANCE_4);
-                    _events.ScheduleEvent(EVENT_INTRO_ALLIANCE_5, 5000, 0, PHASE_INTRO_A);
+                    _events.ScheduleEvent(EVENT_INTRO_ALLIANCE_5, 5s, 0, PHASE_INTRO_A);
                     if (Creature* deathbringer = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_DEATHBRINGER_SAURFANG)))
                         deathbringer->AI()->DoAction(ACTION_CONTINUE_INTRO);
                 }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_festergut.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_festergut.cpp
@@ -100,7 +100,7 @@ class boss_festergut : public CreatureScript
                 events.ScheduleEvent(EVENT_BERSERK, 5min);
                 events.ScheduleEvent(EVENT_INHALE_BLIGHT, 25s, 30s);
                 events.ScheduleEvent(EVENT_GAS_SPORE, 20s, 25s);
-                events.ScheduleEvent(EVENT_GASTRIC_BLOAT, urand(12500, 15000));
+                events.ScheduleEvent(EVENT_GASTRIC_BLOAT, 12500ms, 15s);
                 _maxInoculatedStack = 0;
                 _inhaleCounter = 0;
                 me->RemoveAurasDueToSpell(SPELL_BERSERK2);
@@ -197,7 +197,7 @@ class boss_festergut : public CreatureScript
                                 _inhaleCounter = 0;
                                 if (Creature* professor = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_PROFESSOR_PUTRICIDE)))
                                     professor->AI()->DoAction(ACTION_FESTERGUT_GAS);
-                                events.RescheduleEvent(EVENT_GAS_SPORE, urand(20000, 25000));
+                                events.RescheduleEvent(EVENT_GAS_SPORE, 20s, 25s);
                             }
                             else
                             {
@@ -208,7 +208,7 @@ class boss_festergut : public CreatureScript
                                     me->CastSpell(me, gaseousBlight[_inhaleCounter], me->GetGUID());
                             }
 
-                            events.ScheduleEvent(EVENT_INHALE_BLIGHT, urand(33500, 35000));
+                            events.ScheduleEvent(EVENT_INHALE_BLIGHT, 33500ms, 35s);
                             break;
                         }
                         case EVENT_VILE_GAS:
@@ -242,11 +242,11 @@ class boss_festergut : public CreatureScript
                             Talk(EMOTE_GAS_SPORE);
                             me->CastSpell(me, SPELL_GAS_SPORE, CastSpellExtraArgs().AddSpellMod(SPELLVALUE_MAX_TARGETS, RAID_MODE<int32>(2, 3, 2, 3)));
                             events.ScheduleEvent(EVENT_GAS_SPORE, 40s, 45s);
-                            events.RescheduleEvent(EVENT_VILE_GAS, urand(28000, 35000));
+                            events.RescheduleEvent(EVENT_VILE_GAS, 28s, 35s);
                             break;
                         case EVENT_GASTRIC_BLOAT:
                             DoCastVictim(SPELL_GASTRIC_BLOAT);
-                            events.ScheduleEvent(EVENT_GASTRIC_BLOAT, urand(15000, 17500));
+                            events.ScheduleEvent(EVENT_GASTRIC_BLOAT, 15s, 17500ms);
                             break;
                         case EVENT_BERSERK:
                             DoCast(me, SPELL_BERSERK2);
@@ -343,7 +343,7 @@ class npc_stinky_icc : public CreatureScript
                             break;
                         case EVENT_MORTAL_WOUND:
                             DoCastVictim(SPELL_MORTAL_WOUND);
-                            _events.ScheduleEvent(EVENT_MORTAL_WOUND, urand(10000, 12500));
+                            _events.ScheduleEvent(EVENT_MORTAL_WOUND, 10s, 12500ms);
                             break;
                         default:
                             break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lord_marrowgar.cpp
@@ -138,7 +138,7 @@ class boss_lord_marrowgar : public CreatureScript
         {
             boss_lord_marrowgarAI(Creature* creature) : BossAI(creature, DATA_LORD_MARROWGAR)
             {
-                _boneStormDuration = RAID_MODE<uint32>(20000, 30000, 20000, 30000);
+                _boneStormDuration = RAID_MODE(20s, 30s, 20s, 30s);
                 _baseSpeed = creature->GetSpeedRate(MOVE_RUN);
                 _coldflameLastPos.Relocate(creature);
                 _boneSlice = false;
@@ -221,16 +221,16 @@ class boss_lord_marrowgar : public CreatureScript
                             Talk(EMOTE_BONE_STORM);
                             me->FinishSpell(CURRENT_MELEE_SPELL, false);
                             DoCast(me, SPELL_BONE_STORM);
-                            events.DelayEvents(3000, EVENT_GROUP_SPECIAL);
-                            events.ScheduleEvent(EVENT_BONE_STORM_BEGIN, 3050);
+                            events.DelayEvents(3s, EVENT_GROUP_SPECIAL);
+                            events.ScheduleEvent(EVENT_BONE_STORM_BEGIN, 3050ms);
                             events.ScheduleEvent(EVENT_WARN_BONE_STORM, 90s, 95s);
                             break;
                         case EVENT_BONE_STORM_BEGIN:
                             if (Aura* pStorm = me->GetAura(SPELL_BONE_STORM))
-                                pStorm->SetDuration(int32(_boneStormDuration));
+                                pStorm->SetDuration(int32(_boneStormDuration.count()));
                             me->SetSpeedRate(MOVE_RUN, _baseSpeed*3.0f);
                             Talk(SAY_BONE_STORM);
-                            events.ScheduleEvent(EVENT_BONE_STORM_END, _boneStormDuration+1);
+                            events.ScheduleEvent(EVENT_BONE_STORM_END, _boneStormDuration + 1ms);
                             /* fallthrough */
                         case EVENT_BONE_STORM_MOVE:
                         {
@@ -258,7 +258,7 @@ class boss_lord_marrowgar : public CreatureScript
                             events.CancelEvent(EVENT_BONE_STORM_MOVE);
                             events.ScheduleEvent(EVENT_ENABLE_BONE_SLICE, 10s);
                             if (!IsHeroic())
-                                events.RescheduleEvent(EVENT_BONE_SPIKE_GRAVEYARD, 15000, EVENT_GROUP_SPECIAL);
+                                events.RescheduleEvent(EVENT_BONE_SPIKE_GRAVEYARD, 15s, EVENT_GROUP_SPECIAL);
                             break;
                         case EVENT_ENABLE_BONE_SLICE:
                             _boneSlice = true;
@@ -352,7 +352,7 @@ class boss_lord_marrowgar : public CreatureScript
             Position _coldflameLastPos;
             GuidVector _boneSpikeImmune;
             ObjectGuid _coldflameTarget;
-            uint32 _boneStormDuration;
+            Milliseconds _boneStormDuration;
             float _baseSpeed;
             bool _boneSlice;
         };

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -403,14 +403,14 @@ class boss_professor_putricide : public CreatureScript
                             {
                                 SpellInfo const* spell = sSpellMgr->GetSpellInfo(SPELL_CREATE_CONCOCTION);
                                 DoCast(me, SPELL_CREATE_CONCOCTION);
-                                events.ScheduleEvent(EVENT_PHASE_TRANSITION, sSpellMgr->GetSpellForDifficultyFromSpell(spell, me)->CalcCastTime() + 100);
+                                events.ScheduleEvent(EVENT_PHASE_TRANSITION, Milliseconds(sSpellMgr->GetSpellForDifficultyFromSpell(spell, me)->CalcCastTime()) + 100ms);
                                 break;
                             }
                             case PHASE_COMBAT_3:
                             {
                                 SpellInfo const* spell = sSpellMgr->GetSpellInfo(SPELL_GUZZLE_POTIONS);
                                 DoCast(me, SPELL_GUZZLE_POTIONS);
-                                events.ScheduleEvent(EVENT_PHASE_TRANSITION, sSpellMgr->GetSpellForDifficultyFromSpell(spell, me)->CalcCastTime() + 100);
+                                events.ScheduleEvent(EVENT_PHASE_TRANSITION, Milliseconds(sSpellMgr->GetSpellForDifficultyFromSpell(spell, me)->CalcCastTime()) + 100ms);
                                 break;
                             }
                             default:
@@ -433,7 +433,7 @@ class boss_professor_putricide : public CreatureScript
                         me->SetReactState(REACT_PASSIVE);
                         EngagementStart(nullptr);
                         if (IsHeroic())
-                            events.ScheduleEvent(EVENT_FESTERGUT_GOO, urand(13000, 18000), 0, PHASE_FESTERGUT);
+                            events.ScheduleEvent(EVENT_FESTERGUT_GOO, 13s, 18s, 0, PHASE_FESTERGUT);
                         break;
                     case ACTION_FESTERGUT_GAS:
                         Talk(SAY_FESTERGUT_GASEOUS_BLIGHT);
@@ -486,7 +486,7 @@ class boss_professor_putricide : public CreatureScript
                         break;
                     case ACTION_CHANGE_PHASE:
                         me->SetSpeedRate(MOVE_RUN, _baseSpeed*2.0f);
-                        events.DelayEvents(30000);
+                        events.DelayEvents(30s);
                         me->AttackStop();
                         if (!IsHeroic())
                         {
@@ -587,7 +587,10 @@ class boss_professor_putricide : public CreatureScript
                             break;
                         case EVENT_FESTERGUT_GOO:
                             DoCastAOE(SPELL_MALLEABLE_GOO_SUMMON, CastSpellExtraArgs(true).AddSpellMod(SPELLVALUE_MAX_TARGETS, 1));
-                            events.ScheduleEvent(EVENT_FESTERGUT_GOO, (Is25ManRaid() ? 10000 : 30000) + urand(0, 5000), 0, PHASE_FESTERGUT);
+                            if (Is25ManRaid())
+                                events.ScheduleEvent(EVENT_FESTERGUT_GOO, 10s, 15s, 0, PHASE_FESTERGUT);
+                            else
+                                events.ScheduleEvent(EVENT_FESTERGUT_GOO, 30s, 35s, 0, PHASE_FESTERGUT);
                             break;
                         case EVENT_ROTFACE_DIES:
                             Talk(SAY_ROTFACE_DEATH);
@@ -677,7 +680,7 @@ class boss_professor_putricide : public CreatureScript
                                         me->SetFacingToObject(face);
                                     me->HandleEmoteCommand(EMOTE_ONESHOT_KNEEL);
                                     Talk(SAY_TRANSFORM_1);
-                                    events.ScheduleEvent(EVENT_RESUME_ATTACK, 5500, 0, PHASE_COMBAT_2);
+                                    events.ScheduleEvent(EVENT_RESUME_ATTACK, 5500ms, 0, PHASE_COMBAT_2);
                                     break;
                                 case PHASE_COMBAT_3:
                                     if (Creature* face = me->FindNearestCreature(NPC_TEAR_GAS_TARGET_STALKER, 50.0f))
@@ -685,7 +688,7 @@ class boss_professor_putricide : public CreatureScript
                                     me->HandleEmoteCommand(EMOTE_ONESHOT_KNEEL);
                                     Talk(SAY_TRANSFORM_2);
                                     summons.DespawnIf(AbominationDespawner(me));
-                                    events.ScheduleEvent(EVENT_RESUME_ATTACK, 8500, 0, PHASE_COMBAT_3);
+                                    events.ScheduleEvent(EVENT_RESUME_ATTACK, 8500ms, 0, PHASE_COMBAT_3);
                                     break;
                                 default:
                                     break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
@@ -110,7 +110,7 @@ class boss_rotface : public CreatureScript
             boss_rotfaceAI(Creature* creature) : BossAI(creature, DATA_ROTFACE)
             {
                 infectionStage = 0;
-                infectionCooldown = 14000;
+                infectionCooldown = 14s;
             }
 
             void Reset() override
@@ -123,7 +123,7 @@ class boss_rotface : public CreatureScript
                     events.ScheduleEvent(EVENT_VILE_GAS, 22s, 27s);
 
                 infectionStage = 0;
-                infectionCooldown = 14000;
+                infectionCooldown = 14s;
             }
 
             void JustEngagedWith(Unit* who) override
@@ -214,7 +214,7 @@ class boss_rotface : public CreatureScript
                         case EVENT_HASTEN_INFECTIONS:
                             if (infectionStage++ < 4)
                             {
-                                infectionCooldown -= 2000;
+                                infectionCooldown -= 2s;
                                 events.ScheduleEvent(EVENT_HASTEN_INFECTIONS, 90s);
                             }
                             break;
@@ -238,7 +238,7 @@ class boss_rotface : public CreatureScript
             }
 
         private:
-            uint32 infectionCooldown;
+            Milliseconds infectionCooldown;
             uint32 infectionStage;
         };
 
@@ -434,7 +434,7 @@ class npc_precious_icc : public CreatureScript
                             break;
                         case EVENT_MORTAL_WOUND:
                             DoCastVictim(SPELL_MORTAL_WOUND);
-                            _events.ScheduleEvent(EVENT_MORTAL_WOUND, urand(10000, 12500));
+                            _events.ScheduleEvent(EVENT_MORTAL_WOUND, 10s, 12500ms);
                             break;
                         case EVENT_SUMMON_ZOMBIES:
                             Talk(EMOTE_PRECIOUS_ZOMBIES);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sister_svalna.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sister_svalna.cpp
@@ -544,7 +544,7 @@ struct npc_crok_scourgebane : public EscortAI
     void Reset() override
     {
         _events.Reset();
-        _events.ScheduleEvent(EVENT_SCOURGE_STRIKE, urand(7500, 12500));
+        _events.ScheduleEvent(EVENT_SCOURGE_STRIKE, 7500ms, 12500ms);
         _events.ScheduleEvent(EVENT_DEATH_STRIKE, 25s, 30s);
         me->SetReactState(REACT_DEFENSIVE);
         Initialize();
@@ -567,8 +567,8 @@ struct npc_crok_scourgebane : public EscortAI
                 svalna->AI()->DoAction(ACTION_START_GAUNTLET);
 
             Talk(SAY_CROK_INTRO_1);
-            _events.ScheduleEvent(EVENT_ARNATH_INTRO_2, 7000);
-            _events.ScheduleEvent(EVENT_CROK_INTRO_3, 14000);
+            _events.ScheduleEvent(EVENT_ARNATH_INTRO_2, 7s);
+            _events.ScheduleEvent(EVENT_CROK_INTRO_3, 14s);
             _events.ScheduleEvent(EVENT_START_PATHING, 35s);
             me->setActive(true);
             me->SetFarVisible(true);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -587,7 +587,7 @@ class boss_the_lich_king : public CreatureScript
                 events.ScheduleEvent(EVENT_NECROTIC_PLAGUE, 30s, 33s, 0, PHASE_ONE);
                 events.ScheduleEvent(EVENT_BERSERK, 15min, EVENT_GROUP_BERSERK);
                 if (IsHeroic())
-                    events.ScheduleEvent(EVENT_SHADOW_TRAP, 15500, 0, PHASE_ONE);
+                    events.ScheduleEvent(EVENT_SHADOW_TRAP, 15500ms, 0, PHASE_ONE);
             }
 
             bool CanAIAttack(Unit const* target) const override
@@ -623,7 +623,7 @@ class boss_the_lich_king : public CreatureScript
                         me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_FROZEN_THRONE);
                         // schedule talks
                         me->SetStandState(UNIT_STAND_STATE_STAND);
-                        events.ScheduleEvent(EVENT_INTRO_MOVE_1, 4000);
+                        events.ScheduleEvent(EVENT_INTRO_MOVE_1, 4s);
                         break;
                     case ACTION_START_ATTACK:
                         events.ScheduleEvent(EVENT_START_ATTACK, 5s);
@@ -638,11 +638,11 @@ class boss_the_lich_king : public CreatureScript
                         me->CastSpell(nullptr, SPELL_SUMMON_BROKEN_FROSTMOURNE, TRIGGERED_IGNORE_CAST_IN_PROGRESS);
                         me->CastSpell(nullptr, SPELL_SUMMON_BROKEN_FROSTMOURNE_2, TRIGGERED_IGNORE_CAST_IN_PROGRESS);
                         SetEquipmentSlots(false, EQUIP_BROKEN_FROSTMOURNE);
-                        events.ScheduleEvent(EVENT_OUTRO_TALK_6, 2500, 0, PHASE_OUTRO);
+                        events.ScheduleEvent(EVENT_OUTRO_TALK_6, 2500ms, 0, PHASE_OUTRO);
                         break;
                     case ACTION_FINISH_OUTRO:
-                        events.ScheduleEvent(EVENT_OUTRO_TALK_7, 7000, 0, PHASE_OUTRO);
-                        events.ScheduleEvent(EVENT_OUTRO_TALK_8, 17000, 0, PHASE_OUTRO);
+                        events.ScheduleEvent(EVENT_OUTRO_TALK_7, 7s, 0, PHASE_OUTRO);
+                        events.ScheduleEvent(EVENT_OUTRO_TALK_8, 17s, 0, PHASE_OUTRO);
                         break;
                     case ACTION_TELEPORT_BACK:
                     {
@@ -720,15 +720,15 @@ class boss_the_lich_king : public CreatureScript
                     me->InterruptNonMeleeSpells(true);
                     me->CastSpell(nullptr, SPELL_FURY_OF_FROSTMOURNE, TRIGGERED_NONE);
                     me->SetWalk(true);
-                    events.ScheduleEvent(EVENT_OUTRO_TALK_1, 2600, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_TALK_1, 2600ms, 0, PHASE_OUTRO);
                     events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 6600ms, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 17600, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 27600, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_OUTRO_TALK_2, 34600, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_OUTRO_TALK_3, 43600, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_EMOTE_CAST_SHOUT, 54600, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 58600, 0, PHASE_OUTRO);
-                    events.ScheduleEvent(EVENT_OUTRO_MOVE_CENTER, 69600, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 17600ms, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 27600ms, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_TALK_2, 34600ms, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_TALK_3, 43600ms, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_EMOTE_CAST_SHOUT, 54600ms, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_EMOTE_TALK, 58600ms, 0, PHASE_OUTRO);
+                    events.ScheduleEvent(EVENT_OUTRO_MOVE_CENTER, 69600ms, 0, PHASE_OUTRO);
                     // stop here. rest will get scheduled from MovementInform
                     return;
                 }
@@ -837,22 +837,22 @@ class boss_the_lich_king : public CreatureScript
                 {
                     case POINT_LK_INTRO_1:
                         // schedule for next update cycle, current update must finalize movement
-                        events.ScheduleEvent(EVENT_INTRO_MOVE_2, 1, 0, PHASE_INTRO);
+                        events.ScheduleEvent(EVENT_INTRO_MOVE_2, 1ms, 0, PHASE_INTRO);
                         break;
                     case POINT_LK_INTRO_2:
-                        events.ScheduleEvent(EVENT_INTRO_MOVE_3, 1, 0, PHASE_INTRO);
+                        events.ScheduleEvent(EVENT_INTRO_MOVE_3, 1ms, 0, PHASE_INTRO);
                         break;
                     case POINT_LK_INTRO_3:
                         if (Creature* tirion = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_HIGHLORD_TIRION_FORDRING)))
                             tirion->AI()->DoAction(ACTION_CONTINUE_INTRO);
-                        events.ScheduleEvent(EVENT_INTRO_TALK_1, 9000, 0, PHASE_INTRO);
+                        events.ScheduleEvent(EVENT_INTRO_TALK_1, 9s, 0, PHASE_INTRO);
                         break;
                     case POINT_CENTER_1:
                         me->SetFacingTo(0.0f);
                         Talk(SAY_LK_REMORSELESS_WINTER);
                         me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                         DoCast(me, SPELL_REMORSELESS_WINTER_1);
-                        events.ScheduleEvent(EVENT_QUAKE, 62500, 0, PHASE_TRANSITION);
+                        events.ScheduleEvent(EVENT_QUAKE, 62500ms, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_PAIN_AND_SUFFERING, 4s, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_SUMMON_ICE_SPHERE, 8s, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, 6s, 0, PHASE_TRANSITION);
@@ -867,19 +867,19 @@ class boss_the_lich_king : public CreatureScript
                         me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                         DoCast(me, SPELL_REMORSELESS_WINTER_2);
                         summons.DespawnEntry(NPC_VALKYR_SHADOWGUARD);
-                        events.ScheduleEvent(EVENT_QUAKE_2, 62500, 0, PHASE_TRANSITION);
+                        events.ScheduleEvent(EVENT_QUAKE_2, 62500ms, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_PAIN_AND_SUFFERING, 6s, 0, PHASE_TRANSITION);
                         events.ScheduleEvent(EVENT_SUMMON_ICE_SPHERE, 8s, 0, PHASE_TRANSITION);
-                        events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT_2, 5000, 0, PHASE_TRANSITION);
-                        events.ScheduleEvent(EVENT_DEFILE, 95500, 0, PHASE_THREE);
-                        events.ScheduleEvent(EVENT_SOUL_REAPER, 99500, 0, PHASE_THREE);
-                        events.ScheduleEvent(EVENT_VILE_SPIRITS, 79500, EVENT_GROUP_VILE_SPIRITS, PHASE_THREE);
-                        events.ScheduleEvent(IsHeroic() ? EVENT_HARVEST_SOULS : EVENT_HARVEST_SOUL, 73500, 0, PHASE_THREE);
+                        events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT_2, 5s, 0, PHASE_TRANSITION);
+                        events.ScheduleEvent(EVENT_DEFILE, 95500ms, 0, PHASE_THREE);
+                        events.ScheduleEvent(EVENT_SOUL_REAPER, 99500ms, 0, PHASE_THREE);
+                        events.ScheduleEvent(EVENT_VILE_SPIRITS, 79500ms, EVENT_GROUP_VILE_SPIRITS, PHASE_THREE);
+                        events.ScheduleEvent(IsHeroic() ? EVENT_HARVEST_SOULS : EVENT_HARVEST_SOUL, 73500ms, 0, PHASE_THREE);
                         break;
                     case POINT_LK_OUTRO_1:
-                        events.ScheduleEvent(EVENT_OUTRO_TALK_4, 1, 0, PHASE_OUTRO);
+                        events.ScheduleEvent(EVENT_OUTRO_TALK_4, 1ms, 0, PHASE_OUTRO);
                         events.ScheduleEvent(EVENT_OUTRO_RAISE_DEAD, 1s, 0, PHASE_OUTRO);
-                        events.ScheduleEvent(EVENT_OUTRO_TALK_5, 29000, 0, PHASE_OUTRO);
+                        events.ScheduleEvent(EVENT_OUTRO_TALK_5, 29s, 0, PHASE_OUTRO);
                         break;
                     case POINT_LK_OUTRO_2:
                         if (Creature* tirion = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_HIGHLORD_TIRION_FORDRING)))
@@ -926,7 +926,7 @@ class boss_the_lich_king : public CreatureScript
                             // for some reason blizz sends 2 emotes in row here so (we handle one in Talk)
                             me->HandleEmoteCommand(EMOTE_ONESHOT_TALK_NO_SHEATHE);
                             events.ScheduleEvent(EVENT_EMOTE_CAST_SHOUT, 7s, 0, PHASE_INTRO);
-                            events.ScheduleEvent(EVENT_INTRO_EMOTE_1, 13000, 0, PHASE_INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_EMOTE_1, 13s, 0, PHASE_INTRO);
                             events.ScheduleEvent(EVENT_EMOTE_CAST_SHOUT, 18s, 0, PHASE_INTRO);
                             events.ScheduleEvent(EVENT_INTRO_CAST_FREEZE, 31s, 0, PHASE_INTRO);
                             break;
@@ -959,7 +959,7 @@ class boss_the_lich_king : public CreatureScript
                             break;
                         case EVENT_INFEST:
                             DoCast(me, SPELL_INFEST);
-                            events.ScheduleEvent(EVENT_INFEST, urand(21000, 24000), 0, events.IsInPhase(PHASE_ONE) ? PHASE_ONE : PHASE_TWO);
+                            events.ScheduleEvent(EVENT_INFEST, 21s, 24s, 0, events.IsInPhase(PHASE_ONE) ? PHASE_ONE : PHASE_TWO);
                             break;
                         case EVENT_NECROTIC_PLAGUE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, NecroticPlagueTargetCheck(me, NECROTIC_PLAGUE_LK, NECROTIC_PLAGUE_PLR)))
@@ -967,16 +967,16 @@ class boss_the_lich_king : public CreatureScript
                                 Talk(EMOTE_NECROTIC_PLAGUE_WARNING, target);
                                 DoCast(target, SPELL_NECROTIC_PLAGUE);
                             }
-                            events.ScheduleEvent(EVENT_NECROTIC_PLAGUE, urand(30000, 33000), 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_NECROTIC_PLAGUE, 30s, 33s, 0, PHASE_ONE);
                             break;
                         case EVENT_SHADOW_TRAP:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, SpellTargetSelector(me, SPELL_SHADOW_TRAP)))
                                 DoCast(target, SPELL_SHADOW_TRAP);
-                            events.ScheduleEvent(EVENT_SHADOW_TRAP, 15500, 0, PHASE_ONE);
+                            events.ScheduleEvent(EVENT_SHADOW_TRAP, 15500ms, 0, PHASE_ONE);
                             break;
                         case EVENT_SOUL_REAPER:
                             DoCastVictim(SPELL_SOUL_REAPER);
-                            events.ScheduleEvent(EVENT_SOUL_REAPER, urand(33000, 35000), 0, PHASE_TWO_THREE);
+                            events.ScheduleEvent(EVENT_SOUL_REAPER, 33s, 35s, 0, PHASE_TWO_THREE);
                             break;
                         case EVENT_DEFILE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true, true, -SPELL_HARVEST_SOUL_VALKYR))
@@ -984,7 +984,7 @@ class boss_the_lich_king : public CreatureScript
                                 Talk(EMOTE_DEFILE_WARNING);
                                 DoCast(target, SPELL_DEFILE);
                             }
-                            events.ScheduleEvent(EVENT_DEFILE, urand(32000, 35000), 0, PHASE_TWO_THREE);
+                            events.ScheduleEvent(EVENT_DEFILE, 32s, 35s, 0, PHASE_TWO_THREE);
                             break;
                         case EVENT_HARVEST_SOUL:
                             Talk(SAY_LK_HARVEST_SOUL);
@@ -995,16 +995,16 @@ class boss_the_lich_king : public CreatureScript
                         case EVENT_PAIN_AND_SUFFERING:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                                 me->CastSpell(target, SPELL_PAIN_AND_SUFFERING, TRIGGERED_NONE);
-                            events.ScheduleEvent(EVENT_PAIN_AND_SUFFERING, urand(1500, 4000), 0, PHASE_TRANSITION);
+                            events.ScheduleEvent(EVENT_PAIN_AND_SUFFERING, 1500ms, 4s, 0, PHASE_TRANSITION);
                             break;
                         case EVENT_SUMMON_ICE_SPHERE:
                             DoCastAOE(SPELL_SUMMON_ICE_SPHERE);
-                            events.ScheduleEvent(EVENT_SUMMON_ICE_SPHERE, urand(7500, 8500), 0, PHASE_TRANSITION);
+                            events.ScheduleEvent(EVENT_SUMMON_ICE_SPHERE, 7500ms, 8500ms, 0, PHASE_TRANSITION);
                             break;
                         case EVENT_SUMMON_RAGING_SPIRIT:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
                                 me->CastSpell(target, SPELL_RAGING_SPIRIT, TRIGGERED_NONE);
-                            events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, urand(22000, 23000), 0, PHASE_TRANSITION);
+                            events.ScheduleEvent(EVENT_SUMMON_RAGING_SPIRIT, 22s, 23s, 0, PHASE_TRANSITION);
                             break;
                         case EVENT_SUMMON_RAGING_SPIRIT_2:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 0.0f, true))
@@ -1029,7 +1029,7 @@ class boss_the_lich_king : public CreatureScript
                             me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             Talk(SAY_LK_SUMMON_VALKYR);
                             DoCastAOE(SUMMON_VALKYR, true);
-                            events.ScheduleEvent(EVENT_SUMMON_VALKYR, urand(45000, 50000), 0, PHASE_TWO);
+                            events.ScheduleEvent(EVENT_SUMMON_VALKYR, 45s, 50s, 0, PHASE_TWO);
                             break;
                         case EVENT_START_ATTACK:
                             me->SetReactState(REACT_AGGRESSIVE);
@@ -1039,18 +1039,18 @@ class boss_the_lich_king : public CreatureScript
                         case EVENT_VILE_SPIRITS:
                             me->GetMap()->SetZoneMusic(AREA_ICECROWN_CITADEL, MUSIC_SPECIAL);
                             DoCastAOE(SPELL_VILE_SPIRITS);
-                            events.ScheduleEvent(EVENT_VILE_SPIRITS, urand(35000, 40000), EVENT_GROUP_VILE_SPIRITS, PHASE_THREE);
+                            events.ScheduleEvent(EVENT_VILE_SPIRITS, 35s, 40s, EVENT_GROUP_VILE_SPIRITS, PHASE_THREE);
                             break;
                         case EVENT_HARVEST_SOULS:
                             Talk(SAY_LK_HARVEST_SOUL);
                             DoCastAOE(SPELL_HARVEST_SOULS);
-                            events.ScheduleEvent(EVENT_HARVEST_SOULS, urand(100000, 110000), 0, PHASE_THREE);
+                            events.ScheduleEvent(EVENT_HARVEST_SOULS, 100s, 110s, 0, PHASE_THREE);
                             events.SetPhase(PHASE_FROSTMOURNE); // will stop running UpdateVictim (no evading)
                             me->SetReactState(REACT_PASSIVE);
                             me->AttackStop();
-                            events.DelayEvents(50000, EVENT_GROUP_VILE_SPIRITS);
-                            events.RescheduleEvent(EVENT_DEFILE, 50000, 0, PHASE_THREE);
-                            events.RescheduleEvent(EVENT_SOUL_REAPER, urand(57000, 62000), 0, PHASE_THREE);
+                            events.DelayEvents(50s, EVENT_GROUP_VILE_SPIRITS);
+                            events.RescheduleEvent(EVENT_DEFILE, 50s, 0, PHASE_THREE);
+                            events.RescheduleEvent(EVENT_SOUL_REAPER, 57s, 62s, 0, PHASE_THREE);
                             events.ScheduleEvent(EVENT_START_ATTACK, 49s);
                             events.ScheduleEvent(EVENT_FROSTMOURNE_HEROIC, 6500ms);
                             for (ObjectGuid guid : summons)
@@ -1202,7 +1202,7 @@ class npc_tirion_fordring_tft : public CreatureScript
                             theLichKing->AI()->DoAction(ACTION_START_ENCOUNTER);
                         break;
                     case POINT_TIRION_OUTRO_1:
-                        _events.ScheduleEvent(EVENT_OUTRO_JUMP, 1, 0, PHASE_OUTRO);
+                        _events.ScheduleEvent(EVENT_OUTRO_JUMP, 1ms, 0, PHASE_OUTRO);
                         break;
                 }
             }
@@ -1213,14 +1213,14 @@ class npc_tirion_fordring_tft : public CreatureScript
                 {
                     case ACTION_CONTINUE_INTRO:
                         Talk(SAY_TIRION_INTRO_1);
-                        _events.ScheduleEvent(EVENT_INTRO_TALK_1, 34000, 0, PHASE_INTRO);
+                        _events.ScheduleEvent(EVENT_INTRO_TALK_1, 34s, 0, PHASE_INTRO);
                         break;
                     case ACTION_OUTRO:
                         _events.SetPhase(PHASE_OUTRO);
-                        _events.ScheduleEvent(EVENT_OUTRO_TALK_1, 7000, 0, PHASE_OUTRO);
+                        _events.ScheduleEvent(EVENT_OUTRO_TALK_1, 7s, 0, PHASE_OUTRO);
                         _events.ScheduleEvent(EVENT_OUTRO_BLESS, 18s, 0, PHASE_OUTRO);
                         _events.ScheduleEvent(EVENT_OUTRO_REMOVE_ICE, 23s, 0, PHASE_OUTRO);
-                        _events.ScheduleEvent(EVENT_OUTRO_MOVE_1, 25000, 0, PHASE_OUTRO);
+                        _events.ScheduleEvent(EVENT_OUTRO_MOVE_1, 25s, 0, PHASE_OUTRO);
                         break;
                 }
             }
@@ -1266,7 +1266,7 @@ class npc_tirion_fordring_tft : public CreatureScript
                     {
                         case EVENT_INTRO_TALK_1:
                             Talk(SAY_TIRION_INTRO_2);
-                            _events.ScheduleEvent(EVENT_INTRO_EMOTE_1, 2000, 0, PHASE_INTRO);
+                            _events.ScheduleEvent(EVENT_INTRO_EMOTE_1, 2s, 0, PHASE_INTRO);
                             _events.ScheduleEvent(EVENT_INTRO_CHARGE, 5s, 0, PHASE_INTRO);
                             break;
                         case EVENT_INTRO_EMOTE_1:
@@ -1538,7 +1538,7 @@ class npc_valkyr_shadowguard : public CreatureScript
             void ScheduleHeroicEvents()
             {
                 _events.Reset();
-                _events.ScheduleEvent(EVENT_MOVE_TO_CENTER, 1);
+                _events.ScheduleEvent(EVENT_MOVE_TO_CENTER, 1ms);
                 me->ClearUnitState(UNIT_STATE_EVADE);
             }
 
@@ -1790,12 +1790,12 @@ class npc_terenas_menethil : public CreatureScript
                             me->SetHealth(me->GetMaxHealth() / 2);
                         DoCast(me, SPELL_LIGHTS_FAVOR);
                         _events.Reset();
-                        _events.ScheduleEvent(EVENT_FROSTMOURNE_TALK_1, 2000, PHASE_FROSTMOURNE);
-                        _events.ScheduleEvent(EVENT_FROSTMOURNE_TALK_2, 11000, PHASE_FROSTMOURNE);
+                        _events.ScheduleEvent(EVENT_FROSTMOURNE_TALK_1, 2s, PHASE_FROSTMOURNE);
+                        _events.ScheduleEvent(EVENT_FROSTMOURNE_TALK_2, 11s, PHASE_FROSTMOURNE);
                         if (!IsHeroic())
                         {
                             _events.ScheduleEvent(EVENT_DESTROY_SOUL, 1min, PHASE_FROSTMOURNE);
-                            _events.ScheduleEvent(EVENT_FROSTMOURNE_TALK_3, 25000);
+                            _events.ScheduleEvent(EVENT_FROSTMOURNE_TALK_3, 25s);
                         }
                         break;
                     case ACTION_TELEPORT_BACK:
@@ -1845,8 +1845,8 @@ class npc_terenas_menethil : public CreatureScript
                 if (Creature* lichKing = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_THE_LICH_KING)))
                     me->SetFacingToObject(lichKing);
 
-                _events.ScheduleEvent(EVENT_OUTRO_TERENAS_TALK_1, 2000, 0, PHASE_OUTRO);
-                _events.ScheduleEvent(EVENT_OUTRO_TERENAS_TALK_2, 14000, 0, PHASE_OUTRO);
+                _events.ScheduleEvent(EVENT_OUTRO_TERENAS_TALK_1, 2s, 0, PHASE_OUTRO);
+                _events.ScheduleEvent(EVENT_OUTRO_TERENAS_TALK_2, 14s, 0, PHASE_OUTRO);
             }
 
             void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -317,7 +317,7 @@ class boss_valithria_dreamwalker : public CreatureScript
                 _events.ScheduleEvent(EVENT_INTRO_TALK, 15s);
                 _events.ScheduleEvent(EVENT_DREAM_PORTAL, 45s, 48s);
                 if (IsHeroic())
-                    _events.ScheduleEvent(EVENT_BERSERK, 420000);
+                    _events.ScheduleEvent(EVENT_BERSERK, 420s);
             }
 
             void HealReceived(Unit* healer, uint32& heal) override
@@ -880,7 +880,7 @@ class npc_suppresser : public CreatureScript
             void MovementInform(uint32 type, uint32 /*id*/) override
             {
                 if (type == CHASE_MOTION_TYPE)
-                    _events.RescheduleEvent(EVENT_SUPPRESSION, 1);
+                    _events.RescheduleEvent(EVENT_SUPPRESSION, 1ms);
             }
 
             void UpdateAI(uint32 diff) override
@@ -1089,7 +1089,7 @@ class npc_dream_cloud : public CreatureScript
                             Trinity::AnyPlayerInObjectRangeCheck check(me, 5.0f);
                             Trinity::PlayerSearcher<Trinity::AnyPlayerInObjectRangeCheck> searcher(me, player, check);
                             Cell::VisitWorldObjects(me, searcher, 7.5f);
-                            _events.ScheduleEvent(player ? EVENT_EXPLODE : EVENT_CHECK_PLAYER, 1000);
+                            _events.ScheduleEvent(player ? EVENT_EXPLODE : EVENT_CHECK_PLAYER, 1s);
                             break;
                         }
                         case EVENT_EXPLODE:

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -258,36 +258,36 @@ class npc_highlord_tirion_fordring_lh : public CreatureScript
                             return;
 
                         Talk(SAY_TIRION_INTRO_1);
-                        _events.ScheduleEvent(EVENT_TIRION_INTRO_2, 4000);
-                        _events.ScheduleEvent(EVENT_TIRION_INTRO_3, 14000);
-                        _events.ScheduleEvent(EVENT_TIRION_INTRO_4, 18000);
-                        _events.ScheduleEvent(EVENT_TIRION_INTRO_5, 31000);
-                        _events.ScheduleEvent(EVENT_LK_INTRO_1, 35000);
-                        _events.ScheduleEvent(EVENT_TIRION_INTRO_6, 51000);
-                        _events.ScheduleEvent(EVENT_LK_INTRO_2, 58000);
-                        _events.ScheduleEvent(EVENT_LK_INTRO_3, 74000);
-                        _events.ScheduleEvent(EVENT_LK_INTRO_4, 86000);
-                        _events.ScheduleEvent(EVENT_BOLVAR_INTRO_1, 100000);
-                        _events.ScheduleEvent(EVENT_LK_INTRO_5, 108000);
+                        _events.ScheduleEvent(EVENT_TIRION_INTRO_2, 4s);
+                        _events.ScheduleEvent(EVENT_TIRION_INTRO_3, 14s);
+                        _events.ScheduleEvent(EVENT_TIRION_INTRO_4, 18s);
+                        _events.ScheduleEvent(EVENT_TIRION_INTRO_5, 31s);
+                        _events.ScheduleEvent(EVENT_LK_INTRO_1, 35s);
+                        _events.ScheduleEvent(EVENT_TIRION_INTRO_6, 51s);
+                        _events.ScheduleEvent(EVENT_LK_INTRO_2, 58s);
+                        _events.ScheduleEvent(EVENT_LK_INTRO_3, 74s);
+                        _events.ScheduleEvent(EVENT_LK_INTRO_4, 86s);
+                        _events.ScheduleEvent(EVENT_BOLVAR_INTRO_1, 100s);
+                        _events.ScheduleEvent(EVENT_LK_INTRO_5, 108s);
 
                         if (_instance->GetData(DATA_TEAM_IN_INSTANCE) == HORDE)
                         {
-                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_1, 120000);
-                            _events.ScheduleEvent(EVENT_TIRION_INTRO_H_7, 129000);
-                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_2, 139000);
-                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_3, 150000);
-                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_4, 162000);
-                            _events.ScheduleEvent(EVENT_SAURFANG_RUN, 170000);
+                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_1, 120s);
+                            _events.ScheduleEvent(EVENT_TIRION_INTRO_H_7, 129s);
+                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_2, 139s);
+                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_3, 150s);
+                            _events.ScheduleEvent(EVENT_SAURFANG_INTRO_4, 162s);
+                            _events.ScheduleEvent(EVENT_SAURFANG_RUN, 170s);
                         }
                         else
                         {
-                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_1, 120000);
-                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_2, 124000);
-                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_3, 127000);
-                            _events.ScheduleEvent(EVENT_TIRION_INTRO_A_7, 136000);
-                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_4, 144000);
-                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_5, 151000);
-                            _events.ScheduleEvent(EVENT_MURADIN_RUN, 157000);
+                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_1, 120s);
+                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_2, 124s);
+                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_3, 127s);
+                            _events.ScheduleEvent(EVENT_TIRION_INTRO_A_7, 136s);
+                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_4, 144s);
+                            _events.ScheduleEvent(EVENT_MURADIN_INTRO_5, 151s);
+                            _events.ScheduleEvent(EVENT_MURADIN_RUN, 157s);
                         }
                     }
                 }
@@ -534,7 +534,7 @@ class npc_frost_freeze_trap : public CreatureScript
                 {
                     case 1000:
                     case 11000:
-                        _events.ScheduleEvent(EVENT_ACTIVATE_TRAP, uint32(action));
+                        _events.ScheduleEvent(EVENT_ACTIVATE_TRAP, Milliseconds(action));
                         break;
                     default:
                         break;


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/ICC: Use std::chrono::duration overloads of EventMap
Part 1: without gunship battle and Sindragosa

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build