### PR TITLE
Core/SAI: Spell casts that cannot be executed because the unit is currently casting another spell will be retried asap with priority over other events

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -176,6 +176,12 @@ void SmartScript::OnReset()
             InitTimer(event);
             event.runOnce = false;
         }
+
+        if (event.priority != uint32(-1))
+        {
+            event.priority = uint32(-1);
+            mEventSortingRequired = true;
+        }
     }
     ProcessEventsFor(SMART_EVENT_RESET);
     mLastInvoker.Clear();
@@ -3477,8 +3483,12 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
                 if (me && me->HasUnitState(UNIT_STATE_CASTING))
                 {
                     e.timer = 1;
-                    e.priority = mCurrentPriority++;
-                    mEventSortingRequired = true;
+                    // Change priority only if it's set to default, otherwise keep the current order of events
+                    if (e.priority == uint32(-1))
+                    {
+                        e.priority = mCurrentPriority++;
+                        mEventSortingRequired = true;
+                    }
                     return;
                 }
             }
@@ -3497,7 +3507,8 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
         e.active = true;//activate events with cooldown
 
         // Re-sort events if this was moved to the top of the queue
-        mEventSortingRequired = e.priority != uint32(-1);
+        if (e.priority != uint32(-1))
+            mEventSortingRequired = true;
         // Reset priority to default one as we are executing the event
         e.priority = uint32(-1);
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -177,9 +177,9 @@ void SmartScript::OnReset()
             event.runOnce = false;
         }
 
-        if (event.priority != uint32(-1))
+        if (event.priority != SmartScriptHolder::DEFAULT_PRIORITY)
         {
-            event.priority = uint32(-1);
+            event.priority = SmartScriptHolder::DEFAULT_PRIORITY;
             mEventSortingRequired = true;
         }
     }
@@ -570,7 +570,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         }
 
                         if (spellCastFailed)
-                            RecalcTimer(e, 500, 500);
+                            RaisePriority(e);
                     }
                     else if (go)
                         go->CastSpell(target->ToUnit(), e.action.cast.spell, triggerFlag);
@@ -3482,13 +3482,7 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
             {
                 if (me && me->HasUnitState(UNIT_STATE_CASTING))
                 {
-                    e.timer = 1;
-                    // Change priority only if it's set to default, otherwise keep the current order of events
-                    if (e.priority == SmartScriptHolder::DEFAULT_PRIORITY)
-                    {
-                        e.priority = mCurrentPriority++;
-                        mEventSortingRequired = true;
-                    }
+                    RaisePriority(e);
                     return;
                 }
             }
@@ -3712,6 +3706,17 @@ void SmartScript::OnUpdate(uint32 const diff)
 void SmartScript::SortEvents(SmartAIEventList& events)
 {
     std::sort(events.begin(), events.end());
+}
+
+void SmartScript::RaisePriority(SmartScriptHolder& e)
+{
+    e.timer = 1;
+    // Change priority only if it's set to default, otherwise keep the current order of events
+    if (e.priority == SmartScriptHolder::DEFAULT_PRIORITY)
+    {
+        e.priority = mCurrentPriority++;
+        mEventSortingRequired = true;
+    }
 }
 
 void SmartScript::FillScript(SmartAIEventList e, WorldObject* obj, AreaTriggerEntry const* at)

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3500,12 +3500,6 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
 
         e.active = true;//activate events with cooldown
 
-        // Re-sort events if this was moved to the top of the queue
-        if (e.priority != SmartScriptHolder::DEFAULT_PRIORITY)
-            mEventSortingRequired = true;
-        // Reset priority to default one as we are executing the event
-        e.priority = SmartScriptHolder::DEFAULT_PRIORITY;
-
         switch (e.GetEventType())//process ONLY timed events
         {
             case SMART_EVENT_UPDATE:
@@ -3547,6 +3541,18 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
                 else
                     ProcessEvent(e);
                 break;
+            }
+        }
+
+        if (e.priority != SmartScriptHolder::DEFAULT_PRIORITY)
+        {
+            // Reset priority to default one only if the event hasn't been rescheduled again to next loop
+            if (e.timer > 1)
+            {
+                // Re-sort events if this was moved to the top of the queue
+                 mEventSortingRequired = true;
+                // Reset priority to default one
+                e.priority = SmartScriptHolder::DEFAULT_PRIORITY;
             }
         }
     }
