### PR TITLE
Scripts/Naxxramas: Fix achievement The Immortal / The Undying

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/instance_naxxramas.cpp
@@ -123,7 +123,7 @@ class instance_naxxramas : public InstanceMapScript
                 hadSapphironBirth       = false;
                 CurrentWingTaunt        = SAY_KELTHUZAD_FIRST_WING_TAUNT;
 
-                playerDied              = 0;
+                playerDied              = false;
             }
 
             void OnCreatureCreate(Creature* creature) override
@@ -248,9 +248,9 @@ class instance_naxxramas : public InstanceMapScript
 
             void OnUnitDeath(Unit* unit) override
             {
-                if (unit->GetTypeId() == TYPEID_PLAYER && IsEncounterInProgress())
+                if (!playerDied && unit->IsPlayer() && IsEncounterInProgress())
                 {
-                    playerDied = 1;
+                    playerDied = true;
                     SaveToDB();
                 }
 
@@ -552,6 +552,18 @@ class instance_naxxramas : public InstanceMapScript
                 return false;
             }
 
+            void WriteSaveDataMore(std::ostringstream& data) override
+            {
+                data << uint32(playerDied ? 1 : 0);
+            }
+
+            void ReadSaveDataMore(std::istringstream& data) override
+            {
+                uint32 tmpState;
+                data >> tmpState;
+                playerDied = tmpState != 0;
+            }
+
         protected:
             /* The Arachnid Quarter */
             // Anub'rekhan
@@ -597,7 +609,7 @@ class instance_naxxramas : public InstanceMapScript
             uint8 CurrentWingTaunt;
 
             /* The Immortal / The Undying */
-            uint32 playerDied;
+            bool playerDied;
 
             EventMap events;
         };


### PR DESCRIPTION
**Changes proposed:**

-  Now instance achievement status of The Immortal / The Undying will be saved into DB
achievement should be completed without any raid member die during all bosses encounters, if any member die, but before kill last boss you leave instance and wait until is destroyed (Instance.UnloadDelay) or do a server restart, playerDied will default 0 again because it's not saved.
-  this was reverted after https://github.com/TrinityCore/trinitycore/commit/ef9b4aea5e97ffbd4c0f611bef6fab6e554d82ff#diff-42d3a9126aeb07fb2ad87f5d8513c35eb4ed7082aaaf5af233de8a12e3c1728cL468

**Issues addressed:**

None


**Tests performed:**

tested in-game
