### PR TITLE
Core/BattlePets: Fixes when adding pets

### DIFF
--- a/src/server/game/BattlePets/BattlePetMgr.cpp
+++ b/src/server/game/BattlePets/BattlePetMgr.cpp
@@ -402,6 +402,7 @@ void BattlePetMgr::AddPet(uint32 species, uint32 display, uint16 breed, BattlePe
     updates.push_back(std::ref(pet));
     SendUpdates(std::move(updates), true);
 
+    _owner->GetPlayer()->UpdateCriteria(CriteriaType::UniquePetsOwned);
     _owner->GetPlayer()->UpdateCriteria(CriteriaType::LearnedNewPet, species);
 }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3115,17 +3115,6 @@ bool Player::AddSpell(uint32 spellId, bool active, bool learning, bool dependent
     if (sDB2Manager.GetMount(spellId))
         GetSession()->GetCollectionMgr()->AddMount(spellId, MOUNT_STATUS_NONE, false, IsInWorld() ? false : true);
 
-    // need to add Battle pets automatically into pet journal
-    for (BattlePetSpeciesEntry const* entry : sBattlePetSpeciesStore)
-    {
-        if (entry->SummonSpellID == int32(spellId) && GetSession()->GetBattlePetMgr()->GetPetCount(entry->ID) == 0)
-        {
-            GetSession()->GetBattlePetMgr()->AddPet(entry->ID, BattlePetMgr::SelectPetDisplay(entry), BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
-            UpdateCriteria(CriteriaType::UniquePetsOwned);
-            break;
-        }
-    }
-
     // return true (for send learn packet) only if spell active (in case ranked spells) and not replace old spell
     return active && !disabled && !superceded_old;
 }

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -1206,11 +1206,8 @@ void WorldSession::HandleUseCritterItem(WorldPackets::Item::UseCritterItem& useC
         if (itemEffect->TriggerType != ITEM_SPELLTRIGGER_LEARN_SPELL_ID)
             continue;
 
-        if (BattlePetSpeciesEntry const* entry = sSpellMgr->GetBattlePetSpecies(uint32(itemEffect->SpellID)))
-        {
-            GetBattlePetMgr()->AddPet(entry->ID, BattlePetMgr::SelectPetDisplay(entry), BattlePetMgr::RollPetBreed(entry->ID), BattlePetMgr::GetDefaultPetQuality(entry->ID));
-            _player->UpdateCriteria(CriteriaType::UniquePetsOwned);
-        }
+        if (BattlePetSpeciesEntry const* speciesEntry = sSpellMgr->GetBattlePetSpecies(uint32(itemEffect->SpellID)))
+            GetBattlePetMgr()->AddPet(speciesEntry->ID, BattlePetMgr::SelectPetDisplay(speciesEntry), BattlePetMgr::RollPetBreed(speciesEntry->ID), BattlePetMgr::GetDefaultPetQuality(speciesEntry->ID));
     }
 
     _player->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2146,6 +2146,9 @@ void Spell::EffectLearnSpell()
                 continue;
 
             player->LearnSpell(itemEffect->SpellID, false);
+
+            if (BattlePetSpeciesEntry const* speciesEntry = sSpellMgr->GetBattlePetSpecies(uint32(itemEffect->SpellID)))
+                player->GetSession()->GetBattlePetMgr()->AddPet(speciesEntry->ID, BattlePetMgr::SelectPetDisplay(speciesEntry), BattlePetMgr::RollPetBreed(speciesEntry->ID), BattlePetMgr::GetDefaultPetQuality(speciesEntry->ID));
         }
     }
 
@@ -5713,8 +5716,9 @@ void Spell::EffectUncageBattlePet()
 
     battlePetMgr->AddPet(speciesId, displayId, breed, BattlePetBreedQuality(quality), level);
 
-    if (!plr->HasSpell(speciesEntry->SummonSpellID))
-        plr->LearnSpell(speciesEntry->SummonSpellID, false);
+    if (speciesEntry->SummonSpellID)
+        if (!plr->HasSpell(speciesEntry->SummonSpellID))
+            plr->LearnSpell(speciesEntry->SummonSpellID, false);
 
     plr->SendPlaySpellVisual(plr, SPELL_VISUAL_UNCAGE_PET, 0, 0, 0.f, false);
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add pet when learning it for the first time (summon spell not known).
- Removed code that adds battle pet if its summon spell is known (Learn cageable pet -> Cage pet -> Log out -> Log in -> Pet is added).
- When uncaging check that the species has a summon spell before trying to learn it.


**Target branch(es):** 3.3.5/master

- [ ] 3.3.5
- [x] master

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
