### PR TITLE
Core/Spells: implement SpellInfo helper to filter for relevant mechanic immunities in spell_start packet

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4176,8 +4176,8 @@ void Spell::SendSpellStart()
     uint32 mechanicImmunityMask = 0;
     if (Unit* unitCaster = m_caster->ToUnit())
     {
-        schoolImmunityMask = unitCaster->GetSchoolImmunityMask();
-        mechanicImmunityMask = unitCaster->GetMechanicImmunityMask();
+        schoolImmunityMask = m_timer!= 0 ? unitCaster->GetSchoolImmunityMask() : 0;
+        mechanicImmunityMask = m_timer != 0 ? m_spellInfo->GetMechanicImmunityMask(unitCaster) : 0;
     }
 
     if (schoolImmunityMask || mechanicImmunityMask)

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -3032,6 +3032,24 @@ uint32 SpellInfo::GetAllowedMechanicMask() const
     return _allowedMechanicMask;
 }
 
+uint32 SpellInfo::GetMechanicImmunityMask(Unit* caster) const
+{
+    uint32 casterMechanicImmunityMask = caster->GetMechanicImmunityMask();
+    uint32 mechanicImmunityMask = 0;
+
+    // @todo: research other interrupt flags
+    if (InterruptFlags & SPELL_INTERRUPT_FLAG_INTERRUPT)
+    {
+        if (casterMechanicImmunityMask & (1 << MECHANIC_SILENCE))
+            mechanicImmunityMask |= (1 << MECHANIC_SILENCE);
+
+        if (casterMechanicImmunityMask & (1 << MECHANIC_INTERRUPT))
+            mechanicImmunityMask |= (1 << MECHANIC_INTERRUPT);
+    }
+
+    return mechanicImmunityMask;
+}
+
 float SpellInfo::GetMinRange(bool positive /*= false*/) const
 {
     if (!RangeEntry)

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -532,7 +532,7 @@ class TC_GAME_API SpellInfo
         bool SpellCancelsAuraEffect(SpellInfo const* auraSpellInfo, uint8 auraEffIndex) const;
 
         uint32 GetAllowedMechanicMask() const;
-        
+
         uint32 GetMechanicImmunityMask(Unit* caster) const;
 
     private:

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -532,6 +532,8 @@ class TC_GAME_API SpellInfo
         bool SpellCancelsAuraEffect(SpellInfo const* auraSpellInfo, uint8 auraEffIndex) const;
 
         uint32 GetAllowedMechanicMask() const;
+        
+        uint32 GetMechanicImmunityMask(Unit* caster) const;
 
     private:
         // loading helpers


### PR DESCRIPTION
**Changes proposed:**

-  we no longer send immunities for instant cast spells in SpellStart packets
-  filter out mechanic immunities of a caster for relevant ones which currently are MECHANIC_SILENCE and  MECHANIC_INTERRUPT as sniffs have only shown these two values so far.

The actual benefit from this is that spells sometimes are being falsely shown as not interruptable because all the other immunities may confuse the client about if the spell may be interrupted or not. We now send correct data so these issues should be solved.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:**
- tested in 4.x
