### PR TITLE
[3.3.5] OpenSSL 3.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ build_script:
 
     copy "C:\Program Files\MySQL\MySQL Server 5.7\lib\libmysql.dll" libmysql.dll
 
-    copy "%OPENSSL_ROOT_DIR%\ssleay32.dll" ssleay32.dll
+    copy "%OPENSSL_ROOT_DIR%\libssl-1_1-x64.dll" libssl-1_1-x64.dll
 
-    copy "%OPENSSL_ROOT_DIR%\libeay32.dll" libeay32.dll
+    copy "%OPENSSL_ROOT_DIR%\libcrypto-1_1-x64.dll" libcrypto-1_1-x64.dll
 
     cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ init:
 - ps: ''
 environment:
   BOOST_ROOT: C:\Libraries\boost_1_73_0
-  OPENSSL_ROOT_DIR: C:\OpenSSL-Win64
+  OPENSSL_ROOT_DIR: C:\OpenSSL-v111-Win64
 build_script:
 - cmd: >-
     git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"

--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -128,9 +128,9 @@ if (WIN32)
   if(PLATFORM EQUAL 64)
     set(_OPENSSL_MSI_INSTALL_GUID "117551DB-A110-4BBD-BB05-CFE0BCB3ED31")
     set(_OPENSSL_ROOT_HINTS
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;Inno Setup: App Path]"
       ${OPENSSL_ROOT_DIR}
       ENV OPENSSL_ROOT_DIR
+      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;Inno Setup: App Path]"
       )
     file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" _programfiles)
     set(_OPENSSL_ROOT_PATHS
@@ -142,9 +142,9 @@ if (WIN32)
   else()
     set(_OPENSSL_MSI_INSTALL_GUID "A1EEC576-43B9-4E75-9E02-03DA542D2A38")
     set(_OPENSSL_ROOT_HINTS
-      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"
       ${OPENSSL_ROOT_DIR}
       ENV OPENSSL_ROOT_DIR
+      "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"
       )
     file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" _programfiles)
     set(_OPENSSL_ROOT_PATHS

--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -80,7 +80,6 @@ Set ``OPENSSL_MSVC_STATIC_RT`` set ``TRUE`` to choose the MT version of the lib.
 #]=======================================================================]
 
 set(OPENSSL_EXPECTED_VERSION "1.0")
-set(OPENSSL_MAX_VERSION "1.2")
 
 macro(_OpenSSL_test_and_find_dependencies ssl_library crypto_library)
   if((CMAKE_SYSTEM_NAME STREQUAL "Linux") AND
@@ -574,7 +573,7 @@ if(OPENSSL_FOUND)
   message(STATUS "Found OpenSSL library: ${OPENSSL_LIBRARIES}")
   message(STATUS "Found OpenSSL headers: ${OPENSSL_INCLUDE_DIR}")
   include(EnsureVersion)
-  ENSURE_VERSION_RANGE("${OPENSSL_EXPECTED_VERSION}" "${OPENSSL_VERSION}" "${OPENSSL_MAX_VERSION}" OPENSSL_VERSION_OK)
+  ENSURE_VERSION("${OPENSSL_EXPECTED_VERSION}" "${OPENSSL_VERSION}" OPENSSL_VERSION_OK)
   if(NOT OPENSSL_VERSION_OK)
       message(FATAL_ERROR "TrinityCore needs OpenSSL version ${OPENSSL_EXPECTED_VERSION} but found too new version ${OPENSSL_VERSION}. TrinityCore needs OpenSSL 1.0.x or 1.1.x to work properly. If you still have problems please install OpenSSL 1.0.x if you still have problems search on forum for TCE00022")
   endif()

--- a/src/common/Cryptography/ARC4.cpp
+++ b/src/common/Cryptography/ARC4.cpp
@@ -18,24 +18,16 @@
 #include "ARC4.h"
 #include "Errors.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-#include <openssl/provider.h>
-#endif
-
 Trinity::Crypto::ARC4::ARC4() : _ctx(EVP_CIPHER_CTX_new())
 {
-    EVP_CIPHER const* cipher;
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    _libCtx = OSSL_LIB_CTX_new();
-    _legacyProvider = OSSL_PROVIDER_load(_libCtx, "legacy");
-
-    cipher = EVP_CIPHER_fetch(_libCtx, "RC4", "");
+    _cipher = EVP_CIPHER_fetch(nullptr, "RC4", nullptr);
 #else
-    cipher = EVP_rc4();
+    _cipher = EVP_rc4();
 #endif
 
     EVP_CIPHER_CTX_init(_ctx);
-    int result = EVP_EncryptInit_ex(_ctx, cipher, nullptr, nullptr, nullptr);
+    int result = EVP_EncryptInit_ex(_ctx, _cipher, nullptr, nullptr, nullptr);
     ASSERT(result == 1);
 }
 
@@ -44,8 +36,7 @@ Trinity::Crypto::ARC4::~ARC4()
     EVP_CIPHER_CTX_free(_ctx);
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    OSSL_PROVIDER_unload(_legacyProvider);
-    OSSL_LIB_CTX_free(_libCtx);
+    EVP_CIPHER_free(_cipher);
 #endif
 }
 

--- a/src/common/Cryptography/ARC4.cpp
+++ b/src/common/Cryptography/ARC4.cpp
@@ -23,7 +23,7 @@ Trinity::Crypto::ARC4::ARC4() : _ctx(EVP_CIPHER_CTX_new())
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     _cipher = EVP_CIPHER_fetch(nullptr, "RC4", nullptr);
 #else
-    _cipher = EVP_rc4();
+    EVP_CIPHER const* _cipher = EVP_rc4();
 #endif
 
     EVP_CIPHER_CTX_init(_ctx);

--- a/src/common/Cryptography/ARC4.h
+++ b/src/common/Cryptography/ARC4.h
@@ -38,10 +38,7 @@ namespace Trinity::Crypto
             template <typename Container>
             void UpdateData(Container& c) { UpdateData(std::data(c), std::size(c)); }
         private:
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-            OSSL_LIB_CTX* _libCtx;
-            OSSL_PROVIDER* _legacyProvider;
-#endif
+            EVP_CIPHER* _cipher;
             EVP_CIPHER_CTX* _ctx;
     };
 }

