### PR TITLE
Core/Spells: Paladin's Judgements can be applied on different targets at the same time

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1365,14 +1365,6 @@ bool SpellInfo::IsSingleTarget() const
     if (HasAttribute(SPELL_ATTR5_SINGLE_TARGET_SPELL))
         return true;
 
-    switch (GetSpellSpecific())
-    {
-        case SPELL_SPECIFIC_JUDGEMENT:
-            return true;
-        default:
-            break;
-    }
-
     return false;
 }
 


### PR DESCRIPTION

**Changes proposed:**

-  Remove Judgement of Wisdom, Judgement of Light and Judgement of Justice from IsSingleTarget()
Paladin's Judgements can be applied on different targets at the same time
(This does not mean different judgements of the same caster should stack in the same target)

https://www.warcraftmovies.com/movieview.php?id=138633 <-- min 2:56 - 3:05 and 3:16 - 3:33
Paladin cast Judgement of Light on Keleseth and after that when Judgement CD end, cast Judgement of Light on Dark Nucleus.

https://www.warcraftmovies.com/movieview.php?id=164185
3:46 - 3:54
Paladin cast Judgement of Light on Omx (focus) and after that when Judgement CD end, cast Judgement of Light on Deadlyintent



**Issues addressed:**

None


**Tests performed:**

tested in-game
