### PR TITLE
Scripts/ICC: Use std::chrono::duration overloads of EventMap (Part 2)

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -916,7 +916,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 }
                 else if (action == ACTION_SPAWN_MAGE)
                 {
-                    auto now = GameTime::GetGameTimeSteadyPoint();
+                    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
                     if (_firstMageCooldown > now)
                         _events.ScheduleEvent(EVENT_SUMMON_MAGE, std::chrono::duration_cast<Milliseconds>(_firstMageCooldown - now));
                     else
@@ -1180,7 +1180,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 }
                 else if (action == ACTION_SPAWN_MAGE)
                 {
-                    auto now = GameTime::GetGameTimeSteadyPoint();
+                    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
                     if (_firstMageCooldown > now)
                         _events.ScheduleEvent(EVENT_SUMMON_MAGE, std::chrono::duration_cast<Milliseconds>(_firstMageCooldown - now));
                     else

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -854,7 +854,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 _controller.SetTransport(creature->GetTransport());
                 me->SetRegenerateHealth(false);
                 me->m_CombatDistance = 70.0f;
-                _firstMageCooldown = GameTime::GetGameTime() + 60;
+                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
                 _axethrowersYellCooldown = time_t(0);
                 _rocketeersYellCooldown = time_t(0);
             }
@@ -864,7 +864,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 ScriptedAI::InitializeAI();
 
                 _events.Reset();
-                _firstMageCooldown = GameTime::GetGameTime() + 60;
+                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
                 _axethrowersYellCooldown = time_t(0);
                 _rocketeersYellCooldown = time_t(0);
             }
@@ -897,9 +897,9 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                         muradin->AI()->DoAction(ACTION_SPAWN_ALL_ADDS);
 
                     Talk(SAY_SAURFANG_INTRO_5);
-                    _events.ScheduleEvent(EVENT_INTRO_H_5, 4000);
-                    _events.ScheduleEvent(EVENT_INTRO_H_6, 11000);
-                    _events.ScheduleEvent(EVENT_KEEP_PLAYER_IN_COMBAT, 1);
+                    _events.ScheduleEvent(EVENT_INTRO_H_5, 4s);
+                    _events.ScheduleEvent(EVENT_INTRO_H_6, 11s);
+                    _events.ScheduleEvent(EVENT_KEEP_PLAYER_IN_COMBAT, 1ms);
 
                     _instance->SetBossState(DATA_ICECROWN_GUNSHIP_BATTLE, IN_PROGRESS);
                     // Combat starts now
@@ -916,11 +916,11 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 }
                 else if (action == ACTION_SPAWN_MAGE)
                 {
-                    time_t now = GameTime::GetGameTime();
+                    auto now = GameTime::GetGameTimeSteadyPoint();
                     if (_firstMageCooldown > now)
-                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, (_firstMageCooldown - now) * IN_MILLISECONDS);
+                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, std::chrono::duration_cast<Milliseconds>(_firstMageCooldown - now));
                     else
-                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, 1);
+                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, 1ms);
                 }
                 else if (action == ACTION_SPAWN_ALL_ADDS)
                 {
@@ -954,7 +954,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 {
                     _controller.ClearSlot(PassengerSlots(data));
                     if (data == SLOT_FREEZE_MAGE)
-                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, urand(30000, 33500));
+                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, 30s, 33500ms);
                 }
             }
 
@@ -963,11 +963,11 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 me->GetTransport()->EnableMovement(true);
                 _events.SetPhase(PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_H_1, 5000, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_H_2, 16000, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_SUMMON_SKYBREAKER, 24600, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_H_3, 29600, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_H_4, 39200, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_H_1, 5s, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_H_2, 16s, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_SUMMON_SKYBREAKER, 24600ms, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_H_3, 29600ms, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_H_4, 39200ms, 0, PHASE_INTRO);
                 return false;
             }
 
@@ -1093,7 +1093,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
             EventMap _events;
             PassengerController _controller;
             InstanceScript* _instance;
