### PR TITLE
Core/Auras: Implement SPELL_AURA_397 & SPELL_AURA_398

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -248,7 +248,20 @@ void Battleground::_ProcessPlayerPositionBroadcast(uint32 diff)
         m_LastPlayerPositionBroadcast = 0;
 
         WorldPackets::Battleground::BattlegroundPlayerPositions playerPositions;
-        GetPlayerPositionData(&playerPositions.FlagCarriers);
+
+        for (BattlegroundPlayerPositionSlotInfo const& info : _playerPositionInfo)
+        {
+            if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), info.Guid))
+            {
+                WorldPackets::Battleground::BattlegroundPlayerPosition position;
+                position.Guid = player->GetGUID();
+                position.Pos = player->GetPosition();
+                position.IconID = info.IconId;
+                position.ArenaSlot = info.ArenaSlot;
+                playerPositions.FlagCarriers.push_back(position);
+            }
+        }
+
         SendPacketToAll(playerPositions.Write());
     }
 }

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -249,17 +249,13 @@ void Battleground::_ProcessPlayerPositionBroadcast(uint32 diff)
 
         WorldPackets::Battleground::BattlegroundPlayerPositions playerPositions;
 
-        for (BattlegroundPlayerPositionSlotInfo const& info : _playerPositionInfo)
+        for (WorldPackets::Battleground::BattlegroundPlayerPosition& playerPosition : _playerPositionInfo)
         {
-            if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), info.Guid))
-            {
-                WorldPackets::Battleground::BattlegroundPlayerPosition position;
-                position.Guid = player->GetGUID();
-                position.Pos = player->GetPosition();
-                position.IconID = info.IconId;
-                position.ArenaSlot = info.ArenaSlot;
-                playerPositions.FlagCarriers.push_back(position);
-            }
+            // Update position data if we found player.
+            if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), playerPosition.Guid))
+                playerPosition.Pos = player->GetPosition();
+
+            playerPositions.FlagCarriers.push_back(playerPosition);
         }
 
         SendPacketToAll(playerPositions.Write());

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -138,8 +138,6 @@ Battleground::~Battleground()
 
     for (BattlegroundScoreMap::const_iterator itr = PlayerScores.begin(); itr != PlayerScores.end(); ++itr)
         delete itr->second;
-
-    _playerPositions.clear();
 }
 
 void Battleground::Update(uint32 diff)
@@ -251,13 +249,13 @@ void Battleground::_ProcessPlayerPositionBroadcast(uint32 diff)
 
         WorldPackets::Battleground::BattlegroundPlayerPositions playerPositions;
 
-        for (std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> position : _playerPositions)
+        for (WorldPackets::Battleground::BattlegroundPlayerPosition& playerPosition : _playerPositions)
         {
             // Update position data if we found player.
-            if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), position->Guid))
-                position->Pos = player->GetPosition();
+            if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), playerPosition.Guid))
+                playerPosition.Pos = player->GetPosition();
 
-            playerPositions.FlagCarriers.push_back(*position);
+            playerPositions.FlagCarriers.push_back(playerPosition);
         }
 
         SendPacketToAll(playerPositions.Write());
@@ -1680,16 +1678,16 @@ void Battleground::PSendMessageToAll(uint32 entry, ChatMsg msgType, Player const
     va_end(ap);
 }
 
-void Battleground::AddPlayerPosition(std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> position)
+void Battleground::AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position)
 {
-    _playerPositions.push_back(std::move(position));
+    _playerPositions.push_back(position);
 }
 
 void Battleground::RemovePlayerPosition(ObjectGuid guid)
 {
-    auto const itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> const playerPosition)
+    auto itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
     {
-        return playerPosition->Guid == guid;
+        return info.Guid == guid;
     });
 
     _playerPositions.erase(itr, _playerPositions.end());

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1684,16 +1684,16 @@ void Battleground::PSendMessageToAll(uint32 entry, ChatMsg msgType, Player const
     va_end(ap);
 }
 
