### PR TITLE
Core/Maps: move pooling hand-off outside of Map::CheckRespawn

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3038,45 +3038,41 @@ bool Map::CheckRespawn(RespawnInfo* info)
 
     uint32 poolId = info->spawnId ? sPoolMgr->IsPartOfAPool(info->type, info->spawnId) : 0;
     // Next, check if there's already an instance of this object that would block the respawn
-    // Only do this for unpooled spawns
-    if (!poolId)
+    bool doDelete = false;
+    switch (info->type)
     {
-        bool doDelete = false;
-        switch (info->type)
+        case SPAWN_TYPE_CREATURE:
         {
-            case SPAWN_TYPE_CREATURE:
-            {
-                // escort check for creatures only (if the world config boolean is set)
-                bool const isEscort = (sWorld->getBoolConfig(CONFIG_RESPAWN_DYNAMIC_ESCORTNPC) && data->spawnGroupData->flags & SPAWNGROUP_FLAG_ESCORTQUESTNPC);
+            // escort check for creatures only (if the world config boolean is set)
+            bool const isEscort = (sWorld->getBoolConfig(CONFIG_RESPAWN_DYNAMIC_ESCORTNPC) && data->spawnGroupData->flags & SPAWNGROUP_FLAG_ESCORTQUESTNPC);
 
-                auto range = _creatureBySpawnIdStore.equal_range(info->spawnId);
-                for (auto it = range.first; it != range.second; ++it)
-                {
-                    Creature* creature = it->second;
-                    if (!creature->IsAlive())
-                        continue;
-                    // escort NPCs are allowed to respawn as long as all other instances are already escorting
-                    if (isEscort && creature->IsEscorted())
-                        continue;
-                    doDelete = true;
-                    break;
-                }
+            auto range = _creatureBySpawnIdStore.equal_range(info->spawnId);
+            for (auto it = range.first; it != range.second; ++it)
+            {
+                Creature* creature = it->second;
+                if (!creature->IsAlive())
+                    continue;
+                // escort NPCs are allowed to respawn as long as all other instances are already escorting
+                if (isEscort && creature->IsEscorted())
+                    continue;
+                doDelete = true;
                 break;
             }
-            case SPAWN_TYPE_GAMEOBJECT:
-                // gameobject check is simpler - they cannot be dead or escorting
-                if (_gameobjectBySpawnIdStore.find(info->spawnId) != _gameobjectBySpawnIdStore.end())
-                    doDelete = true;
-                break;
-            default:
-                ABORT_MSG("Invalid spawn type %u with spawnId %u on map %u", uint32(info->type), info->spawnId, GetId());
-                return true;
+            break;
         }
-        if (doDelete)
-        {
-            info->respawnTime = 0;
-            return false;
-        }
+        case SPAWN_TYPE_GAMEOBJECT:
+            // gameobject check is simpler - they cannot be dead or escorting
+            if (_gameobjectBySpawnIdStore.find(info->spawnId) != _gameobjectBySpawnIdStore.end())
+                doDelete = true;
+            break;
+        default:
+            ABORT_MSG("Invalid spawn type %u with spawnId %u on map %u", uint32(info->type), info->spawnId, GetId());
+            return true;
+    }
+    if (doDelete)
+    {
+        info->respawnTime = 0;
+        return false;
     }
 
     // next, check linked respawn time
@@ -3094,21 +3090,6 @@ bool Map::CheckRespawn(RespawnInfo* info)
         info->respawnTime = respawnTime;
         return false;
     }
-
-    // now, check if we're part of a pool
-    if (poolId)
-    {
-        // ok, part of a pool - hand off to pool logic to handle this, we're just going to remove the respawn and call it a day
-        if (info->type == SPAWN_TYPE_GAMEOBJECT)
-            sPoolMgr->UpdatePool<GameObject>(poolId, info->spawnId);
-        else if (info->type == SPAWN_TYPE_CREATURE)
-            sPoolMgr->UpdatePool<Creature>(poolId, info->spawnId);
-        else
-            ABORT_MSG("Invalid spawn type %u (spawnid %u) on map %u", uint32(info->type), info->spawnId, GetId());
-        info->respawnTime = 0;
-        return false;
-    }
-
     // everything ok, let's spawn
     return true;
 }
