### PR TITLE
Improve snare immunity handling

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4377,20 +4377,12 @@ void Unit::RestoreMovementImpairingAuras()
         // restore surviving snare effects
         for (SpellEffectInfo const& spellEffectInfo : aura->GetSpellInfo()->GetEffects())
         {
-            if (!iter->second->HasEffect(spellEffectInfo.EffectIndex))
-            {
-                continue;
-            }
-
             if (spellEffectInfo.Mechanic != MECHANIC_SNARE)
-            {
                 continue;
-            }
 
             AuraEffect* auraEffect = aura->GetEffect(spellEffectInfo.EffectIndex);
             if (auraEffect->GetAmount() == 0 && auraEffect->GetCaster())
                 auraEffect->ChangeAmount(auraEffect->CalculateAmount(auraEffect->GetCaster()), false);
-
         }
 
         ++iter;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1362,7 +1362,7 @@ class TC_GAME_API Unit : public WorldObject
         void RemoveAurasWithInterruptFlags(uint32 flag, uint32 except = 0);
         void RemoveAurasWithAttribute(uint32 flags);
         void RemoveAurasWithFamily(SpellFamilyNames family, uint32 familyFlag1, uint32 familyFlag2, uint32 familyFlag3, ObjectGuid casterGUID);
-        void RemoveAurasWithMechanic(uint32 mechanic_mask, AuraRemoveMode removemode = AURA_REMOVE_BY_DEFAULT, uint32 except = 0);
+        void RemoveAurasWithMechanic(uint32 mechanic_mask, AuraRemoveMode removemode = AURA_REMOVE_BY_DEFAULT, uint32 except = 0, std::function<bool(AuraApplication const*, uint32)> const& check = nullptr);
         void RemoveMovementImpairingAuras(bool withRoot);
         void RemoveAurasByShapeShift();
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1377,6 +1377,8 @@ class TC_GAME_API Unit : public WorldObject
         void RemoveAllGroupBuffsFromCaster(ObjectGuid casterGUID);
         void DelayOwnedAuras(uint32 spellId, ObjectGuid caster, int32 delaytime);
 
+        void RestoreMovementImpairingAuras();
+
         void _RemoveAllAuraStatMods();
         void _ApplyAllAuraStatMods();
 

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -496,6 +496,20 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
         case SPELL_AURA_MANA_SHIELD:
             m_canBeRecalculated = false;
             break;
+        case SPELL_AURA_MOD_DECREASE_SPEED:
+            // snare
+            if (GetBase()->GetType() != UNIT_AURA_TYPE)
+                break;
+
+            if (GetBase()->GetUnitOwner()->GetMechanicImmunityMask() & (1 << MECHANIC_SNARE))
+            {
+                // A speed decrease is being applied, but the target is currently immune to snares
+                amount = 0;
+                m_canBeRecalculated = false;
+            }
+
+            break;
+
         default:
             break;
     }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2895,8 +2895,8 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
 
                         if(countEffectsSnare < countEffects)
                         {
-                            // Spell has some non-snare mechanics.
-                            // Do not remove the aura and settle with setting the amount to 0.
+                            // The aura has some non-snare effects.
+                            // Do not remove the aura and settle with the setting of the snare amount to 0 as we've already done.
                             return false;
                         }
                     }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2906,7 +2906,7 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
                     return true;
                 });
             } else if (mechanicImmunity == (1 << MECHANIC_SNARE))
-                // When immunity is removed, restore snares that were set to 0.
+                // When immunity is removed, restore snare effects that were set to 0.
                 target->RestoreMovementImpairingAuras();
         }
     }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2906,6 +2906,7 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
                     return true;
                 });
             } else if (mechanicImmunity == (1 << MECHANIC_SNARE))
