### PR TITLE
Entities/Unit: Fixed wrong combat stop when remove charm

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11664,7 +11664,7 @@ void Unit::RemoveCharmedBy(Unit* charmer)
         type = CHARM_TYPE_CHARM;
 
     CastStop();
-    CombatStop(); /// @todo CombatStop(true) may cause crash (interrupt spells)
+    AttackStop();
 
     if (_oldFactionId)
     {


### PR DESCRIPTION
**Changes proposed:**

-  Changed CombatStop() to AttackStop()
-  It fix a exploit, allowing players use more potions in fights like Kelthuzad or Lady Deathwhisper

**Target branch(es):** 3.3.5

**Issues addressed:** has no open issue

**Tests performed:**

Builded and tested in game
