### PR TITLE
Core/SmartAI: AI change on charmed

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -704,7 +704,8 @@ void SmartAI::OnCharmed(bool isNew)
 
     GetScript()->ProcessEventsFor(SMART_EVENT_CHARMED, nullptr, 0, 0, charmed);
 
-    UnitAI::OnCharmed(isNew);
+    if (!GetScript()->HasAnyEventWithFlag(SMART_EVENT_FLAG_WHILE_CHARMED)) // we can change AI if there are no events with this flag
+        UnitAI::OnCharmed(isNew);
 }
 
 void SmartAI::DoAction(int32 param)

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -669,7 +669,7 @@ void SmartAI::PassengerBoarded(Unit* who, int8 seatId, bool apply)
     GetScript()->ProcessEventsFor(apply ? SMART_EVENT_PASSENGER_BOARDED : SMART_EVENT_PASSENGER_REMOVED, who, uint32(seatId), 0, apply);
 }
 
-void SmartAI::OnCharmed(bool /*isNew*/)
+void SmartAI::OnCharmed(bool isNew)
 {
     bool const charmed = me->IsCharmed();
     if (charmed) // do this before we change charmed state, as charmed state might prevent these things from processing
@@ -703,6 +703,8 @@ void SmartAI::OnCharmed(bool /*isNew*/)
     }
 
     GetScript()->ProcessEventsFor(SMART_EVENT_CHARMED, nullptr, 0, 0, charmed);
+
+    UnitAI::OnCharmed(isNew);
 }
 
 void SmartAI::DoAction(int32 param)

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -60,6 +60,7 @@ SmartScript::SmartScript()
     mCurrentPriority = 0;
     mEventSortingRequired = false;
     mNestedEventsCounter = 0;
+    mAllEventFlags = 0;
 }
 
 SmartScript::~SmartScript()
@@ -3836,15 +3837,13 @@ void SmartScript::FillScript(SmartAIEventList e, WorldObject* obj, AreaTriggerEn
 
         if (scriptholder.event.event_flags & SMART_EVENT_FLAG_DIFFICULTY_ALL)//if has instance flag add only if in it
         {
-            if (obj && obj->GetMap()->IsDungeon())
-            {
-                if ((1 << (obj->GetMap()->GetSpawnMode()+1)) & scriptholder.event.event_flags)
-                {
-                    mEvents.push_back(scriptholder);
-                }
-            }
-            continue;
+            if (!(obj && obj->GetMap()->IsDungeon()))
+                continue;
+
+            if (!(1 << (obj->GetMap()->GetSpawnMode() + 1) & scriptholder.event.event_flags))
+                continue;
         }
+        mAllEventFlags |= scriptholder.event.event_flags;
         mEvents.push_back(scriptholder);//NOTE: 'world(0)' events still get processed in ANY instance mode
     }
 }

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -56,6 +56,7 @@ class TC_GAME_API SmartScript
         uint32 GetPathId() const { return mPathId; }
         WorldObject* GetBaseObject() const;
         WorldObject* GetBaseObjectOrPlayerTrigger() const;
+        bool HasAnyEventWithFlag(uint32 flag) const { return mAllEventFlags & flag; }
         static bool IsUnit(WorldObject* obj);
         static bool IsPlayer(WorldObject* obj);
         static bool IsCreature(WorldObject* obj);
@@ -130,6 +131,7 @@ class TC_GAME_API SmartScript
         uint32 mCurrentPriority;
         bool mEventSortingRequired;
         uint32 mNestedEventsCounter;
+        uint32 mAllEventFlags;
 
         // Max number of nested ProcessEventsFor() calls to avoid infinite loops
         static constexpr uint32 MAX_NESTED_EVENTS = 10;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9511,7 +9511,6 @@ void Unit::ScheduleAIChange()
         RestoreDisabledAI();
         PushAI(nullptr); //This could actually be PopAI() to get the previous AI but it's required atm to trigger UpdateCharmAI()
     }
-    RefreshAI();
 }
 
 void Unit::RestoreDisabledAI()

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9511,6 +9511,7 @@ void Unit::ScheduleAIChange()
         RestoreDisabledAI();
         PushAI(nullptr); //This could actually be PopAI() to get the previous AI but it's required atm to trigger UpdateCharmAI()
     }
+    RefreshAI();
 }
 
 void Unit::RestoreDisabledAI()


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  SmartAI calls base method UnitAI::OnCharmed to update AI on charmed

Without this change, charmed creature can't update AI.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #25982 (melee attack works correctly)
Partially #23582 (part 2: Enslaved demons should be able to attcak)


**Tests performed:**

Built and tested with warlock's 'Enslave Demon' spell, priest's 'Mind control' spell.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
