### PR TITLE
Change order in HandleLootOpcode

### DIFF
--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -227,11 +227,11 @@ void WorldSession::HandleLootOpcode(WorldPacket& recvData)
     if (!GetPlayer()->IsAlive() || !guid.IsCreatureOrVehicle())
         return;
 
-    GetPlayer()->SendLoot(guid, LOOT_CORPSE);
-
     // interrupt cast
     if (GetPlayer()->IsNonMeleeSpellCast(false))
         GetPlayer()->InterruptNonMeleeSpells(false);
+
+    GetPlayer()->SendLoot(guid, LOOT_CORPSE);
 }
 
 void WorldSession::HandleLootReleaseOpcode(WorldPacket& recvData)


### PR DESCRIPTION
I just can not understand why we have a check occuring after SendLoot. All checks should be before it in this case. Viewing gitblame, this was last touched back about 13 years ago and with no notes explaining the reasoning. Would love a further explaination in the reason why interrupt cast if statement is occurring after a send loot and not before.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Change Order of GetPlayer()->SendLoot(guid, LOOT_CORPSE); to occur after checks and not inbetween checks within the HandleLootOpcode.

**Issues addressed:**

Closes #  My OCD Sanity

**Tests performed:**

It does build with no issues in game from what i can see.
I am able to craft multiple items with tayloring, and able to loot corpses just fine.
cast spells or while crafting does get interrupted when i decide to loot something


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
