### PR TITLE
Clear unused #undef leftover in a refactor

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -218,8 +218,6 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPacket& recvData)
     }
 
     CLOSE_GOSSIP_CLEAR_SHARING_INFO();
-
-#undef CLOSE_GOSSIP_CLEAR_SHARING_INFO
 }
 
 void WorldSession::HandleQuestgiverQueryQuestOpcode(WorldPacket& recvData)


### PR DESCRIPTION
Previously this function was using a macro that was #undef at the end of the function. Since then it uses a lambda function instead and the undef is not needed anymore.

(Please do tell if that kind of tiny PR is not welcome)