### PR TITLE
Scripts/RubySanctum: Fix Xerestrasza Incorrect Usage of GOSSIP_OPTIONQUESTGIVER

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/ruby_sanctum.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/ruby_sanctum.cpp
@@ -71,7 +71,7 @@ class npc_xerestrasza : public CreatureScript
             void Reset() override
             {
                 _events.Reset();
-                me->RemoveFlag(UNIT_NPC_FLAGS, GOSSIP_OPTION_QUESTGIVER);
+                me->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
             }
 
             void DoAction(int32 action) override
@@ -131,7 +131,7 @@ class npc_xerestrasza : public CreatureScript
                             Talk(SAY_XERESTRASZA_EVENT_6);
                             break;
                         case EVENT_XERESTRASZA_EVENT_7:
-                            me->SetFlag(UNIT_NPC_FLAGS, GOSSIP_OPTION_QUESTGIVER);
+                            me->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
                             Talk(SAY_XERESTRASZA_EVENT_7);
                             me->setActive(false);
                             me->SetFarVisible(false);


### PR DESCRIPTION
NPC was using GOSSIP_OPTION_QUESTGIVER as a UNIT_NPC_FLAGS when it should have been using UNIT_NPC_FLAG_QUESTGIVER.

Behavior shouldn't change though as they both coincidentally were 2.

Similar issue as: https://github.com/TrinityCore/TrinityCore/pull/26404/commits/4a692c3623d64276edaba4f81b462607fd1180e3

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix the incorrect enum usage

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
