### PR TITLE
Core/ChatCommands: Parse SpellInfo also from enchant, glyph, talent and trade links

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.cpp
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.cpp
@@ -54,12 +54,20 @@ char const* Trinity::ChatCommands::ArgInfo<GameTele const*>::TryConsume(GameTele
 struct SpellInfoVisitor
 {
     using value_type = SpellInfo const*;
+    value_type operator()(Hyperlink<enchant> enchant) const { return enchant; };
+    value_type operator()(Hyperlink<glyph> glyph) const { return operator()(glyph->Glyph->SpellID); };
     value_type operator()(Hyperlink<spell> spell) const { return *spell; }
+    value_type operator()(Hyperlink<talent> talent) const
+    {
+        return operator()(talent->Talent->SpellRank[talent->Rank - 1]);
+    };
+    value_type operator()(Hyperlink<trade> trade) const { return trade->Spell; };
+
     value_type operator()(uint32 spellId) const { return sSpellMgr->GetSpellInfo(spellId); }
 };
 char const* Trinity::ChatCommands::ArgInfo<SpellInfo const*>::TryConsume(SpellInfo const*& data, char const* args)
 {
-    Variant<Hyperlink<spell>, uint32> val;
+    Variant<Hyperlink<enchant>, Hyperlink<glyph>, Hyperlink<spell>, Hyperlink<talent>, Hyperlink<trade>, uint32> val;
     if ((args = CommandArgsConsumerSingle<decltype(val)>::TryConsumeTo(val, args)))
         data = val.visit(SpellInfoVisitor());
     return args;

--- a/src/server/game/Chat/HyperlinkTags.cpp
+++ b/src/server/game/Chat/HyperlinkTags.cpp
@@ -125,7 +125,7 @@ bool Trinity::Hyperlinks::LinkTags::talent::StoreTo(TalentLinkData& val, char co
     int8 rank; // talent links contain <learned rank>-1, we store <learned rank>
     if (!(t.TryConsumeTo(talentId) && t.TryConsumeTo(rank) && t.IsEmpty()))
         return false;
-    if (rank < -1 || rank > 4)
+    if (rank < -1 || rank >= MAX_TALENT_RANK)
         return false;
     val.Rank = rank+1;
     if (!(val.Talent = sTalentStore.LookupEntry(talentId)))


### PR DESCRIPTION
**Changes proposed:**

-  Core/ChatCommands: Parse SpellInfo also from enchant, glyph, talent and trade links
Now we have a feature complete replacement for `ChatHandler::extractSpellIdFromLink`

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:**

build + tested various links with `.cast`