### PR TITLE
Scripts/World: improve Training Dummy script

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -1464,11 +1464,16 @@ struct npc_training_dummy : NullCreatureAI
 {
     npc_training_dummy(Creature* creature) : NullCreatureAI(creature) { }
 
-    void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
+    void JustEnteredCombat(Unit* who) override
+    {
+        _combatTimer[who->GetGUID()] = 5s;
+    }
+
+    void DamageTaken(Unit* attacker, uint32& damage, DamageEffectType damageType, SpellInfo const* /*spellInfo = nullptr*/) override
     {
         damage = 0;
 
-        if (!attacker)
+        if (!attacker || damageType == DOT)
             return;
 
         _combatTimer[attacker->GetGUID()] = 5s;


### PR DESCRIPTION
**Changes proposed:**

-  Check _combatTimer when you hit Training Dummy with a spell that can't do any damage, by example with taunt, to avoid staying in combat
-  When you cause DoT damage to Training Dummy, you shouldn't refresh combat timer, so I decided check DamageType to exclude DoT's damage<s>, I created DamageEffectTypeTaken because modify all DamageTaken for one script seems too excessive for me</s>
-  Here I leave some proofs of how damage DoT does not refresh the combat in Training Dummies:
https://www.youtube.com/watch?v=R48XiVuLl3E <-- 3:08 hit Training Dummy and enter in combat (Stealth darkens when entering combat), 4:06 stop attack and Training Dummy has DoT, 4:12 leave combat (Stealth can be used again)
https://www.youtube.com/watch?v=h3UXFdwc04s <-- 0:23 leave combat and Training Dummy has DoT's

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

None

**Tests performed:**

 tested in-game
