### PR TITLE
Core/Player: Added fallback to regular gossip menu if no quest_greeting is found

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14749,7 +14749,11 @@ void Player::SendPreparedGossip(WorldObject* source)
             return;
         }
     }
+    SendPreparedGossipForced(source);
+}
 
+void Player::SendPreparedGossipForced(WorldObject* source)
+{
     // in case non empty gossip menu (that not included quests list size) show it
     // (quest entries from quest menu will be included in list)
 
@@ -14823,7 +14827,7 @@ void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 men
             break;
         case GOSSIP_OPTION_QUESTGIVER:
             PrepareQuestMenu(guid);
-            SendPreparedQuest(source);
+            SendPreparedGossip(source);
             break;
         case GOSSIP_OPTION_VENDOR:
         case GOSSIP_OPTION_ARMORER:
@@ -15064,7 +15068,10 @@ void Player::SendPreparedQuest(WorldObject* source)
         }
     }
 
-    PlayerTalkClass->SendQuestGiverQuestListMessage(source);
+    if (sObjectMgr->GetQuestGreeting(source->GetTypeId(), source->GetEntry()))
+        PlayerTalkClass->SendQuestGiverQuestListMessage(source);
+    else
+        SendPreparedGossipForced(source); // fallback to regular gossip menu
 }
 
 bool Player::IsActiveQuest(uint32 quest_id) const

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1537,6 +1537,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         void PrepareGossipMenu(WorldObject* source, uint32 menuId = 0, bool showQuests = false);
         void SendPreparedGossip(WorldObject* source);
+        void SendPreparedGossipForced(WorldObject* source);
         void OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 menuId);
 
         uint32 GetGossipTextId(uint32 menuId, WorldObject* source);


### PR DESCRIPTION
**Changes proposed:**

-  Fallback to showing gossip menu when no quest_greeting is found, without fallback it's not showing any text besides quest options

**Tests performed:**

(Does it build, tested in-game, etc.)
tested ingame with npc ids: 39379, 64764
