### PR TITLE
Core/Flags: Implement UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR, only use…

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2829,7 +2829,8 @@ bool WorldObject::IsValidAttackTarget(WorldObject const* target, SpellInfo const
     // PvP, PvC, CvP case
     // can't attack friendly targets
     if (IsFriendlyTo(target) || target->IsFriendlyTo(this))
-        return false;
+        if (!target->ToUnit()->HasUnitFlag3(UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR))
+            return false;
 
     Player const* playerAffectingAttacker = unit && unit->HasUnitFlag(UNIT_FLAG_PLAYER_CONTROLLED) ? GetAffectingPlayer() : ToGameObject() ? GetAffectingPlayer() : nullptr;
     Player const* playerAffectingTarget = unitTarget && unitTarget->HasUnitFlag(UNIT_FLAG_PLAYER_CONTROLLED) ? target->GetAffectingPlayer() : nullptr;

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -181,7 +181,7 @@ enum UnitFlags2 : uint32
 // EnumUtils: DESCRIBE THIS
 enum UnitFlags3 : uint32
 {
-    UNIT_FLAG3_UNK1                         = 0x00000001,
+    UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR   = 0x00000001,
 };
 
 /// Non Player Character flags

--- a/src/server/game/Entities/Unit/enuminfo_UnitDefines.cpp
+++ b/src/server/game/Entities/Unit/enuminfo_UnitDefines.cpp
@@ -185,7 +185,7 @@ TC_API_EXPORT EnumText EnumUtils<UnitFlags3>::ToString(UnitFlags3 value)
 {
     switch (value)
     {
-        case UNIT_FLAG3_UNK1: return { "UNIT_FLAG3_UNK1", "UNIT_FLAG3_UNK1", "" };
+        case UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR: return { "UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR", "UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR", "" };
         default: throw std::out_of_range("value");
     }
 }
@@ -198,7 +198,7 @@ TC_API_EXPORT UnitFlags3 EnumUtils<UnitFlags3>::FromIndex(size_t index)
 {
     switch (index)
     {
-        case 0: return UNIT_FLAG3_UNK1;
+        case 0: return UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR;
         default: throw std::out_of_range("index");
     }
 }


### PR DESCRIPTION
…d by Soul Effigy afaik, but could be useful in the future

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Rename and implement UNIT_FLAG3_ONLY_ATTACKABLE_BY_CREATOR

**Tests performed:**

Tested in-game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
