### PR TITLE
Core/Quests: check PreviousQuestID values as well when trying to make quest groups available to players

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -5239,7 +5239,7 @@ void ObjectMgr::LoadQuests()
                 TC_LOG_ERROR("sql.sql", "Quest %u has PrevQuestId %i, but no such quest", qinfo->GetQuestId(), qinfo->_prevQuestId);
             else if (prevQuestItr->second._breadcrumbForQuestId)
                 TC_LOG_ERROR("sql.sql", "Quest %u should not be unlocked by breadcrumb quest %u", qinfo->_id, prevQuestId);
-            else
+            else if (qinfo->_prevQuestId > 0)
                 qinfo->DependentPreviousQuests.push_back(prevQuestId);
         }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -5239,6 +5239,8 @@ void ObjectMgr::LoadQuests()
                 TC_LOG_ERROR("sql.sql", "Quest %u has PrevQuestId %i, but no such quest", qinfo->GetQuestId(), qinfo->_prevQuestId);
             else if (prevQuestItr->second._breadcrumbForQuestId)
                 TC_LOG_ERROR("sql.sql", "Quest %u should not be unlocked by breadcrumb quest %u", qinfo->_id, prevQuestId);
+            else
+                qinfo->DependentPreviousQuests.push_back(prevQuestId);
         }
 
         if (uint32 nextQuestId = qinfo->_nextQuestId)


### PR DESCRIPTION
**Changes proposed:**

-  quest groups that required previous quest groups to be rewarded will now function again
Basically this scenario:
![image](https://user-images.githubusercontent.com/18347559/127768620-ba38861d-813e-473f-bde5-275590306f98.png)

Prior to this change, only the NextQuestID field in quest_template_addon was being checked for exclusive groups, breaking the feature to make multiple quests available after finishing an exclusive group

**Target branch(es):** 

- 3.3.5

**Issues addressed:**
- pretty sure there is one, too lazy to search for it

**Tests performed:**
- tested on 4.x


**Known issues and TODO list:** (add/remove lines as needed)
- [ ] test for regressions 

