### PR TITLE
Scripts/Spells: removed deprecated Glyph of Holy Light

### DIFF
--- a/sql/updates/world/master/2022_01_29_03_world.sql
+++ b/sql/updates/world/master/2022_01_29_03_world.sql
@@ -1,1 +1,3 @@
+-- Glyph of Holy Light
 DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pal_glyph_of_holy_light';
+

--- a/sql/updates/world/master/2022_01_29_03_world.sql
+++ b/sql/updates/world/master/2022_01_29_03_world.sql
@@ -1,0 +1,1 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pal_glyph_of_holy_light';

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -594,28 +594,6 @@ class spell_pal_grand_crusader : public SpellScriptLoader
         }
 };
 
-// 54968 - Glyph of Holy Light
-class spell_pal_glyph_of_holy_light : public SpellScript
-{
-    PrepareSpellScript(spell_pal_glyph_of_holy_light);
-
-    void FilterTargets(std::list<WorldObject*>& targets)
-    {
-        uint32 const maxTargets = GetSpellInfo()->MaxAffectedTargets;
-
-        if (targets.size() > maxTargets)
-        {
-            targets.sort(Trinity::HealthPctOrderPred());
-            targets.resize(maxTargets);
-        }
-    }
-
-    void Register() override
-    {
-        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_pal_glyph_of_holy_light::FilterTargets, EFFECT_0, TARGET_UNIT_DEST_AREA_ALLY);
-    }
-};
-
 // 53595 - Hammer of the Righteous
 struct spell_pal_hammer_of_the_righteous : public SpellScript
 {
@@ -1325,7 +1303,6 @@ void AddSC_paladin_spell_scripts()
     RegisterSpellScript(spell_pal_divine_storm);
     RegisterAuraScript(spell_pal_eye_for_an_eye);
     RegisterAuraScript(spell_pal_fist_of_justice);
-    RegisterSpellScript(spell_pal_glyph_of_holy_light);
     new spell_pal_grand_crusader();
     new spell_pal_hand_of_sacrifice();
     RegisterSpellScript(spell_pal_hammer_of_the_righteous);


### PR DESCRIPTION
**Changes proposed:**

-  removed deprecated glyph from Paladin spell scripts.

**Issues addressed:** None.

**Tests performed:** It builds and it was tested in-game.

**Known issues and TODO list:** None.