### PR TITLE
Scripts/Spells: Fix support for 'Teleport This!' (10857)

### DIFF
--- a/sql/updates/world/3.3.5/2021_08_09_55_world.sql
+++ b/sql/updates/world/3.3.5/2021_08_09_55_world.sql
@@ -1,0 +1,8 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (16943,20928) AND `source_type` = 0 AND `id` IN (3,4,5);
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (22348,22350,22351) AND `source_type` = 0;
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (22348,22350,22351);
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 38920 AND `ScriptName` = 'spell_detonate_teleporter';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(38920,'spell_detonate_teleporter');


### PR DESCRIPTION
**Changes proposed:**

https://github.com/TrinityCore/TrinityCore/commit/c00b0551345245c2a91db2e1b62a13fa969c218e removed SMART_EVENT_FLAG_WHILE_CHARMED if creature didn't had VehicleId or CREATURE_DIFFICULTYFLAGS_2_ACTION_TRIGGERS_WHILE_CHARMED. That quest is broken now because involved creatures don't have that flag, means quest is scripted somewhere else. Instead of simply restoring SMART_EVENT_FLAG_WHILE_CHARMED I decided to use spell script to fix the quest so we will not enconter same problem in future.

During that quest you need to posess a creature and cast spell from its pet bar which gives player quest credit.

**Target branch(es):**

3.3.5

**Issues addressed:**

Closes #26780

**Tests performed:**

Builds, tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none