### PR TITLE
Core/Unit: Changes to stunned unit behavior

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11326,6 +11326,10 @@ void Unit::SetStunned(bool apply)
 
             RemoveUnitMovementFlag(MOVEMENTFLAG_ROOT);
         }
+
+        // sends a unit back home in case the effect ends and the unit is not in combat
+        if (IsAlive() && !IsPlayer() && !IsInCombat())
+            GetMotionMaster()->MoveTargetedHome();
     }
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  Send units back home after stun in case there is no combat
-  should get rid of remaining problems outlined here: https://github.com/TrinityCore/TrinityCore/issues/26721#issuecomment-882577305

With a very high chance, several units could get stuck on their current position like shown in the screenshot below.
With this change, affected units return home in all test cases (10/10)
<details>

![WoWScrnShot_072421_121331](https://user-images.githubusercontent.com/37972361/126867295-9bdbceb1-9981-4914-9610-ed2c9bc45933.jpg)

</details>



**Target branch(es):** 3.3.5/master

- [x] 3.3.5

**Issues addressed:**

Closes  https://github.com/TrinityCore/TrinityCore/issues/26721


**Tests performed:**

- [x] Builds
- [x] tested ingame


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] If someone is aware of any situation where this could break something, please let me know or check it with this PR. I cant think of any case where the current behavior would be wanted.
