### PR TITLE
Core/Util: Remove EventMap's non-std::chrono::duration based interface

### DIFF
--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -33,12 +33,7 @@ void EventMap::SetPhase(uint8 phase)
         _phase = uint8(1 << (phase - 1));
 }
 
-void EventMap::ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group /*= 0*/, uint32 phase /*= 0*/)
-{
-    ScheduleEvent(eventId, urand(uint32(minTime.count()), uint32(maxTime.count())), group, phase);
-}
-
-void EventMap::ScheduleEvent(uint32 eventId, uint32 time, uint32 group /*= 0*/, uint8 phase /*= 0*/)
+void EventMap::ScheduleEvent(uint32 eventId, Milliseconds time, uint32 group /*= 0*/, uint8 phase /*= 0*/)
 {
     if (group && group <= 8)
         eventId |= (1 << (group + 15));
@@ -46,17 +41,33 @@ void EventMap::ScheduleEvent(uint32 eventId, uint32 time, uint32 group /*= 0*/, 
     if (phase && phase <= 8)
         eventId |= (1 << (phase + 23));
 
-    _eventMap.insert(EventStore::value_type(_time + time, eventId));
+    _eventMap.insert(EventStore::value_type(_time + time.count(), eventId));
+}
+
+void EventMap::ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group /*= 0*/, uint32 phase /*= 0*/)
+{
+    ScheduleEvent(eventId, randtime(minTime, maxTime), group, phase);
+}
+
+void EventMap::RescheduleEvent(uint32 eventId, Milliseconds time, uint32 group /*= 0*/, uint8 phase /*= 0*/)
+{
+    CancelEvent(eventId);
+    ScheduleEvent(eventId, time, group, phase);
 }
 
 void EventMap::RescheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group /*= 0*/, uint32 phase /*= 0*/)
 {
-    RescheduleEvent(eventId, urand(uint32(minTime.count()), uint32(maxTime.count())), group, phase);
+    RescheduleEvent(eventId, randtime(minTime, maxTime), group, phase);
 }
 
-void EventMap::Repeat(uint32 minTime, uint32 maxTime)
+void EventMap::Repeat(Milliseconds time)
 {
-    Repeat(urand(minTime, maxTime));
+    _eventMap.insert(EventStore::value_type(_time + time.count(), _lastEvent));
+}
+
+void EventMap::Repeat(Milliseconds minTime, Milliseconds maxTime)
+{
+    Repeat(randtime(minTime, maxTime));
 }
 
 uint32 EventMap::ExecuteEvent()
@@ -81,7 +92,12 @@ uint32 EventMap::ExecuteEvent()
     return 0;
 }
 
