### PR TITLE
Core/Auras: Named SPELL_AURA_MOD_DAMAGE_FROM_CASTER_PET

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -453,7 +453,7 @@ enum AuraType : uint32
     SPELL_AURA_378                                          = 378,
     SPELL_AURA_MOD_MANA_REGEN_PCT                           = 379,
     SPELL_AURA_MOD_GLOBAL_COOLDOWN_BY_HASTE                 = 380,  // Allows melee abilities to benefit from haste GCD reduction
-    SPELL_AURA_381                                          = 381,
+    SPELL_AURA_MOD_DAMAGE_FROM_CASTER_PET                   = 381,  // NYI
     SPELL_AURA_MOD_PET_STAT_PCT                             = 382,  // NYI
     SPELL_AURA_IGNORE_SPELL_COOLDOWN                        = 383,  // NYI
     SPELL_AURA_384                                          = 384,

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -447,7 +447,7 @@ NonDefaultConstructible<pAuraEffectHandler> AuraEffectHandler[TOTAL_AURAS]=
     &AuraEffect::HandleNULL,                                      //378
     &AuraEffect::HandleModManaRegenPct,                           //379 SPELL_AURA_MOD_MANA_REGEN_PCT implemented in Player::UpdateManaRegen
     &AuraEffect::HandleNoImmediateEffect,                         //380 SPELL_AURA_MOD_GLOBAL_COOLDOWN_BY_HASTE implemented in Spell::TriggerGlobalCooldown
-    &AuraEffect::HandleNULL,                                      //381
+    &AuraEffect::HandleNULL,                                      //381 SPELL_AURA_MOD_DAMAGE_FROM_CASTER_PET
     &AuraEffect::HandleNULL,                                      //382 SPELL_AURA_MOD_PET_STAT_PCT
     &AuraEffect::HandleNULL,                                      //383 SPELL_AURA_IGNORE_SPELL_COOLDOWN
     &AuraEffect::HandleNULL,                                      //384


### PR DESCRIPTION
**Changes proposed:**

-  Named SPELL_AURA_381

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

It's mostly used additionally to `SPELL_AURA_MOD_SCHOOL_MASK_DAMAGE_FROM_CASTER` (by e.g. Hunters Mark) thats why I named it that way. Checking the spell `Unholy Blight`(115994) made clear that this is absolutely related to pet damage.

We could also go for `SPELL_AURA_MOD_PET_DAMAGE_PCT` or something.