### PR TITLE
Core: Implement "spell_script_names" reloading

### DIFF
--- a/sql/updates/auth/master/2020_12_16_01_rbac_reload_scripts.sql
+++ b/sql/updates/auth/master/2020_12_16_01_rbac_reload_scripts.sql
@@ -1,0 +1,6 @@
+DELETE FROM `rbac_permissions` WHERE `id`=2009;
+INSERT INTO `rbac_permissions` (`id`, `name`) VALUES 
+(2009, 'Command: reload spell_script_names');
+
+DELETE FROM `rbac_linked_permissions` WHERE `id`=192 AND `linkedId`=2009;
+INSERT INTO `rbac_linked_permissions` (`id`, `linkedId`) VALUES (192, 2009);

--- a/sql/updates/world/master/2020_12_16_01_reload_scripts_command.sql
+++ b/sql/updates/world/master/2020_12_16_01_reload_scripts_command.sql
@@ -1,0 +1,3 @@
+DELETE FROM `command` WHERE `name`='reload spell_script_names';
+INSERT INTO `command` (`name`, `permission`, `help`) VALUES 
+('reload spell_script_names', 2009, 'Syntax: .reload spell_script_names');

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -790,6 +790,7 @@ enum RBACPermissions
     // IF YOU ADD NEW PERMISSIONS, ADD THEM IN 3.3.5 BRANCH AS WELL!
     //
     // custom permissions 1000+
+    RBAC_PERM_COMMAND_RELOAD_SPELL_SCRIPT_NAMES              = 2009,
     RBAC_PERM_MAX
 };
 

--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -3560,7 +3560,7 @@ void CriteriaMgr::LoadCriteriaData()
             if (dataType != CRITERIA_DATA_TYPE_SCRIPT)
                 TC_LOG_ERROR("sql.sql", "Table `criteria_data` contains a ScriptName for non-scripted data type (Entry: %u, type %u), useless data.", criteria_id, dataType);
             else
-                scriptId = sObjectMgr->GetScriptId(scriptName);
+                scriptId = sObjectMgr->GetScriptIdOrAdd(scriptName);
         }
 
         CriteriaData data(dataType, fields[2].GetUInt32(), fields[3].GetUInt32(), scriptId);

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -503,7 +503,7 @@ void BattlegroundMgr::LoadBattlegroundTemplates()
         float dist                   = fields[3].GetFloat();
         bgTemplate.MaxStartDistSq    = dist * dist;
         bgTemplate.Weight            = fields[4].GetUInt8();
-        bgTemplate.ScriptId          = sObjectMgr->GetScriptId(fields[5].GetString());
+        bgTemplate.ScriptId          = sObjectMgr->GetScriptIdOrAdd(fields[5].GetString());
         bgTemplate.BattlemasterEntry = bl;
 
         if (bgTemplate.Id != BATTLEGROUND_AA && bgTemplate.Id != BATTLEGROUND_RB && bgTemplate.Id != BATTLEGROUND_RANDOM_EPIC)

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1108,7 +1108,7 @@ void ConditionMgr::LoadConditions(bool isReload)
         cond->NegativeCondition         = fields[10].GetBool();
         cond->ErrorType                 = fields[11].GetUInt32();
         cond->ErrorTextId               = fields[12].GetUInt32();
-        cond->ScriptId                  = sObjectMgr->GetScriptId(fields[13].GetString());
+        cond->ScriptId                  = sObjectMgr->GetScriptIdOrAdd(fields[13].GetString());
 
         if (iConditionTypeOrReference >= 0)
             cond->ConditionType = ConditionTypes(iConditionTypeOrReference);

--- a/src/server/game/Globals/AreaTriggerDataStore.cpp
+++ b/src/server/game/Globals/AreaTriggerDataStore.cpp
@@ -182,7 +182,7 @@ void AreaTriggerDataStore::LoadAreaTriggerTemplates()
             for (uint8 i = 0; i < MAX_AREATRIGGER_ENTITY_DATA; ++i)
                 areaTriggerTemplate.DefaultDatas.Data[i] = fields[4 + i].GetFloat();
 
