### PR TITLE
Scripts/Onyxia: Add AnimationTier::Ground

### DIFF
--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -230,6 +230,7 @@ public:
                     case 9:
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
+                        me->SetAnimationTier(AnimationTier::Ground);
                         if (Creature* trigger = ObjectAccessor::GetCreature(*me, triggerGUID))
                             Unit::Kill(me, trigger);
                         me->SetReactState(REACT_AGGRESSIVE);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->
Onyxia does not walk on the ground in third phase, she stays flying on the ground

**Changes proposed:**

-  Add AnimationTier::Ground

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**
https://github.com/TrinityCore/TrinityCore/pull/24875#issuecomment-692626339


**Tests performed:**

Builds, now after 2nd phase when she lands, not flying over ground but walks

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
