### PR TITLE
Core/Time: Rename GetGameTime{System, Steady}Point methods

### DIFF
--- a/src/common/Metric/Metric.h
+++ b/src/common/Metric/Metric.h
@@ -19,8 +19,8 @@
 #define METRIC_H__
 
 #include "Define.h"
+#include "Duration.h"
 #include "MPSCQueue.h"
-#include <chrono>
 #include <functional>
 #include <iosfwd>
 #include <memory>
@@ -48,7 +48,7 @@ typedef std::pair<std::string, std::string> MetricTag;
 struct MetricData
 {
     std::string Category;
-    std::chrono::system_clock::time_point Timestamp;
+    SystemTimePoint Timestamp;
     MetricDataType Type;
     std::vector<MetricTag> Tags;
 

--- a/src/common/Utilities/Duration.h
+++ b/src/common/Utilities/Duration.h
@@ -32,6 +32,10 @@ typedef std::chrono::minutes Minutes;
 /// Hours shorthand typedef.
 typedef std::chrono::hours Hours;
 
+/// time_point shorthand typedefs
+typedef std::chrono::steady_clock::time_point TimePoint;
+typedef std::chrono::system_clock::time_point SystemTimePoint;
+
 /// Makes std::chrono_literals globally available.
 using namespace std::chrono_literals;
 

--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -2280,17 +2280,17 @@ bool AchievementGlobalMgr::IsRealmCompleted(AchievementEntry const* achievement)
     if (itr == _allCompletedAchievements.end())
         return false;
 
-    if (itr->second == std::chrono::system_clock::time_point::min())
+    if (itr->second == SystemTimePoint ::min())
         return false;
 
-    if (itr->second == std::chrono::system_clock::time_point::max())
+    if (itr->second == SystemTimePoint::max())
         return true;
 
     // Allow completing the realm first kill for entire minute after first person did it
     // it may allow more than one group to achieve it (highly unlikely)
     // but apparently this is how blizz handles it as well
     if (achievement->Flags & ACHIEVEMENT_FLAG_REALM_FIRST_KILL)
-        return (GameTime::GetGameTimeSystemPoint() - itr->second) > Minutes(1);
+        return (GameTime::GetSystemTime() - itr->second) > Minutes(1);
 
     return true;
 }
@@ -2300,7 +2300,7 @@ void AchievementGlobalMgr::SetRealmCompleted(AchievementEntry const* achievement
     if (IsRealmCompleted(achievement))
         return;
 
-    _allCompletedAchievements[achievement->ID] = GameTime::GetGameTimeSystemPoint();
+    _allCompletedAchievements[achievement->ID] = GameTime::GetSystemTime();
 }
 
 //==========================================================
@@ -2552,7 +2552,7 @@ void AchievementGlobalMgr::LoadCompletedAchievements()
     for (uint32 i = 0; i < sAchievementStore.GetNumRows(); ++i)
         if (AchievementEntry const* achievement = sAchievementStore.LookupEntry(i))
             if (achievement->Flags & (ACHIEVEMENT_FLAG_REALM_FIRST_REACH | ACHIEVEMENT_FLAG_REALM_FIRST_KILL))
-                _allCompletedAchievements[achievement->ID] = std::chrono::system_clock::time_point::min();
+                _allCompletedAchievements[achievement->ID] = SystemTimePoint::min();
 
     QueryResult result = CharacterDatabase.Query("SELECT achievement FROM character_achievement GROUP BY achievement");
 
@@ -2580,7 +2580,7 @@ void AchievementGlobalMgr::LoadCompletedAchievements()
             continue;
         }
         else if (achievement->Flags & (ACHIEVEMENT_FLAG_REALM_FIRST_REACH | ACHIEVEMENT_FLAG_REALM_FIRST_KILL))
-            _allCompletedAchievements[achievementId] = std::chrono::system_clock::time_point::max();
+            _allCompletedAchievements[achievementId] = SystemTimePoint::max();
     } while (result->NextRow());
 
     TC_LOG_INFO("server.loading", ">> Loaded %lu realm first completed achievements in %u ms.", (unsigned long)_allCompletedAchievements.size(), GetMSTimeDiffToNow(oldMSTime));

