### PR TITLE
Core/Scripts: Fix heap buffer overflow in BRD Tomb of seven event

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
@@ -366,7 +366,7 @@ public:
                     encounter[i] = NOT_STARTED;
             if (GhostKillCount > 0 && GhostKillCount < TOMB_OF_SEVEN_BOSS_NUM)
                 GhostKillCount = 0;//reset tomb of seven event
-            if (GhostKillCount >= TOMB_OF_SEVEN_BOSS_NUM
+            if (GhostKillCount >= TOMB_OF_SEVEN_BOSS_NUM)
                 GhostKillCount = TOMB_OF_SEVEN_BOSS_NUM;
 
             OUT_LOAD_INST_DATA_COMPLETE;

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
@@ -29,7 +29,7 @@
 
 #define TIMER_TOMBOFTHESEVEN    15000
 #define MAX_ENCOUNTER           6
-constexpr uint8 TOMB_OF_SEVEN_BOSS_NUM{ 7 };
+constexpr uint8 TOMB_OF_SEVEN_BOSS_NUM = 7;
 
 enum Creatures
 {
@@ -194,7 +194,7 @@ public:
                 case GO_TOMB_ENTER: GoTombEnterGUID = go->GetGUID(); break;
                 case GO_TOMB_EXIT:
                     GoTombExitGUID = go->GetGUID();
-                    if (GhostKillCount >= 7)
+                    if (GhostKillCount >= TOMB_OF_SEVEN_BOSS_NUM)
                         HandleGameObject(ObjectGuid::Empty, true, go);
                     else
                         HandleGameObject(ObjectGuid::Empty, false, go);
@@ -258,7 +258,7 @@ public:
                     break;
             }
 
-            if (data == DONE || GhostKillCount >= 7)
+            if (data == DONE || GhostKillCount >= TOMB_OF_SEVEN_BOSS_NUM)
             {
                 OUT_SAVE_INST_DATA;
 
@@ -364,17 +364,17 @@ public:
             for (uint8 i = 0; i < MAX_ENCOUNTER; ++i)
                 if (encounter[i] == IN_PROGRESS)
                     encounter[i] = NOT_STARTED;
-            if (GhostKillCount > 0 && GhostKillCount < 7)
+            if (GhostKillCount > 0 && GhostKillCount < TOMB_OF_SEVEN_BOSS_NUM)
                 GhostKillCount = 0;//reset tomb of seven event
-            if (GhostKillCount >= 7)
-                GhostKillCount = 7;
+            if (GhostKillCount >= TOMB_OF_SEVEN_BOSS_NUM
+                GhostKillCount = TOMB_OF_SEVEN_BOSS_NUM;
 
             OUT_LOAD_INST_DATA_COMPLETE;
         }
 
         void TombOfSevenEvent()
         {
-            if (GhostKillCount < 7 && TombBossGUIDs[TombEventCounter])
+            if (GhostKillCount < TOMB_OF_SEVEN_BOSS_NUM && TombBossGUIDs[TombEventCounter])
             {
                 if (Creature* boss = instance->GetCreature(TombBossGUIDs[TombEventCounter]))
                 {
@@ -390,7 +390,7 @@ public:
         {
             HandleGameObject(GoTombExitGUID, false);//event reseted, close exit door
             HandleGameObject(GoTombEnterGUID, true);//event reseted, open entrance door
-            for (uint8 i = 0; i < 7; ++i)
+            for (uint8 i = 0; i < TOMB_OF_SEVEN_BOSS_NUM; ++i)
             {
                 if (Creature* boss = instance->GetCreature(TombBossGUIDs[i]))
                 {
@@ -425,19 +425,19 @@ public:
 
         void Update(uint32 diff) override
         {
-            if (TombEventStarterGUID && GhostKillCount < 7)
+            if (TombEventStarterGUID && GhostKillCount < TOMB_OF_SEVEN_BOSS_NUM)
             {
                 if (TombTimer <= diff)
                 {
                     TombTimer = TIMER_TOMBOFTHESEVEN;
-                    if ( TombEventCounter < TOMB_OF_SEVEN_BOSS_NUM )
+                    if (TombEventCounter < TOMB_OF_SEVEN_BOSS_NUM)
                     {
                         TombOfSevenEvent();
                         ++TombEventCounter;
                     }
 
                     // Check Killed bosses
-                    for (uint8 i = 0; i < 7; ++i)
+                    for (uint8 i = 0; i < TOMB_OF_SEVEN_BOSS_NUM; ++i)
                     {
                         if (Creature* boss = instance->GetCreature(TombBossGUIDs[i]))
                         {
@@ -449,7 +449,7 @@ public:
                     }
                 } else TombTimer -= diff;
             }
-            if (GhostKillCount >= 7 && TombEventStarterGUID)
+            if (GhostKillCount >= TOMB_OF_SEVEN_BOSS_NUM && TombEventStarterGUID)
                 TombOfSevenEnd();
         }
     };

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/instance_blackrock_depths.cpp
@@ -29,6 +29,7 @@
 
 #define TIMER_TOMBOFTHESEVEN    15000
 #define MAX_ENCOUNTER           6
+constexpr uint8 TOMB_OF_SEVEN_BOSS_NUM{ 7 };
 
 enum Creatures
 {
@@ -134,7 +135,7 @@ public:
 
         uint32 BarAleCount;
         uint32 GhostKillCount;
-        ObjectGuid TombBossGUIDs[7];
+        ObjectGuid TombBossGUIDs[TOMB_OF_SEVEN_BOSS_NUM];
         ObjectGuid TombEventStarterGUID;
         uint32 TombTimer;
         uint32 TombEventCounter;
@@ -429,8 +430,12 @@ public:
                 if (TombTimer <= diff)
                 {
                     TombTimer = TIMER_TOMBOFTHESEVEN;
-                    ++TombEventCounter;
-                    TombOfSevenEvent();
+                    if ( TombEventCounter < TOMB_OF_SEVEN_BOSS_NUM )
+                    {
+                        TombOfSevenEvent();
+                        ++TombEventCounter;
+                    }
+
                     // Check Killed bosses
                     for (uint8 i = 0; i < 7; ++i)
                     {


### PR DESCRIPTION

**Changes proposed:**
Do not access out of bounds array  

**Issues addressed:**
Index was modified every 15 seconds eventually leading to heap buffer overflow

Closes #27919 

**Tests performed:**

(Does it build, tested in-game, etc.)
it builds, wasn't tested