### PR TITLE
Core/Item: Fixed another possible container exploit due to invalid lo…

### DIFF
--- a/src/server/game/Loot/LootItemStorage.cpp
+++ b/src/server/game/Loot/LootItemStorage.cpp
@@ -32,7 +32,7 @@ namespace
     std::unordered_map<uint32, StoredLootContainer> _lootItemStore;
 }
 
-StoredLootItem::StoredLootItem(LootItem const& lootItem) : ItemId(lootItem.itemid), Count(lootItem.count), FollowRules(lootItem.follow_loot_rules),
+StoredLootItem::StoredLootItem(LootItem const& lootItem) : ItemId(lootItem.itemid), Count(lootItem.count), ItemIndex(lootItem.itemIndex), FollowRules(lootItem.follow_loot_rules),
 FFA(lootItem.freeforall), Blocked(lootItem.is_blocked), Counted(lootItem.is_counted), UnderThreshold(lootItem.is_underthreshold),
 NeedsQuest(lootItem.needs_quest), RandomPropertyId(lootItem.randomPropertyId), RandomSuffix(lootItem.randomSuffix)
 {
@@ -157,6 +157,7 @@ bool LootItemStorage::LoadStoredLoot(Item* item, Player* player)
             LootItem li;
             li.itemid = storedItemPair.first;
             li.count = storedItemPair.second.Count;
+            li.itemIndex = storedItemPair.second.ItemIndex;
             li.follow_loot_rules = storedItemPair.second.FollowRules;
             li.freeforall = storedItemPair.second.FFA;
             li.is_blocked = storedItemPair.second.Blocked;

--- a/src/server/game/Loot/LootItemStorage.h
+++ b/src/server/game/Loot/LootItemStorage.h
@@ -35,6 +35,7 @@ struct StoredLootItem
 
     uint32 ItemId;
     uint32 Count;
+    uint32 ItemIndex;
     bool FollowRules;
     bool FFA;
     bool Blocked;


### PR DESCRIPTION
…ading of stored loot items in DB

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Load container loot item index correctly from DB

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
**Issues addressed:**

Closes #  (insert issue tracker number)
Followup of https://github.com/TrinityCore/TrinityCore/commit/d1e913162e0a96918c70ba4ec3f62f4186ee4707

**Tests performed:**
- [ ] Partially loot container, leave non unique items inside and restart server and loot another item. Restart and it should refill recently looted item. 

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
