### PR TITLE
Scripts/Trial of the Crusader: Fix achievement A Tribute to Immortality

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -120,6 +120,7 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 TributeToImmortalityEligible = true;
                 NeedSave = false;
                 CrusadersSpecialState = false;
+                TributeToDedicatedInsanity = false; // NYI, set to true when implement it
             }
 
             void OnPlayerEnter(Player* player) override
@@ -579,7 +580,9 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 for (uint8 i = 0; i < EncounterCount; ++i)
                     saveStream << GetBossState(i) << ' ';
 
-                saveStream << TrialCounter;
+                saveStream << TrialCounter << ' '
+                    << uint32(TributeToImmortalityEligible ? 1 : 0) << ' '
+                    << uint32(TributeToDedicatedInsanity ? 1 : 0);
                 SaveDataBuffer = saveStream.str();
 
                 SaveToDB();
@@ -604,9 +607,9 @@ class instance_trial_of_the_crusader : public InstanceMapScript
 
                 std::istringstream loadStream(strIn);
 
+                uint32 tmpState;
                 for (uint8 i = 0; i < EncounterCount; ++i)
                 {
-                    uint32 tmpState;
                     loadStream >> tmpState;
                     if (tmpState == IN_PROGRESS || tmpState > SPECIAL)
                         tmpState = NOT_STARTED;
@@ -614,6 +617,10 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 }
 
                 loadStream >> TrialCounter;
+                loadStream >> tmpState;
+                TributeToImmortalityEligible = tmpState != 0;
+                loadStream >> tmpState;
+                TributeToDedicatedInsanity = tmpState != 0;
                 EventStage = 0;
 
                 OUT_LOAD_INST_DATA_COMPLETE;
@@ -648,7 +655,7 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                     case A_TRIBUTE_TO_IMMORTALITY_ALLIANCE:
                         return TrialCounter == 50 && TributeToImmortalityEligible;
                     case A_TRIBUTE_TO_DEDICATED_INSANITY:
-                        return false/*uiGrandCrusaderAttemptsLeft == 50 && !bHasAtAnyStagePlayerEquippedTooGoodItem*/;
+                        return false/*TrialCounter == 50 && TributeToDedicatedInsanity*/;
                     default:
                         break;
                 }
@@ -674,6 +681,7 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 uint8 MistressOfPainCount;
                 uint8 NorthrendBeastsCount;
                 bool TributeToImmortalityEligible;
+                bool TributeToDedicatedInsanity;
         };
 
         InstanceScript* GetInstanceScript(InstanceMap* map) const override


### PR DESCRIPTION
**Changes proposed:**
- Now instance achievement A Tribute to Immortality status will be saved into DB
achievement should be completed without any raid member die during all bosses encounters, if any member die, but before kill last boss you leave instance and wait until is destroyed (Instance.UnloadDelay) or do a server restart, TributeToImmortalityEligible will default (true) again because it's not saved.
- Also add support to save instance achievement status of A Tribute to Dedicated Insanity (NYI)

**Issues addressed:**

None


**Tests performed:**

tested in-game
