### PR TITLE
Core/LFG: Fixed a bug where rolecheck timer was milliseconds

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -44,7 +44,7 @@ enum LfgOptions
 
 enum LFGMgrEnum
 {
-    LFG_TIME_ROLECHECK                           = 45 * IN_MILLISECONDS,
+    LFG_TIME_ROLECHECK                           = 45,
     LFG_TIME_BOOT                                = 120,
     LFG_TIME_PROPOSAL                            = 45,
     LFG_QUEUEUPDATE_INTERVAL                     = 15 * IN_MILLISECONDS,


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  roleCheck.cancelTime is time_t (seconds precision) causing role check to not fail for 12h
See: https://github.com/TrinityCore/TrinityCore/blob/57e63bb6a8699494f427efa8b5b03d65239967b5/src/server/game/DungeonFinding/LFGMgr.cpp#L298

**Target branch(es):** 3.3.5/master

- [x ] 3.3.5

