### PR TITLE
Core/Quests: Fixes player choice response selection to use correct referenced ident…

### DIFF
--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -942,6 +942,13 @@ struct PlayerChoice
             [responseId](PlayerChoiceResponse const& playerChoiceResponse) { return playerChoiceResponse.ResponseId == responseId; });
         return itr != Responses.end() ? &(*itr) : nullptr;
     }
+
+    PlayerChoiceResponse const* GetResponseByIdentifier(int32 responseIdentifier) const
+    {
+        auto itr = std::find_if(Responses.begin(), Responses.end(),
+            [responseIdentifier](PlayerChoiceResponse const& playerChoiceResponse) { return playerChoiceResponse.ResponseIdentifier == responseIdentifier; });
+        return itr != Responses.end() ? &(*itr) : nullptr;
+    }
 };
 
 enum SkillRangeType

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -818,15 +818,15 @@ void WorldSession::HandlePlayerChoiceResponse(WorldPackets::Quest::ChoiceRespons
     if (!playerChoice)
         return;
 
-    PlayerChoiceResponse const* playerChoiceResponse = playerChoice->GetResponse(choiceResponse.ResponseID);
+    PlayerChoiceResponse const* playerChoiceResponse = playerChoice->GetResponseByIdentifier(choiceResponse.ResponseIdentifier);
     if (!playerChoiceResponse)
     {
         TC_LOG_ERROR("entities.player.cheat", "Error in CMSG_CHOICE_RESPONSE: %s tried to select invalid player choice response %d (possible packet-hacking detected)",
-            GetPlayerInfo().c_str(), choiceResponse.ResponseID);
+            GetPlayerInfo().c_str(), choiceResponse.ResponseIdentifier);
         return;
     }
 
-    sScriptMgr->OnPlayerChoiceResponse(GetPlayer(), choiceResponse.ChoiceID, choiceResponse.ResponseID);
+    sScriptMgr->OnPlayerChoiceResponse(GetPlayer(), choiceResponse.ChoiceID, choiceResponse.ResponseIdentifier);
 
     if (playerChoiceResponse->Reward)
     {

--- a/src/server/game/Server/Packets/QuestPackets.cpp
+++ b/src/server/game/Server/Packets/QuestPackets.cpp
@@ -758,7 +758,7 @@ WorldPacket const* DisplayPlayerChoice::Write()
 void ChoiceResponse::Read()
 {
     _worldPacket >> ChoiceID;
-    _worldPacket >> ResponseID;
+    _worldPacket >> ResponseIdentifier;
     IsReroll = _worldPacket.ReadBit();
 }
 }

--- a/src/server/game/Server/Packets/QuestPackets.h
+++ b/src/server/game/Server/Packets/QuestPackets.h
@@ -734,7 +734,7 @@ namespace WorldPackets
             void Read() override;
 
             int32 ChoiceID = 0;
-            int32 ResponseID = 0;
+            int32 ResponseIdentifier = 0;
             bool IsReroll = false;
         };
     }


### PR DESCRIPTION
**Changes proposed:**
Use correct identifier for choice response selection (ref [new packet usage](https://gist.github.com/mdX7/93d6c3b821a4877cb5de44d9ae061d70))

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

none

**Known issues and TODO list:** (add/remove lines as needed)

- decide whether we should entirely swap to response identifier usage instead of response id

Comparing old packet from 9.0.2 to 9.1.5 it seems that ResponseIdentifier is the new field, so i guess we may stick to ResponseId usage for everything but choice selection? Ref [packet comparison](https://gist.github.com/mdX7/31926144a990be26869cb6955ef4d984)



