### PR TITLE
Tool/MMAP: Fixed invalid check causing certain tiles not to build

### DIFF
--- a/src/tools/mmaps_generator/MapBuilder.cpp
+++ b/src/tools/mmaps_generator/MapBuilder.cpp
@@ -858,12 +858,10 @@ namespace MMAP
                 //printf("%sNo vertices to build tile!              \n", tileString);
                 break;
             }
-            if (!params.polyCount || !params.polys ||
-                TILES_PER_MAP*TILES_PER_MAP == params.polyCount)
+            if (!params.polyCount || !params.polys)
             {
                 // we have flat tiles with no actual geometry - don't build those, its useless
                 // keep in mind that we do output those into debug info
-                // drop tiles with only exact count - some tiles may have geometry while having less tiles
                 printf("%s No polygons to build on tile!              \n", tileString);
                 break;
             }


### PR DESCRIPTION
example: mmaps_generator 230 will cause tile 33, 29 to not build because of the check. causing NPCs to not have mmap information in some parts of the map.

.go xyz 1380 -831 -88 230 has no mmap tile information because of above check.
https://i.imgur.com/Pypeu4f.png

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  removed invalid check

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
in-game


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
