### PR TITLE
Core/Creature: Update visibility for other Players

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -659,6 +659,11 @@ void Creature::Update(uint32 diff)
     }
 
     UpdateMovementFlags();
+    // updates visibility for other players
+    if (IsSummon() && m_deathState != DEAD)
+    {
+        UpdateObjectVisibility();
+    }
 
     switch (m_deathState)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->
Issue described in https://github.com/TrinityCore/TrinityCore/issues/20136#issuecomment-687663047

**Changes proposed:**
-  When mount vehicle with npcs and relog, other players will see those npcs/vendors on ground, so we update visibility for them using UpdateObjectVisibility();

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #20136


**Tests performed:**
Builds and tested with exact steps on [this gif](https://mega.nz/file/ewl0RQKY#CwvhqwuzKRLJsVHNNA44UGvbaKf4kfEal60fFEC5MRc) 
(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)
- [ ] this could be done in other place?


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
