### PR TITLE
Push docker images to DockerHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
               if [ "$CIRCLE_BRANCH" == "3.3.5" ] || [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "3.3.5-dockerhub" ]; then
                 docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
                 echo "Pushing docker image to dockerhub"
-                docker push --all-tags $image_prefix
+                docker push $image_prefix
               fi
             fi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:$(echo $CIRCLE_BRANCH | tr '/' '-' | tr '[:upper:]' '[:lower:]') .
             docker save $image_prefix | gzip > ../../../docker.tar.gz
             if [ "$DOCKERHUB_PUSH_IMAGES" == "TRUE" ]; then
-              if [ "$CIRCLE_BRANCH" == "3.3.5" ] || [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "3.3.5-dockerhub" ]; then
+              if [ "$CIRCLE_BRANCH" == "3.3.5" ] || [ "$CIRCLE_BRANCH" == "master" ]; then
                 docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
                 echo "Pushing docker image to dockerhub"
                 docker push $image_prefix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
             docker save $image_prefix | gzip > ../../../docker.tar.gz
             if [ "$DOCKERHUB_PUSH_IMAGES" == "TRUE" ]; then
-              if [ "$CIRCLE_BRANCH" == "3.3.5" || "$CIRCLE_BRANCH" == "master" ]; then
+              if [ "$CIRCLE_BRANCH" == "3.3.5" ] || [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "3.3.5-dockerhub" ]; then
                 docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
                 echo "Pushing docker image to dockerhub"
                 docker push $image_prefix:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
               if [ "$CIRCLE_BRANCH" == "3.3.5" ] || [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "3.3.5-dockerhub" ]; then
                 docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
                 echo "Pushing docker image to dockerhub"
-                docker push $image_prefix:$CIRCLE_SHA1
+                docker push --all-tags $image_prefix
               fi
             fi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: Build
@@ -81,7 +81,13 @@ jobs:
             image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-') | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
             docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
-            docker save $image_prefix:$CIRCLE_SHA1 | gzip > ../../../docker.tar.gz
+            docker save $image_prefix | gzip > ../../../docker.tar.gz
+            if [ $DOCKERHUB_PUSH_IMAGES == "TRUE" ]; then
+              if [ $CIRCLE_BRANCH == "3.3.5" || $CIRCLE_BRANCH == "master"]; then
+                docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+                docker push $image_prefix:$CIRCLE_SHA1
+              fi
+            fi
       - store_artifacts:
           path: docker.tar.gz
   nopch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,11 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            if [ "$DOCKERHUB_PUSH_IMAGES" == "TRUE" ]; then
+              cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            else
+              cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            fi
             cd ..
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             mkdir bin
             cd bin
-            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+            cmake ../ -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=static -DSERVERS=1 -DNOJEM=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
             cd ..
       - run:
           name: Build
@@ -82,9 +82,10 @@ jobs:
             echo $image_prefix
             docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
             docker save $image_prefix | gzip > ../../../docker.tar.gz