-void Battleground::AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position)
+void Battleground::AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const& position)
 {
     _playerPositions.push_back(position);
 }
 
 void Battleground::RemovePlayerPosition(ObjectGuid guid)
 {
-    auto itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
+    auto itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const& playerPosition)
     {
-        return info.Guid == guid;
+        return playerPosition.Guid == guid;
     });
 
     _playerPositions.erase(itr, _playerPositions.end());

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -140,6 +140,8 @@ Battleground::~Battleground()
 
     for (BattlegroundScoreMap::const_iterator itr = PlayerScores.begin(); itr != PlayerScores.end(); ++itr)
         delete itr->second;
+
+    _playerPositions.clear();
 }
 
 void Battleground::Update(uint32 diff)
@@ -1003,6 +1005,8 @@ void Battleground::Reset()
     PlayerScores.clear();
 
     ResetBGSubclass();
+
+    _playerPositions.clear();
 }
 
 void Battleground::StartBattleground()

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -112,6 +112,8 @@ Battleground::Battleground(BattlegroundTemplate const* battlegroundTemplate) : _
     StartMessageIds[BG_STARTING_EVENT_FOURTH] = BG_TEXT_BATTLE_HAS_BEGUN;
 }
 
+Battleground::Battleground(Battleground const&) = default;
+
 Battleground::~Battleground()
 {
     // remove objects and creatures

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1678,9 +1678,19 @@ void Battleground::PSendMessageToAll(uint32 entry, ChatMsg msgType, Player const
     va_end(ap);
 }
 
-std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& Battleground::GetPlayerPositions()
+void Battleground::AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position)
 {
-    return _playerPositions;
+    _playerPositions.push_back(position);
+}
+
+void Battleground::RemovePlayerPosition(ObjectGuid guid)
+{
+    auto const& itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
+    {
+        return info.Guid == guid;
+    });
+
+    _playerPositions.erase(itr, _playerPositions.end());
 }
 
 void Battleground::EndNow()
@@ -1901,11 +1911,6 @@ BattlegroundBracketId Battleground::GetBracketId() const
 uint8 Battleground::GetUniqueBracketId() const
 {
     return uint8(GetMinLevel() / 5) - 1; // 10 - 1, 15 - 2, 20 - 3, etc.
-}
-
-std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& Battleground::GetPlayerPositions() const
-{
-    return _playerPositions;
 }
 
 uint32 Battleground::GetMaxPlayers() const

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1678,6 +1678,11 @@ void Battleground::PSendMessageToAll(uint32 entry, ChatMsg msgType, Player const
     va_end(ap);
 }
 
+std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& Battleground::GetPlayerPositions()
+{
+    return _playerPositions;
+}
+
 void Battleground::EndNow()
 {
     RemoveFromBGFreeSlotQueue();
@@ -1896,6 +1901,11 @@ BattlegroundBracketId Battleground::GetBracketId() const
 uint8 Battleground::GetUniqueBracketId() const
 {
     return uint8(GetMinLevel() / 5) - 1; // 10 - 1, 15 - 2, 20 - 3, etc.
+}
+
+std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& Battleground::GetPlayerPositions() const
+{
+    return _playerPositions;
 }
 
 uint32 Battleground::GetMaxPlayers() const

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -249,7 +249,7 @@ void Battleground::_ProcessPlayerPositionBroadcast(uint32 diff)
 
         WorldPackets::Battleground::BattlegroundPlayerPositions playerPositions;
 
-        for (WorldPackets::Battleground::BattlegroundPlayerPosition& playerPosition : _playerPositionInfo)
+        for (WorldPackets::Battleground::BattlegroundPlayerPosition& playerPosition : _playerPositions)
         {
             // Update position data if we found player.
             if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), playerPosition.Guid))

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1685,7 +1685,7 @@ void Battleground::AddPlayerPosition(WorldPackets::Battleground::BattlegroundPla
 
 void Battleground::RemovePlayerPosition(ObjectGuid guid)
 {
-    auto const& itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
+    auto itr = std::remove_if(_playerPositions.begin(), _playerPositions.end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
     {
         return info.Guid == guid;
     });

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -263,6 +263,8 @@ class TC_GAME_API Battleground
         Battleground(Battleground const&);
         virtual ~Battleground();
 
+        Battleground& operator=(Battleground const&) = delete;
+
         void Update(uint32 diff);
 
         virtual bool SetupBattleground()                    // must be implemented in BG subclass

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -503,8 +503,8 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& GetPlayerPositionSlotInfos() const { return _playerPositionInfo; }
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& GetPlayerPositionSlotInfos() { return _playerPositionInfo; }
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& GetPlayerPositions() const { return _playerPositions; }
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& GetPlayerPositions() { return _playerPositions; }
 
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground
@@ -628,6 +628,6 @@ class TC_GAME_API Battleground
         BattlegroundTemplate const* _battlegroundTemplate;
         PVPDifficultyEntry const* _pvpDifficultyEntry;
 
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> _playerPositionInfo;
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> _playerPositions;
 };
 #endif

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -503,8 +503,8 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& GetPlayerPositions() const;
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& GetPlayerPositions();
+        void AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position);
+        void RemovePlayerPosition(ObjectGuid guid);
 
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -260,6 +260,7 @@ class TC_GAME_API Battleground
 {
     public:
         Battleground(BattlegroundTemplate const* battlegroundTemplate);
+        Battleground(Battleground const&);
         virtual ~Battleground();
 
         void Update(uint32 diff);

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -23,6 +23,7 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include <map>
+#include <memory>
 #include <vector>
 
 class BattlegroundMap;
@@ -503,7 +504,7 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        void AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position);
+        void AddPlayerPosition(std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> position);
         void RemovePlayerPosition(ObjectGuid guid);
 
     protected:
@@ -628,6 +629,6 @@ class TC_GAME_API Battleground
         BattlegroundTemplate const* _battlegroundTemplate;
         PVPDifficultyEntry const* _pvpDifficultyEntry;
 
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> _playerPositions;
+        std::vector<std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition>> _playerPositions;
 };
 #endif

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -23,7 +23,6 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include <map>
-#include <memory>
 #include <vector>
 
 class BattlegroundMap;
@@ -504,7 +503,7 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        void AddPlayerPosition(std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> position);
+        void AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position);
         void RemovePlayerPosition(ObjectGuid guid);
 
     protected:
@@ -629,6 +628,6 @@ class TC_GAME_API Battleground
         BattlegroundTemplate const* _battlegroundTemplate;
         PVPDifficultyEntry const* _pvpDifficultyEntry;
 
-        std::vector<std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition>> _playerPositions;
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> _playerPositions;
 };
 #endif

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -503,8 +503,8 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& GetPlayerPositions() const { return _playerPositions; }
-        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& GetPlayerPositions() { return _playerPositions; }
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& GetPlayerPositions() const;
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& GetPlayerPositions();
 
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -23,6 +23,7 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include <map>
+#include <vector>
 
 class BattlegroundMap;
 class Creature;
@@ -228,6 +229,13 @@ enum BattlegroundPlayerPositionConstants
     PLAYER_POSITION_ARENA_SLOT_3        = 4,
     PLAYER_POSITION_ARENA_SLOT_4        = 5,
     PLAYER_POSITION_ARENA_SLOT_5        = 6
+};
+
+struct BattlegroundPlayerPositionSlotInfo
+{
+    uint8 ArenaSlot = 0;
+    uint8 IconId = 0;
+    ObjectGuid Guid;
 };
 
 enum class BattlegroundQueueIdType : uint8
@@ -502,6 +510,9 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
+        std::vector<BattlegroundPlayerPositionSlotInfo> const& GetPlayerPositionSlotInfos() const { return _playerPositionInfo; }
+        std::vector<BattlegroundPlayerPositionSlotInfo>& GetPlayerPositionSlotInfos() { return _playerPositionInfo; }
+
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground
         void EndNow();
@@ -549,7 +560,6 @@ class TC_GAME_API Battleground
         void _ProcessJoin(uint32 diff);
         void _CheckSafePositions(uint32 diff);
         void _ProcessPlayerPositionBroadcast(uint32 diff);
-        virtual void GetPlayerPositionData(std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>* /*positions*/) const { }
 
         // Scorekeeping
         BattlegroundScoreMap PlayerScores;                // Player scores