--- a/src/server/game/Achievements/AchievementMgr.h
+++ b/src/server/game/Achievements/AchievementMgr.h
@@ -21,6 +21,7 @@
 #include "DatabaseEnvFwd.h"
 #include "DBCEnums.h"
 #include "DBCStores.h"
+#include "Duration.h"
 #include "ObjectGuid.h"
 #include <string>
 #include <unordered_map>
@@ -398,9 +399,9 @@ class TC_GAME_API AchievementGlobalMgr
         AchievementListByReferencedId m_AchievementListByReferencedId;
 
         // store realm first achievements
-        // std::chrono::system_clock::time_point::min() is a placeholder value for realm firsts not yet completed
-        // std::chrono::system_clock::time_point::max() is a value assigned to realm firsts complete before worldserver started
-        std::unordered_map<uint32 /*achievementId*/, std::chrono::system_clock::time_point /*completionTime*/> _allCompletedAchievements;
+        // SystemTimePoint::min() is a placeholder value for realm firsts not yet completed
+        // SystemTimePoint::max() is a value assigned to realm firsts complete before worldserver started
+        std::unordered_map<uint32 /*achievementId*/, SystemTimePoint /*completionTime*/> _allCompletedAchievements;
 
         AchievementRewards m_achievementRewards;
         AchievementRewardLocales m_achievementRewardLocales;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22905,7 +22905,7 @@ void Player::ApplyEquipCooldown(Item* pItem)
     if (pItem->GetTemplate()->HasFlag(ITEM_FLAG_NO_EQUIP_COOLDOWN))
         return;
 
-    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+    TimePoint now = GameTime::Now();
     for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
     {
         _Spell const& spellData = pItem->GetTemplate()->Spells[i];

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10070,7 +10070,7 @@ void Unit::ProcSkillsAndReactives(bool isVictim, Unit* procTarget, uint32 typeMa
 
 void Unit::GetProcAurasTriggeredOnEvent(AuraApplicationProcContainer& aurasTriggeringProc, AuraApplicationList* procAuras, ProcEventInfo& eventInfo)
 {
-    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+    TimePoint now = GameTime::Now();
 
     // use provided list of auras which can proc
     if (procAuras)

--- a/src/server/game/Server/WorldPacket.h
+++ b/src/server/game/Server/WorldPacket.h
@@ -21,7 +21,7 @@
 #include "Common.h"
 #include "Opcodes.h"
 #include "ByteBuffer.h"
-#include <chrono>
+#include "Duration.h"
 
 class WorldPacket : public ByteBuffer
 {
@@ -38,7 +38,7 @@ class WorldPacket : public ByteBuffer
         {
         }
 
-        WorldPacket(WorldPacket&& packet, std::chrono::steady_clock::time_point receivedTime) : ByteBuffer(std::move(packet)), m_opcode(packet.m_opcode), m_receivedTime(receivedTime)
+        WorldPacket(WorldPacket&& packet, TimePoint receivedTime) : ByteBuffer(std::move(packet)), m_opcode(packet.m_opcode), m_receivedTime(receivedTime)
         {
         }
 
@@ -80,11 +80,11 @@ class WorldPacket : public ByteBuffer
         uint16 GetOpcode() const { return m_opcode; }
         void SetOpcode(uint16 opcode) { m_opcode = opcode; }
 
-        std::chrono::steady_clock::time_point GetReceivedTime() const { return m_receivedTime; }
+        TimePoint GetReceivedTime() const { return m_receivedTime; }
 
     protected:
         uint16 m_opcode;
-        std::chrono::steady_clock::time_point m_receivedTime; // only set for a specific set of opcodes, for performance reasons.
+        TimePoint m_receivedTime; // only set for a specific set of opcodes, for performance reasons.
 };
 
 #endif

--- a/src/server/game/Server/WorldSocket.h
+++ b/src/server/game/Server/WorldSocket.h
@@ -26,7 +26,6 @@
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "MPSCQueue.h"
-#include <chrono>
 #include <boost/asio/ip/tcp.hpp>
 
 using boost::asio::ip::tcp;
@@ -116,7 +115,7 @@ private:
     uint32 _authSeed;
     AuthCrypt _authCrypt;
 
-    std::chrono::steady_clock::time_point _LastPingTime;
+    TimePoint _LastPingTime;
     uint32 _OverSpeedPings;
 
     std::mutex _worldSessionLock;

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -430,7 +430,7 @@ m_castItemGuid(createInfo.CastItemGUID), m_applyTime(GameTime::GetGameTime()),
 m_owner(createInfo._owner), m_timeCla(0), m_updateTargetMapInterval(0),
 _casterInfo(), m_procCharges(0), m_stackAmount(1),
 m_isRemoved(false), m_isSingleTarget(false), m_isUsingCharges(false), m_dropEvent(nullptr),
-m_procCooldown(std::chrono::steady_clock::time_point::min())
+m_procCooldown(TimePoint::min())
 {
     if (m_spellInfo->ManaPerSecond || m_spellInfo->ManaPerSecondPerLevel)
         m_timeCla = 1 * IN_MILLISECONDS;
@@ -1985,12 +1985,12 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     return true;
 }
 
-bool Aura::IsProcOnCooldown(std::chrono::steady_clock::time_point now) const
+bool Aura::IsProcOnCooldown(TimePoint now) const
 {
     return m_procCooldown > now;
 }
 
-void Aura::AddProcCooldown(std::chrono::steady_clock::time_point cooldownEnd)
+void Aura::AddProcCooldown(TimePoint cooldownEnd)
 {
     m_procCooldown = cooldownEnd;
 }
@@ -2000,7 +2000,7 @@ void Aura::ResetProcCooldown()
     m_procCooldown = std::chrono::steady_clock::now();
 }
 
-void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, std::chrono::steady_clock::time_point now)
+void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, TimePoint now)
 {
     bool prepare = CallScriptPrepareProcHandlers(aurApp, eventInfo);
     if (!prepare)
@@ -2020,7 +2020,7 @@ void Aura::PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInf
     AddProcCooldown(now + procEntry->Cooldown);
 }
 
-uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo, std::chrono::steady_clock::time_point now) const
+uint8 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo, TimePoint now) const
 {
     SpellProcEntry const* procEntry = sSpellMgr->GetSpellProcEntry(GetId());
     // only auras with spell proc entry can trigger proc

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -215,13 +215,13 @@ class TC_GAME_API Aura
         bool CheckAreaTarget(Unit* target);
         bool CanStackWith(Aura const* existingAura) const;
 
-        bool IsProcOnCooldown(std::chrono::steady_clock::time_point now) const;
-        void AddProcCooldown(std::chrono::steady_clock::time_point cooldownEnd);
+        bool IsProcOnCooldown(TimePoint now) const;
+        void AddProcCooldown(TimePoint cooldownEnd);
         void ResetProcCooldown();
         bool IsUsingCharges() const { return m_isUsingCharges; }
         void SetUsingCharges(bool val) { m_isUsingCharges = val; }
-        void PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, std::chrono::steady_clock::time_point now);
-        uint8 GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo, std::chrono::steady_clock::time_point now) const;
+        void PrepareProcToTrigger(AuraApplication* aurApp, ProcEventInfo& eventInfo, TimePoint now);
+        uint8 GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo, TimePoint now) const;
         float CalcProcChance(SpellProcEntry const& procEntry, ProcEventInfo& eventInfo) const;
         void TriggerProcOnEvent(uint8 procEffectMask, AuraApplication* aurApp, ProcEventInfo& eventInfo);
 
@@ -298,7 +298,7 @@ class TC_GAME_API Aura
 
         ChargeDropEvent* m_dropEvent;
 
