### PR TITLE
Core/ChatCommands: Fix a potential crash

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommand.cpp
+++ b/src/server/game/Chat/ChatCommands/ChatCommand.cpp
@@ -140,8 +140,14 @@ static void LogCommandUsage(WorldSession const& session, uint32 permission, std:
     if (AccountMgr::IsPlayerAccount(session.GetSecurity()))
         return;
 
-    if (sAccountMgr->GetRBACPermission(rbac::RBAC_ROLE_PLAYER)->GetLinkedPermissions().count(permission))
-        return;
+    rbac::RBACPermission const* rbacPermission = sAccountMgr->GetRBACPermission(rbac::RBAC_ROLE_PLAYER);
+    if (rbacPermission)
+    {
+        if (rbacPermission->GetLinkedPermissions().count(permission))
+            return;
+    }
+    else
+        TC_LOG_ERROR("sql.sql", "RBAC_ROLE_PLAYER (Id: %u) does not exists, please check rbac_permissions table in auth database", rbac::RBAC_ROLE_PLAYER);
 
     Player* player = session.GetPlayer();
     ObjectGuid targetGuid = player->GetTarget();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Well, I don't see a need to crash server just to avoid log a command linked to rbac role player in the GM log
-  Therefore I decide to avoid this check in case the rbac does not exist and log an error
-  I know it's stupid to change or delete the default roles, but I don't see a need to crash

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Tests performed:**

tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
