### PR TITLE
Core/ThreadManager: delete double include "TemporarySummon.h"

### DIFF
--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -31,7 +31,6 @@
 #include "ObjectAccessor.h"
 #include "WorldPacket.h"
 #include <algorithm>
-#include "TemporarySummon.h"
 
 #include "Hacks/boost_1_74_fibonacci_heap.h"
 BOOST_1_74_FIBONACCI_HEAP_MSVC_COMPILE_FIX(ThreatManager::threat_list_heap::value_type)


### PR DESCRIPTION
**Changes proposed:**
- Delete double include "TemporarySummon.h"

**Target branch(es):** 3.3.5/master
- [x] 3.3.5