### PR TITLE
Core/SAI: Add actions to reset unit_flags to default

### DIFF
--- a/sql/updates/world/3.3.5/2021_10_30_25_world.sql
+++ b/sql/updates/world/3.3.5/2021_10_30_25_world.sql
@@ -1,0 +1,3 @@
+--
+UPDATE `smart_scripts` SET `action_type` = 148 WHERE `action_type` = 146;
+UPDATE `smart_scripts` SET `action_type` = 146 WHERE `action_type` = 145;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2343,12 +2343,29 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             for (WorldObject* target : targets)
             {
-                if (IsUnit(target))
+                if (IsCreature(target))
                 {
                     if (e.action.setImmunePC.immunePC)
-                        target->ToUnit()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                        target->ToCreature()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
                     else
-                        target->ToUnit()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                        target->ToCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_RESET_IMMUNE_PC:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsCreature(target))
+                {
+                    if (CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(target->ToCreature()->GetEntry()))
+                    {
+                        if (cInfo->unit_flags & UNIT_FLAG_IMMUNE_TO_PC)
+                            target->ToCreature()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                        else
+                            target->ToCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);
+                    }
                 }
             }
             break;
@@ -2357,12 +2374,29 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             for (WorldObject* target : targets)
             {
-                if (IsUnit(target))
+                if (IsCreature(target))
                 {
                     if (e.action.setImmuneNPC.immuneNPC)
-                        target->ToUnit()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                        target->ToCreature()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
                     else
-                        target->ToUnit()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                        target->ToCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_RESET_IMMUNE_NPC:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsCreature(target))
+                {
+                    if (CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(target->ToCreature()->GetEntry()))
+                    {
+                        if (cInfo->unit_flags & UNIT_FLAG_IMMUNE_TO_NPC)
+                            target->ToCreature()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                        else
+                            target->ToCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC);
+                    }
                 }
             }
             break;
@@ -2371,12 +2405,29 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             for (WorldObject* target : targets)
             {
-                if (IsUnit(target))
+                if (IsCreature(target))
                 {
                     if (e.action.setUninteractible.uninteractible)
-                        target->ToUnit()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                        target->ToCreature()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
                     else
-                        target->ToUnit()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                        target->ToCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_RESET_UNINTERACTIBLE:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (IsCreature(target))
+                {
+                    if (CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(target->ToCreature()->GetEntry()))
+                    {
+                        if (cInfo->unit_flags & UNIT_FLAG_UNINTERACTIBLE)
+                            target->ToCreature()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                        else
+                            target->ToCreature()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+                    }
                 }
             }
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -941,8 +941,11 @@ bool SmartAIMgr::CheckUnusedActionParams(SmartScriptHolder const& e)
             case SMART_ACTION_SET_HEALTH_PCT: return sizeof(SmartAction::setHealthPct);
             //case SMART_ACTION_CREATE_CONVERSATION: return sizeof(SmartAction::raw);
             case SMART_ACTION_SET_IMMUNE_PC: return sizeof(SmartAction::setImmunePC);
+            case SMART_ACTION_RESET_IMMUNE_PC: return NO_PARAMS;
             case SMART_ACTION_SET_IMMUNE_NPC: return sizeof(SmartAction::setImmuneNPC);
+            case SMART_ACTION_RESET_IMMUNE_NPC: return NO_PARAMS;
             case SMART_ACTION_SET_UNINTERACTIBLE: return sizeof(SmartAction::setUninteractible);
+            case SMART_ACTION_RESET_UNINTERACTIBLE: return NO_PARAMS;
             default:
                 TC_LOG_WARN("sql.sql", "SmartAIMgr: Entry %d SourceType %u Event %u Action %u is using an action with no unused params specified in SmartAIMgr::CheckUnusedActionParams(), please report this.",
                     e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -587,10 +587,13 @@ enum SMART_ACTION
     SMART_ACTION_SET_HEALTH_PCT                     = 142,    // percent
     SMART_ACTION_CREATE_CONVERSATION                = 143,    // don't use on 3.3.5a
     SMART_ACTION_SET_IMMUNE_PC                      = 144,    // 0/1
-    SMART_ACTION_SET_IMMUNE_NPC                     = 145,    // 0/1
-    SMART_ACTION_SET_UNINTERACTIBLE                 = 146,    // 0/1
+    SMART_ACTION_RESET_IMMUNE_PC                    = 145,    //
+    SMART_ACTION_SET_IMMUNE_NPC                     = 146,    // 0/1
+    SMART_ACTION_RESET_IMMUNE_NPC                   = 147,    //
+    SMART_ACTION_SET_UNINTERACTIBLE                 = 148,    // 0/1
+    SMART_ACTION_RESET_UNINTERACTIBLE               = 149,    //
 
-    SMART_ACTION_END                                = 147
+    SMART_ACTION_END                                = 150
 };
 
 enum class SmartActionSummonCreatureFlags


### PR DESCRIPTION
**Changes proposed:**

-  Add actions to reset unit_flags to default
-  Change target of unit_flags actions from unit to creature, we don't want to accidentally make player immune(how it never happened)

**Issues addressed:**

none

**Tests performed:**

none

**Known issues and TODO list:**

- [ ] test it if build will be not broken