### PR TITLE
Core/Spells: Fix Seed of Corruption (Warlock) target selection

### DIFF
--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1156,7 +1156,7 @@ class spell_warl_seed_of_corruption : public SpellScript
         targets.remove_if([&](WorldObject const* target)
         {
             if (Unit const* unitTarget = target->ToUnit())
-                if (WorldLocation* dest = const_cast<WorldLocation*>(GetExplTargetDest()))
+                if (WorldLocation const* dest = GetExplTargetDest())
                     if (!unitTarget->IsWithinLOS(dest->GetPositionX(), dest->GetPositionY(), dest->GetPositionZ()))
                         return true;
 

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -1147,31 +1147,27 @@ class spell_warl_seduction : public SpellScriptLoader
 };
 
 // -27285 - Seed of Corruption
-class spell_warl_seed_of_corruption : public SpellScriptLoader
+class spell_warl_seed_of_corruption : public SpellScript
 {
-    public:
-        spell_warl_seed_of_corruption() : SpellScriptLoader("spell_warl_seed_of_corruption") { }
+    PrepareSpellScript(spell_warl_seed_of_corruption);
 
-        class spell_warl_seed_of_corruption_SpellScript : public SpellScript
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        targets.remove_if([&](WorldObject const* target)
         {
-            PrepareSpellScript(spell_warl_seed_of_corruption_SpellScript);
+            if (Unit const* unitTarget = target->ToUnit())
+                if (WorldLocation* dest = const_cast<WorldLocation*>(GetExplTargetDest()))
+                    if (!unitTarget->IsWithinLOS(dest->GetPositionX(), dest->GetPositionY(), dest->GetPositionZ()))
+                        return true;
 
-            void FilterTargets(std::list<WorldObject*>& targets)
-            {
-                if (GetExplTargetUnit())
-                    targets.remove(GetExplTargetUnit());
-            }
+            return false;
+        });
+    }
 
-            void Register() override
-            {
-                OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_warl_seed_of_corruption_SpellScript::FilterTargets, EFFECT_0, TARGET_UNIT_DEST_AREA_ENEMY);
-            }
-        };
-
-        SpellScript* GetSpellScript() const override
-        {
-            return new spell_warl_seed_of_corruption_SpellScript();
-        }
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_warl_seed_of_corruption::FilterTargets, EFFECT_0, TARGET_UNIT_DEST_AREA_ENEMY);
+    }
 };
 
 // -27243 - Seed of Corruption
@@ -1595,7 +1591,7 @@ void AddSC_warlock_spell_scripts()
     new spell_warl_nether_protection();
     new spell_warl_ritual_of_doom_effect();
     new spell_warl_seduction();
-    new spell_warl_seed_of_corruption();
+    RegisterSpellScript(spell_warl_seed_of_corruption);
     new spell_warl_seed_of_corruption_dummy();
     new spell_warl_seed_of_corruption_generic();
     new spell_warl_shadow_ward();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Patch 2.3.0 (2007-11-13): Seed of Corruption detonation will now obey line of sight: https://wow.gamepedia.com/Seed_of_Corruption
-  Seed of Corruption detonation should also hit seed of corruption actionTarget (this was working fine because GetExplTargetUnit() can't get that target here, I only remove that unnecessary check): http://www.worldoflogs.com/reports/ak6ponc2cou5kufz/xe/?s=1062&e=1349&x=spell+%3D+%22Seed+of+Corruption%22%0D%0AAND+sourceName+%3D+%22Plazma%22

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #26010


**Tests performed:**

tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
