### PR TITLE
Core/Spells: Do not reset periodic timer for stacking DoTs

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2826,7 +2826,7 @@ void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
 
             if (!hitInfo.HitAura)
             {
-                bool const resetPeriodicTimer = !(_triggeredCastFlags & TRIGGERED_DONT_RESET_PERIODIC_TIMER);
+                bool const resetPeriodicTimer = (m_spellInfo->StackAmount < 2) && !(_triggeredCastFlags & TRIGGERED_DONT_RESET_PERIODIC_TIMER);
                 uint8 const allAuraEffectMask = Aura::BuildEffectMaskForOwner(hitInfo.AuraSpellInfo, MAX_EFFECT_MASK, unit);
                 int32 const* bp = hitInfo.AuraBasePoints;
                 if (hitInfo.AuraSpellInfo == m_spellInfo)


### PR DESCRIPTION
**Changes proposed:**

-  Replaces https://github.com/TrinityCore/TrinityCore/pull/25149
-  Implement a new custom attr, to handle with cases that need not reset periodic timer when refreshed

**Target branch(es):** 3.3.5

**Issues addressed:** Has no open issues, but will fix Lacerate (read https://github.com/TrinityCore/TrinityCore/pull/25149)

**Tests performed:**

Builded and tested in game


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Update wiki after merge

