### PR TITLE
Remove combo points on a creature when it evades

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -303,7 +303,7 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     }
 
     me->RemoveAurasOnEvade();
-
+    me->ClearComboPointHolders(); // Remove all combo points targeting this unit
     me->CombatStop(true);
     me->LoadCreaturesAddon();
     me->SetLootRecipient(nullptr);


### PR DESCRIPTION
**Changes proposed:**

-  Remove combo points on a creature when it evades

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Whenever a player engages a creature and gets combo points on it, they're not removed and the player can start combat again starting with >0 combo points.

**Tests performed:**

Does build & tested in game.

**Known issues and TODO list:** (add/remove lines as needed)

None