### PR TITLE
Core/Spells: Clear the actionbar even when there aren't any results

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -27762,8 +27762,7 @@ void Player::ActivateTalentGroup(ChrSpecializationEntry const* spec)
 
 void Player::LoadActions(PreparedQueryResult result)
 {
-    if (result)
-        _LoadActions(result);
+    _LoadActions(result);
 
     SendActionButtons(1);
 }


### PR DESCRIPTION
**Changes proposed:**

Currently when you switch spec for the 1st time the actionbar is empty and the query received will be empty, so the actionbar won't be cleared and all the skills from the previous spec are left on the client, and only on relogin you will notice what's happening.


-  Clear the actionbar even when there aren't any results


**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)