### PR TITLE
EventMap: Remove GetNextEventTime and GetTimer methods

### DIFF
--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -146,18 +146,6 @@ void EventMap::CancelEventGroup(uint32 group)
     }
 }
 
-uint32 EventMap::GetNextEventTime(uint32 eventId) const
-{
-    if (Empty())
-        return 0;
-
-    for (std::pair<uint32 const, uint32> const& itr : _eventMap)
-        if (eventId == (itr.second & 0x0000FFFF))
-            return itr.first;
-
-    return 0;
-}
-
 uint32 EventMap::GetTimeUntilEvent(uint32 eventId) const
 {
     for (std::pair<uint32 const, uint32> const& itr : _eventMap)

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -206,23 +206,6 @@ public:
     void CancelEventGroup(uint32 group);
 
     /**
-    * @name GetNextEventTime
-    * @brief Returns closest occurrence of specified event.
-    * @param eventId Wanted event id.
-    * @return Time of found event.
-    */
-    uint32 GetNextEventTime(uint32 eventId) const;
-
-    /**
-    * @name GetNextEventTime
-    * @return Time of next event.
-    */
-    uint32 GetNextEventTime() const
-    {
-        return Empty() ? 0 : _eventMap.begin()->first;
-    }
-
-    /**
     * @name IsInPhase
     * @brief Returns whether event map is in specified phase or not.
     * @param phase Wanted phase.

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -57,15 +57,6 @@ public:
     }
 
     /**
-    * @name GetTimer
-    * @return Current timer value in ms.
-    */
-    uint32 GetTimer() const
-    {
-        return _time;
-    }
-
-    /**
     * @name GetPhaseMask
     * @return Active phases as mask.
     */


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  EventMap: Remove `GetNextEventTime` family of methods
-  EventMap: Remove `GetTimer` method

Methods **removed**:
```c++
    uint32 GetNextEventTime(uint32 eventId) const;
    uint32 GetNextEventTime() const;
    uint32 GetTimer() const;
```

These methods made an implementation detail of the `EventMap` accessible (the internal timer value) which has no value to the consumer.
The method which should be used instead to get the actual duration until the event in question is `GetTimeUntilEvent`.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build