-void EventMap::DelayEvents(uint32 delay, uint32 group)
+void EventMap::DelayEvents(Milliseconds delay)
+{
+    _time = delay.count() < _time ? _time - delay.count() : 0;
+}
+
+void EventMap::DelayEvents(Milliseconds delay, uint32 group)
 {
     if (!group || group > 8 || Empty())
         return;
@@ -92,7 +108,7 @@ void EventMap::DelayEvents(uint32 delay, uint32 group)
     {
         if (itr->second & (1 << (group + 15)))
         {
-            delayed.insert(EventStore::value_type(itr->first + delay, itr->second));
+            delayed.insert(EventStore::value_type(itr->first + delay.count(), itr->second));
             _eventMap.erase(itr++);
         }
         else

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -58,7 +58,7 @@ public:
 
     /**
     * @name GetTimer
-    * @return Current timer in ms value.
+    * @return Current timer value in ms.
     */
     uint32 GetTimer() const
     {
@@ -114,20 +114,17 @@ public:
 
     /**
     * @name ScheduleEvent
-    * @brief Creates new event entry in map.
+    * @brief Schedules a new event.
     * @param eventId The id of the new event.
     * @param time The time until the event occurs as std::chrono type.
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
     * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
     */
-    void ScheduleEvent(uint32 eventId, Milliseconds time, uint32 group = 0, uint8 phase = 0)
-    {
-        ScheduleEvent(eventId, uint32(time.count()), group, phase);
-    }
+    void ScheduleEvent(uint32 eventId, Milliseconds time, uint32 group = 0, uint8 phase = 0);
 
     /**
     * @name ScheduleEvent
-    * @brief Creates new event entry in map.
+    * @brief Schedules a new event.
     * @param eventId The id of the new event.
     * @param minTime The minimum time until the event occurs as std::chrono type.
     * @param maxTime The maximum time until the event occurs as std::chrono type.
@@ -137,16 +134,6 @@ public:
     void ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group = 0, uint32 phase = 0);
 
     /**
-    * @name ScheduleEvent
-    * @brief Creates new event entry in map.
-    * @param eventId The id of the new event.
-    * @param time The time in milliseconds until the event occurs.
-    * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
-    * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
-    */
-    void ScheduleEvent(uint32 eventId, uint32 time, uint32 group = 0, uint8 phase = 0);
-
-    /**
     * @name RescheduleEvent
     * @brief Cancels the given event and reschedules it.
     * @param eventId The id of the event.
@@ -154,10 +141,7 @@ public:
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
     * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
     */
-    void RescheduleEvent(uint32 eventId, Milliseconds time, uint32 group = 0, uint8 phase = 0)
-    {
-        RescheduleEvent(eventId, uint32(time.count()), group, phase);
-    }
+    void RescheduleEvent(uint32 eventId, Milliseconds time, uint32 group = 0, uint8 phase = 0);
 
     /**
     * @name RescheduleEvent
@@ -171,103 +155,41 @@ public:
     void RescheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group = 0, uint32 phase = 0);
 
     /**
-    * @name RescheduleEvent
-    * @brief Cancels the given event and reschedules it.
-    * @param eventId The id of the event.
-    * @param time The time in milliseconds until the event occurs.
-    * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
-    * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
+    * @name RepeatEvent
+    * @brief Repeats the most recently executed event.
+    * @param time Time until the event occurs as std::chrono type.
     */
-    void RescheduleEvent(uint32 eventId, uint32 time, uint32 group = 0, uint8 phase = 0)
-    {
-        CancelEvent(eventId);
-        ScheduleEvent(eventId, time, group, phase);
-    }
+    void Repeat(Milliseconds time);
 
     /**
     * @name RepeatEvent
-    * @brief Repeats the mostly recently executed event.
-    * @param time Time until in milliseconds as std::chrono::duration the event occurs.
+    * @brief Repeats the most recently executed event.
+    * @param minTime The minimum time until the event occurs as std::chrono type.
+    * @param maxTime The maximum time until the event occurs as std::chrono type.
     */
-    void Repeat(Milliseconds time)
-    {
-        Repeat(uint32(time.count()));
-    }
-
-    /**
-    * @name RepeatEvent
-    * @brief Repeats the mostly recently executed event.
-    * @param time Time until the event occurs.
-    */
-    void Repeat(uint32 time)
-    {
-        _eventMap.insert(EventStore::value_type(_time + time, _lastEvent));
-    }
-
-    /**
-    * @name RepeatEvent
-    * @brief Repeats the mostly recently executed event.
-    * @param minTime Minimum time as std::chrono::duration until the event occurs.
-    * @param maxTime Maximum time as std::chrono::duration until the event occurs.
-    */
-    void Repeat(Milliseconds minTime, Milliseconds maxTime)
-    {
-        Repeat(uint32(minTime.count()), uint32(maxTime.count()));
-    }
-
-    /**
-    * @name RepeatEvent
-    * @brief Repeats the mostly recently executed event, Equivalent to Repeat(urand(minTime, maxTime).
-    * @param minTime Minimum time until the event occurs.
-    * @param maxTime Maximum time until the event occurs.
-    */
-    void Repeat(uint32 minTime, uint32 maxTime);
+    void Repeat(Milliseconds minTime, Milliseconds maxTime);
 
     /**
     * @name ExecuteEvent
-    * @brief Returns the next event to execute and removes it from map.
+    * @brief Returns the next event to be executed and removes it from map.
     * @return Id of the event to execute.
     */
     uint32 ExecuteEvent();
 
     /**
     * @name DelayEvents
-    * @brief Delays all events in the map. If delay is greater than or equal internal timer, delay will be 0.
-    * @param delay Amount of delay in ms as std::chrono::duration.
+    * @brief Delays all events. If delay is greater than or equal internal timer, delay will be 0.
+    * @param delay Amount of delay as std::chrono type.
     */
-    void DelayEvents(Milliseconds delay)
-    {
-        DelayEvents(uint32(delay.count()));
-    }
-
-    /**
-    * @name DelayEvents
-    * @brief Delays all events in the map. If delay is greater than or equal internal timer, delay will be equal to internal timer.
-    * @param delay Amount of delay.
-    */
-    void DelayEvents(uint32 delay)
-    {
-        _time = delay < _time ? _time - delay : 0;
-    }
+    void DelayEvents(Milliseconds delay);
 
     /**
     * @name DelayEvents
     * @brief Delay all events of the same group.
-    * @param delay Amount of delay in ms as std::chrono::duration.
+    * @param delay Amount of delay as std::chrono type.
     * @param group Group of the events.
     */
-    void DelayEvents(Milliseconds delay, uint32 group)
-    {
-        DelayEvents(uint32(delay.count()), group);
-    }
-
-    /**
-    * @name DelayEvents
-    * @brief Delay all events of the same group.
-    * @param delay Amount of delay.
-    * @param group Group of the events.
-    */
-    void DelayEvents(uint32 delay, uint32 group);
+    void DelayEvents(Milliseconds delay, uint32 group);
 
     /**
     * @name CancelEvent
@@ -285,7 +207,7 @@ public:
 
     /**
     * @name GetNextEventTime
-    * @brief Returns closest occurence of specified event.
+    * @brief Returns closest occurrence of specified event.
     * @param eventId Wanted event id.
     * @return Time of found event.
     */


### PR DESCRIPTION
**Changes proposed:**

-  See #25012

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:** Closes #25012

**Tests performed:** ran through Utgarde Pinnacle