### PR TITLE
common/Crypto: ifdef OpenSSL thread locking code

### DIFF
--- a/src/common/Cryptography/OpenSSLCrypto.cpp
+++ b/src/common/Cryptography/OpenSSLCrypto.cpp
@@ -17,6 +17,8 @@
 
 #include <OpenSSLCrypto.h>
 #include <openssl/crypto.h>
+
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
 #include <vector>
 #include <thread>
 #include <mutex>
@@ -62,3 +64,4 @@ void OpenSSLCrypto::threadsCleanup()
     }
     cryptoLocks.resize(0);
 }
+#endif

--- a/src/common/Cryptography/OpenSSLCrypto.h
+++ b/src/common/Cryptography/OpenSSLCrypto.h
@@ -19,6 +19,7 @@
 #define OPENSSL_CRYPTO_H
 
 #include "Define.h"
+#include <openssl/opensslv.h>
 
 /**
 * A group of functions which setup openssl crypto module to work properly in multithreaded enviroment
@@ -26,10 +27,17 @@
 */
 namespace OpenSSLCrypto
 {
+
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
     /// Needs to be called before threads using openssl are spawned
     TC_COMMON_API void threadsSetup();
     /// Needs to be called after threads using openssl are despawned
     TC_COMMON_API void threadsCleanup();
+#else
+    void threadsSetup() { };
+    void threadsCleanup() { };
+#endif
+
 }
 
 #endif


### PR DESCRIPTION


<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

The code in question is not needed for versions 1.1.0 and above
and are no-ops. ifdef the parts until we drop support for < 1.1.0.

Fixes a -Wunused-value warning on GCC 7.5

Ref: https://github.com/openssl/openssl/commit/2e52e7df518d80188c865ea3f7bb3526d14b0c08

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master
