### PR TITLE
Core/Spells: Warlock Death Coil shouldn't be able to crit

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3832,6 +3832,12 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     ApplySpellFix({
+        6789,  // Warlock - Death Coil (Rank 1)
+        17925, // Warlock - Death Coil (Rank 2)
+        17926, // Warlock - Death Coil (Rank 3)
+        27223, // Warlock - Death Coil (Rank 4)
+        47859, // Warlock - Death Coil (Rank 5)
+        47860, // Warlock - Death Coil (Rank 6)
         71838, // Drain Life - Bryntroll Normal
         71839  // Drain Life - Bryntroll Heroic
     }, [](SpellInfo* spellInfo)


### PR DESCRIPTION

**Changes proposed:**

-  Warlock Death Coil shouldn't be able to crit


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #26115


**Tests performed:**

tested in-game
