### PR TITLE
Core/SAI: Added SMART_TARGET_OWNER_OR_SUMMONER_VICTIM

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2956,6 +2956,26 @@ void SmartScript::GetTargets(ObjectVector& targets, SmartScriptHolder const& e, 
                 targets.push_back(target);
             break;
         }
+        case SMART_TARGET_OWNER_OR_SUMMONER_VICTIM:
+        {
+            if (me)
+            {
+                ObjectGuid charmerOrOwnerGuid = me->GetCharmerOrOwnerGUID();
+
+                if (!charmerOrOwnerGuid)
+                    if (TempSummon* tempSummon = me->ToTempSummon())
+                        if (WorldObject* summoner = tempSummon->GetSummoner())
+                            charmerOrOwnerGuid = summoner->GetGUID();
+
+                if (!charmerOrOwnerGuid)
+                    charmerOrOwnerGuid = me->GetCreatorGUID();
+
+                if (Unit* owner = ObjectAccessor::GetUnit(*me, charmerOrOwnerGuid))
+                    if (Unit* victim = owner->GetVictim())
+                        targets.push_back(victim);
+            }
+            break;
+        }
         case SMART_TARGET_POSITION:
         case SMART_TARGET_NONE:
         default:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -616,6 +616,7 @@ bool SmartAIMgr::IsTargetValid(SmartScriptHolder const& e)
         case SMART_TARGET_LOOT_RECIPIENTS:
         case SMART_TARGET_VEHICLE_PASSENGER:
         case SMART_TARGET_CLOSEST_UNSPAWNED_GAMEOBJECT:
+        case SMART_TARGET_OWNER_OR_SUMMONER_VICTIM:
             break;
         default:
             TC_LOG_ERROR("sql.sql", "SmartAIMgr: Not handled target_type(%u), Entry " SI64FMTD " SourceType %u Event %u Action %u, skipped.", e.GetTargetType(), e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1280,6 +1280,7 @@ enum SMARTAI_TARGETS
     SMART_TARGET_FARTHEST                       = 28,   // maxDist, playerOnly, isInLos
     SMART_TARGET_VEHICLE_PASSENGER              = 29,   // seatMask (0 - all seats)
     SMART_TARGET_CLOSEST_UNSPAWNED_GAMEOBJECT   = 30,   // entry(0any), maxDist
+    SMART_TARGET_OWNER_OR_SUMMONER_VICTIM       = 31,   // Victim of Owner or Summoner, Use Owner/Charmer of this unit
 
     SMART_TARGET_END                            = 31
 };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

- Cast the spell 201002 on self. Add a basic sai action on random hostile like cast. You will see that creature don't attack to hostile targets with your action.

**Known issues and TODO list:** (add/remove lines as needed)

- [ ]  
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->

The SMART_TARGET_HOSTILE, can't work in summons with Guardian Mask. Because the Method ThreatManager::CanHaveThreatList(Unit const* who) return false always. 

In retail the summons with property control Guardian can attack normally to hostile units.  In TC we can't have ThreatList and this makes useless SAI_TARGETS that work with threat list. 

We have some options to solve the issue:

- Add a new Target in SAI to get Victim of owner or summoner.
- Set ThreatList enabled for Guardian mobs created via Spells.
