### PR TITLE
Core/SAI: Add support to friendly+hostile to SMART_EVENT_OOC_LOS and SMART_EVENT_IC_LOS

### DIFF
--- a/sql/updates/world/3.3.5/2021_06_08_00_world.sql
+++ b/sql/updates/world/3.3.5/2021_06_08_00_world.sql
@@ -1,0 +1,4 @@
+--
+UPDATE `smart_scripts` SET `event_param1` = 2 WHERE `entryorguid` = 18428 AND `source_type` = 0 AND `id` = 0;
+UPDATE `smart_scripts` SET `event_param1` = 1, `event_param2` = 20 WHERE `entryorguid` = 19283 AND `source_type` = 0 AND `id` = 3;
+UPDATE `smart_scripts` SET `event_type` = 1, `event_param1` = 6000, `event_param2` = 11000, `target_type` = 19, `target_param1` = 24042, `target_param2` = 40 WHERE `entryorguid` = 23760 AND `source_type` = 0 AND `id` = 3;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3179,10 +3179,11 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             //if range is ok and we are actually in LOS
             if (me->IsWithinDistInMap(unit, range) && me->IsWithinLOSInMap(unit))
             {
+                SmartEvent::LOSHostilityMode hostilityMode = static_cast<SmartEvent::LOSHostilityMode>(e.event.los.hostilityMode);
                 //if friendly event&&who is not hostile OR hostile event&&who is hostile
-                if ((e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Any)) ||
-                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::NotHostile) && !me->IsHostileTo(unit)) ||
-                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Hostile) && me->IsHostileTo(unit)))
+                if ((hostilityMode == SmartEvent::LOSHostilityMode::Any) ||
+                    (hostilityMode == SmartEvent::LOSHostilityMode::NotHostile && !me->IsHostileTo(unit)) ||
+                    (hostilityMode == SmartEvent::LOSHostilityMode::Hostile && me->IsHostileTo(unit)))
                 {
                     if (e.event.los.playerOnly && unit->GetTypeId() != TYPEID_PLAYER)
                         return;
@@ -3202,10 +3203,11 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             //if range is ok and we are actually in LOS
             if (me->IsWithinDistInMap(unit, range) && me->IsWithinLOSInMap(unit))
             {
+                SmartEvent::LOSHostilityMode hostilityMode = static_cast<SmartEvent::LOSHostilityMode>(e.event.los.hostilityMode);
                 //if friendly event&&who is not hostile OR hostile event&&who is hostile
-                if ((e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Any)) ||
-                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::NotHostile) && !me->IsHostileTo(unit)) ||
-                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Hostile) && me->IsHostileTo(unit)))
+                if ((hostilityMode == SmartEvent::LOSHostilityMode::Any) ||
+                    (hostilityMode == SmartEvent::LOSHostilityMode::NotHostile && !me->IsHostileTo(unit)) ||
+                    (hostilityMode == SmartEvent::LOSHostilityMode::Hostile && me->IsHostileTo(unit)))
                 {
                     if (e.event.los.playerOnly && unit->GetTypeId() != TYPEID_PLAYER)
                         return;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3180,8 +3180,9 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             if (me->IsWithinDistInMap(unit, range) && me->IsWithinLOSInMap(unit))
             {
                 //if friendly event&&who is not hostile OR hostile event&&who is hostile
-                if ((e.event.los.noHostile && !me->IsHostileTo(unit)) ||
-                    (!e.event.los.noHostile && me->IsHostileTo(unit)))
+                if ((e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Any)) ||
+                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::NotHostile) && !me->IsHostileTo(unit)) ||
+                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Hostile) && me->IsHostileTo(unit)))
                 {
                     if (e.event.los.playerOnly && unit->GetTypeId() != TYPEID_PLAYER)
                         return;
@@ -3202,8 +3203,9 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             if (me->IsWithinDistInMap(unit, range) && me->IsWithinLOSInMap(unit))
             {
                 //if friendly event&&who is not hostile OR hostile event&&who is hostile
-                if ((e.event.los.noHostile && !me->IsHostileTo(unit)) ||
-                    (!e.event.los.noHostile && me->IsHostileTo(unit)))
+                if ((e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Any)) ||
+                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::NotHostile) && !me->IsHostileTo(unit)) ||
+                    (e.event.los.hostilityMode == static_cast<uint32>(SmartEvent::LOS::Hostile) && me->IsHostileTo(unit)))
                 {
                     if (e.event.los.playerOnly && unit->GetTypeId() != TYPEID_PLAYER)
                         return;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -762,6 +762,12 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             case SMART_EVENT_IC_LOS:
                 if (!IsMinMaxValid(e, e.event.los.cooldownMin, e.event.los.cooldownMax))
                     return false;
+                if (e.event.los.hostilityMode >= AsUnderlyingType(SmartEvent::LOSHostilityMode::End))
+                {
+                    TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u uses hostilityMode with invalid value %u (max allowed value %u), skipped.",
+                        e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.event.los.hostilityMode, AsUnderlyingType(SmartEvent::LOSHostilityMode::End) - 1);
+                    return false;
+                }
                 break;
             case SMART_EVENT_RESPAWN:
                 if (e.event.respawn.type == SMART_SCRIPT_RESPAWN_CONDITION_MAP && !sMapStore.LookupEntry(e.event.respawn.map))

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -107,7 +107,7 @@ enum SMART_EVENT
     SMART_EVENT_EVADE                    = 7,       // NONE
     SMART_EVENT_SPELLHIT                 = 8,       // SpellID, School, CooldownMin, CooldownMax
     SMART_EVENT_RANGE                    = 9,       // MinDist, MaxDist, RepeatMin, RepeatMax
