### PR TITLE
Scripts/Commands: fix `.learn all recipes`

### DIFF
--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -405,9 +405,6 @@ public:
             uint8 locale = 0;
             for (; locale < TOTAL_LOCALES; ++locale)
             {
-                if (locale == handler->GetSessionDbcLocale())
-                    continue;
-
                 name = skillInfo->DisplayName[locale];
                 if (!name || !*name)
                     continue;


### PR DESCRIPTION
Fixes issue where if client had **same** locale as server, the command didn't work (comparison should've been != and not ==).  Furthermore, server dbcs only have the server locale for these, and they might or might not match up with the client. Very few server dbcs contain more than one language, so changing == to != will just disallow players from another locale from using the command at all. Therefore I remove the clause completely.

**Changes proposed:**

-  remove locale check from `learn all recipes` command

**Target branch(es):** 3.3.5/master

- [x] 3.3.5
- [ ] master

**Issues addressed:**

**Tests performed:**

Tested ingame

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] If you want to guard against theoretical overlapping skill names between locales ("what if tailoring is enchanting in spanish etc.), add support for some locale qualifier before the name or restore the if clause with != instead of ==. I highly doubt a single such instance exists, especially for professions.