### PR TITLE
[Core/Spells]: Use GetHeal instead of GetEffectiveHeal in Sheath of Light AuraScript

### DIFF
--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -1850,7 +1850,7 @@ class spell_pal_sheath_of_light : public AuraScript
         Unit* target = eventInfo.GetProcTarget();
 
         SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(SPELL_PALADIN_SHEATH_OF_LIGHT_HEAL);
-        int32 amount = CalculatePct(static_cast<int32>(healInfo->GetEffectiveHeal()), aurEff->GetAmount());
+        int32 amount = CalculatePct(static_cast<int32>(healInfo->GetHeal()), aurEff->GetAmount());
 
         ASSERT(spellInfo->GetMaxTicks() > 0);
         amount /= spellInfo->GetMaxTicks();


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

I've noticed that when you proc Paladin talent  [Sheath of Light]  the effect does nothing.
After some debugging I've found out that GetEffectiveHeal returns 0 and GetHeal returns the heal amount

-  Use GetHeal instead of GetEffectiveHeal in Sheath of Light AuraScript

**Target branch(es):** 3.3.5

- [ ] 3.3.5

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**
Compiled and tested and it's working as intended.


**Known issues and TODO list:** (add/remove lines as needed)
None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
