### PR TITLE
Scripts/Commands: Minor improvements in .pinfo and .unban character commands

### DIFF
--- a/sql/updates/world/3.3.5/2021_06_20_00_world.sql
+++ b/sql/updates/world/3.3.5/2021_06_20_00_world.sql
@@ -1,3 +1,4 @@
+--
 DELETE FROM `trinity_string` WHERE `entry`=883;
 INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
 (883, 'Account');

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `trinity_string` WHERE `entry`=883;
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
+(883, 'Account');

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -818,7 +818,8 @@ enum TrinityStrings
     LANG_ACCOUNT_SEC_TYPE                 = 880,
     LANG_RBAC_EMAIL_REQUIRED              = 881,
     //                                    = 882, LANG_PINFO_CHR_MAP_WITH_AREA
-    // Room for in-game strings             883-999 not used
+    LANG_ACCOUNT                          = 883,
+    // Room for in-game strings             884-999 not used
 
     // Level 4 (CLI only commands)
     LANG_COMMAND_EXIT                     = 1000,

--- a/src/server/scripts/Commands/cs_ban.cpp
+++ b/src/server/scripts/Commands/cs_ban.cpp
@@ -702,6 +702,7 @@ public:
             return false;
         }
 
+        handler->PSendSysMessage(LANG_UNBAN_UNBANNED, name.c_str());
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1645,13 +1645,16 @@ public:
             stmt->setUInt32(0, lowguid);
             result2 = CharacterDatabase.Query(stmt);
         }
+        else
+            banType = handler->GetTrinityString(LANG_ACCOUNT);
 
         if (result2)
         {
-            Field* fields = result2->Fetch();
-            banTime       = int64(fields[1].GetUInt64() ? 0 : fields[0].GetUInt32());
-            bannedBy      = fields[2].GetString();
-            banReason     = fields[3].GetString();
+            Field* fields  = result2->Fetch();
+            bool permanent = fields[1].GetBool();
+            banTime        = !permanent ? int64(fields[0].GetUInt32()) : 0;
+            bannedBy       = fields[2].GetString();
+            banReason      = fields[3].GetString();
         }
 
         // Can be used to query data from Characters database


### PR DESCRIPTION
**Changes proposed:**

-  Now .pinfo command show correct bantime in case of not being permanent (currently show always "permanent")
-  Now .pinfo command show bantype Account in case of being bantype account instead of showing "unknown" (not sure if I defined in the proper number LANG_ACCOUNT)
-  Now .unban character command show success text with unban player name

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Tests performed:**

tested in-game
