### PR TITLE
Core/Movement: Remove MOVEMENTFLAG_MASK_MOVING and MOVEMENTFLAG_FLYIN…

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -911,14 +911,20 @@ void MotionMaster::MoveFall(uint32 id/* = 0*/)
     if (_owner->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED))
         return;
 
-    _owner->AddUnitMovementFlag(MOVEMENTFLAG_FALLING);
-    _owner->m_movementInfo.SetFallTime(0);
-
-    // Don't run spline movement for players
+    // Don't run spline movement for players and unit
     if (_owner->GetTypeId() == TYPEID_PLAYER)
     {
-        _owner->ToPlayer()->SetFallInformation(0, _owner->GetPositionZ());
-        return;
+        _owner->AddUnitMovementFlag(MOVEMENTFLAG_FALLING);
+        _owner->m_movementInfo.SetFallTime(0);
+        _owner->ToPlayer()->SetFallInformation(time(NULL), _owner->GetPositionZ());
+    }
+    else if (_owner->GetTypeId() == TYPEID_UNIT)
+    {
+        _owner->RemoveUnitMovementFlag(MOVEMENTFLAG_MASK_MOVING);
+        _owner->RemoveUnitMovementFlag(MOVEMENTFLAG_FLYING | MOVEMENTFLAG_CAN_FLY);
+        _owner->AddUnitMovementFlag(MOVEMENTFLAG_FALLING);
+        _owner->m_movementInfo.SetFallTime(0);
+        _owner->SendMovementFlagUpdate();
     }
 
     Movement::MoveSplineInit init(_owner);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Remove flag can fly when mobs falling.

**Target branch(es):** 3.3.5/master

- [√ ] 3.3.5

**Tests performed:**

Does it build, tested in-game, etc.

**Follow-up**
- We need more checks and feedback.
- Please correct me in the standards.

[Video](https://www.youtube.com/watch?v=dmKeSj49Inc&feature=youtu.be)
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
