### PR TITLE
Core/Spells Add EffectAttributesFlags with NoScaleWithStack (0x40

### DIFF
--- a/src/server/game/DataStores/DB2Structure.h
+++ b/src/server/game/DataStores/DB2Structure.h
@@ -2891,7 +2891,7 @@ struct SpellEffectEntry
     int16 ImplicitTarget[2];
     uint32 SpellID;
 
-    EnumFlag<EffectAttributesFlags> GetEffectAttributes() const { return static_cast<EffectAttributesFlags>(EffectAttributes); }
+    SpellEffectAttributes GetEffectAttributes() const { return static_cast<SpellEffectAttributes>(EffectAttributes); }
 };
 
 struct SpellEquippedItemsEntry

--- a/src/server/game/DataStores/DB2Structure.h
+++ b/src/server/game/DataStores/DB2Structure.h
@@ -2890,6 +2890,8 @@ struct SpellEffectEntry
     flag128 EffectSpellClassMask;
     int16 ImplicitTarget[2];
     uint32 SpellID;
+
+    EnumFlag<EffectAttributesFlags> GetEffectAttributes() const { return static_cast<EffectAttributesFlags>(EffectAttributes); }
 };
 
 struct SpellEquippedItemsEntry

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -1298,6 +1298,8 @@ enum class SpellEffectAttributes
     IgnoreDuringCooldownTimeRateCalculation = 0x800000
 };
 
+DEFINE_ENUM_FLAG(SpellEffectAttributes);
+
 #define MAX_SPELL_EFFECTS 32
 #define MAX_EFFECT_MASK 0xFFFFFFFF
 
@@ -1613,13 +1615,5 @@ enum WorldStateExpressionFunctions
 
     WSE_FUNCTION_MAX,
 };
-
-enum EffectAttributesFlags
-{
-    EFFECT_ATTRIBUTES_FLAGS_NONE                            = 0x0,
-    EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK             = 0x40, // Base value should not be multiplied by the stack value
-};
-
-DEFINE_ENUM_FLAG(EffectAttributesFlags);
 
 #endif

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -1604,4 +1604,12 @@ enum WorldStateExpressionFunctions
     WSE_FUNCTION_MAX,
 };
 
+enum EffectAttributesFlags
+{
+    EFFECT_ATTRIBUTES_FLAGS_NONE                            = 0x0,
+    EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK             = 0x40, // Base value should not be multiplied by the stack value
+};
+
+DEFINE_ENUM_FLAG(EffectAttributesFlags);
+
 #endif

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -667,7 +667,7 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
     }
 
     GetBase()->CallScriptEffectCalcAmountHandlers(this, amount, m_canBeRecalculated);
-    if (!GetSpellEffectInfo()->EffectAttributes.HasFlag(EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK))
+    if (!GetSpellEffectInfo()->EffectAttributes.HasFlag(SpellEffectAttributes::NoScaleWithStack))
         amount *= GetBase()->GetStackAmount();
     return amount;
 }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -667,7 +667,8 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
     }
 
     GetBase()->CallScriptEffectCalcAmountHandlers(this, amount, m_canBeRecalculated);
-    amount *= GetBase()->GetStackAmount();
+    if (!GetSpellEffectInfo()->EffectAttributes.HasFlag(EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK))
+        amount *= GetBase()->GetStackAmount();
     return amount;
 }
 

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -372,6 +372,7 @@ SpellImplicitTargetInfo::StaticData  SpellImplicitTargetInfo::_data[TOTAL_SPELL_
 };
 
 SpellEffectInfo::SpellEffectInfo(SpellInfo const* spellInfo, SpellEffectEntry const* _effect)
