### PR TITLE
spell 37135 shouldn't control all players

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,1 +1,0 @@
-UPDATE `smart_scripts` SET `target_type`=5 WHERE `id`=1 AND `entryorguid`=20045 AND `source_type`=0;

--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,1 @@
+UPDATE `smart_scripts` SET `target_type`=5 WHERE `id`=1 AND `entryorguid`=20045 AND `source_type`=0;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3430,8 +3430,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         46008, // Negative Energy
         45641, // Fire Bloom
         55665, // Life Drain - Sapphiron (H)
-        28796，// Poison Bolt Volly - Faerlina
-        37135  // Domination  
+        28796, // Poison Bolt Volly - Faerlina
+        37135  // Domination
     }, [](SpellInfo* spellInfo)
     {
         spellInfo->MaxAffectedTargets = 5;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3383,8 +3383,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         38762, // Force of Neltharaku
         51122, // Fierce Lightning Stike
         71848, // Toxic Wasteling Find Target
-        36146, // Chains of Naberius
-        37135  // Domination
+        36146  // Chains of Naberius
     }, [](SpellInfo* spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;
@@ -3431,7 +3430,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         46008, // Negative Energy
         45641, // Fire Bloom
         55665, // Life Drain - Sapphiron (H)
-        28796  // Poison Bolt Volly - Faerlina
+        28796，// Poison Bolt Volly - Faerlina
+        37135  // Domination  
     }, [](SpellInfo* spellInfo)
     {
         spellInfo->MaxAffectedTargets = 5;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3383,7 +3383,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         38762, // Force of Neltharaku
         51122, // Fierce Lightning Stike
         71848, // Toxic Wasteling Find Target
-        36146  // Chains of Naberius
+        36146, // Chains of Naberius
+        37135  // Domination
     }, [](SpellInfo* spellInfo)
     {
         spellInfo->MaxAffectedTargets = 1;


### PR DESCRIPTION
https://tbc.wowhead.com/npc=20045/nether-scryer
spell 37135 https://tbc.wowhead.com/spell=37135/domination
There is only one player in the skill description

