### PR TITLE
Core: Replace unchecked Unit::GetVictim calls with Unit::EnsureVictim

### DIFF
--- a/src/server/game/AI/PlayerAI/PlayerAI.cpp
+++ b/src/server/game/AI/PlayerAI/PlayerAI.cpp
@@ -657,7 +657,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             }
             VerifyAndPushSpellCast(spells, SPELL_ENRAGED_REGEN, TARGET_NONE, 3);
             VerifyAndPushSpellCast(spells, SPELL_INTIMIDATING_SHOUT, TARGET_VICTIM, 4);
-            if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+            if (me->GetVictim() && me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING))
             {
                 VerifyAndPushSpellCast(spells, SPELL_PUMMEL, TARGET_VICTIM, 15);
                 VerifyAndPushSpellCast(spells, SPELL_SHIELD_BASH, TARGET_VICTIM, 15);
@@ -752,7 +752,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             VerifyAndPushSpellCast(spells, SPELL_FREEZING_ARROW, TARGET_VICTIM, 2);
             VerifyAndPushSpellCast(spells, SPELL_RAPID_FIRE, TARGET_NONE, 10);
             VerifyAndPushSpellCast(spells, SPELL_KILL_SHOT, TARGET_VICTIM, 10);
-            if (me->GetVictim() && me->GetVictim()->GetPowerType() == POWER_MANA && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_VIPER_STING, me->GetGUID()))
+            if (me->GetVictim() && me->EnsureVictim()->GetPowerType() == POWER_MANA && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_VIPER_STING, me->GetGUID()))
                 VerifyAndPushSpellCast(spells, SPELL_VIPER_STING, TARGET_VICTIM, 5);
 
             switch (GetSpec())
@@ -970,7 +970,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             }
             break;
         case CLASS_MAGE:
-            if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+            if (me->GetVictim() && me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING))
                 VerifyAndPushSpellCast(spells, SPELL_COUNTERSPELL, TARGET_VICTIM, 25);
             VerifyAndPushSpellCast(spells, SPELL_DAMPEN_MAGIC, TARGET_CHARMER, 2);
             VerifyAndPushSpellCast(spells, SPELL_EVOCATION, TARGET_NONE, 3);
@@ -991,7 +991,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     VerifyAndPushSpellCast(spells, SPELL_PRESENCE_OF_MIND, TARGET_NONE, 7);
                     break;
                 case SPEC_MAGE_FIRE:
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_LIVING_BOMB))
+                    if (me->GetVictim() && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_LIVING_BOMB))
                         VerifyAndPushSpellCast(spells, SPELL_LIVING_BOMB, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_COMBUSTION, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_FIREBALL, TARGET_VICTIM, 2);
@@ -1004,7 +1004,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     VerifyAndPushSpellCast(spells, SPELL_FROST_NOVA, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_FROSTBOLT, TARGET_VICTIM, 3);
                     VerifyAndPushSpellCast(spells, SPELL_COLD_SNAP, TARGET_VICTIM, 5);
-                    if (me->GetVictim() && me->GetVictim()->HasAuraState(AURA_STATE_FROZEN, nullptr, me))
+                    if (me->GetVictim() && me->EnsureVictim()->HasAuraState(AURA_STATE_FROZEN, nullptr, me))
                         VerifyAndPushSpellCast(spells, SPELL_ICE_LANCE, TARGET_VICTIM, 5);
                     break;
             }
@@ -1014,7 +1014,7 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
             VerifyAndPushSpellCast(spells, SPELL_FEAR, TARGET_VICTIM, 2);
             VerifyAndPushSpellCast(spells, SPELL_SEED_OF_CORRUPTION, TARGET_VICTIM, 4);
             VerifyAndPushSpellCast(spells, SPELL_HOWL_OF_TERROR, TARGET_NONE, 2);