@@ -624,5 +634,7 @@ class TC_GAME_API Battleground
 
         BattlegroundTemplate const* _battlegroundTemplate;
         PVPDifficultyEntry const* _pvpDifficultyEntry;
+
+        std::vector<BattlegroundPlayerPositionSlotInfo> _playerPositionInfo;
 };
 #endif

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -231,13 +231,6 @@ enum BattlegroundPlayerPositionConstants
     PLAYER_POSITION_ARENA_SLOT_5        = 6
 };
 
-struct BattlegroundPlayerPositionSlotInfo
-{
-    uint8 ArenaSlot = 0;
-    uint8 IconId = 0;
-    ObjectGuid Guid;
-};
-
 enum class BattlegroundQueueIdType : uint8
 {
     Battleground    = 0,
@@ -510,8 +503,8 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        std::vector<BattlegroundPlayerPositionSlotInfo> const& GetPlayerPositionSlotInfos() const { return _playerPositionInfo; }
-        std::vector<BattlegroundPlayerPositionSlotInfo>& GetPlayerPositionSlotInfos() { return _playerPositionInfo; }
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> const& GetPlayerPositionSlotInfos() const { return _playerPositionInfo; }
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>& GetPlayerPositionSlotInfos() { return _playerPositionInfo; }
 
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground
@@ -635,6 +628,6 @@ class TC_GAME_API Battleground
         BattlegroundTemplate const* _battlegroundTemplate;
         PVPDifficultyEntry const* _pvpDifficultyEntry;
 
-        std::vector<BattlegroundPlayerPositionSlotInfo> _playerPositionInfo;
+        std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> _playerPositionInfo;
 };
 #endif

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -506,7 +506,7 @@ class TC_GAME_API Battleground
         // because BattleGrounds with different types and same level range has different m_BracketId
         uint8 GetUniqueBracketId() const;
 
-        void AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const position);
+        void AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const& position);
         void RemovePlayerPosition(ObjectGuid guid);
 
     protected:

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.cpp
@@ -118,19 +118,6 @@ void BattlegroundEY::PostUpdateImpl(uint32 diff)
     }
 }
 
-void BattlegroundEY::GetPlayerPositionData(std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>* positions) const
-{
-    if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), m_FlagKeeper))
-    {
-        WorldPackets::Battleground::BattlegroundPlayerPosition position;
-        position.Guid = player->GetGUID();
-        position.Pos = player->GetPosition();
-        position.IconID = player->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
-        position.ArenaSlot = PLAYER_POSITION_ARENA_SLOT_NONE;
-        positions->push_back(position);
-    }
-}
-
 void BattlegroundEY::StartingEventCloseDoors()
 {
     SpawnBGObject(BG_EY_OBJECT_DOOR_A, RESPAWN_IMMEDIATELY);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
@@ -445,7 +445,6 @@ class BattlegroundEY : public Battleground
         uint32 GetPrematureWinner() override;
 protected:
         void PostUpdateImpl(uint32 diff) override;
-        void GetPlayerPositionData(std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>* positions) const override;
 
         void EventPlayerCapturedFlag(Player* Source, uint32 BgObjectType);
         void EventTeamCapturedPoint(Player* Source, uint32 Point);

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -194,29 +194,6 @@ void BattlegroundWS::PostUpdateImpl(uint32 diff)
     }
 }
 
