### PR TITLE
Core/Movement: added optional velocity overloads for MoveLand and MoveTakeoff MotionMaster helpers

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -679,7 +679,7 @@ void MotionMaster::MoveLand(uint32 id, Position const& pos, Optional<float> velo
     init.MoveTo(PositionToVector3(pos), false);
     init.SetAnimation(AnimationTier::Ground);
     if (velocity)
-        init.SetVelocity(velocity.get());
+        init.SetVelocity(velocity.value());
     Add(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id));
 }
 
@@ -691,7 +691,7 @@ void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, Optional<float> v
     init.MoveTo(PositionToVector3(pos), false);
     init.SetAnimation(AnimationTier::Hover);
     if (velocity)
-        init.SetVelocity(velocity.get());
+        init.SetVelocity(velocity.value());
     Add(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id));
 }
 

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -671,23 +671,27 @@ void MotionMaster::MoveCloserAndStop(uint32 id, Unit* target, float distance)
     }
 }
 
-void MotionMaster::MoveLand(uint32 id, Position const& pos)
+void MotionMaster::MoveLand(uint32 id, Position const& pos, Optional<float> velocity /*= { }*/)
 {
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveLand: '%s', landing point Id: %u (X: %f, Y: %f, Z: %f)", _owner->GetGUID().ToString().c_str(), id, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
 
     Movement::MoveSplineInit init(_owner);
     init.MoveTo(PositionToVector3(pos), false);
     init.SetAnimation(AnimationTier::Ground);
+    if (velocity)
+        init.SetVelocity(velocity.get());
     Add(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id));
 }
 
-void MotionMaster::MoveTakeoff(uint32 id, Position const& pos)
+void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, Optional<float> velocity /*= { }*/)
 {
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveTakeoff: '%s', landing point Id: %u (X: %f, Y: %f, Z: %f)", _owner->GetGUID().ToString().c_str(), id, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
 
     Movement::MoveSplineInit init(_owner);
-    init.MoveTo(PositionToVector3(pos));
+    init.MoveTo(PositionToVector3(pos), false);
     init.SetAnimation(AnimationTier::Hover);
+    if (velocity)
+        init.SetVelocity(velocity.get());
     Add(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id));
 }
 

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -671,7 +671,7 @@ void MotionMaster::MoveCloserAndStop(uint32 id, Unit* target, float distance)
     }
 }
 
-void MotionMaster::MoveLand(uint32 id, Position const& pos, Optional<float> velocity /*= { }*/)
+void MotionMaster::MoveLand(uint32 id, Position const& pos, Optional<float> velocity /*= {}*/)
 {
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveLand: '%s', landing point Id: %u (X: %f, Y: %f, Z: %f)", _owner->GetGUID().ToString().c_str(), id, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
 
@@ -679,11 +679,11 @@ void MotionMaster::MoveLand(uint32 id, Position const& pos, Optional<float> velo
     init.MoveTo(PositionToVector3(pos), false);
     init.SetAnimation(AnimationTier::Ground);
     if (velocity)
-        init.SetVelocity(velocity.value());
+        init.SetVelocity(*velocity);
     Add(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id));
 }
 
-void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, Optional<float> velocity /*= { }*/)
+void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, Optional<float> velocity /*= {}*/)
 {
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveTakeoff: '%s', landing point Id: %u (X: %f, Y: %f, Z: %f)", _owner->GetGUID().ToString().c_str(), id, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
 
@@ -691,7 +691,7 @@ void MotionMaster::MoveTakeoff(uint32 id, Position const& pos, Optional<float> v
     init.MoveTo(PositionToVector3(pos), false);
     init.SetAnimation(AnimationTier::Hover);
     if (velocity)
-        init.SetVelocity(velocity.value());
+        init.SetVelocity(*velocity);
     Add(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id));
 }
 

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -168,8 +168,8 @@ class TC_GAME_API MotionMaster
          */
         void MoveCloserAndStop(uint32 id, Unit* target, float distance);
         // These two movement types should only be used with creatures having landing/takeoff animations
-        void MoveLand(uint32 id, Position const& pos, Optional<float> velocity = { });
-        void MoveTakeoff(uint32 id, Position const& pos, Optional<float> velocity = { });
+        void MoveLand(uint32 id, Position const& pos, Optional<float> velocity = {});
+        void MoveTakeoff(uint32 id, Position const& pos, Optional<float> velocity = {});
         void MoveCharge(float x, float y, float z, float speed = SPEED_CHARGE, uint32 id = EVENT_CHARGE, bool generatePath = false);
         void MoveCharge(PathGenerator const& path, float speed = SPEED_CHARGE);
         void MoveKnockbackFrom(float srcX, float srcY, float speedXY, float speedZ);

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -168,8 +168,8 @@ class TC_GAME_API MotionMaster
          */
         void MoveCloserAndStop(uint32 id, Unit* target, float distance);
         // These two movement types should only be used with creatures having landing/takeoff animations
-        void MoveLand(uint32 id, Position const& pos);
-        void MoveTakeoff(uint32 id, Position const& pos);
+        void MoveLand(uint32 id, Position const& pos, Optional<float> velocity = { });
+        void MoveTakeoff(uint32 id, Position const& pos, Optional<float> velocity = { });
         void MoveCharge(float x, float y, float z, float speed = SPEED_CHARGE, uint32 id = EVENT_CHARGE, bool generatePath = false);
         void MoveCharge(PathGenerator const& path, float speed = SPEED_CHARGE);
         void MoveKnockbackFrom(float srcX, float srcY, float speedXY, float speedZ);


### PR DESCRIPTION
**Changes proposed:**

-  allowing to specify spline speeds for takeoff and land splines. Many creatures that use these types of splines use own speeds for landing and taking off rather than relying on default speeds

- disable pathfinding for MoveTakeoff since it's not needed at all

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:**
- tested on 4.x on multiple bosses

