### PR TITLE
Spells/Auras: Dont save SPELL_AURA_BATTLEGROUND_PLAYER_POSITION auras

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1020,6 +1020,10 @@ bool Aura::CanBeSaved() const
     if (HasEffectType(SPELL_AURA_MOD_CHARM) || HasEffectType(SPELL_AURA_AOE_CHARM))
         return false;
 
+    // no battleground player positions
+    if (HasEffectType(SPELL_AURA_BATTLEGROUND_PLAYER_POSITION) || HasEffectType(SPELL_AURA_BATTLEGROUND_PLAYER_POSITION_FACTIONAL))
+        return false;
+
     // Incanter's Absorbtion - considering the minimal duration and problems with aura stacking
     // we skip saving this aura
     // Also for some reason other auras put as MultiSlot crash core on keeping them after restart,


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Dont save SPELL_AURA_BATTLEGROUND_PLAYER_POSITION(_FACTIONAL) aura

**Target branch(es):**

- master

**Issues addressed:**

Closes: none

**Tests performed:**

- Builds
- Logged in ingame, started battleground, cast spell, logout -> aura removed


**Known issues and TODO list:** (add/remove lines as needed)
- none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->

The current issue we have now is that the aura can be re-applied when the user logs back in after a long time (character removed from world). This should not happen and this PR fixes that issue.
A side issue that does come up with this PR is that if you log back in quickly (so your character is not removed yet), you wont get the aura back.

See https://github.com/TrinityCore/TrinityCore/pull/25988#issuecomment-774761501 and https://github.com/TrinityCore/TrinityCore/commit/e9357dc7f29fc15a72a3dc25b647d577dc979db8#r46933350

Some issues that are related to disconnected players:
- https://github.com/TrinityCore/TrinityCore/issues/19926
- https://github.com/TrinityCore/TrinityCore/issues/18458