### PR TITLE
Core/SAI: Split set/remove unit_flags actions

### DIFF
--- a/sql/updates/world/3.3.5/2021_09_27_00_world.sql
+++ b/sql/updates/world/3.3.5/2021_09_27_00_world.sql
@@ -1,0 +1,7 @@
+--
+UPDATE `smart_scripts` SET `action_type` = 144, `action_param1` = 1 WHERE `action_type` = 18 AND `action_param1` = 256;
+UPDATE `smart_scripts` SET `action_type` = 144, `action_param1` = 0 WHERE `action_type` = 19 AND `action_param1` = 256;
+UPDATE `smart_scripts` SET `action_type` = 145, `action_param1` = 1 WHERE `action_type` = 18 AND `action_param1` = 512;
+UPDATE `smart_scripts` SET `action_type` = 145, `action_param1` = 0 WHERE `action_type` = 19 AND `action_param1` = 512;
+UPDATE `smart_scripts` SET `action_type` = 146, `action_param1` = 1 WHERE `action_type` = 18 AND `action_param1` = 33554432;
+UPDATE `smart_scripts` SET `action_type` = 146, `action_param1` = 0 WHERE `action_type` = 19 AND `action_param1` = 33554432;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2379,6 +2379,48 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                     targetUnit->SetHealth(targetUnit->CountPctFromMaxHealth(e.action.setHealthPct.percent));
             break;
         }
+        case SMART_ACTION_SET_IMMUNE_PC:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsUnit(target))
+                {
+                    if (e.action.setImmunePC.immunePC)
+                        target->ToUnit()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                    else
+                        target->ToUnit()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_SET_IMMUNE_NPC:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsUnit(target))
+                {
+                    if (e.action.setImmuneNPC.immuneNPC)
+                        target->ToUnit()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                    else
+                        target->ToUnit()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_SET_UNINTERACTIBLE:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsUnit(target))
+                {
+                    if (e.action.setUninteractible.uninteractible)
+                        target->ToUnit()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                    else
+                        target->ToUnit()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                }
+            }
+            break;
+        }
         default:
             TC_LOG_ERROR("sql.sql", "SmartScript::ProcessAction: Entry %d SourceType %u, Event %u, Unhandled Action type %u", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1465,6 +1465,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             case SMART_EVENT_FRIENDLY_HEALTH:
             case SMART_EVENT_TARGET_HEALTH_PCT:
             case SMART_EVENT_IS_BEHIND_TARGET:
+            case SMART_EVENT_TARGET_MANA_PCT:
                 TC_LOG_WARN("sql.sql.deprecation", "SmartAIMgr: Deprecated event_type(%u), Entry %d SourceType %u Event %u Action %u, it might be removed in the future, loaded for now.", e.GetEventType(), e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
                 break;
             default:
@@ -2223,6 +2224,9 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         // Deprecated
         case SMART_ACTION_SET_UNIT_FLAG:
         case SMART_ACTION_REMOVE_UNIT_FLAG:
+        case SMART_ACTION_ADD_ITEM:
+        case SMART_ACTION_ADD_DYNAMIC_FLAG:
+        case SMART_ACTION_REMOVE_DYNAMIC_FLAG:
             TC_LOG_WARN("sql.sql.deprecation", "SmartAIMgr: Deprecated action_type(%u), Entry %d SourceType %u Event %u, it might be removed in the future, loaded for now.", e.GetActionType(), e.entryOrGuid, e.GetScriptType(), e.event_id);
             break;
         default:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -956,6 +956,9 @@ bool SmartAIMgr::CheckUnusedActionParams(SmartScriptHolder const& e)
             case SMART_ACTION_SET_HOVER: return sizeof(SmartAction::setHover);
             case SMART_ACTION_SET_HEALTH_PCT: return sizeof(SmartAction::setHealthPct);
             //case SMART_ACTION_CREATE_CONVERSATION: return sizeof(SmartAction::raw);
+            case SMART_ACTION_SET_IMMUNE_PC: return sizeof(SmartAction::setImmunePC);
+            case SMART_ACTION_SET_IMMUNE_NPC: return sizeof(SmartAction::setImmuneNPC);
+            case SMART_ACTION_SET_UNINTERACTIBLE: return sizeof(SmartAction::setUninteractible);
             default:
                 TC_LOG_WARN("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u is using an action with no unused params specified in SmartAIMgr::CheckUnusedActionParams(), please report this.",
                     e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
@@ -2129,6 +2132,21 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             TC_SAI_IS_BOOLEAN_VALID(e, e.action.setHealthRegen.regenHealth);
             break;
         }
+        case SMART_ACTION_SET_IMMUNE_PC:
+        {
+            TC_SAI_IS_BOOLEAN_VALID(e, e.action.setImmunePC.immunePC);
+            break;
+        }
+        case SMART_ACTION_SET_IMMUNE_NPC:
+        {
+            TC_SAI_IS_BOOLEAN_VALID(e, e.action.setImmuneNPC.immuneNPC);
+            break;
+        }
+        case SMART_ACTION_SET_UNINTERACTIBLE:
+        {
+            TC_SAI_IS_BOOLEAN_VALID(e, e.action.setUninteractible.uninteractible);
+            break;
+        }
         case SMART_ACTION_FOLLOW:
         case SMART_ACTION_SET_ORIENTATION:
         case SMART_ACTION_STORE_TARGET_LIST:
@@ -2197,6 +2215,18 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         default:
             TC_LOG_ERROR("sql.sql", "SmartAIMgr: Not handled action_type(%u), event_type(%u), Entry %d SourceType %u Event %u, skipped.", e.GetActionType(), e.GetEventType(), e.entryOrGuid, e.GetScriptType(), e.event_id);
             return false;
+    }
+
+    // Additional check for deprecated
+    switch (e.GetActionType())
+    {
+        // Deprecated
+        case SMART_ACTION_SET_UNIT_FLAG:
+        case SMART_ACTION_REMOVE_UNIT_FLAG:
+            TC_LOG_WARN("sql.sql.deprecation", "SmartAIMgr: Deprecated action_type(%u), Entry %d SourceType %u Event %u, it might be removed in the future, loaded for now.", e.GetActionType(), e.entryOrGuid, e.GetScriptType(), e.event_id);
+            break;
+        default:
+            break;
     }
 
     if (!CheckUnusedActionParams(e))

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -599,8 +599,11 @@ enum SMART_ACTION
     SMART_ACTION_SET_HOVER                          = 141,    // 0/1
     SMART_ACTION_SET_HEALTH_PCT                     = 142,    // percent
     SMART_ACTION_CREATE_CONVERSATION                = 143,    // don't use on 3.3.5a
+    SMART_ACTION_SET_IMMUNE_PC                      = 144,    // 0/1
+    SMART_ACTION_SET_IMMUNE_NPC                     = 145,    // 0/1
+    SMART_ACTION_SET_UNINTERACTIBLE                 = 146,    // 0/1
 
-    SMART_ACTION_END                                = 144
+    SMART_ACTION_END                                = 147
 };
 
 enum class SmartActionSummonCreatureFlags
