### PR TITLE
Scripts/Commands: gm cmd modify gender: set correct customization

### DIFF
--- a/src/server/scripts/Commands/cs_modify.cpp
+++ b/src/server/scripts/Commands/cs_modify.cpp
@@ -23,6 +23,7 @@ Category: commandscripts
 EndScriptData */
 
 #include "ScriptMgr.h"
+#include "CharacterCache.h"
 #include "Chat.h"
 #include "DB2Stores.h"
 #include "Log.h"
@@ -34,9 +35,8 @@ EndScriptData */
 #include "ReputationMgr.h"
 #include "SpellMgr.h"
 #include "SpellPackets.h"
-#include "WorldSession.h"
-#include "CharacterCache.h"
 #include "UpdateFields.h"
+#include "WorldSession.h"
 
 class modify_commandscript : public CommandScript
 {
@@ -927,7 +927,6 @@ public:
 
         target->SetCustomizations(Trinity::Containers::MakeIteratorPair(customizations.begin(), customizations.end()));
 
-        //
         char const* gender_full = gender ? "female" : "male";
 
         handler->PSendSysMessage(LANG_YOU_CHANGE_GENDER, handler->GetNameLink(target).c_str(), gender_full);

--- a/src/server/scripts/Commands/cs_modify.cpp
+++ b/src/server/scripts/Commands/cs_modify.cpp
@@ -916,7 +916,7 @@ public:
                 if (choiceReq && !worldSession->MeetsChrCustomizationReq(choiceReq, playerClass, false, MakeChrCustomizationChoiceRange(customizations)))
                     continue;
 
-                const ChrCustomizationChoiceEntry* choiceEntry = choicesForOption->at(0);
+                ChrCustomizationChoiceEntry const* choiceEntry = choicesForOption->at(0);
                 UF::ChrCustomizationChoice choice;
                 choice.ChrCustomizationOptionID = option->ID;
                 choice.ChrCustomizationChoiceID = choiceEntry->ID;


### PR DESCRIPTION
**Changes proposed:**

-  When using the gm command to modify gender, customization should also be changed since they are not compatible between different genders. This change will select the 1st customization from every option. 

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #25899

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] it builds
- [x] tested in-game

**Known issues and TODO list:** (add/remove lines as needed)