### PR TITLE
Core/Unit: Improve Glancing Blow calculation

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1324,7 +1324,7 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
             // against boss-level targets - 24% chance of 25% average damage reduction (damage reduction range : 20-30%)
             // against level 82 elites - 18% chance of 15% average damage reduction (damage reduction range : 10-20%)
             int32 const reductionMax = leveldif * 10;
-            int32 const reductionMin = std::min(1, reductionMax - 10);
+            int32 const reductionMin = std::max(1, reductionMax - 10);
             float reducePercent = 1.f - irand(reductionMin, reductionMax) / 100.0f;
 
             for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1324,7 +1324,7 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
             // against boss-level targets - 24% chance of 25% average damage reduction (damage reduction range : 20-30%)
             // against level 82 elites - 18% chance of 15% average damage reduction (damage reduction range : 10-20%)
             int32 const reductionMax = leveldif * 10;
-            int32 const reductionMin = reductionMax - 10;
+            int32 const reductionMin = std::min(1, reductionMax - 10);
             float reducePercent = 1.f - irand(reductionMin, reductionMax) / 100.0f;
 
             for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; ++i)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2171,7 +2171,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* victim, WeaponAttackTy
     }
 
     // 4. GLANCING
-    // Max 40% chance to score a glancing blow against mobs that are higher level (can do only players and pets and not with ranged weapon)
+    // Max 40% chance to score a glancing blow against mobs that are same or higher level (can do only players and pets and not with ranged weapon)
     if ((GetTypeId() == TYPEID_PLAYER || IsPet()) &&
         victim->GetTypeId() != TYPEID_PLAYER && !victim->IsPet() &&
         GetLevel() <= victim->GetLevelForTarget(this))

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1316,6 +1316,8 @@ void Unit::CalculateMeleeDamage(Unit* victim, CalcDamageInfo* damageInfo, Weapon
             damageInfo->HitInfo     |= HITINFO_GLANCING;
             damageInfo->TargetState  = VICTIMSTATE_HIT;
             int32 leveldif = int32(victim->GetLevel()) - int32(GetLevel());
+            if (leveldif == 0)
+                leveldif = 1;
             if (leveldif > 3)
                 leveldif = 3;
 
@@ -2172,7 +2174,7 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(Unit const* victim, WeaponAttackTy
     // Max 40% chance to score a glancing blow against mobs that are higher level (can do only players and pets and not with ranged weapon)
     if ((GetTypeId() == TYPEID_PLAYER || IsPet()) &&
         victim->GetTypeId() != TYPEID_PLAYER && !victim->IsPet() &&
-        GetLevel() < victim->GetLevelForTarget(this))
+        GetLevel() <= victim->GetLevelForTarget(this))
     {
         // cap possible value (with bonuses > max skill)
         int32 skill = attackerWeaponSkill;


### PR DESCRIPTION
Hi

**Changes proposed:**

-  Add Glancing Blow vs mob with the same level as the attacker
-  Set a minimum of 1% damage reduction for glancings

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**


**Tests performed:**

hash: 2f9e38612f90f2b438df26eb10f465e2ac53b1f7
I've just read the code and found that a 80 vs 80 can't do Glancing Blow, not tested at all.

**Known issues and TODO list:** (add/remove lines as needed)

I don't know yours coding standards, feel free to comment/edit the PR ;)

**Proof:**

Chance to glancing vs same level: 6%
http://www.worldoflogs.com/reports/k9lp4yw68u6s1asl/details/15/?s=34&e=196

Damage reduction vs same level: 1 - 10%
http://www.worldoflogs.com/reports/k9lp4yw68u6s1asl/xe/?x=targetName%3D%22The+Damned%22%0D%0Aand+%28%0D%0A%28%0D%0AsourceName%3D%22Oranoss%22+and+%28isGlancing+%3D+TRUE%0D%0Aor+fullType+%3D+SWING_DAMAGE%29%0D%0A%29%0D%0Aor+spell%3D%22Sunder+Armor%22%0D%0Aor+spell%3D%22Faerie+Fire%22%0D%0A%29%0D%0A%0D%0A

NB: I've checked the formula against 81-83 btw, everything seems like in the logs.