### PR TITLE
Scripts/Eye: Update Void Reaver to new model & few misc changes

### DIFF
--- a/src/server/scripts/Outland/TempestKeep/Eye/the_eye.h
+++ b/src/server/scripts/Outland/TempestKeep/Eye/the_eye.h
@@ -71,4 +71,6 @@ inline AI* GetTheEyeAI(T* obj)
     return GetInstanceAI<AI>(obj, TheEyeScriptName);
 }
 
+#define RegisterTheEyeCreatureAI(ai_name) RegisterCreatureAIWithFactory(ai_name, GetTheEyeAI)
+
 #endif


### PR DESCRIPTION
**Changes proposed:**

-  few misc changes: reorder headers, move _enraged from Initialize, reorder hooks

Real changes are here

<details>

```diff
diff --git a/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp b/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
index 74426a10c9..91aba64264 100644
--- a/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
+++ b/src/server/scripts/Outland/TempestKeep/Eye/boss_void_reaver.cpp
@@ -15,12 +15,12 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ScriptMgr.h"
+#include "the_eye.h"
 #include "ObjectAccessor.h"
 #include "ScriptedCreature.h"
-#include "the_eye.h"
+#include "ScriptMgr.h"
 
-enum Yells
+enum ReaverTexts
 {
     SAY_AGGRO                   = 0,
     SAY_SLAY                    = 1,
@@ -28,7 +28,7 @@ enum Yells
     SAY_POUNDING                = 3
 };
 
-enum Spells
+enum ReaverSpells
 {
     SPELL_POUNDING              = 34162,
     SPELL_ARCANE_ORB            = 34172,
@@ -36,7 +36,7 @@ enum Spells
     SPELL_BERSERK               = 27680
 };
 
-enum Events
+enum ReaverEvents
 {
     EVENT_POUNDING              = 1,
     EVENT_ARCANE_ORB,
@@ -44,27 +44,26 @@ enum Events
     EVENT_BERSERK
 };
 
-class boss_void_reaver : public CreatureScript
+struct boss_void_reaver : public BossAI
 {
-    public:
-        boss_void_reaver() : CreatureScript("boss_void_reaver") { }
+    boss_void_reaver(Creature* creature) : BossAI(creature, DATA_VOID_REAVER), _enraged(false) { }
 
-        struct boss_void_reaverAI : public BossAI
-        {
-            boss_void_reaverAI(Creature* creature) : BossAI(creature, DATA_VOID_REAVER)
+    void Reset() override
     {
-                Initialize();
+        _Reset();
+        _enraged = false;
     }
 
-            void Initialize()
+    void JustEngagedWith(Unit* who) override
     {
-                Enraged = false;
-            }
+        Talk(SAY_AGGRO);
+        BossAI::JustEngagedWith(who);
+        me->CallForHelp(120.0f);
 
-            void Reset() override
-            {
-                Initialize();
-                _Reset();
+        events.ScheduleEvent(EVENT_POUNDING, 15s);
+        events.ScheduleEvent(EVENT_ARCANE_ORB, 3s);
+        events.ScheduleEvent(EVENT_KNOCK_AWAY, 30s);
+        events.ScheduleEvent(EVENT_BERSERK, 10min);
     }
 
     void KilledUnit(Unit* /*victim*/) override
@@ -75,22 +74,9 @@ class boss_void_reaver : public CreatureScript
     void JustDied(Unit* /*killer*/) override
     {
         Talk(SAY_DEATH);
-                DoZoneInCombat();
         _JustDied();
     }
 
-            void JustEngagedWith(Unit* who) override
-            {
-                Talk(SAY_AGGRO);
-                BossAI::JustEngagedWith(who);
-                me->CallForHelp(120.0f);
-
-                events.ScheduleEvent(EVENT_POUNDING, 15s);
-                events.ScheduleEvent(EVENT_ARCANE_ORB, 3s);
-                events.ScheduleEvent(EVENT_KNOCK_AWAY, 30s);
-                events.ScheduleEvent(EVENT_BERSERK, 10min);
-            }
-
     void UpdateAI(uint32 diff) override
     {
         if (!UpdateVictim())
@@ -141,10 +127,10 @@ class boss_void_reaver : public CreatureScript
                     events.ScheduleEvent(EVENT_KNOCK_AWAY, 30s);
                     break;
                 case EVENT_BERSERK:
-                            if (!Enraged)
+                    if (!_enraged)
                     {
-                                DoCast(me, SPELL_BERSERK);
-                                Enraged = true;
+                        DoCastSelf(SPELL_BERSERK);
+                        _enraged = true;
                     }
                     break;
                 default:
@@ -158,17 +144,11 @@ class boss_void_reaver : public CreatureScript
         DoMeleeAttackIfReady();
     }
 
-        private:
-            bool Enraged;
-        };
-
-        CreatureAI* GetAI(Creature* creature) const override
-        {
-            return GetTheEyeAI<boss_void_reaverAI>(creature);
-        }
+private:
+    bool _enraged;
 };
 
 void AddSC_boss_void_reaver()
 {
-    new boss_void_reaver();
+    RegisterTheEyeCreatureAI(boss_void_reaver);
 }
```

</details>

**Target branch(es):**

- [x] 3.3.5
- [ ] master

**Issues addressed:**

none

**Tests performed:**

Builds, tested