+                // When immunity is removed, restore snares that were set to 0.
                 target->RestoreMovementImpairingAuras();
         }
     }

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2855,13 +2855,17 @@ void SpellInfo::ApplyAllSpellImmunitiesTo(Unit* target, uint8 effIndex, bool app
             if (mechanicImmunity & (1 << i))
                 target->ApplySpellImmune(Id, IMMUNITY_MECHANIC, i, apply);
 
-        if (apply && HasAttribute(SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY))
+        if (HasAttribute(SPELL_ATTR1_DISPEL_AURAS_ON_IMMUNITY))
         {
-            // exception for purely snare mechanic (eg. hands of freedom)!
-            if (mechanicImmunity == (1 << MECHANIC_SNARE))
-                target->RemoveMovementImpairingAuras(false);
-            else
-                target->RemoveAurasWithMechanic(mechanicImmunity, AURA_REMOVE_BY_DEFAULT, Id);
+            if(apply)
+            {
+                // exception for purely snare mechanic (eg. hands of freedom)!
+                if (mechanicImmunity == (1 << MECHANIC_SNARE))
+                    target->RemoveMovementImpairingAuras(false);
+                else
+                    target->RemoveAurasWithMechanic(mechanicImmunity, AURA_REMOVE_BY_DEFAULT, Id);
+            } else if (mechanicImmunity == (1 << MECHANIC_SNARE))
+                target->RestoreMovementImpairingAuras();
         }
     }
 


### PR DESCRIPTION
**Changes proposed:**

- When snare immunity is applied, remove auras whose only effect is a snare (e.g. Hamstring). Auras with multiple effects (e.g. Infected Wounds) will continue to have their snare effects floored to 0.
- If a new aura with a snare effect is applied to a target that is immune (e.g. Infected Wounds on a target with Hand of Freedom), the user should not have the snare effect of the aura applied to them.
- When snare immunity is removed from a unit that has an aura with a snare component (e.g. Hand of Freedom fading from a unit with Infected Wounds), then the value of the snare aura should be recalculated to snare the unit.

**Issues addressed:**

Closes #28096 

**Tests performed:**

Test definitions:

1. Test restoration of snare effects when immunity is removed
    1. Select a spell with a multi-effect aura. Suggested: Infected Wounds
    2. Cast the selected spell on target
    3. Observe speed, should be slower
    4. Cast Hand of Freedom on target.
    5. Observe debuffs, Multi-effect aura aura should still be on the target
    6. Observe speed, should be normal
    7. Before the snare aura ends, cancel Hand of Freedom
    8. Observe speed, should be slower again
2. Test removal of single-effect auras
    1. Select a spell that applies an aura whose only effect is a snare. Suggested: Blast Wave, Hamstring
    2. Cast the selected spell on the target
    3. Cast Hand of Freedom on the target
    4. Observe debuffs, the snare aura should be removed.
3. Test ignoring of single-effect auras with a snare effect when Hand of Freedom is already active
    1. Select a spell with a non-aura effect and a snare effect. Suggested: Blast Wave
    2. Cast Hand of Freedom on the target.
    3. While Hand of Freedom is active, cast the selected snare spell on the target.
    4. Expected behavior: Target takes damage from Blast Wave, Blast Wave aura is not applied.
4. Test ignoring of snare effects on multi-effect auras when Hand of Freedom is already active
    1. Select a spell with a multi-effect aura. Suggested: Frostbolt with Permafrost talent
    2. Cast Hand of Freedom on the target.
    3. While Hand of Freedom is active, cast the selected snare spell on the target.
    4. Expected behavior: Target takes damage from Frostbolt, Frostbolt aura is applied
    5. Observe speed, should not be reduced
    6. Before Frostbolt ends, cancel Hand of Freedom
    7. Observe speed, should be slower

Test results:

1. Success
2. Success
3. Success (this ended up working even without any changes)
4. Success

**Known issues and TODO list:**

- [ ] Fix up removal/ignoring of auras with placeholder effects like Frostbolt. See below comment for an aura test list.
