### PR TITLE
Scripts/Kalimdor: Use std::chrono overload of Creature::DespawnOrUnsummon

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_infinite_corruptor.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_infinite_corruptor.cpp
@@ -91,7 +91,7 @@ class boss_infinite_corruptor : public CreatureScript
                 if (Creature* guardian = me->FindNearestCreature(NPC_GUARDIAN_OF_TIME, 100.0f))
                 {
                     guardian->RemoveAurasDueToSpell(SPELL_CORRUPTION_OF_TIME_TARGET);
-                    guardian->DespawnOrUnsummon(5000);
+                    guardian->DespawnOrUnsummon(5s);
                 }
 
                 if (Creature* rift = me->FindNearestCreature(NPC_TIME_RIFT, 100.0f))

--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/instance_culling_of_stratholme.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/instance_culling_of_stratholme.cpp
@@ -759,7 +759,7 @@ class instance_culling_of_stratholme : public InstanceMapScript
                     {
                         if (creature->GetSpawnId())
                             creature->SetRespawnTime(1);
-                        creature->DespawnOrUnsummon(0, 1s);
+                        creature->DespawnOrUnsummon(0s, 1s);
                     }
 
                     SpawnInfiniteCorruptor();

--- a/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
+++ b/src/server/scripts/Kalimdor/RazorfenDowns/razorfen_downs.cpp
@@ -125,7 +125,7 @@ public:
         void JustDied(Unit* /*killer*/) override
         {
             instance->SetBossState(DATA_EXTINGUISHING_THE_IDOL, DONE);
-            me->DespawnOrUnsummon(5000);
+            me->DespawnOrUnsummon(5s);
         }
 
         void QuestAccept(Player* /*player*/, Quest const* quest) override

--- a/src/server/scripts/Kalimdor/zone_desolace.cpp
+++ b/src/server/scripts/Kalimdor/zone_desolace.cpp
@@ -107,7 +107,7 @@ public:
                 me->GetMotionMaster()->Clear();
                 me->GetMotionMaster()->MoveIdle();
                 me->setActive(false);
-                me->DespawnOrUnsummon(60000);
+                me->DespawnOrUnsummon(60s);
             }
         }
 

--- a/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
+++ b/src/server/scripts/Kalimdor/zone_orgrimmar.cpp
@@ -761,7 +761,7 @@ public:
                             jaina->AI()->Talk(SAY_JAINA_4);
                             jaina->SetWalk(true);
                             jaina->GetMotionMaster()->MovePoint(2, jaina->GetHomePosition());
-                            jaina->DespawnOrUnsummon(5000);
+                            jaina->DespawnOrUnsummon(5s);
                         }
                         events.ScheduleEvent(EVENT_HERALD_SCENE15, 7s);
                         break;

--- a/src/server/scripts/Kalimdor/zone_winterspring.cpp
+++ b/src/server/scripts/Kalimdor/zone_winterspring.cpp
@@ -454,7 +454,7 @@ public:
                     if (Creature* guard = ObjectAccessor::GetCreature(*me, _guardEluneGUID))
                     {
                         guard->GetMotionMaster()->MovePoint(0, wingThicketLocations[2].m_positionX, wingThicketLocations[2].m_positionY, wingThicketLocations[2].m_positionZ);
-                        guard->DespawnOrUnsummon(4000);
+                        guard->DespawnOrUnsummon(4s);
                     }
                     break;
                 case SAY_PRIESTESS_ALTAR_20:
@@ -462,7 +462,7 @@ public:
                     if (Creature* priestess = ObjectAccessor::GetCreature(*me, _firstPriestessGUID))
                     {
                         priestess->GetMotionMaster()->MovePoint(0, wingThicketLocations[0].m_positionX, wingThicketLocations[0].m_positionY, wingThicketLocations[0].m_positionZ);
-                        priestess->DespawnOrUnsummon(4000);
+                        priestess->DespawnOrUnsummon(4s);
                     }
                     break;
                 case SAY_PRIESTESS_ALTAR_21:
@@ -470,7 +470,7 @@ public:
                     if (Creature* priestess = ObjectAccessor::GetCreature(*me, _secondPriestessGUID))
                     {
                         priestess->GetMotionMaster()->MovePoint(0, wingThicketLocations[1].m_positionX, wingThicketLocations[1].m_positionY, wingThicketLocations[1].m_positionZ);
-                        priestess->DespawnOrUnsummon(4000);
+                        priestess->DespawnOrUnsummon(4s);
                     }
                     break;
                 case DATA_EVENT_END:
@@ -494,7 +494,7 @@ public:
                         player->GroupEventHappens(QUEST_GUARDIANS_ALTAR, me);
                         Talk(SAY_RANSHALLA_END_2, player);
                     }
-                    me->DespawnOrUnsummon(4000);
+                    me->DespawnOrUnsummon(4s);
                     break;
             }
         }


### PR DESCRIPTION
**Changes proposed:**

-  Scripts/Kalimdor: Use std::chrono overload of Creature::DespawnOrUnsummon

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:** build