### PR TITLE
Core/Scenario - Fix bad criteria evaluation in scenarios

### DIFF
--- a/src/server/game/Scenarios/Scenario.h
+++ b/src/server/game/Scenarios/Scenario.h
@@ -64,6 +64,7 @@ class TC_GAME_API Scenario : public CriteriaHandler
         virtual void Update(uint32 /*diff*/) { }
 
         bool IsComplete();
+        bool IsCompletedStep(ScenarioStepEntry const* step);
         void SetStepState(ScenarioStepEntry const* step, ScenarioStepState state) { _stepStates[step] = state; }
         ScenarioEntry const* GetEntry() const;
         ScenarioStepState GetStepState(ScenarioStepEntry const* step);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->
**Description:**
This addresses an issue where scenario steps could be completed by only fulfilling a single criteria in that step.

**Changes proposed:**

-  Adjust Scenario criteria evaluation process so that entire criteria trees are not completed when a single child tree is completed.

**Issues addressed:**

-  No open issues found.


**Tests performed:**

- Builds
- Play-testing
  - Scenario - Stormwind Stockades (510)
    - Solo testing "Kill X, Y and Z" for scenario with a single step.
  - Scenario - Upper Blackrock Spire (744) (Underlying support for testing NYI on master)
    - Solo testing "Send Event X, then kill Y, Z" for scenario with multiple steps.


**Known issues and TODO list:** (add/remove lines as needed)

- No known issues.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
