### PR TITLE
Core/ChatCommands: Check if integral/floating point type arguments we…

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -51,7 +51,13 @@ struct ArgInfo<T, std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>>
     {
         char const* next = args;
         std::string token(args, tokenize(next));
-        try { val = std::stoll(token); }
+        try
+        {
+            size_t processedChars = 0;
+            val = std::stoll(token, &processedChars);
+            if (processedChars != token.length())
+                return nullptr;
+        }
         catch (...) { return nullptr; }
         return next;
     }
@@ -65,7 +71,13 @@ struct ArgInfo<T, std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T
     {
         char const* next = args;
         std::string token(args, tokenize(next));
-        try { val = std::stoull(token); }
+        try
+        {
+            size_t processedChars = 0;
+            val = std::stoull(token, &processedChars);
+            if (processedChars != token.length())
+                return nullptr;
+        }
         catch (...) { return nullptr; }
         return next;
     }
@@ -79,7 +91,13 @@ struct ArgInfo<T, std::enable_if_t<std::is_floating_point_v<T>>>
     {
         char const* next = args;
         std::string token(args, tokenize(next));
-        try { val = std::stold(token); }
+        try
+        {
+            size_t processedChars = 0;
+            val = std::stold(token, &processedChars);
+            if (processedChars != token.length())
+                return nullptr;
+        }
         catch (...) { return nullptr; }
         return std::isfinite(val) ? next : nullptr;
     }

--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -54,7 +54,7 @@ struct ArgInfo<T, std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>>
         try
         {
             size_t processedChars = 0;
-            val = std::stoll(token, &processedChars);
+            val = std::stoll(token, &processedChars, 0);
             if (processedChars != token.length())
                 return nullptr;
         }
@@ -74,7 +74,7 @@ struct ArgInfo<T, std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T
         try
         {
             size_t processedChars = 0;
-            val = std::stoull(token, &processedChars);
+            val = std::stoull(token, &processedChars, 0);
             if (processedChars != token.length())
                 return nullptr;
         }


### PR DESCRIPTION
**Changes proposed:**

-  Core/ChatCommands: Check if integral/floating point type arguments were parsed successfully

`std::stoull` will happily parse floating point strings until the decimal separator and return the value.
Make sure for all parsing methods that we actually parsed the whole token.

This allows to use handler arguments like `Variant<uint32, float>` which will be populated with the right type
depending on the token value (e.g `10` vs `10.0`).

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:**

build + in-game
Consumer code not PR'd yet. Possible usage: https://github.com/TrinityCore/TrinityCore/blob/ca25e8d0199730c0976ebc37317e9407aceccc34/src/server/scripts/Commands/cs_debug.cpp#L1305