### PR TITLE
Core/Random: Replace Boost TLS with C++11 one

### DIFF
--- a/src/common/Utilities/Random.cpp
+++ b/src/common/Utilities/Random.cpp
@@ -18,24 +18,11 @@
 #include "Random.h"
 #include "Errors.h"
 #include "SFMTRand.h"
-#include <boost/thread/tss.hpp>
+#include "Util.h"
 #include <random>
 
-static boost::thread_specific_ptr<SFMTRand> sfmtRand;
+static thread_local LazyWrapper<SFMTRand> sfmtRand;
 static RandomEngine engine;
-
-static SFMTRand* GetRng()
-{
-    SFMTRand* rand = sfmtRand.get();
-
-    if (!rand)
-    {
-        rand = new SFMTRand();
-        sfmtRand.reset(rand);
-    }
-
-    return rand;
-}
 
 int32 irand(int32 min, int32 max)
 {
@@ -74,7 +61,7 @@ Milliseconds randtime(Milliseconds min, Milliseconds max)
 
 uint32 rand32()
 {
-    return GetRng()->RandomUInt32();
+    return sfmtRand->RandomUInt32();
 }
 
 double rand_norm()

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -21,6 +21,7 @@
 #include "Define.h"
 #include "Errors.h"
 
+#include <memory>
 #include <string>
 #include <sstream>
 #include <utility>
@@ -522,5 +523,26 @@ Ret* Coalesce(T1* first, T*... rest)
 {
     return static_cast<Ret*>(first ? static_cast<Ret*>(first) : Coalesce<Ret>(rest...));
 }
+
+// Wrapper for lazy initialization
+template<typename T>
+class LazyWrapper
+{
+public:
+    LazyWrapper() = default;
+    ~LazyWrapper() = default;
+
+    // Associated storage is initialized on first use.
+    T* operator-> ()
+    {
+        if (!_impl)
+            _impl = std::make_unique<T>();
+
+        return _impl.get();
+    }
+
+private:
+    std::unique_ptr<T> _impl;
+};
 
 #endif


### PR DESCRIPTION
**Changes proposed:**

-  Core/Utilities: Add a wrapper for lazy initialization
-  Core/Random: Replace Boost TLS with C++11 one

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:** build + debug session with 2 map threads confirmed, that SFMT is initialized per thread

Credits go to @jackpoz and @Naios (ref #15782)