### PR TITLE
Core/Spells: Implemented OnTriggerCastFlagsDefitinion hook

### DIFF
--- a/sql/updates/world/3.3.5/2020_88_57_78_world.sql
+++ b/sql/updates/world/3.3.5/2020_88_57_78_world.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_dru_lacerate';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(-33745,'spell_dru_lacerate');

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -761,6 +761,7 @@ class TC_GAME_API Spell
         void CallScriptObjectTargetSelectHandlers(WorldObject*& target, SpellEffIndex effIndex, SpellImplicitTargetInfo const& targetType);
         void CallScriptDestinationTargetSelectHandlers(SpellDestination& target, SpellEffIndex effIndex, SpellImplicitTargetInfo const& targetType);
         bool CheckScriptEffectImplicitTargets(uint32 effIndex, uint32 effIndexToCheck);
+        void CallScriptOnTriggerCastFlagsDefinition(TriggerCastFlags& triggeredCastFlags);
         std::vector<SpellScript*> m_loadedScripts;
 
         struct HitTriggerSpell

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -208,6 +208,16 @@ void SpellScript::OnCalculateResistAbsorbHandler::Call(SpellScript* spellScript,
     return (spellScript->*pOnCalculateResistAbsorbHandlerScript)(damageInfo, resistAmount, absorbAmount);
 }
 
+SpellScript::OnTriggerCastFlagsDefinitionHandler::OnTriggerCastFlagsDefinitionHandler(SpellOnTriggerCastDefinitionFnType onTriggerCastFlagsDefinitionHandlerScript)
+{
+    pOnTriggerCastFlagsDefinitionHandlerScript = onTriggerCastFlagsDefinitionHandlerScript;
+}
+
+void SpellScript::OnTriggerCastFlagsDefinitionHandler::Call(SpellScript* spellScript, TriggerCastFlags& triggeredCastFlags)
+{
+    return (spellScript->*pOnTriggerCastFlagsDefinitionHandlerScript)(triggeredCastFlags);
+}
+
 SpellScript::EffectHandler::EffectHandler(SpellEffectFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName)
     : _SpellScript::EffectNameCheck(_effName), _SpellScript::EffectHook(_effIndex)
 {

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -310,7 +310,7 @@ class TC_GAME_API SpellScript : public _SpellScript
         };
 
         #define SPELLSCRIPT_FUNCTION_CAST_DEFINES(CLASSNAME) \
-        class OnTriggerCastFlagsDefitinionHandlerFunction : public SpellScript::OnTriggerCastFlagsDefitinionHandler { public: explicit OnTriggerCastFlagsDefitinionHandlerFunction(SpellOnTriggerCastDefinitionFnType _onTriggerCastFlagsDefitinionScript) : SpellScript::OnTriggerCastFlagsDefitinionHandler((SpellScript::SpellOnTriggerCastDefinitionFnType)_onTriggerCastFlagsDefitinionScript) { } }; \
+        class OnTriggerCastFlagsDefinitionHandlerFunction : public SpellScript::OnTriggerCastFlagsDefinitionHandler { public: explicit OnTriggerCastFlagsDefinitionHandlerFunction(SpellOnTriggerCastDefinitionFnType _onTriggerCastFlagsDefitinionScript) : SpellScript::OnTriggerCastFlagsDefinitionHandler((SpellScript::SpellOnTriggerCastDefinitionFnType)_onTriggerCastFlagsDefitinionScript) { } }; \
         class CastHandlerFunction : public SpellScript::CastHandler { public: explicit CastHandlerFunction(SpellCastFnType _pCastHandlerScript) : SpellScript::CastHandler((SpellScript::SpellCastFnType)_pCastHandlerScript) { } }; \
         class CheckCastHandlerFunction : public SpellScript::CheckCastHandler { public: explicit CheckCastHandlerFunction(SpellCheckCastFnType _checkCastHandlerScript) : SpellScript::CheckCastHandler((SpellScript::SpellCheckCastFnType)_checkCastHandlerScript) { } }; \
         class EffectHandlerFunction : public SpellScript::EffectHandler { public: explicit EffectHandlerFunction(SpellEffectFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName) : SpellScript::EffectHandler((SpellScript::SpellEffectFnType)_pEffectHandlerScript, _effIndex, _effName) { } }; \

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -767,6 +767,22 @@ class spell_dru_insect_swarm : public AuraScript
     }
 };
 
+// -33745 - Lacerate
+class spell_dru_lacerate : public SpellScript
+{
+    PrepareSpellScript(spell_dru_lacerate);
+
+    void ChangeTriggerFlag(TriggerCastFlags& triggeredCastFlags)
+    {
+        triggeredCastFlags = TriggerCastFlags(uint32(triggeredCastFlags) | TRIGGERED_DONT_RESET_PERIODIC_TIMER);
+    }
+
+    void Register() override
+    {
+        OnTriggerCastFlagsDefinition += OnTriggerCastFlagsDefinitionFn(spell_dru_lacerate::ChangeTriggerFlag);
+    }
+};
+
 // 24932 - Leader of the Pack
 class spell_dru_leader_of_the_pack : public AuraScript
 {
@@ -1913,6 +1929,7 @@ void AddSC_druid_spell_scripts()
     RegisterSpellScript(spell_dru_idol_lifebloom);
     RegisterSpellScript(spell_dru_innervate);
     RegisterSpellScript(spell_dru_insect_swarm);
+    RegisterSpellScript(spell_dru_lacerate);
     RegisterSpellScript(spell_dru_leader_of_the_pack);
     RegisterSpellScript(spell_dru_lifebloom);
     RegisterSpellScript(spell_dru_living_seed);


### PR DESCRIPTION
**Changes proposed:**

- Add a way to control  TriggerCastFlags for spells casted directly by players
-  A example of utilization is Lacerate (druid). It should continue ticking while refreshed/new stack added (like paladins seal), but to not refresh tick time when new stack is applied, need ```TRIGGERED_DONT_RESET_PERIODIC_TIMER``` and core has way to add it (without put directly in Spell.cpp?)
Proof of lacerate: 
[Log](http://worldoflogs.com/reports/ul76xm556v85ir2v/xe/?s=7529&e=7690&x=spell+%3D+%22Lacerate%22)
![image](https://user-images.githubusercontent.com/7120913/88542809-695b2080-cfed-11ea-98ac-55a683f0306f.png)
- This can be useful for all cases that you need change TriggerCastFlags.

**Target branch(es):** 3.3.5

**Tests performed:** Builded and tested in game

