### PR TITLE
Fix for LUA_STR_CHECK

### DIFF
--- a/src/server/game/Warden/WardenWin.cpp
+++ b/src/server/game/Warden/WardenWin.cpp
@@ -105,7 +105,7 @@ void WardenWin::InitializeModule()
     Request.String_library2 = 0;
     Request.Function2 = 0x00419D40;                         // 0x00400000 + 0x00419D40 FrameScript::GetText
     Request.Function2_set = 1;
-    Request.CheckSumm2 = BuildChecksum(&Request.Unk2, 8);
+    Request.CheckSumm2 = BuildChecksum(&Request.Unk3, 8);
 
     Request.Command3 = WARDEN_SMSG_MODULE_INITIALIZE;
     Request.Size3 = 8;
@@ -420,18 +420,17 @@ void WardenWin::HandleCheckResult(ByteBuffer &buff)
 
                 if (Lua_Result != 0)
                 {
-                    TC_LOG_DEBUG("warden", "RESULT LUA_STR_CHECK fail, CheckId %u account Id %u", id, _session->GetAccountId());
-                    checkFailed = id;
-                    continue;
-                }
-
-                uint8 luaStrLen = buff.read<uint8>();
-                if (luaStrLen != 0)
-                {
-                    std::string str;
-                    str.resize(luaStrLen);
-                    buff.read(reinterpret_cast<uint8*>(str.data()), luaStrLen);
-                    TC_LOG_DEBUG("warden", "Lua string: %s", str.c_str());
+                    uint8 luaStrLen = buff.read<uint8>();
+                    if (luaStrLen != 0)
+                    {
+                        std::string str;
+                        str.resize(luaStrLen);
+                        buff.read(reinterpret_cast<uint8*>(str.data()), luaStrLen);
+                        TC_LOG_DEBUG("warden", "Lua string: %s", str.c_str());
+                        TC_LOG_DEBUG("warden", "RESULT LUA_STR_CHECK fail, CheckId %u account Id %u", id, _session->GetAccountId());
+                        checkFailed = id;
+                        continue;
+                    }
                 }
                 TC_LOG_DEBUG("warden", "RESULT LUA_STR_CHECK passed, CheckId %u account Id %u", id, _session->GetAccountId());
                 break;


### PR DESCRIPTION
The check above is what I use to actually get a real result for LUA_STR_CHECK, which when I used variables that would have a string to them it actually fails the check. When checking for items like a function if it exists of course it won't work... In addition, fixing the Unk2 to Unk3 causes people to be able to adjust the address of the check to the address 0x00419210 to make warden perform the FrameScript__Execute to run lua on the client. This seems to be the big request like in https://github.com/TrinityCore/TrinityCore/issues/23035

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix the real issue with the wrong value passed to the BuildChecksum for the function2 warden check
-  Adjusted the check return for how I was testing on my server, since it's literally checking for a string value I assumed the warden check was to fail if there is an actual string value. Of course it won't pass for things like functions, and what not, but it will return a string value if the item has one.
-  

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)
https://github.com/TrinityCore/TrinityCore/issues/23035

**Tests performed:**

(Does it build, tested in-game, etc.)
Tested in game with warden check 139, the str I initially had was ABCDEFG, which when nil or as a function passed the check, but when I did /script ABCDEFG = "word" the LUA_STR_CHECK failed as it was now a string. 

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
