### PR TITLE
Core/Unit: Remove unnecessary damage check from Unit::SpellCriticalDa…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7098,12 +7098,9 @@ uint32 Unit::SpellCriticalDamageBonus(SpellInfo const* spellProto, uint32 damage
 
     crit_bonus -= damage;
 
-    if (damage > uint32(crit_bonus))
-    {
-        // adds additional damage to critBonus (from talents)
-        if (Player* modOwner = GetSpellModOwner())
-            modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_CRIT_DAMAGE_BONUS, crit_bonus);
-    }
+    // adds additional damage to critBonus (from talents)
+    if (Player* modOwner = GetSpellModOwner())
+        modOwner->ApplySpellMod(spellProto->Id, SPELLMOD_CRIT_DAMAGE_BONUS, crit_bonus);
 
     crit_bonus += damage;
 


### PR DESCRIPTION
It prevents applying SPELLMOD_CRIT_DAMAGE_BONUS while having SPELL_AURA_MOD_CRIT_DAMAGE_BONUS

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Remove _damage > uint32(crit_bonus)_ check. 

As an example, damage = 74, crit_bonus = 148, crit_mod = 2 (from https://www.wowhead.com/spell=154743/brawn). 
After adding pct crit_bonus = 151. 
Then crit_bonus -= damage = 77.
Finally _damage > uint32(crit_bonus)_ is false, so SPELLMOD_CRIT_DAMAGE_BONUS from https://www.wowhead.com/spell=60188/elemental-fury is not applied.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

None.


**Tests performed:**

It was built and tested in-game for shaman tauren with https://www.wowhead.com/spell=154743/brawn racial trait and https://www.wowhead.com/spell=60188/elemental-fury talent.


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Maybe this check is really needed but I don't see when. Can anyone explain then?


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
