### PR TITLE
Core/Spawns: prevent spawn groups from bypassing spawnMask restrictions

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3408,6 +3408,10 @@ bool Map::SpawnGroupSpawn(uint32 groupId, bool ignoreRespawn, bool force, std::v
 
     for (SpawnData const* data : toSpawn)
     {
+        // don't spawn if the current map difficulty is not used by the spawn
+        if (!(data->spawnMask & (1 << GetSpawnMode())))
+            continue;
+
         // don't spawn if the grid isn't loaded (will be handled in grid loader)
         if (!IsGridLoaded(data->spawnPoint))
             continue;


### PR DESCRIPTION

**Changes proposed:**
-  spawn groups were able to completely ignore spawnMasks, allowing them to spawn for all difficulties. That's fixed now and can no longer happen. No more 25 player spawns in 10 player mode.

**Target branch(es):** 
- 3.3.5

**Tests performed:**
 tested on 4.x in firelands

