### PR TITLE
Core/Warden: Send Lua checks only when ingame

### DIFF
--- a/src/server/game/Warden/WardenCheckMgr.h
+++ b/src/server/game/Warden/WardenCheckMgr.h
@@ -85,6 +85,17 @@ constexpr WorldIntConfigs GetWardenCategoryCountConfig(WardenCheckCategory categ
     }
 }
 
+constexpr bool IsWardenCategoryInWorldOnly(WardenCheckCategory category)
+{
+    switch (category)
+    {
+        case INJECT_CHECK_CATEGORY: return false;
+        case LUA_CHECK_CATEGORY:    return true;
+        case MODDED_CHECK_CATEGORY: return false;
+        default:                    return false;
+    }
+}
+
 struct WardenCheck
 {
     uint16 CheckId = 0;

--- a/src/server/game/Warden/WardenWin.cpp
+++ b/src/server/game/Warden/WardenWin.cpp
@@ -235,6 +235,9 @@ void WardenWin::RequestChecks()
 
     for (WardenCheckCategory category : EnumUtils::Iterate<WardenCheckCategory>())
     {
+        if (IsWardenCategoryInWorldOnly(category) && !_session->GetPlayer())
+            continue;
+
         auto& [checks, checksIt] = _checks[category];
         for (uint32 i = 0, n = sWorld->getIntConfig(GetWardenCategoryCountConfig(category)); i < n; ++i)
         {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Core/Warden: Send Lua checks only when ingame

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes an annoying issue of having Lua errors in char selection screen

**Tests performed:**

None

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] This should be tested


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
