### PR TITLE
Core/Player: auto-attacked player stands up from sit or sleep state

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -946,6 +946,10 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
         }
     }
 
+    // check to see if victim is sitting
+    if (victim->IsSitState())
+        victim->SetStandState(UNIT_STAND_STATE_STAND);
+
     return damage;
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -947,7 +947,7 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
     }
 
     // check to see if victim is sitting
-    if (victim->IsSitState())
+    if (victim->GetStandState())
         victim->SetStandState(UNIT_STAND_STATE_STAND);
 
     return damage;


### PR DESCRIPTION
**Changes proposed:**
-  When auto attacking a sitting/sleeping/kneeling player, they should stand up.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**
Fixed a bug that caused a sitting/sleeping/kneeling player to not stand up when getting auto attacked.

**Tests performed:**
builds, tested, and works.

**Known issues and TODO list:** N/A