### PR TITLE
Core/GroupMgr: Execute all group related database cleanup at the beginning of LoadGroups.

### DIFF
--- a/src/server/game/Groups/GroupMgr.cpp
+++ b/src/server/game/Groups/GroupMgr.cpp
@@ -130,10 +130,15 @@ void GroupMgr::LoadGroups()
     {
         uint32 oldMSTime = getMSTime();
 
+        // Delete all members that does not exist
+        CharacterDatabase.DirectExecute("DELETE FROM group_member WHERE memberGuid NOT IN (SELECT guid FROM characters)");
         // Delete all groups whose leader does not exist
         CharacterDatabase.DirectExecute("DELETE FROM `groups` WHERE leaderGuid NOT IN (SELECT guid FROM characters)");
         // Delete all groups with less than 2 members
         CharacterDatabase.DirectExecute("DELETE FROM `groups` WHERE guid NOT IN (SELECT guid FROM group_member GROUP BY guid HAVING COUNT(guid) > 1)");
+        // Delete all rows from group_member or group_instance with no group
+        CharacterDatabase.DirectExecute("DELETE FROM group_member WHERE guid NOT IN (SELECT guid FROM `groups`)");
+        CharacterDatabase.DirectExecute("DELETE FROM group_instance WHERE guid NOT IN (SELECT guid FROM `groups`)");
 
         //                                                        0              1           2             3                 4      5          6      7         8       9
         QueryResult result = CharacterDatabase.Query("SELECT g.leaderGuid, g.lootMethod, g.looterGuid, g.lootThreshold, g.icon1, g.icon2, g.icon3, g.icon4, g.icon5, g.icon6"
@@ -172,12 +177,6 @@ void GroupMgr::LoadGroups()
     TC_LOG_INFO("server.loading", "Loading Group members...");
     {
         uint32 oldMSTime = getMSTime();
-
-        // Delete all rows from group_member or group_instance with no group
-        CharacterDatabase.DirectExecute("DELETE FROM group_member WHERE guid NOT IN (SELECT guid FROM `groups`)");
-        CharacterDatabase.DirectExecute("DELETE FROM group_instance WHERE guid NOT IN (SELECT guid FROM `groups`)");
-        // Delete all members that does not exist
-        CharacterDatabase.DirectExecute("DELETE FROM group_member WHERE memberGuid NOT IN (SELECT guid FROM characters)");
 
         //                                                    0        1           2            3       4
         QueryResult result = CharacterDatabase.Query("SELECT guid, memberGuid, memberFlags, subgroup, roles FROM group_member ORDER BY guid");


### PR DESCRIPTION
**Changes proposed:**
Execute all group related database cleanup at the beginning of LoadGroups.


**Issues addressed:**
Makes certain group_member entries are deleted when their respective groups are removed during cleanup. In cases when LoadGroups aborts early if no groups remain to be loaded after cleanup they would otherwise not be removed.


**Tests performed:**
Changes taken from and tested on: https://github.com/dufernst/LegionCore-7.3.5/commit/71268dc4bfb294501590b71ba9f60a80388252f6
Builds, tested ingame.


**Known issues and TODO list:**
none
