### PR TITLE
Core/Auras: vehicles should not despawn during seat change

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2974,7 +2974,10 @@ void AuraEffect::HandleAuraControlVehicle(AuraApplication const* aurApp, uint8 m
                 caster->ToCreature()->DespawnOrUnsummon();
         }
 
-        if (!(mode & AURA_EFFECT_HANDLE_CHANGE_AMOUNT))
+        bool seatChange = (mode & AURA_EFFECT_HANDLE_CHANGE_AMOUNT)                             // Seat change on the same direct vehicle
+            || target->HasAuraType(SPELL_AURA_CONTROL_VEHICLE);                                 // Seat change to a proxy vehicle (for example turret mounted on a siege engine)
+
+        if (!seatChange)
             caster->_ExitVehicle();
         else
             target->GetVehicleKit()->RemovePassenger(caster);  // Only remove passenger from vehicle without launching exit movement or despawning the vehicle

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2975,7 +2975,7 @@ void AuraEffect::HandleAuraControlVehicle(AuraApplication const* aurApp, uint8 m
         }
 
         bool seatChange = (mode & AURA_EFFECT_HANDLE_CHANGE_AMOUNT)                             // Seat change on the same direct vehicle
-            || target->HasAuraType(SPELL_AURA_CONTROL_VEHICLE);                                 // Seat change to a proxy vehicle (for example turret mounted on a siege engine)
+            || target->HasAuraTypeWithCaster(SPELL_AURA_CONTROL_VEHICLE, caster->GetGUID());    // Seat change to a proxy vehicle (for example turret mounted on a siege engine)
 
         if (!seatChange)
             caster->_ExitVehicle();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Vehicles are despawned while Seat Changes. Some tests and with a big help from Shauren (https://gist.github.com/Shauren/a5a7ebf7f0004ca1dbb8e0aac283bebb) its works now. My change was that at the check only considered auras from caster and not all on the vehicle(without this, that broke some other things(eject from vehicle, despawn vehicle accessory if more as one Vehicle ride spell on the vehicle)
-  
-  

**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:**
https://github.com/TrinityCore/TrinityCore/issues/18089 to half. Seat Change works, timed despawn missed
Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
Build works, ingame test works

**Known issues and TODO list:** (add/remove lines as needed)



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
