### PR TITLE
Scripts/Spells: corrections to Death Knight spell Blood Mastery

### DIFF
--- a/sql/updates/world/master/2021_03_15_00_world_dk_blood_mastery.sql
+++ b/sql/updates/world/master/2021_03_15_00_world_dk_blood_mastery.sql
@@ -1,0 +1,17 @@
+-- 89832 Death Strike Enabler
+DELETE FROM `serverside_spell` WHERE `Id` = 89832 AND `DifficultyID` = 0;
+INSERT INTO `serverside_spell` (`Id`, `DifficultyID`, `SpellName`, `Attributes`, `CastingTimeIndex`, `ProcFlags`, `ProcChance`, `DurationIndex`, `RangeIndex`, `SchoolMask`) VALUES
+(89832, 0, 'Death Strike Enabler', 0x1d0, 1 /* CastingTimeIndex: 0/0/0 */, 0xAAAA8 /*ProcFlags: Damage Taken */, 100 /*Proc Chance*/, 21 /*Duration: -1/0/-1 */, 1 /*Range: Self Only*/, 0x1 /* Physical */);
+
+DELETE FROM `serverside_spell_effect` WHERE `SpellID` = 89832 AND `DifficultyID` = 0;
+INSERT INTO `serverside_spell_effect` (`SpellID`, `EffectIndex`, `DifficultyID`, `Effect`, `EffectAura`, `EffectAuraPeriod`, `EffectChainAmplitude`, `ImplicitTarget1`) VALUES
+(89832, 0, 0, 6 /* APPLY_AURA */, 226 /* PERIODIC_DUMMY */, 1000, 1, 1 /* Target: Caster */);
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_dk_death_strike_enabler');
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(89832, 'spell_dk_death_strike_enabler');
+
+-- Link spells Death Knight (137005)
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 137005 AND `spell_effect` = 89832 AND `type` = 2;
+INSERT INTO `spell_linked_spell` (`spell_trigger`, `spell_effect`, `type`, `comment`) VALUES
+(137005, 89832, 2, 'On Death Knight (passive) trigger Death Strike Enabler (Passive)');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1654,6 +1654,7 @@ void SpellMgr::LoadSpellProcs()
     }
 
     isTriggerAura[SPELL_AURA_DUMMY] = true;
+    isTriggerAura[SPELL_AURA_PERIODIC_DUMMY] = true;
     isTriggerAura[SPELL_AURA_MOD_CONFUSE] = true;
     isTriggerAura[SPELL_AURA_MOD_THREAT] = true;
     isTriggerAura[SPELL_AURA_MOD_STUN] = true; // Aura does not have charges but needs to be removed on trigger


### PR DESCRIPTION
**Changes proposed:**

-  Using EffectLaunch rather than OnEffectHitRather and with the correct effect type

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Missing mechanic: the heal should be done for 25% of the damage received in the last 5 seconds. I'm not aware of any mechanics we have to do it, nor have I seen any proc flags on the spells.