### PR TITLE
Spells/Shaman: Fix loop for proc on "Earthen Rage"

### DIFF
--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -419,7 +419,7 @@ class spell_sha_earthen_rage_passive : public AuraScript
 
     bool CheckProc(ProcEventInfo& procInfo)
     {
-        return !(procInfo.GetSpellInfo()->Id == SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE);
+        return procInfo.GetSpellInfo() && procInfo.GetSpellInfo()->Id != SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE;
     }
 
     void HandleEffectProc(AuraEffect* /*aurEff*/, ProcEventInfo& eventInfo)

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -417,6 +417,11 @@ class spell_sha_earthen_rage_passive : public AuraScript
         return ValidateSpellInfo({ SPELL_SHAMAN_EARTHEN_RAGE_PERIODIC, SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE });
     }
 
+    bool CheckProc(ProcEventInfo& procInfo)
+    {
+        return !(procInfo.GetSpellInfo()->Id == SPELL_SHAMAN_EARTHEN_RAGE_DAMAGE);
+    }
+
     void HandleEffectProc(AuraEffect* /*aurEff*/, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
@@ -426,6 +431,7 @@ class spell_sha_earthen_rage_passive : public AuraScript
 
     void Register() override
     {
+        DoCheckProc += AuraCheckProcFn(spell_sha_earthen_rage_passive::CheckProc);
         OnEffectProc += AuraEffectProcFn(spell_sha_earthen_rage_passive::HandleEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Since the attributes 3 were rewritten the proc of this spell enters in an endless loop of proc due to the correct implementation of the called attribute SPELL_ATTR3_DISABLE_PROC

**Tests performed:**

Tested in-game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
