### PR TITLE
Core/Spells: Don't save druid various flight forms to db

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1059,6 +1059,11 @@ bool Aura::CanBeSaved() const
     if (GetId() == 67483 || GetId() == 67484 || GetId() == 48517 || GetId() == 48518)
         return false;
 
+    // Don't save druid forms, only the dummy. It will cast the appropriate form
+    //        Swift Flight            Flight             Aquatic                Stag
+    if (GetId() == 40120 || GetId() == 33943 || GetId() == 1066 || GetId() == 165961)
+        return false;
+
     // don't save auras removed by proc system
     if (IsUsingCharges() && !GetCharges())
         return false;


### PR DESCRIPTION
**Changes proposed:**

-  Don't save druid various flight forms to db

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

(Does it build, tested in-game, etc.)

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

**Notes:**

While the same ids already exist in an enum in `spell_druid.cpp`, I couldn't find a common place to put it for both of them, and I noticed there are others hardcoded spells ids like that in the same function.

If there is a common (*valid*) place where I can put the spell ids where both `spell_druid.cpp` and `spell_auras.cpp` , do tell.