### PR TITLE
Core/Spells: Fixed a exploit with delayed spells and melee attacks

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -534,6 +534,7 @@ class TC_GAME_API Spell
         bool IsChannelActive() const;
         bool IsAutoActionResetSpell() const;
         bool IsPositive() const;
+        bool IsDelayedSpell() const;
 
         bool IsTriggeredByAura(SpellInfo const* auraSpellInfo) const { return (auraSpellInfo == m_triggeredByAuraSpell); }
 
@@ -574,6 +575,7 @@ class TC_GAME_API Spell
         void TriggerGlobalCooldown();
         void CancelGlobalCooldown();
         void _cast(bool skipCheck = false);
+        void HandleWithMeleeReset();
 
         void SendLoot(ObjectGuid guid, LootType loottype);
         std::pair<float, float> GetMinMaxRange(bool strict) const;


### PR DESCRIPTION
**Changes proposed:**

-  When you cast a positive spell, it resets auto-attack timer
-  But when you cast a negative delayed spell (speed > 0), you will use the auto-attack immediately after cast finish
-  It happens, because we remove UNIT_CAST_STATE inside _cast method, and finish state (when we normally reset auto-attack timers) happens just after a delay. It allow dps casters, stay close of Boss and continue meleeing between casts
- You can use this exploit to get extra mana from Judgement of Wisdom, or in some cases like Elemental Shaman, get a extra dps.

**Target branch(es):** 3.3.5/master

**Issues addressed:**

has no open issue i belive


**Tests performed:**

builded and tested
