### PR TITLE
Travis/CircleCI: Use ninja instead of Makefiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,10 @@ jobs:
       - run:
           name: Setup
           command: |
+            sudo apt-get install -y ninja-build
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1 -G Ninja
             cd ..
       - run:
           name: SQL checks
@@ -41,12 +42,12 @@ jobs:
           name: Build
           command: |
             cd bin
-            make -j 4 -k && make install
+            ninja -k 0 -j 4 && ninja install
       - run:
           name: Unit tests
           command: |
             cd bin
-            make test
+            ninja test
       - run:
           name: Check executables
           command: |
@@ -74,6 +75,7 @@ jobs:
       - run:
           name: Setup
           command: |
+            sudo apt-get install -y ninja-build
             export CCACHE_MAXSIZE="1G"
             export CC="ccache clang"
             export CXX="ccache clang++"
@@ -85,13 +87,13 @@ jobs:
             $CXX --version
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -G Ninja
             cd ..
       - run:
           name: Build
           command: |
             cd bin
-            make -j 4 -k && make install
+            ninja -k 0 -j 4 && ninja install
             ccache -s
             cd check_install/bin
             ./authserver --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - zlib1g-dev
       - libbz2-dev
       - g++-6
+      - ninja-build
 
 services:
   - mysql
@@ -32,7 +33,7 @@ install:
   - mysql -uroot -e 'create database test_mysql;'
   - mkdir bin
   - cd bin
-  - cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
+  - cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -G Ninja
   - cd ..
   - chmod +x contrib/check_updates.sh
 
@@ -47,7 +48,7 @@ script:
   - cat sql/updates/world/3.3.5/*.sql | mysql -utrinity -ptrinity world
   - mysql -uroot < sql/create/drop_mysql.sql
   - cd bin
-  - make -j 4 -k && make install
+  - ninja -k 0 -j 4 && ninja install
   - cd check_install/bin
   - ./authserver --version
   - ./worldserver --version


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Travis/CircleCI: Use ninja instead of Makefiles

Let's see if we get some build time improvements.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master