### PR TITLE
Core/Pet: Don't allow to tame pets that have already a owner

### DIFF
--- a/src/server/scripts/Spells/spell_hunter.cpp
+++ b/src/server/scripts/Spells/spell_hunter.cpp
@@ -1177,6 +1177,12 @@ class spell_hun_tame_beast : public SpellScript
 
             if (caster->GetCharmedGUID())
                 return SPELL_FAILED_ALREADY_HAVE_CHARM;
+
+            if (target->GetOwnerGUID())
+            {
+                caster->SendTameFailure(PETTAME_CREATUREALREADYOWNED);
+                return SPELL_FAILED_DONT_REPORT;
+            }
         }
         else
             return SPELL_FAILED_BAD_IMPLICIT_TARGETS;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't allow to tame pets that have already a owner
- Example at https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=37134 in 25H , the summoned https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=38154 should not be tameable by a player

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Ref #26325 maybe


**Tests performed:**

Tried to tame the summon of https://tcubuntu.northeurope.cloudapp.azure.com/aowow/?npc=37134 in ICC 25H before and after this PR


**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
