### PR TITLE
Scripts/TempestKeep: Use std::chrono::duration overloads of EventMap

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_kaelthas.cpp
@@ -519,7 +519,7 @@ class boss_kaelthas : public CreatureScript
                                 break;
                             case ADVISOR_SANGUINAR:
                                 Talk(SAY_INTRO_SANGUINAR);
-                                events.ScheduleEvent(EVENT_ACTIVE_ADVISOR, 12500);
+                                events.ScheduleEvent(EVENT_ACTIVE_ADVISOR, 12500ms);
                                 break;
                             case ADVISOR_CAPERNIAN:
                                 Talk(SAY_INTRO_CAPERNIAN);
@@ -545,11 +545,11 @@ class boss_kaelthas : public CreatureScript
                     case ACTION_SCHEDULE_COMBAT_EVENTS:
                         _phase = PHASE_COMBAT;
                         events.SetPhase(PHASE_COMBAT);
-                        events.ScheduleEvent(EVENT_FIREBALL, 1000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
-                        events.ScheduleEvent(EVENT_ARCANE_DISRUPTION, 45000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
-                        events.ScheduleEvent(EVENT_FLAMESTRIKE, 30000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
-                        events.ScheduleEvent(EVENT_MIND_CONTROL, 40000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
-                        events.ScheduleEvent(EVENT_SUMMON_PHOENIX, 50000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                        events.ScheduleEvent(EVENT_FIREBALL, 1s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                        events.ScheduleEvent(EVENT_ARCANE_DISRUPTION, 45s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                        events.ScheduleEvent(EVENT_FLAMESTRIKE, 30s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                        events.ScheduleEvent(EVENT_MIND_CONTROL, 40s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                        events.ScheduleEvent(EVENT_SUMMON_PHOENIX, 50s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                         break;
                     default:
                         break;
@@ -598,7 +598,7 @@ class boss_kaelthas : public CreatureScript
                 switch (point)
                 {
                     case POINT_START_TRANSITION:
-                        events.ScheduleEvent(EVENT_TRANSITION_1, 1000);
+                        events.ScheduleEvent(EVENT_TRANSITION_1, 1s);
                         break;
                     case POINT_TRANSITION_CENTER_ASCENDING:
                         me->SetFacingTo(float(M_PI));
@@ -606,18 +606,18 @@ class boss_kaelthas : public CreatureScript
                         me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         me->SetDisableGravity(true);
                         //me->SetHover(true); -- Set in sniffs, but breaks his visual.
-                        events.ScheduleEvent(EVENT_TRANSITION_2, 2000);
+                        events.ScheduleEvent(EVENT_TRANSITION_2, 2s);
                         events.ScheduleEvent(EVENT_SIZE_INCREASE, 5s);
                         break;
                     case POINT_TRANSITION_HALFWAY_ASCENDING:
                         DoCast(me, SPELL_NETHER_BEAM_VISUAL3, true);
-                        events.ScheduleEvent(EVENT_TRANSITION_3, 1000);
+                        events.ScheduleEvent(EVENT_TRANSITION_3, 1s);
                         break;
                     case POINT_TRANSITION_TOP:
                         events.ScheduleEvent(EVENT_EXPLODE, 10s);
                         break;
                     case POINT_TRANSITION_HALFWAY_DESCENDING:
-                        events.ScheduleEvent(EVENT_TRANSITION_5, 2000);
+                        events.ScheduleEvent(EVENT_TRANSITION_5, 2s);
                         break;
                     case POINT_END_TRANSITION:
                         me->SetReactState(REACT_AGGRESSIVE);
@@ -629,7 +629,7 @@ class boss_kaelthas : public CreatureScript
                             AttackStart(target);
 
                         DoAction(ACTION_SCHEDULE_COMBAT_EVENTS);
-                        events.ScheduleEvent(EVENT_GRAVITY_LAPSE, 10000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                        events.ScheduleEvent(EVENT_GRAVITY_LAPSE, 10s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                         break;
                     default:
                         break;
@@ -698,7 +698,7 @@ class boss_kaelthas : public CreatureScript
                             for (uint32 i = 0; i < uiMaxWeapon; ++i)
                                 DoCast(me, m_auiSpellSummonWeapon[i], true);
 
-                            events.ScheduleEvent(EVENT_REVIVE_ADVISORS, 120000);
+                            events.ScheduleEvent(EVENT_REVIVE_ADVISORS, 120s);
                             break;
                         }
                         case EVENT_REVIVE_ADVISORS:
@@ -718,43 +718,43 @@ class boss_kaelthas : public CreatureScript
                                 AttackStart(target);
 
                             DoAction(ACTION_SCHEDULE_COMBAT_EVENTS);
-                            events.ScheduleEvent(EVENT_PYROBLAST, 60000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_PYROBLAST, 60s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_FIREBALL:
                             DoCastVictim(SPELL_FIREBALL);
-                            events.ScheduleEvent(EVENT_FIREBALL, 2500, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_FIREBALL, 2500ms, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_ARCANE_DISRUPTION:
                             DoCastVictim(SPELL_ARCANE_DISRUPTION, true);
-                            events.ScheduleEvent(EVENT_ARCANE_DISRUPTION, 60000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_ARCANE_DISRUPTION, 60s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_FLAMESTRIKE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                                 DoCast(target, SPELL_FLAME_STRIKE);
 
-                            events.ScheduleEvent(EVENT_FLAMESTRIKE, 30000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_FLAMESTRIKE, 30s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_MIND_CONTROL:
                             Talk(SAY_MIND_CONTROL);
                             DoCastAOE(SPELL_MIND_CONTROL, { SPELLVALUE_MAX_TARGETS, 3 });
-                            events.ScheduleEvent(EVENT_MIND_CONTROL, 60000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_MIND_CONTROL, 60s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_SUMMON_PHOENIX:
                             DoCast(me, SPELL_PHOENIX_ANIMATION);
                             Talk(SAY_SUMMON_PHOENIX);
-                            events.ScheduleEvent(EVENT_SUMMON_PHOENIX, urand(45000, 60000), EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_SUMMON_PHOENIX, 45s, 60s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_END_TRANSITION:
                             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE);
                             DoCast(SPELL_FULLPOWER);
-                            events.ScheduleEvent(EVENT_TRANSITION_4, 2000);
+                            events.ScheduleEvent(EVENT_TRANSITION_4, 2s);
                             break;
                         case EVENT_PYROBLAST:
                             _pyrosCast = 0;
                             Talk(EMOTE_PYROBLAST);
                             DoCast(me, SPELL_SHOCK_BARRIER);
-                            events.DelayEvents(10000, EVENT_GROUP_COMBAT);
-                            events.ScheduleEvent(EVENT_PYROBLAST_CAST, 1000, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
+                            events.DelayEvents(10s, EVENT_GROUP_COMBAT);
+                            events.ScheduleEvent(EVENT_PYROBLAST_CAST, 1s, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
                             break;
                         case EVENT_PYROBLAST_CAST:
                             if (_pyrosCast < 3)
@@ -764,16 +764,16 @@ class boss_kaelthas : public CreatureScript
                                 _pyrosCast++;
                             }
                             else
-                                events.ScheduleEvent(EVENT_PYROBLAST, 60000, EVENT_GROUP_COMBAT, PHASE_COMBAT);
+                                events.ScheduleEvent(EVENT_PYROBLAST, 60s, EVENT_GROUP_COMBAT, PHASE_COMBAT);
                             break;
                         case EVENT_GRAVITY_LAPSE:
                             Talk(SAY_GRAVITY_LAPSE);
                             DoCastAOE(SPELL_GRAVITY_LAPSE);
                             DoCast(me, SPELL_NETHER_VAPOR);
-                            events.DelayEvents(24000, EVENT_GROUP_COMBAT);
-                            events.ScheduleEvent(EVENT_NETHER_BEAM, 3000, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
-                            events.ScheduleEvent(EVENT_SHOCK_BARRIER, 1000, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
-                            events.ScheduleEvent(EVENT_GRAVITY_LAPSE, 30000, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
+                            events.DelayEvents(24s, EVENT_GROUP_COMBAT);
+                            events.ScheduleEvent(EVENT_NETHER_BEAM, 3s, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_SHOCK_BARRIER, 1s, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
+                            events.ScheduleEvent(EVENT_GRAVITY_LAPSE, 30s, EVENT_GROUP_SPECIAL, PHASE_COMBAT);
                             break;
                         case EVENT_NETHER_BEAM:
                             if (_netherbeamsCast <= 8)

--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
@@ -84,7 +84,7 @@ class boss_void_reaver : public CreatureScript
                 Talk(SAY_AGGRO);
                 BossAI::JustEngagedWith(who);
 
-                events.ScheduleEvent(EVENT_POUNDING, 15000);
+                events.ScheduleEvent(EVENT_POUNDING, 15s);
                 events.ScheduleEvent(EVENT_ARCANE_ORB, 3s);
                 events.ScheduleEvent(EVENT_KNOCK_AWAY, 30s);
                 events.ScheduleEvent(EVENT_BERSERK, 10min);
@@ -107,7 +107,7 @@ class boss_void_reaver : public CreatureScript
                         case EVENT_POUNDING:
                             DoCastVictim(SPELL_POUNDING);
                             Talk(SAY_POUNDING);
-                            events.ScheduleEvent(EVENT_POUNDING, 15000);
+                            events.ScheduleEvent(EVENT_POUNDING, 15s);
                             break;
                         case EVENT_ARCANE_ORB:
                         {

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_gatewatcher_gyrokill.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_gatewatcher_gyrokill.cpp
@@ -70,7 +70,7 @@ class boss_gatewatcher_gyrokill : public CreatureScript
                 BossAI::JustEngagedWith(who);
                 events.ScheduleEvent(EVENT_STREAM_OF_MACHINE_FLUID, 10s);
                 events.ScheduleEvent(EVENT_SAW_BLADE, 20s);
-                events.ScheduleEvent(EVENT_SHADOW_POWER, 25000);
+                events.ScheduleEvent(EVENT_SHADOW_POWER, 25s);
                 Talk(SAY_AGGRO);
             }
 

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_gatewatcher_ironhand.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_gatewatcher_ironhand.cpp
@@ -64,9 +64,9 @@ class boss_gatewatcher_iron_hand : public CreatureScript
             void JustEngagedWith(Unit* who) override
             {
                 BossAI::JustEngagedWith(who);
-                events.ScheduleEvent(EVENT_STREAM_OF_MACHINE_FLUID, 55000);
-                events.ScheduleEvent(EVENT_JACKHAMMER, 45000);
-                events.ScheduleEvent(EVENT_SHADOW_POWER, 25000);
+                events.ScheduleEvent(EVENT_STREAM_OF_MACHINE_FLUID, 55s);
+                events.ScheduleEvent(EVENT_JACKHAMMER, 45s);
+                events.ScheduleEvent(EVENT_SHADOW_POWER, 25s);
                 Talk(SAY_AGGRO);
             }
 

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_mechano_lord_capacitus.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_mechano_lord_capacitus.cpp
@@ -143,7 +143,7 @@ class boss_mechano_lord_capacitus : public CreatureScript
                                                   SPELL_SUMMON_NETHER_CHARGE_NW,
                                                   SPELL_SUMMON_NETHER_CHARGE_SE,
                                                   SPELL_SUMMON_NETHER_CHARGE_SW);
-                            uint32 netherChargeTimer = DUNGEON_MODE(urand(9000, 11000), urand(2000, 5000));
+                            Milliseconds netherChargeTimer = DUNGEON_MODE(randtime(9s, 11s), randtime(2s, 5s));
                             DoCastSelf(spellId);
                             events.ScheduleEvent(EVENT_SUMMON_NETHER_CHARGE, netherChargeTimer);
                             break;

--- a/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Mechanar/boss_nethermancer_sepethrea.cpp
@@ -112,7 +112,7 @@ class boss_nethermancer_sepethrea : public CreatureScript
                             break;
                         case EVENT_ARCANE_BLAST:
                             DoCastVictim(SPELL_ARCANE_BLAST, true);
-                            events.ScheduleEvent(EVENT_ARCANE_BLAST, 15000);
+                            events.ScheduleEvent(EVENT_ARCANE_BLAST, 15s);
                             break;
                         case EVENT_DRAGONS_BREATH:
                             DoCastVictim(SPELL_DRAGONS_BREATH, true);

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/boss_wrath_scryer_soccothrates.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/boss_wrath_scryer_soccothrates.cpp
@@ -134,7 +134,7 @@ class boss_wrath_scryer_soccothrates : public CreatureScript
                     instance->SetData(DATA_CONVERSATION, DONE);
 
                     preFight = true;
-                    events.ScheduleEvent(EVENT_PREFIGHT_1, 2000);
+                    events.ScheduleEvent(EVENT_PREFIGHT_1, 2s);
                 }
             }
 
@@ -166,38 +166,38 @@ class boss_wrath_scryer_soccothrates : public CreatureScript
                                 case EVENT_PREFIGHT_1:
                                     if (Creature* dalliah = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_DALLIAH)))
                                         dalliah->AI()->Talk(SAY_DALLIAH_CONVO_1);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_2, 3000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_2, 3s);
                                     break;
                                 case EVENT_PREFIGHT_2:
                                     Talk(SAY_SOCCOTHRATES_CONVO_2);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_3, 3000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_3, 3s);
                                     break;
                                 case EVENT_PREFIGHT_3:
                                     if (Creature* dalliah = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_DALLIAH)))
                                         dalliah->AI()->Talk(SAY_DALLIAH_CONVO_2);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_4, 6000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_4, 6s);
                                     break;
                                 case EVENT_PREFIGHT_4:
                                     Talk(SAY_SOCCOTHRATES_CONVO_3);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_5, 2000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_5, 2s);
                                     break;
                                 case EVENT_PREFIGHT_5:
                                     if (Creature* dalliah = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_DALLIAH)))
                                         dalliah->AI()->Talk(SAY_DALLIAH_CONVO_3);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_6, 3000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_6, 3s);
                                     break;
                                 case EVENT_PREFIGHT_6:
                                     Talk(SAY_SOCCOTHRATES_CONVO_4);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_7, 2000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_7, 2s);
                                     break;
                                 case EVENT_PREFIGHT_7:
                                     if (Creature* dalliah = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_DALLIAH)))
                                         dalliah->GetMotionMaster()->MovePoint(0, 118.6048f, 96.84852f, 22.44115f);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_8, 4000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_8, 4s);
                                     break;
                                 case EVENT_PREFIGHT_8:
                                     me->GetMotionMaster()->MovePoint(0, 122.1035f, 192.7203f, 22.44115f);
-                                    events.ScheduleEvent(EVENT_PREFIGHT_9, 4000);
+                                    events.ScheduleEvent(EVENT_PREFIGHT_9, 4s);
                                     break;
                                 case EVENT_PREFIGHT_9:
                                     if (Creature* dalliah = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_DALLIAH)))

--- a/src/server/scripts/Outland/TempestKeep/arcatraz/boss_zereketh_the_unbound.cpp
+++ b/src/server/scripts/Outland/TempestKeep/arcatraz/boss_zereketh_the_unbound.cpp
@@ -64,8 +64,8 @@ class boss_zereketh_the_unbound : public CreatureScript
             void JustEngagedWith(Unit* who) override
             {
                 BossAI::JustEngagedWith(who);
-                events.ScheduleEvent(EVENT_VOID_ZONE, urand (6000, 10000));
-                events.ScheduleEvent(EVENT_SHADOW_NOVA, urand (6000, 10000));
+                events.ScheduleEvent(EVENT_VOID_ZONE, 6s, 10s);
+                events.ScheduleEvent(EVENT_SHADOW_NOVA, 6s, 10s);
                 events.ScheduleEvent(EVENT_SEED_OF_CORRUPTION, 12s, 20s);
                 Talk(SAY_AGGRO);
             }
@@ -92,12 +92,12 @@ class boss_zereketh_the_unbound : public CreatureScript
                         case EVENT_VOID_ZONE:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 100, true))
                                 DoCast(target, SPELL_VOID_ZONE);
