### PR TITLE
Core/Script: fix Silithus Wind Stone exploit

### DIFF
--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -1331,50 +1331,65 @@ class go_wind_stone : public GameObjectScript
                     switch (action)
                     {
                         case GOSSIP_ACTION_INFO_DEF + 1:
+                            player->CastSpell(player, SPELL_TEMPLAR_RANDOM);
                             SummonNPC(me, player, RAND(NPC_TEMPLAR_WATER, NPC_TEMPLAR_FIRE, NPC_TEMPLAR_EARTH, NPC_TEMPLAR_AIR), SPELL_TEMPLAR_RANDOM);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 2:
+                            player->CastSpell(player, SPELL_TEMPLAR_FIRE);
                             SummonNPC(me, player, NPC_TEMPLAR_FIRE, SPELL_TEMPLAR_FIRE);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 3:
+                            player->CastSpell(player, SPELL_TEMPLAR_WATER);
                             SummonNPC(me, player, NPC_TEMPLAR_WATER, SPELL_TEMPLAR_WATER);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 4:
+                            player->CastSpell(player, SPELL_TEMPLAR_EARTH);
                             SummonNPC(me, player, NPC_TEMPLAR_EARTH, SPELL_TEMPLAR_EARTH);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 5:
+                            player->CastSpell(player, SPELL_TEMPLAR_AIR);
                             SummonNPC(me, player, NPC_TEMPLAR_AIR, SPELL_TEMPLAR_AIR);
                             break;
 
                         case GOSSIP_ACTION_INFO_DEF + 6:
+                            player->CastSpell(player, SPELL_DUKE_RANDOM);
                             SummonNPC(me, player, RAND(NPC_DUKE_FIRE, NPC_DUKE_WATER, NPC_DUKE_EARTH, NPC_DUKE_AIR), SPELL_DUKE_RANDOM);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 7:
+                            player->CastSpell(player, SPELL_DUKE_FIRE);
                             SummonNPC(me, player, NPC_DUKE_FIRE, SPELL_DUKE_FIRE);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 8:
+                            player->CastSpell(player, SPELL_DUKE_WATER);
                             SummonNPC(me, player, NPC_DUKE_WATER, SPELL_DUKE_WATER);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 9:
+                            player->CastSpell(player, SPELL_DUKE_EARTH);
                             SummonNPC(me, player, NPC_DUKE_EARTH, SPELL_DUKE_EARTH);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 10:
+                            player->CastSpell(player, SPELL_DUKE_AIR);
                             SummonNPC(me, player, NPC_DUKE_AIR, SPELL_DUKE_AIR);
                             break;
 
                         case GOSSIP_ACTION_INFO_DEF + 11:
+                            player->CastSpell(player, SPELL_ROYAL_RANDOM);
                             SummonNPC(me, player, RAND(NPC_ROYAL_FIRE, NPC_ROYAL_AIR, NPC_ROYAL_EARTH, NPC_ROYAL_WATER), SPELL_ROYAL_RANDOM);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 12:
+                            player->CastSpell(player, SPELL_ROYAL_FIRE);
                             SummonNPC(me, player, NPC_ROYAL_FIRE, SPELL_ROYAL_FIRE);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 13:
+                            player->CastSpell(player, SPELL_ROYAL_WATER);
                             SummonNPC(me, player, NPC_ROYAL_WATER, SPELL_ROYAL_WATER);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 14:
+                            player->CastSpell(player, SPELL_ROYAL_EARTH);
                             SummonNPC(me, player, NPC_ROYAL_EARTH, SPELL_ROYAL_EARTH);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 15:
+                            player->CastSpell(player, SPELL_ROYAL_AIR);
                             SummonNPC(me, player, NPC_ROYAL_AIR, SPELL_ROYAL_AIR);
                             break;
 

--- a/src/server/scripts/Kalimdor/zone_silithus.cpp
+++ b/src/server/scripts/Kalimdor/zone_silithus.cpp
@@ -1214,7 +1214,7 @@ class go_wind_stone : public GameObjectScript
 
                 void SummonNPC(GameObject* go, Player* player, uint32 npc, uint32 spell)
                 {
-                    go->CastSpell(player, spell);
+                    player->CastSpell(player, spell);
                     TempSummon* summons = go->SummonCreature(npc, go->GetPositionX(), go->GetPositionY(), go->GetPositionZ(), player->GetOrientation() - float(M_PI), TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 10min);
                     summons->CastSpell(summons, SPELL_SPAWN_IN, false);
                     switch (summons->GetEntry())
@@ -1331,65 +1331,50 @@ class go_wind_stone : public GameObjectScript
                     switch (action)
                     {
                         case GOSSIP_ACTION_INFO_DEF + 1:
-                            player->CastSpell(player, SPELL_TEMPLAR_RANDOM);
                             SummonNPC(me, player, RAND(NPC_TEMPLAR_WATER, NPC_TEMPLAR_FIRE, NPC_TEMPLAR_EARTH, NPC_TEMPLAR_AIR), SPELL_TEMPLAR_RANDOM);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 2:
-                            player->CastSpell(player, SPELL_TEMPLAR_FIRE);
                             SummonNPC(me, player, NPC_TEMPLAR_FIRE, SPELL_TEMPLAR_FIRE);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 3:
-                            player->CastSpell(player, SPELL_TEMPLAR_WATER);
                             SummonNPC(me, player, NPC_TEMPLAR_WATER, SPELL_TEMPLAR_WATER);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 4:
-                            player->CastSpell(player, SPELL_TEMPLAR_EARTH);
                             SummonNPC(me, player, NPC_TEMPLAR_EARTH, SPELL_TEMPLAR_EARTH);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 5:
-                            player->CastSpell(player, SPELL_TEMPLAR_AIR);
                             SummonNPC(me, player, NPC_TEMPLAR_AIR, SPELL_TEMPLAR_AIR);
                             break;
 
                         case GOSSIP_ACTION_INFO_DEF + 6:
-                            player->CastSpell(player, SPELL_DUKE_RANDOM);
                             SummonNPC(me, player, RAND(NPC_DUKE_FIRE, NPC_DUKE_WATER, NPC_DUKE_EARTH, NPC_DUKE_AIR), SPELL_DUKE_RANDOM);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 7:
-                            player->CastSpell(player, SPELL_DUKE_FIRE);
                             SummonNPC(me, player, NPC_DUKE_FIRE, SPELL_DUKE_FIRE);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 8:
-                            player->CastSpell(player, SPELL_DUKE_WATER);
                             SummonNPC(me, player, NPC_DUKE_WATER, SPELL_DUKE_WATER);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 9:
-                            player->CastSpell(player, SPELL_DUKE_EARTH);
                             SummonNPC(me, player, NPC_DUKE_EARTH, SPELL_DUKE_EARTH);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 10:
-                            player->CastSpell(player, SPELL_DUKE_AIR);
                             SummonNPC(me, player, NPC_DUKE_AIR, SPELL_DUKE_AIR);
                             break;
 
                         case GOSSIP_ACTION_INFO_DEF + 11:
-                            player->CastSpell(player, SPELL_ROYAL_RANDOM);
                             SummonNPC(me, player, RAND(NPC_ROYAL_FIRE, NPC_ROYAL_AIR, NPC_ROYAL_EARTH, NPC_ROYAL_WATER), SPELL_ROYAL_RANDOM);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 12:
-                            player->CastSpell(player, SPELL_ROYAL_FIRE);
                             SummonNPC(me, player, NPC_ROYAL_FIRE, SPELL_ROYAL_FIRE);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 13:
-                            player->CastSpell(player, SPELL_ROYAL_WATER);
                             SummonNPC(me, player, NPC_ROYAL_WATER, SPELL_ROYAL_WATER);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 14:
-                            player->CastSpell(player, SPELL_ROYAL_EARTH);
                             SummonNPC(me, player, NPC_ROYAL_EARTH, SPELL_ROYAL_EARTH);
                             break;
                         case GOSSIP_ACTION_INFO_DEF + 15:
-                            player->CastSpell(player, SPELL_ROYAL_AIR);
                             SummonNPC(me, player, NPC_ROYAL_AIR, SPELL_ROYAL_AIR);
                             break;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixes Wind Stone exploit in Silithus


**Target branch(es):** 3.3.5/master

- [x] 3.3.5


**Issues addressed:**

Closes #23577


**Tests performed:**

Builds & Works ingame


**Known issues and TODO list:** (add/remove lines as needed)

Stuff to note down, mabye for a new issue, not covered by this PR
- [ ] Wind Stone Bosses should have a grace period for about 5 Seconds (potentially for the summoning player to re-equip items after he loses the worn twillight set)
- [ ] Wind Stone Bosses should get aggro on the summoning player AND any other player on that players group
- [ ] Used Wind Stone should be destroyed (currently the spell disables the gameobject) and respawn after some time
- [ ] Spawned Boss should despawn immediately after combat ends (in case of attacking player/s die for example)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