-        std::chrono::steady_clock::time_point m_procCooldown;
+        TimePoint m_procCooldown;
 
     private:
         std::vector<AuraApplication*> _removedApplications;

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -140,7 +140,7 @@ void SpellHistory::SaveToDB(CharacterDatabaseTransaction& trans)
 
 void SpellHistory::Update()
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     for (auto itr = _categoryCooldowns.begin(); itr != _categoryCooldowns.end();)
     {
         if (itr->second->CategoryEnd < now)
@@ -202,7 +202,7 @@ bool SpellHistory::IsReady(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, bo
 template<>
 void SpellHistory::WritePacket<Pet>(WorldPacket& packet) const
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
 
     uint8 cooldownsCount = _spellCooldowns.size();
     packet << uint8(cooldownsCount);
@@ -239,7 +239,7 @@ void SpellHistory::WritePacket<Pet>(WorldPacket& packet) const
 template<>
 void SpellHistory::WritePacket<Player>(WorldPacket& packet) const
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     Clock::time_point infTime = now + InfinityCooldownDelayCheck;
 
     packet << uint16(_spellCooldowns.size());
@@ -289,7 +289,7 @@ void SpellHistory::StartCooldown(SpellInfo const* spellInfo, uint32 itemId, Spel
 
     GetCooldownDurations(spellInfo, itemId, &cooldown, &categoryId, &categoryCooldown);
 
-    Clock::time_point curTime = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point curTime = GameTime::GetSystemTime();
     Clock::time_point catrecTime;
     Clock::time_point recTime;
     bool needsCooldownPacket = false;
@@ -412,7 +412,7 @@ void SpellHistory::ModifyCooldown(uint32 spellId, int32 cooldownModMs)
     if (!cooldownModMs || itr == _spellCooldowns.end())
         return;
 
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     Clock::duration offset = std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(cooldownModMs));
     if (itr->second.CooldownEnd + offset > now)
         itr->second.CooldownEnd += offset;
@@ -506,7 +506,7 @@ uint32 SpellHistory::GetRemainingCooldown(SpellInfo const* spellInfo) const
         end = catItr->second->CategoryEnd;
     }
 
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     if (end < now)
         return 0;
 
@@ -516,7 +516,7 @@ uint32 SpellHistory::GetRemainingCooldown(SpellInfo const* spellInfo) const
 
 void SpellHistory::LockSpellSchool(SpellSchoolMask schoolMask, uint32 lockoutTime)
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     Clock::time_point lockoutEnd = now + std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(lockoutTime));
     for (uint32 i = 0; i < MAX_SPELL_SCHOOL; ++i)
         if (SpellSchoolMask(1 << i) & schoolMask)
@@ -573,7 +573,7 @@ void SpellHistory::LockSpellSchool(SpellSchoolMask schoolMask, uint32 lockoutTim
 
 bool SpellHistory::IsSchoolLocked(SpellSchoolMask schoolMask) const
 {
-    Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+    Clock::time_point now = GameTime::GetSystemTime();
     for (uint32 i = 0; i < MAX_SPELL_SCHOOL; ++i)
         if (SpellSchoolMask(1 << i) & schoolMask)
             if (_schoolLockouts[i] > now)
@@ -585,12 +585,12 @@ bool SpellHistory::IsSchoolLocked(SpellSchoolMask schoolMask) const
 bool SpellHistory::HasGlobalCooldown(SpellInfo const* spellInfo) const
 {
     auto itr = _globalCooldowns.find(spellInfo->StartRecoveryCategory);
-    return itr != _globalCooldowns.end() && itr->second > GameTime::GetGameTimeSystemPoint();
+    return itr != _globalCooldowns.end() && itr->second > GameTime::GetSystemTime();
 }
 
 void SpellHistory::AddGlobalCooldown(SpellInfo const* spellInfo, uint32 duration)
 {
-    _globalCooldowns[spellInfo->StartRecoveryCategory] = GameTime::GetGameTimeSystemPoint() + std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(duration));
+    _globalCooldowns[spellInfo->StartRecoveryCategory] = GameTime::GetSystemTime() + std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(duration));
 }
 
 void SpellHistory::CancelGlobalCooldown(SpellInfo const* spellInfo)
