### PR TITLE
Core/Updater: Fix detection of the mysql binary when a directory is given as path

### DIFF
--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -40,10 +40,10 @@ std::string DBUpdaterUtil::GetCorrectedMySQLExecutable()
 bool DBUpdaterUtil::CheckExecutable()
 {
     boost::filesystem::path exe(GetCorrectedMySQLExecutable());
-    if (!exists(exe))
+    if (!is_regular_file(exe))
     {
         exe = Trinity::SearchExecutableInPath("mysql");
-        if (!exe.empty() && exists(exe))
+        if (!exe.empty() && is_regular_file(exe))
         {
             // Correct the path to the cli
             corrected_path() = absolute(exe).generic_string();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Fix detection of the mysql binary when a directory is given as path.
This ensures that we never pass a directory path StartProcess which results in a crash.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #25216


**Tests performed:**

started worldserver with updates to apply