### PR TITLE
Core/SAI: Don't require BaseObject when creating conversation from smart scripts

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2364,18 +2364,17 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }
         case SMART_ACTION_CREATE_CONVERSATION:
         {
-            if (WorldObject* baseObject = GetBaseObject())
+            WorldObject* baseObject = GetBaseObject();
+
+            for (WorldObject* const target : targets)
             {
-                for (WorldObject* const target : targets)
+                if (Player* playerTarget = target->ToPlayer())
                 {
-                    if (Player* playerTarget = target->ToPlayer())
-                    {
-                        Conversation* conversation = Conversation::CreateConversation(e.action.conversation.id, playerTarget,
-                            *playerTarget, { playerTarget->GetGUID() }, nullptr);
-                        if (!conversation)
-                            TC_LOG_WARN("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_TALK_CONVERSATION: id %u, baseObject %s, target %s - failed to create",
-                                e.action.conversation.id, baseObject->GetName().c_str(), playerTarget->GetName().c_str());
-                    }
+                    Conversation* conversation = Conversation::CreateConversation(e.action.conversation.id, playerTarget,
+                        *playerTarget, { playerTarget->GetGUID() }, nullptr);
+                    if (!conversation)
+                        TC_LOG_WARN("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_TALK_CONVERSATION: id %u, baseObject %s, target %s - failed to create",
+                            e.action.conversation.id, !baseObject ? "" : baseObject->GetName().c_str(), playerTarget->GetName().c_str());
                 }
             }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2373,7 +2373,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     Conversation* conversation = Conversation::CreateConversation(e.action.conversation.id, playerTarget,
                         *playerTarget, { playerTarget->GetGUID() }, nullptr);
                     if (!conversation)
-                        TC_LOG_WARN("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_TALK_CONVERSATION: id %u, baseObject %s, target %s - failed to create",
+                        TC_LOG_WARN("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_CREATE_CONVERSATION: id %u, baseObject %s, target %s - failed to create conversation",
                             e.action.conversation.id, !baseObject ? "" : baseObject->GetName().c_str(), playerTarget->GetName().c_str());
                 }
             }


### PR DESCRIPTION
**Changes proposed:**

-  Don't require BaseObject when creating conversation from smart scripts

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:**