### PR TITLE
Fix kick after map changed and speed changed

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1806,9 +1806,6 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             //remove auras before removing from map...
             RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_CHANGE_MAP | AURA_INTERRUPT_FLAG_MOVE | AURA_INTERRUPT_FLAG_TURNING);
 
-            // players on mount will be dismounted. the speed and height change should not require an ACK and should be applied directly
-            PurgeAndApplyPendingMovementChanges(false);
-
             if (!GetSession()->PlayerLogout())
             {
                 // send transfer packets
@@ -1823,6 +1820,9 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
             // remove from old map now
             if (oldmap)
                 oldmap->RemovePlayerFromMap(this, false);
+
+            // players on mount will be dismounted. the speed and height change should not require an ACK and should be applied directly
+            PurgeAndApplyPendingMovementChanges(false);
 
             m_teleport_dest = WorldLocation(mapid, x, y, z, orientation);
             m_teleport_options = options;


### PR DESCRIPTION
There are some auras will be removed in Player::RemoveFromWorld() and Unit::RemoveFromWorld(), if any auras changed player's speed, you will be kicked after changed map.
So PurgeAndApplyPendingMovementChanges(false) must be after RemovePlayerFromMap(this, false).

**Target branch(es):** 3.3.5/master
- [x] 3.3.5
- [ ] master

**Issues addressed:**
Fix #26607 

**Tests performed:**
tested in-game
