### PR TITLE
Expose binaries built on Circle CI as docker images in the Circle CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,8 @@ jobs:
           name: Create docker images
           command: |
             cd bin/check_install/bin
-            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:latest
-            docker save $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+            # docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:latest
+            # docker save $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
       - store_artifacts:
           path: bin/check_install/bin/docker-worldserver.tar.gz
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=none -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=none -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: Build
@@ -74,7 +74,7 @@ jobs:
           name: Create docker images
           command: |
             cd bin/check_install/bin
-            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver | tr '[:upper:]' '[:lower:]')
+            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest
             docker save $image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
@@ -115,7 +115,7 @@ jobs:
             $CXX --version
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=none -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
             cd ..
       - run:
           name: Build
@@ -126,6 +126,16 @@ jobs:
             cd check_install/bin
             ./authserver --version
             ./worldserver --version
+      - run:
+          name: Create docker images
+          command: |
+            cd bin/check_install/bin
+            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
+            echo $image_prefix
+            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest
+            docker save $image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+      - store_artifacts:
+          path: bin/check_install/bin/docker-worldserver.tar.gz
       - save_cache:
           key: 3.3.5-nopch-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           name: Create docker images
           command: |
             cd bin/check_install/bin
-            cp -r ../../contrib/Docker/*.Dockerfile .
+            cp -r ../../../contrib/Docker/*.Dockerfile .
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file worldserver.Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: Build
@@ -70,6 +70,15 @@ jobs:
             cd bin/check_install/bin
             ./authserver --version
             ./worldserver --version
+      - run:
+          name: Create docker images
+          command: |
+            cd bin/check_install/bin
+            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver | tr '[:upper:]' '[:lower:]')
+            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag image_prefix:latest
+            docker save image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+      - store_artifacts:
+          path: bin/check_install/bin/docker-worldserver.tar.gz
   nopch:
     docker:
       - image: trinitycore/circle-ci:3.3.5-buildpacks-focal
@@ -105,7 +114,7 @@ jobs:
             $CXX --version
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
             cd ..
       - run:
           name: Build
@@ -116,15 +125,6 @@ jobs:
             cd check_install/bin
             ./authserver --version
             ./worldserver --version
-      - run:
-          name: Create docker images
-          command: |
-            cd bin/check_install/bin
-            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver | tr '[:upper:]' '[:lower:]')
-            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag image_prefix:latest
-            docker save image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
-      - store_artifacts:
-          path: bin/check_install/bin/docker-worldserver.tar.gz
       - save_cache:
           key: 3.3.5-nopch-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,13 @@ jobs:
           name: Create docker images
           command: |
             cd bin/check_install/bin
-            cp -r ../../../contrib/Docker/*.Dockerfile .
-            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
+            cp -r ../../../contrib/Docker/Dockerfile .
+            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-') | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file worldserver.Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
-            docker save $image_prefix:$CIRCLE_SHA1 | gzip > ../../../docker-worldserver.tar.gz
+            docker save $image_prefix:$CIRCLE_SHA1 | gzip > ../../../docker.tar.gz
       - store_artifacts:
-          path: docker-worldserver.tar.gz
+          path: docker.tar.gz
   nopch:
     docker:
       - image: trinitycore/circle-ci:3.3.5-buildpacks-focal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,13 +70,16 @@ jobs:
             cd bin/check_install/bin
             ./authserver --version
             ./worldserver --version
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: Create docker images
           command: |
             cd bin/check_install/bin
+            cp -r ../../contrib/Docker/*.Dockerfile .
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
-            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest
+            docker build --file worldserver.Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
             docker save $image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
       - store_artifacts:
           path: bin/check_install/bin/docker-worldserver.tar.gz
@@ -115,7 +118,7 @@ jobs:
             $CXX --version
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=none -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
             cd ..
       - run:
           name: Build
@@ -126,16 +129,6 @@ jobs:
             cd check_install/bin
             ./authserver --version
             ./worldserver --version
-      - run:
-          name: Create docker images
-          command: |
-            cd bin/check_install/bin
-            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
-            echo $image_prefix
-            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest
-            docker save $image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
-      - store_artifacts:
-          path: bin/check_install/bin/docker-worldserver.tar.gz
       - save_cache:
           key: 3.3.5-nopch-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             cp -r ../../../contrib/Docker/Dockerfile .
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-') | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
-            docker build --file worldserver.Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
+            docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
             docker save $image_prefix:$CIRCLE_SHA1 | gzip > ../../../docker.tar.gz
       - store_artifacts:
           path: docker.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,9 @@ jobs:
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-')-worldserver | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file worldserver.Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
-            docker save $image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+            docker save $image_prefix:$CIRCLE_SHA1 | gzip > ../../../docker-worldserver.tar.gz
       - store_artifacts:
-          path: bin/check_install/bin/docker-worldserver.tar.gz
+          path: docker-worldserver.tar.gz
   nopch:
     docker:
       - image: trinitycore/circle-ci:3.3.5-buildpacks-focal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
             $CXX --version
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=0 -DUSE_SCRIPTPCH=0 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install
             cd ..
       - run:
           name: Build
@@ -116,6 +116,14 @@ jobs:
             cd check_install/bin
             ./authserver --version
             ./worldserver --version
+      - run:
+          name: Create docker images
+          command: |
+            cd bin/check_install/bin
+            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:latest
+            docker save $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+      - store_artifacts:
+          path: bin/check_install/bin/docker-worldserver.tar.gz
       - save_cache:
           key: 3.3.5-nopch-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           name: Create docker images
           command: |
             cd bin/check_install/bin
-            cp -r ../../../contrib/Docker/Dockerfile .
+            cp -r ../../../contrib/Docker/* .
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-') | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,9 @@ jobs:
           name: Create docker images
           command: |
             cd bin/check_install/bin
-            # docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 --tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:latest
-            # docker save $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver | tr '[:upper:]' '[:lower:]')
+            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag image_prefix:latest
+            docker save image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
       - store_artifacts:
           path: bin/check_install/bin/docker-worldserver.tar.gz
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
           command: |
             cd bin/check_install/bin
             cp -r ../../../contrib/Docker/* .
+            cp -r ../../../sql ./sql
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-') | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,9 @@ jobs:
           command: |
             cd bin/check_install/bin
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$CIRCLE_BRANCH-worldserver | tr '[:upper:]' '[:lower:]')
-            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag image_prefix:latest
-            docker save image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
+            echo $image_prefix
+            docker build --file '../../contrib/Docker/worldserver.Dockerfile' --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest
+            docker save $image_prefix:$CIRCLE_SHA1 | gzip > docker-worldserver.tar.gz
       - store_artifacts:
           path: bin/check_install/bin/docker-worldserver.tar.gz
   nopch:

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -4,3 +4,5 @@ FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 COPY worldserver /usr/local/bin/
 COPY authserver /usr/local/bin/
 ENTRYPOINT [ "worldserver" ]
+#docker run "image name" --entrypoint=authserver --config authserver.conf
+#docker run "image name" --entrypoint=worldserver --config worldserver.conf

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -2,5 +2,6 @@ FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
 COPY README.md /
+COPY sql /home/circleci/project/sql
 COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]
 ENTRYPOINT [ "echo",  "Check the README.md file for instructions"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]
 COPY README.md /
-ENTRYPOINT [ "echo Check the README.md file for instructions"]
+COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]
+ENTRYPOINT [ "echo",  "Check the README.md file for instructions"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
+USER root
+RUN chmod 777 /
+USER circleci
 COPY README.md /
 COPY --chown=circleci:circleci sql /home/circleci/project/sql
 COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,11 +1,6 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY authserver /usr/local/bin/
-COPY mapextractor /usr/local/bin/
-COPY mmaps_generator /usr/local/bin/
-COPY vmap4asembler /usr/local/bin/
-COPY vmap4extractor /usr/local/bin/
-COPY worldserver /usr/local/bin/
+COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]
 COPY README.md /
 ENTRYPOINT [ "echo Check the README.md file for instructions"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,9 +1,7 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-USER root
-RUN chmod 777 /
-USER circleci
+WORKDIR $HOME
 COPY README.md /
 COPY --chown=circleci:circleci sql /home/circleci/project/sql
 COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -2,4 +2,5 @@ FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
 COPY worldserver /usr/local/bin/
+COPY authserver /usr/local/bin/
 ENTRYPOINT [ "worldserver" ]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,8 +1,11 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY worldserver /usr/local/bin/
 COPY authserver /usr/local/bin/
-ENTRYPOINT [ "worldserver" ]
-#docker run "image name" --entrypoint=authserver --config authserver.conf
-#docker run "image name" --entrypoint=worldserver --config worldserver.conf
+COPY mapextractor /usr/local/bin/
+COPY mmaps_generator /usr/local/bin/
+COPY vmap4asembler /usr/local/bin/
+COPY vmap4extractor /usr/local/bin/
+COPY worldserver /usr/local/bin/
+COPY README.md /
+ENTRYPOINT [ "echo Check the README.md file for instructions"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -2,6 +2,6 @@ FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
 COPY README.md /
-COPY sql /home/circleci/project/sql
+COPY --chown=circleci:circleci sql /home/circleci/project/sql
 COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]
 ENTRYPOINT [ "echo",  "Check the README.md file for instructions"]

--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-WORKDIR $HOME
+WORKDIR /home/circleci
 COPY README.md /
 COPY --chown=circleci:circleci sql /home/circleci/project/sql
 COPY ["authserver", "mapextractor", "mmaps_generator", "vmap4assembler", "vmap4extractor", "worldserver", "/usr/local/bin/"]

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -22,7 +22,22 @@ The instructions below expect basic knowledge about how to configure TrinityCore
         ```
         docker run --entrypoint=worldserver --volume=/host/path/to/configs:/etc/TrinityCore--volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=8085:8085 "image name" --config /etc/TrinityCore/worldserver.conf
         ```
-    Change the ports and other parameters as needed. Consult Docker documentation for additional details about possible configuration settings
+    Change the ports and other parameters as needed. Consult Docker documentation for additional details about possible configuration settings.
+
+## Content
+The image contains:
+- authserver
+- mapextractor
+- mmaps_generator
+- vmap4asembler
+- vmap4extractor
+- worldserver
+- README&#46;md
+
+You can explore the image using
+```
+docker run --entrypoint=/bin/bash -it "image name"
+```
 
 ## Limitations:
 - Database auto-updater: no instructions are given in this README to get the database auto-updater to work. Either apply the updates manually or investigate how to get it to work (most likely some additional --volume parameters should be passed)

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -39,10 +39,9 @@ You can explore the image using
 ```
 docker run --entrypoint=/bin/bash -it "image name"
 ```
-
-You can export the logs from the container with
+Note that the WORKDIR is set to /home/circleci and by default all logs will be saved in that folder. You can export the logs from the container with
 ```
-docker cp "container name":name.log name.log
+docker cp "container name":/home/circleci/name.log name.log
 ```
 
 For more instructions please check docker official documentation.

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -50,6 +50,5 @@ For more instructions please check docker official documentation.
 - Database connection: the instructions provided expect MySQL to run on the host machine. Change ``docker run`` parameters and .conf settings to fit your scenario
 - To import TDB using the autoupdater:
   1. Download the TDB sql file from GitHub
-  1. ``chmod 666 TDB_name.sql`` in the host
   1. Map it with ``--volume=/path/to/TDB_full_name.sql:/home/circleci/TDB_full_name.sql`` added to the commands specified in the main steps above
   1. Run the container

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -42,7 +42,7 @@ docker run --entrypoint=/bin/bash -it "image name"
 
 You can export the logs from the container with
 ```
-docker cp "container name":/path.log name.log
+docker cp "container name":name.log name.log
 ```
 
 For more instructions please check docker official documentation.

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -1,0 +1,29 @@
+# Docker
+Circle CI linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for linux and store that in the job artifacts.
+
+The instructions below expect basic knowledge about how to configure TrinityCore and how to use Docker:
+1. Click on the green ✔ next to each commit
+1. Scroll to "ci/circleci: pch" and click on "Details"
+1. Login to Circle CI if necessary. You might have to repeat again the previous steps after logging in to reach the correct page
+1. Click on "Artifacts" tab in Circle CI website
+1. Download the docker.tar.gz archive containing the docker image
+1. Load the image into your Docker host using
+    ```
+    docker load -i docker.tar.gz
+    ```
+1. Copy the .conf files from TrinityCore GitHub repository to a local folder that will be passed as mapped volume to docker
+1. Set the MySQL host in the .conf files to use the unix socket of MySQL, i.e.: ```".;/var/run/mysqld/mysqld.sock;username;password;database```
+1. Start authserver or worldserver as desired
+    - authserver
+        ```
+        docker run --entrypoint=authserver --volume=/host/path/to/configs:/etc/TrinityCore --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=3724:3724 "image name" --config /etc/TrinityCore/authserver.conf
+        ```
+    - worldserver
+        ```
+        docker run --entrypoint=worldserver --volume=/host/path/to/configs:/etc/TrinityCore--volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=8085:8085 "image name" --config /etc/TrinityCore/worldserver.conf
+        ```
+    Change the ports and other parameters as needed. Consult Docker documentation for additional details about possible configuration settings
+
+## Limitations:
+- Database auto-updater: no instructions are given in this README to get the database auto-updater to work. Either apply the updates manually or investigate how to get it to work (most likely some additional --volume parameters should be passed)
+- Database connection: the instructions provided expect MySQL to run on the host machine. Change ```docker run``` parameters and .conf settings to fit your scenario

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -41,5 +41,4 @@ docker run --entrypoint=/bin/bash -it "image name"
 ```
 
 ## Limitations:
-- Database auto-updater: no instructions are given in this README to get the database auto-updater to work. Either apply the updates manually or investigate how to get it to work (most likely some additional --volume parameters should be passed)
 - Database connection: the instructions provided expect MySQL to run on the host machine. Change ```docker run``` parameters and .conf settings to fit your scenario

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -48,3 +48,8 @@ For more instructions please check docker official documentation.
 
 ## Limitations:
 - Database connection: the instructions provided expect MySQL to run on the host machine. Change ```docker run``` parameters and .conf settings to fit your scenario
+- To import TDB using the autoupdater:
+  1. Download the TDB sql file from GitHub
+  1. ```chmod 666 TDB_name.sql``` in the host
+  1. Map it with ```--volume=/path/to/TDB_full_name.sql:/home/circleci/TDB_full_name.sql``` added to the commands specified in the main steps above
+  1. Run the container

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -13,14 +13,15 @@ The instructions below expect basic knowledge about how to configure TrinityCore
     ```
 1. Copy the .conf files from TrinityCore GitHub repository to a local folder that will be passed as mapped volume to docker
 1. Set the MySQL host in the .conf files to use the unix socket of MySQL, i.e.: ```".;/var/run/mysqld/mysqld.sock;username;password;database```
-1. Start authserver or worldserver as desired
+1. Set the "DataDir" config in worldserver.conf to ```"/trinity/data"```
+1. Start authserver or worldserver as desired, mapping the required volumes
     - authserver
         ```
-        docker run --entrypoint=authserver --volume=/host/path/to/configs:/etc/TrinityCore --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=3724:3724 "image name" --config /etc/TrinityCore/authserver.conf
+        docker run --entrypoint=authserver -it --volume=/host/path/to/configs:/etc/TrinityCore --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=3724:3724 "image name" --config /etc/TrinityCore/authserver.conf
         ```
     - worldserver
         ```
-        docker run --entrypoint=worldserver --volume=/host/path/to/configs:/etc/TrinityCore--volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=8085:8085 "image name" --config /etc/TrinityCore/worldserver.conf
+        docker run --entrypoint=worldserver -it --volume=/host/path/to/configs:/etc/TrinityCore --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock --volume=/path/to/data/directory:/trinity/data -p=8085:8085 "image name" --config /etc/TrinityCore/worldserver.conf
         ```
     Change the ports and other parameters as needed. Consult Docker documentation for additional details about possible configuration settings.
 

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -40,5 +40,12 @@ You can explore the image using
 docker run --entrypoint=/bin/bash -it "image name"
 ```
 
+You can export the logs from the container with
+```
+docker cp "container name":/path.log name.log
+```
+
+For more instructions please check docker official documentation.
+
 ## Limitations:
 - Database connection: the instructions provided expect MySQL to run on the host machine. Change ```docker run``` parameters and .conf settings to fit your scenario

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -17,11 +17,11 @@ The instructions below expect basic knowledge about how to configure TrinityCore
 1. Start authserver or worldserver as desired, mapping the required volumes
     - authserver
         ```
-        docker run --entrypoint=authserver -it --volume=/host/path/to/configs:/etc/TrinityCore --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=3724:3724 "image name" --config /etc/TrinityCore/authserver.conf
+        docker run --entrypoint=authserver -it --volume=/host/path/to/configs:/home/circleci/project/bin/check_install/etc --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock -p=3724:3724 "image name"
         ```
     - worldserver
         ```
-        docker run --entrypoint=worldserver -it --volume=/host/path/to/configs:/etc/TrinityCore --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock --volume=/path/to/data/directory:/trinity/data -p=8085:8085 "image name" --config /etc/TrinityCore/worldserver.conf
+        docker run --entrypoint=worldserver -it --volume=/host/path/to/configs:/home/circleci/project/bin/check_install/etc --volume=/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock --volume=/path/to/data/directory:/trinity/data -p=8085:8085 "image name"
         ```
     Change the ports and other parameters as needed. Consult Docker documentation for additional details about possible configuration settings.
 

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -12,8 +12,8 @@ The instructions below expect basic knowledge about how to configure TrinityCore
     docker load -i docker.tar.gz
     ```
 1. Copy the .conf files from TrinityCore GitHub repository to a local folder that will be passed as mapped volume to docker
-1. Set the MySQL host in the .conf files to use the unix socket of MySQL, i.e.: ```".;/var/run/mysqld/mysqld.sock;username;password;database```
-1. Set the "DataDir" config in worldserver.conf to ```"/trinity/data"```
+1. Set the MySQL host in the .conf files to use the unix socket of MySQL, i.e.: ``".;/var/run/mysqld/mysqld.sock;username;password;database``
+1. Set the "DataDir" config in worldserver.conf to ``"/trinity/data"``
 1. Start authserver or worldserver as desired, mapping the required volumes
     - authserver
         ```
@@ -47,9 +47,9 @@ docker cp "container name":/home/circleci/name.log name.log
 For more instructions please check docker official documentation.
 
 ## Limitations:
-- Database connection: the instructions provided expect MySQL to run on the host machine. Change ```docker run``` parameters and .conf settings to fit your scenario
+- Database connection: the instructions provided expect MySQL to run on the host machine. Change ``docker run`` parameters and .conf settings to fit your scenario
 - To import TDB using the autoupdater:
   1. Download the TDB sql file from GitHub
-  1. ```chmod 666 TDB_name.sql``` in the host
-  1. Map it with ```--volume=/path/to/TDB_full_name.sql:/home/circleci/TDB_full_name.sql``` added to the commands specified in the main steps above
+  1. ``chmod 666 TDB_name.sql`` in the host
+  1. Map it with ``--volume=/path/to/TDB_full_name.sql:/home/circleci/TDB_full_name.sql`` added to the commands specified in the main steps above
   1. Run the container

--- a/contrib/Docker/worldserver.Dockerfile
+++ b/contrib/Docker/worldserver.Dockerfile
@@ -1,5 +1,5 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY worldserver /usb/local/bin/
+COPY worldserver /usr/local/bin/
 ENTRYPOINT [ "worldserver" ]

--- a/contrib/Docker/worldserver.Dockerfile
+++ b/contrib/Docker/worldserver.Dockerfile
@@ -1,0 +1,5 @@
+FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
+
+#Setup
+COPY worldserver worldserver
+ENTRYPOINT [ "worldserver" ]

--- a/contrib/Docker/worldserver.Dockerfile
+++ b/contrib/Docker/worldserver.Dockerfile
@@ -1,5 +1,5 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY worldserver /usb/local/bin/
-ENTRYPOINT [ "worldserver" ]
+COPY ./worldserver /
+ENTRYPOINT [ "/worldserver" ]

--- a/contrib/Docker/worldserver.Dockerfile
+++ b/contrib/Docker/worldserver.Dockerfile
@@ -1,5 +1,5 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY worldserver /usb/bin/worldserver
+COPY worldserver /usb/local/bin/
 ENTRYPOINT [ "worldserver" ]

--- a/contrib/Docker/worldserver.Dockerfile
+++ b/contrib/Docker/worldserver.Dockerfile
@@ -1,5 +1,5 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY worldserver worldserver
+COPY worldserver /usb/bin/worldserver
 ENTRYPOINT [ "worldserver" ]

--- a/contrib/Docker/worldserver.Dockerfile
+++ b/contrib/Docker/worldserver.Dockerfile
@@ -1,5 +1,5 @@
 FROM trinitycore/circle-ci:3.3.5-buildpacks-focal
 
 #Setup
-COPY ./worldserver /
-ENTRYPOINT [ "/worldserver" ]
+COPY worldserver /usb/local/bin/
+ENTRYPOINT [ "worldserver" ]

--- a/src/common/Utilities/StartProcess.cpp
+++ b/src/common/Utilities/StartProcess.cpp
@@ -81,7 +81,7 @@ static int CreateChildProcess(T waiter, std::string const& executable,
                 executable.c_str(), boost::algorithm::join(argsVector, " ").c_str());
     }
 
-    // prepare file with only read permission (boost process opens with with read_write)
+    // prepare file with only read permission (boost process opens with read_write)
     std::shared_ptr<FILE> inputFile(!input.empty() ? fopen(input.c_str(), "rb") : nullptr, [](FILE* ptr)
     {
         if (ptr != nullptr)

--- a/src/common/Utilities/StartProcess.cpp
+++ b/src/common/Utilities/StartProcess.cpp
@@ -81,17 +81,24 @@ static int CreateChildProcess(T waiter, std::string const& executable,
                 executable.c_str(), boost::algorithm::join(argsVector, " ").c_str());
     }
 
+    // prepare file with only read permission (boost process opens with with read_write)
+    std::shared_ptr<FILE> inputFile(!input.empty() ? fopen(input.c_str(), "rb") : nullptr, [](FILE* ptr)
+    {
+        if (ptr != nullptr)
+            fclose(ptr);
+    });
+
     // Start the child process
     child c = [&]()
     {
-        if (!input.empty())
+        if (inputFile)
         {
             // With binding stdin
             return child{
                 exe = boost::filesystem::absolute(executable).string(),
                 args = argsVector,
                 env = environment(boost::this_process::environment()),
-                std_in = input,
+                std_in = inputFile.get(),
                 std_out = outStream,
                 std_err = errStream
             };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Expose binaries built on Circle CI as docker images in the Circle CI artifacts
  - The artifact is always called docker.tar.gz
  - It contains all the binaries (authserver, worldserver, extractors)
  - It can be imported in docker with ```docker load```, more info in the README.md included
  - The docker image is tagged with "github_useranme/github_repository-lowercasebranchname-commitsha1" and github_useranme/github_repository-lowercasebranchname-latest (not sure if the -latest tag works though)
- Include some operational instructions
- Change Circle CI pch job build settings

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

None, but now PRs can be tested without building locally the sources. The images shouldn't be used in production but only for testing/debugging


**Tests performed:**

Logged to character selection screen


**Known issues and TODO list:** (add/remove lines as needed)

- [x] ~~It would be useful to create 2 circle ci TC base images, one for the runtime and one for building TC, to reduce the image size~~
    - Circle CI base images are already quite big (400 MB) and the current size with binaries is 560 MB so it's not worth the effort
- [ ] It would be useful to push the images to dockerhub
  - [ ] Maybe this could be optional and only when DOCKERHUB_* credentials are set in circle ci
- [x] It would be nice if autoupdater worked
  - [x] Test importing TDB


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
