### PR TITLE
Core/Spells: GetPrevSpellChain check disabled spells + riding skills

### DIFF
--- a/sql/updates/world/master/2021_02_05_00_world_disable_artisan_riding.sql
+++ b/sql/updates/world/master/2021_02_05_00_world_disable_artisan_riding.sql
@@ -1,0 +1,20 @@
+-- Delete the following spells from the trainer: Artisan Riding, Cold Weather Flying, Flight Masters License
+DELETE FROM `trainer_spell` WHERE `SpellId` IN (34093, 54198, 90269);
+
+-- Apprentice riding skill
+UPDATE `trainer_spell` SET `MoneyCost` = 10000, `ReqLevel` = 10 WHERE `SpellId` = 33389;
+
+-- Journeyman riding skill
+UPDATE `trainer_spell` SET `MoneyCost` = 500000, `ReqLevel` = 20 WHERE `SpellId` = 33392;
+
+-- Expert riding skill 
+UPDATE `trainer_spell` SET `MoneyCost` = 2500000, `ReqLevel` = 30 WHERE `SpellId` = 34092;
+
+-- Master riding skill 
+UPDATE `trainer_spell` SET `MoneyCost` = 50000000, `ReqLevel` = 40, `ReqAbility1` = 34090 WHERE `SpellId` = 90266;
+
+-- Disable artisan riding spell
+DELETE FROM `disables` WHERE `sourceType` = 0 AND `entry` = 34091;
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(0, 34091, 1, 0, 0, 'Disable artisan riding spell');
+

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -151,14 +151,14 @@ namespace Trainer
             if (!player->HasSpell(spellEffect->TriggerSpell))
                 knowsAllLearnedSpells = false;
 
-            if (uint32 previousRankSpellId = sSpellMgr->GetPrevSpellInChain(spellEffect->TriggerSpell))
+            if (uint32 previousRankSpellId = sSpellMgr->GetPrevSpellInChain(spellEffect->TriggerSpell, player))
                 if (!player->HasSpell(previousRankSpellId))
                     return SpellState::Unavailable;
         }
 
         if (!hasLearnSpellEffect)
         {
-            if (uint32 previousRankSpellId = sSpellMgr->GetPrevSpellInChain(trainerSpell->SpellId))
+            if (uint32 previousRankSpellId = sSpellMgr->GetPrevSpellInChain(trainerSpell->SpellId, player))
                 if (!player->HasSpell(previousRankSpellId))
                     return SpellState::Unavailable;
         }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3136,6 +3136,8 @@ void Player::LearnSpell(uint32 spell_id, bool dependent, int32 fromSkill /*= 0*/
         SendDirectMessage(packet.Write());
     }
 
+    disabled |= DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, spell_id, this, 0);
+
     // learn all disabled higher ranks and required spells (recursive)
     if (disabled)
     {

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "SpellMgr.h"
+#include "DisableMgr.h"
 #include "BattlefieldMgr.h"
 #include "BattlefieldWG.h"
 #include "BattlegroundMgr.h"
@@ -230,11 +231,20 @@ uint32 SpellMgr::GetNextSpellInChain(uint32 spell_id) const
     return 0;
 }
 
-uint32 SpellMgr::GetPrevSpellInChain(uint32 spell_id) const
+uint32 SpellMgr::GetPrevSpellInChain(uint32 spell_id, Unit const* disableCheckUnit /*= nullptr*/) const
 {
-    if (SpellChainNode const* node = GetSpellChainNode(spell_id))
-        if (node->prev)
+    SpellChainNode const* node = nullptr;
+
+    do
+    {
+        node = GetSpellChainNode(spell_id);
+        if (node == nullptr || node->prev == nullptr)
+            break;
+
+        if (disableCheckUnit == nullptr || !DisableMgr::IsDisabledFor(DISABLE_TYPE_SPELL, node->prev->Id, disableCheckUnit, 0))
             return node->prev->Id;
+        spell_id = node->prev->Id;
+    } while (node != nullptr && node->prev != nullptr);
 
     return 0;
 }

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -644,7 +644,7 @@ class TC_GAME_API SpellMgr
         uint32 GetFirstSpellInChain(uint32 spell_id) const;
         uint32 GetLastSpellInChain(uint32 spell_id) const;
         uint32 GetNextSpellInChain(uint32 spell_id) const;
-        uint32 GetPrevSpellInChain(uint32 spell_id) const;
+        uint32 GetPrevSpellInChain(uint32 spell_id, Unit const* disableCheckUnit = nullptr) const;
         uint8 GetSpellRank(uint32 spell_id) const;
         // not strict check returns provided spell if rank not avalible
         uint32 GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict = false) const;

--- a/src/server/scripts/Commands/cs_disable.cpp
+++ b/src/server/scripts/Commands/cs_disable.cpp
@@ -77,7 +77,7 @@ public:
         return commandTable;
     }
 
-    static bool HandleReloadDisablesCommand(ChatHandler* handler, char const* args)
+    static bool HandleReloadDisablesCommand(ChatHandler* /*handler*/, char const* /*args*/)
     {
         DisableMgr::LoadDisables();
         return true;

--- a/src/server/scripts/Commands/cs_disable.cpp
+++ b/src/server/scripts/Commands/cs_disable.cpp
@@ -66,14 +66,21 @@ public:
         };
         static std::vector<ChatCommand> disableCommandTable =
         {
-            { "add",    rbac::RBAC_PERM_COMMAND_DISABLE_ADD,    true, nullptr, "", addDisableCommandTable },
-            { "remove", rbac::RBAC_PERM_COMMAND_DISABLE_REMOVE, true, nullptr, "", removeDisableCommandTable },
+            { "add",    rbac::RBAC_PERM_COMMAND_DISABLE_ADD,    true, nullptr,                      "", addDisableCommandTable },
+            { "remove", rbac::RBAC_PERM_COMMAND_DISABLE_REMOVE, true, nullptr,                      "", removeDisableCommandTable },
+            { "reload", rbac::RBAC_PERM_COMMAND_DISABLE,        true, &HandleReloadDisablesCommand, "" },
         };
         static std::vector<ChatCommand> commandTable =
         {
             { "disable", rbac::RBAC_PERM_COMMAND_DISABLE, false, nullptr, "", disableCommandTable },
         };
         return commandTable;
+    }
+
+    static bool HandleReloadDisablesCommand(ChatHandler* handler, char const* args)
+    {
+        DisableMgr::LoadDisables();
+        return true;
     }
 
     static bool HandleAddDisables(ChatHandler* handler, char const* args, uint8 disableType)


### PR DESCRIPTION
**Changes proposed:**

- GetPrevSpellChain can now get a unit to return only non-disabled spells for that unit
- Player will now check DisableMgr on learning spells
- added reload command to disables
- SQL file to add artisan riding spell as disabled spells for players and update the trainer's riding spells 


**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)