### PR TITLE
Core/Spells: Treat orientation 0 as valid value in EffectTeleportUnits

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1059,9 +1059,6 @@ void Spell::EffectTeleportUnits(SpellEffIndex /*effIndex*/)
     if (targetDest.GetMapId() == MAPID_INVALID)
         targetDest.m_mapId = unitTarget->GetMapId();
 
-    if (!targetDest.GetOrientation() && m_targets.GetUnitTarget())
-        targetDest.SetOrientation(m_targets.GetUnitTarget()->GetOrientation());
-
     if (targetDest.GetMapId() == unitTarget->GetMapId())
         unitTarget->NearTeleportTo(targetDest, unitTarget == m_caster);
     else if (unitTarget->GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
**Changes proposed:**

Currently EffectTeleportUnits uses player's current orientation if in DB teleport orientation is set to 0. Sometimes Blizzard uses 0 and it's shown in sniffs

**Target branch(es):**

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #25273

**Tests performed:**

Tested long time ago, heh. Can test av build later
Edit: tested av build, works