### PR TITLE
Tools/MMapsGenerator: Add some more input parameters to improve mmaps load performances

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -603,7 +603,7 @@ namespace MMAP
 
                 rcFilterLowHangingWalkableObstacles(m_rcContext, config.walkableClimb, *tile.solid);
                 // disabled as it ignores walkableSlopeAngle settings
-                //rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
+                rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
                 rcFilterWalkableLowHeightSpans(m_rcContext, tileCfg.walkableHeight, *tile.solid);
 
                 // add liquid triangles
@@ -836,6 +836,11 @@ namespace MMAP
             header.size = uint32(navDataSize);
             fwrite(&header, sizeof(MmapTileHeader), 1, file);
 
+            /*
+            dtMeshHeader* navDataHeader = (dtMeshHeader*)navData;
+            printf("Poly count: %d\n", navDataHeader->polyCount);
+            */
+
             // write data
             fwrite(navData, sizeof(unsigned char), navDataSize, file);
             fclose(file);
@@ -1016,7 +1021,9 @@ namespace MMAP
         config.maxVertsPerPoly = DT_VERTS_PER_POLYGON;
         config.cs = tileConfig.BASE_UNIT_DIM;
         config.ch = tileConfig.BASE_UNIT_DIM;
-        config.walkableSlopeAngle = 85;
+        // Keeping these 2 slope angles the same reduces a lot the number of polys.
+        // 55 should be the minimum, maybe 70 is ok (keep in mind blink uses mmaps), 85 is too much for players
+        config.walkableSlopeAngle = 55;
         config.walkableSlopeAngleNotSteep = 55;
         config.tileSize = tileConfig.VERTEX_PER_TILE;
         config.walkableRadius = m_bigBaseUnit ? 1 : 2;

--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -31,16 +31,19 @@
 
 namespace MMAP
 {
-    MapBuilder::MapBuilder(bool skipLiquid,
+    MapBuilder::MapBuilder(Optional<float> maxWalkableAngle, Optional<float> maxWalkableAngleNotSteep, bool skipLiquid,
         bool skipContinents, bool skipJunkMaps, bool skipBattlegrounds,
-        bool debugOutput, bool bigBaseUnit, int mapid, char const* offMeshFilePath) :
+        bool debugOutput, bool bigBaseUnit, bool smallOutputSize, int mapid, char const* offMeshFilePath) :
         m_terrainBuilder     (nullptr),
         m_debugOutput        (debugOutput),
         m_offMeshFilePath    (offMeshFilePath),
         m_skipContinents     (skipContinents),
         m_skipJunkMaps       (skipJunkMaps),
         m_skipBattlegrounds  (skipBattlegrounds),
+        m_maxWalkableAngle   (maxWalkableAngle),
+        m_maxWalkableAngleNotSteep (maxWalkableAngleNotSteep),
         m_bigBaseUnit        (bigBaseUnit),
+        m_smallOutputSize    (smallOutputSize),
         m_mapid              (mapid),
         m_totalTiles         (0u),
         m_totalTilesProcessed(0u),
@@ -602,8 +605,9 @@ namespace MMAP
                 delete[] triFlags;
 
                 rcFilterLowHangingWalkableObstacles(m_rcContext, config.walkableClimb, *tile.solid);
-                // disabled as it ignores walkableSlopeAngle settings
-                rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
+                // disabled by default as it ignores walkableSlopeAngle settings
+                if (m_smallOutputSize)
+                    rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
                 rcFilterWalkableLowHeightSpans(m_rcContext, tileCfg.walkableHeight, *tile.solid);
 
                 // add liquid triangles
@@ -1023,8 +1027,8 @@ namespace MMAP
         config.ch = tileConfig.BASE_UNIT_DIM;
         // Keeping these 2 slope angles the same reduces a lot the number of polys.
         // 55 should be the minimum, maybe 70 is ok (keep in mind blink uses mmaps), 85 is too much for players
-        config.walkableSlopeAngle = 55;
-        config.walkableSlopeAngleNotSteep = 55;
+        config.walkableSlopeAngle = m_maxWalkableAngle ? *m_maxWalkableAngle : m_smallOutputSize ? 55 : 85;
+        config.walkableSlopeAngleNotSteep = m_maxWalkableAngleNotSteep ? *m_maxWalkableAngleNotSteep : 55;
         config.tileSize = tileConfig.VERTEX_PER_TILE;
         config.walkableRadius = m_bigBaseUnit ? 1 : 2;
         config.borderSize = config.walkableRadius + 3;

--- a/src/tools/mmaps_generator/MapBuilder.h
+++ b/src/tools/mmaps_generator/MapBuilder.h
@@ -22,6 +22,7 @@
 
 #include "Recast.h"
 #include "DetourNavMesh.h"
+#include "Optional.h"
 #include "ProducerConsumerQueue.h"
 
 #include <vector>
@@ -94,12 +95,15 @@ namespace MMAP
     class MapBuilder
     {
         public:
-            MapBuilder(bool skipLiquid   = false,
+            MapBuilder(Optional<float> maxWalkableAngle,
+                Optional<float> maxWalkableAngleNotSteep,
+                bool skipLiquid          = false,
                 bool skipContinents      = false,
                 bool skipJunkMaps        = true,
                 bool skipBattlegrounds   = false,
                 bool debugOutput         = false,
                 bool bigBaseUnit         = false,
+                bool smallOutputSize     = false,
                 int mapid                = -1,
                 char const* offMeshFilePath = nullptr);
 
@@ -159,7 +163,10 @@ namespace MMAP
             bool m_skipJunkMaps;
             bool m_skipBattlegrounds;
 
+            Optional<float> m_maxWalkableAngle;
+            Optional<float> m_maxWalkableAngleNotSteep;
             bool m_bigBaseUnit;
+            bool m_smallOutputSize;
 
             int32 m_mapid;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Add some more input parameters which affect the resulting mmaps:
- --smallOutputSize: sets both walkableSlopeAngle and walkableSlopeAngleNotSteep to 55°, reducing by a lot the .mmtile size and the number of polys. A rcFilterLedgeSpans() call is included too to filter out some polys. Default to false.
- --maxAngle: Restore this parameter removed some commits ago. Specifies the max walkable angle of a Creature when in combat. Default to 85
- --maxAngleNotSteep: Max walkable angle of a Player and of a Creature out of combat. Must be less or equal than --maxAngle. Default to 55.

A performance profiling comparison highlighted that .mmtile load grows exponential with the number of polys. A small server with GridUnload enabled and without preloading all grids on startup will be more affected than a big server with GridUnload disabled and preloading grids on startup.

The default values are not modified. Re-generating mmaps is required only if specifying different parameters. Different maps can have different settings (but the same map must be generated with the same setting)

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

None


**Tests performed:**

Ran mmaps_generator with a few different parameters, profiled with Intel VTune the changes


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Not sure which angles allowed players to blink in WSG to the alliance base down from the alliance spirit healer.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
