### PR TITLE
Core/Player: Update location of cinematic camera only if there is an active cinematic

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -922,7 +922,7 @@ void Player::Update(uint32 p_time)
 
     // Update cinematic location, if 500ms have passed and we're doing a cinematic now.
     _cinematicMgr->m_cinematicDiff += p_time;
-    if (_cinematicMgr->m_activeCinematicCameraIndex != 0 && GetMSTimeDiffToNow(_cinematicMgr->m_lastCinematicCheck) > CINEMATIC_UPDATEDIFF)
+    if (_cinematicMgr->m_cinematicCamera && _cinematicMgr->m_activeCinematic && GetMSTimeDiffToNow(_cinematicMgr->m_lastCinematicCheck) > CINEMATIC_UPDATEDIFF)
     {
         _cinematicMgr->m_lastCinematicCheck = GameTime::GetGameTimeMS();
         _cinematicMgr->UpdateCinematicLocation(p_time);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  CinematicMgr::UpdateCinematicLocation is being called on every player update without active cinematic. 
-  For single-camera cinematics, UpdateCinematicLocation was working because the client sends twice the opcode CMSG_NEXT_CINEMATIC_CAMERA (so m_activeCinematicCameraIndex has value 1 instead of 0).
> ServerToClient: SMSG_TRIGGER_CINEMATIC (0x27CA) Length: 4 ConnIdx: 0 EP: 127.0.0.1:51917 Time: 03/08/2021 17:35:10.819 Number: 687
Sequence Id: 164
>
> ClientToServer: CMSG_NEXT_CINEMATIC_CAMERA (0x3556) Length: 0 ConnIdx: 1 EP: 127.0.0.1:51918 Time: 03/08/2021 17:35:11.103 Number: 695
>
> ClientToServer: CMSG_NEXT_CINEMATIC_CAMERA (0x3556) Length: 0 ConnIdx: 1 EP: 127.0.0.1:51918 Time: 03/08/2021 17:35:11.103 Number: 696

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**


**Tests performed:**

Builds, tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
