### PR TITLE
Prevent PvP trinket from clearing statuses that ignore caster auras

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2889,7 +2889,11 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
     {
         target->ApplySpellImmune(Id, IMMUNITY_STATE, auraType, apply);
         if (apply && HasAttribute(SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY))
-            target->RemoveAurasByType(auraType);
+            target->RemoveAurasByType(auraType, [](AuraApplication const* aurApp) -> bool
+            {
+                // if the aura has SPELL_ATTR6_IGNORE_CASTER_AURAS, then it cannot be removed by immunity
+                return !aurApp->GetBase()->GetSpellInfo()->HasAttribute(SPELL_ATTR6_IGNORE_CASTER_AURAS);
+            });
     }
 
     for (SpellEffects effectType : immuneInfo.SpellEffectImmune)


### PR DESCRIPTION
**Changes proposed:**

-  When removing auras due to immunity, do not remove auras with the attribute `SPELL_ATTR6_IGNORE_CASTER_AURAS`.

**Issues addressed:**

Brought up in #28088 , though it wasn't the original focus.


**Tests performed:**

```
// Get and equip PVP trinket (tested with a Horde Warlock):
.additem 18852
// Mostly for laughs, give ourselves a speed aura to miss when we apply an Assault debuff to limit our speed.
.aura 1557
// Apply Focused Assault
.aura 46392
// Apply hamstring debuff
.aura 1715
```

While Hamstring is active, use the trinket. It is expected to have Hamstring go away, while Focused Assault remains.

Also tested with Brutal Assault (46393)