### PR TITLE
TrinityCore & MySQL8 & SSL - fix error autoupdate server database.

### DIFF
--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -370,8 +370,17 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
     // Set max allowed packet to 1 GB
     args.emplace_back("--max-allowed-packet=1GB");
 
+#if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 80000
+
+    if (ssl == "ssl")
+        args.emplace_back("--ssl-mode=REQUIRED");
+
+#else
+
     if (ssl == "ssl")
         args.emplace_back("--ssl");
+
+#endif
 
     // Database
     if (!database.empty())


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

If you are using a MySQL 8 server and trying to connect via SSL, then after updating the TC server, if there are sql update files, you will get an error similar to this:

_Applying of file '/home/trinity/TrinityCore/sql/updates/world/3.3.5/2021_11_17_99_test_world.sql' to database 'world' failed! If you are a user, please pull the latest revision from the repository. Also make sure you have not applied any of the databases with your sql client. You cannot use auto-update system and import sql files from TrinityCore repository with your sql client. If you are a developer, please fix your sql query.
Could not update the World database, see log for details._

This is due to the fact that the --ssl parameter has been removed from version 8 in the MySQL server, and now you need to use --ssl-mode=REQUIRED instead. You can read more in the changelog, here https://dev.mysql.com/doc/refman/8.0/en/mysql-nutshell.html



>The client-side --ssl and --ssl-verify-server-cert options have been removed. Use --ssl-mode=REQUIRED instead of --ssl=1 or --enable-ssl. Use --ssl-mode=DISABLED instead of --ssl=0, --skip-ssl, or --disable-ssl. Use --ssl-mode=VERIFY_IDENTITY instead of --ssl-verify-server-cert options. (The server-side --ssl option is still available, but is deprecated as of MySQL 8.0.26 and subject to removal in a future MySQL version.)

>For the C API, MYSQL_OPT_SSL_ENFORCE and MYSQL_OPT_SSL_VERIFY_SERVER_CERT options for mysql_options() correspond to the client-side --ssl and --ssl-verify-server-cert options and are removed. Use MYSQL_OPT_SSL_MODE with an option value of SSL_MODE_REQUIRED or SSL_MODE_VERIFY_IDENTITY instead._


**Issues addressed:**

Partially closes #  (#26826)
> 2. The "ssl" connection parameter should not affect the possibility of updating the server database.