### PR TITLE
Core/Unit: Fix units on vehicles not dismounting on death

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8663,6 +8663,8 @@ void Unit::setDeathState(DeathState s)
     // Death state needs to be updated before RemoveAllAurasOnDeath() is called, to prevent entering combat
     m_deathState = s;
 
+    bool isOnVehicle = GetVehicle() != nullptr;
+
     if (s != ALIVE && s != JUST_RESPAWNED)
     {
         CombatStop();
@@ -8684,18 +8686,28 @@ void Unit::setDeathState(DeathState s)
         // remove aurastates allowing special moves
         ClearAllReactives();
         ClearDiminishings();
-        if (IsInWorld())
+
+        // Don't clear the movement if the Unit was on a vehicle as we are exiting now
+        if (!isOnVehicle)
         {
-            // Only clear MotionMaster for entities that exists in world
-            // Avoids crashes in the following conditions :
-            //  * Using 'call pet' on dead pets
-            //  * Using 'call stabled pet'
-            //  * Logging in with dead pets
-            GetMotionMaster()->Clear();
-            GetMotionMaster()->MoveIdle();
+            if (IsInWorld())
+            {
+                // Only clear MotionMaster for entities that exists in world
+                // Avoids crashes in the following conditions :
+                //  * Using 'call pet' on dead pets
+                //  * Using 'call stabled pet'
+                //  * Logging in with dead pets
+                if (!isOnVehicle)
+                {
+                    GetMotionMaster()->Clear();
+                    GetMotionMaster()->MoveIdle();
+                }
+            }
+
+            StopMoving();
+            DisableSpline();
         }
-        StopMoving();
-        DisableSpline();
+
         // without this when removing IncreaseMaxHealth aura player may stuck with 1 hp
         // do not why since in IncreaseMaxHealth currenthealth is checked
         SetHealth(0);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8697,11 +8697,8 @@ void Unit::setDeathState(DeathState s)
                 //  * Using 'call pet' on dead pets
                 //  * Using 'call stabled pet'
                 //  * Logging in with dead pets
-                if (!isOnVehicle)
-                {
-                    GetMotionMaster()->Clear();
-                    GetMotionMaster()->MoveIdle();
-                }
+                GetMotionMaster()->Clear();
+                GetMotionMaster()->MoveIdle();
             }
 
             StopMoving();


### PR DESCRIPTION


<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fix units on vehicles not dismounting on death by allowing the dismount movement to finish
- Issue added in 982643cd96790ffc54e7a3e507469649f3b074d2

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #23095


**Tests performed:**

Tested #23095 steps ingame


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] No clue if there is a case where this would bug out, with a dead unit still moving. Maybe in that case we should call GetMotionMaster()->Clear() before


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
