### PR TITLE
Scripts/EasternKingdoms: Use std::chrono overload of Creature::DespawnOrUnsummon

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/boss_rend_blackhand.cpp
@@ -234,7 +234,7 @@ public:
                     case 11:
                         if (Creature* gyth = me->FindNearestCreature(NPC_GYTH, 10.0f, true))
                             gyth->AI()->SetData(1, 1);
-                        me->DespawnOrUnsummon(1000, 24h * 7);
+                        me->DespawnOrUnsummon(1s, 7_days);
                         break;
                 }
             }

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockSpire/instance_blackrock_spire.cpp
@@ -97,12 +97,12 @@ public:
                 case NPC_PYROGAURD_EMBERSEER:
                     PyroguardEmberseer = creature->GetGUID();
                     if (GetBossState(DATA_PYROGAURD_EMBERSEER) == DONE)
-                        creature->DespawnOrUnsummon(0, 24h * 7);
+                        creature->DespawnOrUnsummon(0s, 7_days);
                     break;
                 case NPC_WARCHIEF_REND_BLACKHAND:
                     WarchiefRendBlackhand = creature->GetGUID();
                     if (GetBossState(DATA_GYTH) == DONE)
-                        creature->DespawnOrUnsummon(0, 24h * 7);
+                        creature->DespawnOrUnsummon(0s, 7_days);
                     break;
                 case NPC_GYTH:
                     Gyth = creature->GetGUID();
@@ -116,7 +116,7 @@ public:
                 case NPC_LORD_VICTOR_NEFARIUS:
                     LordVictorNefarius = creature->GetGUID();
                     if (GetBossState(DATA_GYTH) == DONE)
-                        creature->DespawnOrUnsummon(0, 24h * 7);
+                        creature->DespawnOrUnsummon(0s, 7_days);
                     break;
                 case NPC_SCARSHIELD_INFILTRATOR:
                     ScarshieldInfiltrator = creature->GetGUID();

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_nefarian.cpp
@@ -285,7 +285,7 @@ public:
                             break;
                         case EVENT_SUCCESS_2:
                             DoCast(me, SPELL_VAELASTRASZZ_SPAWN);
-                            me->DespawnOrUnsummon(1000);
+                            me->DespawnOrUnsummon(1s);
                             break;
                         case EVENT_PATH_3:
                             me->GetMotionMaster()->MovePath(NEFARIUS_PATH_3, false);

--- a/src/server/scripts/EasternKingdoms/Scholomance/boss_kirtonos_the_herald.cpp
+++ b/src/server/scripts/EasternKingdoms/Scholomance/boss_kirtonos_the_herald.cpp
@@ -121,7 +121,7 @@ class boss_kirtonos_the_herald : public CreatureScript
                     brazier->ResetDoorOrButton();
                     brazier->SetGoState(GO_STATE_READY);
                 }
-                me->DespawnOrUnsummon(5000);
+                me->DespawnOrUnsummon(5s);
             }
 
             void IsSummonedBy(WorldObject* /*summoner*/) override

--- a/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
+++ b/src/server/scripts/EasternKingdoms/SunwellPlateau/boss_muru.cpp
@@ -656,7 +656,7 @@ class spell_dark_fiend_skin : public SpellScriptLoader
                     target->AttackStop();
                     target->StopMoving();
                     target->CastSpell(target, SPELL_DARKFIEND_VISUAL, true);
-                    target->DespawnOrUnsummon(3000);
+                    target->DespawnOrUnsummon(3s);
                 }
             }
 

--- a/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulGurub/boss_arlokk.cpp
@@ -165,7 +165,7 @@ class boss_arlokk : public CreatureScript
                 BossAI::EnterEvadeMode(why);
                 if (GameObject* object = instance->GetGameObject(DATA_GONG_BETHEKK))
                     object->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
-                me->DespawnOrUnsummon(4000);
+                me->DespawnOrUnsummon(4s);
             }
 
             void SetData(uint32 id, uint32 /*value*/) override
@@ -392,7 +392,7 @@ class npc_zulian_prowler : public CreatureScript
                     if (arlokk->IsAlive())
                         arlokk->GetAI()->SetData(_sideData, 0);
                 }
-                me->DespawnOrUnsummon(4000);
+                me->DespawnOrUnsummon(4s);
             }
 
             void UpdateAI(uint32 diff) override

--- a/src/server/scripts/EasternKingdoms/zone_isle_of_queldanas.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_isle_of_queldanas.cpp
@@ -371,7 +371,7 @@ struct npc_thalorien_dawnseeker : public ScriptedAI
                     if (Creature* thalorien = ObjectAccessor::GetCreature(*me, _thalorienGUID))
                     {
                         thalorien->SetStandState(UNIT_STAND_STATE_KNEEL);
-                        thalorien->DespawnOrUnsummon(5 * IN_MILLISECONDS);
+                        thalorien->DespawnOrUnsummon(5s);
                     }
 
                     me->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/EasternKingdoms: Use std::chrono overload of Creature::DespawnOrUnsummon


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build