### PR TITLE
Core/AI: Remove code that removed UNIT_DYNFLAG_LOOTABLE from possessed units

### DIFF
--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -67,6 +67,12 @@ void PossessedAI::UpdateAI(uint32 /*diff*/)
     }
 }
 
+void PossessedAI::JustDied(Unit* /*u*/)
+{
+    // We died while possessed, disable our loot
+    me->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+}
+
 void CritterAI::JustEngagedWith(Unit* /*who*/)
 {
     if (!me->HasUnitState(UNIT_STATE_FLEEING))

--- a/src/server/game/AI/CoreAI/PassiveAI.cpp
+++ b/src/server/game/AI/CoreAI/PassiveAI.cpp
@@ -67,19 +67,6 @@ void PossessedAI::UpdateAI(uint32 /*diff*/)
     }
 }
 
-void PossessedAI::JustDied(Unit* /*u*/)
-{
-    // We died while possessed, disable our loot
-    me->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
-}
-
-void PossessedAI::KilledUnit(Unit* victim)
-{
-    // We killed a creature, disable victim's loot
-    if (victim->GetTypeId() == TYPEID_UNIT)
-        victim->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
-}
-
 void CritterAI::JustEngagedWith(Unit* /*who*/)
 {
     if (!me->HasUnitState(UNIT_STATE_FLEEING))

--- a/src/server/game/AI/CoreAI/PassiveAI.h
+++ b/src/server/game/AI/CoreAI/PassiveAI.h
@@ -45,9 +45,6 @@ class TC_GAME_API PossessedAI : public CreatureAI
         void UpdateAI(uint32) override;
         void EnterEvadeMode(EvadeReason /*why*/) override { }
 
-        void JustDied(Unit*) override;
-        void KilledUnit(Unit* victim) override;
-
         static int32 Permissible(Creature const* /*creature*/) { return PERMIT_BASE_NO; }
 };
 

--- a/src/server/game/AI/CoreAI/PassiveAI.h
+++ b/src/server/game/AI/CoreAI/PassiveAI.h
@@ -45,6 +45,8 @@ class TC_GAME_API PossessedAI : public CreatureAI
         void UpdateAI(uint32) override;
         void EnterEvadeMode(EvadeReason /*why*/) override { }
 
+        void JustDied(Unit*) override;
+
         static int32 Permissible(Creature const* /*creature*/) { return PERMIT_BASE_NO; }
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Remove code that removed UNIT_DYNFLAG_LOOTABLE from possessed units

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #24060


**Tests performed:**

None, it needs to be tested


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Needs to be tested
- [ ] No idea why the code was there (as usual no comments at all in the code about WHY the code is there in the first place)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
