### PR TITLE
Core/BattlePets: Implemented CMSG_BATTLE_PET_UPDATE_NOTIFY

### DIFF
--- a/src/server/game/BattlePets/BattlePetMgr.cpp
+++ b/src/server/game/BattlePets/BattlePetMgr.cpp
@@ -734,16 +734,6 @@ void BattlePetMgr::GrantBattlePetExperience(ObjectGuid guid, uint16 xp, BattlePe
     std::vector<std::reference_wrapper<BattlePet>> updates;
     updates.push_back(std::ref(*pet));
     SendUpdates(std::move(updates), false);
-
-    // Update battle pet related update fields
-    if (Creature* summonedBattlePet = player->GetSummonedBattlePet())
-    {
-        if (summonedBattlePet->GetBattlePetCompanionGUID() == guid)
-        {
-            summonedBattlePet->SetWildBattlePetLevel(pet->PacketInfo.Level);
-            player->SetBattlePetData(pet);
-        }
-    }
 }
 
 void BattlePetMgr::GrantBattlePetLevel(ObjectGuid guid, uint16 grantedLevels)
@@ -763,14 +753,12 @@ void BattlePetMgr::GrantBattlePetLevel(ObjectGuid guid, uint16 grantedLevels)
     if (level >= MAX_BATTLE_PET_LEVEL)
         return;
 
-    Player* player = _owner->GetPlayer();
-
     while (grantedLevels > 0 && level < MAX_BATTLE_PET_LEVEL)
     {
         ++level;
         --grantedLevels;
 
-        player->UpdateCriteria(CriteriaType::BattlePetReachLevel, pet->PacketInfo.Species, level);
+        _owner->GetPlayer()->UpdateCriteria(CriteriaType::BattlePetReachLevel, pet->PacketInfo.Species, level);
     }
 
     pet->PacketInfo.Level = level;
@@ -785,16 +773,6 @@ void BattlePetMgr::GrantBattlePetLevel(ObjectGuid guid, uint16 grantedLevels)
     std::vector<std::reference_wrapper<BattlePet>> updates;
     updates.push_back(std::ref(*pet));
     SendUpdates(std::move(updates), false);
-
-    // Update battle pet related update fields
-    if (Creature* summonedBattlePet = player->GetSummonedBattlePet())
-    {
-        if (summonedBattlePet->GetBattlePetCompanionGUID() == guid)
-        {
-            summonedBattlePet->SetWildBattlePetLevel(pet->PacketInfo.Level);
-            player->SetBattlePetData(pet);
-        }
-    }
 }
 
 void BattlePetMgr::HealBattlePetsPct(uint8 pct)
@@ -815,6 +793,25 @@ void BattlePetMgr::HealBattlePetsPct(uint8 pct)
         }
 
     SendUpdates(std::move(updates), false);
+}
+
+void BattlePetMgr::UpdateBattlePetData(ObjectGuid guid)
+{
+    BattlePet* pet = GetPet(guid);
+    if (!pet)
+        return;
+
+    Player* player = _owner->GetPlayer();
+
+    // Update battle pet related update fields
+    if (Creature* summonedBattlePet = player->GetSummonedBattlePet())
+    {
+        if (summonedBattlePet->GetBattlePetCompanionGUID() == guid)
+        {
+            summonedBattlePet->SetWildBattlePetLevel(pet->PacketInfo.Level);
+            player->SetBattlePetData(pet);
+        }
+    }
 }
 
 void BattlePetMgr::SummonPet(ObjectGuid guid)

--- a/src/server/game/BattlePets/BattlePetMgr.h
+++ b/src/server/game/BattlePets/BattlePetMgr.h
@@ -183,6 +183,7 @@ public:
     void GrantBattlePetExperience(ObjectGuid guid, uint16 xp, BattlePetXpSource xpSource);
     void GrantBattlePetLevel(ObjectGuid guid, uint16 grantedLevels);
     void HealBattlePetsPct(uint8 pct);
+    void UpdateBattlePetData(ObjectGuid guid);
 
     void SummonPet(ObjectGuid guid);
     void DismissPet();

