### PR TITLE
Core/Spells: Use Unit::Kill instead of Unit::DealDamage for SPELL_EFF…

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -428,7 +428,7 @@ void Spell::EffectInstaKill()
     data.SpellID = m_spellInfo->Id;
     m_caster->SendMessageToSet(data.Write(), true);
 
-    Unit::DealDamage(unitCaster, unitTarget, unitTarget->GetHealth(), nullptr, NODAMAGE, SPELL_SCHOOL_MASK_NORMAL, nullptr, false);
+    Unit::Kill(unitCaster, unitTarget, false);
 }
 
 void Spell::EffectEnvironmentalDMG()


### PR DESCRIPTION
…ECT_INSTAKILL

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Use Unit::Kill instead of Unit::DealDamage for SPELL_EFFECT_INSTAKILL

**Tests performed:**

(Does it build, tested in-game, etc.)
built, tested ingame