### PR TITLE
Core/Spells: Warrior spell is knocked back with DODGE when returning to rage consumption

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2559,6 +2559,8 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
         // Do not take combo points on dodge and miss
         if (MissCondition != SPELL_MISS_NONE && spell->m_needComboPoints && spell->m_targets.GetUnitTargetGUID() == TargetGUID)
             spell->m_needComboPoints = false;
+        else if (caster->GetTypeId() == TYPEID_PLAYER && MissCondition == SPELL_MISS_PARRY && MissCondition == SPELL_MISS_DODGE && spell->m_spellInfo->PowerType == POWER_RAGE)
+            caster->ModifyPower(POWER_RAGE, spell->m_powerCost);
 
         // _spellHitTarget can be null if spell is missed in DoSpellHitOnUnit
         if (MissCondition != SPELL_MISS_EVADE && _spellHitTarget && !spell->m_caster->IsFriendlyTo(unit) && (!spell->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)))


### PR DESCRIPTION
test https://github.com/TrinityCore/TrinityCore/issues/27218
https://wowwiki-archive.fandom.com/wiki/Parry The above statement is not the same as https://www.bluetracker.gg/wow/topic/eu-en/12911577-18-02-05-kalgans-response- to-warriors/ above does not match
Unable to determine if SPELL_MISS_DODGE is included and returns full cost or 80%

**Changes proposed:**

- Warrior cast spell
-  DODGE and PARRY the hits 
-  return rage cost

**Issues addressed:**
https://github.com/TrinityCore/TrinityCore/issues/27218
**Tests performed:**
 tested in-game,
