### PR TITLE
Remove unneeded DetourNavMesh.h include from SharedDefines.h

### DIFF
--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -20,7 +20,6 @@
 
 #include "DBCEnums.h"
 #include "Define.h"
-#include "DetourNavMesh.h"
 #include "SmartEnum.h"
 
 float const GROUND_HEIGHT_TOLERANCE = 0.05f; // Extra tolerance to z position to check if it is in air or on ground.


### PR DESCRIPTION
**Changes proposed:**

-  Remove unneeded DetourNavMesh.h include from SharedDefines.h

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

**Tests performed:**

Rebuilt clean.

**Known issues and TODO list:** (add/remove lines as needed)