### PR TITLE
Core/Game: Fix dynamic library cache path with git flow branches

### DIFF
--- a/src/server/game/Scripting/ScriptReloadMgr.cpp
+++ b/src/server/game/Scripting/ScriptReloadMgr.cpp
@@ -610,7 +610,7 @@ public:
         boost::system::error_code code;
         if ((!fs::exists(temporary_cache_path_, code)
              || (fs::remove_all(temporary_cache_path_, code) > 0)) &&
-             !fs::create_directory(temporary_cache_path_, code))
+             !fs::create_directories(temporary_cache_path_, code))
         {
             TC_LOG_ERROR("scripts.hotswap", "Couldn't create the cache directory at \"%s\".",
                 temporary_cache_path_.generic_string().c_str());


### PR DESCRIPTION
**Description**
Some common git workflows (`git flow` specifically) typically has forward slashes in their branch names. Since we use branch names for cache directories, the directory may actually be multiple directories deep, so we need to use `create_directories` when we do to avoid errors.

**Changes proposed:**

- Change `create_directory` to `create_directories` when creating the temporary library directory.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Tests performed:**

Builds fine, and libraries load fine on 3.3.5 even with slashes in the branch names. master not tested, but `create_directories` should not fail where `create_directory` doesn't. 