### PR TITLE
Core/SAI: Remove reactState param from SMART_ACTION_WP_START

### DIFF
--- a/sql/updates/world/3.3.5/2021_11_07_03_world.sql
+++ b/sql/updates/world/3.3.5/2021_11_07_03_world.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `smart_scripts` SET `action_param6` = 0 WHERE `action_type` = 53 AND `action_param6` = 3;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1394,9 +1394,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 }
             }
 
-            // Extra validation to ignore invalid values stored in the db, see comment at TEMPORARY_EXTRA_VALUE_FOR_DB_CLEANUP definition
-            if (e.action.wpStart.reactState <= REACT_AGGRESSIVE)
-                me->SetReactState((ReactStates)e.action.wpStart.reactState);
             ENSURE_AI(SmartAI, me->AI())->StartPath(run, entry, repeat, unit);
 
             uint32 quest = e.action.wpStart.quest;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1794,16 +1794,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             if (e.action.wpStart.quest && !IsQuestValid(e, e.action.wpStart.quest))
                 return false;
 
-            // Allow "invalid" value 3 for a while to allow cleanup the values stored in the db for SMART_ACTION_WP_START.
-            // Remember to remove this once the clean is complete.
-            constexpr uint32 TEMPORARY_EXTRA_VALUE_FOR_DB_CLEANUP = 1;
-
-            if (e.action.wpStart.reactState > (REACT_AGGRESSIVE + TEMPORARY_EXTRA_VALUE_FOR_DB_CLEANUP))
-            {
-                TC_LOG_ERROR("sql.sql", "SmartAIMgr: Creature %d Event %u Action %u uses invalid React State %u, skipped.", e.entryOrGuid, e.event_id, e.GetActionType(), e.action.wpStart.reactState);
-                return false;
-            }
-
             TC_SAI_IS_BOOLEAN_VALID(e, e.action.wpStart.run);
             TC_SAI_IS_BOOLEAN_VALID(e, e.action.wpStart.repeat);
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -495,7 +495,7 @@ enum SMART_ACTION
     SMART_ACTION_SUMMON_GO                          = 50,     // GameObjectID, DespawnTime in s
     SMART_ACTION_KILL_UNIT                          = 51,     //
     SMART_ACTION_ACTIVATE_TAXI                      = 52,     // TaxiID
-    SMART_ACTION_WP_START                           = 53,     // run/walk, pathID, canRepeat, quest, despawntime, reactState
+    SMART_ACTION_WP_START                           = 53,     // run/walk, pathID, canRepeat, quest, despawntime
     SMART_ACTION_WP_PAUSE                           = 54,     // time
     SMART_ACTION_WP_STOP                            = 55,     // despawnTime, quest, fail?
     SMART_ACTION_ADD_ITEM                           = 56,     // itemID, count
@@ -853,7 +853,7 @@ struct SmartAction
             SAIBool repeat;
             uint32 quest;
             uint32 despawnTime;
-            uint32 reactState;
+            // uint32 reactState; DO NOT REUSE
         } wpStart;
 
         struct


### PR DESCRIPTION
**Changes proposed:**

-  Remove reactState param from SMART_ACTION_WP_START

**Issues addressed:**

none

**Tests performed:**

none

**Known issues and TODO list:**

- [ ] run worldserver