### PR TITLE
Core/Pet: Attempt to fix assertions triggered when summoning pets

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -320,9 +320,13 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petEntry, uint32 petnumber, bool c
     // PET_SAVE_NOT_IN_SLOT(100) = not stable slot (summoning))
     if (slot == PET_SAVE_NOT_IN_SLOT)
     {
+        uint32 petInfoNumber = petInfo->PetNumber;
+        if (petStable->CurrentPet)
+            owner->RemovePet(nullptr, PET_SAVE_NOT_IN_SLOT);
+
         auto unslottedPetItr = std::find_if(petStable->UnslottedPets.begin(), petStable->UnslottedPets.end(), [&](PetStable::PetInfo const& unslottedPet)
         {
-            return unslottedPet.PetNumber == petInfo->PetNumber;
+            return unslottedPet.PetNumber == petInfoNumber;
         });
         ASSERT(!petStable->CurrentPet);
         ASSERT(unslottedPetItr != petStable->UnslottedPets.end());

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -341,6 +341,19 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petEntry, uint32 petnumber, bool c
         // old petInfo pointer is no longer valid, refresh it
         petInfo = &petStable->CurrentPet.value();
     }
+    else if (PET_SAVE_FIRST_STABLE_SLOT <= slot && slot <= PET_SAVE_LAST_STABLE_SLOT)
+    {
+        auto stabledPet = std::find_if(petStable->StabledPets.begin(), petStable->StabledPets.end(), [petnumber](Optional<PetStable::PetInfo> const& pet)
+        {
+            return pet && pet->PetNumber == petnumber;
+        });
+        ASSERT(stabledPet != petStable->StabledPets.end());
+
+        std::swap(*stabledPet, petStable->CurrentPet);
+
+        // old petInfo pointer is no longer valid, refresh it
+        petInfo = &petStable->CurrentPet.value();
+    }
 
     // Send fake summon spell cast - this is needed for correct cooldown application for spells
     // Example: 46584 - without this cooldown (which should be set always when pet is loaded) isn't set clientside

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -197,6 +197,10 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petEntry, uint32 petnumber, bool c
         return false;
     }
 
+    // Don't try to reload the current pet
+    if (petStable->CurrentPet && owner->GetPet() && petStable->CurrentPet.value().PetNumber == petInfo->PetNumber)
+        return false;
+
     SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(petInfo->CreatedBySpellId);
 
     bool isTemporarySummon = spellInfo && spellInfo->GetDuration() > 0;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -26786,6 +26786,9 @@ Pet* Player::SummonPet(uint32 entry, float x, float y, float z, float ang, PetTy
         return nullptr;
     }
 
