### PR TITLE
Spells/Shaman: Sentry Totem - Fix summon position.

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1398,8 +1398,7 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
                 case TARGET_DEST_CASTER_BACK_RIGHT:
                 {
                     static float const DefaultTotemDistance = 3.0f;
-                    if (!m_spellInfo->Effects[effIndex].HasRadius())
-                        dist = DefaultTotemDistance;
+                    dist = DefaultTotemDistance;
                     break;
                 }
                 default:


### PR DESCRIPTION
Shaman's Sentry Totem (and only Sentry Totem) is being placed far away from the caster, which is a bug. This PR fixes that.

Spell description:
_Summons an immobile Sentry Totem with 100 health **at your feet** for 5 min that allows vision of nearby area and warns of enemies that attack it. Right-Click on buff to switch back and forth between totem sight and shaman sight._



<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Remove `HasRadius()` check and just use the default totem summon distance when placing totems with `TARGET_DEST_CASTER_<FRONT|BACK>_<LEFT|RIGHT>` targeting, as totems should always be placed next to the caster.

**Target branch(es):**

- [x] 3.3.5
- [ ] master


**Tests performed:**

Tested on all totems placable by Shaman. They are all placed and work as intended, Sentry Totem included.


**Notes:**

- This is unrelated to #15870 which is another Sentry Totem bug.
- I wonder why the `HasRadius()` check was used for this kind of target type. Do we use `TARGET_DEST_CASTER_<FRONT|BACK>_<LEFT|RIGHT>` for anything other than totems? In that case this may have unintended side effects.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
