### PR TITLE
Core/Unit: improve SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL immunities

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7780,23 +7780,23 @@ bool Unit::IsImmunedToSpellEffect(SpellInfo const* spellInfo, SpellEffectInfo co
             return true;
     }
 
-    if (!spellInfo->HasAttribute(SPELL_ATTR3_IGNORE_HIT_RESULT))
+    if (AuraType aura = spellEffectInfo.ApplyAuraName)
     {
-        if (AuraType aura = spellEffectInfo.ApplyAuraName)
+        if (!spellInfo->HasAttribute(SPELL_ATTR3_IGNORE_HIT_RESULT))
         {
             SpellImmuneContainer const& list = m_spellImmune[IMMUNITY_STATE];
             if (list.count(aura) > 0)
                 return true;
+        }
 
-            if (!spellInfo->HasAttribute(SPELL_ATTR2_UNAFFECTED_BY_AURA_SCHOOL_IMMUNE))
-            {
-                // Check for immune to application of harmful magical effects
-                AuraEffectList const& immuneAuraApply = GetAuraEffectsByType(SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL);
-                for (AuraEffectList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
-                    if (((*iter)->GetMiscValue() & spellInfo->GetSchoolMask()) &&                   // Check school
-                        ((caster && !IsFriendlyTo(caster)) || !spellInfo->IsPositiveEffect(spellEffectInfo.EffectIndex))) // Harmful
-                        return true;
-            }
+        if (!spellInfo->HasAttribute(SPELL_ATTR2_UNAFFECTED_BY_AURA_SCHOOL_IMMUNE))
+        {
+            // Check for immune to application of harmful magical effects
+            AuraEffectList const& immuneAuraApply = GetAuraEffectsByType(SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL);
+            for (AuraEffectList::const_iterator iter = immuneAuraApply.begin(); iter != immuneAuraApply.end(); ++iter)
+                if (((*iter)->GetMiscValue() & spellInfo->GetSchoolMask()) &&                   // Check school
+                    ((caster && !IsFriendlyTo(caster)) || !spellInfo->IsPositiveEffect(spellEffectInfo.EffectIndex))) // Harmful
+                    return true;
         }
     }
 


### PR DESCRIPTION
**Changes proposed:**

-  Remove SPELL_ATTR3_IGNORE_HIT_RESULT check in SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL immunity check

We only have one spell with SPELL_AURA_MOD_IMMUNE_AURA_APPLY_SCHOOL ID - 48707 Anti-Magic Shell

after ariel- commit: https://github.com/TrinityCore/TrinityCore/commit/352c84943c4495631a5dd1e9285cde35fdc23c37 Anti-Magic Shell does not grant immunity to spells with the attribute SPELL_ATTR3_IGNORE_HIT_RESULT.
old related issues:
https://github.com/TrinityCore/TrinityCore/issues/21343
https://github.com/TrinityCore/TrinityCore/issues/20326
https://github.com/TrinityCore/TrinityCore/issues/23305

proofs:
for some reason warcraftmovies has problems with google chrome, use edge by example.

https://www.warcraftmovies.com/movieview.php?id=124549
At 2:54 is seen that paladin holy gets an immune after cast Judgment of Light on DK with Anti-Magic Shell, the debuff is not applied.

https://www.warcraftmovies.com/movieview.php?id=145857
At 3:44, paladin retry cast Judgment of Justice on DK with Anti-Magic Shell and DK is immune.

https://www.warcraftmovies.com/movieview.php?id=158419
At 2:01 - cast Icy Touch and Frost Fever is not applied, is immune.

https://www.youtube.com/watch?v=230QLHFpeUw
At 1:40 - cast Icy Touch on DK with Anti-Magic Shell and DK is immune.

https://www.youtube.com/watch?v=XpzEHKVOevw&t=83s
At 1:25 - cast Plague Strike on DK with Anti-Magic Shell and DK is immune to Blood Plague.

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

nothing open I think


**Tests performed:**

tested in-game
