### PR TITLE
Core/Movement: Hotfix the crashes that can occur in the movement handlers

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -422,6 +422,7 @@ Unit::~Unit()
     ASSERT(m_removedAuras.empty());
     ASSERT(m_gameObj.empty());
     ASSERT(m_dynObj.empty());
+    ASSERT(!_gameClientMovingMe || _gameClientMovingMe->GetBasePlayer() == this);
 }
 
 void Unit::Update(uint32 p_time)

--- a/src/server/game/Server/GameClient.cpp
+++ b/src/server/game/Server/GameClient.cpp
@@ -28,6 +28,9 @@ GameClient::GameClient(WorldSession* sessionToServer)
 
 void GameClient::AddAllowedMover(Unit* unit)
 {
+    if (GameClient *previousController = unit->GetGameClientMovingMe())
+        previousController->RemoveAllowedMover(unit);
+
     _allowedMovers.insert(unit->GetGUID());
     unit->SetGameClientMovingMe(this);
 }
@@ -36,7 +39,10 @@ void GameClient::RemoveAllowedMover(Unit* unit)
 {
     _allowedMovers.erase(unit->GetGUID());
     if (unit->GetGameClientMovingMe() == this)
+    {
         unit->SetGameClientMovingMe(nullptr);
+        SetActivelyMovedUnit(nullptr);
+    }  
 }
 
 bool GameClient::IsAllowedToMove(Unit* unit) const

--- a/src/server/game/Server/GameClient.cpp
+++ b/src/server/game/Server/GameClient.cpp
@@ -42,7 +42,7 @@ void GameClient::RemoveAllowedMover(Unit* unit)
     {
         unit->SetGameClientMovingMe(nullptr);
         SetActivelyMovedUnit(nullptr);
-    }  
+    }
 }
 
 bool GameClient::IsAllowedToMove(Unit* unit) const

--- a/src/server/game/Server/GameClient.cpp
+++ b/src/server/game/Server/GameClient.cpp
@@ -28,7 +28,7 @@ GameClient::GameClient(WorldSession* sessionToServer)
 
 void GameClient::AddAllowedMover(Unit* unit)
 {
-    if (GameClient *previousController = unit->GetGameClientMovingMe())
+    if (GameClient* previousController = unit->GetGameClientMovingMe())
         previousController->RemoveAllowedMover(unit);
 
     _allowedMovers.insert(unit->GetGUID());

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1665,9 +1665,10 @@ bool WorldSession::IsRightUnitBeingMoved(ObjectGuid guid)
     GameClient* client = GetGameClient();
 
     // the client is attempting to tamper movement data
+    // edit: this wouldn't happen in retail but it does in TC, even with a legitimate client.
     if (!client->GetActivelyMovedUnit() || client->GetActivelyMovedUnit()->GetGUID() != guid)
     {
-        TC_LOG_INFO("entities.unit", "Attempt at tampering movement data by Player %s", _player->GetName().c_str());
+        TC_LOG_DEBUG("entities.unit", "Attempt at tampering movement data by Player %s", _player->GetName().c_str());
         return false;
     }
 


### PR DESCRIPTION
Hotfix the crashes that can occur in the movement handlers since the latest client control logic rework

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Clean up potentially dangling pointers when `GameClient::SetMovedUnit` is called.
- This PR is a hotfix in the sense that the full fix is not implemented yet. The change in src/server/game/Server/WorldSession.cpp should be temporary.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/26531

**Tests performed:**

Tested IG. Feedback and testing from you guys is welcome.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
