### PR TITLE
Creature Animation: Remove Set Facing Call

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2096,9 +2096,6 @@ void Unit::AttackerStateUpdate(Unit* victim, WeaponAttackType attType, bool extr
     if (!extra && _lastExtraAttackSpell)
         _lastExtraAttackSpell = 0;
 
-    if (GetTypeId() == TYPEID_UNIT && !HasUnitFlag(UNIT_FLAG_POSSESSED) && !HasUnitFlag2(UNIT_FLAG2_CANNOT_TURN))
-        SetFacingToObject(victim, false); // update client side facing to face the target (prevents visual glitches when casting untargeted spells)
-
     // melee attack spell cast at main hand attack only - no normal melee dmg dealt
     if (attType == BASE_ATTACK && m_currentSpells[CURRENT_MELEE_SPELL] && !extra)
         m_currentSpells[CURRENT_MELEE_SPELL]->cast();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Remove `SetFacingToObject` call from `AttackerStateUpdate`

Added in: https://github.com/TrinityCore/TrinityCore/commit/f481ae1048aac32ba3a40491f0304d0317234295

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/25342

**Tests performed:**

With that present I can pretty consistently recreate the stuttering attack animation. Not every creature but maybe 1 in 4. More easily reproducable if combat starts in melee range. Numerous times within a 30 minute window, tested in human starting area against Kobold Workers.

With it removed I've done roughly 1 hour of testing in the same way and not managed to replicate the bug.

Re-added it, able to reproduce in about 5 minutes again.


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
