### PR TITLE
Core/ObjectMgr: Solve global storage issue

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -142,6 +142,9 @@ bool normalizePlayerName(std::string& name)
     if (name.empty())
         return false;
 
+    if (name.find(" ") != std::string::npos)
+        return false;
+
     std::wstring tmp;
     if (!Utf8toWStr(name, tmp))
         return false;


### PR DESCRIPTION
**Changes proposed:**
 
* Add a condition for normalizePlayerName to not search for existing names with a blank space " " in the end of the string.
 
**Target branch(es):**
 
* [x]   3.3.5
 
**Tests performed:**
 
* Builds, ingame
