### PR TITLE
MMAP: Build ADT floor just like WMO floor below liquid

### DIFF
--- a/src/tools/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/mmaps_generator/TerrainBuilder.cpp
@@ -493,10 +493,6 @@ namespace MMAP
                             minTLevel = h;
                     }
 
-                    // terrain under the liquid?
-                    if (minLLevel > maxTLevel)
-                        useTerrain = false;
-
                     //liquid under the terrain?
                     if (minTLevel > maxLLevel)
                         useLiquid = false;


### PR DESCRIPTION
Fixes ocean floor pathfinding

To test, go to for example ocean south of booty bay and look through .mmap loc or recastdemo

![image](https://user-images.githubusercontent.com/7995382/147848623-461e9781-85ec-43c0-acca-7d487034bc33.png)

![image](https://user-images.githubusercontent.com/7995382/147848631-e2fa94ff-28c5-42b9-8df3-a05942250349.png)

Before and after images supplied (cmangos recastdemo)