-                            events.ScheduleEvent(EVENT_VOID_ZONE, urand (6000, 10000));
+                            events.ScheduleEvent(EVENT_VOID_ZONE, 6s, 10s);
                             break;
                         case EVENT_SHADOW_NOVA:
                             DoCastVictim(SPELL_SHADOW_NOVA, true);
                             Talk(SAY_SHADOW_NOVA);
-                            events.ScheduleEvent(EVENT_SHADOW_NOVA, urand (6000, 10000));
+                            events.ScheduleEvent(EVENT_SHADOW_NOVA, 6s, 10s);
                             break;
                         case EVENT_SEED_OF_CORRUPTION:
                             if (Unit* target = SelectTarget(SelectTargetMethod::Random, 1, 100, true))

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_commander_sarannis.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_commander_sarannis.cpp
@@ -71,8 +71,8 @@ class boss_commander_sarannis : public CreatureScript
             {
                 BossAI::JustEngagedWith(who);
                 Talk(SAY_AGGRO);
-                events.ScheduleEvent(EVENT_ARCANE_RESONANCE, 42700);
-                events.ScheduleEvent(EVENT_ARCANE_DEVASTATION, 15200);
+                events.ScheduleEvent(EVENT_ARCANE_RESONANCE, 42700ms);
+                events.ScheduleEvent(EVENT_ARCANE_DEVASTATION, 15200ms);
             }
 
             void KilledUnit(Unit* /*victim*/) override
