### PR TITLE
Core/Spells: Do not learn spells that belong to another spec

### DIFF
--- a/src/server/game/DataStores/DB2Stores.h
+++ b/src/server/game/DataStores/DB2Stores.h
@@ -175,6 +175,7 @@ TC_GAME_API extern DB2Storage<SceneScriptPackageEntry>              sSceneScript
 TC_GAME_API extern DB2Storage<SkillLineAbilityEntry>                sSkillLineAbilityStore;
 TC_GAME_API extern DB2Storage<SkillRaceClassInfoEntry>              sSkillRaceClassInfoStore;
 TC_GAME_API extern DB2Storage<SoundKitEntry>                        sSoundKitStore;
+TC_GAME_API extern DB2Storage<SpecializationSpellsEntry>            sSpecializationSpellsStore;
 TC_GAME_API extern DB2Storage<SpellAuraOptionsEntry>                sSpellAuraOptionsStore;
 TC_GAME_API extern DB2Storage<SpellAuraRestrictionsEntry>           sSpellAuraRestrictionsStore;
 TC_GAME_API extern DB2Storage<SpellCastTimesEntry>                  sSpellCastTimesStore;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3014,10 +3014,7 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     {
         if (!itr2->second.AutoLearned)
         {
-            // only add/learn it if we can; check spell requiremetns (spec)
-            uint32 learnSpellSpecId = sSpellMgr->GetSpellSpecId(itr2->second.Spell);
-
-            if (primarySpecId == learnSpellSpecId)
+            if (sSpellMgr->MatchSpellSpecId(itr2->second.Spell, primarySpecId))
             {
                 if (!IsInWorld() || !itr2->second.Active)       // at spells loading, no output, but allow save
                     AddSpell(itr2->second.Spell, itr2->second.Active, true, true, false);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3009,14 +3009,21 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     // learn dependent spells
     SpellLearnSpellMapBounds spell_bounds = sSpellMgr->GetSpellLearnSpellMapBounds(spellId);
 
+    uint32 primarySpecId = GetPrimarySpecialization();
     for (SpellLearnSpellMap::const_iterator itr2 = spell_bounds.first; itr2 != spell_bounds.second; ++itr2)
     {
         if (!itr2->second.AutoLearned)
         {
-            if (!IsInWorld() || !itr2->second.Active)       // at spells loading, no output, but allow save
-                AddSpell(itr2->second.Spell, itr2->second.Active, true, true, false);
-            else                                            // at normal learning
-                LearnSpell(itr2->second.Spell, true);
+            // only add/learn it if we can; check spell requiremetns (spec)
+            uint32 learnSpellSpecId = sSpellMgr->GetSpellSpecId(itr2->second.Spell);
+
+            if (primarySpecId == learnSpellSpecId)
+            {
+                if (!IsInWorld() || !itr2->second.Active)       // at spells loading, no output, but allow save
+                    AddSpell(itr2->second.Spell, itr2->second.Active, true, true, false);
+                else                                            // at normal learning
+                    LearnSpell(itr2->second.Spell, true);
+            }
         }
 
         if (itr2->second.OverridesSpell && itr2->second.Active)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -259,6 +259,15 @@ uint32 SpellMgr::GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict) con
     return spell_id;
 }
 
+uint32 SpellMgr::GetSpellSpecId(uint32 spell_id) const
+{
+    if (SpecializationSpellsEntry const* entry = sSpecializationSpellsStore.LookupEntry(spell_id))
+    {
+        return entry->SpecID;
+    }
+    return 0;
+}
+
 Trinity::IteratorPair<SpellRequiredMap::const_iterator> SpellMgr::GetSpellsRequiredForSpellBounds(uint32 spell_id) const
 {
     return Trinity::Containers::MapEqualRange(mSpellReq, spell_id);

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -259,13 +259,16 @@ uint32 SpellMgr::GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict) con
     return spell_id;
 }
 
-uint32 SpellMgr::GetSpellSpecId(uint32 spell_id) const
+bool SpellMgr::MatchSpellSpecId(uint32 spell_id, uint32 specId) const
 {
-    if (SpecializationSpellsEntry const* entry = sSpecializationSpellsStore.LookupEntry(spell_id))
+    SpellSpecMap::const_iterator itr = mSpellSpecMap.find(spell_id);
+    if (itr != mSpellSpecMap.cend())
     {
-        return entry->SpecID;
+        SpellSpecMap::mapped_type::const_iterator specIter = itr->second.find(specId);
+        return specIter != itr->second.cend();
     }
-    return 0;
+
+    return true;
 }
 
 Trinity::IteratorPair<SpellRequiredMap::const_iterator> SpellMgr::GetSpellsRequiredForSpellBounds(uint32 spell_id) const
@@ -4040,6 +4043,15 @@ void SpellMgr::LoadSpellTotemModel()
 
     TC_LOG_INFO("server.loading", ">> Loaded %u spell totem model records in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
 
+}
+
+void SpellMgr::LoadSpellsSpecializations()
+{
+    for (SpecializationSpellsEntry const* entry : sSpecializationSpellsStore)
+        mSpellSpecMap[entry->SpellID].insert(entry->SpecID);
+
+    for (TalentEntry const* entry : sTalentStore)
+        mSpellSpecMap[entry->SpellID].insert(entry->SpecID);
 }
 
 uint32 SpellMgr::GetModelForTotem(uint32 spellId, uint8 race) const

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -626,6 +626,8 @@ struct SpellInfoLoadHelper
 
 typedef std::map<std::pair<uint32 /*SpellId*/, uint8 /*RaceId*/>, uint32 /*DisplayId*/> SpellTotemModelMap;
 
+typedef std::map<uint32, std::set<uint32>> SpellSpecMap;
+
 class TC_GAME_API SpellMgr
 {
     // Constructors
@@ -649,7 +651,7 @@ class TC_GAME_API SpellMgr
         uint8 GetSpellRank(uint32 spell_id) const;
         // not strict check returns provided spell if rank not avalible
         uint32 GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict = false) const;
-        uint32 GetSpellSpecId(uint32 spell_id) const;
+        bool MatchSpellSpecId(uint32 spell_id, uint32 specId) const;
 
         // Spell Required table
         Trinity::IteratorPair<SpellRequiredMap::const_iterator> GetSpellsRequiredForSpellBounds(uint32 spell_id) const;
@@ -756,6 +758,7 @@ class TC_GAME_API SpellMgr
         void LoadSpellInfoDiminishing();
         void LoadSpellInfoImmunities();
         void LoadSpellTotemModel();
+        void LoadSpellsSpecializations();
 
     private:
         SpellDifficultySearcherMap mSpellDifficultySearcherMap;
@@ -784,6 +787,7 @@ class TC_GAME_API SpellMgr
         PetLevelupSpellMap         mPetLevelupSpellMap;
         PetDefaultSpellsMap        mPetDefaultSpellsMap;           // only spells not listed in related mPetLevelupSpellMap entry
         SpellTotemModelMap         mSpellTotemModel;
+        SpellSpecMap               mSpellSpecMap;
         std::unordered_map<uint32, BattlePetSpeciesEntry const*> mBattlePets;
 };
 

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -649,6 +649,7 @@ class TC_GAME_API SpellMgr
         uint8 GetSpellRank(uint32 spell_id) const;
         // not strict check returns provided spell if rank not avalible
         uint32 GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict = false) const;
+        uint32 GetSpellSpecId(uint32 spell_id) const;
 
         // Spell Required table
         Trinity::IteratorPair<SpellRequiredMap::const_iterator> GetSpellsRequiredForSpellBounds(uint32 spell_id) const;

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1851,6 +1851,9 @@ void World::SetInitialWorldSettings()
     TC_LOG_INFO("server.loading", "Loading Spell Group Stack Rules...");
     sSpellMgr->LoadSpellGroupStackRules();
 
+    TC_LOG_INFO("server.loading", "Loading Spells Specializations...");
+    sSpellMgr->LoadSpellsSpecializations();
+
     TC_LOG_INFO("server.loading", "Loading NPC Texts...");
     sObjectMgr->LoadNPCText();
 


### PR DESCRIPTION
**Changes proposed:**

-  do not learn dependant spells if they belong to another spec

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

**Example for an issue:**

If you go into feral spec with a druid, you willl learn (and have) the following auras:

202155 - Feral Affinity (Guardian)
197490 - Feral Affinity (Restoration)
202157 - Feral Affinity (Balance)

Even though all 3 do not belong to the feral spec.