@@ -3644,8 +3650,6 @@ void SmartScript::OnUpdate(uint32 const diff)
     if (mEventSortingRequired)
     {
         SortEvents(mEvents);
-        //SortEvents(mStoredEvents);
-        //SortEvents(mTimedActionList);
         mEventSortingRequired = false;
     }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3484,7 +3484,7 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
                 {
                     e.timer = 1;
                     // Change priority only if it's set to default, otherwise keep the current order of events
-                    if (e.priority == uint32(-1))
+                    if (e.priority == SmartScriptHolder::DEFAULT_PRIORITY)
                     {
                         e.priority = mCurrentPriority++;
                         mEventSortingRequired = true;
@@ -3507,10 +3507,10 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
         e.active = true;//activate events with cooldown
 
         // Re-sort events if this was moved to the top of the queue
-        if (e.priority != uint32(-1))
+        if (e.priority != SmartScriptHolder::DEFAULT_PRIORITY)
             mEventSortingRequired = true;
         // Reset priority to default one as we are executing the event
-        e.priority = uint32(-1);
+        e.priority = SmartScriptHolder::DEFAULT_PRIORITY;
 
         switch (e.GetEventType())//process ONLY timed events
         {
@@ -3649,9 +3649,9 @@ void SmartScript::OnUpdate(uint32 const diff)
 
     if (mEventSortingRequired)
     {
-        SortEventsByPriority(mEvents);
-        SortEventsByPriority(mStoredEvents);
-        SortEventsByPriority(mTimedActionList);
+        SortEvents(mEvents);
+        //SortEvents(mStoredEvents);
+        //SortEvents(mTimedActionList);
         mEventSortingRequired = false;
     }
 
@@ -3709,15 +3709,9 @@ void SmartScript::OnUpdate(uint32 const diff)
     }
 }
 
-void SmartScript::SortEventsByPriority(SmartAIEventList& events)
+void SmartScript::SortEvents(SmartAIEventList& events)
 {
-    std::stable_sort(events.begin(), events.end(), [](SmartScriptHolder const& lhs, SmartScriptHolder const& rhs)
-    {
-        if (lhs.priority == rhs.priority)
-            return lhs.event_id < rhs.event_id;
-        else
-            return lhs.priority < rhs.priority;
-    });
+    std::sort(events.begin(), events.end());
 }
 
 void SmartScript::FillScript(SmartAIEventList e, WorldObject* obj, AreaTriggerEntry const* at)

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -100,7 +100,7 @@ class TC_GAME_API SmartScript
         void SetPhase(uint32 p);
         bool IsInPhase(uint32 p) const;
 
-        void SortEventsByPriority(SmartAIEventList& events);
+        void SortEvents(SmartAIEventList& events);
 
         SmartAIEventList mEvents;
         SmartAIEventList mInstallEvents;

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -101,6 +101,7 @@ class TC_GAME_API SmartScript
         bool IsInPhase(uint32 p) const;
 
         void SortEvents(SmartAIEventList& events);
+        void RaisePriority(SmartScriptHolder& e);
 
         SmartAIEventList mEvents;
         SmartAIEventList mInstallEvents;

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -100,6 +100,8 @@ class TC_GAME_API SmartScript
         void SetPhase(uint32 p);
         bool IsInPhase(uint32 p) const;
 
+        void SortEventsByPriority(SmartAIEventList& events);
+
         SmartAIEventList mEvents;
         SmartAIEventList mInstallEvents;
         SmartAIEventList mTimedActionList;
@@ -122,6 +124,7 @@ class TC_GAME_API SmartScript
         uint32 mLastTextID;
         uint32 mTalkerEntry;
         bool mUseTextTimer;
+        uint32 mCurrentPriority;
 
         ObjectVectorMap _storedTargets;
 

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -125,6 +125,7 @@ class TC_GAME_API SmartScript
         uint32 mTalkerEntry;
         bool mUseTextTimer;
         uint32 mCurrentPriority;
+        bool mEventSortingRequired;
 
         ObjectVectorMap _storedTargets;
 

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1543,7 +1543,7 @@ enum SmartCastFlags
 struct SmartScriptHolder
 {
     SmartScriptHolder() : entryOrGuid(0), source_type(SMART_SCRIPT_TYPE_CREATURE)
-        , event_id(0), link(0), event(), action(), target(), timer(0), active(false), runOnce(false)
+        , event_id(0), link(0), event(), action(), target(), timer(0), priority(uint32(-1)), active(false), runOnce(false)
         , enableTimed(false) { }
 
     int32 entryOrGuid;
@@ -1561,6 +1561,7 @@ struct SmartScriptHolder
     uint32 GetTargetType() const { return (uint32)target.type; }
 
     uint32 timer;
+    uint32 priority;
     bool active;
     bool runOnce;
     bool enableTimed;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1543,7 +1543,7 @@ enum SmartCastFlags
 struct SmartScriptHolder
 {
     SmartScriptHolder() : entryOrGuid(0), source_type(SMART_SCRIPT_TYPE_CREATURE)
-        , event_id(0), link(0), event(), action(), target(), timer(0), priority(uint32(-1)), active(false), runOnce(false)
+        , event_id(0), link(0), event(), action(), target(), timer(0), priority(DEFAULT_PRIORITY), active(false), runOnce(false)
         , enableTimed(false) { }
 
     int32 entryOrGuid;
@@ -1567,6 +1567,13 @@ struct SmartScriptHolder
     bool enableTimed;
 
     operator bool() const { return entryOrGuid != 0; }
+    // Default comparision operator using priority field as first ordering field
+    bool operator<(SmartScriptHolder const& other) const
+    {
+        return std::tie(priority, entryOrGuid, source_type, event_id, link) < std::tie(other.priority, other.entryOrGuid, other.source_type, other.event_id, other.link);
+    }
+
+    static constexpr uint32 DEFAULT_PRIORITY = std::numeric_limits<uint32>::max();
 };
 
 typedef std::vector<WorldObject*> ObjectVector;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Core/SAI: Spell casts that cannot be executed because the unit is currently casting another spell will be retried asap with priority over other events

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Ref #24914


**Tests performed:**
None

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Debug it and test it
- [x] Maybe use a bool to flag that the events need to be sorted again so stable_sort is called only when needed

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
