### PR TITLE
Core/Quest - fix incorrect answer when sharing

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -569,15 +569,15 @@ void WorldSession::HandlePushQuestToParty(WorldPacket& recvPacket)
         if (!receiver || receiver == sender)
             continue;
 
-        if (!receiver->SatisfyQuestStatus(quest, false))
+        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_REWARDED)
         {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
+            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_FINISH_QUEST);
             continue;
         }
 
-        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
+        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE || receiver->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
         {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_FINISH_QUEST);
+            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
             continue;
         }
 

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -569,15 +569,32 @@ void WorldSession::HandlePushQuestToParty(WorldPacket& recvPacket)
         if (!receiver || receiver == sender)
             continue;
 
-        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_REWARDED)
+        if (!receiver->GetPlayerSharingQuest().IsEmpty())
         {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_FINISH_QUEST);
+            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_BUSY);
             continue;
         }
 
-        if (receiver->GetQuestStatus(questId) == QUEST_STATUS_INCOMPLETE || receiver->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE)
+        switch (receiver->GetQuestStatus(questId))
         {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
+            case QUEST_STATUS_REWARDED:
+            {
+                sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_FINISH_QUEST);
+                continue;
+            }
+            case QUEST_STATUS_INCOMPLETE:
+            case QUEST_STATUS_COMPLETE:
+            {
+                sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_HAVE_QUEST);
+                continue;
+            }
+            default:
+                break;
+        }
+
+        if (!receiver->SatisfyQuestLog(false))
+        {
+            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_LOG_FULL);
             continue;
         }
 
@@ -590,18 +607,6 @@ void WorldSession::HandlePushQuestToParty(WorldPacket& recvPacket)
         if (!receiver->CanTakeQuest(quest, false))
         {
             sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_CANT_TAKE_QUEST);
-            continue;
-        }
-
-        if (!receiver->SatisfyQuestLog(false))
-        {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_LOG_FULL);
-            continue;
-        }
-
-        if (receiver->GetPlayerSharingQuest())
-        {
-            sender->SendPushToPartyResponse(receiver, QUEST_PARTY_MSG_BUSY);
             continue;
         }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  fix incorrect answer when sharing quest and quest is complete from other players

**Issues addressed:**

Closes #  (#27527)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
