### PR TITLE
Fix WSG Assault Bug #28088

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -155,11 +155,13 @@ void BattlegroundWS::PostUpdateImpl(uint32 diff)
             }
         }
 
+
         if (_bothFlagsKept)
         {
             _flagSpellForceTimer += diff;
             if (_flagDebuffState == 0 && _flagSpellForceTimer >= 10*MINUTE*IN_MILLISECONDS)  //10 minutes
             {
+                // Apply Stage 1 (Focused Assault)
                 if (Player* player = ObjectAccessor::FindPlayer(m_FlagKeepers[0]))
                     player->CastSpell(player, WS_SPELL_FOCUSED_ASSAULT, true);
                 if (Player* player = ObjectAccessor::FindPlayer(m_FlagKeepers[1]))
@@ -168,6 +170,7 @@ void BattlegroundWS::PostUpdateImpl(uint32 diff)
             }
             else if (_flagDebuffState == 1 && _flagSpellForceTimer >= 15*MINUTE*IN_MILLISECONDS) //15 minutes
             {
+                // Apply Stage 2 (Brutal Assault)
                 if (Player* player = ObjectAccessor::FindPlayer(m_FlagKeepers[0]))
                 {
                     player->RemoveAurasDueToSpell(WS_SPELL_FOCUSED_ASSAULT);
@@ -181,8 +184,12 @@ void BattlegroundWS::PostUpdateImpl(uint32 diff)
                 _flagDebuffState = 2;
             }
         }
-        else
+        else if ((_flagState[TEAM_ALLIANCE] == BG_WS_FLAG_STATE_ON_BASE || _flagState[TEAM_ALLIANCE] == BG_WS_FLAG_STATE_WAIT_RESPAWN) &&
+         (_flagState[TEAM_HORDE] == BG_WS_FLAG_STATE_ON_BASE || _flagState[TEAM_HORDE] == BG_WS_FLAG_STATE_WAIT_RESPAWN))
         {
+            // Both flags are in base or awaiting respawn.
+            // Remove assault debuffs, reset timers
+
             if (Player* player = ObjectAccessor::FindPlayer(m_FlagKeepers[0]))
             {
                 player->RemoveAurasDueToSpell(WS_SPELL_FOCUSED_ASSAULT);
@@ -485,6 +492,11 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         player->StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_SPELL_TARGET, BG_WS_SPELL_SILVERWING_FLAG_PICKED);
         if (_flagState[1] == BG_WS_FLAG_STATE_ON_PLAYER)
           _bothFlagsKept = true;
+
+        if (_flagDebuffState == 1)
+          player->CastSpell(player, WS_SPELL_FOCUSED_ASSAULT, true);
+        else if (_flagDebuffState == 2)
+          player->CastSpell(player, WS_SPELL_BRUTAL_ASSAULT, true);
     }
 
     //horde flag picked up from base
@@ -503,6 +515,11 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
         player->StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_SPELL_TARGET, BG_WS_SPELL_WARSONG_FLAG_PICKED);
         if (_flagState[0] == BG_WS_FLAG_STATE_ON_PLAYER)
           _bothFlagsKept = true;
+
+        if (_flagDebuffState == 1)
+          player->CastSpell(player, WS_SPELL_FOCUSED_ASSAULT, true);
+        else if (_flagDebuffState == 2)
+          player->CastSpell(player, WS_SPELL_BRUTAL_ASSAULT, true);
     }
 
     //Alliance flag on ground(not in base) (returned or picked up again from ground!)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -155,7 +155,6 @@ void BattlegroundWS::PostUpdateImpl(uint32 diff)
             }
         }
 
-
         if (_bothFlagsKept)
         {
             _flagSpellForceTimer += diff;


### PR DESCRIPTION
**Changes proposed:**

-  Warsong Gulch: Do not clear Focused Assault or Brutal Assault from one
team's flagbearer when the other team's flag is returned. The timer
should only stop / reset when both flags have returned to the pedestal.
-  Warsong Gulch: When a flag is picked up from the pedestal with Focused Assault or
  Brutal Assault active, the new flagbearer should also receive the debuff.

**Issues addressed:**

Closes #28088


**Tests performed:**

- Tested reset in-game.
- Tested re-application when picking up from base in-game.

**Known issues and TODO list:** (add/remove lines as needed)

- [x] Need to test re-application of debuff for new flagbearer in-game.
- [x] Fully test that timer is reset per bug description (return both flags to reset timer, re-take both flags, wait for debuff again)
- [x] Resolve codestyle hiccups