### PR TITLE
Core/Misc: Verify LFG role selections by class

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -1872,8 +1872,10 @@ uint8 LFGMgr::FilterClassRoles(Player* player, uint8 roles)
 {
     // check classes for permitted roles
     roles &= PLAYER_ROLE_ANY;
-    if (!(LfgRoleClasses::TANK & player->GetClassMask())) roles &= ~PLAYER_ROLE_TANK;
-    if (!(LfgRoleClasses::HEALER & player->GetClassMask())) roles &= ~PLAYER_ROLE_HEALER;
+    if (!(LfgRoleClasses::TANK & player->GetClassMask()))
+        roles &= ~PLAYER_ROLE_TANK;
+    if (!(LfgRoleClasses::HEALER & player->GetClassMask()))
+        roles &= ~PLAYER_ROLE_HEALER;
     return roles;
 }
 

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -401,8 +401,6 @@ void LFGMgr::JoinLfg(Player* player, uint8 roles, LfgDungeonSet& dungeons, const
 
     // Sanitize input roles
     roles &= PLAYER_ROLE_ANY;
-
-    // check classes for permitted roles
     roles = FilterClassRoles(player, roles);
 
     // At least 1 role must be selected
@@ -1871,7 +1869,6 @@ uint8 LFGMgr::GetTeam(ObjectGuid guid)
 
 uint8 LFGMgr::FilterClassRoles(Player* player, uint8 roles)
 {
-    // check classes for permitted roles
     roles &= PLAYER_ROLE_ANY;
     if (!(LfgRoleClasses::TANK & player->GetClassMask()))
         roles &= ~PLAYER_ROLE_TANK;

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -399,12 +399,15 @@ void LFGMgr::JoinLfg(Player* player, uint8 roles, LfgDungeonSet& dungeons, const
     if (!player || !player->GetSession() || dungeons.empty())
         return;
 
+    // Sanitize input roles
+    roles &= PLAYER_ROLE_ANY;
+
+    // check classes for permitted roles
+    roles = FilterClassRoles(player, roles);
+
     // At least 1 role must be selected
     if (!(roles & (PLAYER_ROLE_TANK | PLAYER_ROLE_HEALER | PLAYER_ROLE_DAMAGE)))
         return;
-
-    // Sanitize input roles
-    roles &= PLAYER_ROLE_ANY;
 
     Group* grp = player->GetGroup();
     ObjectGuid guid = player->GetGUID();
@@ -709,6 +712,12 @@ void LFGMgr::UpdateRoleCheck(ObjectGuid gguid, ObjectGuid guid /* = ObjectGuid::
 
     // Sanitize input roles
     roles &= PLAYER_ROLE_ANY;
+
+    if (guid) {
+        Player* player = ObjectAccessor::FindPlayer(guid);
+        if (!player) return;
+        roles = FilterClassRoles(player, roles);
+    }
 
     LfgRoleCheck& roleCheck = itRoleCheck->second;
     bool sendRoleChosen = roleCheck.state != LFG_ROLECHECK_DEFAULT && guid;
@@ -1857,6 +1866,15 @@ uint8 LFGMgr::GetTeam(ObjectGuid guid)
     uint8 team = PlayersStore[guid].GetTeam();
     TC_LOG_TRACE("lfg.data.player.team.get", "Player: %s, Team: %u", guid.ToString().c_str(), team);
     return team;
+}
+
+uint8 LFGMgr::FilterClassRoles(Player* player, uint8 roles)
+{
+    // check classes for permitted roles
+    roles &= PLAYER_ROLE_ANY;
+    if (!(LfgRoleClasses::TANK & player->GetClassMask())) roles &= ~PLAYER_ROLE_TANK;
+    if (!(LfgRoleClasses::HEALER & player->GetClassMask())) roles &= ~PLAYER_ROLE_HEALER;
+    return roles;
 }
 
 uint8 LFGMgr::RemovePlayerFromGroup(ObjectGuid gguid, ObjectGuid guid)

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -711,7 +711,8 @@ void LFGMgr::UpdateRoleCheck(ObjectGuid gguid, ObjectGuid guid /* = ObjectGuid::
     // Sanitize input roles
     roles &= PLAYER_ROLE_ANY;
 
-    if (guid) {
+    if (guid)
+    {
         if (Player* player = ObjectAccessor::FindPlayer(guid))
             roles = FilterClassRoles(player, roles);
         else

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -714,9 +714,10 @@ void LFGMgr::UpdateRoleCheck(ObjectGuid gguid, ObjectGuid guid /* = ObjectGuid::
     roles &= PLAYER_ROLE_ANY;
 
     if (guid) {
-        Player* player = ObjectAccessor::FindPlayer(guid);
-        if (!player) return;
-        roles = FilterClassRoles(player, roles);
+        if (Player* player = ObjectAccessor::FindPlayer(guid))
+            roles = FilterClassRoles(player, roles);
+        else
+            return;
     }
 
     LfgRoleCheck& roleCheck = itRoleCheck->second;

--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -24,6 +24,7 @@
 #include "LFGQueue.h"
 #include "LFGGroupData.h"
 #include "LFGPlayerData.h"
+#include "SharedDefines.h"
 #include <unordered_map>
 
 class Group;

--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -128,6 +128,11 @@ enum LfgRoleCheckState
     LFG_ROLECHECK_NO_ROLE                        = 6       // Someone selected no role
 };
 
+enum LfgRoleClasses {
+    TANK   = 0b10000100011, // warrior, paladin, dk, druid
+    HEALER = 0b10001010010, // paladin, priest, shaman, druid
+};
+
 // Forward declaration (just to have all typedef together)
 struct LFGDungeonData;
 struct LfgReward;
@@ -415,6 +420,7 @@ class TC_GAME_API LFGMgr
 
     private:
         uint8 GetTeam(ObjectGuid guid);
+        uint8 FilterClassRoles(Player* player, uint8 roles);
         void RestoreState(ObjectGuid guid, char const* debugMsg);
         void ClearState(ObjectGuid guid, char const* debugMsg);
         void SetDungeon(ObjectGuid guid, uint32 dungeon);

--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -129,8 +129,15 @@ enum LfgRoleCheckState
 };
 
 enum LfgRoleClasses {
-    TANK   = 0b10000100011, // warrior, paladin, dk, druid
-    HEALER = 0b10001010010, // paladin, priest, shaman, druid
+    TANK = (1 << (CLASS_WARRIOR - 1)) |
+           (1 << (CLASS_PALADIN - 1)) |
+           (1 << (CLASS_DEATH_KNIGHT - 1)) |
+           (1 << (CLASS_DRUID - 1)),
+
+    HEALER = (1 << (CLASS_PALADIN - 1)) |
+             (1 << (CLASS_PRIEST - 1)) |
+             (1 << (CLASS_SHAMAN - 1)) |
+             (1 << (CLASS_DRUID - 1)),
 };
 
 // Forward declaration (just to have all typedef together)


### PR DESCRIPTION
**Changes proposed:**

- Silently filter out invalid LFG role selections based on player classes (warriors should not be able queue as healers etc.)
- Cause the default "did not select any roles" message to display if a player selects only invalid roles

**Issues addressed:**
Currently, players can select whatever roles they want in LFG. Since this concerns an exploit, though a very minor one, I won't post the steps to reproduce it here. Maintainers may contact me if you need help setting it up.

![image](https://user-images.githubusercontent.com/76849026/144098720-88be3fcc-258a-4ace-9bae-e5056e890fc3.png)

**Tests performed:**
Tested the following in-game:
- Joining LFG with every class individually, checking for both false positives/negatives. All works as expected.
- Joining LFG with a group, selecting valid/invalid pairs with both party leader and other characters. All works as expected.
- Re-queuing with a group and selecting valid/invalid pairs. All works as expected.

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Decide if invalid selections should really be silent.
- [ ] Someone more familiar with LFGMgr look at if I covered all possible places this can happen.