### PR TITLE
Core/Units: add new functionality for units to block or enable combat interactions

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -44,12 +44,9 @@
         return false;
     if (a->HasUnitState(UNIT_STATE_IN_FLIGHT) || b->HasUnitState(UNIT_STATE_IN_FLIGHT))
         return false;
-    if (Creature const* aCreature = a->ToCreature())
-        if (aCreature->IsCombatDisallowed())
-            return false;
-    if (Creature const* bCreature = b->ToCreature())
-        if (bCreature->IsCombatDisallowed())
-            return false;
+    // ... both units must not be ignoring combat
+    if (a->IsIgnoringCombat() || b->IsIgnoringCombat())
+        return false;
     if (a->IsFriendlyTo(b) || b->IsFriendlyTo(a))
         return false;
     Player const* playerA = a->GetCharmerOrOwnerPlayerOrPlayerItself();

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -614,6 +614,9 @@ bool Creature::UpdateEntry(uint32 entry, CreatureData const* data /*= nullptr*/,
         ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_ATTACK_ME, true);
     }
 
+    if (cInfo->flags_extra & CREATURE_FLAG_EXTRA_NO_COMBAT)
+        SetIgnoringCombat(true);
+
     LoadTemplateRoot();
     InitializeMovementFlags();
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -614,8 +614,7 @@ bool Creature::UpdateEntry(uint32 entry, CreatureData const* data /*= nullptr*/,
         ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_ATTACK_ME, true);
     }
 
-    if (cInfo->flags_extra & CREATURE_FLAG_EXTRA_NO_COMBAT)
-        SetIgnoringCombat(true);
+    SetIgnoringCombat((cInfo->flags_extra & CREATURE_FLAG_EXTRA_NO_COMBAT) != 0);
 
     LoadTemplateRoot();
     InitializeMovementFlags();

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -91,7 +91,6 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         bool IsCivilian() const { return (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_CIVILIAN) != 0; }
         bool IsTrigger() const { return (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_TRIGGER) != 0; }
         bool IsGuard() const { return (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_GUARD) != 0; }
-        bool IsCombatDisallowed() const { return (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_NO_COMBAT) != 0; }
 
         void InitializeMovementFlags();
         void UpdateMovementFlags();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -382,6 +382,7 @@ Unit::Unit(bool isWorldObject) :
     _oldFactionId = 0;
     _isWalkingBeforeCharm = false;
     _instantCast = false;
+    _isIgnoringCombat(false);
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -382,7 +382,7 @@ Unit::Unit(bool isWorldObject) :
     _oldFactionId = 0;
     _isWalkingBeforeCharm = false;
     _instantCast = false;
-    _isIgnoringCombat(false);
+    _isIgnoringCombat = false;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1686,6 +1686,11 @@ class TC_GAME_API Unit : public WorldObject
 
         float GetCollisionHeight() const override;
 
+        // returns if the unit is ignoring any combat interaction
+        bool IsIgnoringCombat() const { return _isIgnoringCombat; }
+        // enables/disables combat interaction of this unit.
+        void SetIgnoringCombat(bool apply) { _isIgnoringCombat = apply; }
+
         std::string GetDebugInfo() const override;
     protected:
         explicit Unit (bool isWorldObject);
@@ -1832,6 +1837,8 @@ class TC_GAME_API Unit : public WorldObject
 
         SpellHistory* m_spellHistory;
         PositionUpdateInfo _positionUpdateInfo;
+
+        bool _isIgnoringCombat;
 };
 
 namespace Trinity


### PR DESCRIPTION
**Changes proposed:**
As a followup to 6440c3bcac85a40de5c34aef1d8a8856966cc140 and the discussions about it, these changes will add a larger span of possibilities.
-  all units will now be able to ignore combat entirely via member variable in the unit class. The added helpers allow us to change that ignore state during runtime.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:** (Does it build, tested in-game, etc.)
tested on 4.x

**Known issues and TODO list:** (add/remove lines as needed)
- [ ] (optional) https://paste2.org/p8aK1KZF
this is a list of all creatures from creaturedifficulty dbc table up to expansion 3 that have the ignore combat difficulty flag. There are MANY creatures that are set to ignore combat that should not have set it by default so there must be some indicator whenever this flag is suposed to be applied right on creation or applied during runtime.

