### PR TITLE
Core/Spells: Add itemTarget check in Spell::EffectEnchantItemTmp

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2467,6 +2467,9 @@ void Spell::EffectEnchantItemTmp(SpellEffIndex effIndex)
     if (effectHandleMode != SPELL_EFFECT_HANDLE_HIT_TARGET)
         return;
 
+    if (!itemTarget)
+        return;
+
     Player* player = m_caster->ToPlayer();
     if (!player)
         return;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add not NULL check for itemTarget

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Fixes possible crash in case of implicitly selected unit target in `m_UniqueTargetInfo`. In such case `Spell::DoAllEffectOnTarget(TargetInfo* target)` is called and `nullptr `is passed to `Spell::HandleEffects` for `itemTarget` leading to exception in `Player* item_owner = itemTarget->GetOwner()`.
Example: https://www.wowhead.com/spell=334294/flametongue-weapon

**Tests performed:**

It builds. 
Tested in-game with https://www.wowhead.com/spell=334294/flametongue-weapon within next spell script code fragment:
```
SpellCastTargets *targets = new SpellCastTargets();

if (Item* weapon = player->GetWeaponForAttack(BASE_ATTACK, true))
{
    targets->SetItemTarget(weapon);
    player->CastSpell(*targets, sSpellMgr->GetSpellInfo(SPELL_SHAMAN_FLAMETONGUE_WEAPON_ENCHANT, GetCastDifficulty()), nullptr);
}
```


**Known issues and TODO list:** (add/remove lines as needed)

The workaround could also be done in `OnObjectTargetSelect` hook of spell script.
<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
