### PR TITLE
Fixed player_choice_response the reading structure is now correct work

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -10471,7 +10471,7 @@ void ObjectMgr::LoadPlayerChoices()
 
             PlayerChoiceResponse& response = choice->Responses.back();
             response.ResponseId         = responseId;
-            response.ResponseId         = fields[2].GetUInt16();
+            response.ResponseIdentifier = fields[2].GetUInt16();
             response.ChoiceArtFileId    = fields[3].GetInt32();
             response.Flags              = fields[4].GetInt32();
             response.WidgetSetID        = fields[5].GetUInt32();


### PR DESCRIPTION

Changes proposed:

-  Playerchoice now works since ResponseIdentifier is the identifying structure to reproduce the playerchoice


Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [ ] master

Tests performed: