### PR TITLE
Core/ChatCommands: Do not try to consume integral types if the token is empty

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -55,6 +55,9 @@ struct ArgInfo<T, std::enable_if_t<std::is_integral_v<T>>>
         char const* next = args;
         std::string_view token(args, Trinity::Impl::ChatCommands::tokenize(next));
 
+        if (!token.length())
+            return nullptr;
+
         std::from_chars_result result;
         if (StringStartsWith(token, "0x"))
             result = std::from_chars(token.data() + 2, token.data() + token.length(), val, 16);


### PR DESCRIPTION

The `if ((token.data() + token.length()) != result.ptr)` check does not trigger
in this case.

**Changes proposed:**

-  Core/ChatCommands: Do not try to consume integral types if the token is empty


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

Thanks @jackpoz for noticing this issue.
