### PR TITLE
Core/Scripts: Added OnConversationExpire hook to ConversationScripts

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,18 @@
+-- 
+DELETE FROM `conversation_line_template` WHERE `Id` IN (32915, 32916, 32917, 32918, 32919, 32926);
+INSERT INTO `conversation_line_template` (`Id`, `StartTime`, `UiCameraID`, `ActorIdx`, `Flags`, `VerifiedBuild`) VALUES
+(32915, 0, 0, 0, 0, 40120),
+(32916, 9878, 0, 0, 0, 40120),
+(32917, 22389, 0, 0, 0, 40120),
+(32918, 33855, 0, 0, 0, 40120),
+(32919, 43842, 0, 0, 0, 40120),
+(32926, 55409, 0, 1, 1, 40120);
+
+DELETE FROM `conversation_template` WHERE `Id`=13254;
+INSERT INTO `conversation_template` (`Id`, `FirstLineID`, `LastLineEndTime`, `TextureKitId`, `ScriptName`, `VerifiedBuild`) VALUES
+(13254, 32915, 55409, 0, 'conversation_allied_race_dk_defender_of_azeroth', 40120);
+
+DELETE FROM `conversation_actors` WHERE (`ConversationId`=13254 AND `Idx`=0);
+INSERT INTO `conversation_actors` (`ConversationId`, `ConversationActorId`, `ConversationActorGuid`,  `Idx`, `VerifiedBuild`) VALUES
+-- (13254, 0, 0, 1, 40120), -- Full: 0x0800040000000000FFFFFFFFFFFFFFFF Player/0 R1/S16777215 Map: 0 (Eastern Kingdoms) Low: 1099511627775
+(13254, 74042, 1050053, 0, 40120); -- Full: 0x203AF51F209DEB400009E0000059DA73 Creature/0 R3773/S2528 Map: 2297 (Icecrown Citadel (8.3)) Entry: 161709 (Highlord Darion Mograine) Low: 5888627

--- a/src/server/game/Entities/Conversation/Conversation.cpp
+++ b/src/server/game/Entities/Conversation/Conversation.cpp
@@ -71,6 +71,7 @@ void Conversation::Update(uint32 diff)
     }
     else
     {
+        sScriptMgr->OnConversationExpire(this);
         Remove(); // expired
         return;
     }

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2171,6 +2171,14 @@ void ScriptMgr::OnConversationCreate(Conversation* conversation, Unit* creator)
     tmpscript->OnConversationCreate(conversation, creator);
 }
 
+void ScriptMgr::OnConversationExpire(Conversation* conversation)
+{
+    ASSERT(conversation);
+
+    GET_SCRIPT(ConversationScript, conversation->GetScriptId(), tmpscript);
+    tmpscript->OnConversationExpire(conversation);
+}
+
 // Scene
 void ScriptMgr::OnSceneStart(Player* player, uint32 sceneInstanceID, SceneTemplate const* sceneTemplate)
 {

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -828,6 +828,9 @@ class TC_GAME_API ConversationScript : public ScriptObject
 
         // Called when Conversation is created but not added to Map yet.
         virtual void OnConversationCreate(Conversation* /*conversation*/, Unit* /*creator*/) { }
+
+        // Called when Conversation is expired
+        virtual void OnConversationExpire(Conversation* /*conversation*/) { }
 };
 
 class TC_GAME_API SceneScript : public ScriptObject
@@ -1132,6 +1135,7 @@ class TC_GAME_API ScriptMgr
     public: /* ConversationScript */
 
         void OnConversationCreate(Conversation* conversation, Unit* creator);
+        void OnConversationExpire(Conversation* conversation);
 
     public: /* SceneScript */
 

--- a/src/server/scripts/World/conversation_scripts.cpp
+++ b/src/server/scripts/World/conversation_scripts.cpp
@@ -15,6 +15,35 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Conversation.h"
+#include "ObjectAccessor.h"
+
+class conversation_allied_race_dk_defender_of_azeroth : public ConversationScript
+{
+public:
+    enum KilledMonsterCreditIds : uint32
+    {
+        NPC_TALK_TO_YOUR_COMMANDER_CREDIT   = 161709,
+        NPC_LISTEN_TO_YOUR_COMMANDER_CREDIT = 163027
+    };
+
+    conversation_allied_race_dk_defender_of_azeroth() : ConversationScript("conversation_allied_race_dk_defender_of_azeroth") { }
+
+    void OnConversationCreate(Conversation* conversation, Unit* creator) override
+    {
+        conversation->AddActor(creator->GetGUID(), 1);
+        if (Player* player = creator->ToPlayer())
+            player->KilledMonsterCredit(NPC_TALK_TO_YOUR_COMMANDER_CREDIT);
+    }
+
+    void OnConversationExpire(Conversation* conversation) override
+    {
+        if (Player* creator = ObjectAccessor::GetPlayer(*conversation, conversation->GetCreatorGuid()))
+            creator->KilledMonsterCredit(NPC_LISTEN_TO_YOUR_COMMANDER_CREDIT);
+    }
+};
+
 void AddSC_conversation_scripts()
 {
+    new conversation_allied_race_dk_defender_of_azeroth();
 }

--- a/src/server/scripts/World/conversation_scripts.cpp
+++ b/src/server/scripts/World/conversation_scripts.cpp
@@ -18,6 +18,7 @@
 #include "ScriptMgr.h"
 #include "Conversation.h"
 #include "ObjectAccessor.h"
+#include "Player.h"
 
 class conversation_allied_race_dk_defender_of_azeroth : public ConversationScript
 {

--- a/src/server/scripts/World/conversation_scripts.cpp
+++ b/src/server/scripts/World/conversation_scripts.cpp
@@ -15,6 +15,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "ScriptMgr.h"
 #include "Conversation.h"
 #include "ObjectAccessor.h"
 


### PR DESCRIPTION
* also added example for Defender of Azeroth conversation

**Changes proposed:**

-  Added OnConversationExpire hook to ConversationScripts
-  Added conversation script for Defender of Azeroth conversation
-  

**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
build, tested ingame with
```sql

UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=161709;
DELETE FROM `smart_scripts` WHERE `entryorguid`=161709 AND `source_type`=0;
INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `event_type`, `event_param1`, `action_type`, `action_param1`, `action_param2`, `target_type`, `target_param1`, `comment`) VALUES 
(161709, 0, 0, 62, 25082, 134, 316983, 0, 1, 0, 'Darion Mograine - On Gossip Option Select - Invoker Cast - Self'),
(161709, 0, 1, 62, 25082, 143, 13254, 1, 7, 0, 'Darion Mograine - On Gossip Option Select - Create Conversation - Invoker'),
(161709, 0, 2, 62, 25082, 72, 0, 0, 0, 0, 'Darion Mograine - On Gossip Option Select - Close Gossip');
```
