### PR TITLE
CI/CircleCI: Authenticate to DockerHub when pulling the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,13 @@ jobs:
   codestyle_and_sql:
     docker:
       - image: trinitycore/circle-ci:3.3.5-buildpacks-focal
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
       - image: circleci/mysql:8
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_ROOT_PASSWORD: ''
@@ -33,6 +39,9 @@ jobs:
   pch:
     docker:
       - image: trinitycore/circle-ci:3.3.5-buildpacks-focal
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - run:
           name: Checkout
@@ -64,6 +73,9 @@ jobs:
   nopch:
     docker:
       - image: trinitycore/circle-ci:3.3.5-buildpacks-focal
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - run:
           name: Requirements


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

CI/CircleCI: Authenticate to DockerHub when pulling the docker image

For more information see the following links:
- https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/
- https://docs.docker.com/docker-hub/download-rate-limit/
- https://circleci.com/docs/2.0/private-images/

Add DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD secrets to CircleCI Environment Variables. DOCKERHUB_PASSWORD can be either the password or an access token.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

None


**Tests performed:**

Tested adding the credentials to GitHub Secrets (they don't work) and to Circle CI project settings (they work).
If no credentials are found, anonymous authentication will be used


**Known issues and TODO list:** (add/remove lines as needed)

- Every user who doesn't want to have their Circle CI builds delayed/fail will have to add their fork to Circle CI and add docker hub credentials as env variables.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
