### PR TITLE
Core/ChatCommands: Add support for enum type arguments

### DIFF
--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -665,6 +665,15 @@ bool StringToBool(std::string const& str)
     return lowerStr == "1" || lowerStr == "true" || lowerStr == "yes";
 }
 
+bool StringEqualI(std::string const& str1, std::string const& str2)
+{
+    return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(),
+                      [](char a, char b)
+                      {
+                          return std::tolower(a) == std::tolower(b);
+                      });
+}
+
 bool StringContainsStringI(std::string const& haystack, std::string const& needle)
 {
     return haystack.end() !=

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -469,6 +469,11 @@ void wstrToUpper(std::wstring& str)
     std::transform(str.begin(), str.end(), str.begin(), wcharToUpper);
 }
 
+void strToLower(std::string& str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), [](char c) { return std::tolower(c); });
+}
+
 void wstrToLower(std::wstring& str)
 {
     std::transform(str.begin(), str.end(), str.begin(), wcharToLower);
@@ -672,6 +677,11 @@ bool StringEqualI(std::string const& str1, std::string const& str2)
                       {
                           return std::tolower(a) == std::tolower(b);
                       });
+}
+
+bool StringStartsWith(std::string const& needle, std::string const& haystack)
+{
+    return (haystack.rfind(needle, 0) == 0);
 }
 
 bool StringContainsStringI(std::string const& haystack, std::string const& needle)

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -679,7 +679,7 @@ bool StringEqualI(std::string const& str1, std::string const& str2)
                       });
 }
 
-bool StringStartsWith(std::string const& needle, std::string const& haystack)
+bool StringStartsWith(std::string const& haystack, std::string const& needle)
 {
     return (haystack.rfind(needle, 0) == 0);
 }

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -341,6 +341,7 @@ inline std::vector<uint8> HexStrToByteVector(std::string const& str, bool revers
 
 TC_COMMON_API bool StringToBool(std::string const& str);
 
+TC_COMMON_API bool StringEqualI(std::string const& str1, std::string const& str2);
 TC_COMMON_API bool StringContainsStringI(std::string const& haystack, std::string const& needle);
 template <typename T>
 inline bool ValueContainsStringI(std::pair<T, std::string> const& haystack, std::string const& needle)

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -343,7 +343,7 @@ inline std::vector<uint8> HexStrToByteVector(std::string const& str, bool revers
 TC_COMMON_API bool StringToBool(std::string const& str);
 
 TC_COMMON_API bool StringEqualI(std::string const& str1, std::string const& str2);
-TC_COMMON_API bool StringStartsWith(std::string const& needle, std::string const& haystack);
+TC_COMMON_API bool StringStartsWith(std::string const& haystack, std::string const& needle);
 TC_COMMON_API bool StringContainsStringI(std::string const& haystack, std::string const& needle);
 template <typename T>
 inline bool ValueContainsStringI(std::pair<T, std::string> const& haystack, std::string const& needle)

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -289,6 +289,7 @@ inline wchar_t wcharToLower(wchar_t wchar)
 }
 
 TC_COMMON_API void wstrToUpper(std::wstring& str);
+TC_COMMON_API void strToLower(std::string& str);
 TC_COMMON_API void wstrToLower(std::wstring& str);
 
 TC_COMMON_API std::wstring GetMainPartOfName(std::wstring const& wname, uint32 declension);
@@ -342,6 +343,7 @@ inline std::vector<uint8> HexStrToByteVector(std::string const& str, bool revers
 TC_COMMON_API bool StringToBool(std::string const& str);
 
 TC_COMMON_API bool StringEqualI(std::string const& str1, std::string const& str2);
+TC_COMMON_API bool StringStartsWith(std::string const& needle, std::string const& haystack);
 TC_COMMON_API bool StringContainsStringI(std::string const& haystack, std::string const& needle);
 template <typename T>
 inline bool ValueContainsStringI(std::pair<T, std::string> const& haystack, std::string const& needle)

--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -99,6 +99,24 @@ struct ArgInfo<std::string, void>
     }
 };
 
+// enum
+template <typename T>
+struct ArgInfo<T, std::enable_if_t<std::is_enum_v<T>>>
+{
+    typedef typename std::underlying_type<T>::type uType;
+
+    static char const* TryConsume(T& val, char const* args)
+    {
+        uType uVal = 0;
+
+        char const* retVal = ArgInfo<uType>::TryConsume(uVal, args);
+        if (retVal)
+            val = static_cast<T>(uVal);
+
+        return retVal;
+    }
+};
+
 // a container tag
 template <typename T>
 struct ArgInfo<T, std::enable_if_t<std::is_base_of_v<ContainerTag, T>>>

--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -116,7 +116,7 @@ struct ArgInfo<T, std::enable_if_t<std::is_enum_v<T>>>
 
         auto itr = std::find_if(EnumUtils::Begin<T>(), EnumUtils::End<T>(), [strVal](T val)
         {
-            return EnumUtils::ToConstant(val) == strVal;
+            return StringEqualI(EnumUtils::ToConstant(val), strVal);
         });
 
         if (itr != EnumUtils::End<T>())

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -533,13 +533,8 @@ public:
     }
 
     //set npcflag of creature
-    static bool HandleNpcSetFlagCommand(ChatHandler* handler, char const* args)
+    static bool HandleNpcSetFlagCommand(ChatHandler* handler, NPCFlags npcFlags)
     {
-        if (!*args)
-            return false;
-
-        uint32 npcFlags = (uint32) atoi(args);
-
         Creature* creature = handler->getSelectedCreature();
 
         if (!creature)


### PR DESCRIPTION

**Changes proposed:**

-  Core/ChatCommands: Add support for enum type arguments

This allows for chat handler signatures like
```c++
static bool HandleDebugAnimCommand(ChatHandler* handler, Emote emote)
```


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

