### PR TITLE
Core/AH: Add search delay to SMSG_AUCTION_BIDDER_LIST_RESULT and SMSG_AUCTION_OWNER_LIST_RESULT

### DIFF
--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -700,7 +700,7 @@ void WorldSession::HandleAuctionListBidderItems(WorldPacket& recvData)
     auctionHouse->BuildListBidderItems(data, player, count, totalcount);
     data.put<uint32>(0, count);                           // add count to placeholder
     data << totalcount;
-    data << (uint32)300;                                    //unk 2.3.0
+    data << (uint32)sWorld->getIntConfig(CONFIG_AUCTION_SEARCH_DELAY);
     SendPacket(&data);
 }
 
@@ -737,7 +737,7 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket& recvData)
     auctionHouse->BuildListOwnerItems(data, _player, count, totalcount);
     data.put<uint32>(0, count);
     data << (uint32) totalcount;
-    data << (uint32) 0;
+    data << (uint32) sWorld->getIntConfig(CONFIG_AUCTION_SEARCH_DELAY);
     SendPacket(&data);
 }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add AH search delay to SMSG_AUCTION_BIDDER_LIST_RESULT and SMSG_AUCTION_OWNER_LIST_RESULT

When investigating in the client they all set DAT_00acf628 which is used to delay searches and affecting the return value of functions like CanSendAuctionQuery in LUA.

Additionally WPP lists this as the meaning: https://github.com/TrinityCore/WowPacketParser/blob/a659b55dcd086ba3beb0ea9d1f0389aaa8480da7/WowPacketParser/Parsing/Parsers/AuctionHouseHandler.cs#L204

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Tests performed:**

In-game tested this disabling search functionality similarly to the delay sent SMSG_AUCTION_LIST_RESULT.
