### PR TITLE
Core/Player: Allow use larger statistics on items

### DIFF
--- a/sql/updates/world/3.3.5/2020_08_21_01_world_335.sql
+++ b/sql/updates/world/3.3.5/2020_08_21_01_world_335.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `item_template`
+	CHANGE COLUMN `stat_value1` `stat_value1` INT NOT NULL DEFAULT 0 AFTER `stat_type1`,
+	CHANGE COLUMN `stat_value2` `stat_value2` INT NOT NULL DEFAULT 0 AFTER `stat_type2`,
+	CHANGE COLUMN `stat_value3` `stat_value3` INT NOT NULL DEFAULT 0 AFTER `stat_type3`,
+	CHANGE COLUMN `stat_value4` `stat_value4` INT NOT NULL DEFAULT 0 AFTER `stat_type4`,
+	CHANGE COLUMN `stat_value5` `stat_value5` INT NOT NULL DEFAULT 0 AFTER `stat_type5`,
+	CHANGE COLUMN `stat_value6` `stat_value6` INT NOT NULL DEFAULT 0 AFTER `stat_type6`,
+	CHANGE COLUMN `stat_value7` `stat_value7` INT NOT NULL DEFAULT 0 AFTER `stat_type7`,
+	CHANGE COLUMN `stat_value8` `stat_value8` INT NOT NULL DEFAULT 0 AFTER `stat_type8`,
+	CHANGE COLUMN `stat_value9` `stat_value9` INT NOT NULL DEFAULT 0 AFTER `stat_type9`,
+	CHANGE COLUMN `stat_value10` `stat_value10` INT NOT NULL DEFAULT 0 AFTER `stat_type10`;

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2887,7 +2887,7 @@ void ObjectMgr::LoadItemTemplates()
         for (uint8 i = 0; i < itemTemplate.StatsCount; ++i)
         {
             itemTemplate.ItemStat[i].ItemStatType  = uint32(fields[28 + i*2].GetUInt8());
-            itemTemplate.ItemStat[i].ItemStatValue = int32(fields[29 + i*2].GetInt16());
+            itemTemplate.ItemStat[i].ItemStatValue = int32(fields[29 + i*2].GetInt32());
         }
 
         itemTemplate.ScalingStatDistribution = uint32(fields[48].GetUInt16());


### PR DESCRIPTION
**Changes proposed:**

-  I think players should be able to use items with larger statistics without core edits.

**Target branch(es):**

* [x]   3.3.5


**Tests performed:**

Builds, tested ingame