### PR TITLE
Tweaks to detect PQR for example

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -221,6 +221,18 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
     if (msg.size() > 255)
         return;
 
+    // Handle the warden SendAddonMessage here
+    if (lang == LANG_ADDON)
+    {
+        if (to == sender->GetName())
+        {
+            if (msg.find("Warden") != std::string::npos)
+            {
+                TC_LOG_INFO("addon", "[%d] %s: %s", sender->GetSession()->GetAccountId(), sender->GetName().c_str(), msg.c_str());
+                return;
+            }
+        }
+    }
 
     // no chat commands in AFK/DND autoreply, and it can be empty
     if (!(type == CHAT_MSG_AFK || type == CHAT_MSG_DND))

--- a/src/server/game/Warden/WardenCheckMgr.cpp
+++ b/src/server/game/Warden/WardenCheckMgr.cpp
@@ -93,6 +93,8 @@ void WardenCheckMgr::LoadWardenChecks()
 
         if (type == MEM_CHECK || type == MODULE_CHECK)
             MemChecksIdPool.push_back(id);
+        else if (type == LUA_STR_CHECK)
+            StrChecksIdPool.push_back(id);
         else
             OtherChecksIdPool.push_back(id);
 

--- a/src/server/game/Warden/WardenCheckMgr.h
+++ b/src/server/game/Warden/WardenCheckMgr.h
@@ -72,6 +72,7 @@ class TC_GAME_API WardenCheckMgr
 
         std::vector<uint16> const& GetAvailableMemoryChecks() const { return MemChecksIdPool; }
         std::vector<uint16> const& GetAvailableOtherChecks() const { return OtherChecksIdPool; }
+        std::vector<uint16> const& GetAvailableStrChecks() const { return StrChecksIdPool; }
 
         void LoadWardenChecks();
         void LoadWardenOverrides();
@@ -81,6 +82,7 @@ class TC_GAME_API WardenCheckMgr
         std::unordered_map<uint32, WardenCheckResult> CheckResultStore;
         std::vector<uint16> MemChecksIdPool;
         std::vector<uint16> OtherChecksIdPool;
+        std::vector<uint16> StrChecksIdPool;
 };
 
 #define sWardenCheckMgr WardenCheckMgr::instance()

--- a/src/server/game/Warden/WardenWin.h
+++ b/src/server/game/Warden/WardenWin.h
@@ -81,6 +81,8 @@ class TC_GAME_API WardenWin : public Warden
         std::vector<uint16>::const_iterator _memChecksIt;
         std::vector<uint16> _otherChecks;
         std::vector<uint16>::const_iterator _otherChecksIt;
+        std::vector<uint16> _strChecks;
+        std::vector<uint16>::const_iterator _strChecksIt;
         std::vector<uint16> _currentChecks;
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Change LUA_STR_SEARCH to be FrameScript__Execute instead of FrameScript__GetText
-  Modify the checks to send 1 of the lua commands per warden check (otherwise it may be a long time till it's called again)
-  Modify the chat handler to log if the sender is the recipient and the message contains Warden

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)
https://github.com/TrinityCore/TrinityCore/issues/23035

**Tests performed:**

(Does it build, tested in-game, etc.)
It builds. The check I used was:
Check ID 139 with the str being:
"if CastSpellByID and not CSBID_H then hooksecurefunc('CastSpellByID', function() if debugstack():find('PQR') then SendAddonMessage("Warden", "PQR Found", "WHISPER", UnitName("player")) end end) CSBID_H = true end"

The reason I decided to do hooksecurefunc and check the debugstack is because CastSpellByID/CastSpellByName should never come from a call outside of the Interface\AddOn call path and wouldn't include PQR in the debugstack

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
