### PR TITLE
Core/Authserver: Remove redundant conversion during Reconnect Proof cmd

### DIFF
--- a/src/server/authserver/Server/AuthSession.cpp
+++ b/src/server/authserver/Server/AuthSession.cpp
@@ -680,12 +680,9 @@ bool AuthSession::HandleReconnectProof()
     if (_accountInfo.Login.empty())
         return false;
 
-    BigNumber t1;
-    t1.SetBinary(reconnectProof->R1, 16);
-
     Trinity::Crypto::SHA1 sha;
     sha.UpdateData(_accountInfo.Login);
-    sha.UpdateData(t1.ToByteArray<16>());
+    sha.UpdateData(reconnectProof->R1, 16);
     sha.UpdateData(_reconnectProof);
     sha.UpdateData(_sessionKey);
     sha.Finalize();


### PR DESCRIPTION
**Changes proposed:**

Title speaks for itself.

```
BigNumber t1;
t1.SetBinary(reconnectProof->R1, 16);

t1.ToByteArray<16>() == reconnectProof->R1
```

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


**Tests performed:**

Made reconnect to the auth server.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
