### PR TITLE
Allow config settings to be optional

### DIFF
--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -79,7 +79,7 @@ bool ConfigMgr::Reload(std::string& error)
 }
 
 template<class T>
-T ConfigMgr::GetValueDefault(std::string const& name, T def) const
+T ConfigMgr::GetValueDefault(std::string const& name, T def, bool quiet) const
 {
     try
     {
@@ -87,8 +87,11 @@ T ConfigMgr::GetValueDefault(std::string const& name, T def) const
     }
     catch (bpt::ptree_bad_path const&)
     {
-        TC_LOG_WARN("server.loading", "Missing name %s in config file %s, add \"%s = %s\" to this file",
-            name.c_str(), _filename.c_str(), name.c_str(), std::to_string(def).c_str());
+        if (!quiet)
+        {
+            TC_LOG_WARN("server.loading", "Missing name %s in config file %s, add \"%s = %s\" to this file",
+                name.c_str(), _filename.c_str(), name.c_str(), std::to_string(def).c_str());
+        }
     }
     catch (bpt::ptree_bad_data const&)
     {
@@ -100,7 +103,7 @@ T ConfigMgr::GetValueDefault(std::string const& name, T def) const
 }
 
 template<>
-std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std::string def) const
+std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std::string def, bool quiet) const
 {
     try
     {
@@ -108,8 +111,11 @@ std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std
     }
     catch (bpt::ptree_bad_path const&)
     {
-        TC_LOG_WARN("server.loading", "Missing name %s in config file %s, add \"%s = %s\" to this file",
-            name.c_str(), _filename.c_str(), name.c_str(), def.c_str());
+        if (!quiet)
+        {
+            TC_LOG_WARN("server.loading", "Missing name %s in config file %s, add \"%s = %s\" to this file",
+                name.c_str(), _filename.c_str(), name.c_str(), def.c_str());
+        }
     }
     catch (bpt::ptree_bad_data const&)
     {
@@ -120,28 +126,28 @@ std::string ConfigMgr::GetValueDefault<std::string>(std::string const& name, std
     return def;
 }
 
-std::string ConfigMgr::GetStringDefault(std::string const& name, const std::string& def) const
+std::string ConfigMgr::GetStringDefault(std::string const& name, const std::string& def, bool quiet) const
 {
-    std::string val = GetValueDefault(name, def);
+    std::string val = GetValueDefault(name, def, quiet);
     val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
     return val;
 }
 
-bool ConfigMgr::GetBoolDefault(std::string const& name, bool def) const
+bool ConfigMgr::GetBoolDefault(std::string const& name, bool def, bool quiet) const
 {
-    std::string val = GetValueDefault(name, std::string(def ? "1" : "0"));
+    std::string val = GetValueDefault(name, std::string(def ? "1" : "0"), quiet);
     val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
     return StringToBool(val);
 }
 
-int ConfigMgr::GetIntDefault(std::string const& name, int def) const
+int ConfigMgr::GetIntDefault(std::string const& name, int def, bool quiet) const
 {
-    return GetValueDefault(name, def);
+    return GetValueDefault(name, def, quiet);
 }
 
-float ConfigMgr::GetFloatDefault(std::string const& name, float def) const
+float ConfigMgr::GetFloatDefault(std::string const& name, float def, bool quiet) const
 {
-    return GetValueDefault(name, def);
+    return GetValueDefault(name, def, quiet);
 }
 
 std::string const& ConfigMgr::GetFilename()

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -37,10 +37,10 @@ public:
 
     bool Reload(std::string& error);
 
-    std::string GetStringDefault(std::string const& name, const std::string& def) const;
-    bool GetBoolDefault(std::string const& name, bool def) const;
-    int GetIntDefault(std::string const& name, int def) const;
-    float GetFloatDefault(std::string const& name, float def) const;
+    std::string GetStringDefault(std::string const& name, const std::string& def, bool quiet = false) const;
+    bool GetBoolDefault(std::string const& name, bool def, bool quiet = false) const;
+    int GetIntDefault(std::string const& name, int def, bool quiet = false) const;
+    float GetFloatDefault(std::string const& name, float def, bool quiet = false) const;
 
     std::string const& GetFilename();
     std::vector<std::string> const& GetArguments() const;
@@ -48,7 +48,7 @@ public:
 
 private:
     template<class T>
-    T GetValueDefault(std::string const& name, T def) const;
+    T GetValueDefault(std::string const& name, T def, bool quiet) const;
 };
 
 #define sConfigMgr ConfigMgr::instance()


### PR DESCRIPTION
Add a `quiet` boolean (defaults to `false`) to all the `sConfigMgr` getters.

If it is specified, the default is returned without generating a warning message.