+    if (petType == SUMMON_PET && petStable.CurrentPet)
+        RemovePet(nullptr, PET_SAVE_NOT_IN_SLOT);
+
     pet->SetCreatorGUID(GetGUID());
     pet->SetFaction(GetFaction());
 

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -542,8 +542,6 @@ void WorldSession::HandleUnstablePet(WorldPacket& recvData)
     }
     else
     {
-        std::swap(*stabledPet, petStable->CurrentPet);
-
         // update current pet slot in db immediately to maintain slot consistency, dismissed pet was already saved
         CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_PET_SLOT_BY_ID);
         stmt->setUInt8(0, PET_SAVE_AS_CURRENT);

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -416,7 +416,7 @@ void WorldSession::HandleStablePet(WorldPacket& recvData)
             if (pet)
             {
                 // stable summoned pet
-                _player->RemovePet(pet, PetSaveMode(PET_SAVE_FIRST_STABLE_SLOT + freeSlot));
+                _player->RemovePet(pet, PetSaveMode(PET_SAVE_FIRST_STABLE_SLOT + freeSlot), true);
                 std::swap(petStable->StabledPets[freeSlot], petStable->CurrentPet);
                 SendPetStableResult(STABLE_SUCCESS_STABLE);
                 return;

--- a/src/server/game/Handlers/NPCHandler.cpp
+++ b/src/server/game/Handlers/NPCHandler.cpp
@@ -416,7 +416,7 @@ void WorldSession::HandleStablePet(WorldPacket& recvData)
             if (pet)
             {
                 // stable summoned pet
-                _player->RemovePet(pet, PetSaveMode(PET_SAVE_FIRST_STABLE_SLOT + freeSlot), true);
+                _player->RemovePet(pet, PetSaveMode(PET_SAVE_FIRST_STABLE_SLOT + freeSlot));
                 std::swap(petStable->StabledPets[freeSlot], petStable->CurrentPet);
                 SendPetStableResult(STABLE_SUCCESS_STABLE);
                 return;

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2846,9 +2846,6 @@ class spell_gen_pet_summoned : public SpellScript
 
         if (player->GetLastPetNumber())
         {
-            if (HandleStabledPetCase())
-                return;
-
             PetType newPetType = (player->GetClass() == CLASS_HUNTER) ? HUNTER_PET : SUMMON_PET;
             Pet* newPet = new Pet(player, newPetType);
             if (newPet->LoadPetFromDB(player, 0, player->GetLastPetNumber(), true))
@@ -2873,20 +2870,6 @@ class spell_gen_pet_summoned : public SpellScript
             else
                 delete newPet;
         }
-    }
-
-    bool HandleStabledPetCase()
-    {
-        Player* player = GetCaster()->ToPlayer();
-
-        if (player->GetPetStable())
-        {
-            std::pair<PetStable::PetInfo const*, PetSaveMode> info = Pet::GetLoadPetInfo(*player->GetPetStable(), 0, player->GetLastPetNumber(), true);
-            if (info.second != PET_SAVE_AS_CURRENT && info.second != PET_SAVE_NOT_IN_SLOT)
-                return true;
-        }
-
-        return false;
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2841,6 +2841,9 @@ class spell_gen_pet_summoned : public SpellScript
         Player* player = GetCaster()->ToPlayer();
         if (player->GetLastPetNumber())
         {
+            if (HandlePetAlreadySummonedCase())
+                return;
+
             PetType newPetType = (player->GetClass() == CLASS_HUNTER) ? HUNTER_PET : SUMMON_PET;
             Pet* newPet = new Pet(player, newPetType);
             if (newPet->LoadPetFromDB(player, 0, player->GetLastPetNumber(), true))
@@ -2865,6 +2868,54 @@ class spell_gen_pet_summoned : public SpellScript
             else
                 delete newPet;
         }
+    }
+
+    bool HandlePetAlreadySummonedCase()
+    {
+        // The code below has been copied from Spell::EffectSummonPet() to handle the case of summoning the current pet again
+
+        Player* owner = GetCaster()->ToPlayer();
+        Pet* OldSummon = owner->GetPet();
+
+        // if pet requested type already exist
+        if (OldSummon)
+        {
+            uint32 lastPetNumber = owner->GetLastPetNumber();
+            if (OldSummon->GetCharmInfo()->GetPetNumber() == lastPetNumber)
+            {
+                // revive the pet if it is dead
+                if (OldSummon->getDeathState() != ALIVE && OldSummon->getDeathState() != JUST_RESPAWNED)
+                    OldSummon->setDeathState(JUST_RESPAWNED);
+
+                OldSummon->SetFullHealth();
+                OldSummon->SetPower(OldSummon->GetPowerType(), OldSummon->GetMaxPower(OldSummon->GetPowerType()));
+
+                ASSERT(OldSummon->GetMap() == owner->GetMap());
+
+                //OldSummon->GetMap()->Remove(OldSummon->ToCreature(), false);
+
+                float px, py, pz;
+                owner->GetClosePoint(px, py, pz, OldSummon->GetCombatReach());
+
+                OldSummon->NearTeleportTo(px, py, pz, OldSummon->GetOrientation());
+                //OldSummon->Relocate(px, py, pz, OldSummon->GetOrientation());
+                //OldSummon->SetMap(owner->GetMap());
+                //owner->GetMap()->Add(OldSummon->ToCreature());
+                if (OldSummon->getPetType() == SUMMON_PET)
+                {
+                    OldSummon->SetHealth(OldSummon->GetMaxHealth());
+                    OldSummon->SetPower(OldSummon->GetPowerType(), OldSummon->GetMaxPower(OldSummon->GetPowerType()));
+                    OldSummon->GetSpellHistory()->ResetAllCooldowns();
+                }
+
+                if (owner->GetTypeId() == TYPEID_PLAYER && OldSummon->isControlled())
+                    owner->ToPlayer()->PetSpellInitialize();
+
+                return true;
+            }
+        }
+
+        return false;
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2839,7 +2839,6 @@ class spell_gen_pet_summoned : public SpellScript
     void HandleScript(SpellEffIndex /*effIndex*/)
     {
         Player* player = GetCaster()->ToPlayer();
-
         if (player->GetLastPetNumber())
         {
             PetType newPetType = (player->GetClass() == CLASS_HUNTER) ? HUNTER_PET : SUMMON_PET;

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2844,6 +2844,9 @@ class spell_gen_pet_summoned : public SpellScript
             if (HandlePetAlreadySummonedCase())
                 return;
 
+            if (HandleStabledPetCase())
+                return;
+
             PetType newPetType = (player->GetClass() == CLASS_HUNTER) ? HUNTER_PET : SUMMON_PET;
             Pet* newPet = new Pet(player, newPetType);
             if (newPet->LoadPetFromDB(player, 0, player->GetLastPetNumber(), true))
@@ -2913,6 +2916,20 @@ class spell_gen_pet_summoned : public SpellScript
 
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    bool HandleStabledPetCase()
+    {
+        Player* player = GetCaster()->ToPlayer();
+
+        if (player->GetPetStable())
+        {
+            std::pair<PetStable::PetInfo const*, PetSaveMode> info = Pet::GetLoadPetInfo(*player->GetPetStable(), 0, player->GetLastPetNumber(), true);
+            if (info.second != PET_SAVE_AS_CURRENT && info.second != PET_SAVE_NOT_IN_SLOT)
+                return true;
         }
 
         return false;

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2839,6 +2839,11 @@ class spell_gen_pet_summoned : public SpellScript
     void HandleScript(SpellEffIndex /*effIndex*/)
     {
         Player* player = GetCaster()->ToPlayer();
+
+        // Don't try to summon any pet when being dead
+        if (!player->IsAlive())
+            return;
+
         if (player->GetLastPetNumber())
         {
             if (HandlePetAlreadySummonedCase())

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2840,10 +2840,6 @@ class spell_gen_pet_summoned : public SpellScript
     {
         Player* player = GetCaster()->ToPlayer();
 
-        // Don't try to summon any pet when being dead
-        if (!player->IsAlive())
-            return;
-
         if (player->GetLastPetNumber())
         {
             PetType newPetType = (player->GetClass() == CLASS_HUNTER) ? HUNTER_PET : SUMMON_PET;

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2846,9 +2846,6 @@ class spell_gen_pet_summoned : public SpellScript
 
         if (player->GetLastPetNumber())
         {
-            if (HandlePetAlreadySummonedCase())
-                return;
-
             if (HandleStabledPetCase())
                 return;
 
@@ -2876,54 +2873,6 @@ class spell_gen_pet_summoned : public SpellScript
             else
                 delete newPet;
         }
-    }
-
-    bool HandlePetAlreadySummonedCase()
-    {
-        // The code below has been copied from Spell::EffectSummonPet() to handle the case of summoning the current pet again
-
-        Player* owner = GetCaster()->ToPlayer();
-        Pet* OldSummon = owner->GetPet();
-
-        // if pet requested type already exist
-        if (OldSummon)
-        {
-            uint32 lastPetNumber = owner->GetLastPetNumber();
-            if (OldSummon->GetCharmInfo()->GetPetNumber() == lastPetNumber)
-            {
-                // revive the pet if it is dead
-                if (OldSummon->getDeathState() != ALIVE && OldSummon->getDeathState() != JUST_RESPAWNED)
-                    OldSummon->setDeathState(JUST_RESPAWNED);
-
-                OldSummon->SetFullHealth();
-                OldSummon->SetPower(OldSummon->GetPowerType(), OldSummon->GetMaxPower(OldSummon->GetPowerType()));
-
-                ASSERT(OldSummon->GetMap() == owner->GetMap());
-
-                //OldSummon->GetMap()->Remove(OldSummon->ToCreature(), false);
-
-                float px, py, pz;
-                owner->GetClosePoint(px, py, pz, OldSummon->GetCombatReach());
-
-                OldSummon->NearTeleportTo(px, py, pz, OldSummon->GetOrientation());
-                //OldSummon->Relocate(px, py, pz, OldSummon->GetOrientation());
-                //OldSummon->SetMap(owner->GetMap());
-                //owner->GetMap()->Add(OldSummon->ToCreature());
-                if (OldSummon->getPetType() == SUMMON_PET)
-                {
-                    OldSummon->SetHealth(OldSummon->GetMaxHealth());
-                    OldSummon->SetPower(OldSummon->GetPowerType(), OldSummon->GetMaxPower(OldSummon->GetPowerType()));
-                    OldSummon->GetSpellHistory()->ResetAllCooldowns();
-                }
-
-                if (owner->GetTypeId() == TYPEID_PLAYER && OldSummon->isControlled())
-                    owner->ToPlayer()->PetSpellInitialize();
-
-                return true;
-            }
-        }
-
-        return false;
     }
 
     bool HandleStabledPetCase()


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Core/Pet: Attempt to fix an assertion triggered when re-summoning the current pet
-  Attempts to fix #26491 and #26492

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)
#26491

**Tests performed:**

- Case 1 01530be2fa8f79e38c6e7d5b8718b05782fe2ae9 (handled with generic code in Pet.cpp)
  - get a player with pet, by example warlock and summon pet
  - do command .cast 6962
  - do command .save
- Case 2 db3898ce62a8f31360a25af1d32990c200a06402 (handled with generic code in Pet.cpp)
  - get a hunter with a tamed pet
  - .npc add temp 34775
  - mount in vehicle and switch to right or left seat
  - cast Call Pet hunter spell (.cast 883)
  - cast Call Stabled Pet (.cast 62757)
  - keep the pet in the stable
  - dismount vehicle
  - do .save
- Case 3 db3898ce62a8f31360a25af1d32990c200a06402 (handled with generic code in Pet.cpp)
  - get a hunter with a tamed pet
  - cast Call Stabled Pet (.cast 62757)
  - keep the pet in the stable
  - do command .cast 6962
  - do command .save
- Case 4 3435faf13177ba53209c9cc30bf77360d2cb351c (handled with generic code in Pet.cpp)
  - get a warlock, summon a pet (by example imp)
  - .die on warlock character
  - (now you are dead, so use /g to talk on guild chat and use commands)
  - .cast 6962 triggered
  - .revive
  - summon a different pet (by example voidwalker)
  - use a mount
  - dismount
- Case 5 3435faf13177ba53209c9cc30bf77360d2cb351c (handled with generic code in Pet.cpp) 
  - get a warlock and summon a pet (by example imp)
  - .npc add temp 34775
  - mount in vehicle and switch to right or left seat
  - summon a different pet (by example voidwalker)
- Case 6 b9f1dbaf1dc4fa5bea0147e84c25d5c1444584e0 (handled with generic code in Player.cpp)
  - create a new warlock character
  - summon a pet (by example imp)
  - mount on a vehicle that allow use spells (by example 34775) and switch to left or right   
  - passenger seat
  - cast any other summon pet (by example summon voidwalker)

**Known issues and TODO list:** (add/remove lines as needed)

- More cases should be tested


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
