### PR TITLE
Core/Loot: Prevent loot already looted item

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -24850,7 +24850,7 @@ void Player::StoreLootItem(uint8 lootSlot, Loot* loot)
 
     LootItem* item = loot->LootItemInSlot(lootSlot, this, &qitem, &ffaitem, &conditem);
 
-    if (!item)
+    if (!item || item->is_looted)
     {
         SendEquipError(EQUIP_ERR_ALREADY_LOOTED, nullptr, nullptr);
         return;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Prevent loot already looted item (explained here: https://github.com/TrinityCore/TrinityCore/issues/14956#issuecomment-660157745)
-  I'm going to leave the PR draft for a few days in case someone wants to test it as jackpoz told me

<details>
  <summary>Example with log:</summary>
  
  ```
2020-07-18_18:53:54 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:53:54 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Patosa' (GUID Full: 0x000000000000a591 Type: Player Low: 42385), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Patosa' (GUID Full: 0x000000000000a591 Type: Player Low: 42385), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Patosa' (GUID Full: 0x000000000000a591 Type: Player Low: 42385), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:01 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:54:50 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Humahuaca' (GUID Full: 0x000000000000a422 Type: Player Low: 42018), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Humahuaca' (GUID Full: 0x000000000000a422 Type: Player Low: 42018), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Humahuaca' (GUID Full: 0x000000000000a422 Type: Player Low: 42018), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:03 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:55:04 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:55:04 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:04 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:55:17 Player::StoreLootItem: Player 'Patosa' (GUID Full: 0x000000000000a591 Type: Player Low: 42385), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:17 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:55:17 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:56:39 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:56:39 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:56:57 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:57:58 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:57:58 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:57:58 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:57:58 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:58:03 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:58:03 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:58:03 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:58:03 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:58:03 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:58:03 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:58:49 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:58:49 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:58:49 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_18:58:49 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:58:49 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_18:59:02 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_18:59:02 Player::StoreLootItem: Player 'Ayah' (GUID Full: 0x000000000000a68d Type: Player Low: 42637), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_19:00:01 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_19:03:27 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_19:03:27 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_19:03:58 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_19:03:58 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_19:03:58 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_19:04:46 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_19:04:46 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_19:04:46 Player::StoreLootItem: Player 'Whoisafk' (GUID Full: 0x000000000000a407 Type: Player Low: 41991), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_19:19:02 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5017 and is a Quest Item
2020-07-18_19:19:02 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5018 and is a Quest Item
2020-07-18_19:19:02 Player::StoreLootItem: Player 'Sroyg' (GUID Full: 0x000000000000a6cf Type: Player Low: 42703), trying to loot a already looted item ID: 5019 and is a Quest Item
2020-07-18_21:46:20 Player::StoreLootItem: Player 'Ansuz' (GUID Full: 0x000000000000a455 Type: Player Low: 42069), trying to loot a already looted item ID: 34983 and is a Quest Item
2020-07-18_22:40:45 Player::StoreLootItem: Player 'Aleatoria' (GUID Full: 0x0000000000008cbf Type: Player Low: 36031), trying to loot a already looted item ID: 9523 and is a Quest Item
2020-07-18_23:04:38 Player::StoreLootItem: Player 'Tecazobb' (GUID Full: 0x000000000000ab9c Type: Player Low: 43932), trying to loot a already looted item ID: 11830 and is a Quest Item
2020-07-18_23:30:05 Player::StoreLootItem: Player 'Ansuz' (GUID Full: 0x000000000000a455 Type: Player Low: 42069), trying to loot a already looted item ID: 34977 and is a Quest Item
2020-07-19_00:41:02 Player::StoreLootItem: Player 'Linlei' (GUID Full: 0x000000000000948d Type: Player Low: 38029), trying to loot a already looted item ID: 26042
2020-07-19_01:21:38 Player::StoreLootItem: Player 'Chamaita' (GUID Full: 0x000000000000871e Type: Player Low: 34590), trying to loot a already looted item ID: 33470
2020-07-19_02:15:17 Player::StoreLootItem: Player 'Naara' (GUID Full: 0x000000000000aefb Type: Player Low: 44795), trying to loot a already looted item ID: 21808 and is a Quest Item
2020-07-19_03:06:09 Player::StoreLootItem: Player 'Diruku' (GUID Full: 0x000000000000ae84 Type: Player Low: 44676), trying to loot a already looted item ID: 829 and is a Quest Item
2020-07-19_03:11:01 Player::StoreLootItem: Player 'Darkasaitrex' (GUID Full: 0x0000000000007bf5 Type: Player Low: 31733), trying to loot a already looted item ID: 829 and is a Quest Item
2020-07-19_04:21:46 Player::StoreLootItem: Player 'Angelzo' (GUID Full: 0x00000000000090fb Type: Player Low: 37115), trying to loot a already looted item ID: 33470
2020-07-19_04:53:11 Player::StoreLootItem: Player 'Pakita' (GUID Full: 0x0000000000008038 Type: Player Low: 32824), trying to loot a already looted item ID: 33470
2020-07-19_05:41:39 Player::StoreLootItem: Player 'Suripanta' (GUID Full: 0x000000000000a72e Type: Player Low: 42798), trying to loot a already looted item ID: 11316 and is a Quest Item
2020-07-19_05:41:40 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11114 and is a Quest Item
2020-07-19_05:44:36 Player::StoreLootItem: Player 'Raizher' (GUID Full: 0x000000000000ab19 Type: Player Low: 43801), trying to loot a already looted item ID: 1013 and is a Quest Item
2020-07-19_05:58:13 Player::StoreLootItem: Player 'Azmenei' (GUID Full: 0x000000000000a5b9 Type: Player Low: 42425), trying to loot a already looted item ID: 11831 and is a Quest Item
2020-07-19_05:58:53 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11316 and is a Quest Item
2020-07-19_06:03:56 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11830 and is a Quest Item
2020-07-19_06:03:56 Player::StoreLootItem: Player 'Suripanta' (GUID Full: 0x000000000000a72e Type: Player Low: 42798), trying to loot a already looted item ID: 11830 and is a Quest Item
2020-07-19_06:22:25 Player::StoreLootItem: Player 'Azmenei' (GUID Full: 0x000000000000a5b9 Type: Player Low: 42425), trying to loot a already looted item ID: 11830 and is a Quest Item
2020-07-19_06:34:59 Player::StoreLootItem: Player 'Suripanta' (GUID Full: 0x000000000000a72e Type: Player Low: 42798), trying to loot a already looted item ID: 11834 and is a Quest Item
2020-07-19_06:48:07 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11830 and is a Quest Item
2020-07-19_06:52:10 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11316 and is a Quest Item
2020-07-19_07:00:03 Player::StoreLootItem: Player 'Azmenei' (GUID Full: 0x000000000000a5b9 Type: Player Low: 42425), trying to loot a already looted item ID: 11316 and is a Quest Item
2020-07-19_07:03:04 Player::StoreLootItem: Player 'Azmenei' (GUID Full: 0x000000000000a5b9 Type: Player Low: 42425), trying to loot a already looted item ID: 11316 and is a Quest Item
2020-07-19_08:16:29 Player::StoreLootItem: Player 'Andycookies' (GUID Full: 0x000000000000a4b0 Type: Player Low: 42160), trying to loot a already looted item ID: 3397 and is a Quest Item
2020-07-19_08:17:27 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 3397 and is a Quest Item
2020-07-19_08:26:59 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 3337 and is a Quest Item
2020-07-19_08:27:53 Player::StoreLootItem: Player 'Andycookies' (GUID Full: 0x000000000000a4b0 Type: Player Low: 42160), trying to loot a already looted item ID: 3337 and is a Quest Item
2020-07-19_08:29:48 Player::StoreLootItem: Player 'Andycookies' (GUID Full: 0x000000000000a4b0 Type: Player Low: 42160), trying to loot a already looted item ID: 3337 and is a Quest Item
2020-07-19_08:59:17 Player::StoreLootItem: Player 'Pantros' (GUID Full: 0x00000000000064f0 Type: Player Low: 25840), trying to loot a already looted item ID: 33470
2020-07-19_10:01:59 Player::StoreLootItem: Player 'Andycookies' (GUID Full: 0x000000000000a4b0 Type: Player Low: 42160), trying to loot a already looted item ID: 4503 and is a Quest Item
2020-07-19_10:07:05 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 4503 and is a Quest Item
2020-07-19_10:08:57 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 4503 and is a Quest Item
2020-07-19_10:08:57 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 4522 and is a Quest Item
2020-07-19_10:09:20 Player::StoreLootItem: Player 'Andycookies' (GUID Full: 0x000000000000a4b0 Type: Player Low: 42160), trying to loot a already looted item ID: 4503 and is a Quest Item
2020-07-19_10:10:37 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 4503 and is a Quest Item
2020-07-19_10:13:56 Player::StoreLootItem: Player 'Cristianovik' (GUID Full: 0x000000000000726e Type: Player Low: 29294), trying to loot a already looted item ID: 4522 and is a Quest Item
2020-07-19_10:18:10 Player::StoreLootItem: Player 'Suripanta' (GUID Full: 0x000000000000a72e Type: Player Low: 42798), trying to loot a already looted item ID: 11479 and is a Quest Item
2020-07-19_10:18:31 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11479 and is a Quest Item
2020-07-19_10:20:03 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11478 and is a Quest Item
2020-07-19_10:27:01 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11479 and is a Quest Item
2020-07-19_10:42:32 Player::StoreLootItem: Player 'Kamirya' (GUID Full: 0x000000000000a7c5 Type: Player Low: 42949), trying to loot a already looted item ID: 11834 and is a Quest Item
2020-07-19_16:47:51 Player::StoreLootItem: Player 'Baphy' (GUID Full: 0x000000000000a452 Type: Player Low: 42066), trying to loot a already looted item ID: 35484 and is a Quest Item
2020-07-19_17:13:15 Player::StoreLootItem: Player 'Ansuz' (GUID Full: 0x000000000000a455 Type: Player Low: 42069), trying to loot a already looted item ID: 35586 and is a Quest Item
2020-07-19_19:43:09 Player::StoreLootItem: Player 'Obizpo' (GUID Full: 0x0000000000005258 Type: Player Low: 21080), trying to loot a already looted item ID: 33470
2020-07-19_20:59:05 Player::StoreLootItem: Player 'Baphy' (GUID Full: 0x000000000000a452 Type: Player Low: 42066), trying to loot a already looted item ID: 34711 and is a Quest Item
2020-07-19_21:08:42 Player::StoreLootItem: Player 'Epilef' (GUID Full: 0x0000000000002a04 Type: Player Low: 10756), trying to loot a already looted item ID: 33470
2020-07-19_22:04:18 Player::StoreLootItem: Player 'Laissezfaire' (GUID Full: 0x000000000000a1a7 Type: Player Low: 41383), trying to loot a already looted item ID: 23218 and is a Quest Item
2020-07-19_22:04:36 Player::StoreLootItem: Player 'Laissezfaire' (GUID Full: 0x000000000000a1a7 Type: Player Low: 41383), trying to loot a already looted item ID: 23218 and is a Quest Item
2020-07-19_23:59:33 Player::StoreLootItem: Player 'Perverzo' (GUID Full: 0x0000000000009d47 Type: Player Low: 40263), trying to loot a already looted item ID: 22677 and is a Quest Item
2020-07-20_00:22:59 Player::StoreLootItem: Player 'Montaraz' (GUID Full: 0x00000000000095ed Type: Player Low: 38381), trying to loot a already looted item ID: 23894 and is a Quest Item
2020-07-20_00:27:08 Player::StoreLootItem: Player 'Loquis' (GUID Full: 0x000000000000afb6 Type: Player Low: 44982), trying to loot a already looted item ID: 750 and is a Quest Item
2020-07-20_00:35:10 Player::StoreLootItem: Player 'Yimer' (GUID Full: 0x0000000000007be8 Type: Player Low: 31720), trying to loot a already looted item ID: 34908 and is a Quest Item
2020-07-20_01:06:53 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 4870 and is a Quest Item
2020-07-20_01:06:53 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 4870 and is a Quest Item
2020-07-20_01:06:53 Player::StoreLootItem: Player 'Mexacaza' (GUID Full: 0x000000000000af9f Type: Player Low: 44959), trying to loot a already looted item ID: 4870 and is a Quest Item
2020-07-20_01:07:00 Player::StoreLootItem: Player 'Sacamepunta' (GUID Full: 0x000000000000afb2 Type: Player Low: 44978), trying to loot a already looted item ID: 4870 and is a Quest Item
2020-07-20_01:08:31 Player::StoreLootItem: Player 'Mexacaza' (GUID Full: 0x000000000000af9f Type: Player Low: 44959), trying to loot a already looted item ID: 4870 and is a Quest Item
2020-07-20_01:14:11 Player::StoreLootItem: Player 'Loquis' (GUID Full: 0x000000000000afb6 Type: Player Low: 44982), trying to loot a already looted item ID: 6952 and is a Quest Item
2020-07-20_02:05:58 Player::StoreLootItem: Player 'Evelina' (GUID Full: 0x00000000000055ce Type: Player Low: 21966), trying to loot a already looted item ID: 33470
2020-07-20_02:06:35 Player::StoreLootItem: Player 'Pompeyo' (GUID Full: 0x000000000000afb7 Type: Player Low: 44983), trying to loot a already looted item ID: 3084 and is a Quest Item
2020-07-20_02:06:35 Player::StoreLootItem: Player 'Pompeyo' (GUID Full: 0x000000000000afb7 Type: Player Low: 44983), trying to loot a already looted item ID: 3083 and is a Quest Item
2020-07-20_02:11:16 Player::StoreLootItem: Player 'Pompeyo' (GUID Full: 0x000000000000afb7 Type: Player Low: 44983), trying to loot a already looted item ID: 3084 and is a Quest Item
2020-07-20_02:12:23 Player::StoreLootItem: Player 'Loquis' (GUID Full: 0x000000000000afb6 Type: Player Low: 44982), trying to loot a already looted item ID: 3083 and is a Quest Item
2020-07-20_02:14:59 Player::StoreLootItem: Player 'Montaraz' (GUID Full: 0x00000000000095ed Type: Player Low: 38381), trying to loot a already looted item ID: 24280 and is a Quest Item
2020-07-20_02:17:28 Player::StoreLootItem: Player 'Noirclown' (GUID Full: 0x000000000000ae9d Type: Player Low: 44701), trying to loot a already looted item ID: 1467 and is a Quest Item
2020-07-20_03:04:55 Player::StoreLootItem: Player 'Skfonsi' (GUID Full: 0x000000000000afa9 Type: Player Low: 44969), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:05:55 Player::StoreLootItem: Player 'Skfonsi' (GUID Full: 0x000000000000afa9 Type: Player Low: 44969), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:05:55 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:09:39 Player::StoreLootItem: Player 'Mexacaza' (GUID Full: 0x000000000000af9f Type: Player Low: 44959), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:09:39 Player::StoreLootItem: Player 'Mexacaza' (GUID Full: 0x000000000000af9f Type: Player Low: 44959), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:09:50 Player::StoreLootItem: Player 'Sacamepunta' (GUID Full: 0x000000000000afb2 Type: Player Low: 44978), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:10:36 Player::StoreLootItem: Player 'Mexacaza' (GUID Full: 0x000000000000af9f Type: Player Low: 44959), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:10:36 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:13:47 Player::StoreLootItem: Player 'Skfonsi' (GUID Full: 0x000000000000afa9 Type: Player Low: 44969), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:15:36 Player::StoreLootItem: Player 'Toronegro' (GUID Full: 0x000000000000afac Type: Player Low: 44972), trying to loot a already looted item ID: 5087 and is a Quest Item
2020-07-20_03:28:24 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 5062 and is a Quest Item
2020-07-20_03:29:31 Player::StoreLootItem: Player 'Skfonsi' (GUID Full: 0x000000000000afa9 Type: Player Low: 44969), trying to loot a already looted item ID: 5062 and is a Quest Item
2020-07-20_03:29:43 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 5062 and is a Quest Item
2020-07-20_03:41:21 Player::StoreLootItem: Player 'Skfonsi' (GUID Full: 0x000000000000afa9 Type: Player Low: 44969), trying to loot a already looted item ID: 5030 and is a Quest Item
2020-07-20_03:47:01 Player::StoreLootItem: Player 'Sacamepunta' (GUID Full: 0x000000000000afb2 Type: Player Low: 44978), trying to loot a already looted item ID: 5030 and is a Quest Item
2020-07-20_03:49:49 Player::StoreLootItem: Player 'Toronegro' (GUID Full: 0x000000000000afac Type: Player Low: 44972), trying to loot a already looted item ID: 5030 and is a Quest Item
2020-07-20_03:51:41 Player::StoreLootItem: Player 'Sacamepunta' (GUID Full: 0x000000000000afb2 Type: Player Low: 44978), trying to loot a already looted item ID: 5030 and is a Quest Item
2020-07-20_03:54:07 Player::StoreLootItem: Player 'Sacamepunta' (GUID Full: 0x000000000000afb2 Type: Player Low: 44978), trying to loot a already looted item ID: 5030 and is a Quest Item
2020-07-20_03:54:07 Player::StoreLootItem: Player 'Toronegro' (GUID Full: 0x000000000000afac Type: Player Low: 44972), trying to loot a already looted item ID: 5030 and is a Quest Item
2020-07-20_03:54:50 Player::StoreLootItem: Player 'Mirameymuero' (GUID Full: 0x000000000000afa6 Type: Player Low: 44966), trying to loot a already looted item ID: 5062 and is a Quest Item
2020-07-20_03:55:37 Player::StoreLootItem: Player 'Clarke' (GUID Full: 0x000000000000ad05 Type: Player Low: 44293), trying to loot a already looted item ID: 725 and is a Quest Item
2020-07-20_04:03:10 Player::StoreLootItem: Player 'Clarke' (GUID Full: 0x000000000000ad05 Type: Player Low: 44293), trying to loot a already looted item ID: 829 and is a Quest Item
2020-07-20_04:04:29 Player::StoreLootItem: Player 'Neme' (GUID Full: 0x000000000000afb8 Type: Player Low: 44984), trying to loot a already looted item ID: 3110 and is a Quest Item
2020-07-20_06:45:14 Player::StoreLootItem: Player 'Xayahh' (GUID Full: 0x000000000000abc1 Type: Player Low: 43969), trying to loot a already looted item ID: 23167 and is a Quest Item

  ```
  
</details>

**Target branch(es):** 3.3.5

- [X] 3.3.5
- [ ] master

**Issues addressed:** Closes #14956


**Tests performed:** Tested in-game and logged to see results


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
