### PR TITLE
Scripts/Zone: Add Northshire Abbey infantry-worg battle scripts

### DIFF
--- a/sql/updates/world/master/9999_99_99_00_world.sql
+++ b/sql/updates/world/master/9999_99_99_00_world.sql
@@ -1,0 +1,8 @@
+-- Northshire Abbey scripts
+-- Stormwind Infantry attacks Blackrock Worg
+SET @ID := 49869;
+UPDATE `creature_template` SET `scriptname` = "npc_stormwind_infantry", `ainame` = "" WHERE `entry` = @ID;
+
+-- Blackrock Worg attacks Stormwind Infantry
+SET @ID := 49871;
+UPDATE `creature_template` SET `scriptname` = "npc_blackrock_worg", `ainame` = "" WHERE `entry` = @ID;


### PR DESCRIPTION
Ported from Cataclysm Preservation Project. This commit adds the
scripted battle between Blackrock Worgs and Stormwind Infantries.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add C++ scripts for Blackrock Worg and Stormwind Infantry in Northshire Abbey
-  Modify world database table creature_template so C++ scripts are used

**Issues addressed:**

None

**Tests performed:**

Tested under Windows, in game, with multiple classes.

**Known issues and TODO list:** (add/remove lines as needed)



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
