### PR TITLE
Scripts/Commands: avoid crash on lookup spell (id)

### DIFF
--- a/src/server/scripts/Commands/cs_lookup.cpp
+++ b/src/server/scripts/Commands/cs_lookup.cpp
@@ -959,10 +959,15 @@ public:
 
             bool known = target && target->HasSpell(id);
 
-            SpellEffectInfo const& spellEffectInfo = spellInfo->GetEffect(EFFECT_0);
-            bool learn = spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL);
+            bool learn = false;
+            SpellInfo const* learnSpellInfo;
+            if (spellInfo->GetEffects().size()) {
+                SpellEffectInfo const& spellEffectInfo = spellInfo->GetEffect(EFFECT_0);
+                learn = spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL);
 
-            SpellInfo const* learnSpellInfo = sSpellMgr->GetSpellInfo(spellEffectInfo.TriggerSpell, DIFFICULTY_NONE);
+                if (learn)
+                    learnSpellInfo = sSpellMgr->GetSpellInfo(spellEffectInfo.TriggerSpell, DIFFICULTY_NONE);
+            }
 
             bool talent = spellInfo->HasAttribute(SPELL_ATTR0_CU_IS_TALENT);
             bool passive = spellInfo->IsPassive();
@@ -970,7 +975,7 @@ public:
 
             // unit32 used to prevent interpreting uint8 as char at output
             // find rank of learned spell for learning spell, or talent rank
-            uint32 rank = learn && learnSpellInfo ? learnSpellInfo->GetRank() : spellInfo->GetRank();
+            uint32 rank = learnSpellInfo ? learnSpellInfo->GetRank() : spellInfo->GetRank();
 
             // send spell in "id - [name, rank N] [talent] [passive] [learn] [known]" format
             std::ostringstream ss;

--- a/src/server/scripts/Commands/cs_lookup.cpp
+++ b/src/server/scripts/Commands/cs_lookup.cpp
@@ -886,10 +886,17 @@ public:
 
                     bool known = target && target->HasSpell(spellInfo->Id);
 
-                    SpellEffectInfo const& spellEffectInfo = spellInfo->GetEffect(EFFECT_0);
-                    bool learn = spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL);
-
-                    SpellInfo const* learnSpellInfo = sSpellMgr->GetSpellInfo(spellEffectInfo.TriggerSpell, spellInfo->Difficulty);
+                    bool learn = false;
++                   SpellInfo const* learnSpellInfo = nullptr;
++                   for (SpellEffectInfo const& spellEffectInfo : spellInfo->GetEffects())
++                   {
++                       if (spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL))
++                       {
++                           learn = true;
++                           learnSpellInfo = sSpellMgr->GetSpellInfo(spellEffectInfo.TriggerSpell, spellInfo->Difficulty);
++                           break;
++                       }
++                   }
 
                     bool talent = spellInfo->HasAttribute(SPELL_ATTR0_CU_IS_TALENT);
                     bool passive = spellInfo->IsPassive();
@@ -897,7 +904,7 @@ public:
 
                     // unit32 used to prevent interpreting uint8 as char at output
                     // find rank of learned spell for learning spell, or talent rank
-                    uint32 rank = learn && learnSpellInfo ? learnSpellInfo->GetRank() : spellInfo->GetRank();
+                    uint32 rank = learnSpellInfo ? learnSpellInfo->GetRank() : spellInfo->GetRank();
 
                     // send spell in "id - [name, rank N] [talent] [passive] [learn] [known]" format
                     std::ostringstream ss;
@@ -960,14 +967,16 @@ public:
             bool known = target && target->HasSpell(id);
 
             bool learn = false;
-            SpellInfo const* learnSpellInfo;
-            if (spellInfo->GetEffects().size()) {
-                SpellEffectInfo const& spellEffectInfo = spellInfo->GetEffect(EFFECT_0);
-                learn = spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL);
-
-                if (learn)
-                    learnSpellInfo = sSpellMgr->GetSpellInfo(spellEffectInfo.TriggerSpell, DIFFICULTY_NONE);
-            }
++           SpellInfo const* learnSpellInfo = nullptr;
++           for (SpellEffectInfo const& spellEffectInfo : spellInfo->GetEffects())
++           {
++               if (spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL))
++               {
++                   learn = true;
++                   learnSpellInfo = sSpellMgr->GetSpellInfo(spellEffectInfo.TriggerSpell, DIFFICULTY_NONE);
++                   break;
++               }
++           }
 
             bool talent = spellInfo->HasAttribute(SPELL_ATTR0_CU_IS_TALENT);
             bool passive = spellInfo->IsPassive();


### PR DESCRIPTION
GetEffect assertion fails for spells with no linked SpellEffect entries.
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Loop over effects instead of getting only EFFECT_0
-  Ensure (implicitly via the above) that the spell has effects

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Tests performed:**

Built, tested in game - works as expected from 'normal' spells

**Potential Improvements:**

- The two lookup spell methods are mostly the same. Perhaps they should be merged or remade into wrappers of a common method?


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
