### PR TITLE
Game/Spells: SPELL_EFFECT_LEAP_BACK will always force a backwards jump

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4100,8 +4100,8 @@ void Spell::EffectLeapBack()
 
     float speedxy = effectInfo->MiscValue / 10.f;
     float speedz = damage / 10.f;
-    // Disengage
-    unitTarget->JumpTo(speedxy, speedz, m_spellInfo->IconFileDataId != 132572);
+
+    unitTarget->JumpTo(speedxy, speedz, false);
 
     // changes fall time
     if (m_caster->GetTypeId() == TYPEID_PLAYER)


### PR DESCRIPTION
* there are a few spells with a negative MiscValueA, which forces a leap forward even tho it is set as backward.
* there are a few spells with MiscValueB, which is not considered anywhere in this spell effect (more research is needed to test what this value is doing on Blizzard's part).

**Changes proposed:**

-  removed old check for disengage and set backward for all leap back spells.

**Issues addressed:** Closes https://github.com/TrinityCore/TrinityCore/issues/19717.

**Tests performed:** It builds and it was tested in-game.

**Known issues and TODO list:** None.