-            areaTriggerTemplate.ScriptId = sObjectMgr->GetScriptId(fields[10].GetString());
+            areaTriggerTemplate.ScriptId = sObjectMgr->GetScriptIdOrAdd(fields[10].GetString());
             if (!areaTriggerTemplate.Id.IsServerSide)
             {
                 areaTriggerTemplate.PolygonVertices = std::move(verticesByAreaTrigger[areaTriggerTemplate.Id.Id]);

--- a/src/server/game/Globals/ConversationDataStore.cpp
+++ b/src/server/game/Globals/ConversationDataStore.cpp
@@ -163,7 +163,7 @@ void ConversationDataStore::LoadConversationTemplates()
             conversationTemplate.FirstLineId        = fields[1].GetUInt32();
             conversationTemplate.LastLineEndTime    = fields[2].GetUInt32();
             conversationTemplate.TextureKitId       = fields[3].GetUInt32();
-            conversationTemplate.ScriptId           = sObjectMgr->GetScriptId(fields[4].GetString());
+            conversationTemplate.ScriptId           = sObjectMgr->GetScriptIdOrAdd(fields[4].GetString());
 
             conversationTemplate.Actors = std::move(actorsByConversation[conversationTemplate.Id]);
             conversationTemplate.ActorGuids = std::move(actorGuidsByConversation[conversationTemplate.Id]);

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1596,7 +1596,8 @@ class TC_GAME_API ObjectMgr
         void LoadScriptNames();
         ScriptNameContainer const& GetAllScriptNames() const;
         std::string const& GetScriptName(uint32 id) const;
-        uint32 GetScriptId(std::string const& name);
+        uint32 GetScriptIdOrAdd(std::string const& name);
+        bool FindScriptId(std::string const& name) const;
 
         SpellClickInfoMapBounds GetSpellClickInfoMapBounds(uint32 creature_id) const
         {

--- a/src/server/game/OutdoorPvP/OutdoorPvPMgr.cpp
+++ b/src/server/game/OutdoorPvP/OutdoorPvPMgr.cpp
@@ -78,7 +78,7 @@ void OutdoorPvPMgr::InitOutdoorPvP()
         }
 
         OutdoorPvPTypes realTypeId = OutdoorPvPTypes(typeId);
-        m_OutdoorPvPDatas[realTypeId] = sObjectMgr->GetScriptId(fields[1].GetString());
+        m_OutdoorPvPDatas[realTypeId] = sObjectMgr->GetScriptIdOrAdd(fields[1].GetString());
 
         ++count;
     }

--- a/src/server/game/Quests/QuestDef.cpp
+++ b/src/server/game/Quests/QuestDef.cpp
@@ -226,7 +226,7 @@ void Quest::LoadQuestTemplateAddon(Field* fields)
     _requiredMaxRepValue = fields[14].GetInt32();
     _sourceItemIdCount = fields[15].GetUInt8();
     _specialFlags = fields[16].GetUInt8();
-    _scriptId = sObjectMgr->GetScriptId(fields[17].GetString());
+    _scriptId = sObjectMgr->GetScriptIdOrAdd(fields[17].GetString());
 
     if (_specialFlags & QUEST_SPECIAL_FLAGS_AUTO_ACCEPT)
         _flags |= QUEST_FLAGS_AUTO_ACCEPT;

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -885,9 +885,16 @@ public:
 
         std::unique_ptr<ScriptType> script_ptr(script);
 
+        if (!sObjectMgr->FindScriptId(script->GetName()))
+        {
+            // The script uses a script name from database, but isn't assigned to anything.
+            TC_LOG_ERROR("sql.sql", "Script named '%s' does not have a script name assigned in database.",
+                script->GetName().c_str());
+        }
+
         // Get an ID for the script. An ID only exists if it's a script that is assigned in the database
         // through a script name (or similar).
-        if (uint32 const id = sObjectMgr->GetScriptId(script->GetName()))
+        if (uint32 const id = sObjectMgr->GetScriptIdOrAdd(script->GetName()))
         {
             // Try to find an existing script.
             for (auto const& stored_script : _scripts)

--- a/src/server/game/Weather/WeatherMgr.cpp
+++ b/src/server/game/Weather/WeatherMgr.cpp
@@ -92,7 +92,7 @@ void LoadWeatherData()
             }
         }
 
-        wzc.ScriptId = sObjectMgr->GetScriptId(fields[13].GetString());
+        wzc.ScriptId = sObjectMgr->GetScriptIdOrAdd(fields[13].GetString());
 
         ++count;
     }

--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -150,6 +150,7 @@ public:
             { "spell_linked_spell",            rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_LINKED_SPELL,               true,  &HandleReloadSpellLinkedSpellCommand,           "" },
             { "spell_pet_auras",               rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_PET_AURAS,                  true,  &HandleReloadSpellPetAurasCommand,              "" },
             { "spell_proc",                    rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_PROC,                       true,  &HandleReloadSpellProcsCommand,                 "" },
+            { "spell_script_names",            rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_SCRIPT_NAMES,               true,  &HandleReloadScriptNamesCommand,                "" },
             { "spell_scripts",                 rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_SCRIPTS,                    true,  &HandleReloadSpellScriptsCommand,               "" },
             { "spell_target_position",         rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_TARGET_POSITION,            true,  &HandleReloadSpellTargetPositionCommand,        "" },
             { "spell_threats",                 rbac::RBAC_PERM_COMMAND_RELOAD_SPELL_THREATS,                    true,  &HandleReloadSpellThreatsCommand,               "" },
@@ -941,6 +942,15 @@ public:
         if (*args != 'a')
             handler->SendGlobalGMSysMessage("DB Table 'waypoint_data' reloaded.");
 
+        return true;
+    }
+
+    static bool HandleReloadScriptNamesCommand(ChatHandler* handler, const char* args)
+    {
+        TC_LOG_INFO("misc", "Reloading spell_script_names...");
+        sObjectMgr->LoadSpellScriptNames();
+        sObjectMgr->ValidateSpellScripts();
+        handler->SendGlobalGMSysMessage("spell script names reloaded.");
         return true;
     }
 


### PR DESCRIPTION
It is now possible to add scripts/templates without server restart
(based on and part of dc92d02678f23835375ca9b708bc9db6fe0a8ada)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Add reload spell_script_names command.

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

None.


**Tests performed:**

Built and tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)

None.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
