### PR TITLE
Core/Unit: Allow gaining Weapon Skill when hit is missed with ranged weapon

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5837,8 +5837,6 @@ bool Player::UpdateSkillPro(uint16 SkillId, int32 Chance, uint32 step)
 void Player::UpdateWeaponSkill(WeaponAttackType attType)
 {
     Unit* victim = GetVictim();
-    if (!victim)
-        return;
 
     if (IsInFeralForm())
         return;                                             // always maximized SKILL_FERAL_COMBAT in fact


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  with this change: https://github.com/TrinityCore/TrinityCore/commit/e20e51a3855595817df89ac69494b9fd41e1acb3 if you miss hit with a ranged weapon, you can't gain skill, Player::UpdateWeaponSkill shouldn't return if !victim

**Target branch(es):** 3.3.5

- [X] 3.3.5
- [ ] master

**Issues addressed:** None


**Tests performed:** Tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
