### PR TITLE
Scripts/Uldaman: Fix Ironaya crash

### DIFF
--- a/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp
+++ b/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp
@@ -33,82 +33,70 @@ enum Ironaya
     SPELL_WSTOMP                = 11876
 };
 
-class boss_ironaya : public CreatureScript
+struct boss_ironaya : public ScriptedAI
 {
-    public:
+    boss_ironaya(Creature* creature) : ScriptedAI(creature)
+    {
+        Initialize();
+    }
 
-        boss_ironaya()
-            : CreatureScript("boss_ironaya")
+    void Initialize()
+    {
+        _hasCastKnockaway = false;
+        _hasCastWstomp = false;
+    }
+
+    void Reset() override
+    {
+        _scheduler.CancelAll();
+        Initialize();
+    }
+
+    void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
+    {
+        if (!_hasCastKnockaway && HealthBelowPct(50) && me->GetVictim())
         {
+            _hasCastKnockaway = true;
+            DoCastVictim(SPELL_KNOCKAWAY, true);
+            ResetThreat(me->GetVictim(), me);
         }
 
-        struct boss_ironayaAI : public ScriptedAI
+        if (!_hasCastWstomp && HealthBelowPct(25))
         {
-            boss_ironayaAI(Creature* creature) : ScriptedAI(creature)
-            {
-                Initialize();
-            }
-
-            void Initialize()
-            {
-                uiArcingTimer = 3000;
-                bHasCastKnockaway = false;
-                bHasCastWstomp = false;
-            }
-
-            uint32 uiArcingTimer;
-            bool bHasCastWstomp;
-            bool bHasCastKnockaway;
-
-            void Reset() override
-            {
-                Initialize();
-            }
-
-            void JustEngagedWith(Unit* /*who*/) override { }
-
-            void UpdateAI(uint32 uiDiff) override
-            {
-                //Return since we have no target
-                if (!UpdateVictim())
-                    return;
-
-                //If we are <50% hp do knockaway ONCE
-                if (!bHasCastKnockaway && HealthBelowPct(50) && me->GetVictim())
-                {
-                    DoCastVictim(SPELL_KNOCKAWAY, true);
-                    me->GetThreatManager().ResetThreat(me->EnsureVictim());
-
-                    //Shouldn't cast this agian
-                    bHasCastKnockaway = true;
-                }
-
-                //uiArcingTimer
-                if (uiArcingTimer <= uiDiff)
-                {
-                    DoCast(me, SPELL_ARCINGSMASH);
-                    uiArcingTimer = 13000;
-                } else uiArcingTimer -= uiDiff;
-
-                if (!bHasCastWstomp && HealthBelowPct(25))
-                {
-                    DoCast(me, SPELL_WSTOMP);
-                    bHasCastWstomp = true;
-                }
-
-                DoMeleeAttackIfReady();
-            }
-        };
-
-        CreatureAI* GetAI(Creature* creature) const override
-        {
-            return GetUldamanAI<boss_ironayaAI>(creature);
+            _hasCastWstomp = true;
+            DoCastSelf(SPELL_WSTOMP);
         }
+    }
+
+    void JustEngagedWith(Unit* /*who*/) override
+    {
+        _scheduler.Schedule(3s, [this](TaskContext task)
+        {
+            DoCastSelf(SPELL_ARCINGSMASH);
+            task.Repeat(13s);
+        });
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!UpdateVictim())
+            return;
+
+        _scheduler.Update(diff, [this]
+        {
+            DoMeleeAttackIfReady();
+        });
+    }
+
+private:
+    TaskScheduler _scheduler;
+    bool _hasCastKnockaway;
+    bool _hasCastWstomp;
 };
 
 //This is the actual function called only once durring InitScripts()
 //It must define all handled functions that are to be run in this script
 void AddSC_boss_ironaya()
 {
-    new boss_ironaya();
+    RegisterUldamanCreatureAI(boss_ironaya);
 }

--- a/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp
+++ b/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp
@@ -52,7 +52,7 @@ struct boss_ironaya : public ScriptedAI
         Initialize();
     }
 
-    void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
+    void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
     {
         if (!_hasCastKnockaway && HealthBelowPct(50) && me->GetVictim())
         {

--- a/src/server/scripts/EasternKingdoms/Uldaman/uldaman.h
+++ b/src/server/scripts/EasternKingdoms/Uldaman/uldaman.h
@@ -50,4 +50,6 @@ inline AI* GetUldamanAI(T* obj)
     return GetInstanceAI<AI>(obj, UldamanScriptName);
 }
 
+#define RegisterUldamanCreatureAI(ai_name) RegisterCreatureAIWithFactory(ai_name, GetUldamanAI)
+
 #endif


### PR DESCRIPTION
**Changes proposed:**

-  Fix Ironaya crash when ResetThreat: https://github.com/TrinityCore/TrinityCore/blob/ed939325374216d6a049e778d6ad864c65283ae6/src/server/scripts/EasternKingdoms/Uldaman/boss_ironaya.cpp#L76-L84
SPELL_KNOCKAWAY (ID - 10101 Knock Away) has SPELL_EFFECT_WEAPON_DAMAGE, so can kill the victim, in that case, when ResetThreat do EnsureVictim and ASSERT is triggered:
https://github.com/TrinityCore/TrinityCore/blob/1403de8dafbadb92dfd16c47b63156f9216a2bdd/src/server/game/Entities/Unit/Unit.h#L849-L854
-  Little code cleanup, because is ancient script and I prefer check HealthBelowPct inside DamageTaken instead every UpdateAI tick.
I don't want do a fully instance rewrite, the focus of this PR is fix the crash, anyone can do rewrite later


**Issues addressed:**

Closes: None, maybe .die Treeston again :D (https://github.com/TrinityCore/TrinityCore/commit/e2a1ccd118d129b96e09ff1a15ed0adb1d4a3897#diff-096cfd16b5b45a8321f215ef98d7cf24dd99013dec4983ef2db15b86aa140e8c)


**Tests performed:**

Tested in-game
