### PR TITLE
Core/Spells: removed hackfix for Elemental Oath and replaced it with a proper implementation

### DIFF
--- a/sql/updates/world/3.3.5/2022_02_21_00_world.sql
+++ b/sql/updates/world/3.3.5/2022_02_21_00_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_sha_clearcasting';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(16246, 'spell_sha_clearcasting');

--- a/sql/updates/world/3.3.5/2022_02_22_00_world.sql
+++ b/sql/updates/world/3.3.5/2022_02_22_00_world.sql
@@ -1,3 +1,4 @@
+--
 DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_sha_clearcasting';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (16246, 'spell_sha_clearcasting');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3596,18 +3596,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Stances = UI64LIT(1) << (FORM_TREE - 1);
     });
 
-    // Elemental Oath
-    ApplySpellFix({
-        51466, // (Rank 1)
-        51470  // (Rank 2)
-    }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->_GetEffect(EFFECT_1).Effect = SPELL_EFFECT_APPLY_AURA;
-        spellInfo->_GetEffect(EFFECT_1).ApplyAuraName = SPELL_AURA_ADD_FLAT_MODIFIER;
-        spellInfo->_GetEffect(EFFECT_1).MiscValue = SPELLMOD_EFFECT2;
-        spellInfo->_GetEffect(EFFECT_1).SpellClassMask = flag96(0x00000000, 0x00004000, 0x00000000);
-    });
-
     // Improved Shadowform (Rank 1)
     ApplySpellFix({ 47569 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -1896,7 +1896,7 @@ class spell_sha_clearcasting : public AuraScript
     {
         Unit const* owner = GetUnitOwner();
         if (Aura const* aura = owner->GetAuraOfRankedSpell(SPELL_SHAMAN_ELEMENTAL_OATH, owner->GetGUID()))
-            amount = aura->GetSpellInfo()->GetEffect(EFFECT_1).BasePoints;
+            amount = aura->GetSpellInfo()->GetEffect(EFFECT_1).CalcValue();
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -343,6 +343,30 @@ class spell_sha_cleansing_totem_pulse : public SpellScript
     }
 };
 
+// 16246 - Clearcasting
+class spell_sha_clearcasting : public AuraScript
+{
+    PrepareAuraScript(spell_sha_clearcasting);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SHAMAN_ELEMENTAL_OATH });
+    }
+
+    // Elemental Oath bonus
+    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
+    {
+        Unit const* owner = GetUnitOwner();
+        if (Aura const* aura = owner->GetAuraOfRankedSpell(SPELL_SHAMAN_ELEMENTAL_OATH, owner->GetGUID()))
+            amount = aura->GetSpellInfo()->GetEffect(EFFECT_1).CalcValue();
+    }
+
+    void Register() override
+    {
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_sha_clearcasting::CalculateAmount, EFFECT_1, SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+    }
+};
+
 // -974 - Earth Shield
 class spell_sha_earth_shield : public AuraScript
 {
@@ -1878,30 +1902,6 @@ class spell_sha_windfury_weapon : public AuraScript
     {
         DoCheckProc += AuraCheckProcFn(spell_sha_windfury_weapon::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_sha_windfury_weapon::HandleProc, EFFECT_0, SPELL_AURA_DUMMY);
-    }
-};
-
-// 16246 - Clearcasting
-class spell_sha_clearcasting : public AuraScript
-{
-    PrepareAuraScript(spell_sha_clearcasting);
-
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_SHAMAN_ELEMENTAL_OATH });
-    }
-
-    // Elemental Oath bonus
-    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
-    {
-        Unit const* owner = GetUnitOwner();
-        if (Aura const* aura = owner->GetAuraOfRankedSpell(SPELL_SHAMAN_ELEMENTAL_OATH, owner->GetGUID()))
-            amount = aura->GetSpellInfo()->GetEffect(EFFECT_1).CalcValue();
-    }
-
-    void Register() override
-    {
-        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_sha_clearcasting::CalculateAmount, EFFECT_1, SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
     }
 };
 

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -41,6 +41,7 @@ enum ShamanSpells
     SPELL_SHAMAN_CLEANSING_TOTEM_EFFECT         = 52025,
     SPELL_SHAMAN_EARTH_SHIELD_HEAL              = 379,
     SPELL_SHAMAN_ELEMENTAL_MASTERY              = 16166,
+    SPELL_SHAMAN_ELEMENTAL_OATH                 = 51466,
     SPELL_SHAMAN_EXHAUSTION                     = 57723,
     SPELL_SHAMAN_FIRE_NOVA_R1                   = 1535,
     SPELL_SHAMAN_FIRE_NOVA_TRIGGERED_R1         = 8349,
@@ -1880,6 +1881,30 @@ class spell_sha_windfury_weapon : public AuraScript
     }
 };
 
+// 16246 - Clearcasting
+class spell_sha_clearcasting : public AuraScript
+{
+    PrepareAuraScript(spell_sha_clearcasting);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SHAMAN_ELEMENTAL_OATH });
+    }
+
+    // Elemental Oath bonus
+    void CalculateAmount(AuraEffect const* /*aurEff*/, int32& amount, bool& /*canBeRecalculated*/)
+    {
+        Unit const* owner = GetUnitOwner();
+        if (Aura const* aura = owner->GetAuraOfRankedSpell(SPELL_SHAMAN_ELEMENTAL_OATH, owner->GetGUID()))
+            amount = aura->GetSpellInfo()->GetEffect(EFFECT_1).BasePoints;
+    }
+
+    void Register() override
+    {
+        DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_sha_clearcasting::CalculateAmount, EFFECT_1, SPELL_AURA_MOD_DAMAGE_PERCENT_DONE);
+    }
+};
+
 void AddSC_shaman_spell_scripts()
 {
     RegisterSpellScript(spell_sha_ancestral_awakening);
@@ -1890,6 +1915,7 @@ void AddSC_shaman_spell_scripts()
     RegisterSpellScript(spell_sha_bloodlust);
     RegisterSpellScript(spell_sha_chain_heal);
     RegisterSpellScript(spell_sha_cleansing_totem_pulse);
+    RegisterSpellScript(spell_sha_clearcasting);
     RegisterSpellScript(spell_sha_earth_shield);
     RegisterSpellScript(spell_sha_earthbind_totem);
     RegisterSpellScript(spell_sha_earthen_power);


### PR DESCRIPTION
**Changes proposed:**

- removed hack'fix' for Elemental Oath which wasn't even working in the first place.
- properly handle the damage bonus by handling the 2nd aura effect amount calculation of Clearcasting

**Tests performed:**
- tested on 4.x. The talent never changed between then and now

