### PR TITLE
Scripts/World+Outland+Spells:: Use std::chrono overload of Creature::DespawnOrUnsummon

### DIFF
--- a/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
+++ b/src/server/scripts/Outland/zone_blades_edge_mountains.cpp
@@ -122,7 +122,7 @@ public:
                 return;
 
             if (id == 0)
-                me->DespawnOrUnsummon(1);
+                me->DespawnOrUnsummon(1ms);
         }
 
         void SpellHit(WorldObject* caster, SpellInfo const* spellInfo) override
@@ -614,7 +614,7 @@ class npc_simon_bunny : public CreatureScript
                 if (GameObject* relic = me->FindNearestGameObject(large ? GO_APEXIS_MONUMENT : GO_APEXIS_RELIC, searchDistance))
                     relic->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE);
 
-                me->DespawnOrUnsummon(1000);
+                me->DespawnOrUnsummon(1s);
             }
 
             /*
@@ -949,7 +949,7 @@ public:
                 // Spell 37392 does not exist in dbc, manually spawning
                 me->SummonCreature(NPC_OSCILLATING_FREQUENCY_SCANNER_TOP_BUNNY, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 0.5f, me->GetOrientation(), TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 50000);
                 me->SummonGameObject(GO_OSCILLATING_FREQUENCY_SCANNER, *me, QuaternionData(), 50);
-                me->DespawnOrUnsummon(50000);
+                me->DespawnOrUnsummon(50s);
             }
 
             timer = 500;

--- a/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
+++ b/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
@@ -422,7 +422,7 @@ public:
                     PlayerGUID.Clear();
                 }
 
-                me->DespawnOrUnsummon(1);
+                me->DespawnOrUnsummon(1ms);
             }
         }
 

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -2991,7 +2991,7 @@ public:
             if (Creature* ghoul = ObjectAccessor::GetCreature(*player, ghoulGuid))
             {
                 ghoul->RemoveCharmedBy(player);
-                ghoul->DespawnOrUnsummon(1000);
+                ghoul->DespawnOrUnsummon(1s);
             }
 
             player->RemoveAura(SPELL_GHOUL_FRENZY);

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -41,10 +41,10 @@ class spell_generic_quest_update_entry_SpellScript : public SpellScript
         uint32 _originalEntry;
         uint32 _newEntry;
         bool _shouldAttack;
-        uint32 _despawnTime;
+        Milliseconds _despawnTime;
 
     public:
-        spell_generic_quest_update_entry_SpellScript(uint16 spellEffect, uint8 effIndex, uint32 originalEntry, uint32 newEntry, bool shouldAttack, uint32 despawnTime = 0) :
+        spell_generic_quest_update_entry_SpellScript(uint16 spellEffect, uint8 effIndex, uint32 originalEntry, uint32 newEntry, bool shouldAttack, Milliseconds despawnTime = 0s) :
             SpellScript(), _spellEffect(spellEffect), _effIndex(effIndex), _originalEntry(originalEntry),
             _newEntry(newEntry), _shouldAttack(shouldAttack), _despawnTime(despawnTime) { }
 
@@ -57,7 +57,7 @@ class spell_generic_quest_update_entry_SpellScript : public SpellScript
                     if (_shouldAttack)
                         creatureTarget->EngageWithTarget(GetCaster());
 
-                    if (_despawnTime)
+                    if (_despawnTime != 0s)
                         creatureTarget->DespawnOrUnsummon(_despawnTime);
                 }
         }
@@ -208,8 +208,9 @@ enum Quests6124_6129Data
     NPC_CURED_GAZELLE   = 12297,
     NPC_SICKLY_DEER     = 12298,
     NPC_CURED_DEER      = 12299,
-    DESPAWN_TIME        = 30000
 };
+
+constexpr Milliseconds Quest6124_6129_DESPAWN_TIME = 30s;
 
 class spell_q6124_6129_apply_salve : public SpellScriptLoader
 {
@@ -246,7 +247,7 @@ class spell_q6124_6129_apply_salve : public SpellScriptLoader
                         if (newEntry)
                         {
                             creatureTarget->UpdateEntry(newEntry);
-                            creatureTarget->DespawnOrUnsummon(DESPAWN_TIME);
+                            creatureTarget->DespawnOrUnsummon(Quest6124_6129_DESPAWN_TIME);
                             caster->KilledMonsterCredit(newEntry);
                         }
                     }
@@ -955,7 +956,7 @@ class spell_q9874_liquid_fire : public SpellScriptLoader
                     {
                         caster->KilledMonsterCredit(NPC_VILLAGER_KILL_CREDIT);
                         target->CastSpell(target, SPELL_FLAMES, true);
-                        target->DespawnOrUnsummon(60000);
+                        target->DespawnOrUnsummon(60s);
                     }
             }
 
@@ -999,7 +1000,7 @@ class spell_q12805_lifeblood_dummy : public SpellScriptLoader
                 {
                     caster->KilledMonsterCredit(NPC_SHARD_KILL_CREDIT);
                     target->CastSpell(target, uint32(GetEffectValue()), true);
-                    target->DespawnOrUnsummon(2000);
+                    target->DespawnOrUnsummon(2s);
                 }
             }
 
@@ -2227,7 +2228,7 @@ class spell_q12690_burst_at_the_seams_52510 : public SpellScript
 
     void HandleScript(SpellEffIndex /*effIndex*/)
     {
-        GetCaster()->ToCreature()->DespawnOrUnsummon(2 * IN_MILLISECONDS);
+        GetCaster()->ToCreature()->DespawnOrUnsummon(2s);
     }
 
     void Register() override

--- a/src/server/scripts/World/boss_emerald_dragons.cpp
+++ b/src/server/scripts/World/boss_emerald_dragons.cpp
@@ -442,7 +442,7 @@ class npc_spirit_shade : public CreatureScript
                 if (moveType == FOLLOW_MOTION_TYPE && data == _summonerGuid.GetCounter())
                 {
                     me->CastSpell(nullptr, SPELL_DARK_OFFERING, false);
-                    me->DespawnOrUnsummon(1000);
+                    me->DespawnOrUnsummon(1s);
                 }
             }
 

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -914,7 +914,7 @@ class go_veil_skith_cage : public GameObjectScript
                    for (Creature* creature : childrenList)
                    {
                        player->KilledMonsterCredit(NPC_CAPTIVE_CHILD, creature->GetGUID());
-                       creature->DespawnOrUnsummon(5000);
+                       creature->DespawnOrUnsummon(5s);
                        creature->GetMotionMaster()->MovePoint(1, me->GetPositionX() + 5, me->GetPositionY(), me->GetPositionZ());
                        creature->AI()->Talk(SAY_FREE_0);
                        creature->GetMotionMaster()->Clear();

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -2334,7 +2334,7 @@ class npc_train_wrecker : public CreatureScript
                 if (GameObject* target = ObjectAccessor::GetGameObject(*me, _target))
                     return target;
                 me->HandleEmoteCommand(EMOTE_ONESHOT_RUDE);
-                me->DespawnOrUnsummon(3 * IN_MILLISECONDS);
+                me->DespawnOrUnsummon(3s);
                 return nullptr;
             }
 
@@ -2400,7 +2400,7 @@ class npc_train_wrecker : public CreatureScript
                                 break;
                             }
                             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_DANCE);
-                            me->DespawnOrUnsummon(5 * IN_MILLISECONDS);
+                            me->DespawnOrUnsummon(5s);
                             _nextAction = 0;
                             break;
                         default:


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/World+Outland+Spells:: Use std::chrono overload of Creature::DespawnOrUnsummon

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build