### PR TITLE
Core/Spells: Modify cooldowns when cooldown aura starts

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -175,8 +175,8 @@ NonDefaultConstructible<pAuraEffectHandler> AuraEffectHandler[TOTAL_AURAS]=
     &AuraEffect::HandleAuraWaterWalk,                             //104 SPELL_AURA_WATER_WALK
     &AuraEffect::HandleAuraFeatherFall,                           //105 SPELL_AURA_FEATHER_FALL
     &AuraEffect::HandleAuraHover,                                 //106 SPELL_AURA_HOVER
-    &AuraEffect::HandleNoImmediateEffect,                         //107 SPELL_AURA_ADD_FLAT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
-    &AuraEffect::HandleNoImmediateEffect,                         //108 SPELL_AURA_ADD_PCT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
+    &AuraEffect::HandleAuraAddFlatModifier,                       //107 SPELL_AURA_ADD_FLAT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
+    &AuraEffect::HandleAuraAddPctModifier,                        //108 SPELL_AURA_ADD_PCT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
     &AuraEffect::HandleNoImmediateEffect,                         //109 SPELL_AURA_ADD_TARGET_TRIGGER
     &AuraEffect::HandleModPowerRegenPCT,                          //110 SPELL_AURA_MOD_POWER_REGEN_PERCENT implemented in Player::Regenerate, Creature::Regenerate
     &AuraEffect::HandleNoImmediateEffect,                         //111 SPELL_AURA_INTERCEPT_MELEE_RANGED_ATTACKS implemented in Unit::GetMeleeHitRedirectTarget
