### PR TITLE
Scripts/UtgardeKeep: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/boss_ingvar_the_plunderer.cpp
@@ -185,9 +185,9 @@ class boss_ingvar_the_plunderer : public CreatureScript
             {
                 events.SetPhase(PHASE_UNDEAD);
                 events.ScheduleEvent(EVENT_DARK_SMASH, 14s, 18s, 0, PHASE_UNDEAD);
-                events.ScheduleEvent(EVENT_DREADFUL_ROAR, 0, 0, PHASE_UNDEAD);
+                events.ScheduleEvent(EVENT_DREADFUL_ROAR, 0ms, 0, PHASE_UNDEAD);
                 events.ScheduleEvent(EVENT_WOE_STRIKE, 10s, 14s, 0, PHASE_UNDEAD);
-                events.ScheduleEvent(EVENT_SHADOW_AXE, 30*IN_MILLISECONDS, 0, PHASE_UNDEAD);
+                events.ScheduleEvent(EVENT_SHADOW_AXE, 30s, 0, PHASE_UNDEAD);
             }
 
             void KilledUnit(Unit* who) override
@@ -253,7 +253,7 @@ class boss_ingvar_the_plunderer : public CreatureScript
                         case EVENT_SHADOW_AXE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 0.0f, true))
                                 DoCast(target, SPELL_SHADOW_AXE_SUMMON);
-                            events.ScheduleEvent(EVENT_SHADOW_AXE, 30*IN_MILLISECONDS, 0, PHASE_UNDEAD);
+                            events.ScheduleEvent(EVENT_SHADOW_AXE, 30s, 0, PHASE_UNDEAD);
                             break;
                         default:
                             break;
@@ -312,7 +312,7 @@ class npc_annhylde_the_caller : public CreatureScript
                             ingvar->CastSpell(ingvar, SPELL_SCOURG_RESURRECTION_DUMMY, true);
                             DoCast(ingvar, SPELL_SCOURG_RESURRECTION_BEAM);
                         }
-                        _events.ScheduleEvent(EVENT_RESURRECT_1, 8000);
+                        _events.ScheduleEvent(EVENT_RESURRECT_1, 8s);
                         break;
                     case 2:
                         me->DespawnOrUnsummon();
@@ -340,7 +340,7 @@ class npc_annhylde_the_caller : public CreatureScript
                                 ingvar->RemoveAura(SPELL_INGVAR_FEIGN_DEATH);
                                 ingvar->CastSpell(ingvar, SPELL_SCOURG_RESURRECTION_HEAL, false);
                             }
-                            _events.ScheduleEvent(EVENT_RESURRECT_2, 3000);
+                            _events.ScheduleEvent(EVENT_RESURRECT_2, 3s);
                             break;
                         case EVENT_RESURRECT_2:
                             if (Creature* ingvar = ObjectAccessor::GetCreature(*me, _instance->GetGuidData(DATA_INGVAR)))

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -225,8 +225,8 @@ class boss_svala : public CreatureScript
                 if (spellInfo->Id == SPELL_RITUAL_STRIKE_EFF_1 && !events.IsInPhase(NORMAL) && !events.IsInPhase(SVALADEAD))
                 {
                     events.SetPhase(NORMAL);
-                    events.ScheduleEvent(EVENT_SINISTER_STRIKE, 7 * IN_MILLISECONDS, 0, NORMAL);
-                    events.ScheduleEvent(EVENT_CALL_FLAMES, urand(10 * IN_MILLISECONDS, 20 * IN_MILLISECONDS), 0, NORMAL);
+                    events.ScheduleEvent(EVENT_SINISTER_STRIKE, 7s, 0, NORMAL);
+                    events.ScheduleEvent(EVENT_CALL_FLAMES, 10s, 20s, 0, NORMAL);
                     SetCombatMovement(true);
 
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 300.0f, true))
@@ -248,7 +248,7 @@ class boss_svala : public CreatureScript
                 {
                     _sacrificed = true;
                     events.SetPhase(SACRIFICING);
-                    events.ScheduleEvent(EVENT_RITUAL_PREPARATION, 0, 0, SACRIFICING);
+                    events.ScheduleEvent(EVENT_RITUAL_PREPARATION, 0s, 0, SACRIFICING);
                 }
 
                 if (events.IsInPhase(NORMAL))
