### PR TITLE
Core/Battlegrounds: Update BattlemasterListFlags

### DIFF
--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -3037,7 +3037,7 @@ bool CriteriaHandler::ModifierSatisfied(ModifierTreeEntry const* modifier, uint6
         case ModifierTreeType::PlayerIsInPvpBrawl: // 220
         {
             BattlemasterListEntry const* bg = sBattlemasterListStore.LookupEntry(referencePlayer->GetBattlegroundTypeId());
-            if (!bg || !(bg->GetFlags().HasFlag(BattlemasterListFlags::Brawl)))
+            if (!bg || !(bg->GetFlags().HasFlag(BattlemasterListFlags::IsBrawl)))
                 return false;
             break;
         }

--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -3037,7 +3037,7 @@ bool CriteriaHandler::ModifierSatisfied(ModifierTreeEntry const* modifier, uint6
         case ModifierTreeType::PlayerIsInPvpBrawl: // 220
         {
             BattlemasterListEntry const* bg = sBattlemasterListStore.LookupEntry(referencePlayer->GetBattlegroundTypeId());
-            if (!bg || !(bg->Flags & BATTLEMASTER_LIST_FLAG_BRAWL))
+            if (!bg || !(bg->GetFlags().HasFlag(BattlemasterListFlags::Brawl)))
                 return false;
             break;
         }

--- a/src/server/game/DataStores/DB2Structure.h
+++ b/src/server/game/DataStores/DB2Structure.h
@@ -509,6 +509,8 @@ struct BattlemasterListEntry
     int32 IconFileDataID;
     int32 RequiredPlayerConditionID;
     int16 MapID[16];
+
+    EnumFlag<BattlemasterListFlags> GetFlags() const { return static_cast<BattlemasterListFlags>(Flags); }
 };
 
 #define MAX_BROADCAST_TEXT_EMOTES 3

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -195,14 +195,14 @@ enum AzeriteTierUnlockSetFlags
 
 enum class BattlemasterListFlags : uint32
 {
-    Disabled            = 0x01,
-    SkipRoleCheck       = 0x02,
-    ObsoleteDoNotList   = 0x04,
-    CanInitWarGame      = 0x08,
-    CanSpecificQueue    = 0x10,
-    Brawl               = 0x20,
-    Factional           = 0x40,
-    Unknown80           = 0x80
+    InternalOnly                = 0x01,
+    RatedOnly                   = 0x02, // Only set for rated battlegrounds
+    ObsoleteDoNotList           = 0x04,
+    ShowInWarGames              = 0x08,
+    ShowInPvpBattlegroundList   = 0x10,
+    IsBrawl                     = 0x20,
+    IsFactional                 = 0x40,
+    Unknown80                   = 0x80
 };
 
 DEFINE_ENUM_FLAG(BattlemasterListFlags);

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -202,7 +202,7 @@ enum class BattlemasterListFlags : uint32
     ShowInPvpBattlegroundList   = 0x10,
     IsBrawl                     = 0x20,
     IsFactional                 = 0x40,
-    Unknown80                   = 0x80
+    IsEpic                      = 0x80
 };
 
 DEFINE_ENUM_FLAG(BattlemasterListFlags);

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -193,16 +193,19 @@ enum AzeriteTierUnlockSetFlags
 
 #define BATTLE_PET_SPECIES_MAX_ID 3159
 
-enum BattlemasterListFlags
+enum class BattlemasterListFlags : uint32
 {
-    BATTLEMASTER_LIST_FLAG_DISABLED             = 0x01,
-    BATTLEMASTER_LIST_FLAG_SKIP_ROLE_CHECK      = 0x02,
-    BATTLEMASTER_LIST_FLAG_UNK04                = 0x04,
-    BATTLEMASTER_LIST_FLAG_CAN_INIT_WAR_GAME    = 0x08,
-    BATTLEMASTER_LIST_FLAG_CAN_SPECIFIC_QUEUE   = 0x10,
-    BATTLEMASTER_LIST_FLAG_BRAWL                = 0x20,
-    BATTLEMASTER_LIST_FLAG_FACTIONAL            = 0x40
+    Disabled            = 0x01,
+    SkipRoleCheck       = 0x02,
+    ObsoleteDoNotList   = 0x04,
+    CanInitWarGame      = 0x08,
+    CanSpecificQueue    = 0x10,
+    Brawl               = 0x20,
+    Factional           = 0x40,
+    Unknown80           = 0x80
 };
+
+DEFINE_ENUM_FLAG(BattlemasterListFlags);
 
 enum class ChrRacesFlag : int32
 {

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -82,7 +82,7 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPackets::Battleground::Batt
 
     BattlemasterListEntry const* battlemasterListEntry = sBattlemasterListStore.AssertEntry(bgQueueTypeId.BattlemasterListId);
 
-    if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, bgQueueTypeId.BattlemasterListId, nullptr) || battlemasterListEntry->GetFlags().HasFlag(BattlemasterListFlags::Disabled))
+    if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, bgQueueTypeId.BattlemasterListId, nullptr) || battlemasterListEntry->GetFlags().HasFlag(BattlemasterListFlags::InternalOnly))
     {
         ChatHandler(this).PSendSysMessage(LANG_BG_DISABLED);
         return;

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -82,7 +82,7 @@ void WorldSession::HandleBattlemasterJoinOpcode(WorldPackets::Battleground::Batt
 
     BattlemasterListEntry const* battlemasterListEntry = sBattlemasterListStore.AssertEntry(bgQueueTypeId.BattlemasterListId);
 
-    if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, bgQueueTypeId.BattlemasterListId, nullptr) || (battlemasterListEntry->Flags & BATTLEMASTER_LIST_FLAG_DISABLED) != 0)
+    if (DisableMgr::IsDisabledFor(DISABLE_TYPE_BATTLEGROUND, bgQueueTypeId.BattlemasterListId, nullptr) || battlemasterListEntry->GetFlags().HasFlag(BattlemasterListFlags::Disabled))
     {
         ChatHandler(this).PSendSysMessage(LANG_BG_DISABLED);
         return;


### PR DESCRIPTION
**Changes proposed:**

- Convert to enum class
- defined flag 0x04 (from [wow.tools](https://wow.tools/dbc/?dbc=battlemasterlist&build=9.1.0.39653#page=1&colFilter[14]=0x04))
- add new unknown flag 0x80 also from [wow.tools](https://wow.tools/dbc/?dbc=battlemasterlist&build=9.1.0.39653#page=1&colFilter[14]=0x80)

**Target branch(es):**

- master

**Issues addressed:**

Closes: none


**Tests performed:**

- Builds


**Known issues and TODO list:** (add/remove lines as needed)

- [x] Maybe we should update the names so they match the ones from wow.tools?
- [ ] Checkout flag 0x80. Seems to be only set for epic battlegrounds


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
