### PR TITLE
Core/QuestHandler: Fix potential crash caused by QUEST_FLAGS_PARTY_ACCEPT with conditions

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -192,7 +192,7 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPacket& recvData)
                     {
                         Player* player = itr->GetSource();
 
-                        if (!player || player == _player)     // not self
+                        if (!player || player == _player || !player->IsInMap(_player))     // not self and in same map
                             continue;
 
                         if (player->CanTakeQuest(quest, true))


### PR DESCRIPTION
**Changes proposed:**

-  Check in the same map for quest accept opcode for group sharing via QUEST_FLAGS_PARTY_ACCEPT quest flags.

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master


Reasoning:

```
2021-09-01_21:08:44 ERROR Cross-thread inventory interaction:
 0# Player::GetItemByPos(unsigned char, unsigned char) const in [redacted]
 1# Player::HasItemCount(unsigned int, unsigned int, bool) const in [redacted]
 2# Condition::Meets(ConditionSourceInfo&) const in [redacted]
 3# ConditionMgr::IsObjectMeetToConditionList(ConditionSourceInfo&, std::vector<Condition*, std::allocator<Condition*> > const&) const in [redacted]
 4# ConditionMgr::IsObjectMeetToConditions(ConditionSourceInfo&, std::vector<Condition*, std::allocator<Condition*> > const&) const in [redacted]
 5# ConditionMgr::IsObjectMeetingNotGroupedConditions(ConditionSourceType, unsigned int, ConditionSourceInfo&) const in [redacted]
 6# ConditionMgr::IsObjectMeetingNotGroupedConditions(ConditionSourceType, unsigned int, WorldObject*, WorldObject*, WorldObject*) const in [redacted]
 7# Player::SatisfyQuestConditions(Quest const*, bool) in [redacted]
 8# WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPacket&) in [redacted]
 9# WorldSession::ProcessPacketQueue(LockedQueue<WorldPacket*>&, PacketFilter&, unsigned int) in [redacted]
10# WorldSession::Update(unsigned int, PacketFilter&, WorldSessionUpdateFlags&) in [redacted]
11# Map::ProcessPlayerSessionUpdates(unsigned int, unsigned int&) in [redacted]
12# Map::Update(unsigned int) in [redacted]
```

Player sends CMSG_QUESTGIVER_ACCEPT_QUEST with quest that has QUEST_FLAGS_PARTY_ACCEPT and also has a condition set for having a certain item. This will search a player's inventory accross maps which is a race condition that can lead to server crashes.