### PR TITLE
Core/ChatCommands: Honor exact matches during enum arg parsing

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -142,7 +142,7 @@ struct ArgInfo<T, std::enable_if_t<std::is_enum_v<T>>>
         if (it == SearchMap.end() || !StringStartsWith(it->first, s)) // not a match
             return nullptr;
 
-        if (it->first != s) // we don't have an exact match. Continue looking for matching values
+        if (it->first != s) // we don't have an exact match - check if it is unique
         {
             auto it2 = it;
             ++it2;

--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -142,10 +142,13 @@ struct ArgInfo<T, std::enable_if_t<std::is_enum_v<T>>>
         if (it == SearchMap.end() || !StringStartsWith(it->first, s)) // not a match
             return nullptr;
 
-        auto it2 = it;
-        ++it2;
-        if (it2 != SearchMap.end() && StringStartsWith(it2->first, s)) // not unique
-            return nullptr;
+        if (it->first != s) // we don't have an exact match. Continue looking for matching values
+        {
+            auto it2 = it;
+            ++it2;
+            if (it2 != SearchMap.end() && StringStartsWith(it2->first, s)) // not unique
+                return nullptr;
+        }
 
         if (it->second)
             return &*it->second;


### PR DESCRIPTION

**Changes proposed:**

- Core/ChatCommands: Honor exact matches during enum arg parsing
Considering an enum with values EMOTE_ONESHOT_TALK and EMOTE_ONESHOT_TALK_NO_SHEATHE
matching an argument with value "EMOTE_ONESHOT_TALK" did not lead to unique results.
Skip the substring search when we have an exact match.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:**

build + in-game