### PR TITLE
Core/ChatCommands: Add Variant.get<typename> overload

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandTags.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandTags.h
@@ -156,14 +156,16 @@ namespace Trinity::ChatCommands
         Variant& operator=(T&& arg) { base::operator=(std::forward<T>(arg)); return *this; }
 
         template <size_t index>
-        constexpr decltype(auto) get() { return std::get<index>(static_cast<base const&>(*this)); }
+        constexpr decltype(auto) get() { return std::get<index>(static_cast<base&>(*this)); }
         template <size_t index>
         constexpr decltype(auto) get() const { return std::get<index>(static_cast<base const&>(*this)); }
         template <typename type>
-        constexpr decltype(auto) get() { return std::get<type>(static_cast<base const&>(*this)); }
+        constexpr decltype(auto) get() { return std::get<type>(static_cast<base&>(*this)); }
         template <typename type>
         constexpr decltype(auto) get() const { return std::get<type>(static_cast<base const&>(*this)); }
 
+        template <typename T>
+        constexpr decltype(auto) visit(T&& arg) const { return std::visit(std::forward<T>(arg), static_cast<base&>(*this)); }
         template <typename T>
         constexpr decltype(auto) visit(T&& arg) const { return std::visit(std::forward<T>(arg), static_cast<base const&>(*this)); }
 

--- a/src/server/game/Chat/ChatCommands/ChatCommandTags.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandTags.h
@@ -159,6 +159,10 @@ namespace Trinity::ChatCommands
         constexpr decltype(auto) get() { return std::get<index>(static_cast<base const&>(*this)); }
         template <size_t index>
         constexpr decltype(auto) get() const { return std::get<index>(static_cast<base const&>(*this)); }
+        template <typename type>
+        constexpr decltype(auto) get() { return std::get<type>(static_cast<base const&>(*this)); }
+        template <typename type>
+        constexpr decltype(auto) get() const { return std::get<type>(static_cast<base const&>(*this)); }
 
         template <typename T>
         constexpr decltype(auto) visit(T&& arg) const { return std::visit(std::forward<T>(arg), static_cast<base const&>(*this)); }

--- a/src/server/game/Chat/ChatCommands/ChatCommandTags.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandTags.h
@@ -165,7 +165,7 @@ namespace Trinity::ChatCommands
         constexpr decltype(auto) get() const { return std::get<type>(static_cast<base const&>(*this)); }
 
         template <typename T>
-        constexpr decltype(auto) visit(T&& arg) const { return std::visit(std::forward<T>(arg), static_cast<base&>(*this)); }
+        constexpr decltype(auto) visit(T&& arg) { return std::visit(std::forward<T>(arg), static_cast<base&>(*this)); }
         template <typename T>
         constexpr decltype(auto) visit(T&& arg) const { return std::visit(std::forward<T>(arg), static_cast<base const&>(*this)); }
 


### PR DESCRIPTION
**Changes proposed:**

-  Core/ChatCommands: Add `Variant.get<typename>` overload

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master