### PR TITLE
Core/EventMap: Finish std::chrono-fication

### DIFF
--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -94,7 +94,16 @@ uint32 EventMap::ExecuteEvent()
 
 void EventMap::DelayEvents(Milliseconds delay)
 {
-    _time = delay < _time - _time.min() ? _time - delay : TimePoint::min();
+    if (Empty())
+        return;
+
+    EventStore delayed = std::move(_eventMap);
+    for (EventStore::iterator itr = delayed.begin(); itr != delayed.end();)
+    {
+        EventStore::node_type node = delayed.extract(itr++);
+        node.key() = node.key() + delay;
+        _eventMap.insert(_eventMap.end(), std::move(node));
+    }
 }
 
 void EventMap::DelayEvents(Milliseconds delay, uint32 group)

--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -146,11 +146,11 @@ void EventMap::CancelEventGroup(uint32 group)
     }
 }
 
-uint32 EventMap::GetTimeUntilEvent(uint32 eventId) const
+Milliseconds EventMap::GetTimeUntilEvent(uint32 eventId) const
 {
     for (std::pair<TimePoint const, uint32> const& itr : _eventMap)
         if (eventId == (itr.second & 0x0000FFFF))
-            return std::chrono::duration_cast<Milliseconds>((itr.first - _time)).count();
+            return std::chrono::duration_cast<Milliseconds>(itr.first - _time);
 
-    return std::numeric_limits<uint32>::max();
+    return Milliseconds::max();
 }

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -26,7 +26,7 @@ class TC_COMMON_API EventMap
 {
     /**
     * Internal storage type.
-    * Key: Time as uint32 when the event should occur.
+    * Key: Time as TimePoint when the event should occur.
     * Value: The event data as uint32.
     *
     * Structure of event data:
@@ -35,10 +35,10 @@ class TC_COMMON_API EventMap
     * - Bit 24 - 31: Phase
     * - Pattern: 0xPPGGEEEE
     */
-    typedef std::multimap<uint32, uint32> EventStore;
+    typedef std::multimap<TimePoint, uint32> EventStore;
 
 public:
-    EventMap() : _time(0), _phase(0), _lastEvent(0) { }
+    EventMap() : _time(TimePoint::min()), _phase(0), _lastEvent(0) { }
 
     /**
     * @name Reset
@@ -52,6 +52,16 @@ public:
     * @param time Value in ms to be added to time.
     */
     void Update(uint32 time)
+    {
+        Update(Milliseconds(time));
+    }
+
+    /**
+    * @name Update
+    * @brief Updates the timer of the event map.
+    * @param time Value in ms to be added to time.
+    */
+    void Update(Milliseconds time)
     {
         _time += time;
     }
@@ -226,7 +236,7 @@ private:
     * has reached their time value. Its value is changed in the
     * Update method.
     */
-    uint32 _time;
+    TimePoint _time;
 
     /**
     * @name _phase

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -179,7 +179,7 @@ public:
 
     /**
     * @name DelayEvents
-    * @brief Delays all events. If delay is greater than or equal internal timer, delay will be 0.
+    * @brief Delays all events.
     * @param delay Amount of delay as std::chrono type.
     */
     void DelayEvents(Milliseconds delay);

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -115,7 +115,7 @@ public:
 
     /**
     * @name ScheduleEvent
-    * @brief Schedules a new event.
+    * @brief Schedules a new event. An existing event is not canceled.
     * @param eventId The id of the new event.
     * @param time The time until the event occurs as std::chrono type.
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
@@ -125,7 +125,7 @@ public:
 
     /**
     * @name ScheduleEvent
-    * @brief Schedules a new event.
+    * @brief Schedules a new event. An existing event is not canceled.
     * @param eventId The id of the new event.
     * @param minTime The minimum time until the event occurs as std::chrono type.
     * @param maxTime The maximum time until the event occurs as std::chrono type.

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -219,11 +219,11 @@ public:
 
     /**
     * @name GetTimeUntilEvent
-    * @brief Returns time in milliseconds until next event.
+    * @brief Returns time as std::chrono type until next event.
     * @param eventId of the event.
-    * @return Time of next event.
+    * @return Time of next event. If event is not scheduled returns Milliseconds::max()
     */
-    uint32 GetTimeUntilEvent(uint32 eventId) const;
+    Milliseconds GetTimeUntilEvent(uint32 eventId) const;
 
 private:
     /**

--- a/src/server/scripts/Northrend/Naxxramas/boss_anubrekhan.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_anubrekhan.cpp
@@ -185,7 +185,8 @@ public:
                 switch (eventId)
                 {
                     case EVENT_IMPALE:
-                        if (events.GetTimeUntilEvent(EVENT_LOCUST) < 5 * IN_MILLISECONDS) break; // don't chain impale tank -> locust swarm
+                        if (events.GetTimeUntilEvent(EVENT_LOCUST) < 5s)
+                            break; // don't chain impale tank -> locust swarm
                         if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0))
                             DoCast(target, SPELL_IMPALE);
                         else

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -877,7 +877,7 @@ class boss_leviathan_mk_ii : public CreatureScript
                             DoCastVictim(SPELL_SCRIPT_EFFECT_PLASMA_BLAST);
                             events.RescheduleEvent(EVENT_PLASMA_BLAST, 30s, 45s, 0, PHASE_LEVIATHAN_MK_II);
 
-                            if (events.GetTimeUntilEvent(EVENT_NAPALM_SHELL) < 9000)
+                            if (events.GetTimeUntilEvent(EVENT_NAPALM_SHELL) < 9s)
                                 events.RescheduleEvent(EVENT_NAPALM_SHELL, 9s, 0, PHASE_LEVIATHAN_MK_II); // The actual spell is cast by the turret, we should not let it interrupt itself.
                             break;
                         case EVENT_SHOCK_BLAST:
@@ -892,7 +892,7 @@ class boss_leviathan_mk_ii : public CreatureScript
                             DoCastAOE(SPELL_FORCE_CAST_NAPALM_SHELL);
                             events.RescheduleEvent(EVENT_NAPALM_SHELL, 6s, 15s, 0, PHASE_LEVIATHAN_MK_II);
 
-                            if (events.GetTimeUntilEvent(EVENT_PLASMA_BLAST) < 2000)
+                            if (events.GetTimeUntilEvent(EVENT_PLASMA_BLAST) < 2s)
                                 events.RescheduleEvent(EVENT_PLASMA_BLAST, 2s, 0, PHASE_LEVIATHAN_MK_II);  // The actual spell is cast by the turret, we should not let it interrupt itself.
                             break;
                         case EVENT_MOVE_POINT_2:

--- a/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_illidan.cpp
@@ -915,8 +915,8 @@ struct boss_illidan_stormrage : public BossAI
                     if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 150.0f, true))
                         DoCast(target, SPELL_DARK_BARRAGE);
                     events.RescheduleEvent(EVENT_EYE_BLAST, Seconds(5), GROUP_PHASE_2);
-                    uint32 currentTime = events.GetTimeUntilEvent(EVENT_FLY_TO_RANDOM_PILLAR);
-                    events.RescheduleEvent(EVENT_FLY_TO_RANDOM_PILLAR, Seconds(currentTime) + Seconds(30), GROUP_PHASE_2);
+                    Milliseconds currentTime = events.GetTimeUntilEvent(EVENT_FLY_TO_RANDOM_PILLAR);
+                    events.RescheduleEvent(EVENT_FLY_TO_RANDOM_PILLAR, currentTime + 30s, GROUP_PHASE_2);
                     break;
                 }
                 case EVENT_FIREBALL:

--- a/tests/common/test-EventMap.cpp
+++ b/tests/common/test-EventMap.cpp
@@ -15,7 +15,9 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
 #include "catch2/catch.hpp"
+
 #include "EventMap.h"
 
 enum EVENTS
@@ -282,8 +284,8 @@ TEST_CASE("Delay all events", "[EventMap]")
     {
         eventMap.DelayEvents(1s);
 
-        // Timer hasn't ticked yet, so maximum delay is 0ms: 1s (init) + 0s (delay) = 1s
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1s);
+        // 1s (init) + 1s (delay) = 2s
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 2s);
     }
 
     SECTION("With timer update smaller than delay")
@@ -291,7 +293,8 @@ TEST_CASE("Delay all events", "[EventMap]")
         eventMap.Update(500);
         eventMap.DelayEvents(1s);
 
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1s);
+        // 1s (init) + 1s (delay) - 500ms (tick) = 1500ms
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1500ms);
     }
 
     SECTION("With timer update larger than delay")

--- a/tests/common/test-EventMap.cpp
+++ b/tests/common/test-EventMap.cpp
@@ -66,6 +66,13 @@ TEST_CASE("Schedule an event", "[EventMap]")
         REQUIRE(eventMap.Empty());
         REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == Milliseconds::max());
     }
+
+    SECTION("Event is past it's execution time")
+    {
+        eventMap.Update(2000);
+
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == -1s);
+    }
 }
 
 // TODO: The semantics of this case are not well defined.

--- a/tests/common/test-EventMap.cpp
+++ b/tests/common/test-EventMap.cpp
@@ -77,21 +77,40 @@ TEST_CASE("Schedule an event", "[EventMap]")
     }
 }
 
-// TODO: The semantics of this case are not well defined.
-//       Document them first, check consumers and adapt test
-//       accordingly.
-TEST_CASE("Schedule existing event", "[EventMap][!mayfail]")
+TEST_CASE("Schedule existing event", "[EventMap]")
 {
     EventMap eventMap;
 
-    eventMap.ScheduleEvent(EVENT_1, 1s);
-    eventMap.ScheduleEvent(EVENT_1, 1s);
+    SECTION("Same time")
+    {
+        eventMap.ScheduleEvent(EVENT_1, 1s);
+        eventMap.ScheduleEvent(EVENT_1, 1s);
 
-    eventMap.Update(1000);
-    uint32 id = eventMap.ExecuteEvent();
+        eventMap.Update(1000);
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
 
-    REQUIRE(id == EVENT_1);
-    REQUIRE(eventMap.Empty());
+        id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+
+        REQUIRE(eventMap.Empty());
+    }
+
+    SECTION("Different time")
+    {
+        eventMap.ScheduleEvent(EVENT_1, 1s);
+        eventMap.ScheduleEvent(EVENT_1, 2s);
+
+        eventMap.Update(1000);
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+
+        eventMap.Update(1000);
+        id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+
+        REQUIRE(eventMap.Empty());
+    }
 }
 
 TEST_CASE("Cancel a scheduled event", "[EventMap]")

--- a/tests/common/test-EventMap.cpp
+++ b/tests/common/test-EventMap.cpp
@@ -174,6 +174,41 @@ TEST_CASE("Reschedule a non-scheduled event", "[EventMap]")
     REQUIRE(id == EVENT_1);
 }
 
+TEST_CASE("Repeat an event (empty map)", "[EventMap]")
+{
+    EventMap eventMap;
+
+    eventMap.Repeat(1s);
+    eventMap.Update(1s);
+
+    uint32 id = eventMap.ExecuteEvent();
+    REQUIRE(id == 0);
+}
+
+TEST_CASE("Repeat an event (populated map)", "[EventMap]")
+{
+    EventMap eventMap;
+    eventMap.ScheduleEvent(EVENT_1, 1s);
+
+    SECTION("Scheduled event with delay not reached")
+    {
+        eventMap.Update(500ms);
+        eventMap.Repeat(1s);
+
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == 0);
+    }
+
+    SECTION("Scheduled event with delay not reached")
+    {
+        eventMap.Update(1s);
+        eventMap.Repeat(1s);
+
+        uint32 id = eventMap.ExecuteEvent();
+        REQUIRE(id == EVENT_1);
+    }
+}
+
 TEST_CASE("Schedule event with phase", "[EventMap]")
 {
     EventMap eventMap;

--- a/tests/common/test-EventMap.cpp
+++ b/tests/common/test-EventMap.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Schedule an event", "[EventMap]")
 
         REQUIRE(id == 0);
         REQUIRE_FALSE(eventMap.Empty());
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 900);
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 900ms);
     }
 
     SECTION("Event has reached its delay")
@@ -64,7 +64,7 @@ TEST_CASE("Schedule an event", "[EventMap]")
 
         REQUIRE(id == EVENT_1);
         REQUIRE(eventMap.Empty());
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == std::numeric_limits<uint32>::max());
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == Milliseconds::max());
     }
 }
 
@@ -269,14 +269,14 @@ TEST_CASE("Delay all events", "[EventMap]")
     EventMap eventMap;
     eventMap.ScheduleEvent(EVENT_1, 1s);
 
-    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1000);
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1s);
 
     SECTION("Without timer update")
     {
         eventMap.DelayEvents(1s);
 
-        // Timer hasn't ticked yet, so maximum delay is 0ms
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1000);
+        // Timer hasn't ticked yet, so maximum delay is 0ms: 1s (init) + 0s (delay) = 1s
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1s);
     }
 
     SECTION("With timer update smaller than delay")
@@ -284,7 +284,7 @@ TEST_CASE("Delay all events", "[EventMap]")
         eventMap.Update(500);
         eventMap.DelayEvents(1s);
 
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1000);
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 1s);
     }
 
     SECTION("With timer update larger than delay")
@@ -293,7 +293,7 @@ TEST_CASE("Delay all events", "[EventMap]")
         eventMap.DelayEvents(1s);
 
         // 1s (init) + 1s (delay) - 2s (tick) = 0s
-        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 0);
+        REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 0s);
     }
 }
 
@@ -307,9 +307,9 @@ TEST_CASE("Delay grouped events", "[EventMap]")
     eventMap.Update(2000);
     eventMap.DelayEvents(3s, GROUP_1);
 
-    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 2000);
-    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_2) == 0);
-    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_3) == 4000);
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_1) == 2s);
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_2) == 0s);
+    REQUIRE(eventMap.GetTimeUntilEvent(EVENT_3) == 4s);
 }
 
 TEST_CASE("Reset map", "[EventMap]")


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  EventMap: finish std::chrono-fication
-  EventMap: Unify semantics of DelayEvents
`DelayEvents(Milliseconds delay)` had different semantics than `DelayEvents(Milliseconds delay, uint32 group)`.
The first method delayed the events only in the case the internal timer already ticked at least for the amount of delay. In contrast the latter method delayed events regardless of the internal timer value.
Use the latter semantics for `DelayEvents(Milliseconds delay)` as well which makes the outcome more predictable.
Callers were examined. No usage was found which depends on this edge case.

-  EventMap: Add some more tests

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build + unit tests



