### PR TITLE
Core/Spells: Avoid leave combat with Invisibility (mage) in certain situations

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1524,7 +1524,6 @@ void Aura::HandleAuraSpecificMods(AuraApplication const* aurApp, Unit* caster, b
                         if (removeMode != AURA_REMOVE_BY_EXPIRE)
                             break;
                         target->CastSpell(target, 32612, GetEffect(1));
-                        target->CombatStop();
                         break;
                     default:
                         break;


### PR DESCRIPTION
**Changes proposed:**

-  Revert 4b0acb743264971859a7c26684394792706f5209 due to spell ID - 32612 Invisibility has SPELL_EFFECT_SANCTUARY that properly controls if should exit combat
https://github.com/TrinityCore/TrinityCore/blob/0817be8f76dead48e2c0eeb7d5a7434a452f0dcf/src/server/game/Spells/SpellEffects.cpp#L3574-L3596
-  Prevent leave combat during dungeon boss encounter when use invisibility

**Issues addressed:**

None


**Tests performed:**

Tested in-game

