### PR TITLE
Core/Map: Workaround to fix wrong areaid inside of The Crimson Hall

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2715,6 +2715,11 @@ ZLiquidStatus Map::GetLiquidStatus(uint32 phaseMask, float x, float y, float z, 
 
 void Map::GetFullTerrainStatusForPosition(uint32 phaseMask, float x, float y, float z, PositionFullTerrainStatus& data, uint8 reqLiquidType, float collisionHeight) const
 {
+    // Workaround: we have a bug in Z position inside of The Crimson Hall (ICC), that make vmgr->getAreaAndLiquidData return wrong area
+    // this wrong area make spells of Blood Orb object fail
+    if (GetId() == 631/*Icecrown Citadel*/ && G3D::fuzzyGe(z, 350.963013f))
+        z += 0.1f;
+
     VMAP::IVMapManager* vmgr = VMAP::VMapFactory::createOrGetVMapManager();
     VMAP::AreaAndLiquidData vmapData;
     VMAP::AreaAndLiquidData dynData;


### PR DESCRIPTION
**Changes proposed:**

-  The Crimson Hall inside of ICC, has a weird Z bug
If you enter walking there, this happens:

![image](https://user-images.githubusercontent.com/7120913/91721528-4df4af80-eb6f-11ea-9899-09fd9b829828.png)

instead of:

![image](https://user-images.githubusercontent.com/7120913/91721567-5e0c8f00-eb6f-11ea-9e75-3c2527fa39ac.png)

It causes this bug: https://youtu.be/mQb_PkCl9Rs
Making you have wrong areaid until you jump.
And wrong areaid, make Blood Orb spells fail, because they have "allowed area" stuff

**Target branch(es):** 3.3.5 , but maybe master too, idk

**Issues addressed:** Has no open issue about it

**Tests performed:** Builded and tested in game