@@ -260,12 +260,12 @@ class boss_svala : public CreatureScript
                     {
                         case EVENT_INTRO_SVALA_TALK_0:
                             Talk(SAY_SVALA_INTRO_0);
-                            events.ScheduleEvent(EVENT_INTRO_ARTHAS_TALK_0, 8.1 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_ARTHAS_TALK_0, 8100ms, 0, INTRO);
                             break;
                         case EVENT_INTRO_ARTHAS_TALK_0:
                             if (Creature* arthas = ObjectAccessor::GetCreature(*me, _arthasGUID))
                                 arthas->AI()->Talk(SAY_DIALOG_OF_ARTHAS_1);
-                            events.ScheduleEvent(EVENT_INTRO_TRANSFORM_0, 10 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_TRANSFORM_0, 10s, 0, INTRO);
                             break;
                         case EVENT_INTRO_TRANSFORM_0:
                         {
@@ -287,12 +287,12 @@ class boss_svala : public CreatureScript
                                     (*itr)->GetMotionMaster()->MovePoint(1, spectatorWP[0]);
                                 }
                             }
-                            events.ScheduleEvent(EVENT_INTRO_TRANSFORM_1, 4.2 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_TRANSFORM_1, 4200ms, 0, INTRO);
                             break;
                         }
                         case EVENT_INTRO_TRANSFORM_1:
                             me->CastSpell(me, SPELL_SVALA_TRANSFORMING1, false);
-                            events.ScheduleEvent(EVENT_INTRO_TRANSFORM_2, 6.2 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_TRANSFORM_2, 6200ms, 0, INTRO);
                             break;
                         case EVENT_INTRO_TRANSFORM_2:
                             me->CastSpell(me, SPELL_SVALA_TRANSFORMING2, false);
@@ -304,23 +304,23 @@ class boss_svala : public CreatureScript
                             me->RemoveAllAuras();
                             me->UpdateEntry(NPC_SVALA_SORROWGRAVE);
                             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-                            events.ScheduleEvent(EVENT_INTRO_SVALA_TALK_1, 6 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_SVALA_TALK_1, 6s, 0, INTRO);
                             break;
                         case EVENT_INTRO_SVALA_TALK_1:
                             Talk(SAY_SVALA_INTRO_1);
-                            events.ScheduleEvent(EVENT_INTRO_ARTHAS_TALK_1, 12 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_ARTHAS_TALK_1, 12s, 0, INTRO);
                             break;
                         case EVENT_INTRO_ARTHAS_TALK_1:
                             if (Creature* arthas = ObjectAccessor::GetCreature(*me, _arthasGUID))
                                 arthas->AI()->Talk(SAY_DIALOG_OF_ARTHAS_2);
-                            events.ScheduleEvent(EVENT_INTRO_SVALA_TALK_2, 9 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_SVALA_TALK_2, 9s, 0, INTRO);
                             break;
                         case EVENT_INTRO_SVALA_TALK_2:
                             Talk(SAY_SVALA_INTRO_2);
                             me->SetFacingTo(1.58f);
                             if (Creature* arthas = ObjectAccessor::GetCreature(*me, _arthasGUID))
                                 arthas->SetVisible(false);
-                            events.ScheduleEvent(EVENT_INTRO_RELOCATE_SVALA, 13.8 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_RELOCATE_SVALA, 13800ms, 0, INTRO);
                             break;
                         case EVENT_INTRO_RELOCATE_SVALA:
                         {
@@ -332,7 +332,7 @@ class boss_svala : public CreatureScript
                             me->GetMotionMaster()->MoveLand(0, pos);
                             me->SetDisableGravity(false, true);
                             me->SetHover(true);
-                            events.ScheduleEvent(EVENT_INTRO_DESPAWN_ARTHAS, 3 * IN_MILLISECONDS, 0, INTRO);
+                            events.ScheduleEvent(EVENT_INTRO_DESPAWN_ARTHAS, 3s, 0, INTRO);
                             break;
                         }
                         case EVENT_INTRO_DESPAWN_ARTHAS:
@@ -344,8 +344,8 @@ class boss_svala : public CreatureScript
                             _arthasGUID.Clear();
                             events.SetPhase(NORMAL);
                             _introCompleted = true;
-                            events.ScheduleEvent(EVENT_SINISTER_STRIKE, 7 * IN_MILLISECONDS, 0, NORMAL);
-                            events.ScheduleEvent(EVENT_CALL_FLAMES, urand(10 * IN_MILLISECONDS, 20 * IN_MILLISECONDS), 0, NORMAL);
+                            events.ScheduleEvent(EVENT_SINISTER_STRIKE, 7s, 0, NORMAL);
+                            events.ScheduleEvent(EVENT_CALL_FLAMES, 10s, 20s, 0, NORMAL);
                             break;
                         case EVENT_SINISTER_STRIKE:
                             DoCastVictim(SPELL_SINSTER_STRIKE);
@@ -354,7 +354,7 @@ class boss_svala : public CreatureScript
                         case EVENT_CALL_FLAMES:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
                                 DoCast(target, SPELL_CALL_FLAMES);
