### PR TITLE
Split all addon chat logs into separate log streams

### DIFF
--- a/src/server/scripts/World/chat_log.cpp
+++ b/src/server/scripts/World/chat_log.cpp
@@ -22,6 +22,12 @@
 #include "Log.h"
 #include "Player.h"
 
+#define TC_LOG_CHAT(TYPE, ...)                       \
+    if (lang != LANG_ADDON)                          \
+        TC_LOG_DEBUG("chat.log." TYPE, __VA_ARGS__); \
+    else                                             \
+        TC_LOG_DEBUG("chat.log.addon." TYPE, __VA_ARGS__);
+
 class ChatLogScript : public PlayerScript
 {
     public:
@@ -32,17 +38,17 @@ class ChatLogScript : public PlayerScript
             switch (type)
             {
                 case CHAT_MSG_SAY:
-                    TC_LOG_DEBUG("chat.log.say", "Player %s says (language %u): %s",
+                    TC_LOG_CHAT("say", "Player %s says (language %u): %s",
                         player->GetName().c_str(), lang, msg.c_str());
                     break;
 
                 case CHAT_MSG_EMOTE:
-                    TC_LOG_DEBUG("chat.log.emote", "Player %s emotes: %s",
+                    TC_LOG_CHAT("emote", "Player %s emotes: %s",
                         player->GetName().c_str(), msg.c_str());
                     break;
 
                 case CHAT_MSG_YELL:
-                    TC_LOG_DEBUG("chat.log.yell", "Player %s yells (language %u): %s",
+                    TC_LOG_CHAT("yell", "Player %s yells (language %u): %s",
                         player->GetName().c_str(), lang, msg.c_str());
                     break;
             }
@@ -50,12 +56,8 @@ class ChatLogScript : public PlayerScript
 
         void OnChat(Player* player, uint32 /*type*/, uint32 lang, std::string& msg, Player* receiver) override
         {
-            if (lang != LANG_ADDON)
-                TC_LOG_DEBUG("chat.log.whisper", "Player %s tells %s: %s",
-                    player->GetName().c_str(), receiver ? receiver->GetName().c_str() : "<unknown>", msg.c_str());
-            else
-                TC_LOG_DEBUG("chat.log.addon.whisper", "Player %s tells %s: %s",
-                    player->GetName().c_str(), receiver ? receiver->GetName().c_str() : "<unknown>", msg.c_str());
+            TC_LOG_CHAT("whisper", "Player %s tells %s: %s",
+               player->GetName().c_str(), receiver ? receiver->GetName().c_str() : "<unknown>", msg.c_str());
         }
 
         void OnChat(Player* player, uint32 type, uint32 lang, std::string& msg, Group* group) override
@@ -65,49 +67,37 @@ class ChatLogScript : public PlayerScript
             switch (type)
             {
                 case CHAT_MSG_PARTY:
-                    if (lang != LANG_ADDON)
-                        TC_LOG_DEBUG("chat.log.party", "Player %s tells group with leader %s: %s",
-                            player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
-                    else
-                        TC_LOG_DEBUG("chat.log.addon.party", "Player %s tells group with leader %s: %s",
-                            player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
+                    TC_LOG_CHAT("party", "Player %s tells group with leader %s: %s",
+                        player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
                     break;
 
                 case CHAT_MSG_PARTY_LEADER:
-                    TC_LOG_DEBUG("chat.log.party", "Leader %s tells group: %s",
+                    TC_LOG_CHAT("party", "Leader %s tells group: %s",
                         player->GetName().c_str(), msg.c_str());
                     break;
 
                 case CHAT_MSG_RAID:
-                    if (lang != LANG_ADDON)
-                        TC_LOG_DEBUG("chat.log.raid", "Player %s tells raid with leader %s: %s",
-                            player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
-                    else
-                        TC_LOG_DEBUG("chat.log.addon.raid", "Player %s tells raid with leader %s: %s",
-                            player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
+                    TC_LOG_CHAT("raid", "Player %s tells raid with leader %s: %s",
+                        player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
                     break;
 
                 case CHAT_MSG_RAID_LEADER:
-                    TC_LOG_DEBUG("chat.log.raid", "Leader player %s tells raid: %s",
+                    TC_LOG_CHAT("raid", "Leader player %s tells raid: %s",
                         player->GetName().c_str(), msg.c_str());
                     break;
 
                 case CHAT_MSG_RAID_WARNING:
-                    TC_LOG_DEBUG("chat.log.raid", "Leader player %s warns raid with: %s",
+                    TC_LOG_CHAT("raid", "Leader player %s warns raid with: %s",
                         player->GetName().c_str(), msg.c_str());
                     break;
 
                 case CHAT_MSG_INSTANCE_CHAT:
-                    if (lang != LANG_ADDON)
-                        TC_LOG_DEBUG("chat.log.bg", "Player %s tells instance with leader %s: %s",
-                            player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
-                    else
-                        TC_LOG_DEBUG("chat.log.addon.bg", "Player %s tells instance with leader %s: %s",
-                            player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
+                    TC_LOG_CHAT("bg", "Player %s tells instance with leader %s: %s",
+                        player->GetName().c_str(), group ? group->GetLeaderName() : "<unknown>", msg.c_str());
                     break;
 
                 case CHAT_MSG_INSTANCE_CHAT_LEADER:
-                    TC_LOG_DEBUG("chat.log.bg", "Leader player %s tells instance: %s",
+                    TC_LOG_CHAT("bg", "Leader player %s tells instance: %s",
                         player->GetName().c_str(), msg.c_str());
                     break;
             }
@@ -118,16 +108,12 @@ class ChatLogScript : public PlayerScript
             switch (type)
             {
                 case CHAT_MSG_GUILD:
-                    if (lang != LANG_ADDON)
-                        TC_LOG_DEBUG("chat.log.guild", "Player %s tells guild %s: %s",
-                            player->GetName().c_str(), guild ? guild->GetName().c_str() : "<unknown>", msg.c_str());
-                    else
-                        TC_LOG_DEBUG("chat.log.addon.guild", "Player %s sends to guild %s: %s",
-                            player->GetName().c_str(), guild ? guild->GetName().c_str() : "<unknown>", msg.c_str());
+                    TC_LOG_CHAT("guild", "Player %s tells guild %s: %s",
+                        player->GetName().c_str(), guild ? guild->GetName().c_str() : "<unknown>", msg.c_str());
                     break;
 
                 case CHAT_MSG_OFFICER:
-                    TC_LOG_DEBUG("chat.log.guild.officer", "Player %s tells guild %s officers: %s",
+                    TC_LOG_CHAT("guild.officer", "Player %s tells guild %s officers: %s",
                         player->GetName().c_str(), guild ? guild->GetName().c_str() : "<unknown>", msg.c_str());
                     break;
             }
@@ -157,3 +143,5 @@ void AddSC_chat_log()
 {
     new ChatLogScript();
 }
+
+#undef TC_LOG_CHAT

--- a/src/server/scripts/World/chat_log.cpp
+++ b/src/server/scripts/World/chat_log.cpp
@@ -119,7 +119,7 @@ class ChatLogScript : public PlayerScript
             }
         }
 
-        void OnChat(Player* player, uint32 /*type*/, uint32 /*lang*/, std::string& msg, Channel* channel) override
+        void OnChat(Player* player, uint32 /*type*/, uint32 lang, std::string& msg, Channel* channel) override
         {
             bool isSystem = channel &&
                             (channel->HasFlag(CHANNEL_FLAG_TRADE) ||
@@ -128,12 +128,14 @@ class ChatLogScript : public PlayerScript
                              channel->HasFlag(CHANNEL_FLAG_LFG));
 
             if (isSystem)
-                TC_LOG_DEBUG("chat.log.system", "Player %s tells channel %s: %s",
+            {
+                TC_LOG_CHAT("system", "Player %s tells channel %s: %s",
                     player->GetName().c_str(), channel->GetName().c_str(), msg.c_str());
+            }
             else
             {
                 std::string channelName = channel ? channel->GetName() : "<unknown>";
-                TC_LOG_DEBUG("chat.log.channel." + channelName, "Player %s tells channel %s: %s",
+                TC_LOG_CHAT("channel." + channelName, "Player %s tells channel %s: %s",
                     player->GetName().c_str(), channelName.c_str(), msg.c_str());
             }
         }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Move all addon chat logs into separate log streams to avoid addon chatter spamming the standard chat logs

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:**

Closes #25815

**Tests performed:**

Compiles, verified behavior via lua `SendChatMessage`.


This is my first contribution here, so let me know if I missed anything in the process!

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
