### PR TITLE
Core/Unit: prevent in-combat despawn for guardian/pet 

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -302,6 +302,17 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
         return false;
     }
 
+    // Case: Unit is a minion (Guardian/Pet) but owner is already dead.
+    // Fight ends without minions death - we despawn the minion here.
+    if (me->GetOwner())
+    {
+        if ((me->IsGuardian() || me->IsPet()) && !me->GetOwner()->IsAlive())
+        {
+            me->DespawnOrUnsummon();
+            return true;
+        }
+    }
+
     me->RemoveAurasOnEvade();
     me->ClearComboPointHolders(); // Remove all combo points targeting this unit
     me->CombatStop(true);


### PR DESCRIPTION
**Changes proposed:**

-  Summoned Pets & Guardians stay alive after their master has been killed

**Target branch(es):** 3.3.5/master

- [X] 3.3.5

**Issues addressed:**

Closes #21763

**Tests performed:**

- [X] Builds
- [X] Tested in-game


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Would be nice if we have a few more people test this. I tested all the cases that came up to my mind. Totems get correctly despawned, charm effects will be stopped. Creatures summoned by scripts will continue whatever the script intended to do. Eventually this should only affect creatures that are summoned by spells like Voidwalkers.

- [ ] The issue mentions that a minion should be despawned if the master gets killed with a one-shot. This is true. In my opinion, this behavior is out of scope of this PR and unrelated to the mechanic here. Blizzard has a delay on aggro chains/effects. Trinitycore has an instant aggro tick. If this ever gets corrected, this PR will also cover the one-shot mechanic without any needed changes. Therefore, i believe that the issue can be closed if this gets merged. Feel free to discuss.

Additional thanks to @acidmanifesto for his input and showing me his own attempt in solving this. It bothered me enough to take a look myself :grin: