### PR TITLE
Core/Spells: Fixed fallback values for EquippedItemSubClassMask and EquippedItemInventoryTypeMask

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1174,8 +1174,8 @@ SpellInfo::SpellInfo(SpellNameEntry const* spellName, ::Difficulty difficulty, S
     // SpellEquippedItemsEntry
     SpellEquippedItemsEntry const* _equipped = data.EquippedItems;
     EquippedItemClass = _equipped ? _equipped->EquippedItemClass : -1;
-    EquippedItemSubClassMask = _equipped ?_equipped->EquippedItemSubclass : -1;
-    EquippedItemInventoryTypeMask = _equipped ? _equipped->EquippedItemInvTypes : -1;
+    EquippedItemSubClassMask = _equipped ?_equipped->EquippedItemSubclass : 0;
+    EquippedItemInventoryTypeMask = _equipped ? _equipped->EquippedItemInvTypes : 0;
 
     // SpellInterruptsEntry
     if (SpellInterruptsEntry const* _interrupt = data.Interrupts)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Changed fallback values for EquippedItemSubClassMask and EquippedItemInventoryTypeMask from -1 to 0. This also matches behavior in 3.3.5 Spell.dbc.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Fixes all bitmask checks related to the two fields e.g. `SpellInfo::IsRangedWeaponSpell()` incorrectly returning true for Wake of Ashes, causing the server to calculate ap bonus from ranged instead of melee.

**Tests performed:**

(Does it build, tested in-game, etc.)
Builds, tested with Wake of Ashes.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
