### PR TITLE
Fix starting level for GMs creating a DK

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -546,7 +546,7 @@ bool Player::Create(ObjectGuid::LowType guidlow, CharacterCreateInfo* createInfo
         ? sWorld->getIntConfig(CONFIG_START_PLAYER_LEVEL)
         : sWorld->getIntConfig(CONFIG_START_DEATH_KNIGHT_PLAYER_LEVEL);
 
-    if (m_session->HasPermission(rbac::RBAC_PERM_USE_START_GM_LEVEL))
+    if (GetClass() != CLASS_DEATH_KNIGHT && m_session->HasPermission(rbac::RBAC_PERM_USE_START_GM_LEVEL))
     {
         uint32 gm_level = sWorld->getIntConfig(CONFIG_START_GM_LEVEL);
         if (gm_level > start_level)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -546,9 +546,9 @@ bool Player::Create(ObjectGuid::LowType guidlow, CharacterCreateInfo* createInfo
         ? sWorld->getIntConfig(CONFIG_START_PLAYER_LEVEL)
         : sWorld->getIntConfig(CONFIG_START_DEATH_KNIGHT_PLAYER_LEVEL);
 
-    if (GetClass() != CLASS_DEATH_KNIGHT && m_session->HasPermission(rbac::RBAC_PERM_USE_START_GM_LEVEL))
+    if (m_session->HasPermission(rbac::RBAC_PERM_USE_START_GM_LEVEL))
     {
-        uint32 gm_level = sWorld->getIntConfig(CONFIG_START_GM_LEVEL);
+        uint32 gm_level = std::max(sWorld->getIntConfig(CONFIG_START_GM_LEVEL), sWorld->getIntConfig(CONFIG_START_DEATH_KNIGHT_PLAYER_LEVEL));
         if (gm_level > start_level)
             start_level = gm_level;
     }


### PR DESCRIPTION
**Changes proposed:**

-  Add an additional check to setting player start level to exclude DKs from the GM.StartLevel override of StartPlayerLevel/StartDeathKnightPlayerLevel


**Issues addressed:**
I didn't open an issue with this, but it feels incorrect that setting StartPlayerLevel to 80 would override the StartDeathKnightPlayerLevel being 55 still for GMs.  If the GM.StartLevel is less than the PlayerStartLevel, the previous version of this code would always make the GM.StartLevel config value match the StartPlayerLevel at runtime, which made GM DeathKnights level 80.  If this is intended behavior, feel free to reject this PR.

**Tests performed:**

Tested in game

