### PR TITLE
Fix small file matching error in enumutils_describe.py 

### DIFF
--- a/contrib/enumutils_describe.py
+++ b/contrib/enumutils_describe.py
@@ -155,7 +155,7 @@ def processFile(path, filename):
 
     output.write('}\n')
 
-FilenamePattern = compile(r'^(.+).h$')
+FilenamePattern = compile(r'^(.+)\.h$')
 for root, dirs, files in walk('.'):
     for n in files:
         nameMatch = FilenamePattern.match(n)


### PR DESCRIPTION
**Changes proposed:**

Fixed enumutils_describe.py matching every extension ending with a 'h' instead of only .h file
The character '.' means every character in regex rather than an actual dot, while the original intent here is about an actual dot. So it has to be escaped.

**Target branch(es):** 

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Now doesn't match .sh files for example.

**Tests performed:**

Ran the file and created enums again.

**Known issues and TODO list:**

None