### PR TITLE
Updated commands learn/unlearn

### DIFF
--- a/src/server/game/Chat/ChatCommands/ChatCommandTags.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandTags.h
@@ -148,6 +148,19 @@ namespace Trinity::ChatCommands
         TC_GAME_API ChatCommandResult TryConsume(ChatHandler const* handler, std::string_view args);
     };
 
+    struct TC_GAME_API SpellIdentifier : Trinity::Impl::ChatCommands::ContainerTag
+    {
+        using value_type = SpellInfo const*;
+
+        operator uint32() const;
+        operator SpellInfo const* () const;
+
+        ChatCommandResult TryConsume(ChatHandler const* handler, std::string_view args);
+
+    private:
+        SpellInfo const* _spellInfo;
+    };
+
     struct TC_GAME_API AccountIdentifier : Trinity::Impl::ChatCommands::ContainerTag
     {
         using value_type = uint32;

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -89,7 +89,7 @@ public:
             return false;
         }
         SpellInfo const* spellInfo = _spell;
-        if (!spellInfo || !SpellMgr::IsSpellValid(spellInfo, handler->GetSession()->GetPlayer()))
+        if (!SpellMgr::IsSpellValid(spellInfo, handler->GetSession()->GetPlayer()))
         {
             handler->PSendSysMessage(LANG_COMMAND_SPELL_BROKEN, spellInfo->Id);
             handler->SetSentErrorMessage(true);


### PR DESCRIPTION
**Changes proposed:**

Refactor **.learn** and **.unlearn** commands using the same style as the recent command argument updates by Treeston.
Added a **SpellIdentifier** ContainerTag to help with this purpose.

**Target branch(es):** 

- [x] 3.3.5
- [ ] master

**Issues addressed:**

None

**Tests performed:**

Builds and both command seem to work just like before, with improved error output.

**Known issues and TODO list:** 

None