### PR TITLE
Core/Disables: Fixed params_1 (SPELL_DISABLE_AREA) data loading for DISABLE_TYPE_SPELL

### DIFF
--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -117,7 +117,7 @@ void LoadDisables()
 
                 if (flags & SPELL_DISABLE_AREA)
                 {
-                    for (std::string_view areaStr : Trinity::Tokenize(params_0, ',', true))
+                    for (std::string_view areaStr : Trinity::Tokenize(params_1, ',', true))
                     {
                         if (Optional<uint32> areaId = Trinity::StringTo<uint32>(areaStr))
                             data.params[1].insert(*areaId);


### PR DESCRIPTION
**Changes proposed:**

-  Fixed params_1 (SPELL_DISABLE_AREA) data loading for DISABLE_TYPE_SPELL
Typo introduced here: https://github.com/TrinityCore/TrinityCore/commit/534a2388b7c662c8796aabb1ec8cb424879799b6#diff-3b34adf0bd23cbcab28ddee37f35fcebc6f5397e6f2add002f0f10db9215003fR120

**Target branch(es):** 3.3.5/master

- [X] 3.3.5
- [ ] master

**Issues addressed:**

.die @Treeston 


**Tests performed:**

tested in-game
