### PR TITLE
Core/Creature: rename CREATURE_FLAG_EXTRA_IGNORE_COMBAT into CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -44,8 +44,8 @@
         return false;
     if (a->HasUnitState(UNIT_STATE_IN_FLIGHT) || b->HasUnitState(UNIT_STATE_IN_FLIGHT))
         return false;
-    // ... both units must not be ignoring combat
-    if (a->IsIgnoringCombat() || b->IsIgnoringCombat())
+    // ... both units must be allowed to enter combat
+    if (a->IsCombatDisallowed() || b->IsCombatDisallowed())
         return false;
     if (a->IsFriendlyTo(b) || b->IsFriendlyTo(a))
         return false;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -621,7 +621,7 @@ bool Creature::UpdateEntry(uint32 entry, CreatureData const* data /*= nullptr*/,
         ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_ATTACK_ME, true);
     }
 
-    SetIgnoringCombat((cInfo->flags_extra & CREATURE_FLAG_EXTRA_IGNORE_COMBAT) != 0);
+    SetIsCombatDisallowed((cInfo->flags_extra & CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT) != 0);
 
     LoadTemplateRoot();
     InitializeMovementFlags();
@@ -1182,7 +1182,7 @@ Unit* Creature::SelectVictim()
 
 void Creature::InitializeReactState()
 {
-    if (IsTotem() || IsTrigger() || IsCritter() || IsSpiritService())
+    if (IsTotem() || IsTrigger() || IsCritter() || IsSpiritService() || (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_IGNORE_COMBAT))
         SetReactState(REACT_PASSIVE);
     /*
     else if (IsCivilian())

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1182,7 +1182,7 @@ Unit* Creature::SelectVictim()
 
 void Creature::InitializeReactState()
 {
-    if (IsTotem() || IsTrigger() || IsCritter() || IsSpiritService() || (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_IGNORE_COMBAT))
+    if (IsTotem() || IsTrigger() || IsCritter() || IsSpiritService())
         SetReactState(REACT_PASSIVE);
     /*
     else if (IsCivilian())

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -56,7 +56,7 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS = 0x00080000,       // Taunt is subject to diminishing returns on this creature
     CREATURE_FLAG_EXTRA_ALL_DIMINISH         = 0x00100000,       // creature is subject to all diminishing returns as players are
     CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ = 0x00200000,       // creature does not need to take player damage for kill credit
-    CREATURE_FLAG_EXTRA_IGNORE_COMBAT        = 0x00400000,       // changes react state to REACT_PASSIVE, based on original difficulty flag
+    CREATURE_FLAG_EXTRA_UNUSED_22            = 0x00400000,
     CREATURE_FLAG_EXTRA_UNUSED_23            = 0x00800000,
     CREATURE_FLAG_EXTRA_UNUSED_24            = 0x01000000,
     CREATURE_FLAG_EXTRA_UNUSED_25            = 0x02000000,
@@ -68,7 +68,8 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_UNUSED_31            = 0x80000000,
 
     // Masks
-    CREATURE_FLAG_EXTRA_UNUSED               = (CREATURE_FLAG_EXTRA_UNUSED_23 | CREATURE_FLAG_EXTRA_UNUSED_24 | CREATURE_FLAG_EXTRA_UNUSED_25 |
+    CREATURE_FLAG_EXTRA_UNUSED               = (CREATURE_FLAG_EXTRA_UNUSED_22 |
+                                                CREATURE_FLAG_EXTRA_UNUSED_23 | CREATURE_FLAG_EXTRA_UNUSED_24 | CREATURE_FLAG_EXTRA_UNUSED_25 |
                                                 CREATURE_FLAG_EXTRA_UNUSED_26 | CREATURE_FLAG_EXTRA_UNUSED_27 | CREATURE_FLAG_EXTRA_UNUSED_31), // SKIP
 
     CREATURE_FLAG_EXTRA_DB_ALLOWED           = (0xFFFFFFFF & ~(CREATURE_FLAG_EXTRA_UNUSED | CREATURE_FLAG_EXTRA_DUNGEON_BOSS)) // SKIP

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -47,7 +47,7 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_GHOST_VISIBILITY     = 0x00000400,       // creature will only be visible to dead players
     CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK   = 0x00000800,       // creature will use offhand attacks
     CREATURE_FLAG_EXTRA_NO_SELL_VENDOR       = 0x00001000,       // players can't sell items to this vendor
-    CREATURE_FLAG_EXTRA_IGNORE_COMBAT        = 0x00002000,       // creature is not allowed to enter combat
+    CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT  = 0x00002000,       // creature is not allowed to enter combat
     CREATURE_FLAG_EXTRA_WORLDEVENT           = 0x00004000,       // custom flag for world event creatures (left room for merging)
     CREATURE_FLAG_EXTRA_GUARD                = 0x00008000,       // Creature is guard
     CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH   = 0x00010000,       // creature ignores feign death
@@ -56,7 +56,7 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS = 0x00080000,       // Taunt is subject to diminishing returns on this creature
     CREATURE_FLAG_EXTRA_ALL_DIMINISH         = 0x00100000,       // creature is subject to all diminishing returns as players are
     CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ = 0x00200000,       // creature does not need to take player damage for kill credit
-    CREATURE_FLAG_EXTRA_UNUSED_22            = 0x00400000,
+    CREATURE_FLAG_EXTRA_IGNORE_COMBAT        = 0x00400000,       // changes react state to REACT_PASSIVE, based on original difficulty flag
     CREATURE_FLAG_EXTRA_UNUSED_23            = 0x00800000,
     CREATURE_FLAG_EXTRA_UNUSED_24            = 0x01000000,
     CREATURE_FLAG_EXTRA_UNUSED_25            = 0x02000000,
@@ -68,8 +68,7 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_UNUSED_31            = 0x80000000,
 
     // Masks
-    CREATURE_FLAG_EXTRA_UNUSED               = (CREATURE_FLAG_EXTRA_UNUSED_22 |
-                                                CREATURE_FLAG_EXTRA_UNUSED_23 | CREATURE_FLAG_EXTRA_UNUSED_24 | CREATURE_FLAG_EXTRA_UNUSED_25 |
+    CREATURE_FLAG_EXTRA_UNUSED               = (CREATURE_FLAG_EXTRA_UNUSED_23 | CREATURE_FLAG_EXTRA_UNUSED_24 | CREATURE_FLAG_EXTRA_UNUSED_25 |
                                                 CREATURE_FLAG_EXTRA_UNUSED_26 | CREATURE_FLAG_EXTRA_UNUSED_27 | CREATURE_FLAG_EXTRA_UNUSED_31), // SKIP
 
     CREATURE_FLAG_EXTRA_DB_ALLOWED           = (0xFFFFFFFF & ~(CREATURE_FLAG_EXTRA_UNUSED | CREATURE_FLAG_EXTRA_DUNGEON_BOSS)) // SKIP

--- a/src/server/game/Entities/Creature/enuminfo_CreatureData.cpp
+++ b/src/server/game/Entities/Creature/enuminfo_CreatureData.cpp
@@ -44,7 +44,7 @@ TC_API_EXPORT EnumText EnumUtils<CreatureFlagsExtra>::ToString(CreatureFlagsExtr
         case CREATURE_FLAG_EXTRA_GHOST_VISIBILITY: return { "CREATURE_FLAG_EXTRA_GHOST_VISIBILITY", "CREATURE_FLAG_EXTRA_GHOST_VISIBILITY", "creature will only be visible to dead players" };
         case CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK: return { "CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK", "CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK", "creature will use offhand attacks" };
         case CREATURE_FLAG_EXTRA_NO_SELL_VENDOR: return { "CREATURE_FLAG_EXTRA_NO_SELL_VENDOR", "CREATURE_FLAG_EXTRA_NO_SELL_VENDOR", "players can't sell items to this vendor" };
-        case CREATURE_FLAG_EXTRA_IGNORE_COMBAT: return { "CREATURE_FLAG_EXTRA_IGNORE_COMBAT", "CREATURE_FLAG_EXTRA_IGNORE_COMBAT", "creature is not allowed to enter combat" };
+        case CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT: return { "CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT", "CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT", "creature is not allowed to enter combat" };
         case CREATURE_FLAG_EXTRA_WORLDEVENT: return { "CREATURE_FLAG_EXTRA_WORLDEVENT", "CREATURE_FLAG_EXTRA_WORLDEVENT", "custom flag for world event creatures (left room for merging)" };
         case CREATURE_FLAG_EXTRA_GUARD: return { "CREATURE_FLAG_EXTRA_GUARD", "CREATURE_FLAG_EXTRA_GUARD", "Creature is guard" };
         case CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH: return { "CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH", "CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH", "creature ignores feign death" };
@@ -53,7 +53,7 @@ TC_API_EXPORT EnumText EnumUtils<CreatureFlagsExtra>::ToString(CreatureFlagsExtr
         case CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS: return { "CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS", "CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS", "Taunt is subject to diminishing returns on this creature" };
         case CREATURE_FLAG_EXTRA_ALL_DIMINISH: return { "CREATURE_FLAG_EXTRA_ALL_DIMINISH", "CREATURE_FLAG_EXTRA_ALL_DIMINISH", "creature is subject to all diminishing returns as players are" };
         case CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ: return { "CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ", "CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ", "creature does not need to take player damage for kill credit" };
-        case CREATURE_FLAG_EXTRA_UNUSED_22: return { "CREATURE_FLAG_EXTRA_UNUSED_22", "CREATURE_FLAG_EXTRA_UNUSED_22", "" };
+        case CREATURE_FLAG_EXTRA_IGNORE_COMBAT: return { "CREATURE_FLAG_EXTRA_IGNORE_COMBAT", "CREATURE_FLAG_EXTRA_IGNORE_COMBAT", "changes react state to REACT_PASSIVE, based on original difficulty flag" };
         case CREATURE_FLAG_EXTRA_UNUSED_23: return { "CREATURE_FLAG_EXTRA_UNUSED_23", "CREATURE_FLAG_EXTRA_UNUSED_23", "" };
         case CREATURE_FLAG_EXTRA_UNUSED_24: return { "CREATURE_FLAG_EXTRA_UNUSED_24", "CREATURE_FLAG_EXTRA_UNUSED_24", "" };
         case CREATURE_FLAG_EXTRA_UNUSED_25: return { "CREATURE_FLAG_EXTRA_UNUSED_25", "CREATURE_FLAG_EXTRA_UNUSED_25", "" };
@@ -88,7 +88,7 @@ TC_API_EXPORT CreatureFlagsExtra EnumUtils<CreatureFlagsExtra>::FromIndex(size_t
         case 10: return CREATURE_FLAG_EXTRA_GHOST_VISIBILITY;
         case 11: return CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK;
         case 12: return CREATURE_FLAG_EXTRA_NO_SELL_VENDOR;
-        case 13: return CREATURE_FLAG_EXTRA_IGNORE_COMBAT;
+        case 13: return CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT;
         case 14: return CREATURE_FLAG_EXTRA_WORLDEVENT;
         case 15: return CREATURE_FLAG_EXTRA_GUARD;
         case 16: return CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH;
@@ -97,7 +97,7 @@ TC_API_EXPORT CreatureFlagsExtra EnumUtils<CreatureFlagsExtra>::FromIndex(size_t
         case 19: return CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS;
         case 20: return CREATURE_FLAG_EXTRA_ALL_DIMINISH;
         case 21: return CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ;
-        case 22: return CREATURE_FLAG_EXTRA_UNUSED_22;
+        case 22: return CREATURE_FLAG_EXTRA_IGNORE_COMBAT;
         case 23: return CREATURE_FLAG_EXTRA_UNUSED_23;
         case 24: return CREATURE_FLAG_EXTRA_UNUSED_24;
         case 25: return CREATURE_FLAG_EXTRA_UNUSED_25;
@@ -129,7 +129,7 @@ TC_API_EXPORT size_t EnumUtils<CreatureFlagsExtra>::ToIndex(CreatureFlagsExtra v
         case CREATURE_FLAG_EXTRA_GHOST_VISIBILITY: return 10;
         case CREATURE_FLAG_EXTRA_USE_OFFHAND_ATTACK: return 11;
         case CREATURE_FLAG_EXTRA_NO_SELL_VENDOR: return 12;
-        case CREATURE_FLAG_EXTRA_IGNORE_COMBAT: return 13;
+        case CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT: return 13;
         case CREATURE_FLAG_EXTRA_WORLDEVENT: return 14;
         case CREATURE_FLAG_EXTRA_GUARD: return 15;
         case CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH: return 16;
@@ -138,7 +138,7 @@ TC_API_EXPORT size_t EnumUtils<CreatureFlagsExtra>::ToIndex(CreatureFlagsExtra v
         case CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS: return 19;
         case CREATURE_FLAG_EXTRA_ALL_DIMINISH: return 20;
         case CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ: return 21;
-        case CREATURE_FLAG_EXTRA_UNUSED_22: return 22;
+        case CREATURE_FLAG_EXTRA_IGNORE_COMBAT: return 22;
         case CREATURE_FLAG_EXTRA_UNUSED_23: return 23;
         case CREATURE_FLAG_EXTRA_UNUSED_24: return 24;
         case CREATURE_FLAG_EXTRA_UNUSED_25: return 25;

--- a/src/server/game/Entities/Creature/enuminfo_CreatureData.cpp
+++ b/src/server/game/Entities/Creature/enuminfo_CreatureData.cpp
@@ -53,7 +53,7 @@ TC_API_EXPORT EnumText EnumUtils<CreatureFlagsExtra>::ToString(CreatureFlagsExtr
         case CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS: return { "CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS", "CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS", "Taunt is subject to diminishing returns on this creature" };
         case CREATURE_FLAG_EXTRA_ALL_DIMINISH: return { "CREATURE_FLAG_EXTRA_ALL_DIMINISH", "CREATURE_FLAG_EXTRA_ALL_DIMINISH", "creature is subject to all diminishing returns as players are" };
         case CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ: return { "CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ", "CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ", "creature does not need to take player damage for kill credit" };
-        case CREATURE_FLAG_EXTRA_IGNORE_COMBAT: return { "CREATURE_FLAG_EXTRA_IGNORE_COMBAT", "CREATURE_FLAG_EXTRA_IGNORE_COMBAT", "changes react state to REACT_PASSIVE, based on original difficulty flag" };
+        case CREATURE_FLAG_EXTRA_UNUSED_22: return { "CREATURE_FLAG_EXTRA_UNUSED_22", "CREATURE_FLAG_EXTRA_UNUSED_22", "" };
         case CREATURE_FLAG_EXTRA_UNUSED_23: return { "CREATURE_FLAG_EXTRA_UNUSED_23", "CREATURE_FLAG_EXTRA_UNUSED_23", "" };
         case CREATURE_FLAG_EXTRA_UNUSED_24: return { "CREATURE_FLAG_EXTRA_UNUSED_24", "CREATURE_FLAG_EXTRA_UNUSED_24", "" };
         case CREATURE_FLAG_EXTRA_UNUSED_25: return { "CREATURE_FLAG_EXTRA_UNUSED_25", "CREATURE_FLAG_EXTRA_UNUSED_25", "" };
@@ -97,7 +97,7 @@ TC_API_EXPORT CreatureFlagsExtra EnumUtils<CreatureFlagsExtra>::FromIndex(size_t
         case 19: return CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS;
         case 20: return CREATURE_FLAG_EXTRA_ALL_DIMINISH;
         case 21: return CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ;
-        case 22: return CREATURE_FLAG_EXTRA_IGNORE_COMBAT;
+        case 22: return CREATURE_FLAG_EXTRA_UNUSED_22;
         case 23: return CREATURE_FLAG_EXTRA_UNUSED_23;
         case 24: return CREATURE_FLAG_EXTRA_UNUSED_24;
         case 25: return CREATURE_FLAG_EXTRA_UNUSED_25;
@@ -138,7 +138,7 @@ TC_API_EXPORT size_t EnumUtils<CreatureFlagsExtra>::ToIndex(CreatureFlagsExtra v
         case CREATURE_FLAG_EXTRA_OBEYS_TAUNT_DIMINISHING_RETURNS: return 19;
         case CREATURE_FLAG_EXTRA_ALL_DIMINISH: return 20;
         case CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ: return 21;
-        case CREATURE_FLAG_EXTRA_IGNORE_COMBAT: return 22;
+        case CREATURE_FLAG_EXTRA_UNUSED_22: return 22;
         case CREATURE_FLAG_EXTRA_UNUSED_23: return 23;
         case CREATURE_FLAG_EXTRA_UNUSED_24: return 24;
         case CREATURE_FLAG_EXTRA_UNUSED_25: return 25;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -388,7 +388,7 @@ Unit::Unit(bool isWorldObject) :
     _oldFactionId = 0;
     _isWalkingBeforeCharm = false;
     _instantCast = false;
-    _isIgnoringCombat = false;
+    _isCombatDisallowed = false;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1741,10 +1741,10 @@ class TC_GAME_API Unit : public WorldObject
 
         float GetCollisionHeight() const override;
 
-        // returns if the unit is ignoring any combat interaction
-        bool IsIgnoringCombat() const { return _isIgnoringCombat; }
-        // enables/disables combat interaction of this unit.
-        void SetIgnoringCombat(bool apply) { _isIgnoringCombat = apply; }
+        // returns if the unit can't enter combat
+        bool IsCombatDisallowed() const { return _isCombatDisallowed; }
+        // enables / disables combat interaction of this unit
+        void SetIsCombatDisallowed(bool apply) { _isCombatDisallowed = apply; }
 
         std::string GetDebugInfo() const override;
     protected:
@@ -1893,7 +1893,7 @@ class TC_GAME_API Unit : public WorldObject
         SpellHistory* m_spellHistory;
         PositionUpdateInfo _positionUpdateInfo;
 
-        bool _isIgnoringCombat;
+        bool _isCombatDisallowed;
 
         /* Player Movement fields START*/
 


### PR DESCRIPTION
**Changes proposed:**

-  Make No Combat flag purely custom without any reference to original Ignore Combat flag
-  Create Ignore Combat flag which just changes react state to passive

Some quick facts to better understand these changes:

To me it looks like we need improvements here instead of making another custom flag:

```cpp
bool SpellInfo::HasInitialAggro() const
{
    return !(HasAttribute(SPELL_ATTR1_NO_THREAT) || HasAttribute(SPELL_ATTR3_NO_INITIAL_AGGRO));
}
```
For example we have #25628.
Maybe we need to check if more auras should not cause combat? Because we already used that flag several times just to make triggers with auras not cause combat at all to prevent combat stuck. I can't check some of those auras at this moment.

Slightly after that flag was implemented in TC, Ovahlord made some changes to handle it differently: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/a2fa0c2ffae36bc60c0fec68a76a9dd800b21781. If I understand correctly with those changes if creature casts immediate damage spell, it will not enter in combat with player. I checked one creature with that flag and it entered in combat with player after casting such spell. So...
Also it's a DB flag, if we use it wrongly, we'll have to change its implementation later. But since we used it for hundreds of creatures, we'll just break lots of them. And yes, since we can't change that flag at runtime, we'll have to change reactstate directly and that is too not safe. At the same time react state of creatures with that flag will be changed only few times. At least in 3.3.5. But yeah, better to create a completely new function which will change only reactstate only from passive to aggressive to match original AI action(see below). Because if by any chance implementation of that flag will be changed and it will not change react state but something else, we'll have to change all scripts where creature with that flag changes its reactstate. Otherwise those scripts will not work.

The reason why it's named Ignore Combat is because creature... ignores it, does not respond to attacks, that's it.

I was too naive to treat that flag as original Ignore Combat flag and used it only if creature has corresponding difficulty flag. Slighly later I finally understood that that flag even cannot be used where Blizz used it, it simply breaks scripts. I renamed it to match original name, I used it only if creature has corresponding difficulty flag but I can't use it in all cases where Blizz used it. Nonsense.
With current implementation we can't remove effect of that flag via SAI. We should. Some of units with that flags spawns passive and then can became aggressive. Blizz uses actions: Reset "Ignore combat" flag for unit(s) / Set "Ignore combat" flag for unit(s)

**Target branch(es):**

3.3.5

**Issues addressed:**

none

**Tests performed:**

Build, tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none