### PR TITLE
Core/ChatCommands: Drop PlayerIdentifier's cast operators which could return nullptr

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandTags.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandTags.h
@@ -149,12 +149,11 @@ namespace Trinity::ChatCommands
         PlayerIdentifier() : _name(), _guid(), _player(nullptr) {}
         PlayerIdentifier(Player& player);
 
-        operator ObjectGuid() { return _guid; }
-        Player* operator->() const { return _player; }
-        explicit operator bool() const { return (_player != nullptr); }
-        bool operator!() const { return (_player == nullptr); }
+        operator ObjectGuid() const { return _guid; }
+        operator std::string const&() const { return _name; }
+        operator std::string_view() const { return _name; }
 
-        std::string const& GetName() { return _name; }
+        std::string const& GetName() const { return _name; }
         ObjectGuid GetGUID() const { return _guid; }
         bool IsConnected() const { return (_player != nullptr); }
         Player* GetConnectedPlayer() const { return _player; }

--- a/src/server/game/Chat/ChatCommands/ChatCommandTags.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandTags.h
@@ -149,9 +149,6 @@ namespace Trinity::ChatCommands
         PlayerIdentifier() : _name(), _guid(), _player(nullptr) {}
         PlayerIdentifier(Player& player);
 
-        template <typename T>
-        operator std::enable_if_t<std::is_base_of_v<T, Player>, T*>() const { return static_cast<T*>(_player); }
-        operator value_type() const { return _player; }
         operator ObjectGuid() { return _guid; }
         Player* operator->() const { return _player; }
         explicit operator bool() const { return (_player != nullptr); }

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -248,7 +248,6 @@ public:
         Player const* target = player->GetConnectedPlayer();
 
         LocaleConstant loc = handler->GetSessionDbcLocale();
-        std::string const& targetName = player->GetName();
         char const* knownStr = handler->GetTrinityString(LANG_KNOWN);
 
         // Search in CharTitles.dbc
@@ -268,7 +267,7 @@ public:
                 if (target->GetUInt32Value(PLAYER_CHOSEN_TITLE) == titleInfo->MaskID)
                     activeStr = handler->GetTrinityString(LANG_ACTIVE);
 
-                std::string titleName = Trinity::StringFormat(name, targetName.c_str());
+                std::string titleName = Trinity::StringFormat(name, player->GetName().c_str());
 
                 // send title in "id (idx:idx) - [namedlink locale]" format
                 if (handler->GetSession())
@@ -377,7 +376,7 @@ public:
                 if (handler->HasLowerSecurity(nullptr, player->GetGUID()))
                     return false;
 
-                handler->PSendSysMessage(LANG_RENAME_PLAYER_GUID, handler->playerLink(player->GetName()).c_str(), player->GetGUID().GetCounter());
+                handler->PSendSysMessage(LANG_RENAME_PLAYER_GUID, handler->playerLink(*player).c_str(), player->GetGUID().GetCounter());
 
                 CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
                 stmt->setUInt16(0, uint16(AT_LOGIN_RENAME));
@@ -404,7 +403,7 @@ public:
         }
         else
         {
-            handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER_GUID, handler->playerLink(player->GetName()).c_str(), player->GetGUID().GetCounter());
+            handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER_GUID, handler->playerLink(*player).c_str(), player->GetGUID().GetCounter());
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
             stmt->setUInt16(0, static_cast<uint16>(AT_LOGIN_CUSTOMIZE));
             stmt->setUInt32(1, player->GetGUID().GetCounter());
@@ -428,7 +427,7 @@ public:
         }
         else
         {
-            handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER_GUID, handler->playerLink(player->GetName()).c_str(), player->GetGUID().GetCounter());
+            handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER_GUID, handler->playerLink(*player).c_str(), player->GetGUID().GetCounter());
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
             stmt->setUInt16(0, uint16(AT_LOGIN_CHANGE_FACTION));
             stmt->setUInt32(1, player->GetGUID().GetCounter());
@@ -452,7 +451,7 @@ public:
         }
         else
         {
-            handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER_GUID, handler->playerLink(player->GetName()).c_str(), player->GetGUID().GetCounter());
+            handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER_GUID, handler->playerLink(*player).c_str(), player->GetGUID().GetCounter());
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
             stmt->setUInt16(0, uint16(AT_LOGIN_CHANGE_RACE));
             stmt->setUInt32(1, player->GetGUID().GetCounter());
