### PR TITLE
Core/Maps: increase value of fixed offset when retrieving floor Z

### DIFF
--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -24,7 +24,7 @@
 #include "SmartEnum.h"
 
 float const GROUND_HEIGHT_TOLERANCE = 0.05f; // Extra tolerance to z position to check if it is in air or on ground.
-constexpr float Z_OFFSET_FIND_HEIGHT = 0.5f;
+constexpr float Z_OFFSET_FIND_HEIGHT = 1.5f;
 
 enum SpellEffIndex : uint8
 {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  increase value of fixed offset when retrieving floor Z

well here is explained a bit: #26092
after that change, you can fall under textures more frecuently in certain situations, because before with collisionHeight we have higher value than 0.5f

I added a extra print collisionHeight in ".npc info" and ".pinfo" commands to see values, karazhan boss (malchezaar) has 8 collisionHeight, players varies depending on race, about 2 collisionHeight (gnome 1.2, tauren 2.3), can be higher/smaller depending on scale (.mod scale or auras that modify scale)
Z_OFFSET_FIND_HEIGHT = 0.5f is not sufficient, so I increase to 1.5f to avoid this problems


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master


**Tests performed:**

tested all cases described here: #26092



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
