### PR TITLE
Core/Spells: Aura refresh improvements

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -300,7 +300,7 @@ uint8 Aura::BuildEffectMaskForOwner(SpellInfo const* spellProto, uint8 available
     return effMask & availableEffectMask;
 }
 
-Aura* Aura::TryRefreshStackOrCreate(AuraCreateInfo& createInfo)
+Aura* Aura::TryRefreshStackOrCreate(AuraCreateInfo& createInfo, bool updateEffectMask)
 {
     ASSERT_NODEBUGINFO(createInfo.Caster || createInfo.CasterGUID);
 
@@ -331,8 +331,9 @@ Aura* Aura::TryRefreshStackOrCreate(AuraCreateInfo& createInfo)
         Unit* unit = createInfo._owner->ToUnit();
 
         // check effmask on owner application (if existing)
-        if (AuraApplication* aurApp = foundAura->GetApplicationOfTarget(unit->GetGUID()))
-            aurApp->UpdateApplyEffectMask(effMask);
+        if (updateEffectMask)
+            if (AuraApplication* aurApp = foundAura->GetApplicationOfTarget(unit->GetGUID()))
+                aurApp->UpdateApplyEffectMask(effMask);
         return foundAura;
     }
     else

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -103,7 +103,7 @@ class TC_GAME_API Aura
         typedef std::unordered_map<ObjectGuid, AuraApplication*> ApplicationMap;
 
         static uint8 BuildEffectMaskForOwner(SpellInfo const* spellProto, uint8 availableEffectMask, WorldObject* owner);
-        static Aura* TryRefreshStackOrCreate(AuraCreateInfo& createInfo);
+        static Aura* TryRefreshStackOrCreate(AuraCreateInfo& createInfo, bool updateEffectMask = true);
         static Aura* TryCreate(AuraCreateInfo& createInfo);
         static Aura* Create(AuraCreateInfo& createInfo);
         explicit Aura(AuraCreateInfo const& createInfo);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2841,7 +2841,7 @@ void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
                     .SetOwnerEffectMask(aura_effmask)
                     .IsRefresh = &refresh;
 
-                if (Aura* aura = Aura::TryRefreshStackOrCreate(createInfo))
+                if (Aura* aura = Aura::TryRefreshStackOrCreate(createInfo, false))
                 {
                     hitInfo.HitAura = aura->ToUnitAura();
 
@@ -2870,6 +2870,9 @@ void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
                         hitInfo.HitAura->SetMaxDuration(hitInfo.AuraDuration);
                         hitInfo.HitAura->SetDuration(hitInfo.AuraDuration);
                     }
+
+                    if (refresh)
+                        hitInfo.HitAura->AddStaticApplication(unit, aura_effmask);
                 }
             }
             else


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Well, I will try to explain a little what I have been checking
after ariel- Spell internals rework https://github.com/TrinityCore/TrinityCore/pull/21395 there is a problem with refreshing auras that have not applied all their effects the first time, we can see this comment by example: https://github.com/TrinityCore/TrinityCore/issues/23031#issuecomment-583768999

I have done the tests with ID - 44614 Frostfire Bolt (Rank 1) and ID - 46924 Bladestorm, the problem is the same
When you cast Frostfire bolt on a target with bladestorm, the target is immune to SPELL_AURA_MOD_DECREASE_SPEED, so the first effect of the spell does not apply (this is correct).
But when bladestorm ends and you cast again Frostfire bolt on the target before first Frostfire bolt ends, you refresh the aura application, but the first effect (SPELL_AURA_MOD_DECREASE_SPEED) applies and removes instantly
so I decided to add a few logs to see what was happening: https://github.com/Jildor/TrinityCore/commit/8f714d70f6f1f64464c8ad136c449d5c3f228d35

and here is the result:
<details>
  <summary>combatlog</summary>
  
