### PR TITLE
IsAllowingDeadTargets now checks effects targets as well

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1550,9 +1550,7 @@ bool SpellInfo::IsRequiringDeadTarget() const
 bool SpellInfo::IsAllowingDeadTarget() const
 {
     if (HasAttribute(SPELL_ATTR2_CAN_TARGET_DEAD) || Targets & (TARGET_FLAG_CORPSE_ALLY | TARGET_FLAG_CORPSE_ENEMY | TARGET_FLAG_UNIT_DEAD))
-    {
         return true;
-    }
 
     for (SpellEffectInfo const* effect : _effects)
     {

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1549,7 +1549,24 @@ bool SpellInfo::IsRequiringDeadTarget() const
 
 bool SpellInfo::IsAllowingDeadTarget() const
 {
-    return HasAttribute(SPELL_ATTR2_CAN_TARGET_DEAD) || Targets & (TARGET_FLAG_CORPSE_ALLY | TARGET_FLAG_CORPSE_ENEMY | TARGET_FLAG_UNIT_DEAD);
+    if (HasAttribute(SPELL_ATTR2_CAN_TARGET_DEAD) || Targets & (TARGET_FLAG_CORPSE_ALLY | TARGET_FLAG_CORPSE_ENEMY | TARGET_FLAG_UNIT_DEAD))
+    {
+        return true;
+    }
+
+    for (SpellEffectInfo const* effect : _effects)
+    {
+        if (!effect)
+            continue;
+
+        switch (effect->TargetA.GetTarget())
+        {
+        case TARGET_CORPSE_SRC_AREA_RAID:
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool SpellInfo::IsGroupBuff() const

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1559,11 +1559,8 @@ bool SpellInfo::IsAllowingDeadTarget() const
         if (!effect)
             continue;
 
-        if (effect->TargetA.GetObjectType() == TARGET_OBJECT_TYPE_CORPSE ||
-            effect->TargetB.GetObjectType() == TARGET_OBJECT_TYPE_CORPSE)
-        {
+        if (effect->TargetA.GetObjectType() == TARGET_OBJECT_TYPE_CORPSE || effect->TargetB.GetObjectType() == TARGET_OBJECT_TYPE_CORPSE)
             return true;
-        }
     }
 
     return false;

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1559,9 +1559,9 @@ bool SpellInfo::IsAllowingDeadTarget() const
         if (!effect)
             continue;
 
-        switch (effect->TargetA.GetTarget())
+        if (effect->TargetA.GetObjectType() == TARGET_OBJECT_TYPE_CORPSE ||
+            effect->TargetB.GetObjectType() == TARGET_OBJECT_TYPE_CORPSE)
         {
-        case TARGET_CORPSE_SRC_AREA_RAID:
             return true;
         }
     }


### PR DESCRIPTION
**Changes proposed:**

-  IsAllowingDeadTargets() now checks the `_effects` target and not just it's own target

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #25900 

**Tests performed:**

- [x] It builds
- [x] Tests in-game