-    SMART_EVENT_OOC_LOS                  = 10,      // NoHostile, MaxRnage, CooldownMin, CooldownMax
+    SMART_EVENT_OOC_LOS                  = 10,      // HostilityMode, MaxRnage, CooldownMin, CooldownMax
     SMART_EVENT_RESPAWN                  = 11,      // type, MapId, ZoneId
     SMART_EVENT_TARGET_HEALTH_PCT        = 12,      // HPMin%, HPMax%, RepeatMin, RepeatMax
     SMART_EVENT_VICTIM_CASTING           = 13,      // RepeatMin, RepeatMax, spellid
@@ -123,7 +123,7 @@ enum SMART_EVENT
     SMART_EVENT_HAS_AURA                 = 23,      // Param1 = SpellID, Param2 = Stack amount, Param3/4 RepeatMin, RepeatMax
     SMART_EVENT_TARGET_BUFFED            = 24,      // Param1 = SpellID, Param2 = Stack amount, Param3/4 RepeatMin, RepeatMax
     SMART_EVENT_RESET                    = 25,      // Called after combat, when the creature respawn and spawn.
-    SMART_EVENT_IC_LOS                   = 26,      // NoHostile, MaxRnage, CooldownMin, CooldownMax
+    SMART_EVENT_IC_LOS                   = 26,      // HostilityMode, MaxRnage, CooldownMin, CooldownMax
     SMART_EVENT_PASSENGER_BOARDED        = 27,      // CooldownMin, CooldownMax
     SMART_EVENT_PASSENGER_REMOVED        = 28,      // CooldownMin, CooldownMax
     SMART_EVENT_CHARMED                  = 29,      // onRemove (0 - on apply, 1 - on remove)
@@ -218,7 +218,10 @@ struct SmartEvent
 
         struct
         {
-            uint32 noHostile;
+            /// <summary>
+            /// Hostility mode of the event. 0: hostile, 1: not hostile, 2: any
+            /// </summary>
+            uint32 hostilityMode;
             uint32 maxDist;
             uint32 cooldownMin;
             uint32 cooldownMax;
@@ -444,6 +447,13 @@ struct SmartEvent
             uint32 param4;
             uint32 param5;
         } raw;
+    };
+
+    enum class LOS : uint32
+    {
+        Hostile = 0,
+        NotHostile = 1,
+        Any = 2
     };
 };
 

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -449,11 +449,12 @@ struct SmartEvent
         } raw;
     };
 
-    enum class LOS : uint32
+    enum class LOSHostilityMode : uint32
     {
         Hostile = 0,
         NotHostile = 1,
-        Any = 2
+        Any = 2,
+        End
     };
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Change SMART_EVENT_OOC_LOS and SMART_EVENT_IC_LOS first parameter to have 3 values:
- 0 : Hostile
- 1 : Not hostile (not that Friendly and Not hostile have different meanings)
- 2 : Any, as in both Hostile and Not hostile

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Close #24789

**Tests performed:**

None


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Not sure if we have a codestyle to compare enum classes to uint32, I used static_cast 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
