### PR TITLE
Core/DBUpdater: Apply updates in a transaction

### DIFF
--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -332,7 +332,7 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
     Path const& path)
 {
     std::vector<std::string> args;
-    args.reserve(7);
+    args.reserve(9);
 
     // CLI Client connection info
     args.emplace_back("-h" + host);
@@ -382,13 +382,18 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
 
 #endif
 
+    // Execute sql file
+    args.emplace_back("-e");
+    // value for -e argument is passed separately to avoid wrong quoting in boost::process
+    args.emplace_back(Trinity::StringFormat("BEGIN; SOURCE %s; COMMIT;", path.generic_string().c_str()));
+
     // Database
     if (!database.empty())
         args.emplace_back(database);
 
     // Invokes a mysql process which doesn't leak credentials to logs
     int const ret = Trinity::StartProcess(DBUpdaterUtil::GetCorrectedMySQLExecutable(), args,
-                                 "sql.updates", path.generic_string(), true);
+                                 "sql.updates", "", true);
 
     if (ret != EXIT_SUCCESS)
     {


### PR DESCRIPTION
**Changes proposed:**

-  Wrap each sql update in a transaction

Useful for development, cherry-picking and in the rare case a broken sql gets pushed

**Tests performed:**

Tested on windows and with spaces in sql file name

**TODO list:**

- [x] Test on linux
- [x] Test on linux with spaces in name/path
- [x] Test on windows with spaces in path to cloned dir