### PR TITLE
Core/SAI: Add Offset to SET_HOME_POS

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1874,7 +1874,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (IsCreature(target))
                 {
                     if (e.GetTargetType() == SMART_TARGET_SELF)
-                        target->ToCreature()->SetHomePosition(me->GetPositionX()+e.target.x, me->GetPositionY()+e.target.y, me->GetPositionZ()+e.target.z, me->GetOrientation()+e.target.o);
+                        target->ToCreature()->SetHomePosition(me->GetPositionX()+e.target.x, me->GetPositionY()+e.target.y, me->GetPositionZ()+e.target.z, me->GetOrientation());
                     else if (e.GetTargetType() == SMART_TARGET_POSITION)
                         target->ToCreature()->SetHomePosition(e.target.x, e.target.y, e.target.z, e.target.o);
                     else if (e.GetTargetType() == SMART_TARGET_CREATURE_RANGE || e.GetTargetType() == SMART_TARGET_CREATURE_GUID ||
@@ -1885,7 +1885,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                              e.GetTargetType() == SMART_TARGET_CLOSEST_ENEMY || e.GetTargetType() == SMART_TARGET_CLOSEST_FRIENDLY ||
                              e.GetTargetType() == SMART_TARGET_CLOSEST_UNSPAWNED_GAMEOBJECT)
                     {
-                        target->ToCreature()->SetHomePosition(target->GetPositionX()+e.target.x, target->GetPositionY()+e.target.y, target->GetPositionZ()+e.target.z, target->GetOrientation()+e.target.o);
+                        target->ToCreature()->SetHomePosition(target->GetPositionX()+e.target.x, target->GetPositionY()+e.target.y, target->GetPositionZ()+e.target.z, target->GetOrientation());
                     }
                     else
                         TC_LOG_ERROR("sql.sql", "SmartScript: Action target for SMART_ACTION_SET_HOME_POS is invalid, skipping");

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -1874,7 +1874,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                 if (IsCreature(target))
                 {
                     if (e.GetTargetType() == SMART_TARGET_SELF)
-                        target->ToCreature()->SetHomePosition(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ(), me->GetOrientation());
+                        target->ToCreature()->SetHomePosition(me->GetPositionX()+e.target.x, me->GetPositionY()+e.target.y, me->GetPositionZ()+e.target.z, me->GetOrientation()+e.target.o);
                     else if (e.GetTargetType() == SMART_TARGET_POSITION)
                         target->ToCreature()->SetHomePosition(e.target.x, e.target.y, e.target.z, e.target.o);
                     else if (e.GetTargetType() == SMART_TARGET_CREATURE_RANGE || e.GetTargetType() == SMART_TARGET_CREATURE_GUID ||
@@ -1885,7 +1885,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                              e.GetTargetType() == SMART_TARGET_CLOSEST_ENEMY || e.GetTargetType() == SMART_TARGET_CLOSEST_FRIENDLY ||
                              e.GetTargetType() == SMART_TARGET_CLOSEST_UNSPAWNED_GAMEOBJECT)
                     {
-                        target->ToCreature()->SetHomePosition(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), target->GetOrientation());
+                        target->ToCreature()->SetHomePosition(target->GetPositionX()+e.target.x, target->GetPositionY()+e.target.y, target->GetPositionZ()+e.target.z, target->GetOrientation()+e.target.o);
                     }
                     else
                         TC_LOG_ERROR("sql.sql", "SmartScript: Action target for SMART_ACTION_SET_HOME_POS is invalid, skipping");

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -538,7 +538,7 @@ enum SMART_ACTION
     SMART_ACTION_SEND_GOSSIP_MENU                   = 98,     // menuId, optionId
     SMART_ACTION_GO_SET_LOOT_STATE                  = 99,     // state
     SMART_ACTION_SEND_TARGET_TO_TARGET              = 100,    // id
-    SMART_ACTION_SET_HOME_POS                       = 101,    // none (if target self/gameobject/creature, can use targetX/Y/Z/O as offset)
+    SMART_ACTION_SET_HOME_POS                       = 101,    // none (if target self/gameobject/creature, can use targetX/Y/Z as offset)
     SMART_ACTION_SET_HEALTH_REGEN                   = 102,    // 0/1
     SMART_ACTION_SET_ROOT                           = 103,    // off/on
     SMART_ACTION_SET_GO_FLAG                        = 104,    // UNUSED, DO NOT REUSE

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -517,7 +517,7 @@ enum SMART_ACTION
     SMART_ACTION_RESET_SCRIPT_BASE_OBJECT           = 77,     // UNUSED, DO NOT REUSE
     SMART_ACTION_CALL_SCRIPT_RESET                  = 78,     // none
     SMART_ACTION_SET_RANGED_MOVEMENT                = 79,     // Distance, angle
-    SMART_ACTION_CALL_TIMED_ACTIONLIST              = 80,     // ID (overwrites already running actionlist), stop after combat?(0/1), timer update type(0-OOC, 1-IC, 2-ALWAYS)
+    SMART_ACTION_CALL_TIMED_ACTIONLIST              = 80,     // Actionlist ID, timer update type(0-OOC, 1-IC, 2-ALWAYS), allowOverride (0/1)
     SMART_ACTION_SET_NPC_FLAG                       = 81,     // Flags
     SMART_ACTION_ADD_NPC_FLAG                       = 82,     // Flags
     SMART_ACTION_REMOVE_NPC_FLAG                    = 83,     // Flags
@@ -538,7 +538,7 @@ enum SMART_ACTION
     SMART_ACTION_SEND_GOSSIP_MENU                   = 98,     // menuId, optionId
     SMART_ACTION_GO_SET_LOOT_STATE                  = 99,     // state
     SMART_ACTION_SEND_TARGET_TO_TARGET              = 100,    // id
-    SMART_ACTION_SET_HOME_POS                       = 101,    // none
+    SMART_ACTION_SET_HOME_POS                       = 101,    // none (if target self/gameobject/creature, can use targetX/Y/Z/O as offset)
     SMART_ACTION_SET_HEALTH_REGEN                   = 102,    // 0/1
     SMART_ACTION_SET_ROOT                           = 103,    // off/on
     SMART_ACTION_SET_GO_FLAG                        = 104,    // UNUSED, DO NOT REUSE


### PR DESCRIPTION
**Changes proposed:**

-  Add possibility to use an position offset on SMART_ACTION_SET_HOME_POS when using player/creature/gameobject as target
-  Fix comment on SMART_ACTION_CALL_TIMED_ACTIONLIST to reflect reality

**Issues addressed:**

Closes: None

**Tests performed:**

Builds, works as it should, tested in-game. Tiny change, won't break anything.
Tested with SQL query
```sql
SELECT * FROM `smart_scripts`
WHERE `action_type` = 101 AND target_type <> 8 AND (`target_x` <> 0 OR `target_y` <> 0 OR `target_z` <> 0 OR `target_o` <> 0);
```
to return nothing, meaning that no scripts had target position params set by accident before this was possible.  

(101 = is SMART_ACTION_SET_HOME_POS)
(8 = is not SMART_TARGET_POSITION)


**Known issues and TODO list:** 

- None
