### PR TITLE
Remove Magic Number dealing with freeze and unfreeze gm cmd.

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -2530,7 +2530,8 @@ public:
                 // Add the freeze aura and set the proper duration
                 // Player combat status and flags are now handled
                 // in Freeze Spell AuraScript (OnApply)
-                Aura* freeze = player->AddAura(9454, player);
+				constexpr int FreezeAura = 9454;
+                Aura* freeze = player->AddAura(FreezeAura, player);
                 if (freeze)
                 {
                     if (freezeDuration)
@@ -2570,7 +2571,8 @@ public:
             // Remove Freeze spell (allowing movement and spells)
             // Player Flags + Neutral faction removal is now
             // handled on the Freeze Spell AuraScript (OnRemove)
-            player->RemoveAurasDueToSpell(9454);
+            constexpr int FreezeAura = 9454;			
+            player->RemoveAurasDueToSpell(FreezeAura);
         }
         else
         {

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -61,6 +61,11 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+enum Spells
+{
+    FreezeAura = 9454;
+};
+
 using namespace Trinity::ChatCommands;
 
 class misc_commandscript : public CommandScript
@@ -2530,7 +2535,6 @@ public:
                 // Add the freeze aura and set the proper duration
                 // Player combat status and flags are now handled
                 // in Freeze Spell AuraScript (OnApply)
-                constexpr int FreezeAura = 9454;
                 Aura* freeze = player->AddAura(FreezeAura, player);
                 if (freeze)
                 {
@@ -2571,7 +2575,6 @@ public:
             // Remove Freeze spell (allowing movement and spells)
             // Player Flags + Neutral faction removal is now
             // handled on the Freeze Spell AuraScript (OnRemove)
-            constexpr int FreezeAura = 9454;
             player->RemoveAurasDueToSpell(FreezeAura);
         }
         else

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -63,7 +63,7 @@
 
 enum Spells
 {
-    FreezeAura = 9454;
+    FreezeAura = 9454
 };
 
 using namespace Trinity::ChatCommands;

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -2530,7 +2530,7 @@ public:
                 // Add the freeze aura and set the proper duration
                 // Player combat status and flags are now handled
                 // in Freeze Spell AuraScript (OnApply)
-				constexpr int FreezeAura = 9454;
+                constexpr int FreezeAura = 9454;
                 Aura* freeze = player->AddAura(FreezeAura, player);
                 if (freeze)
                 {

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -2571,7 +2571,7 @@ public:
             // Remove Freeze spell (allowing movement and spells)
             // Player Flags + Neutral faction removal is now
             // handled on the Freeze Spell AuraScript (OnRemove)
-            constexpr int FreezeAura = 9454;			
+            constexpr int FreezeAura = 9454;
             player->RemoveAurasDueToSpell(FreezeAura);
         }
         else


### PR DESCRIPTION
Remove Magic Number dealing with freeze and unfreeze gm cmd.
A magic number is a direct usage of a number in the code.
Magic numbers are an anti-pattern and should generally be avoided. 
They inhibit readability and refactorability.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Remove Magic Number dealing with freeze and unfreeze gm cmd.

**Issues addressed:**

Closes #  None.

**Tests performed:**

(Does it build, tested in-game, etc.)

Builds and works without error. Tested and command still works with no issues.

**How to Test:**
Simple in game test is to type .freeze in game while selecting a player to ensure command still works.

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Code Review
