### PR TITLE
StringConvert.h

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -11,6 +11,28 @@ else()
   message(STATUS "Clang: Minimum version required is ${CLANG_EXPECTED_VERSION}, found ${CMAKE_CXX_COMPILER_VERSION} - ok!")
 endif()
 
+include(CheckCXXSourceCompiles)
+
+check_cxx_source_compiles("
+#include <charconv>
+#include <cstdint>
+
+int main()
+{
+    uint64_t n;
+    char const c[] = \"0\";
+    std::from_chars(c, c+1, n);
+    return static_cast<int>(n);
+}
+" CLANG_HAVE_PROPER_CHARCONV)
+
+if (NOT CLANG_HAVE_PROPER_CHARCONV)
+  message(STATUS "Clang: Detected from_chars bug for 64-bit integers, workaround enabled")
+  target_compile_definitions(trinity-compile-option-interface
+  INTERFACE
+    -DTRINITY_NEED_CHARCONV_WORKAROUND)
+endif()
+
 if(WITH_WARNINGS)
   target_compile_options(trinity-warning-interface
     INTERFACE

--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -11,6 +11,9 @@ else()
   message(STATUS "Clang: Minimum version required is ${CLANG_EXPECTED_VERSION}, found ${CMAKE_CXX_COMPILER_VERSION} - ok!")
 endif()
 
+# This tests for a bug in clang-7 that causes linkage to fail for 64-bit from_chars (in some configurations)
+# If the clang requirement is bumped to >= clang-8, you can remove this check, as well as
+# the associated ifdef block in src/common/Utilities/StringConvert.h
 include(CheckCXXSourceCompiles)
 
 check_cxx_source_compiles("

--- a/src/common/Configuration/Config.cpp
+++ b/src/common/Configuration/Config.cpp
@@ -17,6 +17,7 @@
 
 #include "Config.h"
 #include "Log.h"
+#include "StringConvert.h"
 #include "Util.h"
 #include <boost/property_tree/ini_parser.hpp>
 #include <algorithm>
@@ -137,7 +138,15 @@ bool ConfigMgr::GetBoolDefault(std::string const& name, bool def, bool quiet) co
 {
     std::string val = GetValueDefault(name, std::string(def ? "1" : "0"), quiet);
     val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
-    return StringToBool(val);
+    Optional<bool> boolVal = Trinity::StringTo<bool>(val);
+    if (boolVal)
+        return *boolVal;
+    else
+    {
+        TC_LOG_ERROR("server.loading", "Bad value defined for name %s in config file %s, going to use '%s' instead",
+            name.c_str(), _filename.c_str(), def ? "true" : "false");
+        return def;
+    }
 }
 
 int ConfigMgr::GetIntDefault(std::string const& name, int def, bool quiet) const

--- a/src/common/Utilities/StringConvert.h
+++ b/src/common/Utilities/StringConvert.h
@@ -31,7 +31,7 @@ namespace Trinity::Impl::StringConvertImpl
 {
     template <typename T, typename = void> struct For
     {
-        static_assert(!std::is_same_v<T,T>, "Unsupported type used for ToString or StringTo");
+        static_assert(Trinity::dependant_false_v<T>, "Unsupported type used for ToString or StringTo");
         /*
         static Optional<T> FromString(std::string_view str, ...);
         static std::string ToString(T&& val, ...);
@@ -76,7 +76,7 @@ namespace Trinity::Impl::StringConvertImpl
 
         static std::string ToString(T val)
         {
-            std::string buf(20,0); /* 2^64 is 20 decimal characters, -(2^63) is 20 including the sign */
+            std::string buf(20,'\0'); /* 2^64 is 20 decimal characters, -(2^63) is 20 including the sign */
             char* const start = buf.data();
             char* const end = (start + buf.length());
             std::to_chars_result const res = std::to_chars(start, end, val);

--- a/src/common/Utilities/StringConvert.h
+++ b/src/common/Utilities/StringConvert.h
@@ -92,6 +92,13 @@ namespace Trinity::Impl::StringConvertImpl
     };
 
 #ifdef TRINITY_NEED_CHARCONV_WORKAROUND
+    /*
+        If this is defined, std::from_chars will cause linkage errors for 64-bit types.
+        (This is a bug in clang-7.)
+
+        If the clang requirement is bumped to >= clang-8, remove this ifdef block and its
+        associated check in cmake/compiler/clang/settings.cmake
+    */
     template <>
     struct For<uint64, void>
     {

--- a/src/common/Utilities/StringConvert.h
+++ b/src/common/Utilities/StringConvert.h
@@ -31,7 +31,7 @@ namespace Trinity::Impl::StringConvertImpl
 {
     template <typename T, typename = void> struct For
     {
-        static_assert("Unsupported type used for ToString or StringTo");
+        static_assert(!std::is_same_v<T,T>, "Unsupported type used for ToString or StringTo");
         /*
         static Optional<T> FromString(std::string_view str, ...);
         static std::string ToString(T&& val, ...);
@@ -56,11 +56,6 @@ namespace Trinity::Impl::StringConvertImpl
                     base = 2;
                     str.remove_prefix(2);
                 }
-                else if (str.substr(0, 1) == "0")
-                {
-                    base = 8;
-                    str.remove_prefix(1);
-                }
                 else
                     base = 10;
 
@@ -81,7 +76,7 @@ namespace Trinity::Impl::StringConvertImpl
 
         static std::string ToString(T val)
         {
-            std::string buf(20,0); /* largest unsigned 64-bit value is 20 decimal characters, largest signed 64-bit value is 19 */
+            std::string buf(20,0); /* 2^64 is 20 decimal characters, -(2^63) is 20 including the sign */
             char* const start = buf.data();
             char* const end = (start + buf.length());
             std::to_chars_result const res = std::to_chars(start, end, val);
@@ -169,10 +164,16 @@ namespace Trinity::Impl::StringConvertImpl
 namespace Trinity
 {
     template <typename Result, typename... Params>
-    Optional<Result> StringTo(std::string_view str, Params&&... params) { return Trinity::Impl::StringConvertImpl::For<Result>::FromString(str, std::forward<Params>(params)...); }
+    Optional<Result> StringTo(std::string_view str, Params&&... params)
+    {
+        return Trinity::Impl::StringConvertImpl::For<Result>::FromString(str, std::forward<Params>(params)...);
+    }
 
     template <typename Type, typename... Params>
-    std::string ToString(Type&& val, Params&&... params) { return Trinity::Impl::StringConvertImpl::For<std::decay_t<Type>>::ToString(std::forward<Type>(val), std::forward<Params>(params)...); }
+    std::string ToString(Type&& val, Params&&... params)
+    {
+        return Trinity::Impl::StringConvertImpl::For<std::decay_t<Type>>::ToString(std::forward<Type>(val), std::forward<Params>(params)...);
+    }
 }
 
 #endif

--- a/src/common/Utilities/StringConvert.h
+++ b/src/common/Utilities/StringConvert.h
@@ -1,0 +1,171 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_STRINGCONVERT_H
+#define TRINITY_STRINGCONVERT_H
+
+#include "Define.h"
+#include "Errors.h"
+#include "Optional.h"
+#include "Util.h"
+#include <charconv>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+namespace Trinity::Impl::StringConvertImpl
+{
+    template <typename T, typename = void> struct For
+    {
+        static_assert("Unsupported type used for ToString or StringTo");
+        /*
+        static Optional<T> FromString(std::string_view str, ...);
+        static std::string ToString(T&& val, ...);
+        */
+    };
+
+    // @todo relax this once proper std::from_chars support exists
+    template <typename T>
+    struct For<T, std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool>>>
+    {
+        static Optional<T> FromString(std::string_view str, int base = 10)
+        {
+            if (base == 0)
+            {
+                if (StringEqualI(str.substr(0, 2), "0x"))
+                {
+                    base = 16;
+                    str.remove_prefix(2);
+                }
+                else if (StringEqualI(str.substr(0, 2), "0b"))
+                {
+                    base = 2;
+                    str.remove_prefix(2);
+                }
+                else if (str.substr(0, 1) == "0")
+                {
+                    base = 8;
+                    str.remove_prefix(1);
+                }
+                else
+                    base = 10;
+
+                if (str.empty())
+                    return std::nullopt;
+            }
+
+            char const* const start = str.data();
+            char const* const end = (start + str.length());
+
+            T val;
+            std::from_chars_result const res = std::from_chars(start, end, val, base);
+            if (res.ptr == end)
+                return val;
+            else
+                return std::nullopt;
+        }
+
+        static std::string ToString(T val)
+        {
+            std::string buf(20,0); /* largest unsigned 64-bit value is 20 decimal characters, largest signed 64-bit value is 19 */
+            char* const start = buf.data();
+            char* const end = (start + buf.length());
+            std::to_chars_result const res = std::to_chars(start, end, val);
+            ASSERT(res.ec == std::errc());
+            buf.resize(res.ptr - start);
+            return buf;
+        }
+    };
+
+#ifdef TRINITY_NEED_CHARCONV_WORKAROUND
+    template <>
+    struct For<uint64, void>
+    {
+        static Optional<uint64> FromString(std::string_view str, int base = 10)
+        {
+            if (str.empty())
+                return std::nullopt;
+            try
+            {
+                size_t n;
+                uint64 val = std::stoull(std::string(str), &n, base);
+                if (n != str.length())
+                    return std::nullopt;
+                return val;
+            }
+            catch (...) { return std::nullopt; }
+        }
+
+        static std::string ToString(uint64 val)
+        {
+            return std::to_string(val);
+        }
+    };
+
+    template <>
+    struct For<int64, void>
+    {
+        static Optional<int64> FromString(std::string_view str, int base = 10)
+        {
+            try {
+                if (str.empty())
+                    return std::nullopt;
+                size_t n;
+                int64 val = std::stoll(std::string(str), &n, base);
+                if (n != str.length())
+                    return std::nullopt;
+                return val;
+            }
+            catch (...) { return std::nullopt; }
+        }
+
+        static std::string ToString(int64 val)
+        {
+            return std::to_string(val);
+        }
+    };
+#endif
+
+    template <>
+    struct For<bool, void>
+    {
+        static Optional<bool> FromString(std::string_view str)
+        {
+            if ((str == "1") || StringEqualI(str, "y") || StringEqualI(str, "on") || StringEqualI(str, "yes") || StringEqualI(str, "true"))
+                return true;
+            if ((str == "0") || StringEqualI(str, "n") || StringEqualI(str, "off") || StringEqualI(str, "no") || StringEqualI(str, "false"))
+                return false;
+            return std::nullopt;
+        }
+
+        static std::string ToString(bool val)
+        {
+            return (val ? "1" : "0");
+        }
+    };
+}
+
+namespace Trinity
+{
+    template <typename Result, typename... Params>
+    Optional<Result> StringTo(std::string_view str, Params&&... params) { return Trinity::Impl::StringConvertImpl::For<Result>::FromString(str, std::forward<Params>(params)...); }
+
+    template <typename Type, typename... Params>
+    std::string ToString(Type&& val, Params&&... params) { return Trinity::Impl::StringConvertImpl::For<std::decay_t<Type>>::ToString(std::forward<Type>(val), std::forward<Params>(params)...); }
+}
+
+#endif

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -651,11 +651,6 @@ void Trinity::Impl::HexStrToByteArray(std::string_view str, uint8* out, size_t o
     }
 }
 
-bool StringToBool(std::string_view str)
-{
-    return ((str == "1") || StringEqualI(str, "true") || StringEqualI(str, "yes"));
-}
-
 bool StringEqualI(std::string_view str1, std::string_view str2)
 {
     return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(),

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -562,7 +562,7 @@ Ret* Coalesce(T1* first, T*... rest)
 namespace Trinity
 {
     template <typename T>
-    struct dependent_false { static constexpr bool value = false; };
+    struct dependant_false { static constexpr bool value = false; };
 
     template <typename T>
     constexpr bool dependant_false_v = dependant_false<T>::value;

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -20,6 +20,7 @@
 
 #include "Define.h"
 #include "Errors.h"
+#include "Optional.h"
 
 #include <array>
 #include <string>
@@ -344,8 +345,6 @@ inline std::vector<uint8> HexStrToByteVector(std::string_view str, bool reverse 
     Trinity::Impl::HexStrToByteArray(str, buf.data(), sz, reverse);
     return buf;
 }
-
-TC_COMMON_API bool StringToBool(std::string_view str);
 
 TC_COMMON_API bool StringEqualI(std::string_view str1, std::string_view str2);
 TC_COMMON_API bool StringStartsWith(std::string_view haystack, std::string_view needle);

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -559,4 +559,13 @@ Ret* Coalesce(T1* first, T*... rest)
         return static_cast<Ret*>(first);
 }
 
+namespace Trinity
+{
+    template <typename T>
+    struct dependent_false { static constexpr bool value = false; };
+
+    template <typename T>
+    constexpr bool dependant_false_v = dependant_false<T>::value;
+}
+
 #endif

--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -21,6 +21,7 @@
 #include "ChatCommandHelpers.h"
 #include "ChatCommandTags.h"
 #include "SmartEnum.h"
+#include "StringConvert.h"
 #include "Util.h"
 #include <charconv>
 #include <map>
@@ -55,20 +56,10 @@ struct ArgInfo<T, std::enable_if_t<std::is_integral_v<T>>>
         char const* next = args;
         std::string_view token(args, Trinity::Impl::ChatCommands::tokenize(next));
 
-        if (!token.length())
-            return nullptr;
-
-        std::from_chars_result result;
-        if (StringStartsWith(token, "0x"))
-            result = std::from_chars(token.data() + 2, token.data() + token.length(), val, 16);
-        else if (StringStartsWith(token, "0b"))
-            result = std::from_chars(token.data() + 2, token.data() + token.length(), val, 2);
+        if (Optional<T> v = StringTo<T>(token, 0))
+            val = *v;
         else
-            result = std::from_chars(token.data(), token.data() + token.length(), val, 10);
-
-        if ((token.data() + token.length()) != result.ptr)
             return nullptr;
-
         return next;
     }
 };

--- a/src/server/game/Chat/Hyperlinks.h
+++ b/src/server/game/Chat/Hyperlinks.h
@@ -19,6 +19,7 @@
 #define TRINITY_HYPERLINKS_H
 
 #include "ObjectGuid.h"
+#include "StringConvert.h"
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -105,19 +106,15 @@ namespace Trinity::Hyperlinks
             }
 
             template <typename T>
-            static std::enable_if_t<std::is_integral_v<T> && std::is_unsigned_v<T>, bool> StoreTo(T& val, char const* pos, size_t len)
+            static std::enable_if_t<std::is_integral_v<T>, bool> StoreTo(T& val, char const* pos, size_t len)
             {
-                try { val = std::stoull(std::string(pos, len)); }
-                catch (...) { return false; }
-                return true;
-            }
-
-            template <typename T>
-            static std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, bool> StoreTo(T& val, char const* pos, size_t len)
-            {
-                try { val = std::stoll(std::string(pos, len)); }
-                catch (...) { return false; }
-                return true;
+                if (Optional<T> res = Trinity::StringTo<T>(std::string_view(pos, len)))
+                {
+                    val = *res;
+                    return true;
+                }
+                else
+                    return false;
             }
 
             static bool StoreTo(ObjectGuid& val, char const* pos, size_t len)

--- a/src/server/game/Chat/Hyperlinks.h
+++ b/src/server/game/Chat/Hyperlinks.h
@@ -119,9 +119,13 @@ namespace Trinity::Hyperlinks
 
             static bool StoreTo(ObjectGuid& val, char const* pos, size_t len)
             {
-                try { val.Set(std::stoul(std::string(pos, len), nullptr, 16)); }
-                catch (...) { return false; }
-                return true;
+                if (Optional<uint64> res = Trinity::StringTo<uint64>(std::string_view(pos, len), 16))
+                {
+                    val.Set(*res);
+                    return true;
+                }
+                else
+                    return false;
             }
         };
 


### PR DESCRIPTION
Centralize String-to-type conversion in a single header.

More importantly, add a workaround for a compiler bug in clang 7 (which we still support, thanks Debian 10).

clang will fail to link if `std::from_chars` is used for a 64-bit parameter. This would break the build if any chat commands used 64-bit arguments, for example. Awkward.

cmake now tests for existence of the bug, and we work around it if found (by falling back to `std::sto(u)ll`).