### PR TITLE
CI/CircleCI: Force ccache directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
             export CCACHE_CPP2=yes
             export USE_CCACHE=1
             export PATH=/usr/lib/ccache:$PATH
+            export CCACHE_DIR=$HOME/.ccache
             ccache -z
             ccache -s
             git config user.email "circleci@build.bot" && git config user.name "Circle CI"


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Force ccache directory in Cirlce CI to avoid using a different directory, especially in forks, and ending up not saving anything in the cache

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Super slow no-pch build in forks if setting up Circle CI on your own


**Tests performed:**

Waiting for Circle CI to finish building


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
