### PR TITLE
Change size of SMSG_AUTH_CHALLENGE WorldPacket from 37 to 40 in WorldSocket::HandleSendAuthSession

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -126,7 +126,7 @@ bool WorldSocket::Update()
 
 void WorldSocket::HandleSendAuthSession()
 {
-    WorldPacket packet(SMSG_AUTH_CHALLENGE, 37);
+    WorldPacket packet(SMSG_AUTH_CHALLENGE, 40);
     packet << uint32(1);                                    // 1...31
     packet.append(_authSeed);
 


### PR DESCRIPTION
Change size of SMSG_AUTH_CHALLENGE WorldPacket from 37 to 40 in WorldSocket::HandleSendAuthSession

This won't change much except avoiding a resize of the internal buffer, since 37 is too small