-            time_t _firstMageCooldown;
+            std::chrono::steady_clock::time_point _firstMageCooldown;
             time_t _axethrowersYellCooldown;
             time_t _rocketeersYellCooldown;
         };
@@ -1118,7 +1118,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 _controller.SetTransport(creature->GetTransport());
                 me->SetRegenerateHealth(false);
                 me->m_CombatDistance = 70.0f;
-                _firstMageCooldown = GameTime::GetGameTime() + 60;
+                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
                 _riflemanYellCooldown = time_t(0);
                 _mortarYellCooldown = time_t(0);
             }
@@ -1128,7 +1128,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 ScriptedAI::InitializeAI();
 
                 _events.Reset();
-                _firstMageCooldown = GameTime::GetGameTime() + 60;
+                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
                 _riflemanYellCooldown = time_t(0);
                 _mortarYellCooldown = time_t(0);
             }
@@ -1161,9 +1161,9 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                         muradin->AI()->DoAction(ACTION_SPAWN_ALL_ADDS);
 
                     Talk(SAY_MURADIN_INTRO_6);
-                    _events.ScheduleEvent(EVENT_INTRO_A_6, 5000);
-                    _events.ScheduleEvent(EVENT_INTRO_A_7, 11000);
-                    _events.ScheduleEvent(EVENT_KEEP_PLAYER_IN_COMBAT, 1);
+                    _events.ScheduleEvent(EVENT_INTRO_A_6, 5s);
+                    _events.ScheduleEvent(EVENT_INTRO_A_7, 11s);
+                    _events.ScheduleEvent(EVENT_KEEP_PLAYER_IN_COMBAT, 1ms);
 
                     _instance->SetBossState(DATA_ICECROWN_GUNSHIP_BATTLE, IN_PROGRESS);
                     // Combat starts now
@@ -1180,11 +1180,11 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 }
                 else if (action == ACTION_SPAWN_MAGE)
                 {
-                    time_t now = GameTime::GetGameTime();
+                    auto now = GameTime::GetGameTimeSteadyPoint();
                     if (_firstMageCooldown > now)
-                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, (_firstMageCooldown - now) * IN_MILLISECONDS);
+                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, std::chrono::duration_cast<Milliseconds>(_firstMageCooldown - now));
                     else
-                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, 1);
+                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, 1ms);
                 }
                 else if (action == ACTION_SPAWN_ALL_ADDS)
                 {
@@ -1218,7 +1218,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 {
                     _controller.ClearSlot(PassengerSlots(data));
                     if (data == SLOT_FREEZE_MAGE)
-                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, urand(30000, 33500));
+                        _events.ScheduleEvent(EVENT_SUMMON_MAGE, 30s, 33500ms);
                 }
             }
 
@@ -1227,12 +1227,12 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                 me->GetTransport()->EnableMovement(true);
                 _events.SetPhase(PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_A_1, 5000);
-                _events.ScheduleEvent(EVENT_INTRO_A_2, 10000, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_A_1, 5s);
+                _events.ScheduleEvent(EVENT_INTRO_A_2, 10s, 0, PHASE_INTRO);
                 _events.ScheduleEvent(EVENT_INTRO_SUMMON_ORGRIMS_HAMMER, 28s, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_A_3, 33000, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_A_4, 39000, 0, PHASE_INTRO);
-                _events.ScheduleEvent(EVENT_INTRO_A_5, 45000, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_A_3, 33s, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_A_4, 39s, 0, PHASE_INTRO);
+                _events.ScheduleEvent(EVENT_INTRO_A_5, 45s, 0, PHASE_INTRO);
                 return false;
             }
 
@@ -1361,7 +1361,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
             EventMap _events;
             PassengerController _controller;
             InstanceScript* _instance;
-            time_t _firstMageCooldown;
+            std::chrono::steady_clock::time_point _firstMageCooldown;
             time_t _riflemanYellCooldown;
             time_t _mortarYellCooldown;
         };

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -249,7 +249,7 @@ class boss_sindragosa : public CreatureScript
                 events.ScheduleEvent(EVENT_TAIL_SMASH, 20s, EVENT_GROUP_LAND_PHASE);
                 events.ScheduleEvent(EVENT_FROST_BREATH, 8s, 12s, EVENT_GROUP_LAND_PHASE);
                 events.ScheduleEvent(EVENT_UNCHAINED_MAGIC, 9s, 14s, EVENT_GROUP_LAND_PHASE);