@@ -712,7 +712,7 @@ void SpellHistory::RestoreCooldownStateAfterDuel()
 
         for (auto itr = _spellCooldowns.begin(); itr != _spellCooldowns.end(); ++itr)
         {
-            Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+            Clock::time_point now = GameTime::GetSystemTime();
             uint32 cooldownDuration = itr->second.CooldownEnd > now ? std::chrono::duration_cast<std::chrono::milliseconds>(itr->second.CooldownEnd - now).count() : 0;
 
             // cooldownDuration must be between 0 and 10 minutes in order to avoid any visual bugs

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -86,7 +86,7 @@ public:
     template<class Type, class Period>
     void AddCooldown(uint32 spellId, uint32 itemId, std::chrono::duration<Type, Period> cooldownDuration)
     {
-        Clock::time_point now = GameTime::GetGameTimeSystemPoint();
+        Clock::time_point now = GameTime::GetSystemTime();
         AddCooldown(spellId, itemId, now + std::chrono::duration_cast<Clock::duration>(cooldownDuration), 0, now);
     }
 

--- a/src/server/game/Time/GameTime.cpp
+++ b/src/server/game/Time/GameTime.cpp
@@ -25,8 +25,8 @@ namespace GameTime
     time_t GameTime = time(nullptr);
     uint32 GameMSTime = 0;
 
-    std::chrono::system_clock::time_point GameTimeSystemPoint = std::chrono::system_clock::time_point::min();
-    std::chrono::steady_clock::time_point GameTimeSteadyPoint = std::chrono::steady_clock::time_point::min();
+    SystemTimePoint GameTimeSystemPoint = SystemTimePoint ::min();
+    TimePoint GameTimeSteadyPoint = TimePoint::min();
 
     time_t GetStartTime()
     {
@@ -43,12 +43,12 @@ namespace GameTime
         return GameMSTime;
     }
 
-    std::chrono::system_clock::time_point GetGameTimeSystemPoint()
+    SystemTimePoint GetSystemTime()
     {
         return GameTimeSystemPoint;
     }
 
-    std::chrono::steady_clock::time_point GetGameTimeSteadyPoint()
+    TimePoint Now()
     {
         return GameTimeSteadyPoint;
     }

--- a/src/server/game/Time/GameTime.h
+++ b/src/server/game/Time/GameTime.h
@@ -19,7 +19,7 @@
 #define __GAMETIME_H
 
 #include "Define.h"
-#include <chrono>
+#include "Duration.h"
 
 namespace GameTime
 {
@@ -33,10 +33,10 @@ namespace GameTime
     TC_GAME_API uint32 GetGameTimeMS();
 
     /// Current chrono system_clock time point
-    TC_GAME_API std::chrono::system_clock::time_point GetGameTimeSystemPoint();
+    TC_GAME_API SystemTimePoint GetSystemTime();
 
     /// Current chrono steady_clock time point
-    TC_GAME_API std::chrono::steady_clock::time_point GetGameTimeSteadyPoint();
+    TC_GAME_API TimePoint Now();
 
     /// Uptime (in secs)
     TC_GAME_API uint32 GetUptime();

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_icecrown_gunship_battle.cpp
@@ -854,7 +854,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 _controller.SetTransport(creature->GetTransport());
                 me->SetRegenerateHealth(false);
                 me->m_CombatDistance = 70.0f;
-                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
+                _firstMageCooldown = GameTime::Now() + 60s;
                 _axethrowersYellCooldown = time_t(0);
                 _rocketeersYellCooldown = time_t(0);
             }
@@ -864,7 +864,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 ScriptedAI::InitializeAI();
 
                 _events.Reset();
-                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
+                _firstMageCooldown = GameTime::Now() + 60s;
                 _axethrowersYellCooldown = time_t(0);
                 _rocketeersYellCooldown = time_t(0);
             }
@@ -916,7 +916,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
                 }
                 else if (action == ACTION_SPAWN_MAGE)
                 {
-                    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+                    TimePoint now = GameTime::Now();
                     if (_firstMageCooldown > now)
                         _events.ScheduleEvent(EVENT_SUMMON_MAGE, std::chrono::duration_cast<Milliseconds>(_firstMageCooldown - now));
                     else
@@ -1093,7 +1093,7 @@ class npc_high_overlord_saurfang_igb : public CreatureScript
             EventMap _events;
             PassengerController _controller;
             InstanceScript* _instance;
-            std::chrono::steady_clock::time_point _firstMageCooldown;
+            TimePoint _firstMageCooldown;
             time_t _axethrowersYellCooldown;
             time_t _rocketeersYellCooldown;
         };
@@ -1118,7 +1118,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 _controller.SetTransport(creature->GetTransport());
                 me->SetRegenerateHealth(false);
                 me->m_CombatDistance = 70.0f;
-                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
+                _firstMageCooldown = GameTime::Now() + 60s;
                 _riflemanYellCooldown = time_t(0);
                 _mortarYellCooldown = time_t(0);
             }
@@ -1128,7 +1128,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 ScriptedAI::InitializeAI();
 
                 _events.Reset();
-                _firstMageCooldown = GameTime::GetGameTimeSteadyPoint() + 60s;
+                _firstMageCooldown = GameTime::Now() + 60s;
                 _riflemanYellCooldown = time_t(0);
                 _mortarYellCooldown = time_t(0);
             }