@@ -3628,6 +3628,20 @@ void AuraEffect::HandleAuraModMaxPower(AuraApplication const* aurApp, uint8 mode
     UnitMods unitMod = UnitMods(UNIT_MOD_POWER_START + power);
 
     target->HandleStatFlatModifier(unitMod, TOTAL_VALUE, float(GetAmount()), apply);
+}
+
+void AuraEffect::HandleAuraAddFlatModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
+{
+    AuraEffectHandleModes auraMode = (AuraEffectHandleModes)mode;
+    if (apply && GetMiscValue() == SPELLMOD_COOLDOWN)
+        aurApp->GetTarget()->GetSpellHistory()->ApplyModCooldowns(GetSpellEffectInfo()->SpellClassMask);
+}
+
+void AuraEffect::HandleAuraAddPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
+{
+    AuraEffectHandleModes auraMode = (AuraEffectHandleModes)mode;
+    if (apply && GetMiscValue() == SPELLMOD_COOLDOWN)
+        aurApp->GetTarget()->GetSpellHistory()->ApplyModCooldowns(GetSpellEffectInfo()->SpellClassMask);
 }
 
 /********************************/

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3632,7 +3632,6 @@ void AuraEffect::HandleAuraModMaxPower(AuraApplication const* aurApp, uint8 mode
 
 void AuraEffect::HandleAuraAddFlatPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
 {
-    AuraEffectHandleModes auraMode = (AuraEffectHandleModes)mode;
     if (apply && GetMiscValue() == SPELLMOD_COOLDOWN)
         aurApp->GetTarget()->GetSpellHistory()->ApplyModCooldowns(GetSpellEffectInfo()->SpellClassMask);
 }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3630,7 +3630,7 @@ void AuraEffect::HandleAuraModMaxPower(AuraApplication const* aurApp, uint8 mode
     target->HandleStatFlatModifier(unitMod, TOTAL_VALUE, float(GetAmount()), apply);
 }
 
-void AuraEffect::HandleAuraAddFlatPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
+void AuraEffect::HandleAuraAddFlatPctModifier(AuraApplication const* aurApp, uint8 /*mode*/, bool apply) const
 {
     if (apply && GetMiscValue() == SPELLMOD_COOLDOWN)
         aurApp->GetTarget()->GetSpellHistory()->ApplyModCooldowns(GetSpellEffectInfo()->SpellClassMask);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -175,8 +175,8 @@ NonDefaultConstructible<pAuraEffectHandler> AuraEffectHandler[TOTAL_AURAS]=
     &AuraEffect::HandleAuraWaterWalk,                             //104 SPELL_AURA_WATER_WALK
     &AuraEffect::HandleAuraFeatherFall,                           //105 SPELL_AURA_FEATHER_FALL
     &AuraEffect::HandleAuraHover,                                 //106 SPELL_AURA_HOVER
-    &AuraEffect::HandleAuraAddFlatModifier,                       //107 SPELL_AURA_ADD_FLAT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
-    &AuraEffect::HandleAuraAddPctModifier,                        //108 SPELL_AURA_ADD_PCT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
+    &AuraEffect::HandleAuraAddFlatPctModifier,                    //107 SPELL_AURA_ADD_FLAT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
+    &AuraEffect::HandleAuraAddFlatPctModifier,                    //108 SPELL_AURA_ADD_PCT_MODIFIER implemented in AuraEffect::CalculateSpellMod()
     &AuraEffect::HandleNoImmediateEffect,                         //109 SPELL_AURA_ADD_TARGET_TRIGGER
     &AuraEffect::HandleModPowerRegenPCT,                          //110 SPELL_AURA_MOD_POWER_REGEN_PERCENT implemented in Player::Regenerate, Creature::Regenerate
     &AuraEffect::HandleNoImmediateEffect,                         //111 SPELL_AURA_INTERCEPT_MELEE_RANGED_ATTACKS implemented in Unit::GetMeleeHitRedirectTarget
@@ -3630,14 +3630,7 @@ void AuraEffect::HandleAuraModMaxPower(AuraApplication const* aurApp, uint8 mode
     target->HandleStatFlatModifier(unitMod, TOTAL_VALUE, float(GetAmount()), apply);
 }
 
-void AuraEffect::HandleAuraAddFlatModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
-{
-    AuraEffectHandleModes auraMode = (AuraEffectHandleModes)mode;
-    if (apply && GetMiscValue() == SPELLMOD_COOLDOWN)
-        aurApp->GetTarget()->GetSpellHistory()->ApplyModCooldowns(GetSpellEffectInfo()->SpellClassMask);
-}
-
-void AuraEffect::HandleAuraAddPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
+void AuraEffect::HandleAuraAddFlatPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const
 {
     AuraEffectHandleModes auraMode = (AuraEffectHandleModes)mode;
     if (apply && GetMiscValue() == SPELLMOD_COOLDOWN)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -240,8 +240,7 @@ class TC_GAME_API AuraEffect
         void HandleOverrideAttackPowerBySpellPower(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleModVersatilityByPct(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModMaxPower(AuraApplication const* aurApp, uint8 mode, bool apply) const;
-        void HandleAuraAddFlatModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const;
-        void HandleAuraAddPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const;
+        void HandleAuraAddFlatPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         //   heal and energize
         void HandleModPowerRegen(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleModPowerRegenPCT(AuraApplication const* aurApp, uint8 mode, bool apply) const;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.h
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.h
@@ -240,6 +240,8 @@ class TC_GAME_API AuraEffect
         void HandleOverrideAttackPowerBySpellPower(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleModVersatilityByPct(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleAuraModMaxPower(AuraApplication const* aurApp, uint8 mode, bool apply) const;
+        void HandleAuraAddFlatModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const;
+        void HandleAuraAddPctModifier(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         //   heal and energize
         void HandleModPowerRegen(AuraApplication const* aurApp, uint8 mode, bool apply) const;
         void HandleModPowerRegenPCT(AuraApplication const* aurApp, uint8 mode, bool apply) const;

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -105,40 +105,6 @@ public:
 
     void ApplyModCooldowns(flag128 spellClasMask);
 
-    template<typename Predicate>
-    void ModifyCooldowns(Predicate predicate, uint32 amount)
-    {
-        UpdateCooldowns(predicate, [amount](uint32 spellId, CooldownEntry const& spellEntry) {
-            return amount;
-        });
-    }
-
-    template<typename Predicate, typename UpdateFn>
-    void ModifyCooldowns(Predicate predicate, UpdateFn updateFn)
-    {
-        Player* playerOwner = GetPlayerOwner();
-        if (!playerOwner)
-            return;
-
-        Clock::time_point now = GameTime::GetGameTimeSystemPoint();
-
-        for (CooldownStorageType::iterator itr = _spellCooldowns.begin(); itr != _spellCooldowns.end();)
-        {
-            if (predicate(itr->first))
-            {
-                uint32 reduceCooldownBy = updateFn(itr->first, std::ref(itr->second));
-                Clock::duration offset = std::chrono::duration_cast<Clock::duration>(std::chrono::milliseconds(-reduceCooldownBy));
-
-                CooldownStorageType::iterator curr = itr;
-                ModifyCooldown(itr, offset);
-                if (itr == curr)
-                    ++itr;
-            }
-            else
-                ++itr;
-        }
-    }
-
     void AddCooldown(uint32 spellId, uint32 cooldownMS, uint32 itemId, Clock::time_point cooldownEnd, uint32 categoryId, Clock::time_point categoryEnd, bool onHold = false);
     void ModifyCooldown(uint32 spellId, int32 cooldownModMs);
     void ModifyCooldown(uint32 spellId, Clock::duration cooldownMod);

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -22,6 +22,7 @@
 #include "DatabaseEnvFwd.h"
 #include "GameTime.h"
 #include "SpellPackets.h"
+#include "Util.h"
 #include <chrono>
 #include <deque>
 #include <vector>


### PR DESCRIPTION
**Changes proposed:**

-  Modify cooldowns when cooldown aura starts

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

**Notes:**

- The implementation is based on the assumption that the % of cooldown reduction is from the spell cooldown, and not from the cooldown left, regardless of the fact it is done while the spell is on cooldown.

**Example for an issue:**

1. Use a druid with guardian spec
2. Use Thrash. It will start the 6s cd
3. Use Berserk. Your cd should be lowered by 75%, although It is not.