### PR TITLE
Core/BossAI: Remove _DespawnAtEvade(uint32, Creature*) overload

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -593,12 +593,12 @@ bool BossAI::CanAIAttack(Unit const* target) const
     return IsInBoundary(target);
 }
 
-void BossAI::_DespawnAtEvade(Seconds delayToRespawn, Creature* who)
+void BossAI::_DespawnAtEvade(Seconds delayToRespawn /*= 30s*/, Creature* who /*= nullptr*/)
 {
-    if (delayToRespawn < Seconds(2))
+    if (delayToRespawn < 2s)
     {
         TC_LOG_ERROR("scripts.ai", "BossAI::_DespawnAtEvade: called with delay of %ld seconds, defaulting to 2 (me: %s)", delayToRespawn.count(), me->GetGUID().ToString().c_str());
-        delayToRespawn = Seconds(2);
+        delayToRespawn = 2s;
     }
 
     if (!who)
@@ -611,7 +611,7 @@ void BossAI::_DespawnAtEvade(Seconds delayToRespawn, Creature* who)
         return;
     }
 
-    who->DespawnOrUnsummon(0, Seconds(delayToRespawn));
+    who->DespawnOrUnsummon(0, delayToRespawn);
 
     if (instance && who == me)
         instance->SetBossState(_bossId, FAIL);

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -337,8 +337,7 @@ class TC_GAME_API BossAI : public ScriptedAI
         void _JustEngagedWith(Unit* who);
         void _JustDied();
         void _JustReachedHome();
-        void _DespawnAtEvade(Seconds delayToRespawn,  Creature* who = nullptr);
-        void _DespawnAtEvade(uint32 delayToRespawn = 30, Creature* who = nullptr) { _DespawnAtEvade(Seconds(delayToRespawn), who); }
+        void _DespawnAtEvade(Seconds delayToRespawn = 30s,  Creature* who = nullptr);
 
         void TeleportCheaters();
 

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_hadronox.cpp
@@ -261,8 +261,8 @@ public:
             me->GetCreatureListWithEntryInGrid(triggers, NPC_WORLDTRIGGER_LARGE);
             for (Creature* trigger : triggers)
                 if (trigger->HasAura(SPELL_SUMMON_CHAMPION_PERIODIC) || trigger->HasAura(SPELL_WEB_FRONT_DOORS) || trigger->HasAura(SPELL_WEB_SIDE_DOORS))
-                    _DespawnAtEvade(25, trigger);
-            _DespawnAtEvade(25);
+                    _DespawnAtEvade(25s, trigger);
+            _DespawnAtEvade(25s);
             summons.DespawnAll();
             for (ObjectGuid gNerubian : _anubar)
                 if (Creature* nerubian = ObjectAccessor::GetCreature(*me, gNerubian))


### PR DESCRIPTION
Use _DespawnAtEvade(Seconds,  Creature*) instead

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Core/BossAI: Remove _DespawnAtEvade(uint32, Creature*) overload

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build
