### PR TITLE
Core/Totem: Immune to all positive spells.

### DIFF
--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -159,8 +159,8 @@ bool Totem::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index, Wor
 {
     // immune to all positive spells, except of stoneclaw totem absorb and sentry totem bind sight
     // totems positive spells have unit_caster target
-    if (spellInfo->Effects[index].Effect != SPELL_EFFECT_DUMMY && 
-        spellInfo->Effects[index].Effect != SPELL_EFFECT_SCRIPT_EFFECT && 
+    if (spellInfo->Effects[index].Effect != SPELL_EFFECT_DUMMY &&
+        spellInfo->Effects[index].Effect != SPELL_EFFECT_SCRIPT_EFFECT &&
         spellInfo->IsPositive() && spellInfo->Effects[index].TargetA.GetTarget() != TARGET_UNIT_CASTER &&
         spellInfo->Effects[index].TargetA.GetCheckType() != TARGET_CHECK_ENTRY && spellInfo->Id != SENTRY_STONECLAW_SPELLID && spellInfo->Id != SENTRY_BIND_SIGHT_SPELLID)
         return true;

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -162,7 +162,7 @@ bool Totem::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index, Wor
     if (spellInfo->Effects[index].Effect != SPELL_EFFECT_DUMMY && 
         spellInfo->Effects[index].Effect != SPELL_EFFECT_SCRIPT_EFFECT && 
         spellInfo->IsPositive() && spellInfo->Effects[index].TargetA.GetTarget() != TARGET_UNIT_CASTER &&
-        spellInfo->Effects[index].TargetA.GetCheckType() != TARGET_CHECK_ENTRY && spellInfo->Id != 55277 && spellInfo->Id != 6277)
+        spellInfo->Effects[index].TargetA.GetCheckType() != TARGET_CHECK_ENTRY && spellInfo->Id != SENTRY_STONECLAW_SPELLID && spellInfo->Id != SENTRY_BIND_SIGHT_SPELLID)
         return true;
 
     switch (spellInfo->Effects[index].ApplyAuraName)

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -158,7 +158,7 @@ void Totem::UnSummon(uint32 msTime)
 bool Totem::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index, WorldObject const* caster) const
 {
     // immune to all positive spells, except of stoneclaw totem absorb and sentry totem bind sight
-	// totems positive spells have unit_caster target
+    // totems positive spells have unit_caster target
     if (spellInfo->Effects[index].Effect != SPELL_EFFECT_DUMMY && 
         spellInfo->Effects[index].Effect != SPELL_EFFECT_SCRIPT_EFFECT && 
         spellInfo->IsPositive() && spellInfo->Effects[index].TargetA.GetTarget() != TARGET_UNIT_CASTER &&

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -157,9 +157,13 @@ void Totem::UnSummon(uint32 msTime)
 
 bool Totem::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index, WorldObject const* caster) const
 {
-    /// @todo possibly all negative auras immune?
-    if (GetEntry() == 5925)
-        return false;
+    // immune to all positive spells, except of stoneclaw totem absorb and sentry totem bind sight
+	// totems positive spells have unit_caster target
+    if (spellInfo->Effects[index].Effect != SPELL_EFFECT_DUMMY && 
+        spellInfo->Effects[index].Effect != SPELL_EFFECT_SCRIPT_EFFECT && 
+        spellInfo->IsPositive() && spellInfo->Effects[index].TargetA.GetTarget() != TARGET_UNIT_CASTER &&
+        spellInfo->Effects[index].TargetA.GetCheckType() != TARGET_CHECK_ENTRY && spellInfo->Id != 55277 && spellInfo->Id != 6277)
+        return true;
 
     switch (spellInfo->Effects[index].ApplyAuraName)
     {

--- a/src/server/game/Entities/Totem/Totem.h
+++ b/src/server/game/Entities/Totem/Totem.h
@@ -31,6 +31,10 @@ enum TotemType
 
 #define SENTRY_TOTEM_ENTRY    3968
 
+// Totems spells
+#define SENTRY_STONECLAW_SPELLID  55277
+#define SENTRY_BIND_SIGHT_SPELLID  6277
+
 class TC_GAME_API Totem : public Minion
 {
     public:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Immune to all positive spells, except of stoneclaw totem absorb and sentry totem bind sight
- Totems positive spells have unit_caster target

**Target branch(es):** 3.3.5/master

- [√ ] 3.3.5

**Tests performed:**

Does it build, tested in-game, etc.

**Tests:**
[Look video](https://youtu.be/qw6ySrBLgho)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
