### PR TITLE
Core/SAI: Don't set pathid if it's changed after calling script

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -242,14 +242,15 @@ void SmartAI::EndPath(bool fail)
     if (fail)
         return;
 
-    GetScript()->ProcessEventsFor(SMART_EVENT_WAYPOINT_ENDED, nullptr, _currentWaypointNode, GetScript()->GetPathId());
+    uint32 pathid = GetScript()->GetPathId();
+    GetScript()->ProcessEventsFor(SMART_EVENT_WAYPOINT_ENDED, nullptr, _currentWaypointNode, pathid);
 
     if (_repeatWaypointPath)
     {
         if (IsAIControlled())
             StartPath(mRun, GetScript()->GetPathId(), _repeatWaypointPath);
     }
-    else
+    else if (pathid == GetScript()->GetPathId()) // if it's not the same pathid, our script wants to start another path; don't override it
         GetScript()->SetPathId(0);
 
     if (mDespawnState == 1)

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1592,7 +1592,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         {
             if (!sConversationDataStore->GetConversationTemplate(e.action.conversation.id))
             {
-                TC_LOG_ERROR("sql.sql", "SmartAIMgr: SMART_ACTION_TALK_CONVERSATION Entry " SI64FMTD " SourceType %u Event %u Action %u uses invalid entry %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.conversation.id);
+                TC_LOG_ERROR("sql.sql", "SmartAIMgr: SMART_ACTION_CREATE_CONVERSATION Entry " SI64FMTD " SourceType %u Event %u Action %u uses invalid entry %u, skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.action.conversation.id);
                 return false;
             }
 


### PR DESCRIPTION
**Changes proposed:**

-  Don't set pathid if it's changed after calling script
- Correctly renamed log text from `SMART_ACTION_TALK_CONVERSATION` to `SMART_ACTION_CREATE_CONVERSATION 

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

- [x] It builds
- [x] Tested in-game

**Known issues and TODO list:**

**Use case:**

- Need npc to start waypoint after finished another one; that is, I have an SAI entry with source="waypoint ended" and action ="start waypoint"