### PR TITLE
Core/Maps: Always update the grid of player summons even if far away

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -830,8 +830,10 @@ void Map::Update(uint32 t_diff)
                 VisitNearbyCellsOf(unit, grid_object_update, world_object_update);
         }
 
-        { // Update player's guardians
+        { // Update player's summons
             std::unordered_set<Unit*> toVisit;
+
+            // Totems
             for (ObjectGuid const& summonGuid : player->m_SummonSlot)
                 if (summonGuid)
                     if (Creature* unit = GetCreature(summonGuid))

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -829,6 +829,18 @@ void Map::Update(uint32 t_diff)
             for (Unit* unit : toVisit)
                 VisitNearbyCellsOf(unit, grid_object_update, world_object_update);
         }
+
+        { // Update player's guardians
+            std::unordered_set<Unit*> toVisit;
+            for (ObjectGuid const& summonGuid : player->m_SummonSlot)
+                if (summonGuid)
+                    if (Creature* unit = GetCreature(summonGuid))
+                        if (unit->GetMapId() == player->GetMapId() && !unit->IsWithinDistInMap(player, GetVisibilityRange(), false))
+                            toVisit.insert(unit);
+
+            for (Unit* unit : toVisit)
+                VisitNearbyCellsOf(unit, grid_object_update, world_object_update);
+        }
     }
 
     // non-player active objects, increasing iterator in the loop in case of object removal

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -831,14 +831,14 @@ void Map::Update(uint32 t_diff)
         }
 
         { // Update player's summons
-            std::unordered_set<Unit*> toVisit;
+            std::vector<Unit*> toVisit;
 
             // Totems
             for (ObjectGuid const& summonGuid : player->m_SummonSlot)
                 if (summonGuid)
                     if (Creature* unit = GetCreature(summonGuid))
                         if (unit->GetMapId() == player->GetMapId() && !unit->IsWithinDistInMap(player, GetVisibilityRange(), false))
-                            toVisit.insert(unit);
+                            toVisit.push_back(unit);
 
             for (Unit* unit : toVisit)
                 VisitNearbyCellsOf(unit, grid_object_update, world_object_update);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Always update the grid of player summons even if far away

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #24212


**Tests performed:**

None yet


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Some more type of summons/guardians should be added


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
