### PR TITLE
Core/Spells - correction for setting pvp flag for players

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2322,7 +2322,8 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     if (_spellHitTarget)
     {
         // if target is flagged for pvp also flag caster if a player
-        if (unit->IsPvP() && spell->m_caster->GetTypeId() == TYPEID_PLAYER)
+        // but respect current pvp rules (buffing/healing npcs flagged for pvp only flags you if they are in combat)
+        if (unit->IsPvP() && (unit->IsInCombat() || unit->IsCharmedOwnedByPlayerOrPlayer()) && spell->m_caster->GetTypeId() == TYPEID_PLAYER)
             _enablePVP = true; // Decide on PvP flagging now, but act on it later.
 
         SpellMissInfo missInfo = spell->PreprocessSpellHit(_spellHitTarget, ScaleAura, *this);


### PR DESCRIPTION
**Changes proposed:**

-  Follow up for https://github.com/TrinityCore/TrinityCore/pull/27974
-  respect pvp rules - buffing / healing a npc that is flagged for pvp should not flag you for pvp unless the npc is currently in combat


**Issues addressed:**
I could not find an open issue for this.


**Tests performed:**
- [x] builds
- [x] tested ingame


**Known issues and TODO list:** (add/remove lines as needed)
None that i know of