### PR TITLE
Improve Aura reaction with invincibility

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2889,7 +2889,11 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
     {
         target->ApplySpellImmune(Id, IMMUNITY_STATE, auraType, apply);
         if (apply && HasAttribute(SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY))
-            target->RemoveAurasByType(auraType);
+            target->RemoveAurasByType(auraType, [](AuraApplication const* aurApp) -> bool
+            {
+                // if the aura has SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY, then it cannot be removed by immunity
+                return !aurApp->GetBase()->GetSpellInfo()->HasAttribute(SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY);
+            });
     }
 
     for (SpellEffects effectType : immuneInfo.SpellEffectImmune)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3150,6 +3150,16 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->_GetEffect(EFFECT_0).TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ANY);
     });
 
+    // Warsong Gulch Anti-Stall Debuffs
+    ApplySpellFix({
+        46392, // Focused Assault
+        46393, // Brutal Assault
+    }, [](SpellInfo* spellInfo)
+    {
+        // due to discrepancies between ranks
+        spellInfo->Attributes |= SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY;
+    });
+
     // Summon Skeletons
     ApplySpellFix({ 52611, 52612 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
**Changes proposed:**

-  Do not remove auras flagged with SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY
-  Mark Focused Assault and Brutal Assault with SPELL_ATTR0_UNAFFECTED_BY_INVULNERABILITY

**Issues addressed:**

Brought up in #28088 , though it wasn't the original focus.

**Tests performed:**

```
// Get and equip PVP trinket (tested with a Horde Warlock):
.additem 18852
// Mostly for laughs, give ourselves a speed aura to miss when we apply an Assault debuff to limit our speed.
.aura 1557
// Apply Focused Assault
.aura 46392
// Apply hamstring debuff
.aura 1715
```

While Hamstring is active, use the trinket. It is expected to have Hamstring go away, while Focused Assault remains.

Also tested with Brutal Assault (46393)

**Notes**

Second attempt at this concept after #28098 