--- a/src/server/game/Handlers/BattlePetHandler.cpp
+++ b/src/server/game/Handlers/BattlePetHandler.cpp
@@ -127,3 +127,8 @@ void WorldSession::HandleBattlePetSummon(WorldPackets::BattlePet::BattlePetSummo
     else
         GetBattlePetMgr()->DismissPet();
 }
+
+void WorldSession::HandleBattlePetUpdateNotify(WorldPackets::BattlePet::BattlePetUpdateNotify& battlePetUpdateNotify)
+{
+    GetBattlePetMgr()->UpdateBattlePetData(battlePetUpdateNotify.PetGuid);
+}

--- a/src/server/game/Server/Packets/BattlePetPackets.cpp
+++ b/src/server/game/Server/Packets/BattlePetPackets.cpp
@@ -203,3 +203,8 @@ void WorldPackets::BattlePet::BattlePetSummon::Read()
 {
     _worldPacket >> PetGuid;
 }
+
+void WorldPackets::BattlePet::BattlePetUpdateNotify::Read()
+{
+    _worldPacket >> PetGuid;
+}

--- a/src/server/game/Server/Packets/BattlePetPackets.h
+++ b/src/server/game/Server/Packets/BattlePetPackets.h
@@ -254,6 +254,16 @@ namespace WorldPackets
 
             ObjectGuid PetGuid;
         };
+
+        class BattlePetUpdateNotify final : public ClientPacket
+        {
+        public:
+            BattlePetUpdateNotify(WorldPacket&& packet) : ClientPacket(CMSG_BATTLE_PET_UPDATE_NOTIFY, std::move(packet)) { }
+
+            void Read() override;
+
+            ObjectGuid PetGuid;
+        };
     }
 }
 

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -219,7 +219,7 @@ void OpcodeTable::Initialize()
     DEFINE_HANDLER(CMSG_BATTLE_PET_SET_FLAGS,                               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleBattlePetSetFlags);
     DEFINE_HANDLER(CMSG_BATTLE_PET_SUMMON,                                  STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleBattlePetSummon);
     DEFINE_HANDLER(CMSG_BATTLE_PET_UPDATE_DISPLAY_NOTIFY,                   STATUS_UNHANDLED, PROCESS_THREADUNSAFE, &WorldSession::Handle_NULL);
-    DEFINE_HANDLER(CMSG_BATTLE_PET_UPDATE_NOTIFY,                           STATUS_UNHANDLED, PROCESS_THREADUNSAFE, &WorldSession::Handle_NULL);
+    DEFINE_HANDLER(CMSG_BATTLE_PET_UPDATE_NOTIFY,                           STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleBattlePetUpdateNotify);
     DEFINE_HANDLER(CMSG_BEGIN_TRADE,                                        STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleBeginTradeOpcode);
     DEFINE_HANDLER(CMSG_BINDER_ACTIVATE,                                    STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleBinderActivateOpcode);
     DEFINE_HANDLER(CMSG_BLACK_MARKET_BID_ON_ITEM,                           STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleBlackMarketBidOnItem);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -208,6 +208,7 @@ namespace WorldPackets
         class BattlePetSetFlags;
         class BattlePetClearFanfare;
         class BattlePetSummon;
+        class BattlePetUpdateNotify;
         class CageBattlePet;
     }
 
@@ -1779,6 +1780,7 @@ class TC_GAME_API WorldSession
         void HandleBattlePetSetFlags(WorldPackets::BattlePet::BattlePetSetFlags& battlePetSetFlags);
         void HandleBattlePetClearFanfare(WorldPackets::BattlePet::BattlePetClearFanfare& battlePetClearFanfare);
         void HandleBattlePetSummon(WorldPackets::BattlePet::BattlePetSummon& battlePetSummon);
+        void HandleBattlePetUpdateNotify(WorldPackets::BattlePet::BattlePetUpdateNotify& battlePetUpdateNotify);
         void HandleCageBattlePet(WorldPackets::BattlePet::CageBattlePet& cageBattlePet);
 
         // Warden


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implemented CMSG_BATTLE_PET_UPDATE_NOTIFY. When using a battle-training stone (level or xp only), the client sends this opcode and the server updates the player and battle pet update fields.

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