--- a/src/common/Cryptography/ARC4.h
+++ b/src/common/Cryptography/ARC4.h
@@ -38,6 +38,10 @@ namespace Trinity::Crypto
             template <typename Container>
             void UpdateData(Container& c) { UpdateData(std::data(c), std::size(c)); }
         private:
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            OSSL_LIB_CTX* _libCtx;
+            OSSL_PROVIDER* _legacyProvider;
+#endif
             EVP_CIPHER_CTX* _ctx;
     };
 }

--- a/src/common/Cryptography/ARC4.h
+++ b/src/common/Cryptography/ARC4.h
@@ -38,7 +38,9 @@ namespace Trinity::Crypto
             template <typename Container>
             void UpdateData(Container& c) { UpdateData(std::data(c), std::size(c)); }
         private:
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
             EVP_CIPHER* _cipher;
+#endif
             EVP_CIPHER_CTX* _ctx;
     };
 }

--- a/src/common/Cryptography/CryptoConstants.h
+++ b/src/common/Cryptography/CryptoConstants.h
@@ -24,6 +24,7 @@ namespace Trinity::Crypto
 {
     struct Constants
     {
+        static constexpr size_t MD5_DIGEST_LENGTH_BYTES = 16;
         static constexpr size_t SHA1_DIGEST_LENGTH_BYTES = 20;
         static constexpr size_t SHA256_DIGEST_LENGTH_BYTES = 32;
     };

--- a/src/common/Cryptography/CryptoHash.h
+++ b/src/common/Cryptography/CryptoHash.h
@@ -96,7 +96,7 @@ namespace Trinity::Impl
                 if (this == &right)
                     return *this;
 
-                int result = EVP_MD_CTX_copy(_ctx, right._ctx);
+                int result = EVP_MD_CTX_copy_ex(_ctx, right._ctx);
                 ASSERT(result == 1);
                 _digest = right._digest;
                 return *this;

--- a/src/common/Cryptography/HMAC.h
+++ b/src/common/Cryptography/HMAC.h
@@ -118,7 +118,7 @@ namespace Trinity::Impl
 
             void Finalize()
             {
-                size_t length = 0;
+                size_t length = DIGEST_LENGTH;
                 int result = EVP_DigestSignFinal(_ctx, _digest.data(), &length);
                 ASSERT(result == 1);
                 ASSERT(length == DIGEST_LENGTH);

--- a/src/common/Cryptography/HMAC.h
+++ b/src/common/Cryptography/HMAC.h
@@ -86,9 +86,10 @@ namespace Trinity::Impl
                 if (this == &right)
                     return *this;
 
-                int result = EVP_MD_CTX_copy(_ctx, right._ctx);
+                int result = EVP_MD_CTX_copy_ex(_ctx, right._ctx);
                 ASSERT(result == 1);
-                _key = right._key; // EVP_PKEY uses reference counting internally, just copy the pointer
+                _key = right._key;      // EVP_PKEY uses reference counting internally, just copy the pointer
+                EVP_PKEY_up_ref(_key);  // Bump reference count for PKEY, as every instance of this class holds two references to PKEY and destructor decrements it twice
                 _digest = right._digest;
                 return *this;
             }

--- a/src/common/Cryptography/OpenSSLCrypto.cpp
+++ b/src/common/Cryptography/OpenSSLCrypto.cpp
@@ -38,9 +38,15 @@ static void threadIdCallback(CRYPTO_THREADID * id)
     (void)id;
     CRYPTO_THREADID_set_numeric(id, std::hash<std::thread::id>()(std::this_thread::get_id()));
 }
