### PR TITLE
[Exploit] Do not allow to queue for rated arena without a group

### DIFF
--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -620,6 +620,10 @@ void WorldSession::HandleBattlemasterJoinArena(WorldPacket& recvData)
 
     recvData >> guid >> arenaslot >> asGroup >> isRated;
 
+    // ignore if rated but queued solo
+    if (isRated && !asGroup)
+        return;
+
     // ignore if we already in BG or BG queue
     if (_player->InBattleground())
         return;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't trust packet send from client

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**
If you send CMSG_BATTLEMASTER_JOIN_ARENA with rated=1 and asgroup=0 you will be placed in rated arena queue without a group. (Client will display skirmish because of how we build SMSG_BATTLEFIELD_STATUS but in fact you end up in rated arena queue container.


**Tests performed:**
tested in-game
(Does it build, tested in-game, etc.)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