@@ -713,22 +712,22 @@ public:
         return true;
     }
 
-    static bool HandleCharacterEraseCommand(ChatHandler* handler, PlayerIdentifier player)
+    static bool HandleCharacterEraseCommand(ChatHandler* handler, PlayerIdentifier playerIdent)
     {
         uint32 accountId;
-        if (player.IsConnected())
+        if (Player* player = playerIdent.GetConnectedPlayer())
         {
             accountId = player->GetSession()->GetAccountId();
             player->GetSession()->KickPlayer("HandleCharacterEraseCommand GM Command deleting character");
         }
         else
-            accountId = sCharacterCache->GetCharacterAccountIdByGuid(player);
+            accountId = sCharacterCache->GetCharacterAccountIdByGuid(playerIdent);
 
         std::string accountName;
         AccountMgr::GetName(accountId, accountName);
 
-        Player::DeleteFromDB(player, accountId, true, true);
-        handler->PSendSysMessage(LANG_CHARACTER_DELETED, player.GetName().c_str(), player.GetGUID().GetCounter(), accountName.c_str(), accountId);
+        Player::DeleteFromDB(playerIdent, accountId, true, true);
+        handler->PSendSysMessage(LANG_CHARACTER_DELETED, playerIdent.GetName().c_str(), playerIdent.GetGUID().GetCounter(), accountName.c_str(), accountId);
 
         return true;
     }
@@ -775,7 +774,7 @@ public:
         }
 
         if (!handler->GetSession() || (handler->GetSession()->GetPlayer() != player->GetConnectedPlayer()))      // including chr == NULL
-            handler->PSendSysMessage(LANG_YOU_CHANGE_LVL, handler->playerLink(player->GetName()).c_str(), newlevel);
+            handler->PSendSysMessage(LANG_YOU_CHANGE_LVL, handler->playerLink(*player).c_str(), newlevel);
 
         return true;
     }

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -712,22 +712,22 @@ public:
         return true;
     }
 
-    static bool HandleCharacterEraseCommand(ChatHandler* handler, PlayerIdentifier playerIdent)
+    static bool HandleCharacterEraseCommand(ChatHandler* handler, PlayerIdentifier player)
     {
         uint32 accountId;
-        if (Player* player = playerIdent.GetConnectedPlayer())
+        if (Player* target = player.GetConnectedPlayer())
         {
-            accountId = player->GetSession()->GetAccountId();
-            player->GetSession()->KickPlayer("HandleCharacterEraseCommand GM Command deleting character");
+            accountId = target->GetSession()->GetAccountId();
+            target->GetSession()->KickPlayer("HandleCharacterEraseCommand GM Command deleting character");
         }
         else
-            accountId = sCharacterCache->GetCharacterAccountIdByGuid(playerIdent);
+            accountId = sCharacterCache->GetCharacterAccountIdByGuid(player);
 
         std::string accountName;
         AccountMgr::GetName(accountId, accountName);
 
-        Player::DeleteFromDB(playerIdent, accountId, true, true);
-        handler->PSendSysMessage(LANG_CHARACTER_DELETED, playerIdent.GetName().c_str(), playerIdent.GetGUID().GetCounter(), accountName.c_str(), accountId);
+        Player::DeleteFromDB(player, accountId, true, true);
+        handler->PSendSysMessage(LANG_CHARACTER_DELETED, player.GetName().c_str(), player.GetGUID().GetCounter(), accountName.c_str(), accountId);
 
         return true;
     }

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1901,7 +1901,7 @@ public:
         stmt->setString(3, muteReasonStr);
         LoginDatabase.Execute(stmt);
 
-        std::string nameLink = handler->playerLink(player->GetName());
+        std::string nameLink = handler->playerLink(*player);
         if (sWorld->getBoolConfig(CONFIG_SHOW_MUTE_IN_WORLD))
             sWorld->SendWorldText(LANG_COMMAND_MUTEMESSAGE_WORLD, muteBy.c_str(), nameLink.c_str(), muteTime, muteReasonStr.c_str());
         if (target)


### PR DESCRIPTION
**Changes proposed:**

-  Core/ChatCommands: Drop PlayerIdentifier's cast operators which could return nullptr

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master