### PR TITLE
Game/Player: Fixed Backlash/Backdraft priority

### DIFF
--- a/sql/updates/world/3.3.5/2040_18_51_00_world.sql
+++ b/sql/updates/world/3.3.5/2040_18_51_00_world.sql
@@ -1,0 +1,2 @@
+-- Backdraft
+UPDATE `spell_proc` SET `SpellFamilyMask1`=131264 WHERE `SpellId` IN(54274,54276,54277);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21121,6 +21121,17 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
                 // special case (skip > 10sec spell casts for instant cast setting)
                 if (op == SPELLMOD_CASTING_TIME && mod->value <= -100 && basevalue >= T(10000))
                     return;
+                else if (!Player::HasSpellModApplied(mod, spell))
+                {
+                    // special case for Surge of Light, don't apply critical chance reduction if other mods not applied (ie procs while casting another spell)
+                    // (Surge of Light is the only PCT_MOD on critical chance)
+                    if (op == SPELLMOD_CRITICAL_CHANCE)
+                        return;
+                    // special case for Backdraft, dont' apply GCD reduction if cast time reduction wasn't applied (ie when Backlash is consumed first)
+                    // (Backdraft is the only PCT_MOD on global cooldown)
+                    else if (op == SPELLMOD_GLOBAL_COOLDOWN)
+                        return;
+                }
 
                 totalmul += CalculatePct(1.0f, mod->value);
                 break;
@@ -21207,6 +21218,14 @@ void Player::ApplyModToSpell(SpellModifier* mod, Spell* spell)
 
     // register inside spell, proc system uses this to drop charges
     spell->m_appliedMods.insert(mod->ownerAura);
+}
+
+bool Player::HasSpellModApplied(SpellModifier* mod, Spell* spell)
+{
+    if (!spell)
+        return false;
+
+    return spell->m_appliedMods.count(mod->ownerAura) != 0;
 }
 
 void Player::SetSpellModTakingSpell(Spell* spell, bool apply)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21123,11 +21123,11 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
                     return;
                 else if (!Player::HasSpellModApplied(mod, spell))
                 {
-                    // special case for Surge of Light, don't apply critical chance reduction if other mods not applied (ie procs while casting another spell)
+                    // Special case for Surge of Light, do not apply critical chance reduction if others mods was not applied (i.e. procs while casting another spell)
                     // (Surge of Light is the only PCT_MOD on critical chance)
                     if (op == SPELLMOD_CRITICAL_CHANCE)
                         return;
-                    // special case for Backdraft, dont' apply GCD reduction if cast time reduction wasn't applied (ie when Backlash is consumed first)
+                    // Special case for Backdraft: do not apply GCD reduction if cast time reduction was not applied (i.e. when Backlash is consumed first).
                     // (Backdraft is the only PCT_MOD on global cooldown)
                     else if (op == SPELLMOD_GLOBAL_COOLDOWN)
                         return;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1478,6 +1478,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         template <class T>
         void ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* spell = nullptr) const;
         static void ApplyModToSpell(SpellModifier* mod, Spell* spell);
+        static bool HasSpellModApplied(SpellModifier* mod, Spell* spell);
         void SetSpellModTakingSpell(Spell* spell, bool apply);
 
         void RemoveArenaSpellCooldowns(bool removeActivePetCooldowns = false);


### PR DESCRIPTION
**Changes proposed:**

-  Backlash must have priority on proc vs Backdraft.
-  Backdraft should not proc with Shadowfury, Shadowflame.

This PR restore a old behavior in backlash vs backdraft. It was fixed in https://github.com/TrinityCore/TrinityCore/commit/07fb65a6f2ae490bd74a53c945b4eb166c2ec953 but removed in https://github.com/TrinityCore/TrinityCore/commit/e73bfe8df89e4fb6aecc7cb3a1e266e868510799

But base case is still valid. With new priority system, Backlash will have priority over Backdraft when applying SPELLMOD_CASTING_TIME, but Backdraft will be consumed anyway while applying SPELLMOD_GLOBAL_COOLDOWN.

About Surge of Light, issue is still valid too

Some proofs about backdraft not proccing with shadowfury/shadowflame

https://www.youtube.com/watch?v=wgzKJbY3prw&feature=youtu.be&t=417
https://www.youtube.com/watch?v=QHfkeFnqabg&feature=youtu.be&t=92
https://www.youtube.com/watch?v=l8p9kz4svQI&feature=youtu.be&t=762

**Target branch(es):** 3.3.5

**Issues addressed:** has no open issues about it

**Tests performed:** builded and tested in game


