### PR TITLE
Build: Remove fine-grained CXX feature checks

### DIFF
--- a/cmake/macros/ConfigureBaseTargets.cmake
+++ b/cmake/macros/ConfigureBaseTargets.cmake
@@ -19,20 +19,7 @@ add_library(trinity-feature-interface INTERFACE)
 
 target_compile_features(trinity-feature-interface
   INTERFACE
-    cxx_std_17
-    cxx_alias_templates
-    cxx_auto_type
-    cxx_constexpr
-    cxx_decltype
-    cxx_decltype_auto
-    cxx_final
-    cxx_lambdas
-    cxx_generic_lambdas
-    cxx_variadic_templates
-    cxx_defaulted_functions
-    cxx_nullptr
-    cxx_trailing_return_types
-    cxx_return_type_deduction)
+    cxx_std_17)
 
 # An interface library to make the warnings level available to other targets
 # This interface taget is set-up through the platform specific script


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
With C++17 enabled these don't serve any purpose.
See https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

**Tests performed:**
build
