### PR TITLE
Core/Addon: Correct Banned Addon length in SMSG_ADDON_INFO packet

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1176,6 +1176,7 @@ void WorldSession::SendAddonsInfo()
         data.append(itr->VersionMD5, sizeof(itr->VersionMD5));
         data << uint32(itr->Timestamp);
         data << uint32(1);  // IsBanned
+        bannedAddonCount++;
     }
 
     data.put<uint32>(sizePos, bannedAddonCount);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Sending banned addon list length in SMSG_ADDON_INFO. It was 99.9% implemented but was never working as far as I could tell. https://github.com/gladmmo/GladMMO.TrinityCore/commit/d24ef896dfd9932ca8b74b5683fdda71b77f0287

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Seems to work fine in-game now. Addons won't load in-game:

![image](https://user-images.githubusercontent.com/5829095/92553482-a2132a00-f228-11ea-94c9-2a9277a87fc5.png)


**Known issues and TODO list:**

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
