### PR TITLE
Script/Special: actually remove money from player when disabling or enabling experience gain from the related NPC

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -1750,6 +1750,8 @@ enum BehstenSlahtz
     OPTION_ID_XP_ON    = 1      // "I wish to start gaining experience again."
 };
 
+const int32 DisableEnableExperienceCost = 100000;
+
 class npc_experience : public CreatureScript
 {
 public:
@@ -1778,6 +1780,7 @@ public:
         {
             uint32 const action = player->PlayerTalkClass->GetGossipOptionAction(gossipListId);
             ClearGossipMenuFor(player);
+            player->ModifyMoney(-DisableEnableExperienceCost);
 
             switch (action)
             {


### PR DESCRIPTION
**Changes proposed:**

- When enabling or disabling experience gain from the NPCs [Behsten](https://www.wowhead.com/npc=35365/behsten#comments) (Alliance) or [Slahtz](https://www.wowhead.com/npc=35364/slahtz) (Horde), you need to have 10 gold in order to disable/enable exp, but it won't be taken from you. That's because the gossip requring gold is only set on DB, but the script does not take money.

Note: since in order to reach this code path you need to have at least 10 gold, I did not add an additional check in the script.


**Issues addressed:**

Could not find any.


**Tests performed:**

Builds, tested and working.