### PR TITLE
Core/Conditions: Added CONDITION_SCENARIO_STEP

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -43,6 +43,7 @@
 #include "RaceMask.h"
 #include "Realm.h"
 #include "ReputationMgr.h"
+#include "Scenario.h"
 #include "ScriptMgr.h"
 #include "Spell.h"
 #include "SpellAuras.h"
@@ -146,6 +147,7 @@ ConditionMgr::ConditionTypeInfo const ConditionMgr::StaticConditionTypeData[COND
     { "Object Entry or Guid",      true, true,  true  },
     { "Object TypeMask",           true, false, false },
     { "BattlePet Species Learned", true, true,  true  },
+    { "On Scenario Step",          true, false, false },
 };
 
 // Checks if object meets the condition
@@ -574,6 +576,13 @@ bool Condition::Meets(ConditionSourceInfo& sourceInfo) const
                     static_cast<uint8>(ConditionValue2));
             break;
         }
+        case CONDITION_SCENARIO_STEP:
+        {
+            if (Scenario const* scenario = object->GetScenario())
+                if (ScenarioStepEntry const* step = scenario->GetStep())
+                    condMeets = step->ID == ConditionValue1;
+            break;
+        }
         default:
             condMeets = false;
             break;
@@ -777,6 +786,9 @@ uint32 Condition::GetSearcherTypeMaskForCondition() const
             break;
         case CONDITION_BATTLE_PET_COUNT:
             mask |= GRID_MAP_TYPE_MASK_PLAYER;
+            break;
+        case CONDITION_SCENARIO_STEP:
+            mask |= GRID_MAP_TYPE_MASK_ALL;
             break;
         default:
             ABORT_MSG("Condition::GetSearcherTypeMaskForCondition - missing condition handling!");
@@ -2601,6 +2613,15 @@ bool ConditionMgr::isConditionTypeValid(Condition* cond) const
                 return false;
             }
             break;
+        case CONDITION_SCENARIO_STEP:
+        {
+            if (!sScenarioStepStore.LookupEntry(cond->ConditionValue1))
+            {
+                TC_LOG_ERROR("sql.sql", "%s has non existing ScenarioStep in value1 (%u), skipped.", cond->ToString(true).c_str(), cond->ConditionValue1);
+                return false;
+            }
+            break;
+        }
         default:
             TC_LOG_ERROR("sql.sql", "%s Invalid ConditionType in `condition` table, ignoring.", cond->ToString().c_str());
             return false;

--- a/src/server/game/Conditions/ConditionMgr.h
+++ b/src/server/game/Conditions/ConditionMgr.h
@@ -110,6 +110,7 @@ enum ConditionTypes
     CONDITION_OBJECT_ENTRY_GUID        = 51,                   // TypeID           entry          guid               true if object is type TypeID and the entry is 0 or matches entry of the object or matches guid of the object
     CONDITION_TYPE_MASK                = 52,                   // TypeMask         0              0                  true if object is type object's TypeMask matches provided TypeMask
     CONDITION_BATTLE_PET_COUNT         = 53,                   // SpecieId         count          ComparisonType     true if player has `count` of battle pet species
+    CONDITION_SCENARIO_STEP            = 54,                   // ScenarioStepId   0              0                  true if player is at scenario with current step equal to ScenarioStepID
     CONDITION_MAX
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Added a way to check in which scenario stage is the current object. Useful for some questlines that only happen in Scenarios and not in a open world, (By example: the artifacts questlines).
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
