### PR TITLE
Core/Event: Add event Weekly Bonus

### DIFF
--- a/src/server/scripts/Events/events_script_loader.cpp
+++ b/src/server/scripts/Events/events_script_loader.cpp
@@ -26,6 +26,7 @@ void AddSC_event_lunar_festival();
 void AddSC_event_midsummer();
 void AddSC_event_operation_gnomeregan();
 void AddSC_event_pilgrims_bounty();
+void AddSC_event_weekly_bonus();
 void AddSC_event_winter_veil();
 void AddSC_event_zalazane_fall();
 
@@ -43,6 +44,7 @@ void AddEventsScripts()
     AddSC_event_midsummer();
     AddSC_event_operation_gnomeregan();
     AddSC_event_pilgrims_bounty();
+    AddSC_event_weekly_bonus();
     AddSC_event_winter_veil();
     AddSC_event_zalazane_fall();
 }

--- a/src/server/scripts/Events/weekly_bonus.cpp
+++ b/src/server/scripts/Events/weekly_bonus.cpp
@@ -20,20 +20,38 @@
 
 constexpr auto MAX_WEEKLY_EVENT = 5;
 
+enum Spells
+{
+    SPELL_SIGN_OF_THE_SKIRMISHER    = 186401,
+    SPELL_SIGN_OF_BATTLE            = 186403,
+    SPELL_SIGN_OF_THE_CRITTER       = 186406,
+    SPELL_SIGN_OF_THE_WARRIOR       = 225787,
+    SPELL_SIGN_OF_THE_EMISSARY      = 225787
+};
+
+enum Events
+{
+    ARENA_SKIRMISH_BONUS_EVENT      = 91,
+    BATTLEGROUND_BONUS_EVENT        = 99,
+    PET_BATTLE_BONUS_EVENT          = 86,
+    SHADOWLANDS_DUNGEON_EVENT       = 102,
+    WORLD_QUEST_BONUS_EVENT         = 94
+};
+
 int32 events[MAX_WEEKLY_EVENT] = {
-    91,  //  561 - Arena Skirmish Bonus Event
-    99,  //  563 - Battleground Bonus Event
-    86,  //  565 - Pet Battle Bonus Event
-    102, // 1217 - Shadowlands Dungeon Event
-    94   //  592 - World Quest Bonus Event
+    ARENA_SKIRMISH_BONUS_EVENT,
+    BATTLEGROUND_BONUS_EVENT,
+    PET_BATTLE_BONUS_EVENT,
+    SHADOWLANDS_DUNGEON_EVENT,
+    WORLD_QUEST_BONUS_EVENT
 };
 
 int32 auras[MAX_WEEKLY_EVENT] = {
-    186401, // Sign of the Skirmisher
-    186403, // Sign of Battle
-    186406, // Sign of the Critter
-    225787, // Sign of the Warrior
-    225788  // Sign of the Emissary
+    SPELL_SIGN_OF_THE_SKIRMISHER,
+    SPELL_SIGN_OF_BATTLE,
+    SPELL_SIGN_OF_THE_CRITTER,
+    SPELL_SIGN_OF_THE_WARRIOR,
+    SPELL_SIGN_OF_THE_EMISSARY
 };
 
 class Weekly_Bonus_Event_PlayerScript : public PlayerScript
@@ -51,7 +69,7 @@ public:
         for (uint8 i = 0; i < MAX_WEEKLY_EVENT; ++i)        
             if (sGameEventMgr->IsActiveEvent(events[i]))
             {
-                player->AddAura(auras[i], player);
+                player->CastSpell(nullptr, auras[i]);
                 break;
             }
     }

--- a/src/server/scripts/Events/weekly_bonus.cpp
+++ b/src/server/scripts/Events/weekly_bonus.cpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GameEventMgr.h"
+#include "ScriptMgr.h"
+
+constexpr auto MAX_WEEKLY_EVENT = 5;
+
+int32 events[MAX_WEEKLY_EVENT] = {
+    91,  //  561 - Arena Skirmish Bonus Event
+    99,  //  563 - Battleground Bonus Event
+    86,  //  565 - Pet Battle Bonus Event
+    102, // 1217 - Shadowlands Dungeon Event
+    94   //  592 - World Quest Bonus Event
+};
+
+int32 auras[MAX_WEEKLY_EVENT] = {
+    186401, // Sign of the Skirmisher
+    186403, // Sign of Battle
+    186406, // Sign of the Critter
+    225787, // Sign of the Warrior
+    225788  // Sign of the Emissary
+};
+
+class Weekly_Bonus_Event_PlayerScript : public PlayerScript
+{
+public:
+    Weekly_Bonus_Event_PlayerScript() :PlayerScript("Weekly_Bonus_Event_PlayerScript") {}
+
+    void OnLogin(Player* player, bool /*firstLogin*/)
+    {
+        for (uint8 i = 0; i < MAX_WEEKLY_EVENT; ++i)
+            if (!sGameEventMgr->IsActiveEvent(events[i]))
+                if (player->HasAura(auras[i]))
+                    player->RemoveAura(auras[i]);
+
+        for (uint8 i = 0; i < MAX_WEEKLY_EVENT; ++i)        
+            if (sGameEventMgr->IsActiveEvent(events[i]))
+            {
+                player->AddAura(auras[i], player);
+                break;
+            }
+    }
+};
+
+void AddSC_event_weekly_bonus()
+{
+    new Weekly_Bonus_Event_PlayerScript();
+};

--- a/src/server/scripts/Events/weekly_bonus.cpp
+++ b/src/server/scripts/Events/weekly_bonus.cpp
@@ -62,16 +62,14 @@ public:
     void OnLogin(Player* player, bool /*firstLogin*/)
     {
         for (uint8 i = 0; i < MAX_WEEKLY_EVENT; ++i)
+        {
             if (!sGameEventMgr->IsActiveEvent(events[i]))
                 if (player->HasAura(auras[i]))
                     player->RemoveAura(auras[i]);
 
-        for (uint8 i = 0; i < MAX_WEEKLY_EVENT; ++i)        
             if (sGameEventMgr->IsActiveEvent(events[i]))
-            {
                 player->CastSpell(nullptr, auras[i]);
-                break;
-            }
+        }
     }
 };
 


### PR DESCRIPTION
 **Changes proposed:**
Add bonus for the following events, according to the [wowhead guide](https://www.wowhead.com/bonus-events):

 561 - Arena Skirmish Bonus Event     - 186401 - Sign of the Skirmisher
 563 - Battleground Bonus Event        - 186403 - Sign of Battle
 565 - Pet Battle Bonus Event              - 186406 - Sign of the Critter
 592 - World Quest Bonus Event         - 225788 - Sign of the Emissary
1217 - Shadowlands Dungeon Event  - 225787 - Sign of the Warrior

This PR I did, according to the ID of the events added in this issues [#28091](https://github.com/TrinityCore/TrinityCore/issues/28091)

**Tests performed:**
- [X] Does it build
- [X] Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)
- [X] Add weekly_bonus.cpp in Event