### PR TITLE
Add support for Catch2 as unit test framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: SQL checks
@@ -42,7 +42,15 @@ jobs:
           command: |
             cd bin
             make -j 4 -k && make install
-            cd check_install/bin
+      - run:
+          name: Unit tests
+          command: |
+            cd bin
+            make test
+      - run:
+          name: Check executables
+          command: |
+            cd bin/check_install/bin
             ./authserver --version
             ./worldserver --version
   nopch:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.11)
 
 # add this options before PROJECT keyword
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
@@ -90,3 +90,12 @@ add_subdirectory(dep)
 
 # add core sources
 add_subdirectory(src)
+
+include(CTest)
+if(BUILD_TESTING)
+  list(APPEND CMAKE_MODULE_PATH
+    "${Catch2_SOURCE_DIR}/contrib")
+  include(Catch)
+
+  add_subdirectory(tests)
+endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -53,3 +53,4 @@ option(COPY_CONF        "Copy authserver and worldserver .conf.dist files to the
 set(WITH_SOURCE_TREE    "hierarchical" CACHE STRING "Build the source tree for IDE's.")
 set_property(CACHE WITH_SOURCE_TREE PROPERTY STRINGS no flat hierarchical hierarchical-folders)
 option(WITHOUT_GIT      "Disable the GIT testing routines"                            0)
+option(BUILD_TESTING    "Build test suite" 0)

--- a/cmake/showoptions.cmake
+++ b/cmake/showoptions.cmake
@@ -40,6 +40,12 @@ else()
   message("* Build map/vmap tools   : No")
 endif()
 
+if(BUILD_TESTING)
+  message("* Build unit tests       : Yes")
+else()
+  message("* Build unit tests       : No (default)")
+endif()
+
 if(USE_COREPCH)
   message("* Build core w/PCH       : Yes (default)")
 else()

--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -35,3 +35,12 @@ if(TOOLS)
   add_subdirectory(bzip2)
   add_subdirectory(libmpq)
 endif()
+
+if(BUILD_TESTING)
+  include(FetchContent)
+  FetchContent_Declare(Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG        v2.13.0
+    GIT_SHALLOW    1)
+  FetchContent_MakeAvailable(Catch2)
+endif()

--- a/dep/PackageList.txt
+++ b/dep/PackageList.txt
@@ -68,3 +68,7 @@ recastnavigation (Recast is state of the art navigation mesh construction toolse
 argon2
   https://github.com/P-H-C/phc-winner-argon2
   Version: 62358ba
+
+catch2
+  https://github.com/catchorg/Catch2
+  Version: v2.13.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+# This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+#
+# This file is free software; as a special exception the author gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+CollectSourceFiles(
+  ${CMAKE_CURRENT_SOURCE_DIR}/common
+  COMMON_SOURCES
+)
+
+add_executable(tests-common ${COMMON_SOURCES})
+
+target_link_libraries(tests-common
+  PRIVATE
+    common
+    Catch2::Catch2)
+
+catch_discover_tests(tests-common)

--- a/tests/common/test-EventMap.cpp
+++ b/tests/common/test-EventMap.cpp
@@ -1,0 +1,322 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "catch2/catch.hpp"
+#include "EventMap.h"
+
+enum EVENTS
+{
+    EVENT_1 = 1,
+    EVENT_2 = 2,
+    EVENT_3 = 3
+};
+
+enum PHASES
+{
+    PHASE_1 = 1,
+    PHASE_2 = 2
+};
+
+enum GROUPS
+{
+    GROUP_1 = 1,
+    GROUP_2 = 2
+};
+
+TEST_CASE("Schedule an event", "[EventMap]")
+{
+    EventMap eventMap;
+
+    REQUIRE(eventMap.Empty());
+
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+
+    REQUIRE_FALSE(eventMap.Empty());
+
+    SECTION("Event has not yet reached its delay")
+    {
+        eventMap.Update(100);
+        uint32 id = eventMap.ExecuteEvent();
+
+        REQUIRE(id == 0);
+        REQUIRE_FALSE(eventMap.Empty());
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 900);
+    }
+
+    SECTION("Event has reached its delay")
+    {
+        eventMap.Update(1000);
+        uint32 id = eventMap.ExecuteEvent();
+
+        REQUIRE(id == EVENT_1);
+        REQUIRE(eventMap.Empty());
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == std::numeric_limits<uint32>::max());
+    }
+}
+
+// TODO: The semantics of this case are not well defined.
+//       Document them first, check consumers and adapt test
+//       accordingly.
+TEST_CASE("Schedule existing event", "[EventMap][!mayfail]")
+{
+    EventMap eventMap;
+
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+
+    eventMap.Update(1000);
+    uint32 id = eventMap.ExecuteEvent();
+
+    REQUIRE(id == EVENT_1);
+    REQUIRE(eventMap.Empty());
+}
+
+TEST_CASE("Cancel a scheduled event", "[EventMap]")
+{
+    EventMap eventMap;
+
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+    eventMap.ScheduleEvent(EVENT_2, 1s);
+
+    eventMap.CancelEvent(EVENT_1);
+    REQUIRE_FALSE(eventMap.Empty());
+
+    eventMap.Update(1000);
+    uint32 id = eventMap.ExecuteEvent();
+
+    REQUIRE(id == EVENT_2);
+    REQUIRE(eventMap.Empty());
+}
+
+TEST_CASE("Cancel non-existing event", "[EventMap]")
+{
+    EventMap eventMap;
+    REQUIRE(eventMap.Empty());
+
+    eventMap.CancelEvent(EVENT_1);
+    REQUIRE(eventMap.Empty());
+}
+
+TEST_CASE("Reschedule an event", "[EventMap]")
+{
+    EventMap eventMap;
+
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+    eventMap.RescheduleEvent(EVENT_1, 2s);
+
+    eventMap.Update(1000);
+    uint32 id = eventMap.ExecuteEvent();
+
+    REQUIRE(id == 0);
+
+    eventMap.Update(1000);
+    id = eventMap.ExecuteEvent();
+
+    REQUIRE(id == EVENT_1);
+}
+
+TEST_CASE("Reschedule a non-scheduled event", "[EventMap]")
+{
+    EventMap eventMap;
+
+    eventMap.RescheduleEvent(EVENT_1, 2s);
+
+    eventMap.Update(1000);
+    uint32 id = eventMap.ExecuteEvent();
+
+    REQUIRE(id == 0);
+
+    eventMap.Update(1000);
+    id = eventMap.ExecuteEvent();
+
+    REQUIRE(id == EVENT_1);
+}
+
+TEST_CASE("Schedule event with phase", "[EventMap]")
+{
+    EventMap eventMap;
+    REQUIRE(eventMap.Empty());
+
+    eventMap.ScheduleEvent(EVENT_1, 1s, 0, PHASE_1);
+    eventMap.ScheduleEvent(EVENT_2, 1s, 0, PHASE_2);
+
+    SECTION("In default phase. Execute all events.")
+    {
+        eventMap.Update(1000);
+
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+        REQUIRE_FALSE(eventMap.Empty());
+
+        id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_2);
+        REQUIRE(eventMap.Empty());
+    }
+
+    SECTION("Execute only events of specified phase")
+    {
+        eventMap.SetPhase(PHASE_1);
+        eventMap.Update(1000);
+
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+        REQUIRE_FALSE(eventMap.Empty());
+
+        id = eventMap.ExecuteEvent();
+        REQUIRE(id == 0);
+        REQUIRE(eventMap.Empty());
+    }
+
+    SECTION("Execute events from multiple phases (1)")
+    {
+        eventMap.AddPhase(PHASE_1);
+        eventMap.AddPhase(PHASE_2);
+        eventMap.Update(1000);
+
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+        REQUIRE_FALSE(eventMap.Empty());
+
+        id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_2);
+        REQUIRE(eventMap.Empty());
+    }
+
+    SECTION("Execute events from multiple phases (2)")
+    {
+        eventMap.AddPhase(PHASE_1);
+        eventMap.Update(1000);
+
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+        REQUIRE_FALSE(eventMap.Empty());
+
+        eventMap.RemovePhase(PHASE_2);
+        id = eventMap.ExecuteEvent();
+        REQUIRE(id == 0);
+        REQUIRE(eventMap.Empty());
+    }
+}
+
+TEST_CASE("Phase helper methods", "[EventMap]")
+{
+    EventMap eventMap;
+
+    eventMap.SetPhase(PHASE_1);
+    REQUIRE(eventMap.GetPhaseMask() == 0x1);
+    REQUIRE(eventMap.IsInPhase(PHASE_1));
+    REQUIRE_FALSE(eventMap.IsInPhase(PHASE_2));
+
+    eventMap.AddPhase(PHASE_2);
+    REQUIRE(eventMap.GetPhaseMask() == 0x3);
+    REQUIRE(eventMap.IsInPhase(PHASE_1));
+    REQUIRE(eventMap.IsInPhase(PHASE_2));
+
+    eventMap.RemovePhase(PHASE_1);
+    REQUIRE(eventMap.GetPhaseMask() == 0x2);
+    REQUIRE_FALSE(eventMap.IsInPhase(PHASE_1));
+    REQUIRE(eventMap.IsInPhase(PHASE_2));
+}
+
+TEST_CASE("Cancel event group", "[EventMap]")
+{
+    EventMap eventMap;
+    eventMap.ScheduleEvent(EVENT_2, 1s, GROUP_1);
+
+    SECTION("Only event in group")
+    {
+        eventMap.CancelEventGroup(GROUP_1);
+        REQUIRE(eventMap.Empty());
+    }
+
+    SECTION("Group with groupless event")
+    {
+        eventMap.ScheduleEvent(EVENT_1, 1s);
+
+        eventMap.CancelEventGroup(GROUP_1);
+        REQUIRE_FALSE(eventMap.Empty());
+    }
+
+    SECTION("Two groups")
+    {
+        eventMap.ScheduleEvent(EVENT_1, 1s);
+        eventMap.ScheduleEvent(EVENT_3, 1s, GROUP_2);
+
+        eventMap.CancelEventGroup(GROUP_1);
+        REQUIRE_FALSE(eventMap.Empty());
+
+        eventMap.CancelEventGroup(GROUP_2);
+        REQUIRE_FALSE(eventMap.Empty());
+    }
+}
+
+TEST_CASE("Delay all events", "[EventMap]")
+{
+    EventMap eventMap;
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1000);
+
+    SECTION("Without timer update")
+    {
+        eventMap.DelayEvents(1s);
+
+        // Timer hasn't ticked yet, so maximum delay is 0ms
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1000);
+    }
+
+    SECTION("With timer update smaller than delay")
+    {
+        eventMap.Update(500);
+        eventMap.DelayEvents(1s);
+
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1000);
+    }
+
+    SECTION("With timer update larger than delay")
+    {
+        eventMap.Update(2000);
+        eventMap.DelayEvents(1s);
+
+        // 1s (init) + 1s (delay) - 2s (tick) = 0s
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 0);
+    }
+}
+
+TEST_CASE("Delay grouped events", "[EventMap]")
+{
+    EventMap eventMap;
+    eventMap.ScheduleEvent(EVENT_1, 1s, GROUP_1);
+    eventMap.ScheduleEvent(EVENT_2, 2s, GROUP_2);
+    eventMap.ScheduleEvent(EVENT_3, 6s);
+
+    eventMap.Update(2000);
+    eventMap.DelayEvents(3s, GROUP_1);
+
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 2000);
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_2) == 0);
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_3) == 4000);
+}
+
+TEST_CASE("Reset map", "[EventMap]")
+{
+    EventMap eventMap;
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+    eventMap.Reset();
+
+    REQUIRE(eventMap.Empty());
+}

--- a/tests/common/test-main.cpp
+++ b/tests/common/test-main.cpp
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add catch2 as unit test framework which is called through ctest
-  Add some basic tests for EventMap

**How to run unit tests**:
 - Run CMake with `-DBUILD_TESTING=1`
 - Build tests with `make all` or `make tests-common`
 - Run tests with `make test`

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build and **unit tests**

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Wire it up for CI
- [ ] Add some docs how to execute unit tests