### PR TITLE
Core/Movement: Fixed desync in knockback movement

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -547,6 +547,7 @@ void WorldSession::HandleMoveKnockBackAck(WorldPackets::Movement::MoveKnockBackA
     if (_player->m_unitMovedByMe->GetGUID() != movementAck.Ack.Status.guid)
         return;
 
+    movementAck.Ack.Status.time = AdjustClientMovementTime(movementAck.Ack.Status.time);
     _player->m_movementInfo = movementAck.Ack.Status;
 
     WorldPackets::Movement::MoveUpdateKnockBack updateKnockBack;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixed desynchronization of client when a player performs a knockback movement

**Issues addressed:**
None

**Tests performed:**
Builds, tested in-game.

Test case:
- Player 1 casts the spell 79043 on himself
- Player 2 (observer) sees the knockback move executed by player 1. 
- Before applying this change, during the upward movement of player 1 (the knockback itself), player 2 saw the movement with small jumps and it wasn't fluid

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
