### PR TITLE
Scripts/Spells: Script one more player talk

### DIFF
--- a/sql/updates/world/3.3.5/2022_02_12_20_world.sql
+++ b/sql/updates/world/3.3.5/2022_02_12_20_world.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 49550 AND `ScriptName` = 'spell_call_out_injured_soldier';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(49550,'spell_call_out_injured_soldier');

--- a/sql/updates/world/3.3.5/2022_02_14_00_world.sql
+++ b/sql/updates/world/3.3.5/2022_02_14_00_world.sql
@@ -1,4 +1,4 @@
 --
-DELETE FROM `spell_script_names` WHERE `spell_id` = 49550 AND `ScriptName` = 'spell_call_out_injured_soldier';
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_call_out_injured_soldier';
 INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
 (49550,'spell_call_out_injured_soldier');

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -777,6 +777,40 @@ class spell_moti_hourglass_cast_see_invis_on_master : public SpellScript
     }
 };
 
+/*######
+## Quest 12457: The Chain Gun And You
+######*/
+
+enum TheChainGunAndYou
+{
+    TEXT_CALL_OUT_1    = 27083,
+    TEXT_CALL_OUT_2    = 27084
+};
+
+// BasePoints of the dummy effect is ID of npc_text used to group texts, it's not implemented so texts are grouped manually. Same with 49556 but looks like it's not used
+// 49550 - Call Out Injured Soldier
+class spell_call_out_injured_soldier : public SpellScript
+{
+    PrepareSpellScript(spell_call_out_injured_soldier);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return sObjectMgr->GetBroadcastText(TEXT_CALL_OUT_1) && sObjectMgr->GetBroadcastText(TEXT_CALL_OUT_2);
+    }
+
+    void HandleScript(SpellEffIndex /*effIndex*/)
+    {
+        if (Vehicle* vehicle = GetCaster()->GetVehicleKit())
+            if (Unit* passenger = vehicle->GetPassenger(0))
+                passenger->Unit::Say(RAND(TEXT_CALL_OUT_1, TEXT_CALL_OUT_2), passenger);
+    }
+
+    void Register() override
+    {
+        OnEffectHit += SpellEffectFn(spell_call_out_injured_soldier::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 void AddSC_dragonblight()
 {
     new npc_commander_eligor_dawnbringer();
@@ -787,4 +821,5 @@ void AddSC_dragonblight()
     RegisterSpellScript(spell_warsong_battle_standard);
     RegisterSpellScript(spell_moti_mirror_image_script_effect);
     RegisterSpellScript(spell_moti_hourglass_cast_see_invis_on_master);
+    RegisterSpellScript(spell_call_out_injured_soldier);
 }


### PR DESCRIPTION
**Changes proposed:**

-  Script one more player talk. The spell is used by vehicle and targets vehicle, in script vehicle forces passenger to talk

**Issues addressed:**

none

**Tests performed:**

builds, tested