### PR TITLE
Core/Units: prevent units z offset from dropping below map surface when disabling hovering

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13243,7 +13243,7 @@ bool Unit::SetHover(bool enable, bool /*packetOnly = false*/, bool /*updateAnima
         //! Dying creatures will MoveFall from setDeathState
         if (hoverHeight && (!isDying() || GetTypeId() != TYPEID_UNIT))
         {
-            float newZ = GetPositionZ() - hoverHeight;
+            float newZ = std::max<float>(GetFloorZ(), GetPositionZ() - hoverHeight);
             UpdateAllowedPositionZ(GetPositionX(), GetPositionY(), newZ);
             UpdateHeight(newZ);
         }


### PR DESCRIPTION
**Changes proposed:**

-  units will no longer snap below map surface when disabling hovering when a unit already is closer to the ground that it should(tm) be (for example when doing manual movements that put you closer to the ground).


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:**
- tested on 4.x on assembly on iron rework branch

