### PR TITLE
Core/SAI: Use GetBaseObject as second param of SMART_ACTION_ACTIVATE_GAMEOBJECT & reorder GameObjectActions

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2308,7 +2308,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             {
                 if (GameObject* targetGo = target->ToGameObject())
                 {
-                    targetGo->ActivateObject(GameObjectActions(e.action.activateGameObject.gameObjectAction));
+                    targetGo->ActivateObject(GameObjectActions(e.action.activateGameObject.gameObjectAction), GetBaseObject());
                 }
             }
             break;


### PR DESCRIPTION
**Changes proposed:**

-  Use GetBaseObject as second param of SMART_ACTION_ACTIVATE_GAMEOBJECT to make actions with unitCaster param work
-  Reorder GameObjectActions. I **clearly** understand why they were implemented like that but it only makes work harder. They has specific order which helps to understand how exactly they should be used

**Issues addressed:**

none

**Tests performed:**

none

**Known issues and TODO list:**

- [ ] maybe check if GetBaseObject is null