### PR TITLE
Core/Spells: Fix looting not breaking stealth

### DIFF
--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -231,6 +231,9 @@ void WorldSession::HandleLootOpcode(WorldPacket& recvData)
     if (GetPlayer()->IsNonMeleeSpellCast(false))
         GetPlayer()->InterruptNonMeleeSpells(false);
 
+    // remove auras with 0x800 flag (stealth, disguises, etc)
+    GetPlayer()->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_USE);
+
     GetPlayer()->SendLoot(guid, LOOT_CORPSE);
 }
 

--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -231,8 +231,7 @@ void WorldSession::HandleLootOpcode(WorldPacket& recvData)
     if (GetPlayer()->IsNonMeleeSpellCast(false))
         GetPlayer()->InterruptNonMeleeSpells(false);
 
-    // remove auras with 0x800 flag (stealth, disguises, etc)
-    GetPlayer()->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_USE);
+    GetPlayer()->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_LOOTING);
 
     GetPlayer()->SendLoot(guid, LOOT_CORPSE);
 }

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -54,8 +54,8 @@ enum SpellAuraInterruptFlags : uint32
     AURA_INTERRUPT_FLAG_NOT_ABOVEWATER              = 0x00000080,   // 7    removed by entering water
     AURA_INTERRUPT_FLAG_NOT_UNDERWATER              = 0x00000100,   // 8    removed by leaving water
     AURA_INTERRUPT_FLAG_NOT_SHEATHED                = 0x00000200,   // 9    removed by unsheathing
-    AURA_INTERRUPT_FLAG_TALK                        = 0x00000400,   // 10   talk to npc / loot? action on creature
-    AURA_INTERRUPT_FLAG_USE                         = 0x00000800,   // 11   mine/use/open action on gameobject
+    AURA_INTERRUPT_FLAG_TALK                        = 0x00000400,   // 10   talk to npc / interact?
+    AURA_INTERRUPT_FLAG_USE                         = 0x00000800,   // 11   mine/use/open action on gameobject / loot
     AURA_INTERRUPT_FLAG_MELEE_ATTACK                = 0x00001000,   // 12   removed by attacking
     AURA_INTERRUPT_FLAG_SPELL_ATTACK                = 0x00002000,   // 13   ???
     AURA_INTERRUPT_FLAG_UNK14                       = 0x00004000,   // 14

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -55,7 +55,7 @@ enum SpellAuraInterruptFlags : uint32
     AURA_INTERRUPT_FLAG_NOT_UNDERWATER              = 0x00000100,   // 8    removed by leaving water
     AURA_INTERRUPT_FLAG_NOT_SHEATHED                = 0x00000200,   // 9    removed by unsheathing
     AURA_INTERRUPT_FLAG_TALK                        = 0x00000400,   // 10   talk to npc / interact?
-    AURA_INTERRUPT_FLAG_USE                         = 0x00000800,   // 11   mine/use/open action on gameobject / loot
+    AURA_INTERRUPT_FLAG_LOOTING                     = 0x00000800,   // 11   mine/use/open action on gameobject / loot
     AURA_INTERRUPT_FLAG_MELEE_ATTACK                = 0x00001000,   // 12   removed by attacking
     AURA_INTERRUPT_FLAG_SPELL_ATTACK                = 0x00002000,   // 13   ???
     AURA_INTERRUPT_FLAG_UNK14                       = 0x00004000,   // 14


### PR DESCRIPTION
**Changes proposed:**

-  Remove auras with 0x800 flag on loot action

**Issues addressed:**

Closes #27222


**Tests performed:**

Builds, tested in-game , works as it should.


**Research**

Regarding AuraInterruptFlags, most of the spells which should be interrupted on loot have both flags 0x400 and 0x800, but not all of them. Looking through the spells it is pretty obvious that 0x800 is indeed the right flag to use.  

One clear giveaway example: https://tbc.wowhead.com/spell=30448/shadow-of-the-forest
("Aura is cancelled upon combat or looting.")
And it has only flag 0x800, but not 0x400.

<details markdown=1><summary markdown="span">Spells with 0x400 & 0x800 (110 total)</summary>

