### PR TITLE
Core/Combat: Allow refresh pvp combat when assisting a unit that is in pvp combat

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -237,14 +237,11 @@ void CombatManager::InheritCombatStatesFrom(Unit const* who)
     }
     for (auto& ref : mgr._pvpRefs)
     {
-        if (!IsInCombatWith(ref.first))
-        {
-            Unit* target = ref.second->GetOther(who);
-            if ((_owner->IsImmuneToPC() && target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED)) ||
-                (_owner->IsImmuneToNPC() && !target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED)))
-                continue;
-            SetInCombatWith(target);
-        }
+        Unit* target = ref.second->GetOther(who);
+        if ((_owner->IsImmuneToPC() && target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED)) ||
+            (_owner->IsImmuneToNPC() && !target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED)))
+            continue;
+        SetInCombatWith(target);
     }
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  Allow refresh pvp combat when assisting a unit that is in pvp combat

```
Actions that will get you into combat
- Casting a Buff or Healing spell on a unit that is in combat"
```
https://wowwiki-archive.fandom.com/wiki/Combat

If you have player A fighting player B, they are both in pvp combat.
If a third player C (assistant) tries to assist (heal or buff) to player A for example, player C enters in pvp combat (up to this point is correct), but if he continues to assist player A, player C leaves combat at 5 seconds, he should refresh those 5 seconds each time he assists player A.

summoning @Treeston since I'm not very familiar with the combat system, I don't know if this fix is the proper solution.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

None


**Tests performed:**

tested in-game
