### PR TITLE
fix missing header when building with dynamic script reloader

### DIFF
--- a/src/server/game/Scripting/ScriptReloadMgr.cpp
+++ b/src/server/game/Scripting/ScriptReloadMgr.cpp
@@ -56,9 +56,9 @@ ScriptReloadMgr* ScriptReloadMgr::instance()
 #include <algorithm>
 #include <fstream>
 #include <future>
-#include <thread>
 #include <memory>
 #include <sstream>
+#include <thread>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/server/game/Scripting/ScriptReloadMgr.cpp
+++ b/src/server/game/Scripting/ScriptReloadMgr.cpp
@@ -56,6 +56,7 @@ ScriptReloadMgr* ScriptReloadMgr::instance()
 #include <algorithm>
 #include <fstream>
 #include <future>
+#include <thread>
 #include <memory>
 #include <sstream>
 #include <type_traits>


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix missing `#include <thread>` causing a compilation error when building with `-DSCRIPTS=dynamic`

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