```
1539  Feed Pet
1784  Stealth
1785  Stealth  (Rank 2)
1786  Stealth  (Rank 3)
1787  Stealth  (Rank 4)
1856  Vanish  (Rank 1)
1857  Vanish  (Rank 2)
3385  Boar Charge
3648  Phase Out
3680  Lesser Invisibility
4079  Cloaking
4141  Summon Myzrael
4981  Inducing Vision
5010  Scorch Breath
5169  Defias Disguise
5215  Prowl
5264  South Seas Pirate Disguise
5265  Stonesplinter Trogg Disguise
5266  Syndicate Disguise
5267  Dalaran Wizard Disguise
5268  Dark Iron Dwarf Disguise
5384  Feign Death
6298  Form of the Moonstalker
6538  Dig Trap
6783  Prowl  (Rank 2)
6920  Hide  (Rank 2)
7104  Sneak
7291  Food (TEST)
7870  Lesser Invisibility
7974  Azrethoc's Flight  (Rank 1)
8218  Sneak
8226  Fake Death
8359  Left for Dead
8606  Summon Cyclonian
8611  Phase Shift
8822  Stealth
8874  Stealth (TEST)  (Rank 1)
9093  Rift Spawn Invisibility
9587  Magic Potion
9736  Arantir's Deception  (Rank 1)
9740  Arantir's Deception  (Rank 1)
9913  Prowl  (Rank 3)
9976  Polly Eats the E.C.A.C.  (Rank 1)
10032  Uber Stealth
10849  Form of the Moonstalker (no invis)
11013  Sneak
11327  Vanish  (Rank 1)
11329  Vanish  (Rank 2)
11392  Invisibility
11548  Summon Spider God
12189  Summon Echeyakee
12199  Summon Ishamuhale
12332  Lathoric the Black
12845  Lesser Invisibility
12883  Longsight
15056  Distract Move
16031  Releasing Corrupt Ooze
16093  Self Visual - Sleep Until Cancelled (DND)
16380  Greater Invisibility
17651  Image Projection
17652  Image Projection
18400  Piccolo of the Flaming Fire
23355  Feed Pet Effect (Quest Test)
25247  Longsight
26888  Vanish  (Rank 3)
26889  Vanish  (Rank 3)
27617  Vanish  (Rank 2)
27827  Spirit of Redemption
28500  Invisibility
29309  Phase Shift
29627  Nether Step
30015  Summon Naias
30628  Arcane Invisibility
31621  Stealth
32612  Invisibility
32811  Greater Invisibility
35413  Seed of Revitalization
35571  Feign Death Test
36535  Greater Invis (For Fragments of Memory)
36544  Dispel Shadowmoon Infernal Invis
37097  Crate Disguise
40259  Boar Charge
40772  Boar Charge
41253  Greater Invisibility
42378  Spyglass 02
43051  Spyglass
43128  Raptor Charge
44036  Fade
44290  Vanish
44530  Boar Charge
47032  Budd's Sneak
50346  Boar Charge
51755  Camouflage
52060  Invisibility
52742  Sleep
54435  Demonic Empowerment
54436  Demonic Empowerment
55797  Telluric Poultice
58984  Shadowmeld  (Racial)
59045  Camoflogue  (Rank 4)
59646  The Fall of Humanity  (Racial)
59721  The Fall of Humanity  (Racial)
59722  The Fall of Humanity  (Racial)
61267  Intravenous Health Regeneration
61268  Mana Regeneration
62196  Shadowmeld  (Racial)
62199  Shadowmeld  (Racial)
67340  Hide  (Rank 2)
69759  Spirit Heal
75731  Instant Statue
```
</details>

<details markdown=1><summary markdown="span">Spells with 0x400, not 0x800 (25 total)</summary>

```
66  Invisibility
9192  "Plucky" Resumes Human Form  (Shapeshift)
9220  "Plucky" Resumes Chicken Form  (Shapeshift)
24450  Prowl  (Rank 1)
24453  Prowl  (Rank 3)
32930  Blue Beam
37679  Arakkoa Channeling (no duration)
38792  Freeze Anim Interruptible
38909  Green Beam - Left Hand
39218  Baelmon Channeling (no duration)
43157  Tillinghast's Plague Canister
43778  Channel Cast Directed (no effects)
44035  Return to the Spirit Realm
44795  Parachute
45220  Channel Cast Directed (no effects)
45614  Shroud of the Scourge
50553  Parachute
51270  Corpse Exploded
51753  Camouflage
53208  Parachute
54168  Parachute
54649  Parachute
61243  Parachute
67765  Invisibility
79404  Parachute
```
</details>

<details markdown=1><summary markdown="span">Spells with 0x800, not 0x400 (23 total)</summary>

```
17961  Scarlet Illusion
19690  Scarlet Illusion
19937  Illusion: Black Dragonkin
20540  Ashenvale Outrunner Sneak  (Rank 1)
21134  Will of Ragnaros
22766  Sneak  (Rank 1)
30430  Embrace of the Serpent
30448  Shadow of the Forest
32756  Shadowy Disguise
34603  Sunfury Disguise
37093  Blood Elf Disguise
37095  Blood Elf Disguise
37717  Sneak  (Rank 1)
38080  Male Shadowy Disguise
38081  Female Shadowy Disguise
38157  Overseer Disguise
42786  Echo of Ymiron
43351  Cleansing Soul
43369  Worg Disguise
43466  Echo of Ymiron
45278  King Mrgl-Mrgl's Spare Suit
46337  Crab Disguise
52366  Quetz'lun's Ritual
```
</details>