### PR TITLE
Core/SAI: Fix creatures casting with flag SMARTCAST_COMBAT_MOVE not switching to melee when the school of the spell they are trying to cast gets silenced (and other cases of spell failure)

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -553,24 +553,16 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                             me->InterruptNonMeleeSpells(false);
 
                         SpellCastResult result = me->CastSpell(target->ToUnit(), e.action.cast.spell, triggerFlag);
+                        bool spellCastFailed = (result != SPELL_CAST_OK && result != SPELL_FAILED_SPELL_IN_PROGRESS);
 
                         if (e.action.cast.castFlags & SMARTCAST_COMBAT_MOVE)
                         {
                             // If cast flag SMARTCAST_COMBAT_MOVE is set combat movement will not be allowed unless target is outside spell range, out of mana, or LOS.
-                            bool allowMove = false;
-                            switch (result)
-                            {
-                                // In these cases there's nothing to do
-                                case SPELL_CAST_OK:
-                                case SPELL_FAILED_SPELL_IN_PROGRESS:
-                                    break;
-                                default:
-                                    allowMove = true;
-                                    break;
-                            }
-
-                            ENSURE_AI(SmartAI, me->AI())->SetCombatMove(allowMove, true);
+                            ENSURE_AI(SmartAI, me->AI())->SetCombatMove(spellCastFailed, true);
                         }
+
+                        if (spellCastFailed)
+                            RecalcTimer(e, 500, 500);
                     }
                     else if (go)
                         go->CastSpell(target->ToUnit(), e.action.cast.spell, triggerFlag);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix creatures casting with flag SMARTCAST_COMBAT_MOVE not switching to melee when the school of the spell they are trying to cast gets silenced (and other cases of spell failure)
- Retry casting after 500 ms if a cast failed

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Improves #24912
Fixes #24914


**Tests performed:**

- https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=18121 using https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=2139 with and without https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?spell=11255


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] It would be nice if the mobs retried to cast when interrupted


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
