### PR TITLE
Scripts/Spells: Druid TravelForm freeze fix

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1118,6 +1118,9 @@ public:
 
         void AfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
+            if (triggeredSpellId == m_scriptSpellId)
+                return;
+
             Player* player = GetTarget()->ToPlayer();
 
             if (triggeredSpellId) // Apply new form


### PR DESCRIPTION
**Changes proposed:**

-  Checking for the same trigger as the one removed, in case of a teleport, as to not end up in an infinite loop.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #25939 

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [x] This is a quick fix to the server freezing, but the druid spell it self won't work properly (nor does it currently work properly). Will create a different issue to address that.