@@ -1180,7 +1180,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
                 }
                 else if (action == ACTION_SPAWN_MAGE)
                 {
-                    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+                    TimePoint now = GameTime::Now();
                     if (_firstMageCooldown > now)
                         _events.ScheduleEvent(EVENT_SUMMON_MAGE, std::chrono::duration_cast<Milliseconds>(_firstMageCooldown - now));
                     else
@@ -1361,7 +1361,7 @@ class npc_muradin_bronzebeard_igb : public CreatureScript
             EventMap _events;
             PassengerController _controller;
             InstanceScript* _instance;
-            std::chrono::steady_clock::time_point _firstMageCooldown;
+            TimePoint _firstMageCooldown;
             time_t _riflemanYellCooldown;
             time_t _mortarYellCooldown;
         };

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -228,7 +228,7 @@ class spell_dru_eclipse : public AuraScript
         if (!spellInfo || !(spellInfo->SpellFamilyFlags[0] & 4)) // Starfire
             return false;
 
-        return _solarProcCooldownEnd <= GameTime::GetGameTimeSteadyPoint();
+        return _solarProcCooldownEnd <= GameTime::Now();
     }
 
     bool CheckLunar(AuraEffect const*  /*aurEff*/, ProcEventInfo& eventInfo)
@@ -241,14 +241,14 @@ class spell_dru_eclipse : public AuraScript
         if (!roll_chance_i(60))
             return false;
 
-        return _lunarProcCooldownEnd <= GameTime::GetGameTimeSteadyPoint();
+        return _lunarProcCooldownEnd <= GameTime::Now();
     }
 
     void ProcSolar(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
 
-        _solarProcCooldownEnd = GameTime::GetGameTimeSteadyPoint() + Seconds(30);
+        _solarProcCooldownEnd = GameTime::Now() + 30s;
         eventInfo.GetActor()->CastSpell(eventInfo.GetActor(), SPELL_DRUID_ECLIPSE_SOLAR_PROC, aurEff);
     }
 
@@ -256,7 +256,7 @@ class spell_dru_eclipse : public AuraScript
     {
         PreventDefaultAction();
 
-        _lunarProcCooldownEnd = GameTime::GetGameTimeSteadyPoint() + Seconds(30);
+        _lunarProcCooldownEnd = GameTime::Now() + 30s;
         eventInfo.GetActor()->CastSpell(eventInfo.GetActor(), SPELL_DRUID_ECLIPSE_LUNAR_PROC, aurEff);
     }
 
@@ -271,8 +271,8 @@ class spell_dru_eclipse : public AuraScript
         OnEffectProc += AuraEffectProcFn(spell_dru_eclipse::ProcLunar, EFFECT_1, SPELL_AURA_DUMMY);
     }
 
-    std::chrono::steady_clock::time_point _lunarProcCooldownEnd = std::chrono::steady_clock::time_point::min();
-    std::chrono::steady_clock::time_point _solarProcCooldownEnd = std::chrono::steady_clock::time_point::min();
+    TimePoint _lunarProcCooldownEnd = std::chrono::steady_clock::time_point::min();
+    TimePoint _solarProcCooldownEnd = std::chrono::steady_clock::time_point::min();
 };
 
 // 5229 - Enrage

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1992,7 +1992,7 @@ class spell_pal_sacred_shield_dummy : public SpellScriptLoader
                 if (!caster)
                     return;
 
-                std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+                TimePoint now = GameTime::Now();
                 if (_cooldownEnd > now)
                     return;
 
@@ -2010,7 +2010,7 @@ class spell_pal_sacred_shield_dummy : public SpellScriptLoader
             }
 
             // Cooldown tracking can't be done in DB because of T8 bonus
-            std::chrono::steady_clock::time_point _cooldownEnd = std::chrono::steady_clock::time_point::min();
+            TimePoint _cooldownEnd = std::chrono::steady_clock::time_point::min();
         };
 
         AuraScript* GetAuraScript() const override


### PR DESCRIPTION
**Changes proposed:**
See #25042 for details.

`GetGameTimeSystemPoint()` -> `GetSystemTime()`
`GetGameTimeSteadyPoint()` -> `Now()`

Also add 2 new typedefs:
```c++
typedef std::chrono::steady_clock::time_point TimePoint;
typedef std::chrono::system_clock::time_point SystemTimePoint;
```

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #25042 


**Tests performed:** build