```log
11:42:37> [Jildor] casts [Bladestorm].
11:42:37> [Jildor] gains [Jildor's] [Bladestorm].
11:42:37> [Gildormage] begins casting [Frostfire Bolt].
11:42:41> [Gildormage's] [Frostfire Bolt] hits [Jildor] for 640 Frostfire.
11:42:41> [Jildor] is afflicted by [Gildormage's] [Frostfire Bolt].
11:42:43> [Jildor's] [Bladestorm] fades from [Jildor].
11:42:43> [Gildormage] begins casting [Frostfire Bolt].
11:42:44> [Jildor] suffers 18 Frostfire damage from [Gildormage's] [Frostfire Bolt].
11:42:47> [Gildormage's] [Frostfire Bolt] hits [Jildor] for 646 Frostfire.
11:42:47> [Gildormage's] [Frostfire Bolt] is refreshed on [Jildor].
11:42:47> [Gildormage's] [Frostfire Bolt] dissipates from [Jildor].
11:42:47> [Jildor] is afflicted by [Gildormage's] [Frostfire Bolt].
11:42:50> [Jildor] suffers 18 Frostfire damage from [Gildormage's] [Frostfire Bolt].
```
</details>

video ingame: https://imgur.com/Lh1GkGB


<details>
  <summary>server log</summary>
  
```log
// Log cast Frostfire bolt Rank 1 with bladestorm

2020-09-30_11:42:34 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 1
2020-09-30_11:42:34 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 2
2020-09-30_11:42:34 Spell::DoSpellEffectHit check 1: SpellId: 44614, aura_effmask: 4, effIndex: 2
2020-09-30_11:42:34 UnitAura::AddStaticApplication check 1: SpellId: 44614, effMask: 4
2020-09-30_11:42:34 UnitAura::AddStaticApplication check 2: SpellId: 44614, effMask: 4
2020-09-30_11:42:34 UnitAura::AddStaticApplication check 3: SpellId: 44614, effMask: 4
2020-09-30_11:42:34 Test Spell::EffectApplyAura First application: SpellId: 44614, effIndex: 2
2020-09-30_11:42:34 Spell::TargetInfo::DoDamageAndTriggers Refresh check 1: SpellId: 44614, EffectMask: 6, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:34 Spell::TargetInfo::DoDamageAndTriggers Refresh check 2: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:34 Spell::TargetInfo::DoDamageAndTriggers Refresh check 3: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:34 Unit::_ApplyAura check 1: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:34 Unit::_ApplyAura check 2: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:34 Unit::_ApplyAura check 3: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:34 Unit::_ApplyAura check 4: SpellId: 44614, effMask: 4, Flags: 132, GetEffectMask: 4
2020-09-30_11:42:34 Spell::TargetInfo::DoDamageAndTriggers Refresh check 4: SpellId: 44614, effMask: 4, Flags: 132, GetEffectMask: 4

// Refresh without bladestorm

2020-09-30_11:42:39 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 0
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 1: SpellId: 44614, aura_effmask: 1, effIndex: 0
2020-09-30_11:42:39 Test Aura::TryRefreshStackOrCreate (refresh): SpellId: 44614, effMask: 1, Flags: 132, GetEffectMask: 4
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 2: SpellId: 44614, effIndex: 0, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 3: SpellId: 44614, effIndex: 0, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 5: SpellId: 44614, effIndex: 0, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Test Spell::EffectApplyAura Updated: SpellId: 44614, effIndex: 0, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 1
2020-09-30_11:42:39 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 2
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 1: SpellId: 44614, aura_effmask: 4, effIndex: 2
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 4: SpellId: 44614, effIndex: 2, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 UnitAura::AddStaticApplication check 1: SpellId: 44614, effMask: 4
2020-09-30_11:42:39 UnitAura::AddStaticApplication check 2: SpellId: 44614, effMask: 4
2020-09-30_11:42:39 UnitAura::AddStaticApplication check 3: SpellId: 44614, effMask: 4
2020-09-30_11:42:39 Spell::DoSpellEffectHit check 5: SpellId: 44614, effIndex: 2, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Test Spell::EffectApplyAura Updated: SpellId: 44614, effIndex: 2, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Spell::TargetInfo::DoDamageAndTriggers Refresh check 1: SpellId: 44614, EffectMask: 7, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Spell::TargetInfo::DoDamageAndTriggers Refresh check 2: SpellId: 44614, effMask: 5, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Spell::TargetInfo::DoDamageAndTriggers Refresh check 3: SpellId: 44614, effMask: 5, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Unit::_ApplyAura check 1: SpellId: 44614, effMask: 5, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Unit::_ApplyAura check 2: SpellId: 44614, effMask: 5, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Unit::_ApplyAura check 3: SpellId: 44614, effMask: 5, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:39 Unit::_ApplyAura check 4: SpellId: 44614, effMask: 5, Flags: 133, GetEffectMask: 5
2020-09-30_11:42:39 Spell::TargetInfo::DoDamageAndTriggers Refresh check 4: SpellId: 44614, effMask: 5, Flags: 133, GetEffectMask: 5
2020-09-30_11:42:40 Test UpdateTargetMap check 1: SpellId: 44614, effIndex: 4, Flags: 133, GetEffectMask: 5
2020-09-30_11:42:40 Test UpdateTargetMap check 2: SpellId: 44614, effIndex: 4, Flags: 133, GetEffectMask: 5
2020-09-30_11:42:40 Test UpdateTargetMap check 4: SpellId: 44614, effIndex: 4, Flags: 133, GetEffectMask: 5
2020-09-30_11:42:40 Test UpdateTargetMap check 6: SpellId: 44614, effIndex: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:40 Unit::_ApplyAura check 1: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:40 Unit::_ApplyAura check 2: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:40 Unit::_ApplyAura check 3: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_11:42:40 Unit::_ApplyAura check 4: SpellId: 44614, effMask: 4, Flags: 132, GetEffectMask: 4
2020-09-30_11:42:40 Test UpdateTargetMap check 7: SpellId: 44614, effIndex: 4, Flags: 132, GetEffectMask: 4
```
</details>


