### PR TITLE
Core/Quest - fix incorrect answer when sharing

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -569,18 +569,18 @@ void WorldSession::HandlePushQuestToParty(WorldPacket& recvPacket)
         if (!receiver || receiver == sender)
             continue;
 
-        if (!receiver->SatisfyQuestStatus(quest, false))
-        {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
-            continue;
-        }
-
-        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
+        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_REWARDED)
         {
             sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_FINISH_QUEST);
             continue;
         }
-
+        
+        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE || receiver->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
+        {
+            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
+            continue;
+        }
+        
         if (!receiver->SatisfyQuestDay(quest, false))
         {
             sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_NOT_ELIGIBLE_TODAY);

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -574,13 +574,13 @@ void WorldSession::HandlePushQuestToParty(WorldPacket& recvPacket)
             sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_FINISH_QUEST);
             continue;
         }
-        
+
         if (receiver->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE || receiver->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
         {
             sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
             continue;
         }
-        
+
         if (!receiver->SatisfyQuestDay(quest, false))
         {
             sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_NOT_ELIGIBLE_TODAY);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  fix incorrect answer when sharing quest anв quest is complete from other players


**Issues addressed:**

Closes #  (#27527)



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