@@ -119,12 +119,12 @@ class boss_commander_sarannis : public CreatureScript
                         case EVENT_ARCANE_RESONANCE:
                             Talk(SAY_ARCANE_RESONANCE);
                             DoCastVictim(SPELL_ARCANE_RESONANCE, true);
-                            events.ScheduleEvent(EVENT_ARCANE_RESONANCE, 42700);
+                            events.ScheduleEvent(EVENT_ARCANE_RESONANCE, 42700ms);
                             break;
                         case EVENT_ARCANE_DEVASTATION:
                             Talk(SAY_ARCANE_DEVASTATION);
                             DoCastVictim(SPELL_ARCANE_DEVASTATION, true);
-                            events.ScheduleEvent(EVENT_ARCANE_DEVASTATION, urand(11000, 19200));
+                            events.ScheduleEvent(EVENT_ARCANE_DEVASTATION, 11s, 19200ms);
                             break;
                         default:
                             break;

--- a/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
+++ b/src/server/scripts/Outland/TempestKeep/botanica/boss_thorngrin_the_tender.cpp
@@ -73,7 +73,10 @@ class boss_thorngrin_the_tender : public CreatureScript
                 BossAI::JustEngagedWith(who);
                 Talk(SAY_AGGRO);
                 events.ScheduleEvent(EVENT_SACRIFICE, 5700ms);