-            if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_CORRUPTION, me->GetGUID()))
+            if (me->GetVictim() && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_CORRUPTION, me->GetGUID()))
                 VerifyAndPushSpellCast(spells, SPELL_CORRUPTION, TARGET_VICTIM, 10);
             switch (GetSpec())
             {
@@ -1043,15 +1043,15 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                         if (!me->IsWithinMeleeRange(me->GetVictim()))
                             VerifyAndPushSpellCast(spells, SPELL_DEMON_CHARGE, TARGET_VICTIM, 20);
                     }
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
+                    if (me->GetVictim() && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_IMMOLATE, TARGET_VICTIM, 5);
                     if (me->HasAura(AURA_MOLTEN_CORE))
                         VerifyAndPushSpellCast(spells, SPELL_INCINERATE, TARGET_VICTIM, 10);
                     break;
                 case SPEC_WARLOCK_DESTRUCTION:
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
+                    if (me->GetVictim() && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_IMMOLATE, TARGET_VICTIM, 8);
-                    if (me->GetVictim() && me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
+                    if (me->GetVictim() && me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_IMMOLATE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_CONFLAGRATE, TARGET_VICTIM, 8);
                     VerifyAndPushSpellCast(spells, SPELL_SHADOWFURY, TARGET_VICTIM, 5);
                     VerifyAndPushSpellCast(spells, SPELL_CHAOS_BOLT, TARGET_VICTIM, 10);
@@ -1105,11 +1105,11 @@ PlayerAI::TargetedSpell SimpleCharmedPlayerAI::SelectAppropriateCastForSpec()
                     uint32 const mainAttackSpell = me->HasAura(AURA_ECLIPSE_LUNAR) ? SPELL_STARFIRE : SPELL_WRATH;
                     VerifyAndPushSpellCast(spells, SPELL_STARFALL, TARGET_NONE, 20);
                     VerifyAndPushSpellCast(spells, mainAttackSpell, TARGET_VICTIM, 10);
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_INSECT_SWARM, me->GetGUID()))
+                    if (me->GetVictim() && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_INSECT_SWARM, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_INSECT_SWARM, TARGET_VICTIM, 7);
-                    if (me->GetVictim() && !me->GetVictim()->GetAuraApplicationOfRankedSpell(SPELL_MOONFIRE, me->GetGUID()))
+                    if (me->GetVictim() && !me->EnsureVictim()->GetAuraApplicationOfRankedSpell(SPELL_MOONFIRE, me->GetGUID()))
                         VerifyAndPushSpellCast(spells, SPELL_MOONFIRE, TARGET_VICTIM, 5);
-                    if (me->GetVictim() && me->GetVictim()->HasUnitState(UNIT_STATE_CASTING))
+                    if (me->GetVictim() && me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING))
                         VerifyAndPushSpellCast(spells, SPELL_TYPHOON, TARGET_NONE, 15);
                     break;
                 }

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_anubarak.cpp
@@ -486,7 +486,7 @@ struct npc_anubarak_anub_ar_assassin : public npc_anubarak_pet_template
     {
         _scheduler.Schedule(6s, [this](TaskContext task)
         {
-            if (me->GetVictim() && me->GetVictim()->isInBack(me))
+            if (me->GetVictim() && me->EnsureVictim()->isInBack(me))
                 DoCastVictim(SPELL_BACKSTAB);
 
             task.Repeat();

--- a/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
+++ b/src/server/scripts/Northrend/AzjolNerub/AzjolNerub/boss_krikthir_the_gatewatcher.cpp
@@ -738,7 +738,7 @@ class npc_anub_ar_skirmisher : public CreatureScript
                             _events.Repeat(randtime(Seconds(20), Seconds(25)));
                             break;
                         case EVENT_BACKSTAB:
-                            if (me->GetVictim() && me->GetVictim()->isInBack(me))
+                            if (me->GetVictim() && me->EnsureVictim()->isInBack(me))
                                 DoCastVictim(SPELL_BACKSTAB);
                             _events.Repeat(randtime(Seconds(10), Seconds(13)));
                             break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -433,7 +433,7 @@ public:
         if (unit->GetTypeId() != TYPEID_PLAYER || _me->GetDistance(unit) > 100.0f)
             return false;
 
-        if (_me->GetVictim() && _me->GetVictim()->GetGUID() == unit->GetGUID())
+        if (_me->GetVictim() && _me->EnsureVictim()->GetGUID() == unit->GetGUID())
             return false;
 
         if (unit->HasAura(SPELL_DEATH_PLAGUE_AURA) || unit->HasAura(SPELL_RECENTLY_INFECTED))

--- a/src/server/scripts/Pet/pet_hunter.cpp
+++ b/src/server/scripts/Pet/pet_hunter.cpp
@@ -82,7 +82,7 @@ class npc_pet_hunter_snake_trap : public CreatureScript
 
             void UpdateAI(uint32 diff) override
             {
-                if (me->GetVictim() && me->GetVictim()->HasBreakableByDamageCrowdControlAura())
+                if (me->GetVictim() && me->EnsureVictim()->HasBreakableByDamageCrowdControlAura())
                 { // don't break cc
                     me->GetThreatManager().ClearFixate();
                     me->InterruptNonMeleeSpells(false);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Use Unit::EnsureVictim everywhere Unit::GetVictim is referenced but not checked for nullptr

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Compiles


**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
