### PR TITLE
Core/Movement: allow waypoints to use 0 as valid facing value

### DIFF
--- a/sql/updates/world/3.3.5/2021_07_06_xx_world.sql
+++ b/sql/updates/world/3.3.5/2021_07_06_xx_world.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `waypoint_data` CHANGE `orientation` `orientation` FLOAT DEFAULT NULL NULL;
+UPDATE `waypoint_data` SET `orientation`= NULL WHERE `orientation`= 0;

--- a/sql/updates/world/3.3.5/2022_04_16_00_world.sql
+++ b/sql/updates/world/3.3.5/2022_04_16_00_world.sql
@@ -1,2 +1,5 @@
 ALTER TABLE `waypoint_data` CHANGE `orientation` `orientation` FLOAT DEFAULT NULL NULL;
 UPDATE `waypoint_data` SET `orientation`= NULL WHERE `orientation`= 0;
+
+ALTER TABLE `waypoints` CHANGE `orientation` `orientation` FLOAT DEFAULT NULL NULL;
+UPDATE `waypoints` SET `orientation`= NULL WHERE `orientation`= 0;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -77,7 +77,9 @@ void SmartWaypointMgr::LoadFromDB()
         float x = fields[2].GetFloat();
         float y = fields[3].GetFloat();
         float z = fields[4].GetFloat();
-        float o = fields[5].GetFloat();
+        Optional<float> o;
+        if (!fields[5].IsNull())
+            o = fields[5].GetFloat();
         uint32 delay = fields[6].GetUInt32();
 
         if (lastEntry != entry)

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -344,9 +344,8 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
     //! but formationDest contains global coordinates
     init.MoveTo(waypoint.x, waypoint.y, waypoint.z);
 
-    //! Accepts angles such as 0.00001 and -0.00001, 0 must be ignored, default value in waypoint table
-    if (waypoint.orientation && waypoint.delay)
-        init.SetFacing(waypoint.orientation);
+    if (waypoint.orientation.has_value() && waypoint.delay > 0)
+        init.SetFacing(*waypoint.orientation);
 
     switch (waypoint.moveType)
     {

--- a/src/server/game/Movement/Waypoints/WaypointDefines.h
+++ b/src/server/game/Movement/Waypoints/WaypointDefines.h
@@ -35,7 +35,7 @@ enum WaypointMoveType
 struct WaypointNode
 {
     WaypointNode() : id(0), x(0.f), y(0.f), z(0.f), delay(0), eventId(0), moveType(WAYPOINT_MOVE_TYPE_RUN), eventChance(0) { }
-    WaypointNode(uint32 _id, float _x, float _y, float _z, float _orientation = { }, uint32 _delay = 0)
+    WaypointNode(uint32 _id, float _x, float _y, float _z, Optional<float> _orientation = { }, uint32 _delay = 0)
     {
         id = _id;
         x = _x;

--- a/src/server/game/Movement/Waypoints/WaypointDefines.h
+++ b/src/server/game/Movement/Waypoints/WaypointDefines.h
@@ -19,6 +19,7 @@
 #define TRINITY_WAYPOINTDEFINES_H
 
 #include "Define.h"
+#include "Optional.h"
 #include <vector>
 
 enum WaypointMoveType
@@ -33,8 +34,8 @@ enum WaypointMoveType
 
 struct WaypointNode
 {
-    WaypointNode() : id(0), x(0.f), y(0.f), z(0.f), orientation(0.f), delay(0), eventId(0), moveType(WAYPOINT_MOVE_TYPE_RUN), eventChance(0) { }
-    WaypointNode(uint32 _id, float _x, float _y, float _z, float _orientation = 0.f, uint32 _delay = 0)
+    WaypointNode() : id(0), x(0.f), y(0.f), z(0.f), delay(0), eventId(0), moveType(WAYPOINT_MOVE_TYPE_RUN), eventChance(0) { }
+    WaypointNode(uint32 _id, float _x, float _y, float _z, float _orientation = { }, uint32 _delay = 0)
     {
         id = _id;
         x = _x;
@@ -48,7 +49,8 @@ struct WaypointNode
     }
 
     uint32 id;
-    float x, y, z, orientation;
+    float x, y, z;
+    Optional<float> orientation;
     uint32 delay;
     uint32 eventId;
     uint32 moveType;

--- a/src/server/game/Movement/Waypoints/WaypointManager.cpp
+++ b/src/server/game/Movement/Waypoints/WaypointManager.cpp
@@ -43,7 +43,9 @@ void WaypointMgr::Load()
         float x = fields[2].GetFloat();
         float y = fields[3].GetFloat();
         float z = fields[4].GetFloat();
-        float o = fields[5].GetFloat();
+        Optional<float> o;
+        if (!fields[5].IsNull())
+            o = fields[5].GetFloat();
 
         Trinity::NormalizeMapCoord(x);
         Trinity::NormalizeMapCoord(y);
@@ -100,7 +102,9 @@ void WaypointMgr::ReloadPath(uint32 id)
         float x = fields[1].GetFloat();
         float y = fields[2].GetFloat();
         float z = fields[3].GetFloat();
-        float o = fields[4].GetFloat();
+        Optional<float> o;
+        if (!fields[4].IsNull())
+            o = fields[4].GetFloat();
 
         Trinity::NormalizeMapCoord(x);
         Trinity::NormalizeMapCoord(y);

--- a/src/server/game/Scripting/ScriptSystem.cpp
+++ b/src/server/game/Scripting/ScriptSystem.cpp
@@ -80,7 +80,7 @@ void SystemMgr::LoadScriptWaypoints()
 
         WaypointPath& path = _waypointStore[entry];
         path.id = entry;
-        path.nodes.emplace_back(id, x, y, z, 0.f, waitTime);
+        path.nodes.emplace_back(id, x, y, z, std::nullopt, waitTime);
 
         ++count;
     } while (result->NextRow());


### PR DESCRIPTION
**Changes proposed:**

-  make waypoint orientation values nullable to support angle values of 0 as well as there actually are some cases that use such values

Closes #26037

**Target branch(es):**
- 3.3.5

**Tests performed:**
- tested on 4.x, no issues discovered
