### PR TITLE
Core/SAI: Prevent loading invalid smart_scripts entry

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -134,6 +134,12 @@ void SmartAIMgr::LoadSmartAIFromDB()
         SmartScriptHolder temp;
 
         temp.entryOrGuid = fields[0].GetInt32();
+        if (!temp.entryOrGuid)
+        {
+            TC_LOG_ERROR("sql.sql", "SmartAIMgr::LoadSmartAIFromDB: invalid entryorguid (0), skipped loading.");
+            continue;
+        }
+
         SmartScriptType source_type = (SmartScriptType)fields[1].GetUInt8();
         if (source_type >= SMART_SCRIPT_TYPE_MAX)
         {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't load smart_scripts with entryorguid 0

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [x] master

**Issues addressed:**
Fixed an issue where invalid data was loaded, this invalid data would be used by all summoned creature replacing their "existing" SAI

Closes #  (insert issue tracker number)
-

**Tests performed:**
builds, won't load SAI
(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
