### PR TITLE
Core/ChatCommands: Add support for std::array-type arguments

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommand.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommand.h
@@ -86,6 +86,23 @@ struct CommandArgsConsumerSingle<std::vector<T>>
     }
 };
 
+template <typename T, std::size_t C>
+struct CommandArgsConsumerSingle<std::array<T, C>>
+{
+    static char const* TryConsumeTo(std::array<T, C>& val, char const* args)
+    {
+        for (T& t : val)
+        {
+            args = CommandArgsConsumerSingle<T>::TryConsumeTo(t, args);
+
+            if (!args)
+                return nullptr;
+        }
+
+        return args;
+    }
+};
+
 template <>
 struct CommandArgsConsumerSingle<CommandArgs*>
 {


### PR DESCRIPTION
**Changes proposed:**

-  Core/ChatCommands: Add support for std::array-type arguments

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:**

build + in-game