### PR TITLE
Scripts/UtgardePinnacle: Svala Sorrowgrave Ritual improvements

### DIFF
--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -164,7 +164,7 @@ class boss_svala : public CreatureScript
                 else
                     events.SetPhase(IDLE);
 
-                me->SetDisableGravity(false);
+                me->SetDisableGravity(false, true);
 
                 Initialize();
 

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -163,7 +163,7 @@ class boss_svala : public CreatureScript
                 else
                     events.SetPhase(IDLE);
 
-                me->SetDisableGravity(false, true);
+                me->SetDisableGravity(false);
 
                 Initialize();
 
@@ -280,11 +280,11 @@ class boss_svala : public CreatureScript
                             break;
                         }
                         case EVENT_INTRO_TRANSFORM_1:
-                            me->CastSpell(me, SPELL_SVALA_TRANSFORMING1, false);
+                            DoCastSelf(SPELL_SVALA_TRANSFORMING1);
                             events.ScheduleEvent(EVENT_INTRO_TRANSFORM_2, 6200ms, 0, INTRO);
                             break;
                         case EVENT_INTRO_TRANSFORM_2:
-                            me->CastSpell(me, SPELL_SVALA_TRANSFORMING2, false);
+                            DoCastSelf(SPELL_SVALA_TRANSFORMING2);
                             if (Creature* arthas = ObjectAccessor::GetCreature(*me, _arthasGUID))
                             {
                                 arthas->InterruptNonMeleeSpells(true);
@@ -313,7 +313,7 @@ class boss_svala : public CreatureScript
                             break;
                         case EVENT_INTRO_RELOCATE_SVALA:
                         {
-                            me->SetDisableGravity(false, true);
+                            me->SetDisableGravity(false);
                             me->SetHover(true);
                             me->GetMotionMaster()->MoveFall();
 
@@ -350,30 +350,28 @@ class boss_svala : public CreatureScript
                                 me->SetReactState(REACT_PASSIVE);
                                 me->AttackStop();
                                 me->StopMoving();
-                                me->SetDisableGravity(true, true);
+                                me->SetDisableGravity(true);
                                 instance->SetGuidData(DATA_SACRIFICED_PLAYER, sacrificeTarget->GetGUID());
                                 Talk(SAY_SACRIFICE_PLAYER);
                                 DoCast(sacrificeTarget, SPELL_RITUAL_PREPARATION);
-                                DoCast(me, SPELL_RITUAL_DISARM);
-                                DoCast(me, SPELL_RITUAL_OF_THE_SWORD);
+                                DoCastSelf(SPELL_RITUAL_DISARM);
+                                DoCastSelf(SPELL_RITUAL_OF_THE_SWORD);
                             }
                             events.ScheduleEvent(EVENT_SPAWN_RITUAL_CHANNELERS, 1s, 0, SACRIFICING);
                             events.ScheduleEvent(EVENT_FINISH_RITUAL, 27s, 0);
                             break;
                         case EVENT_SPAWN_RITUAL_CHANNELERS:
-                            DoCast(me, SPELL_RITUAL_CHANNELER_1, true);
-                            DoCast(me, SPELL_RITUAL_CHANNELER_2, true);
-                            DoCast(me, SPELL_RITUAL_CHANNELER_3, true);
+                            DoCastSelf(SPELL_RITUAL_CHANNELER_1, true);
+                            DoCastSelf(SPELL_RITUAL_CHANNELER_2, true);
+                            DoCastSelf(SPELL_RITUAL_CHANNELER_3, true);
                             events.ScheduleEvent(EVENT_RITUAL_STRIKE, 2s, 0, SACRIFICING);
                             break;
                         case EVENT_RITUAL_STRIKE:
-                            DoCast(me, SPELL_RITUAL_STRIKE_TRIGGER, true);
+                            DoCastSelf(SPELL_RITUAL_STRIKE_TRIGGER, true);
                             break;
                         case EVENT_FINISH_RITUAL:
-                            me->SetDisableGravity(false, true);
+                            me->SetDisableGravity(false);
                             me->SetReactState(REACT_AGGRESSIVE);
-                            if (Unit* target = me->SelectNearestPlayer(100.0f))
-                                AttackStart(target);
                             events.SetPhase(NORMAL);
                             events.ScheduleEvent(EVENT_SINISTER_STRIKE, 7s, 0, NORMAL);
                             events.ScheduleEvent(EVENT_CALL_FLAMES, 10s, 20s, 0, NORMAL);
@@ -424,7 +422,7 @@ class npc_ritual_channeler : public CreatureScript
                 Initialize();
 
                 if (IsHeroic())
-                    DoCast(me, SPELL_SHADOWS_IN_THE_DARK);
+                    DoCastSelf(SPELL_SHADOWS_IN_THE_DARK);
             }
 
             void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -119,7 +119,6 @@ enum Events
     //SACRIFICING
     EVENT_SPAWN_RITUAL_CHANNELERS,
     EVENT_RITUAL_STRIKE,