-void BattlegroundWS::GetPlayerPositionData(std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>* positions) const
-{
-    if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), m_FlagKeepers[TEAM_ALLIANCE]))
-    {
-        WorldPackets::Battleground::BattlegroundPlayerPosition position;
-        position.Guid = player->GetGUID();
-        position.Pos = player->GetPosition();
-        position.IconID = PLAYER_POSITION_ICON_ALLIANCE_FLAG;
-        position.ArenaSlot = PLAYER_POSITION_ARENA_SLOT_NONE;
-        positions->push_back(position);
-    }
-
-    if (Player* player = ObjectAccessor::GetPlayer(GetBgMap(), m_FlagKeepers[TEAM_HORDE]))
-    {
-        WorldPackets::Battleground::BattlegroundPlayerPosition position;
-        position.Guid = player->GetGUID();
-        position.Pos = player->GetPosition();
-        position.IconID = PLAYER_POSITION_ICON_HORDE_FLAG;
-        position.ArenaSlot = PLAYER_POSITION_ARENA_SLOT_NONE;
-        positions->push_back(position);
-    }
-}
-
 void BattlegroundWS::StartingEventCloseDoors()
 {
     for (uint32 i = BG_WS_OBJECT_DOOR_A_1; i <= BG_WS_OBJECT_DOOR_H_4; ++i)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -273,7 +273,6 @@ class BattlegroundWS : public Battleground
 
     protected:
         void PostUpdateImpl(uint32 diff) override;
-        void GetPlayerPositionData(std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition>* positions) const override;
 
     private:
         ObjectGuid m_FlagKeepers[2];                            // 0 - alliance, 1 - horde

--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -469,8 +469,8 @@ enum AuraType : uint32
     SPELL_AURA_SHOW_CONFIRMATION_PROMPT                     = 394,
     SPELL_AURA_AREA_TRIGGER                                 = 395,  // NYI
     SPELL_AURA_TRIGGER_SPELL_ON_POWER_AMOUNT                = 396,  // NYI Triggers spell when health goes above (MiscA = 0) or falls below (MiscA = 1) specified percent value (once, not every time condition has meet)
-    SPELL_AURA_397                                          = 397,
-    SPELL_AURA_398                                          = 398,
+    SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION          = 397,
+    SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION_2        = 398,
     SPELL_AURA_MOD_TIME_RATE                                = 399,
     SPELL_AURA_MOD_SKILL_2                                  = 400,
     SPELL_AURA_401                                          = 401,

--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -469,8 +469,8 @@ enum AuraType : uint32
     SPELL_AURA_SHOW_CONFIRMATION_PROMPT                     = 394,
     SPELL_AURA_AREA_TRIGGER                                 = 395,  // NYI
     SPELL_AURA_TRIGGER_SPELL_ON_POWER_AMOUNT                = 396,  // NYI Triggers spell when health goes above (MiscA = 0) or falls below (MiscA = 1) specified percent value (once, not every time condition has meet)
-    SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION          = 397,
-    SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION_2        = 398,
+    SPELL_AURA_BATTLEGROUND_PLAYER_POSITION_FACTIONAL       = 397,
+    SPELL_AURA_BATTLEGROUND_PLAYER_POSITION                 = 398,
     SPELL_AURA_MOD_TIME_RATE                                = 399,
     SPELL_AURA_MOD_SKILL_2                                  = 400,
     SPELL_AURA_401                                          = 401,

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6395,17 +6395,17 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
         else
             TC_LOG_WARN("spell.auras", "Unknown aura effect %u handled by HandleBattlegroundPlayerPosition.", GetAuraType());
 
-        bg->GetPlayerPositionSlotInfos().push_back(playerPosition);
+        bg->GetPlayerPositions().push_back(playerPosition);
     }
     else
     {
         ObjectGuid const& guid = target->GetGUID();
-        auto const& itr = std::remove_if(bg->GetPlayerPositionSlotInfos().begin(), bg->GetPlayerPositionSlotInfos().end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
+        auto const& itr = std::remove_if(bg->GetPlayerPositions().begin(), bg->GetPlayerPositions().end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
         {
             return info.Guid == guid;
         });
 
-        bg->GetPlayerPositionSlotInfos().erase(itr, bg->GetPlayerPositionSlotInfos().end());
+        bg->GetPlayerPositions().erase(itr, bg->GetPlayerPositions().end());
     }
 }
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6383,19 +6383,19 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
 
     if (apply)
     {
-        WorldPackets::Battleground::BattlegroundPlayerPosition playerPosition;
-        playerPosition.Guid = target->GetGUID();
-        playerPosition.ArenaSlot = static_cast<uint8>(GetMiscValue());
-        playerPosition.Pos = target->GetPosition();
+        std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> playerPosition = std::make_shared<WorldPackets::Battleground::BattlegroundPlayerPosition>();
+        playerPosition->Guid = target->GetGUID();
+        playerPosition->ArenaSlot = static_cast<uint8>(GetMiscValue());
+        playerPosition->Pos = target->GetPosition();
 
         if (GetAuraType() == SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION)
-            playerPosition.IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_HORDE_FLAG : PLAYER_POSITION_ICON_ALLIANCE_FLAG;
+            playerPosition->IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_HORDE_FLAG : PLAYER_POSITION_ICON_ALLIANCE_FLAG;
         else if (GetAuraType() == SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION_2)
-            playerPosition.IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
+            playerPosition->IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
         else
             TC_LOG_WARN("spell.auras", "Unknown aura effect %u handled by HandleBattlegroundPlayerPosition.", GetAuraType());
 
-        bg->AddPlayerPosition(playerPosition);
+        bg->AddPlayerPosition(std::move(playerPosition));
     }
     else
         bg->RemovePlayerPosition(target->GetGUID());

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6393,9 +6393,7 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
         else if (GetAuraType() == SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION_2)
             playerPosition.IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
         else
