### PR TITLE
[Crash/ScriptMgr]: Fix Hotswap not reinitializing AIs after destroying them and then crashing due to unhandled AI checks

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -548,7 +548,7 @@ class CreatureGameObjectAreaTriggerScriptRegistrySwapHooks
                     // When the script Id of the script isn't removed in this
                     // context change, do nothing.
                     uint32 aiId = object.second->AI() ? object.second->AI()->GetId() : 0;
-                    if (idsToRemove.find(aiId) != idsToRemove.end())
+                    if (idsToRemove.find(aiId) != idsToRemove.end() || aiId != object.second->GetScriptId())
                         visitor(object.second);
                 }
             };

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -548,7 +548,7 @@ class CreatureGameObjectAreaTriggerScriptRegistrySwapHooks
                     // When the script Id of the script isn't removed in this
                     // context change, do nothing.
                     uint32 aiId = object.second->AI() ? object.second->AI()->GetId() : 0;
-                    if (idsToRemove.find(aiId) != idsToRemove.end() || aiId != object.second->GetScriptId())
+                    if (idsToRemove.find(aiId) != idsToRemove.end() || (aiId == 0 && object.second->GetScriptId()))
                         visitor(object.second);
                 }
             };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
