### PR TITLE
Core/Packets: do not tell the client to request questgiver details for followup quests that cannot be taken yet

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -17416,7 +17416,8 @@ void Player::SendQuestReward(Quest const* quest, Creature const* questGiver, uin
         else if (questGiver->IsQuestGiver())
             packet.LaunchQuest = true;
         else if (quest->GetNextQuestInChain() && !quest->HasFlag(QUEST_FLAGS_AUTOCOMPLETE))
-            packet.UseQuestReward = true;
+            if (Quest const* rewardQuest = sObjectMgr->GetQuestTemplate(quest->GetNextQuestInChain()))
+                packet.UseQuestReward = CanTakeQuest(rewardQuest, false);
     }
 
     packet.HideChatMessage = hideChatMessage;


### PR DESCRIPTION
**Changes proposed:**

-  correctly send the useReward field in reward quest packets. The field causes the client UI to bug out if you cannot request the questgiver details for the reward quest yet due to an incomplete quest chain.

**Tests performed:**

Tested on 4.x
