### PR TITLE
Core/Battlegrounds: Avoid teleport players when relogin inside Strand of the Ancients

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundSA.cpp
@@ -489,7 +489,8 @@ void BattlegroundSA::AddPlayer(Player* player)
 
     SendTransportInit(player);
 
-    TeleportToEntrancePosition(player);
+    if (!isInBattleground)
+        TeleportToEntrancePosition(player);
 }
 
 void BattlegroundSA::RemovePlayer(Player* /*player*/, ObjectGuid /*guid*/, uint32 /*team*/) { }


### PR DESCRIPTION
**Changes proposed:**

-  As I commented here: #27280
I have noticed that in SotA when you relogin you are teleported, you shouldn't be teleported every time you relogin inside Strand of the Ancients.

**Issues addressed:**

None

**Tests performed:**

Tested in-game

