### PR TITLE
Build: Add support to MariaDB 10.5 on Windows

### DIFF
--- a/cmake/macros/FindMySQL.cmake
+++ b/cmake/macros/FindMySQL.cmake
@@ -105,6 +105,8 @@ find_path(MYSQL_INCLUDE_DIR
     "$ENV{MYSQL_ROOT}/include"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.4;INSTALLDIR]/include/mysql"
     "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.4 (x64);INSTALLDIR]/include/mysql"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.5;INSTALLDIR]/include/mysql"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.5 (x64);INSTALLDIR]/include/mysql"
   DOC
     "Specify the directory containing mysql.h."
 )
@@ -159,6 +161,8 @@ if(WIN32)
       "$ENV{MYSQL_ROOT}/lib"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.4;INSTALLDIR]/lib"
       "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.4 (x64);INSTALLDIR]/lib"
+      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.5;INSTALLDIR]/lib"
+      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.5 (x64);INSTALLDIR]/lib"
     DOC "Specify the location of the mysql library here."
   )
 endif(WIN32)
@@ -222,6 +226,8 @@ if(WIN32)
         "$ENV{MYSQL_ROOT}/bin"
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.4;INSTALLDIR]/bin"
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.4 (x64);INSTALLDIR]/bin"
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.5;INSTALLDIR]/bin"
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MariaDB 10.5 (x64);INSTALLDIR]/bin"
      DOC
         "path to your mysql binary."
     )


### PR DESCRIPTION
**Changes proposed:**
- Add support to MariaDB 10.5 on Windows

**Target branch(es):**
- [x] 3.3.5

**Tests performed:**
- Build and in-game

<details>
<summary>Cmake Logs </summary>

```CMake
Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.19041.
The C compiler identification is MSVC 19.27.29111.0
The CXX compiler identification is MSVC 19.27.29111.0
Detecting C compiler ABI info
Detecting C compiler ABI info - done
Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe - skipped
Detecting C compile features
Detecting C compile features - done
Detecting CXX compiler ABI info
Detecting CXX compiler ABI info - done
Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe - skipped
Detecting CXX compile features
Detecting CXX compile features - done
Detected 64-bit platform
MSVC: Minimum version required is 19.24, found 19.27.29111.0 - ok!
MSVC: 64-bit platform, enforced -D_WIN64 parameter
MSVC: Enabled increased number of sections in object files
MSVC: Overloaded standard names
MSVC: Disabled NON-SECURE warnings
MSVC: Disabled POSIX warnings
MSVC: Disabled generic compiletime warnings
Found MySQL library: C:/Program Files/MariaDB 10.5/lib/libmariadb.lib
Found MySQL headers: C:/Program Files/MariaDB 10.5/include/mysql
Found MySQL executable: C:/Program Files/MariaDB 10.5/bin/mysql.exe
Found git binary : C:/Program Files/Git/cmd/git.exe

* TrinityCore revision   : cb22cd35ea04 2020-08-30 07:24:13 +0700 (mariadb-10.5 branch)

* Install core to        : C:/Program Files (x86)/TrinityCore
* Install configs to     : C:/Program Files (x86)/TrinityCore

* Build world/auth       : Yes (default)
* Build with scripts     : Yes (static)
* Build map/vmap tools   : Yes (default)
* Build unit tests       : No (default)
* Build core w/PCH       : Yes (default)
* Build scripts w/PCH    : Yes (default)
* Show compile-warnings  : No  (default)
* Use coreside debug     : No  (default)
* Show source tree       : Yes (hierarchical)
* Use GIT revision hash  : Yes (default)

Looking for pthread.h
Looking for pthread.h - not found
Found Threads: TRUE  
Found Boost: C:/local/boost_1_72_0 (found suitable version "1.72.0", minimum required is "1.70") found components: system filesystem program_options iostreams regex 
Performing Test boost_filesystem_copy_links_without_NO_SCOPED_ENUM
Performing Test boost_filesystem_copy_links_without_NO_SCOPED_ENUM - Success
Looking for open
Looking for open - found
Found OpenSSL library: optimized;C:/Program Files/OpenSSL-Win64/lib/VC/libssl64MD.lib;C:/Program Files/OpenSSL-Win64/lib/VC/libcrypto64MD.lib;debug;C:/Program Files/OpenSSL-Win64/lib/VC/libssl64MDd.lib;C:/Program Files/OpenSSL-Win64/lib/VC/libcrypto64MDd.lib
Found OpenSSL headers: C:/Program Files/OpenSSL-Win64/include

* Script configuration (static):
    |
    +- worldserver
    |   +- Battlefield
    |   +- Commands
    |   +- Custom
    |   +- EasternKingdoms
    |   +- Events
    |   +- Kalimdor
    |   +- Northrend
    |   +- OutdoorPvP
    |   +- Outland
    |   +- Pet
    |   +- Spells
    |   +- World
    |

Configuring done
```
</details>