So I think we shouldn't do:
https://github.com/TrinityCore/TrinityCore/blob/0d152e932cdd986f62ae22bd9fc40569892a2453/src/server/game/Spells/Auras/SpellAuras.cpp#L333-L335

because we do here:
https://github.com/TrinityCore/TrinityCore/blob/0d152e932cdd986f62ae22bd9fc40569892a2453/src/server/game/Spells/SpellEffects.cpp#L1084-L1089

and we should execute AddStaticApplication in case of aura applications is refresh and is the first hit for prevent aura remove and reapply


and here the result with the PR fix

<details>
  <summary>combatlog</summary>
  
```log
12:17:00> [Jildor] casts [Bladestorm].
12:17:00> [Jildor] gains [Jildor's] [Bladestorm].
12:17:01> [Gildormage] begins casting [Frostfire Bolt].
12:17:04> [Gildormage's] [Frostfire Bolt] hits [Jildor] for 660 Frostfire.
12:17:05> [Jildor] is afflicted by [Gildormage's] [Frostfire Bolt].
12:17:06> [Jildor's] [Bladestorm] fades from [Jildor].
12:17:07> [Gildormage] begins casting [Frostfire Bolt].
12:17:07> [Jildor] suffers 18 Frostfire damage from [Gildormage's] [Frostfire Bolt].
12:17:10> [Jildor] suffers 18 Frostfire damage from [Gildormage's] [Frostfire Bolt].
12:17:11> [Gildormage's] [Frostfire Bolt] hits [Jildor] for 581 Frostfire.
12:17:11> [Gildormage's] [Frostfire Bolt] is refreshed on [Jildor].
12:17:14> [Jildor] suffers 18 Frostfire damage from [Gildormage's] [Frostfire Bolt].
```
</details>

video ingame: https://imgur.com/3I0f5Ab


<details>
  <summary>server log</summary>
  
