### PR TITLE
Game/ActionHouse: Fixed some clothes chests not showing in AH

### DIFF
--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -758,13 +758,8 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
 
         if (inventoryType != 0xffffffff && proto->InventoryType != inventoryType)
         {
-            // Cloth chests can have 2 inventory type: INVTYPE_CHEST and INVTYPE_ROBE. We need show both because AH always send as INVTYPE_CHEST
-            if (itemClass == ITEM_CLASS_ARMOR && itemSubClass == ITEM_SUBCLASS_ARMOR_CLOTH && inventoryType == INVTYPE_CHEST)
-            {
-                if (proto->InventoryType != INVTYPE_CHEST && proto->InventoryType != INVTYPE_ROBE)
-                    continue;
-            }
-            else
+            // Cloth items can have INVTYPE_CHEST or INVTYPE_ROBE
+            if (!(inventoryType == INVTYPE_CHEST && proto->InventoryType == INVTYPE_ROBE))
                 continue;
         }
 

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -757,7 +757,16 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
             continue;
 
         if (inventoryType != 0xffffffff && proto->InventoryType != inventoryType)
-            continue;
+        {
+            // Cloth chests can have 2 inventory type: INVTYPE_CHEST and INVTYPE_ROBE. We need show both because AH always send as INVTYPE_CHEST
+            if (itemClass == ITEM_CLASS_ARMOR && itemSubClass == ITEM_SUBCLASS_ARMOR_CLOTH && inventoryType == INVTYPE_CHEST)
+            {
+                if (proto->InventoryType != INVTYPE_CHEST && proto->InventoryType != INVTYPE_ROBE)
+                    continue;
+            }
+            else
+                continue;
+        }
 
         if (quality != 0xffffffff && proto->Quality != quality)
             continue;


### PR DESCRIPTION
**Changes proposed:**

-  If you go in auction house aba: armor -> cloth -> chest, it will skip some items.
- It happens because AH always send INVTYPE_CHEST, but cloth chest items can have INVTYPE_CHEST or INVTYPE_ROBE
- It make one of ours filter check fail 

**Target branch(es):** 3.3.5


**Tests performed:** builded and tested in game