-                            events.ScheduleEvent(EVENT_CALL_FLAMES, urand(10 * IN_MILLISECONDS, 20 * IN_MILLISECONDS), 0, NORMAL);
+                            events.ScheduleEvent(EVENT_CALL_FLAMES, 10s, 20s, 0, NORMAL);
                             break;
                         case EVENT_RITUAL_PREPARATION:
                             if (Unit* sacrificeTarget = SelectTarget(SelectTargetMethod::Random, 0, 80.0f, true))
@@ -365,20 +365,20 @@ class boss_svala : public CreatureScript
                                 SetCombatMovement(false);
                                 DoCast(me, SPELL_RITUAL_OF_THE_SWORD);
                             }
-                            events.ScheduleEvent(EVENT_SPAWN_RITUAL_CHANNELERS, 1 * IN_MILLISECONDS, 0, SACRIFICING);
+                            events.ScheduleEvent(EVENT_SPAWN_RITUAL_CHANNELERS, 1s, 0, SACRIFICING);
                             break;
                         case EVENT_SPAWN_RITUAL_CHANNELERS:
                             DoCast(me, SPELL_RITUAL_CHANNELER_1, true);
                             DoCast(me, SPELL_RITUAL_CHANNELER_2, true);
                             DoCast(me, SPELL_RITUAL_CHANNELER_3, true);
-                            events.ScheduleEvent(EVENT_RITUAL_STRIKE, 2 * IN_MILLISECONDS, 0, SACRIFICING);
+                            events.ScheduleEvent(EVENT_RITUAL_STRIKE, 2s, 0, SACRIFICING);
                             break;
                         case EVENT_RITUAL_STRIKE:
                             me->StopMoving();
                             me->GetMotionMaster()->MoveIdle();
                             me->InterruptNonMeleeSpells(true);
                             DoCast(me, SPELL_RITUAL_STRIKE_TRIGGER, true);
-                            events.ScheduleEvent(EVENT_RITUAL_DISARM, 200, 0, SACRIFICING);
+                            events.ScheduleEvent(EVENT_RITUAL_DISARM, 200ms, 0, SACRIFICING);
                             break;
                         case EVENT_RITUAL_DISARM:
                             DoCast(me, SPELL_RITUAL_DISARM);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_ymiron.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_ymiron.cpp
@@ -145,7 +145,7 @@ public:
             events.ScheduleEvent(EVENT_BANE, 18s, 23s, EVENT_GROUP_BASE_SPELLS);
             events.ScheduleEvent(EVENT_FETID_ROT, 8s, 13s, EVENT_GROUP_BASE_SPELLS);
             events.ScheduleEvent(EVENT_DARK_SLASH, 28s, 33s, EVENT_GROUP_BASE_SPELLS);
-            events.ScheduleEvent(EVENT_ANCESTORS_VENGEANCE, DUNGEON_MODE(60000, 45000), EVENT_GROUP_BASE_SPELLS);
+            events.ScheduleEvent(EVENT_ANCESTORS_VENGEANCE, DUNGEON_MODE(60s, 45s), EVENT_GROUP_BASE_SPELLS);
         }
 
         void SpellHitTarget(WorldObject* target, SpellInfo const* spellInfo) override
@@ -223,7 +223,7 @@ public:
                 DespawnBoatGhosts(SpiritFountGUID);
 
                 events.CancelEvent(ActiveBoat[ActiveOrder[ActivedNumber]].event); // Cancels the event started on the previous transition.
-                events.DelayEvents(10000, EVENT_GROUP_BASE_SPELLS);
+                events.DelayEvents(10s, EVENT_GROUP_BASE_SPELLS);
 
                 ActivedNumber = Order;
             }
@@ -247,11 +247,11 @@ public:
                     break;
                 case EVENT_ANCESTORS_VENGEANCE:
                     DoCast(me, SPELL_ANCESTORS_VENGEANCE);
-                    events.ScheduleEvent(EVENT_ANCESTORS_VENGEANCE, DUNGEON_MODE(urand(60000, 65000), urand(45000, 50000)));
+                    events.ScheduleEvent(EVENT_ANCESTORS_VENGEANCE, DUNGEON_MODE(randtime(60s, 65s), randtime(45s, 50s)));
                     break;
                 case EVENT_RESUME_COMBAT:
                     me->SetReactState(REACT_AGGRESSIVE);
-                    events.ScheduleEvent(ActiveBoat[ActiveOrder[ActivedNumber]].event, 5000);
+                    events.ScheduleEvent(ActiveBoat[ActiveOrder[ActivedNumber]].event, 5s);
                     break;
                 case EVENT_BJORN_SPIRIT_FOUNT:
                     DoCast(SPELL_SUMMON_SPIRIT_FOUNT);


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/UtgardeKeep: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build