### PR TITLE
Core/Quest: When removing an item required for a quest, update every quest in the quest log instead of stopping at the first objective that matches the removed item.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16406,7 +16406,6 @@ void Player::ItemRemovedQuestCheck(uint32 entry, uint32 count)
                     m_QuestStatusSave[questid] = QUEST_DEFAULT_SAVE_TYPE;
                     IncompleteQuest(questid);
                 }
-                return;
             }
         }
     }


### PR DESCRIPTION
**Changes proposed:**

-  When removing an item required for a quest, update every quest in the quest log instead of stopping at the first objective that matches the removed item.
-  As it was done here ( 91f214cd220e3f23ff713853f991ffc7d323173a ) when obtaining an item necessary to complete the quest, do the same when item is removed.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #25662 and maybe #10586 (is it the same issue?)


**Tests performed:**

tested in-game with #25662 steps
