### PR TITLE
Core/Spell: Fix Mage Frostfire bolt, now it will not put target into combat at expire

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -572,7 +572,7 @@ class spell_mage_frostfire_bolt : public AuraScript
     void Register() override
     {
         AfterEffectApply += AuraEffectApplyFn(spell_mage_frostfire_bolt::ApplyPermafrost, EFFECT_0, SPELL_AURA_MOD_DECREASE_SPEED, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
-        AfterEffectRemove += AuraEffectRemoveFn(spell_mage_frostfire_bolt::ApplyPermafrost, EFFECT_0, SPELL_AURA_MOD_DECREASE_SPEED, AURA_EFFECT_HANDLE_REAL);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_mage_frostfire_bolt::RemovePermafrost, EFFECT_0, SPELL_AURA_MOD_DECREASE_SPEED, AURA_EFFECT_HANDLE_REAL);
     }
 };
 


### PR DESCRIPTION
**Changes proposed:**

- well i think it's easy to see, a silly mistake
-  commit by ariel- https://github.com/TrinityCore/TrinityCore/commit/bd3530dd1f71ce0cd4ce8368af3947cb525349b2#diff-ad8a1f47bc6f70bb19d62d0c3067532e0200177601d12b7fd1bad284da57c9afR684


**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

Closes #24652


**Tests performed:**

tested in-game