-                events.ScheduleEvent(EVENT_HELLFIRE, IsHeroic() ? urand(17400, 19300) : 18000);
+                if (IsHeroic())
+                    events.ScheduleEvent(EVENT_HELLFIRE, 17400ms, 19300ms);
+                else
+                    events.ScheduleEvent(EVENT_HELLFIRE, 18s);
                 events.ScheduleEvent(EVENT_ENRAGE, 12s);
             }
 
@@ -122,12 +125,15 @@ class boss_thorngrin_the_tender : public CreatureScript
                                 Talk(SAY_CAST_SACRIFICE);
                                 DoCast(target, SPELL_SACRIFICE, true);
                             }
-                            events.ScheduleEvent(EVENT_SACRIFICE, 29400);
+                            events.ScheduleEvent(EVENT_SACRIFICE, 29400ms);
                             break;
                         case EVENT_HELLFIRE:
                             Talk(SAY_CAST_HELLFIRE);
                             DoCastVictim(SPELL_HELLFIRE, true);
-                            events.ScheduleEvent(EVENT_HELLFIRE, IsHeroic() ? urand(17400, 19300) : 18000);
+                            if (IsHeroic())
+                                events.ScheduleEvent(EVENT_HELLFIRE, 17400ms, 19300ms);
+                            else
+                                events.ScheduleEvent(EVENT_HELLFIRE, 18s);
                             break;
                         case EVENT_ENRAGE:
                             Talk(EMOTE_ENRAGE);


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/TempestKeep: Use std::chrono::duration overloads of EventMap

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build