-            if [ $DOCKERHUB_PUSH_IMAGES == "TRUE" ]; then
-              if [ $CIRCLE_BRANCH == "3.3.5" || $CIRCLE_BRANCH == "master"]; then
+            if [ "$DOCKERHUB_PUSH_IMAGES" == "TRUE" ]; then
+              if [ "$CIRCLE_BRANCH" == "3.3.5" || "$CIRCLE_BRANCH" == "master" ]; then
                 docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+                echo "Pushing docker image to dockerhub"
                 docker push $image_prefix:$CIRCLE_SHA1
               fi
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,9 @@ jobs:
             cd bin/check_install/bin
             cp -r ../../../contrib/Docker/* .
             cp -r ../../../sql ./sql
-            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-$(echo $CIRCLE_BRANCH | tr '/' '-') | tr '[:upper:]' '[:lower:]')
+            image_prefix=$(echo $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')
             echo $image_prefix
-            docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:latest .
+            docker build --file Dockerfile --force-rm --tag $image_prefix:$CIRCLE_SHA1 --tag $image_prefix:$(echo $CIRCLE_BRANCH | tr '/' '-' | tr '[:upper:]' '[:lower:]') .
             docker save $image_prefix | gzip > ../../../docker.tar.gz
             if [ "$DOCKERHUB_PUSH_IMAGES" == "TRUE" ]; then
               if [ "$CIRCLE_BRANCH" == "3.3.5" ] || [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "3.3.5-dockerhub" ]; then

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -1,8 +1,25 @@
 # Docker
 
-The Circle CI Linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for Linux, and stores that in the job artifacts.
+The Circle CI Linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for Linux, and stores that in the job artifacts. For 3.3.5 and master branches, it also pushes the images to https://hub.docker.com/r/trinitycore/trinitycore
 
-The instructions below expect a basic knowledge of how to configure TrinityCore and how to use Docker:
+The instructions below expect a basic knowledge of how to configure TrinityCore and how to use Docker.
+
+## Load the docker image
+For 3.3.5 and master branches, it's possible to pull the images from DockerHub.
+- For latest 3.3.5 use the following command:
+  ```
+  docker pull trinitycore/trinitycore:3.3.5
+  ```
+- For latest master use the following command:
+  ```
+  docker pull trinitycore/trinitycore:master
+  ```
+- For a specific 3.3.5 or master commit, use the following command, replacing "commit_hash" with the hash of the commit:
+  ```
+  docker pull trinitycore/trinitycore:commit_hash
+  ```
+
+For Pull Requests or branches other than 3.3.5 or master, follow the steps below to load the image from Circle CI
 1. Click the green tick ✔ next to each commit.
 1. Scroll to "ci/circleci: pch" and click "Details".
 1. Log in to Circle CI if necessary. You may have to repeat the previous steps after logging in, to reach the correct page.
@@ -13,6 +30,7 @@ The instructions below expect a basic knowledge of how to configure TrinityCore 
     docker load -i docker.tar.gz
     ```
 
+## Start authserver/worldserver from docker
 1. Copy the .conf files from the TrinityCore GitHub repository to a local folder which will be passed on as a mapped volume to docker.
 1. Set the MySQL host in the .conf files to use the UNIX socket of MySQL, i.e.: `".;/var/run/mysqld/mysqld.sock;username;password;database"`
 1. Set the "DataDir" config in worldserver.conf to `"/trinity/data"`

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -1,16 +1,16 @@
 # Docker
 
-The Circle CI Linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for Linux, and stores that in the job artifacts. For 3.3.5 and master branches, it also pushes the images to https://hub.docker.com/r/trinitycore/trinitycore
+The Circle CI Linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for Linux, and stores that in the job artifacts. For the 3.3.5 and master branches, it also pushes the images to https://hub.docker.com/r/trinitycore/trinitycore .
 
 The instructions below expect a basic knowledge of how to configure TrinityCore and how to use Docker.
 
-## Load the docker image
-For 3.3.5 and master branches, it's possible to pull the images from DockerHub.
-- For latest 3.3.5 use the following command:
+## Load the Docker image
+For the 3.3.5 and master branches, it's possible to pull the images from DockerHub.
+- For latest 3.3.5, use the following command:
   ```
   docker pull trinitycore/trinitycore:3.3.5
   ```
-- For latest master use the following command:
+- For latest master, use the following command:
   ```
   docker pull trinitycore/trinitycore:master
   ```
@@ -19,7 +19,7 @@ For 3.3.5 and master branches, it's possible to pull the images from DockerHub.
   docker pull trinitycore/trinitycore:commit_hash
   ```
 
-For Pull Requests or branches other than 3.3.5 or master, follow the steps below to load the image from Circle CI
+For Pull Requests or branches other than 3.3.5 or master, follow the steps below to load the image from Circle CI:
 1. Click the green tick ✔ next to each commit.
 1. Scroll to "ci/circleci: pch" and click "Details".
 1. Log in to Circle CI if necessary. You may have to repeat the previous steps after logging in, to reach the correct page.
@@ -30,8 +30,8 @@ For Pull Requests or branches other than 3.3.5 or master, follow the steps below
     docker load -i docker.tar.gz
     ```
 
-## Start authserver/worldserver from docker
-1. Copy the .conf files from the TrinityCore GitHub repository to a local folder which will be passed on as a mapped volume to docker.
+## Start authserver/worldserver from Docker
+1. Copy the .conf files from the TrinityCore GitHub repository to a local folder which will be passed on as a mapped volume to Docker.
 1. Set the MySQL host in the .conf files to use the UNIX socket of MySQL, i.e.: `".;/var/run/mysqld/mysqld.sock;username;password;database"`
 1. Set the "DataDir" config in worldserver.conf to `"/trinity/data"`
 1. Start authserver or worldserver as desired, mapping the required volumes:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add new Circle CI Environmental Variable (not GitHub) DOCKERHUB_PUSH_IMAGES to enable/disable pushing Docker images created by Circle CI to DockerHub, disabled by default. Requires "TRUE" as value to be enabled.
- Filter branches pushed to "3.3.5" and "master"
- Tag images with branch name and commit hash
- Each fork will push to its own dockerhub repository (if enabled)
- Change Circle CI pch build from Debug -DNDEBUG to Release (RelWithDebInfo slowed the build by 10 more minutes than just Release and pushing Debug images means none will use them) when DOCKERHUB_PUSH_IMAGES is enabled. Existing forks that will not set DOCKERHUB_PUSH_IMAGES will not be affected by this change.
**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

None

**Tests performed:**

- Ran Circle CI a few times, you can see the pushed images at https://hub.docker.com/r/jackpoz/trinitycore/tags?page=1&ordering=last_updated
- Did a pull locally
![image](https://user-images.githubusercontent.com/1153754/109390812-febbeb80-7913-11eb-95b7-6b47e8d37ef7.png)

**Known issues and TODO list:** (add/remove lines as needed)

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
