### PR TITLE
Core/Scenario - Fix outdated ScenarioState packet structure

### DIFF
--- a/src/server/game/Server/Packets/ScenarioPackets.cpp
+++ b/src/server/game/Server/Packets/ScenarioPackets.cpp
@@ -46,6 +46,7 @@ WorldPacket const* WorldPackets::Scenario::ScenarioState::Write()
     _worldPacket << uint32(BonusObjectives.size());
     _worldPacket << uint32(PickedSteps.size());
     _worldPacket << uint32(Spells.size());
+    _worldPacket << PlayerGuidUnknown;
 
     for (uint32 i = 0; i < PickedSteps.size(); ++i)
         _worldPacket << uint32(PickedSteps[i]);

--- a/src/server/game/Server/Packets/ScenarioPackets.cpp
+++ b/src/server/game/Server/Packets/ScenarioPackets.cpp
@@ -46,7 +46,7 @@ WorldPacket const* WorldPackets::Scenario::ScenarioState::Write()
     _worldPacket << uint32(BonusObjectives.size());
     _worldPacket << uint32(PickedSteps.size());
     _worldPacket << uint32(Spells.size());
-    _worldPacket << PlayerGuidUnknown;
+    _worldPacket << PlayerGUID;
 
     for (uint32 i = 0; i < PickedSteps.size(); ++i)
         _worldPacket << uint32(PickedSteps[i]);

--- a/src/server/game/Server/Packets/ScenarioPackets.h
+++ b/src/server/game/Server/Packets/ScenarioPackets.h
@@ -59,7 +59,7 @@ namespace WorldPackets
             std::vector<BonusObjectiveData> BonusObjectives;
             std::vector<uint32> PickedSteps;
             std::vector<ScenarioSpellUpdate> Spells;
-            ObjectGuid PlayerGuidUnknown = ObjectGuid::Empty;
+            ObjectGuid PlayerGUID = ObjectGuid::Empty;
             bool ScenarioComplete = false;
         };
 

--- a/src/server/game/Server/Packets/ScenarioPackets.h
+++ b/src/server/game/Server/Packets/ScenarioPackets.h
@@ -59,7 +59,7 @@ namespace WorldPackets
             std::vector<BonusObjectiveData> BonusObjectives;
             std::vector<uint32> PickedSteps;
             std::vector<ScenarioSpellUpdate> Spells;
-            ObjectGuid PlayerGUID = ObjectGuid::Empty;
+            ObjectGuid PlayerGUID;
             bool ScenarioComplete = false;
         };
 

--- a/src/server/game/Server/Packets/ScenarioPackets.h
+++ b/src/server/game/Server/Packets/ScenarioPackets.h
@@ -59,6 +59,7 @@ namespace WorldPackets
             std::vector<BonusObjectiveData> BonusObjectives;
             std::vector<uint32> PickedSteps;
             std::vector<ScenarioSpellUpdate> Spells;
+            ObjectGuid PlayerGuidUnknown = ObjectGuid::Empty;
             bool ScenarioComplete = false;
         };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix Scenario State packet by updating the structure to include a new missing property.

**Issues addressed:**

-  No open issues found.


**Tests performed:**

- Builds
- Play-testing
  - Scenario - Stormwind Stockades (510)
    - Solo testing "Kill X, Y and Z" for scenario with a single step.
    - Packet is now broadcast to client with expected results.


**Known issues and TODO list:** (add/remove lines as needed)

- New packet property is not assigned a real value.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
