### PR TITLE
Tools/Extractors: Implement remote casc mode

### DIFF
--- a/src/tools/extractor_common/CascHandles.h
+++ b/src/tools/extractor_common/CascHandles.h
@@ -41,6 +41,7 @@ namespace CASC
         ~Storage();
 
         static Storage* Open(boost::filesystem::path const& path, uint32 localeMask, char const* product);
+        static Storage* OpenRemote(boost::filesystem::path const& path, uint32 localeMask, char const* product, char const* region);
 
         uint32 GetBuildNumber() const;
         uint32 GetInstalledLocalesMask() const;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Implement remote casc feature in mapextractor and vmapexport
- Add -c argument to activate remote casc
- Add -r argument to set the remote casc region (default is eu)
- Add -dl argument to vmapexport to select the corrent dbc locale 


**Tests performed:**
- It build and export all nesessary files




<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
