### PR TITLE
Scripts/RubySanctum: Improve Halion boundary

### DIFF
--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -572,6 +572,7 @@ class npc_halion_controller : public CreatureScript
                 _materialCorporealityValue = 5;
                 _materialDamageTaken = 0;
                 _twilightDamageTaken = 0;
+                SetBoundary(_instance->GetBossBoundary(DATA_HALION));
             }
 
             void JustAppeared() override

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/instance_ruby_sanctum.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/instance_ruby_sanctum.cpp
@@ -30,7 +30,7 @@ Position const HalionControllerSpawnPos = { 3156.037f, 533.2656f, 72.97205f, 0.0
 BossBoundaryData const boundaries =
 {
     { DATA_GENERAL_ZARITHRIAN, new EllipseBoundary(Position(3013.409f, 529.492f), 45.0, 100.0) },
-    { DATA_HALION,             new CircleBoundary(Position(3156.037f, 533.2656f), 48.5)        }
+    { DATA_HALION,             new CircleBoundary(Position(3156.037f, 533.2656f), 52.5)        }
 };
 
 DoorData const doorData[] =


### PR DESCRIPTION
**Changes proposed:**

-  adjust Halion circleBoundary size
boundary radius was a little smaller (tested with .debug boundary command)

-  improve DoCheckEvade
in this commit: https://github.com/TrinityCore/TrinityCore/commit/0b33a8281f6be3458ef3698349f00a1f6aabb0b5#diff-4dbcd97850a76ba57320148f9e3ed30e52f4302b362a63ddddb1a1007cb14f50R760-R770 an event was added for check if all alive players are inside boss combat zone, otherwise, evade and despawn.
But npc_halion_controller doesn't have boundary, so that check does not work properly

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master


**Tests performed:**

tested in-game
