### PR TITLE
Build/CMake: Make CONF_DIR show up in CMake GUIs in Unix systems

### DIFF
--- a/cmake/platform/unix/settings.cmake
+++ b/cmake/platform/unix/settings.cmake
@@ -1,6 +1,6 @@
 # set default configuration directory
 if(NOT CONF_DIR)
-  set(CONF_DIR ${CMAKE_INSTALL_PREFIX}/etc)
+  set(CONF_DIR ${CMAKE_INSTALL_PREFIX}/etc CACHE PATH "Configuration directory")
   message(STATUS "UNIX: Using default configuration directory")
 endif()
 


### PR DESCRIPTION
**Changes proposed:**

-  Make CONF_DIR show up in CMake GUIs

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:**

**Tests performed:**

**Known issues and TODO list:** (add/remove lines as needed)