### PR TITLE
Core/Entities: Move GridObject to its own header

### DIFF
--- a/src/server/game/Entities/Corpse/Corpse.h
+++ b/src/server/game/Entities/Corpse/Corpse.h
@@ -19,6 +19,7 @@
 #define TRINITYCORE_CORPSE_H
 
 #include "Object.h"
+#include "GridObject.h"
 #include "DatabaseEnvFwd.h"
 #include "GridDefines.h"
 #include "Loot.h"

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -24,6 +24,7 @@
 #include "DatabaseEnvFwd.h"
 #include "Duration.h"
 #include "Loot.h"
+#include "GridObject.h"
 #include "MapObject.h"
 #include <list>
 

--- a/src/server/game/Entities/DynamicObject/DynamicObject.h
+++ b/src/server/game/Entities/DynamicObject/DynamicObject.h
@@ -19,6 +19,7 @@
 #define TRINITYCORE_DYNAMICOBJECT_H
 
 #include "Object.h"
+#include "GridObject.h"
 #include "MapObject.h"
 
 class Unit;

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -19,6 +19,7 @@
 #define TRINITYCORE_GAMEOBJECT_H
 
 #include "Object.h"
+#include "GridObject.h"
 #include "DatabaseEnvFwd.h"
 #include "GameObjectData.h"
 #include "Loot.h"

--- a/src/server/game/Entities/Object/GridObject.h
+++ b/src/server/game/Entities/Object/GridObject.h
@@ -1,0 +1,20 @@
+#ifndef _GRIDOBJECT_H
+#define _GRIDOBJECT_H
+
+#include "GridReference.h"
+#include "GridRefManager.h"
+
+template<class T>
+class GridObject
+{
+    public:
+        virtual ~GridObject() { }
+
+        bool IsInGrid() const { return _gridRef.isValid(); }
+        void AddToGrid(GridRefManager<T>& m) { ASSERT(!IsInGrid()); _gridRef.link(&m, (T*)this); }
+        void RemoveFromGrid() { ASSERT(IsInGrid()); _gridRef.unlink(); }
+    private:
+        GridReference<T> _gridRef;
+};
+
+#endif

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -21,8 +21,6 @@
 #include "Common.h"
 #include "Duration.h"
 #include "EventProcessor.h"
-#include "GridReference.h"
-#include "GridRefManager.h"
 #include "ModelIgnoreFlags.h"
 #include "MovementInfo.h"
 #include "ObjectDefines.h"
@@ -242,19 +240,6 @@ class TC_GAME_API Object
         bool PrintIndexError(uint32 index, bool set) const;
         Object(Object const& right) = delete;
         Object& operator=(Object const& right) = delete;
-};
-
-template<class T>
-class GridObject
-{
-    public:
-        virtual ~GridObject() { }
-
-        bool IsInGrid() const { return _gridRef.isValid(); }
-        void AddToGrid(GridRefManager<T>& m) { ASSERT(!IsInGrid()); _gridRef.link(&m, (T*)this); }
-        void RemoveFromGrid() { ASSERT(IsInGrid()); _gridRef.unlink(); }
-    private:
-        GridReference<T> _gridRef;
 };
 
 template <class T_VALUES, class T_FLAGS, class FLAG_TYPE, uint8 ARRAY_SIZE>

--- a/src/server/game/Entities/Object/Updates/UpdateMask.h
+++ b/src/server/game/Entities/Object/Updates/UpdateMask.h
@@ -20,6 +20,7 @@
 
 #include "UpdateFields.h"
 #include "ByteBuffer.h"
+#include "Errors.h"
 
 class UpdateMask
 {

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -18,6 +18,7 @@
 #ifndef _PLAYER_H
 #define _PLAYER_H
 
+#include "GridObject.h"
 #include "Unit.h"
 #include "DatabaseEnvFwd.h"
 #include "DBCEnums.h"


### PR DESCRIPTION
**Changes proposed:**

-  Move GridObject to its own header

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

**Tests performed:**

Did a rebuild

**Known issues and TODO list:** (add/remove lines as needed)

