### PR TITLE
Core/Creature - correctly apply npc pvp flags

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2544,7 +2544,7 @@ bool Creature::LoadCreaturesAddon()
         // 3 ShapeshiftForm     Must be determined/set by shapeshift spell/aura
 
         SetSheath(SheathState(cainfo->bytes2 & 0xFF));
-        ReplaceAllPvpFlags(UNIT_BYTE2_FLAG_NONE);
+        ReplaceAllPvpFlags(UnitPVPStateFlags((cainfo->bytes2 >> 8) & 0xFF));
         ReplaceAllPetFlags(UNIT_PET_FLAG_NONE);
         SetShapeshiftForm(FORM_NONE);
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Reads value 256 from creature_template_addon | creature_addon bytes2 and applies pvp flag
- Players can buff/heal the affected npcs again

**Issues addressed:**

Closes #26009

**Tests performed:**

- [x] builds
- [x] tested ingame

**Known issues and TODO list:** 

- This is just groundwork, we have a lot of missing or wrong data in database for this change. Might require sniffing and correcting countless creatures again
- Also needed for fixing "npc_garments_of_quests" but requires adding of bytes2 data to them (would be correct, confirmed via sniff)

Does not fix follow up problems:
- Buffing pvp flagged npc`s flaggs the player for pvp (not correct)
- Buffed Npcs dont get affected by the buff (Priest Stamina buff does not increase npc`s health)
- Npcs lose buffs on reset


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