-        {
             TC_LOG_WARN("spell.auras", "Unknown aura effect %u handled by HandleBattlegroundPlayerPosition.", GetAuraType());
-        }
 
         bg->GetPlayerPositionSlotInfos().push_back(playerPosition);
     }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6383,19 +6383,19 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
 
     if (apply)
     {
-        std::shared_ptr<WorldPackets::Battleground::BattlegroundPlayerPosition> playerPosition = std::make_shared<WorldPackets::Battleground::BattlegroundPlayerPosition>();
-        playerPosition->Guid = target->GetGUID();
-        playerPosition->ArenaSlot = static_cast<uint8>(GetMiscValue());
-        playerPosition->Pos = target->GetPosition();
+        WorldPackets::Battleground::BattlegroundPlayerPosition playerPosition;
+        playerPosition.Guid = target->GetGUID();
+        playerPosition.ArenaSlot = static_cast<uint8>(GetMiscValue());
+        playerPosition.Pos = target->GetPosition();
 
         if (GetAuraType() == SPELL_AURA_BATTLEGROUND_PLAYER_POSITION_FACTIONAL)
-            playerPosition->IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_HORDE_FLAG : PLAYER_POSITION_ICON_ALLIANCE_FLAG;
+            playerPosition.IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_HORDE_FLAG : PLAYER_POSITION_ICON_ALLIANCE_FLAG;
         else if (GetAuraType() == SPELL_AURA_BATTLEGROUND_PLAYER_POSITION)
-            playerPosition->IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
+            playerPosition.IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
         else
             TC_LOG_WARN("spell.auras", "Unknown aura effect %u handled by HandleBattlegroundPlayerPosition.", GetAuraType());
 
-        bg->AddPlayerPosition(std::move(playerPosition));
+        bg->AddPlayerPosition(playerPosition);
     }
     else
         bg->RemovePlayerPosition(target->GetGUID());

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -464,8 +464,8 @@ NonDefaultConstructible<pAuraEffectHandler> AuraEffectHandler[TOTAL_AURAS]=
     &AuraEffect::HandleShowConfirmationPrompt,                    //394 SPELL_AURA_SHOW_CONFIRMATION_PROMPT
     &AuraEffect::HandleCreateAreaTrigger,                         //395 SPELL_AURA_AREA_TRIGGER
     &AuraEffect::HandleNULL,                                      //396 SPELL_AURA_TRIGGER_SPELL_ON_POWER_AMOUNT
-    &AuraEffect::HandleBattlegroundPlayerPosition,                //397 SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION
-    &AuraEffect::HandleBattlegroundPlayerPosition,                //398 SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION_2
+    &AuraEffect::HandleBattlegroundPlayerPosition,                //397 SPELL_AURA_BATTLEGROUND_PLAYER_POSITION_FACTIONAL
+    &AuraEffect::HandleBattlegroundPlayerPosition,                //398 SPELL_AURA_BATTLEGROUND_PLAYER_POSITION
     &AuraEffect::HandleNULL,                                      //399 SPELL_AURA_MOD_TIME_RATE
     &AuraEffect::HandleAuraModSkill,                              //400 SPELL_AURA_MOD_SKILL_2
     &AuraEffect::HandleNULL,                                      //401
