### PR TITLE
Core/Spell: Fixed overflow in LoadSpellLearnSpells

### DIFF
--- a/sql/updates/world/3.3.5/2021_09_28_00_world.sql
+++ b/sql/updates/world/3.3.5/2021_09_28_00_world.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `spell_learn_spell` 
+  MODIFY `entry` int(10) UNSIGNED NOT NULL DEFAULT 0 FIRST,
+  MODIFY `SpellID` int(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `entry`;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1098,10 +1098,10 @@ void SpellMgr::LoadSpellLearnSpells()
     {
         Field* fields = result->Fetch();
 
-        uint32 spell_id = fields[0].GetUInt16();
+        uint32 spell_id = fields[0].GetUInt32();
 
         SpellLearnSpellNode node;
-        node.spell       = fields[1].GetUInt16();
+        node.spell       = fields[1].GetUInt32();
         node.active      = fields[2].GetBool();
         node.autoLearned = false;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Allow to insert entries into spell_learn_spell > uint16 (full range of blizzlike spells)
-  Fixed overflow when loading spell_learn_spell causing learning random spells with > uint16 entries.


**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
Both

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
