### PR TITLE
Core/Hotfixes: Add basic client support for optional data

### DIFF
--- a/sql/updates/hotfixes/master/9999_99_99_99_hotfixes.sql
+++ b/sql/updates/hotfixes/master/9999_99_99_99_hotfixes.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS `hotfix_optional_data`;
+CREATE TABLE `hotfix_optional_data` (
+	`TableHash` INT(10) UNSIGNED NOT NULL,
+	`RecordId` INT(11) NOT NULL,
+	`locale` VARCHAR(4) NOT NULL COLLATE 'utf8mb4_unicode_ci',
+	`Data` BLOB NULL DEFAULT NULL,
+	`VerifiedBuild` INT(11) NOT NULL DEFAULT '0',
+	PRIMARY KEY (`TableHash`, `RecordId`, `locale`) USING BTREE
+)
+COLLATE='utf8_general_ci'
+ENGINE=MyISAM
+;

--- a/src/server/game/DataStores/DB2Stores.h
+++ b/src/server/game/DataStores/DB2Stores.h
@@ -301,9 +301,11 @@ public:
 
     void LoadHotfixData();
     void LoadHotfixBlob(uint32 localeMask);
+    void LoadHotfixOptionalData(uint32 localeMask);
     uint32 GetHotfixCount() const;
     HotfixContainer const& GetHotfixData() const;
     std::vector<uint8> const* GetHotfixBlobData(uint32 tableHash, int32 recordId, LocaleConstant locale);
+    std::vector<uint8> const* GetHotfixOptionalData(uint32 tableHash, int32 recordId, LocaleConstant locale);
 
     uint32 GetEmptyAnimStateID() const;
     std::vector<uint32> GetAreasForGroup(uint32 areaGroupId) const;

--- a/src/server/game/Handlers/HotfixHandler.cpp
+++ b/src/server/game/Handlers/HotfixHandler.cpp
@@ -78,6 +78,10 @@ void WorldSession::HandleHotfixRequest(WorldPackets::Hotfix::HotfixRequest& hotf
             {
                 std::size_t pos = hotfixQueryResponse.HotfixContent.size();
                 storage->WriteRecord(uint32(hotfixRecord.RecordID), GetSessionDbcLocale(), hotfixQueryResponse.HotfixContent);
+
+                if (std::vector<uint8> const* optionalData = sDB2Manager.GetHotfixOptionalData(hotfixRecord.TableHash, hotfixRecord.RecordID, GetSessionDbcLocale()))
+                    hotfixQueryResponse.HotfixContent.append(optionalData->data(), optionalData->size());
+
                 hotfixData.Size = hotfixQueryResponse.HotfixContent.size() - pos;
             }
             else if (std::vector<uint8> const* blobData = sDB2Manager.GetHotfixBlobData(hotfixRecord.TableHash, hotfixRecord.RecordID, GetSessionDbcLocale()))

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1667,6 +1667,8 @@ void World::SetInitialWorldSettings()
     sDB2Manager.LoadHotfixBlob(m_availableDbcLocaleMask);
     TC_LOG_INFO("misc", "Loading hotfix info...");
     sDB2Manager.LoadHotfixData();
+    TC_LOG_INFO("misc", "Loading hotfix optional data...");
+    sDB2Manager.LoadHotfixOptionalData(m_availableDbcLocaleMask);
     ///- Close hotfix database - it is only used during DB2 loading
     HotfixDatabase.Close();
     ///- Load M2 fly by cameras


### PR DESCRIPTION
**Changes proposed:**

-  Adding store for optional data
-  Append optional data at the end of hotfix (like blizzard)
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**


**Tests performed:**

Nothing tested yet


**Known issues and TODO list:** (add/remove lines as needed)