@@ -1196,6 +1199,21 @@ struct SmartAction
         {
             uint32 percent;
         } setHealthPct;
+
+        struct
+        {
+            SAIBool immunePC;
+        } setImmunePC;
+
+        struct
+        {
+            SAIBool immuneNPC;
+        } setImmuneNPC;
+
+        struct
+        {
+            SAIBool uninteractible;
+        } setUninteractible;
 
         //! Note for any new future actions
         //! All parameters must have type uint32


### PR DESCRIPTION
**Changes proposed:**

-  Deprecate SMART_ACTION_SET_UNIT_FLAG & SMART_ACTION_REMOVE_UNIT_FLAG
-  Create new bool actions to set ImmunePC, ImmuneNPC, Uninteractible (former not selectable)

The plan was to use here SetImmuneTo and create SetUninteractible. However I noticed that SetImmuneTo has param keepInCombat which allows to keep creature in combat after making it immune to PC\NPC. Not sure but looks like only if creature has passive react state. Later I checked how it works without calling SetImmuneTo, by changing flags directly(how it always was in SAI). Turned out it doesn't matter how flag was set, creature will remain in combat if it's passive

I have no idea when it started but to me it looks like dependency created by people who think they need to make creature immune to PC\NPC during combat at all cost. From my experience in case of bosses Blizz makes them passive or uninteractible and passive. Probably that's why UNIT_FLAG_NON_ATTACKABLE is so popular in C++ scripts(200 cases, should be 0). Simply because it keeps creature in combat but at the same time makes creature non-attackable. Those scripts were not written from sniffs. Same with scripts which calls SetImmuneTo mid combat

On top of that:
- I have a feeling we should not use **pet react states** to make normal creature passive or defensive
- There's no such param in original actions. Even if system which uses those action is not used for really complicated bosses, it doesn't matter because it's really bad to have differently handled functions in different systems, especially if that function is used in thousands of scripts. They should be same no matter where they are used. We have huge difference between how core scripts and DB scripts works but on retail they all are same, no matter if it's boss or normal mob. The only difference between bosses and simple creatures is you can make bosses more complex but in game they acts in same way
- In https://github.com/TrinityCore/TrinityCore/issues/26912#issuecomment-922333781 I made an assumption that combat-related flags are messed up and their behavior is not entirely correct. You also can see how flags works

Pretty sure creature leaves combat instantly when flags are set, no matter if it's passive or not. I know it looks ugly but I don't want to use here SetImmuneTo because I have no idea if its effect is same or not. Maybe later I'll try to figure out if it can be used

**Target branch(es):**

- [x] 3.3.5
- [ ] master

**Issues addressed:**

none

**Tests performed:**

not tested, didn't tried to build

**Known issues and TODO list:**

should be tested + sql