### PR TITLE
Core/Unit: send npcs home after fear runs out

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11392,6 +11392,10 @@ void Unit::SetFeared(bool apply)
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
         }
+        if (!(GetTypeId() == TYPEID_PLAYER) && !IsInCombat())
+        {
+            GetMotionMaster()->MoveTargetedHome();
+        }
     }
 
     // block / allow control to real player in control (eg charmer)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11391,10 +11391,8 @@ void Unit::SetFeared(bool apply)
             GetMotionMaster()->Remove(FLEEING_MOTION_TYPE);
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
-        }
-        if (!(GetTypeId() == TYPEID_PLAYER) && !IsInCombat())
-        {
-            GetMotionMaster()->MoveTargetedHome();
+            if (!IsPlayer() && !IsInCombat())
+                GetMotionMaster()->MoveTargetedHome();
         }
     }
 


### PR DESCRIPTION
**Changes proposed:**

-  send creatures back to home position after fear


**Target branch(es):**

- [x] 3.3.5


**Issues addressed:**

Closes #21106

Also gets rid of problems around the Honor Hold fear event (#22362 #24218)

**Tests performed:**

- [x] Builds
- [x] Creature out of combat before being feared and out of combat after fear runs out -> returns home
- [x] Creature out of combat before being feared but taken into combat before fear runs out -> continue combat
- [x] Creature in combat before being feared but out of combat before fear runs out -> return home
- [x] Creature in combat before being feared and in combat when fear runs out -> continue combat


**Known issues and TODO list:**

none that im aware of