+#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+OSSL_PROVIDER* LegacyProvider;
+OSSL_PROVIDER* DefaultProvider;
+#endif
 
-void OpenSSLCrypto::threadsSetup()
+void OpenSSLCrypto::threadsSetup([[maybe_unused]] boost::filesystem::path const& providerModulePath)
 {
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
     cryptoLocks.resize(CRYPTO_num_locks());
     for(int i = 0 ; i < CRYPTO_num_locks(); ++i)
     {
@@ -52,10 +58,18 @@ void OpenSSLCrypto::threadsSetup()
 
     (void)&lockingCallback;
     CRYPTO_set_locking_callback(lockingCallback);
+#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
+    OSSL_PROVIDER_set_default_search_path(nullptr, providerModulePath.string().c_str());
+#endif
+    LegacyProvider = OSSL_PROVIDER_load(nullptr, "legacy");
+    DefaultProvider = OSSL_PROVIDER_load(nullptr, "default");
+#endif
 }
 
 void OpenSSLCrypto::threadsCleanup()
 {
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
     CRYPTO_set_locking_callback(nullptr);
     CRYPTO_THREADID_set_callback(nullptr);
     for(int i = 0 ; i < CRYPTO_num_locks(); ++i)
@@ -63,5 +77,9 @@ void OpenSSLCrypto::threadsCleanup()
         delete cryptoLocks[i];
     }
     cryptoLocks.resize(0);
-}
+#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_PROVIDER_unload(LegacyProvider);
+    OSSL_PROVIDER_unload(DefaultProvider);
+    OSSL_PROVIDER_set_default_search_path(nullptr, nullptr);
 #endif
+}

--- a/src/common/Cryptography/OpenSSLCrypto.h
+++ b/src/common/Cryptography/OpenSSLCrypto.h
@@ -19,7 +19,7 @@
 #define TRINITY_OPENSSL_CRYPTO_H
 
 #include "Define.h"
-#include <openssl/opensslv.h>
+#include <boost/filesystem/path.hpp>
 
 /**
 * A group of functions which setup openssl crypto module to work properly in multithreaded enviroment
@@ -27,17 +27,10 @@
 */
 namespace OpenSSLCrypto
 {
-
-#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x1010000fL
     /// Needs to be called before threads using openssl are spawned
-    TC_COMMON_API void threadsSetup();
+    TC_COMMON_API void threadsSetup(boost::filesystem::path const& providerModulePath);
     /// Needs to be called after threads using openssl are despawned
     TC_COMMON_API void threadsCleanup();
-#else
-    void threadsSetup() { };
-    void threadsCleanup() { };
-#endif
-
 }
 
 #endif

