### PR TITLE
Core/Unit: Fix for Pets/Guardians not engaging combat if master is attacked

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -687,20 +687,17 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
     // Hook for OnDamage Event
     sScriptMgr->OnDamage(attacker, victim, damage);
 
-    if (victim->GetTypeId() == TYPEID_PLAYER)
+    // Signal to pets that their owner was attacked - except when DOT.
+    if (attacker != victim && damagetype != DOT)
     {
-        // Signal to pets that their owner was attacked - except when DOT.
-        if (attacker != victim && damagetype != DOT)
-        {
-            for (Unit* controlled : victim->m_Controlled)
-                if (Creature* cControlled = controlled->ToCreature())
-                    if (CreatureAI* controlledAI = cControlled->AI())
-                        controlledAI->OwnerAttackedBy(attacker);
-        }
-
-        if (victim->ToPlayer()->GetCommandStatus(CHEAT_GOD))
-            return 0;
+        for (Unit* controlled : victim->m_Controlled)
+            if (Creature* cControlled = controlled->ToCreature())
+                if (CreatureAI* controlledAI = cControlled->AI())
+                    controlledAI->OwnerAttackedBy(attacker);
     }
+
+    if (Player* player = victim->ToPlayer(); player && player->GetCommandStatus(CHEAT_GOD))
+        return 0;
 
     if (damagetype != NODAMAGE)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Long Story short:
1) a unit is always a player or a creature
2) i dont know anything about c++
3) big thanks to @Treeston for a wonderful c++ and trinitycore lesson and sadly also some thanks to @MaxtorCoder for being part of it

-  Fixes Pets/Guardians not getting into combat when their master is attacked

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:** 
Closes #24340


**Tests performed:** (Does it build, tested in-game, etc.)
- [x] Builds
- [x] tested ingame

**Known issues and TODO list:** (add/remove lines as needed)

There shouldnt be any side effects

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
