### PR TITLE
Core/Units: removed an incorrect addition of SPELL_AURA_MOD_CRIT_CHANCE_FOR_CASTER benefits

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2747,13 +2747,6 @@ float Unit::GetUnitCriticalChanceTaken(Unit const* attacker, WeaponAttackType at
     else
         chance += GetTotalAuraModifier(SPELL_AURA_MOD_ATTACKER_MELEE_CRIT_CHANCE);
 
-    chance += GetTotalAuraModifier(SPELL_AURA_MOD_CRIT_CHANCE_FOR_CASTER, [attacker](AuraEffect const* aurEff) -> bool
-    {
-        if (aurEff->GetCasterGUID() == attacker->GetGUID())
-            return true;
-        return false;
-    });
-
     // reduce crit chance from Rating for players
     if (attacker->CanApplyResilience())
         Unit::ApplyResilience(this, &chance, nullptr, false, (attackType == RANGED_ATTACK ? CR_CRIT_TAKEN_RANGED : CR_CRIT_TAKEN_MELEE));
@@ -7212,8 +7205,7 @@ float Unit::SpellCritChanceTaken(Unit const* caster, SpellInfo const* spellInfo,
             return 0.f;
     }
 
-    // for this types the bonus was already added in GetUnitCriticalChance, do not add twice
-    if (caster && spellInfo->DmgClass != SPELL_DAMAGE_CLASS_MELEE && spellInfo->DmgClass != SPELL_DAMAGE_CLASS_RANGED)
+    if (caster)
     {
         crit_chance += GetTotalAuraModifier(SPELL_AURA_MOD_CRIT_CHANCE_FOR_CASTER, [caster, spellInfo](AuraEffect const* aurEff) -> bool
         {


### PR DESCRIPTION

**Changes proposed:**

-  SPELL_AURA_MOD_CRIT_CHANCE_FOR_CASTER is no longer going to be considered for basic melee attacks as this effect should only affect spells. This fixes an issue that was causing these aura effect types to increase crit chances for all melee attacks instead of only the abilities that are specified in the class mask of the effect.
- 
**Target branch(es):** 3.3.5/master

- 3.3.5

**Tests performed:**
- tested on 4.x with the enhancement shaman storm strike buff

