### PR TITLE
Scripts/Quest: Update 'Who Are They?'

### DIFF
--- a/sql/updates/world/3.3.5/2022_03_07_01_world.sql
+++ b/sql/updates/world/3.3.5/2022_03_07_01_world.sql
@@ -1,0 +1,32 @@
+-- From 2.0.12 DBC
+UPDATE `spell_dbc` SET `Attributes` = 384, `AttributesEx2` = 128, `ProcChance` = 101, `RangeIndex` = 12, `Effect1` = 77, `EffectImplicitTargetA1` = 25, `SpellName` = 'Cancel Shadowy Disguise', `DmgMultiplier1` = 1 WHERE `Id` = 32780;
+
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_terokkar_free_webbed' WHERE `ScriptName` = 'spell_free_webbed_terokkar';
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_terokkar_free_webbed_on_quest' WHERE `ScriptName` = 'spell_free_webbed_terokkar_on_quest';
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_terokkar_shadowy_disguise_cast_from_questgiver' WHERE `ScriptName` = 'spell_q10041_q10040_who_are_they';
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_terokkar_shadowy_disguise','spell_terokkar_cancel_shadowy_disguise');
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(32756,'spell_terokkar_shadowy_disguise'),
+(32780,'spell_terokkar_cancel_shadowy_disguise');
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = -32756;
+
+UPDATE `quest_template_addon` SET `SourceSpellID` = 0 WHERE `ID` IN (10040,10041);
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (18714,18715) AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`event_param5`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_param4`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(18714,0,0,0,19,0,100,0,10041,0,0,0,0,11,48917,0,0,0,0,0,7,0,0,0,0,0,0,0,0,"Scout Neftis - On Quest 'Who Are They?' Taken - Cast 'Who Are They: Cast from Questgiver'"),
+(18714,0,1,2,62,0,100,0,7772,0,0,0,0,11,48917,0,0,0,0,0,7,0,0,0,0,0,0,0,0,"Scout Neftis - On Gossip Option 0 Selected - Cast 'Who Are They: Cast from Questgiver'"),
+(18714,0,2,0,61,0,100,0,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,"Scout Neftis - On Gossip Option 0 Selected - Close Gossip"),
+
+(18715,0,0,0,19,0,100,0,10040,0,0,0,0,11,48917,0,0,0,0,0,7,0,0,0,0,0,0,0,0,"Private Weeks - On Quest 'Who Are They?' Taken - Cast 'Who Are They: Cast from Questgiver'"),
+(18715,0,1,2,62,0,100,0,7771,0,0,0,0,11,48917,0,0,0,0,0,7,0,0,0,0,0,0,0,0,"Private Weeks - On Gossip Option 0 Selected - Cast 'Who Are They: Cast from Questgiver'"),
+(18715,0,2,0,61,0,100,0,0,0,0,0,0,72,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,"Private Weeks - On Gossip Option 0 Selected - Close Gossip");
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 15 AND `SourceGroup` IN (7771,7772);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`,`SourceGroup`,`SourceEntry`,`SourceId`,`ElseGroup`,`ConditionTypeOrReference`,`ConditionTarget`,`ConditionValue1`,`ConditionValue2`,`ConditionValue3`,`NegativeCondition`,`ErrorType`,`ErrorTextId`,`ScriptName`,`Comment`) VALUES
+(15,7771,0,0,0,47,0,10040,10,0,0,0,0,'',"Group 0: Show Gossip Option 0 if player has taken quest 'Who Are They?'"),
+(15,7771,0,0,0,1,0,32756,0,0,1,0,0,"","Group 0: Show Gossip Option 0 if player does not have aura 'Shadowy Disguise'"),
+(15,7772,0,0,0,47,0,10041,10,0,0,0,0,'',"Group 0: Show Gossip Option 0 if player has taken quest 'Who Are They?'"),
+(15,7772,0,0,0,1,0,32756,0,0,1,0,0,"","Group 0: Show Gossip Option 0 if player does not have aura 'Shadowy Disguise'");

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -587,39 +587,6 @@ class spell_q12851_going_bearback : public AuraScript
     }
 };
 
-enum Whoarethey
-{
-    SPELL_MALE_DISGUISE = 38080,
-    SPELL_FEMALE_DISGUISE = 38081,
-    SPELL_GENERIC_DISGUISE = 32756
-};
-
-// 48917 - Who Are They: Cast from Questgiver
-class spell_q10041_q10040_who_are_they : public SpellScript
-{
-    PrepareSpellScript(spell_q10041_q10040_who_are_they);
-
-    bool Validate(SpellInfo const* /*spellEntry*/) override
-    {
-        return ValidateSpellInfo({ SPELL_MALE_DISGUISE, SPELL_FEMALE_DISGUISE, SPELL_GENERIC_DISGUISE });
-    }
-
-    void HandleScript(SpellEffIndex effIndex)
-    {
-        PreventHitDefaultEffect(effIndex);
-        if (Player* target = GetHitPlayer())
-        {
-            target->CastSpell(target, target->GetNativeGender() == GENDER_MALE ? SPELL_MALE_DISGUISE : SPELL_FEMALE_DISGUISE, true);
-            target->CastSpell(target, SPELL_GENERIC_DISGUISE, true);
-        }
-    }
-
-    void Register() override
-    {
-        OnEffectHitTarget += SpellEffectFn(spell_q10041_q10040_who_are_they::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
-    }
-};
-
 // http://www.wowhead.com/quest=12659 Scalps!
 enum Quest12659Data
 {
@@ -2081,7 +2048,6 @@ void AddSC_quest_spell_scripts()
     RegisterSpellScript(spell_q12459_seeds_of_natures_wrath);
     RegisterSpellScript(spell_q12634_despawn_fruit_tosser);
     RegisterSpellScript(spell_q12851_going_bearback);
-    RegisterSpellScript(spell_q10041_q10040_who_are_they);
     RegisterSpellScript(spell_q12659_ahunaes_knife);
     RegisterSpellScript(spell_q9874_liquid_fire);
     RegisterSpellScript(spell_q12805_lifeblood_dummy);


### PR DESCRIPTION
**Changes proposed:**

There are several signs Shadowy Disguise is master spell and handles real transform spells on apply\remove, e.g. when player is mounted and tries to receive disguise by clicking on gossip\taking quest, SMSG_CAST_FAILED is sent only for master spell and not for transform spells, meaning player didn't even tried to cast transform spell; other disguise spells works the same way - 1 master aura and 2 spells for transform which player casts depending on gender after master aura is applied; only master spell has NOT_SHAPESHIFT attr and Stances Not, blocking spell cast if needed; also order of packets.
They also used a small hack here - master aura has 2 charges for a reason - one is consumed after player casts transform spell, without it master aura will be removed completely. Funny. Previously both stacks were visible because spells were used in the wrong order
So initial spell casted by questgiver does nothing but forces player to cast master-disguise, master-disguise on apply\remove applies\removes transform spells, cancel disguise spell removes master-disguise

>Dru's Shadowy Disguise failed.(You are mounted.)
>Dru's Shadowy Disguise failed.(You are in shapeshift form)

Errors if mounted\in form, it's correct

**Issues addressed:**

none

**Tests performed:**

builds, tested