@@ -6388,9 +6388,9 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
         playerPosition->ArenaSlot = static_cast<uint8>(GetMiscValue());
         playerPosition->Pos = target->GetPosition();
 
-        if (GetAuraType() == SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION)
+        if (GetAuraType() == SPELL_AURA_BATTLEGROUND_PLAYER_POSITION_FACTIONAL)
             playerPosition->IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_HORDE_FLAG : PLAYER_POSITION_ICON_ALLIANCE_FLAG;
-        else if (GetAuraType() == SPELL_AURA_UPDATE_BATTLEGROUND_PLAYER_POSITION_2)
+        else if (GetAuraType() == SPELL_AURA_BATTLEGROUND_PLAYER_POSITION)
             playerPosition->IconID = target->GetTeam() == ALLIANCE ? PLAYER_POSITION_ICON_ALLIANCE_FLAG : PLAYER_POSITION_ICON_HORDE_FLAG;
         else
             TC_LOG_WARN("spell.auras", "Unknown aura effect %u handled by HandleBattlegroundPlayerPosition.", GetAuraType());

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6395,18 +6395,10 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
         else
             TC_LOG_WARN("spell.auras", "Unknown aura effect %u handled by HandleBattlegroundPlayerPosition.", GetAuraType());
 
-        bg->GetPlayerPositions().push_back(playerPosition);
+        bg->AddPlayerPosition(playerPosition);
     }
     else
-    {
-        ObjectGuid const& guid = target->GetGUID();
-        auto const& itr = std::remove_if(bg->GetPlayerPositions().begin(), bg->GetPlayerPositions().end(), [guid](WorldPackets::Battleground::BattlegroundPlayerPosition const info)
-        {
-            return info.Guid == guid;
-        });
-
-        bg->GetPlayerPositions().erase(itr, bg->GetPlayerPositions().end());
-    }
+        bg->RemovePlayerPosition(target->GetGUID());
 }
 
 template TC_GAME_API void AuraEffect::GetTargetList(std::list<Unit*>&) const;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6377,7 +6377,11 @@ void AuraEffect::HandleBattlegroundPlayerPosition(AuraApplication const* aurApp,
     if (!target)
         return;
 
-    Battleground* bg = target->GetBattleground();
+    BattlegroundMap* battlegroundMap = target->GetMap()->ToBattlegroundMap();
+    if (!battlegroundMap)
+        return;
+
+    Battleground* bg = battlegroundMap->GetBG();
     if (!bg)
         return;
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -319,6 +319,7 @@ class TC_GAME_API AuraEffect
         void HandleCreateAreaTrigger(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleLinkedSummon(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleModOverrideZonePVPType(AuraApplication const* aurApp, uint8 mode, bool apply) const;
+        void HandleBattlegroundPlayerPosition(AuraApplication const* aurApp, uint8 mode, bool apply) const;
 
         // aura effect periodic tick handlers
         void HandlePeriodicDummyAuraTick(Unit* target, Unit* caster) const;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Define SPELL_AURA_397 & SPELL_AURA_398. More info can be found in #24794
-  Remove GetPlayerPositionData virtual function in Battleground class
-  Save the players in a vector in the base battleground class.

**Target branch(es):** 3.3.5/master

-  3.3.5 maybe
- master

**Issues addressed:**

Closes #24794


**Tests performed:**
- Builds
- Went in game, queued for Eye of the Storm (specific), cast 34976 and then with debugger went through everything. Also removed the buff by clicking on it and went through the debugger again. Also checked map if the flag was showing up, it did.


**Known issues and TODO list:**

- Names might not be very blizzlike
- Some coding standards?

**Notes:**
It's been a while.
I went for a vector because the order of insertion is being kept in the packets. (first player who takes flag is the first one in the position).
Unsure about making a new struct for it... Maybe I should have just used the one from the WorldPackets and updated the position each time. Not sure if that's something thats acceptable tho (in case of updating packets etc might get a little more complex)

Edit: Using the packet class makes things a lot cleaner tho

Any feedback is welcome :)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