```log
// Log cast Frostfire bolt Rank 1 with bladestorm and fix applied

2020-09-30_12:17:02 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 1
2020-09-30_12:17:02 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 2
2020-09-30_12:17:02 Spell::DoSpellEffectHit check 1: SpellId: 44614, aura_effmask: 4, effIndex: 2
2020-09-30_12:17:02 UnitAura::AddStaticApplication check 1: SpellId: 44614, effMask: 4
2020-09-30_12:17:02 UnitAura::AddStaticApplication check 2: SpellId: 44614, effMask: 4
2020-09-30_12:17:02 UnitAura::AddStaticApplication check 3: SpellId: 44614, effMask: 4
2020-09-30_12:17:02 Test Spell::EffectApplyAura First application: SpellId: 44614, effIndex: 2
2020-09-30_12:17:02 Spell::TargetInfo::DoDamageAndTriggers Refresh check 1: SpellId: 44614, EffectMask: 6, Flags: 128, GetEffectMask: 0
2020-09-30_12:17:02 Spell::TargetInfo::DoDamageAndTriggers Refresh check 2: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_12:17:02 Spell::TargetInfo::DoDamageAndTriggers Refresh check 3: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_12:17:02 Unit::_ApplyAura check 1: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_12:17:02 Unit::_ApplyAura check 2: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_12:17:02 Unit::_ApplyAura check 3: SpellId: 44614, effMask: 4, Flags: 128, GetEffectMask: 0
2020-09-30_12:17:02 Unit::_ApplyAura check 4: SpellId: 44614, effMask: 4, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:02 Spell::TargetInfo::DoDamageAndTriggers Refresh check 4: SpellId: 44614, effMask: 4, Flags: 132, GetEffectMask: 4

// Refresh without bladestorm

2020-09-30_12:17:08 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 0
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 1: SpellId: 44614, aura_effmask: 1, effIndex: 0
2020-09-30_12:17:08 Test Aura::TryRefreshStackOrCreate (refresh): SpellId: 44614, effMask: 1, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 2: SpellId: 44614, effIndex: 0, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 3: SpellId: 44614, effIndex: 0, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 UnitAura::AddStaticApplication check 1: SpellId: 44614, effMask: 1
2020-09-30_12:17:08 UnitAura::AddStaticApplication check 2: SpellId: 44614, effMask: 1
2020-09-30_12:17:08 UnitAura::AddStaticApplication check 3: SpellId: 44614, effMask: 1
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 5: SpellId: 44614, effIndex: 0, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Test Spell::EffectApplyAura Updated: SpellId: 44614, effIndex: 0, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 1
2020-09-30_12:17:08 Spell::TargetInfo::DoTargetSpellHit check 1: SpellId: 44614, effIndex: 2
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 1: SpellId: 44614, aura_effmask: 4, effIndex: 2
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 4: SpellId: 44614, effIndex: 2, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 UnitAura::AddStaticApplication check 1: SpellId: 44614, effMask: 4
2020-09-30_12:17:08 UnitAura::AddStaticApplication check 2: SpellId: 44614, effMask: 4
2020-09-30_12:17:08 UnitAura::AddStaticApplication check 3: SpellId: 44614, effMask: 4
2020-09-30_12:17:08 Spell::DoSpellEffectHit check 5: SpellId: 44614, effIndex: 2, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Test Spell::EffectApplyAura Updated: SpellId: 44614, effIndex: 2, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Spell::TargetInfo::DoDamageAndTriggers Refresh check 1: SpellId: 44614, EffectMask: 7, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Spell::TargetInfo::DoDamageAndTriggers Refresh check 2: SpellId: 44614, effMask: 5, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Spell::TargetInfo::DoDamageAndTriggers Refresh check 3: SpellId: 44614, effMask: 1, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Unit::_ApplyAura check 1: SpellId: 44614, effMask: 1, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Unit::_ApplyAura check 2: SpellId: 44614, effMask: 1, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Unit::_ApplyAura check 3: SpellId: 44614, effMask: 1, Flags: 132, GetEffectMask: 4
2020-09-30_12:17:08 Unit::_ApplyAura check 4: SpellId: 44614, effMask: 1, Flags: 133, GetEffectMask: 5
2020-09-30_12:17:08 Spell::TargetInfo::DoDamageAndTriggers Refresh check 4: SpellId: 44614, effMask: 1, Flags: 133, GetEffectMask: 5
```
</details>

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

None, I think


**Tests performed:**

tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
