### PR TITLE
Core/Spells: defined and implemented SPELL_ATTR7_CANT_DODGE, SPELL_ATTR7_CANT_PARRY and SPELL_ATTR7_CANT_MISS

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2447,6 +2447,9 @@ SpellMissInfo WorldObject::MagicSpellHitResult(Unit* victim, SpellInfo const* sp
     if (!victim->IsAlive() && victim->GetTypeId() != TYPEID_PLAYER)
         return SPELL_MISS_NONE;
 
+    if (spellInfo->HasAttribute(SPELL_ATTR7_CANT_MISS))
+        return SPELL_MISS_NONE;
+
     SpellSchoolMask schoolMask = spellInfo->GetSchoolMask();
     // PvP - PvE spell misschances per leveldif > 2
     int32 lchance = victim->GetTypeId() == TYPEID_PLAYER ? 7 : 11;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2421,8 +2421,8 @@ SpellMissInfo Unit::MeleeSpellHitResult(Unit* victim, SpellInfo const* spellInfo
     if (spellInfo->HasAttribute(SPELL_ATTR0_IMPOSSIBLE_DODGE_PARRY_BLOCK))
         return SPELL_MISS_NONE;
 
-    bool canDodge = true;
-    bool canParry = true;
+    bool canDodge = !spellInfo->HasAttribute(SPELL_ATTR7_CANT_DODGE);
+    bool canParry = !spellInfo->HasAttribute(SPELL_ATTR7_CANT_PARRY);
     bool canBlock = spellInfo->HasAttribute(SPELL_ATTR3_BLOCKABLE_SPELL);
 
     // if victim is casting or cc'd it can't avoid attacks
@@ -12050,6 +12050,10 @@ int32 Unit::CalculateAOEAvoidance(int32 damage, uint32 schoolMask, ObjectGuid co
 // Crit or block - determined on damage calculation phase! (and can be both in some time)
 float Unit::MeleeSpellMissChance(Unit const* victim, WeaponAttackType attType, int32 skillDiff, uint32 spellId) const
 {
+    SpellInfo const* spellInfo = spellId ? sSpellMgr->GetSpellInfo(spellId) : nullptr;
+    if (spellInfo && spellInfo->HasAttribute(SPELL_ATTR7_CANT_MISS))
+        return 0.f;
+
     //calculate miss chance
     float missChance = victim->GetUnitMissChance();
 

--- a/src/server/shared/SharedDefines.h
+++ b/src/server/shared/SharedDefines.h
@@ -684,9 +684,9 @@ enum SpellAttr7 : uint32
     SPELL_ATTR7_UNK20                            = 0x00100000, // TITLE Unknown attribute 20@Attr7 DESCRIPTION Invulnerability related?
     SPELL_ATTR7_UNK21                            = 0x00200000, // TITLE Unknown attribute 21@Attr7
     SPELL_ATTR7_IGNORE_COLD_WEATHER_FLYING       = 0x00400000, // TITLE Ignore cold weather flying restriction DESCRIPTION Set for loaner mounts, allows them to be used despite lacking required flight skill
-    SPELL_ATTR7_UNK23                            = 0x00800000, // TITLE Unknown attribute 23@Attr7
-    SPELL_ATTR7_UNK24                            = 0x01000000, // TITLE Unknown attribute 24@Attr7
-    SPELL_ATTR7_UNK25                            = 0x02000000, // TITLE Unknown attribute 25@Attr7
+    SPELL_ATTR7_CANT_DODGE                       = 0x00800000, // TITLE Spell cannot be dodged
+    SPELL_ATTR7_CANT_PARRY                       = 0x01000000, // TITLE Spell cannot be parried
+    SPELL_ATTR7_CANT_MISS                        = 0x02000000, // TITLE Spell cannot be missed
     SPELL_ATTR7_UNK26                            = 0x04000000, // TITLE Unknown attribute 26@Attr7
     SPELL_ATTR7_UNK27                            = 0x08000000, // TITLE Unknown attribute 27@Attr7
     SPELL_ATTR7_CONSOLIDATED_RAID_BUFF           = 0x10000000, // TITLE Consolidate in raid buff frame (client only)

--- a/src/server/shared/enuminfo_SharedDefines.cpp
+++ b/src/server/shared/enuminfo_SharedDefines.cpp
@@ -1194,9 +1194,9 @@ TC_API_EXPORT EnumText EnumUtils<SpellAttr7>::ToString(SpellAttr7 value)
         case SPELL_ATTR7_UNK20: return { "SPELL_ATTR7_UNK20", "Unknown attribute 20@Attr7", "Invulnerability related?" };
         case SPELL_ATTR7_UNK21: return { "SPELL_ATTR7_UNK21", "Unknown attribute 21@Attr7", "" };
         case SPELL_ATTR7_IGNORE_COLD_WEATHER_FLYING: return { "SPELL_ATTR7_IGNORE_COLD_WEATHER_FLYING", "Ignore cold weather flying restriction", "Set for loaner mounts, allows them to be used despite lacking required flight skill" };
-        case SPELL_ATTR7_UNK23: return { "SPELL_ATTR7_UNK23", "Unknown attribute 23@Attr7", "" };
-        case SPELL_ATTR7_UNK24: return { "SPELL_ATTR7_UNK24", "Unknown attribute 24@Attr7", "" };
-        case SPELL_ATTR7_UNK25: return { "SPELL_ATTR7_UNK25", "Unknown attribute 25@Attr7", "" };
+        case SPELL_ATTR7_CANT_DODGE: return { "SPELL_ATTR7_CANT_DODGE", "Spell cannot be dodged", "" };
+        case SPELL_ATTR7_CANT_PARRY: return { "SPELL_ATTR7_CANT_PARRY", "Spell cannot be parried", "" };
+        case SPELL_ATTR7_CANT_MISS: return { "SPELL_ATTR7_CANT_MISS", "Spell cannot be missed", "" };
         case SPELL_ATTR7_UNK26: return { "SPELL_ATTR7_UNK26", "Unknown attribute 26@Attr7", "" };
         case SPELL_ATTR7_UNK27: return { "SPELL_ATTR7_UNK27", "Unknown attribute 27@Attr7", "" };
         case SPELL_ATTR7_CONSOLIDATED_RAID_BUFF: return { "SPELL_ATTR7_CONSOLIDATED_RAID_BUFF", "Consolidate in raid buff frame (client only)", "" };
@@ -1238,9 +1238,9 @@ TC_API_EXPORT SpellAttr7 EnumUtils<SpellAttr7>::FromIndex(size_t index)
         case 20: return SPELL_ATTR7_UNK20;
         case 21: return SPELL_ATTR7_UNK21;
         case 22: return SPELL_ATTR7_IGNORE_COLD_WEATHER_FLYING;
-        case 23: return SPELL_ATTR7_UNK23;
-        case 24: return SPELL_ATTR7_UNK24;
-        case 25: return SPELL_ATTR7_UNK25;
+        case 23: return SPELL_ATTR7_CANT_DODGE;
+        case 24: return SPELL_ATTR7_CANT_PARRY;
+        case 25: return SPELL_ATTR7_CANT_MISS;
         case 26: return SPELL_ATTR7_UNK26;
         case 27: return SPELL_ATTR7_UNK27;
         case 28: return SPELL_ATTR7_CONSOLIDATED_RAID_BUFF;
@@ -1279,9 +1279,9 @@ TC_API_EXPORT size_t EnumUtils<SpellAttr7>::ToIndex(SpellAttr7 value)
         case SPELL_ATTR7_UNK20: return 20;
         case SPELL_ATTR7_UNK21: return 21;
         case SPELL_ATTR7_IGNORE_COLD_WEATHER_FLYING: return 22;
-        case SPELL_ATTR7_UNK23: return 23;
-        case SPELL_ATTR7_UNK24: return 24;
-        case SPELL_ATTR7_UNK25: return 25;
+        case SPELL_ATTR7_CANT_DODGE: return 23;
+        case SPELL_ATTR7_CANT_PARRY: return 24;
+        case SPELL_ATTR7_CANT_MISS: return 25;
         case SPELL_ATTR7_UNK26: return 26;
         case SPELL_ATTR7_UNK27: return 27;
         case SPELL_ATTR7_CONSOLIDATED_RAID_BUFF: return 28;


### PR DESCRIPTION
**Changes proposed:**

- Define and implement SPELL_ATTR7_CANT_DODGE, SPELL_ATTR7_CANT_PARRY and SPELL_ATTR7_CANT_MISS
-  Fix hit chance of: Rogue Mutilate main and off hand damage, Warrior Shattering Throw, ICC - Blood Princes Empowered Shadow Lance and ICC - Sindragosa Icy Grip

original commit: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/6052573c87de75414e42dd0c6831603017c18dd4 by @Ovahlord 

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

None


**Tests performed:**

tested in-game