@@ -3269,31 +3250,65 @@ void Map::DoRespawn(SpawnObjectType type, ObjectGuid::LowType spawnId, uint32 gr
 
 void Map::ProcessRespawns()
 {
+    // defer pool hand-off until after the loop to ensure internal consistency before going to external logic
+    struct PoolQueueEntry
+    {
+        PoolQueueEntry(uint32 p, SpawnObjectType t, ObjectGuid::LowType i) : poolId(p), spawnType(t), spawnId(i) {}
+        uint32 const poolId;
+        SpawnObjectType const spawnType;
+        ObjectGuid::LowType const spawnId;
+    };
+    std::vector<PoolQueueEntry> poolQueue;
+
     time_t now = GameTime::GetGameTime();
     while (!_respawnTimes.empty())
     {
         RespawnInfo* next = _respawnTimes.top();
         if (now < next->respawnTime) // done for this tick
             break;
+
+        if (uint32 poolId = sPoolMgr->IsPartOfAPool(next->type, next->spawnId)) // is this part of a pool?
+        { // if yes, respawn will be handled by (external) pooling logic, just delete the respawn time
+            _respawnTimes.pop();
+            GetRespawnMapForType(next->type).erase(next->spawnId);
+            poolQueue.emplace_back(poolId, next->type, next->spawnId);
+            continue;
+        }
+
         if (CheckRespawn(next)) // see if we're allowed to respawn
-        {
-            // ok, respawn
+        { // ok, respawn
             _respawnTimes.pop();
             GetRespawnMapForType(next->type).erase(next->spawnId);
             DoRespawn(next->type, next->spawnId, next->gridId);
             delete next;
         }
-        else if (!next->respawnTime) // just remove respawn entry without rescheduling
-        {
+        else if (!next->respawnTime)
+        { // just remove respawn entry without rescheduling
             _respawnTimes.pop();
             GetRespawnMapForType(next->type).erase(next->spawnId);
             delete next;
         }
-        else // value changed, update heap position
-        {
+        else
+        { // new respawn time, update heap position
             ASSERT(now < next->respawnTime); // infinite loop guard
             _respawnTimes.decrease(next->handle);
             SaveRespawnInfoDB(*next);
+        }
+    }
+
+    // ok, now that every is safely stashed away again, tell pooling system to do its thing
+    for (PoolQueueEntry entry : poolQueue)
+    {
+        switch (entry.spawnType)
+        {
+            case SPAWN_TYPE_GAMEOBJECT:
+                sPoolMgr->UpdatePool<GameObject>(entry.poolId, entry.spawnId);
+                break;
+            case SPAWN_TYPE_CREATURE:
+                sPoolMgr->UpdatePool<Creature>(entry.poolId, entry.spawnId);
+                break;
+            default:
+                ABORT_MSG("Invalid spawn type %u (spawnid %u) on map %u", uint32(entry.spawnType), entry.spawnId, GetId());
         }
     }
 }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3036,9 +3036,8 @@ bool Map::CheckRespawn(RespawnInfo* info)
         return false;
     }
 
-    uint32 poolId = info->spawnId ? sPoolMgr->IsPartOfAPool(info->type, info->spawnId) : 0;
     // Next, check if there's already an instance of this object that would block the respawn
-    bool doDelete = false;
+    bool alreadyExists = false;
     switch (info->type)
     {
         case SPAWN_TYPE_CREATURE:
@@ -3055,7 +3054,7 @@ bool Map::CheckRespawn(RespawnInfo* info)
                 // escort NPCs are allowed to respawn as long as all other instances are already escorting
                 if (isEscort && creature->IsEscorted())
                     continue;
-                doDelete = true;
+                alreadyExists = true;
                 break;
             }
             break;
@@ -3063,13 +3062,13 @@ bool Map::CheckRespawn(RespawnInfo* info)
         case SPAWN_TYPE_GAMEOBJECT:
             // gameobject check is simpler - they cannot be dead or escorting
             if (_gameobjectBySpawnIdStore.find(info->spawnId) != _gameobjectBySpawnIdStore.end())
-                doDelete = true;
+                alreadyExists = true;
             break;
         default:
             ABORT_MSG("Invalid spawn type %u with spawnId %u on map %u", uint32(info->type), info->spawnId, GetId());
             return true;
     }
-    if (doDelete)
+    if (alreadyExists)
     {
         info->respawnTime = 0;
         return false;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3268,9 +3268,10 @@ void Map::ProcessRespawns()
 
         if (uint32 poolId = sPoolMgr->IsPartOfAPool(next->type, next->spawnId)) // is this part of a pool?
         { // if yes, respawn will be handled by (external) pooling logic, just delete the respawn time
+            poolQueue.emplace_back(poolId, next->type, next->spawnId);
+
             _respawnTimes.pop();
             GetRespawnMapForType(next->type).erase(next->spawnId);
-            poolQueue.emplace_back(poolId, next->type, next->spawnId);
             delete next;
             continue;
         }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3271,6 +3271,7 @@ void Map::ProcessRespawns()
             _respawnTimes.pop();
             GetRespawnMapForType(next->type).erase(next->spawnId);
             poolQueue.emplace_back(poolId, next->type, next->spawnId);
+            delete next;
             continue;
         }
 

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -845,3 +845,18 @@ void PoolMgr::UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id)
 template void PoolMgr::UpdatePool<Pool>(uint32 pool_id, uint32 db_guid_or_pool_id);
 template void PoolMgr::UpdatePool<GameObject>(uint32 pool_id, uint32 db_guid_or_pool_id);
 template void PoolMgr::UpdatePool<Creature>(uint32 pool_id, uint32 db_guid_or_pool_id);
+
+void PoolMgr::UpdatePool(uint32 pool_id, SpawnObjectType type, uint32 spawnId)
+{
+    switch (type)
+    {
+        case SPAWN_TYPE_CREATURE:
+            UpdatePool<Creature>(pool_id, spawnId);
+            break;
+        case SPAWN_TYPE_GAMEOBJECT:
+            UpdatePool<GameObject>(pool_id, spawnId);
+            break;
+        default:
+            ABORT_MSG("Invalid spawn type %u passed to PoolMgr::IsPartOfPool (with spawnId %u)", uint32(type), spawnId);
+    }
+}

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -120,6 +120,7 @@ class TC_GAME_API PoolMgr
 
         template<typename T>
         void UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id);
+        void UpdatePool(uint32 pool_id, SpawnObjectType type, ObjectGuid::LowType spawnId);
 
     private:
         template<typename T>


### PR DESCRIPTION
This ensures that pooling logic can't stomp all over our nice Map internals

fixes #25777