### PR TITLE
Core/Spells: players shouldn't force their orientation (serverside) on each periodictick when channeling

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -869,7 +869,8 @@ void AuraEffect::PeriodicTick(AuraApplication* aurApp, Unit* caster) const
     Unit* target = aurApp->GetTarget();
 
     // Update serverside orientation of tracking channeled auras on periodic update ticks
-    if (caster && m_spellInfo->IsChanneled() && m_spellInfo->HasAttribute(SPELL_ATTR1_CHANNEL_TRACK_TARGET))
+    // exclude players because can turn during channeling and shouldn't desync orientation client/server
+    if (caster && caster->GetTypeId() != TYPEID_PLAYER && m_spellInfo->IsChanneled() && m_spellInfo->HasAttribute(SPELL_ATTR1_CHANNEL_TRACK_TARGET))
     {
         ObjectGuid const channelGuid = caster->GetChannelObjectGuid();
         if (!channelGuid.IsEmpty() && channelGuid != caster->GetGUID())

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -870,7 +870,7 @@ void AuraEffect::PeriodicTick(AuraApplication* aurApp, Unit* caster) const
 
     // Update serverside orientation of tracking channeled auras on periodic update ticks
     // exclude players because can turn during channeling and shouldn't desync orientation client/server
-    if (caster && caster->GetTypeId() != TYPEID_PLAYER && m_spellInfo->IsChanneled() && m_spellInfo->HasAttribute(SPELL_ATTR1_CHANNEL_TRACK_TARGET))
+    if (caster && !caster->IsPlayer() && m_spellInfo->IsChanneled() && m_spellInfo->HasAttribute(SPELL_ATTR1_CHANNEL_TRACK_TARGET))
     {
         ObjectGuid const channelGuid = caster->GetChannelObjectGuid();
         if (!channelGuid.IsEmpty() && channelGuid != caster->GetGUID())


### PR DESCRIPTION
**Changes proposed:**

-  exclude players form force their orientation (serverside) on each periodictick when channeling because can turn during channeling and shouldn't desync orientation client/server

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #26095


**Tests performed:**

tested in-game