-                events.ScheduleEvent(EVENT_ICY_GRIP, 33500, EVENT_GROUP_LAND_PHASE);
+                events.ScheduleEvent(EVENT_ICY_GRIP, 33500ms, EVENT_GROUP_LAND_PHASE);
                 events.ScheduleEvent(EVENT_AIR_PHASE, 50s);
                 Initialize();
 
@@ -372,7 +372,7 @@ class boss_sindragosa : public CreatureScript
                         DoZoneInCombat();
                         break;
                     case POINT_TAKEOFF:
-                        events.ScheduleEvent(EVENT_AIR_MOVEMENT, 1);
+                        events.ScheduleEvent(EVENT_AIR_MOVEMENT, 1ms);
                         break;
                     case POINT_AIR_PHASE:
                     {
@@ -380,7 +380,7 @@ class boss_sindragosa : public CreatureScript
                         args.AddSpellMod(SPELLVALUE_MAX_TARGETS, RAID_MODE<int32>(2, 5, 2, 6));
                         me->CastSpell(nullptr, SPELL_ICE_TOMB_TARGET, args);
                         me->SetFacingTo(float(M_PI), true);
-                        events.ScheduleEvent(EVENT_AIR_MOVEMENT_FAR, 1);
+                        events.ScheduleEvent(EVENT_AIR_MOVEMENT_FAR, 1ms);
                         events.ScheduleEvent(EVENT_FROST_BOMB, 9s);
                         break;
                     }
@@ -389,7 +389,7 @@ class boss_sindragosa : public CreatureScript
                         events.ScheduleEvent(EVENT_LAND, 30s);
                         break;
                     case POINT_LAND:
-                        events.ScheduleEvent(EVENT_LAND_GROUND, 1);
+                        events.ScheduleEvent(EVENT_LAND_GROUND, 1ms);
                         break;
                     case POINT_LAND_GROUND:
                     {
@@ -511,7 +511,7 @@ class boss_sindragosa : public CreatureScript
                             pos.m_positionZ += 17.0f;
                             me->GetMotionMaster()->MoveTakeoff(POINT_TAKEOFF, pos);
                             events.CancelEventGroup(EVENT_GROUP_LAND_PHASE);
-                            events.ScheduleEvent(EVENT_AIR_PHASE, 110000);
+                            events.ScheduleEvent(EVENT_AIR_PHASE, 110s);
                             break;
                         }
                         case EVENT_AIR_MOVEMENT:
@@ -924,9 +924,9 @@ class npc_rimefang : public CreatureScript
                             me->AttackStop();
                             me->SetCanFly(true);
                             me->GetMotionMaster()->MovePoint(POINT_FROSTWYRM_FLY_IN, RimefangFlyPos);
-                            float moveTime = me->GetExactDist(&RimefangFlyPos)/(me->GetSpeed(MOVE_FLIGHT)*0.001f);
-                            _events.ScheduleEvent(EVENT_ICY_BLAST, uint64(moveTime) + urand(60000, 70000));
-                            _events.ScheduleEvent(EVENT_ICY_BLAST_CAST, uint64(moveTime) + 250);
+                            Milliseconds moveTime = Milliseconds(uint64(me->GetExactDist(&RimefangFlyPos)/(me->GetSpeed(MOVE_FLIGHT)*0.001f)));
+                            _events.ScheduleEvent(EVENT_ICY_BLAST, moveTime + 60s, moveTime + 70s);
+                            _events.ScheduleEvent(EVENT_ICY_BLAST_CAST, moveTime + 250ms);
                             break;
                         }
                         case EVENT_ICY_BLAST_CAST:


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/ICC: Use std::chrono::duration overloads of EventMap
Part 2: gunship battle and Sindragosa

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Contributes to #25012


**Tests performed:** build