### PR TITLE
Core/Trainers: Battle pet trainers

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Trainer.h"
+#include "BattlePetMgr.h"
 #include "Creature.h"
 #include "NPCPackets.h"
 #include "Player.h"
@@ -72,6 +73,19 @@ namespace Trainer
             return;
         }
 
+        bool sendSpellVisual = true;
+        BattlePetSpeciesEntry const* speciesEntry = sSpellMgr->GetBattlePetSpecies(trainerSpell->SpellId);
+        if (speciesEntry)
+        {
+            if (player->GetSession()->GetBattlePetMgr()->HasMaxPetCount(speciesEntry))
+            {
+                // Don't send any error to client (intended)
+                return;
+            }
+
+            sendSpellVisual = false;
+        }
+
         float reputationDiscount = player->GetReputationPriceDiscount(npc);
         int64 moneyCost = int64(trainerSpell->MoneyCost * reputationDiscount);
         if (!player->HasEnoughMoney(moneyCost))
@@ -82,14 +96,31 @@ namespace Trainer
 
         player->ModifyMoney(-moneyCost);
 
-        npc->SendPlaySpellVisualKit(179, 0, 0);     // 53 SpellCastDirected
-        player->SendPlaySpellVisualKit(362, 1, 0);  // 113 EmoteSalute
+        if (sendSpellVisual)
+        {
+            npc->SendPlaySpellVisualKit(179, 0, 0);     // 53 SpellCastDirected
+            player->SendPlaySpellVisualKit(362, 1, 0);  // 113 EmoteSalute
+        }
 
         // learn explicitly or cast explicitly
         if (trainerSpell->IsCastable())
+        {
             player->CastSpell(player, trainerSpell->SpellId, true);
+        }
         else
-            player->LearnSpell(trainerSpell->SpellId, false);
+        {
+            bool dependent = false;
+
+            if (speciesEntry)
+            {
+                player->GetSession()->GetBattlePetMgr()->AddPet(speciesEntry->ID, BattlePetMgr::SelectPetDisplay(speciesEntry), BattlePetMgr::RollPetBreed(speciesEntry->ID), BattlePetMgr::GetDefaultPetQuality(speciesEntry->ID));
+                // If the spell summons a battle pet, we fake that it has been learned and the battle pet is added
+                // marking as dependent prevents saving the spell to database (intended)
+                dependent = true;
+            }
+
+            player->LearnSpell(trainerSpell->SpellId, dependent);
+        }
     }
 
     Spell const* Trainer::GetSpell(uint32 spellId) const

--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -22,6 +22,7 @@
 #include "Player.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
+#include "WorldSession.h"
 
 namespace Trainer
 {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Trainers who teach battle pets will add the pet to the journal (Spell visual kits won't be sent in this case).
-  The battle pet summoning spell is no longer permanently learned.

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
