### PR TITLE
Scripts/Baradin Hold: fixed a crash in Occuthar's Focused Fire target selection

### DIFF
--- a/src/server/scripts/EasternKingdoms/BaradinHold/boss_occuthar.cpp
+++ b/src/server/scripts/EasternKingdoms/BaradinHold/boss_occuthar.cpp
@@ -266,9 +266,7 @@ class spell_occuthar_eyes_of_occuthar : public SpellScriptLoader
                 if (targets.empty())
                     return;
 
-                WorldObject* target = Trinity::Containers::SelectRandomContainerElement(targets);
-                targets.clear();
-                targets.push_back(target);
+                Trinity::Containers::RandomResize(targets, 1);
             }
 
             void HandleScript(SpellEffIndex /*effIndex*/)

--- a/src/server/scripts/EasternKingdoms/BaradinHold/boss_occuthar.cpp
+++ b/src/server/scripts/EasternKingdoms/BaradinHold/boss_occuthar.cpp
@@ -205,26 +205,6 @@ class npc_eyestalk : public CreatureScript
         }
 };
 
-class FocusedFireTargetSelector
-{
-    public:
-        FocusedFireTargetSelector(Creature* me, const Unit* victim) : _me(me), _victim(victim) { }
-
-        bool operator() (WorldObject* target)
-        {
-            if (target == _victim && _me->GetThreatManager().GetThreatListSize() > 1)
-                return true;
-
-            if (target->GetTypeId() != TYPEID_PLAYER)
-                return true;
-
-            return false;
-        }
-
-        Creature* _me;
-        Unit const* _victim;
-};
-
 // 96872 - Focused Fire
 class spell_occuthar_focused_fire : public SpellScriptLoader
 {
@@ -237,13 +217,16 @@ class spell_occuthar_focused_fire : public SpellScriptLoader
 
             void FilterTargets(std::list<WorldObject*>& targets)
             {
-                if (targets.empty())
+                if (targets.size() < 2)
                     return;
 
-                targets.remove_if(FocusedFireTargetSelector(GetCaster()->ToCreature(), GetCaster()->GetVictim()));
-                WorldObject* target = Trinity::Containers::SelectRandomContainerElement(targets);
-                targets.clear();
-                targets.push_back(target);
+                targets.remove_if([&](WorldObject const* target)
+                {
+                    return GetCaster()->GetVictim() == target;
+                });
+
+                if (targets.size() > 2)
+                    Trinity::Containers::RandomResize(targets, 1);
             }
 
             void Register() override

--- a/src/server/scripts/EasternKingdoms/BaradinHold/boss_occuthar.cpp
+++ b/src/server/scripts/EasternKingdoms/BaradinHold/boss_occuthar.cpp
@@ -225,7 +225,7 @@ class spell_occuthar_focused_fire : public SpellScriptLoader
                     return GetCaster()->GetVictim() == target;
                 });
 
-                if (targets.size() > 2)
+                if (targets.size() >= 2)
                     Trinity::Containers::RandomResize(targets, 1);
             }
 


### PR DESCRIPTION
**Changes proposed:**

-  reworked the target selection for Occu'thar's Focused Fire to modernize the script and to fix a crash that was caused by storing a nullptr target, which made the core blow up since it expects a fully valid target list at this point.
- Also allow Occu'thar to actually hit his victim when no other target option is available

**Tests performed:**
- tested on 4.x