+    : EffectAttributes(EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK)
 {
     ASSERT(spellInfo);
     ASSERT(_effect);
@@ -404,6 +405,7 @@ SpellEffectInfo::SpellEffectInfo(SpellInfo const* spellInfo, SpellEffectEntry co
     Scaling.Variance = _effect->Variance;
     Scaling.ResourceCoefficient = _effect->ResourceCoefficient;
     ImplicitTargetConditions = nullptr;
+    EffectAttributes = _effect->GetEffectAttributes();
 }
 
 bool SpellEffectInfo::IsEffect() const

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -372,7 +372,7 @@ SpellImplicitTargetInfo::StaticData  SpellImplicitTargetInfo::_data[TOTAL_SPELL_
 };
 
 SpellEffectInfo::SpellEffectInfo(SpellInfo const* spellInfo, SpellEffectEntry const* _effect)
-    : EffectAttributes(EFFECT_ATTRIBUTES_FLAGS_NONE)
+    : EffectAttributes(SpellEffectAttributes::None)
 {
     ASSERT(spellInfo);
     ASSERT(_effect);

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -372,7 +372,7 @@ SpellImplicitTargetInfo::StaticData  SpellImplicitTargetInfo::_data[TOTAL_SPELL_
 };
 
 SpellEffectInfo::SpellEffectInfo(SpellInfo const* spellInfo, SpellEffectEntry const* _effect)
-    : EffectAttributes(EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK)
+    : EffectAttributes(EFFECT_ATTRIBUTES_FLAGS_NONE)
 {
     ASSERT(spellInfo);
     ASSERT(_effect);

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -353,7 +353,7 @@ public:
     flag128   SpellClassMask;
     float     BonusCoefficientFromAP;
     std::vector<Condition*>* ImplicitTargetConditions;
-    EnumFlag<EffectAttributesFlags> EffectAttributes;
+    EnumFlag<SpellEffectAttributes> EffectAttributes;
     // SpellScalingEntry
     struct ScalingInfo
     {
@@ -366,7 +366,7 @@ public:
                         RealPointsPerLevel(0), BasePoints(0), PointsPerResource(0), Amplitude(0), ChainAmplitude(0),
                         BonusCoefficient(0), MiscValue(0), MiscValueB(0), Mechanic(MECHANIC_NONE), PositionFacing(0),
                         RadiusEntry(nullptr), ChainTargets(0), ItemType(0), TriggerSpell(0), BonusCoefficientFromAP(0.0f),
-                        ImplicitTargetConditions(nullptr), EffectAttributes(EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK) { }
+                        ImplicitTargetConditions(nullptr), EffectAttributes(SpellEffectAttributes::None) { }
     SpellEffectInfo(SpellInfo const* spellInfo, SpellEffectEntry const* effect);
 
     bool IsEffect() const;

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -353,6 +353,7 @@ public:
     flag128   SpellClassMask;
     float     BonusCoefficientFromAP;
     std::vector<Condition*>* ImplicitTargetConditions;
+    EnumFlag<EffectAttributesFlags> EffectAttributes;
     // SpellScalingEntry
     struct ScalingInfo
     {
@@ -364,7 +365,8 @@ public:
     SpellEffectInfo() : _spellInfo(nullptr), EffectIndex(0), Effect(0), ApplyAuraName(0), ApplyAuraPeriod(0),
                         RealPointsPerLevel(0), BasePoints(0), PointsPerResource(0), Amplitude(0), ChainAmplitude(0),
                         BonusCoefficient(0), MiscValue(0), MiscValueB(0), Mechanic(MECHANIC_NONE), PositionFacing(0),
-                        RadiusEntry(nullptr), ChainTargets(0), ItemType(0), TriggerSpell(0), BonusCoefficientFromAP(0.0f), ImplicitTargetConditions(nullptr) { }
+                        RadiusEntry(nullptr), ChainTargets(0), ItemType(0), TriggerSpell(0), BonusCoefficientFromAP(0.0f),
+                        ImplicitTargetConditions(nullptr), EffectAttributes(EFFECT_ATTRIBUTES_FLAGS_NO_SCALE_WITH_STACK) { }
     SpellEffectInfo(SpellInfo const* spellInfo, SpellEffectEntry const* effect);
 
     bool IsEffect() const;


### PR DESCRIPTION
**Changes proposed:**

- Defined enum EffectAttributesFlags with NoScaleWithStack value (0x40) and implemeneted

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #26021 

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)


@mdX7 Thanks for helping figuring this out!