--- a/src/common/Cryptography/OpenSSLCrypto.h
+++ b/src/common/Cryptography/OpenSSLCrypto.h
@@ -15,8 +15,8 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENSSL_CRYPTO_H
-#define OPENSSL_CRYPTO_H
+#ifndef TRINITY_OPENSSL_CRYPTO_H
+#define TRINITY_OPENSSL_CRYPTO_H
 
 #include "Define.h"
 #include <openssl/opensslv.h>

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -34,12 +34,14 @@
 #include "IPLocation.h"
 #include "GitRevision.h"
 #include "MySQLThreading.h"
+#include "OpenSSLCrypto.h"
 #include "ProcessPriority.h"
 #include "RealmList.h"
 #include "SecretMgr.h"
 #include "SharedDefines.h"
 #include "Util.h"
 #include <boost/asio/signal_set.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <openssl/crypto.h>
@@ -128,6 +130,10 @@ int main(int argc, char** argv)
 
     for (std::string const& key : overriddenKeys)
         TC_LOG_INFO("server.authserver", "Configuration field '%s' was overridden with environment variable.", key.c_str());
+
+    OpenSSLCrypto::threadsSetup(boost::dll::program_location().remove_filename());
+
+    std::shared_ptr<void> opensslHandle(nullptr, [](void*) { OpenSSLCrypto::threadsCleanup(); });
 
     // authserver PID file creation
     std::string pidFile = sConfigMgr->GetStringDefault("PidFile", "");

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
         []()
         {
             TC_LOG_INFO("server.authserver", "Using configuration file %s.", sConfigMgr->GetFilename().c_str());
-            TC_LOG_INFO("server.authserver", "Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
+            TC_LOG_INFO("server.authserver", "Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
             TC_LOG_INFO("server.authserver", "Using Boost version: %i.%i.%i", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
         }
     );

--- a/src/server/game/Addons/AddonMgr.cpp
+++ b/src/server/game/Addons/AddonMgr.cpp
@@ -16,11 +16,11 @@
  */
 
 #include "AddonMgr.h"
+#include "CryptoHash.h"
 #include "DatabaseEnv.h"
 #include "DBCStores.h"
 #include "Log.h"
 #include "Timer.h"
-#include <openssl/md5.h>
 
 namespace AddonMgr
 {
@@ -82,8 +82,8 @@ void LoadFromDB()
             std::string name = fields[1].GetString();
             std::string version = fields[2].GetString();
 
-            MD5(reinterpret_cast<uint8 const*>(name.c_str()), name.length(), addon.NameMD5);
-            MD5(reinterpret_cast<uint8 const*>(version.c_str()), version.length(), addon.VersionMD5);
+            addon.NameMD5 = Trinity::Crypto::MD5::GetDigestOf(name);
+            addon.VersionMD5 = Trinity::Crypto::MD5::GetDigestOf(version);
 
             m_bannedAddons.push_back(addon);
 

--- a/src/server/game/Addons/AddonMgr.h
+++ b/src/server/game/Addons/AddonMgr.h
@@ -19,6 +19,7 @@
 #define _ADDONMGR_H
 
 #include "Define.h"
+#include <array>
 #include <string>
 #include <vector>
 
@@ -36,8 +37,8 @@ struct SavedAddon
 struct BannedAddon
 {
     uint32 Id;
-    uint8 NameMD5[16];
-    uint8 VersionMD5[16];
+    std::array<uint8, 16> NameMD5;
+    std::array<uint8, 16> VersionMD5;
     uint32 Timestamp;
 };
 

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1206,8 +1206,8 @@ void WorldSession::SendAddonsInfo()
     for (; itr != bannedAddons->end(); ++itr)
     {
         data << uint32(itr->Id);
-        data.append(itr->NameMD5, sizeof(itr->NameMD5));
-        data.append(itr->VersionMD5, sizeof(itr->VersionMD5));
+        data.append(itr->NameMD5);
+        data.append(itr->VersionMD5);
         data << uint32(itr->Timestamp);
         data << uint32(1);  // IsBanned
         bannedAddonCount++;

--- a/src/server/game/Warden/WardenMac.cpp
+++ b/src/server/game/Warden/WardenMac.cpp
@@ -18,6 +18,7 @@
 #include "WardenMac.h"
 #include "ByteBuffer.h"
 #include "Common.h"
+#include "CryptoHash.h"
 #include "GameTime.h"
 #include "Log.h"
 #include "Opcodes.h"
@@ -28,7 +29,6 @@
 #include "WorldPacket.h"
 #include "WorldSession.h"
 
-#include <openssl/md5.h>
 #include <array>
 
 WardenMac::WardenMac() : Warden() { }
@@ -231,12 +231,7 @@ void WardenMac::HandleCheckResult(ByteBuffer &buff)
         //found = true;
     }
 
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
-    MD5_Update(&ctx, str.c_str(), str.size());
-    std::array<uint8, 16> ourMD5Hash;
-    MD5_Final(ourMD5Hash.data(), &ctx);
-
+    std::array<uint8, 16> ourMD5Hash = Trinity::Crypto::MD5::GetDigestOf(str);
     std::array<uint8, 16> theirsMD5Hash;
     buff.read(theirsMD5Hash);
 

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -55,6 +55,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #include <boost/asio/signal_set.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/program_options.hpp>
 #include <csignal>
@@ -209,7 +210,7 @@ extern int main(int argc, char** argv)
     for (std::string const& key : overriddenKeys)
         TC_LOG_INFO("server.worldserver", "Configuration field '%s' was overridden with environment variable.", key.c_str());
 
-    OpenSSLCrypto::threadsSetup();
+    OpenSSLCrypto::threadsSetup(boost::dll::program_location().remove_filename());
 
     std::shared_ptr<void> opensslHandle(nullptr, [](void*) { OpenSSLCrypto::threadsCleanup(); });
 

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -201,7 +201,7 @@ extern int main(int argc, char** argv)
         []()
         {
             TC_LOG_INFO("server.worldserver", "Using configuration file %s.", sConfigMgr->GetFilename().c_str());
-            TC_LOG_INFO("server.worldserver", "Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, SSLeay_version(SSLEAY_VERSION));
+            TC_LOG_INFO("server.worldserver", "Using SSL version: %s (library: %s)", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
             TC_LOG_INFO("server.worldserver", "Using Boost version: %i.%i.%i", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
         }
     );


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  back port of OpenSSL 3.0 support from `master`-branch

**Issues addressed:**

##### ARC4 changes
*rc4* is still provided in the legacy provider
```c++
#if OPENSSL_VERSION_NUMBER >= 0x30000000L
    _libctx = OSSL_LIB_CTX_new();
    _legacy_provider = OSSL_PROVIDER_load(_libctx, "legacy");

    cipher = EVP_CIPHER_fetch(_libctx, "RC4", "");
#else
    cipher = EVP_rc4();
#endif
```

##### HMAC.h changes
```c++
void Finalize()
{
    size_t length = DIGEST_LENGTH;
    int result = EVP_DigestSignFinal(_ctx, _digest.data(), &length);
        ASSERT(result == 1);
        ASSERT(length == DIGEST_LENGTH);
}
```

According to: https://www.openssl.org/docs/man3.0/man3/EVP_DigestSignFinal.html

> EVP_DigestSign() signs tbslen bytes of data at tbs and places the signature in sig and its length in siglen in a similar way to EVP_DigestSignFinal(). In the event of a failure EVP_DigestSign() cannot be called again without reinitialising the EVP_MD_CTX. If sig is NULL before the call then siglen will be populated with the required size for the sig buffer. If sig is non-NULL before the call then siglen should contain the length of the sig buffer.


**Tests performed:**

- [x] build on Ubuntu 18.04
- [x] build on Ubuntu 20.04
- [x] build on Ubuntu 22.04
- [x] build on Debian 11
- [x] run on 22.04 and 5 min playtime


**Known issues and TODO list:** (add/remove lines as needed)

- none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
