### PR TITLE
Move WorldSession::WriteMovementInfo to MovementInfo

### DIFF
--- a/src/server/game/Entities/Object/MovementInfo.h
+++ b/src/server/game/Entities/Object/MovementInfo.h
@@ -20,6 +20,8 @@
 
 #include "ObjectGuid.h"
 #include "Position.h"
+#include "WorldPacket.h"
+#include "UnitDefines.h"
 
 struct MovementInfo
 {
@@ -91,6 +93,42 @@ struct MovementInfo
     void SetFallTime(uint32 val) { fallTime = val; }
 
     void OutDebug();
+
+    void Write(WorldPacket* data)
+    {
+        *data << guid.WriteAsPacked();
+        *data << flags;
+        *data << flags2;
+        *data << time;
+        *data << pos.PositionXYZOStream();
+
+        if (HasMovementFlag(MOVEMENTFLAG_ONTRANSPORT))
+        {
+           *data << transport.guid.WriteAsPacked();
+           *data << transport.pos.PositionXYZOStream();
+           *data << transport.time;
+           *data << transport.seat;
+
+           if (HasExtraMovementFlag(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT))
+               *data << transport.time2;
+        }
+
+        if (HasMovementFlag(MovementFlags(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING)) || HasExtraMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING))
+            *data << pitch;
+
+        *data << fallTime;
+
+        if (HasMovementFlag(MOVEMENTFLAG_FALLING))
+        {
+            *data << jump.zspeed;
+            *data << jump.sinAngle;
+            *data << jump.cosAngle;
+            *data << jump.xyspeed;
+        }
+
+        if (HasMovementFlag(MOVEMENTFLAG_SPLINE_ELEVATION))
+            *data << splineElevation;
+    }
 };
 
 #endif // MovementInfo_h__

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -383,7 +383,7 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
     }
 
     movementInfo.guid = mover->GetGUID();
-    WriteMovementInfo(&data, &movementInfo);
+    movementInfo.Write(&data);
     mover->SendMessageToSet(&data, _player);
 
     mover->m_movementInfo = movementInfo;

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -987,42 +987,6 @@ void WorldSession::ReadMovementInfo(WorldPacket &data, MovementInfo* mi)
     #undef REMOVE_VIOLATING_FLAGS
 }
 
-void WorldSession::WriteMovementInfo(WorldPacket* data, MovementInfo* mi)
-{
-    *data << mi->guid.WriteAsPacked();
-    *data << mi->flags;
-    *data << mi->flags2;
-    *data << mi->time;
-    *data << mi->pos.PositionXYZOStream();
-
-    if (mi->HasMovementFlag(MOVEMENTFLAG_ONTRANSPORT))
-    {
-       *data << mi->transport.guid.WriteAsPacked();
-       *data << mi->transport.pos.PositionXYZOStream();
-       *data << mi->transport.time;
-       *data << mi->transport.seat;
-
-       if (mi->HasExtraMovementFlag(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT))
-           *data << mi->transport.time2;
-    }
-
-    if (mi->HasMovementFlag(MovementFlags(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING)) || mi->HasExtraMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING))
-        *data << mi->pitch;
-
-    *data << mi->fallTime;
-
-    if (mi->HasMovementFlag(MOVEMENTFLAG_FALLING))
-    {
-        *data << mi->jump.zspeed;
-        *data << mi->jump.sinAngle;
-        *data << mi->jump.cosAngle;
-        *data << mi->jump.xyspeed;
-    }
-
-    if (mi->HasMovementFlag(MOVEMENTFLAG_SPLINE_ELEVATION))
-        *data << mi->splineElevation;
-}
-
 void WorldSession::ReadAddonsInfo(ByteBuffer &data)
 {
     if (data.rpos() + 4 > data.size())

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -410,7 +410,6 @@ class TC_GAME_API WorldSession
         void SendAddonsInfo();
 
         void ReadMovementInfo(WorldPacket& data, MovementInfo* mi);
-        void WriteMovementInfo(WorldPacket* data, MovementInfo* mi);
 
         void SendPacket(WorldPacket const* packet);
         void SendNotification(const char *format, ...) ATTR_PRINTF(2, 3);


### PR DESCRIPTION
**Changes proposed:**

-  Move WriteMovementInfo method out of WorldSession

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

**Tests performed:**

Rebuilt

**Known issues and TODO list:** (add/remove lines as needed)

- This doesn't belong in WorldSession (and neither does ReadMovementInfo for that matter, but it has a dependency on Player, so I'll address that in a separate PR). Where it needs to end up and in what shape/ form should be discussed. As a first step I've made it a simple member method in the header file, but it could be operator << too.