-    EVENT_RITUAL_DISARM,
     EVENT_FINISH_RITUAL
 };
 
@@ -355,10 +354,11 @@ class boss_svala : public CreatureScript
                                 instance->SetGuidData(DATA_SACRIFICED_PLAYER, sacrificeTarget->GetGUID());
                                 Talk(SAY_SACRIFICE_PLAYER);
                                 DoCast(sacrificeTarget, SPELL_RITUAL_PREPARATION);
+                                DoCast(me, SPELL_RITUAL_DISARM);
                                 DoCast(me, SPELL_RITUAL_OF_THE_SWORD);
                             }
                             events.ScheduleEvent(EVENT_SPAWN_RITUAL_CHANNELERS, 1s, 0, SACRIFICING);
-                            events.ScheduleEvent(EVENT_FINISH_RITUAL, 26s, 0);
+                            events.ScheduleEvent(EVENT_FINISH_RITUAL, 27s, 0);
                             break;
                         case EVENT_SPAWN_RITUAL_CHANNELERS:
                             DoCast(me, SPELL_RITUAL_CHANNELER_1, true);
@@ -368,10 +368,6 @@ class boss_svala : public CreatureScript
                             break;
                         case EVENT_RITUAL_STRIKE:
                             DoCast(me, SPELL_RITUAL_STRIKE_TRIGGER, true);
-                            events.ScheduleEvent(EVENT_RITUAL_DISARM, 200ms, 0, SACRIFICING);
-                            break;
-                        case EVENT_RITUAL_DISARM:
-                            DoCast(me, SPELL_RITUAL_DISARM);
                             break;
                         case EVENT_FINISH_RITUAL:
                             me->SetDisableGravity(false, true);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -349,6 +349,8 @@ class boss_svala : public CreatureScript
                             {
                                 me->InterruptNonMeleeSpells(true);
                                 me->SetReactState(REACT_PASSIVE);
+                                me->AttackStop();
+                                me->StopMoving();
                                 me->SetDisableGravity(true, true);
                                 instance->SetGuidData(DATA_SACRIFICED_PLAYER, sacrificeTarget->GetGUID());
                                 Talk(SAY_SACRIFICE_PLAYER);
@@ -359,9 +361,6 @@ class boss_svala : public CreatureScript
                             events.ScheduleEvent(EVENT_FINISH_RITUAL, 26s, 0);
                             break;
                         case EVENT_SPAWN_RITUAL_CHANNELERS:
-                            me->GetMotionMaster()->Clear();
-                            me->GetMotionMaster()->MoveIdle();
-                            me->StopMoving();
                             DoCast(me, SPELL_RITUAL_CHANNELER_1, true);
                             DoCast(me, SPELL_RITUAL_CHANNELER_2, true);
                             DoCast(me, SPELL_RITUAL_CHANNELER_3, true);
@@ -378,10 +377,7 @@ class boss_svala : public CreatureScript
                             me->SetDisableGravity(false, true);
                             me->SetReactState(REACT_AGGRESSIVE);
                             if (Unit* target = me->SelectNearestPlayer(100.0f))
-                            {
                                 AttackStart(target);
-                                me->GetMotionMaster()->MoveChase(target);
-                            }
                             events.SetPhase(NORMAL);
                             events.ScheduleEvent(EVENT_SINISTER_STRIKE, 7s, 0, NORMAL);
                             events.ScheduleEvent(EVENT_CALL_FLAMES, 10s, 20s, 0, NORMAL);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_svala.cpp
@@ -376,7 +376,6 @@ class boss_svala : public CreatureScript
                             break;
                         case EVENT_FINISH_RITUAL:
                             me->SetDisableGravity(false, true);
-                            me->GetMotionMaster()->MoveFall();
                             me->SetReactState(REACT_AGGRESSIVE);
                             if (Unit* target = me->SelectNearestPlayer(100.0f))
                             {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Set passive, interrupt spells and stop movement when ritual start
-  Set aggressive when ritual end
-  prevent svala fall (visual) when ritual start after wipe
-  Svala should be disarmed before teleport when ritual start
-  Remove unneded SetCombatMovement
- Delay EVENT_FINISH_RITUAL 2 sec more because otherwise it is executed before the end of the duration of SPELL_RITUAL_OF_THE_SWORD

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #25970


**Tests performed:**

 tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
