### PR TITLE
Core/Player: Prevent Forced UpdateObjectVisibility Before in World

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22550,7 +22550,8 @@ template void Player::UpdateVisibilityOf(DynamicObject* target, UpdateData& data
 
 void Player::UpdateObjectVisibility(bool forced)
 {
-    if (!forced)
+    // Sending visibility updates to the client before in world causes strange behavior
+    if (!forced || !IsInWorld())
         AddToNotify(NOTIFY_VISIBILITY_CHANGED);
     else
     {


### PR DESCRIPTION
It's critical for the client to not recieve SMSG_UPDATE_OBJECT object create blocks before the world is loaded. It can cause some very mind boggling and subtle bugs.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Preventing immediate handling for Player::UpdateObjectVisibility when not in world

**Issues addressed:**

This partially addresses this 2 year old issue I raised: https://github.com/TrinityCore/TrinityCore/issues/24846

https://github.com/TrinityCore/TrinityCore/issues/20401

**Tests performed:**

One of the most obvious examples of bugs this issue causes is strange lighting/coloring/rendering of GameObjects that initially spawn on your client. See the below: 

https://user-images.githubusercontent.com/5829095/163336454-4b63047c-d6c0-4990-aa53-9e6e976e7d76.mp4

![af12a39067285dbcc34aa7c891581317](https://user-images.githubusercontent.com/5829095/163336587-85000d45-bfbc-494a-8dfa-eefbd2a81782.png)

After this commit these objects no longer appear incorrectly colored. This probably fixes other subtle bugs too that happen around logging in or worldporting.

**Known issues and TODO list:** (add/remove lines as needed)

Obviously this change is a very low level Core change. I will have trouble fully testing the impact, sorry. Maybe this negatively affects something.
