### PR TITLE
Core/BattlePets: Summoning spells mustn't be learned

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2147,20 +2147,17 @@ void Spell::EffectLearnSpell()
             if (itemEffect->TriggerType != ITEM_SPELLTRIGGER_LEARN_SPELL_ID)
                 continue;
 
-            //  If the spell summons a battle pet, we fake that it has been learned and the battle pet is added
+            bool dependent = false;
+
             if (BattlePetSpeciesEntry const* speciesEntry = sSpellMgr->GetBattlePetSpecies(uint32(itemEffect->SpellID)))
             {
-                if (player->IsInWorld())
-                {
-                    WorldPackets::Spells::LearnedSpells packet;
-                    packet.SpellID.push_back(itemEffect->SpellID);
-                    packet.SuppressMessaging = false;
-                    player->SendDirectMessage(packet.Write());
-                }
                 player->GetSession()->GetBattlePetMgr()->AddPet(speciesEntry->ID, BattlePetMgr::SelectPetDisplay(speciesEntry), BattlePetMgr::RollPetBreed(speciesEntry->ID), BattlePetMgr::GetDefaultPetQuality(speciesEntry->ID));
+                // If the spell summons a battle pet, we fake that it has been learned and the battle pet is added
+                // marking as dependent prevents saving the spell to database (intended)
+                dependent = true;
             }
-            else
-                player->LearnSpell(itemEffect->SpellID, false);
+
+            player->LearnSpell(itemEffect->SpellID, dependent);
         }
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Battle pet summoning spells shouldn't be learned

I'm not quite sure, so I did some tests on retail:
- They're never sent in SMSG_SEND_KNOWN_SPELLS (mount spells are).
- Sample of sending opcodes using item https://www.wowhead.com/item=10361/brown-snake and uncaging that same battle pet species:
  - First time:
      - Using item: CMSG_USE_ITEM -> SMSG_LEARNED_SPELLS
      - Using item: CMSG_USE_CRITTER_ITEM (it seems that once the client receives SMSG_LEARNED_SPELLS during the session, it only sends CMSG_USE_CRITTER_ITEM)
  - Delete all copies of the pet. Log out. Log in:
      - Uncaging: CMSG_USE_ITEM
      - Uncaging: CMSG_USE_ITEM
      - Using item: CMSG_USE_ITEM -> SMSG_LEARNED_SPELLS
   - Keep a copy of the pet. Log out. Log in
      - Using item: CMSG_USE_ITEM -> SMSG_LEARNED_SPELLS

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
