### PR TITLE
Core/Combat: Fixed combat after remove charm

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -295,20 +295,32 @@ void CombatManager::EndAllPvECombat()
         _pveRefs.begin()->second->EndCombat();
 }
 
-void CombatManager::EndPvECombatWithPlayers()
+void CombatManager::EndAllInvalidCombat()
 {
     auto it = _pveRefs.begin(), end = _pveRefs.end();
     while (it != end)
     {
         CombatReference* const ref = it->second;
-        Unit* other = ref->GetOther(_owner);
-        if (other->GetTypeId() == TYPEID_PLAYER || other->GetCharmerOrOwnerOrSelf()->GetTypeId() == TYPEID_PLAYER)
+        if (!CanBeginCombat(_owner, ref->GetOther(_owner)))
         {
             it = _pveRefs.erase(it), end = _pveRefs.end(); // erase manually here to avoid iterator invalidation
             ref->EndCombat();
         }
         else
             ++it;
+    }
+
+    auto it2 = _pvpRefs.begin(), end2 = _pvpRefs.end();
+    while (it2 != end2)
+    {
+        CombatReference* const ref = it2->second;
+        if (!CanBeginCombat(_owner, ref->GetOther(_owner)))
+        {
+            it2 = _pvpRefs.erase(it2), end2 = _pvpRefs.end(); // erase manually here to avoid iterator invalidation
+            ref->EndCombat();
+        }
+        else
+            ++it2;
     }
 }
 

--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -295,7 +295,7 @@ void CombatManager::EndAllPvECombat()
         _pveRefs.begin()->second->EndCombat();
 }
 
-void CombatManager::EndAllInvalidCombat()
+void CombatManager::RevalidateCombat()
 {
     auto it = _pveRefs.begin(), end = _pveRefs.end();
     while (it != end)

--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -295,6 +295,23 @@ void CombatManager::EndAllPvECombat()
         _pveRefs.begin()->second->EndCombat();
 }
 
+void CombatManager::EndPvECombatWithPlayers()
+{
+    auto it = _pveRefs.begin(), end = _pveRefs.end();
+    while (it != end)
+    {
+        CombatReference* const ref = it->second;
+        Unit* other = ref->GetOther(_owner);
+        if (other->GetTypeId() == TYPEID_PLAYER || other->GetCharmerOrOwnerOrSelf()->GetTypeId() == TYPEID_PLAYER)
+        {
+            it = _pveRefs.erase(it), end = _pveRefs.end(); // erase manually here to avoid iterator invalidation
+            ref->EndCombat();
+        }
+        else
+            ++it;
+    }
+}
+
 void CombatManager::EndAllPvPCombat()
 {
     while (!_pvpRefs.empty())

--- a/src/server/game/Combat/CombatManager.h
+++ b/src/server/game/Combat/CombatManager.h
@@ -122,6 +122,7 @@ class TC_GAME_API CombatManager
         // flags any pvp refs for suppression on owner's side - these refs will not generate combat until refreshed
         void SuppressPvPCombat();
         void EndAllPvECombat();
+        void EndPvECombatWithPlayers();
         void EndAllPvPCombat();
         void EndAllCombat() { EndAllPvECombat(); EndAllPvPCombat(); }
 

--- a/src/server/game/Combat/CombatManager.h
+++ b/src/server/game/Combat/CombatManager.h
@@ -122,7 +122,7 @@ class TC_GAME_API CombatManager
         // flags any pvp refs for suppression on owner's side - these refs will not generate combat until refreshed
         void SuppressPvPCombat();
         void EndAllPvECombat();
-        void EndPvECombatWithPlayers();
+        void EndAllInvalidCombat();
         void EndAllPvPCombat();
         void EndAllCombat() { EndAllPvECombat(); EndAllPvPCombat(); }
 

--- a/src/server/game/Combat/CombatManager.h
+++ b/src/server/game/Combat/CombatManager.h
@@ -122,7 +122,7 @@ class TC_GAME_API CombatManager
         // flags any pvp refs for suppression on owner's side - these refs will not generate combat until refreshed
         void SuppressPvPCombat();
         void EndAllPvECombat();
-        void EndAllInvalidCombat();
+        void RevalidateCombat();
         void EndAllPvPCombat();
         void EndAllCombat() { EndAllPvECombat(); EndAllPvPCombat(); }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11665,6 +11665,8 @@ void Unit::RemoveCharmedBy(Unit* charmer)
 
     CastStop();
     AttackStop();
+    if (GetTypeId() == TYPEID_PLAYER)
+        m_combatManager.EndPvECombatWithPlayers();
 
     if (_oldFactionId)
     {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11665,8 +11665,6 @@ void Unit::RemoveCharmedBy(Unit* charmer)
 
     CastStop();
     AttackStop();
-    if (GetTypeId() == TYPEID_PLAYER)
-        m_combatManager.EndPvECombatWithPlayers();
 
     if (_oldFactionId)
     {
@@ -11687,6 +11685,7 @@ void Unit::RemoveCharmedBy(Unit* charmer)
     ASSERT(type != CHARM_TYPE_VEHICLE || (GetTypeId() == TYPEID_UNIT && IsVehicle()));
 
     charmer->SetCharm(this, false);
+    m_combatManager.EndAllInvalidCombat();
 
     Player* playerCharmer = charmer->ToPlayer();
     if (playerCharmer)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11685,7 +11685,7 @@ void Unit::RemoveCharmedBy(Unit* charmer)
     ASSERT(type != CHARM_TYPE_VEHICLE || (GetTypeId() == TYPEID_UNIT && IsVehicle()));
 
     charmer->SetCharm(this, false);
-    m_combatManager.EndAllInvalidCombat();
+    m_combatManager.RevalidateCombat();
 
     Player* playerCharmer = charmer->ToPlayer();
     if (playerCharmer)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Remove PVE combat with players, when charm ends

**Issues addressed:**

https://github.com/TrinityCore/TrinityCore/pull/27038#issuecomment-958784361


**Tests performed:**

Builded and tested in game


