### PR TITLE
Core/Battlegrounds: Avoid increasing player count per team when re-logging if player was already in the BG

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -991,10 +991,12 @@ void Battleground::AddPlayer(Player* player)
     bp.OfflineRemoveTime = 0;
     bp.Team = team;
 
+    bool const isInBattleground = IsPlayerInBattleground(player->GetGUID());
     // Add to list/maps
     m_Players[player->GetGUID()] = bp;
 
-    UpdatePlayersCountByTeam(team, false);                  // +1 player
+    if (!isInBattleground)
+        UpdatePlayersCountByTeam(team, false);                  // +1 player
 
     WorldPacket data;
     sBattlegroundMgr->BuildPlayerJoinedBattlegroundPacket(&data, player);


### PR DESCRIPTION
**Changes proposed:**

-  Avoid increasing player count per team when re-logging if player was already in the BG
after this ariel- commit: https://github.com/TrinityCore/TrinityCore/commit/3f9cf3fdb6ab4d8c696c67df8289df016f9447ae#diff-baadebd8cd1117ca48225f316a5ab3fd5fd55b20963394d302341147183db067R17335
when player loggin inside running BG, BG do AddPlayer, so m_PlayersCount is increased every time player re-log
Avoid premature countdown timer from stopping counting if there are not enough players

**Issues addressed:**

Closes: None


**Tests performed:**

Tested in-game
