### PR TITLE
Make Position::HasInLine really check if the target pos is in line an…

### DIFF
--- a/src/server/game/Entities/Object/Position.cpp
+++ b/src/server/game/Entities/Object/Position.cpp
@@ -124,7 +124,8 @@ bool Position::HasInLine(Position const* pos, float objSize, float width) const
 
     width += objSize;
     float angle = GetRelativeAngle(pos);
-    return std::fabs(std::sin(angle)) * GetExactDist2d(pos->GetPositionX(), pos->GetPositionY()) < width;
+    float xAxisDistance = std::fabs(std::cos(angle)) * GetExactDist2d(pos->GetPositionX(), pos->GetPositionY());
+    return G3D::fuzzyLe(xAxisDistance, (width / 2.0f));
 }
 
 std::string Position::ToString() const


### PR DESCRIPTION
…d not if its in range in the cone

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Currently Position::HasInLine does check if the target position is in a distance less than width IN a line, this is not correct because we only want to know if the target position is in LINE with an infinite y axis distance
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
