### PR TITLE
Combat Trigger on Spell Launch

### DIFF
--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -85,18 +85,8 @@ void CombatReference::EndCombat()
     delete this;
 }
 
-bool PvPCombatReference::Update(uint32 tdiff)
+void CombatReference::Refresh()
 {
-    if (_combatTimer <= tdiff)
-        return false;
-    _combatTimer -= tdiff;
-    return true;
-}
-
-void PvPCombatReference::Refresh()
-{
-    _combatTimer = PVP_COMBAT_TIMEOUT;
-
     bool needFirstAI = false, needSecondAI = false;
     if (_suppressFirst)
     {
@@ -115,12 +105,25 @@ void PvPCombatReference::Refresh()
         CombatManager::NotifyAICombat(second, first);
 }
 
-void PvPCombatReference::SuppressFor(Unit* who)
+void CombatReference::SuppressFor(Unit* who)
 {
     Suppress(who);
     if (who->GetCombatManager().UpdateOwnerCombatState())
         if (UnitAI* ai = who->GetAI())
             ai->JustExitedCombat();
+}
+
+bool PvPCombatReference::Update(uint32 tdiff)
+{
+    if (_combatTimer <= tdiff)
+        return false;
+    _combatTimer -= tdiff;
+    return true;
+}
+
+void PvPCombatReference::RefreshTimer()
+{
+    _combatTimer = PVP_COMBAT_TIMEOUT;
 }
 
 CombatManager::~CombatManager()
@@ -145,10 +148,18 @@ void CombatManager::Update(uint32 tdiff)
     }
 }
 
+bool CombatManager::HasPvECombat() const
+{
+    for (auto const& [guid, ref] : _pveRefs)
+        if (!ref->IsSuppressedFor(_owner))
+            return true;
+    return false;
+}
+
 bool CombatManager::HasPvECombatWithPlayers() const
 {
     for (std::pair<ObjectGuid const, CombatReference*> const& reference : _pveRefs)
-        if (reference.second->GetOther(_owner)->GetTypeId() == TYPEID_PLAYER)
+        if (!reference.second->IsSuppressedFor(_owner) && reference.second->GetOther(_owner)->GetTypeId() == TYPEID_PLAYER)
             return true;
 
     return false;
@@ -164,25 +175,29 @@ bool CombatManager::HasPvPCombat() const
 
 Unit* CombatManager::GetAnyTarget() const
 {
-    if (!_pveRefs.empty())
-        return _pveRefs.begin()->second->GetOther(_owner);
+    for (auto const& pair : _pveRefs)
+        if (!pair.second->IsSuppressedFor(_owner))
+            return pair.second->GetOther(_owner);
     for (auto const& pair : _pvpRefs)
         if (!pair.second->IsSuppressedFor(_owner))
             return pair.second->GetOther(_owner);
     return nullptr;
 }
 
-bool CombatManager::SetInCombatWith(Unit* who, bool suppressPvpSecond)
+bool CombatManager::SetInCombatWith(Unit* who, bool addSecondUnitSuppressed)
 {
     // Are we already in combat? If yes, refresh pvp combat
-    auto it = _pvpRefs.find(who->GetGUID());
-    if (it != _pvpRefs.end())
+    if (PvPCombatReference* existingPvpRef = Trinity::Containers::MapGetValuePtr(_pvpRefs, who->GetGUID()))
     {
-        it->second->Refresh();
+        existingPvpRef->RefreshTimer();
+        existingPvpRef->Refresh();
         return true;
     }
-    else if (_pveRefs.find(who->GetGUID()) != _pveRefs.end())
+    if (CombatReference* existingPveRef = Trinity::Containers::MapGetValuePtr(_pveRefs, who->GetGUID()))
+    {
+        existingPveRef->Refresh();
         return true;
+    }
 
     // Otherwise, check validity...
     if (!CombatManager::CanBeginCombat(_owner, who))
@@ -191,14 +206,12 @@ bool CombatManager::SetInCombatWith(Unit* who, bool suppressPvpSecond)
     // ...then create new reference
     CombatReference* ref;
     if (_owner->IsControlledByPlayer() && who->IsControlledByPlayer())
-    {
-        PvPCombatReference* refPvp = new PvPCombatReference(_owner, who);
-        if (suppressPvpSecond)
-            refPvp->SuppressFor(who);
-        ref = refPvp;
-    }
+        ref = new PvPCombatReference(_owner, who);
     else
         ref = new CombatReference(_owner, who);
+
+    if (addSecondUnitSuppressed)
+        ref->Suppress(who);
 
     // ...and insert it into both managers
     PutReference(who->GetGUID(), ref);

--- a/src/server/game/Combat/CombatManager.cpp
+++ b/src/server/game/Combat/CombatManager.cpp
@@ -172,7 +172,7 @@ Unit* CombatManager::GetAnyTarget() const
     return nullptr;
 }
 
-bool CombatManager::SetInCombatWith(Unit* who)
+bool CombatManager::SetInCombatWith(Unit* who, bool suppressPvpSecond)
 {
     // Are we already in combat? If yes, refresh pvp combat
     auto it = _pvpRefs.find(who->GetGUID());
@@ -191,7 +191,12 @@ bool CombatManager::SetInCombatWith(Unit* who)
     // ...then create new reference
     CombatReference* ref;
     if (_owner->IsControlledByPlayer() && who->IsControlledByPlayer())
-        ref = new PvPCombatReference(_owner, who);
+    {
+        PvPCombatReference* refPvp = new PvPCombatReference(_owner, who);
+        if (suppressPvpSecond)
+            refPvp->SuppressFor(who);
+        ref = refPvp;
+    }
     else
         ref = new CombatReference(_owner, who);
 

--- a/src/server/game/Combat/CombatManager.h
+++ b/src/server/game/Combat/CombatManager.h
@@ -114,7 +114,7 @@ class TC_GAME_API CombatManager
         Unit* GetAnyTarget() const;
 
         // return value is the same as calling IsInCombatWith immediately after this returns
-        bool SetInCombatWith(Unit* who);
+        bool SetInCombatWith(Unit* who, bool suppressPvpSecond = false);
         bool IsInCombatWith(ObjectGuid const& who) const;
         bool IsInCombatWith(Unit const* who) const;
         void InheritCombatStatesFrom(Unit const* who);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1141,7 +1141,7 @@ class TC_GAME_API Unit : public WorldObject
 
         bool IsInCombat() const { return HasUnitFlag(UNIT_FLAG_IN_COMBAT); }
         bool IsInCombatWith(Unit const* who) const { return who && m_combatManager.IsInCombatWith(who); }
-        void SetInCombatWith(Unit* enemy) { if (enemy) m_combatManager.SetInCombatWith(enemy); }
+        void SetInCombatWith(Unit* enemy, bool suppressPvpTargetCombat = false) { if (enemy) m_combatManager.SetInCombatWith(enemy, suppressPvpTargetCombat); }
         void ClearInCombat() { m_combatManager.EndAllCombat(); }
         void UpdatePetCombatState();
         // Threat handling

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1141,7 +1141,7 @@ class TC_GAME_API Unit : public WorldObject
 
         bool IsInCombat() const { return HasUnitFlag(UNIT_FLAG_IN_COMBAT); }
         bool IsInCombatWith(Unit const* who) const { return who && m_combatManager.IsInCombatWith(who); }
-        void SetInCombatWith(Unit* enemy, bool suppressPvpTargetCombat = false) { if (enemy) m_combatManager.SetInCombatWith(enemy, suppressPvpTargetCombat); }
+        void SetInCombatWith(Unit* enemy, bool addSecondUnitSuppressed = false) { if (enemy) m_combatManager.SetInCombatWith(enemy, addSecondUnitSuppressed); }
         void ClearInCombat() { m_combatManager.EndAllCombat(); }
         void UpdatePetCombatState();
         // Threat handling

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2030,37 +2030,6 @@ void Spell::CleanupTargetList()
     m_delayMoment = 0;
 }
 
-class ProcImpactDelayed : public BasicEvent
-{
-public:
-    ProcImpactDelayed(Unit* owner, ObjectGuid casterGUID, const bool enterCombat, bool enablePVP) : _owner(owner), _casterGUID(casterGUID), _enterCombat(enterCombat), _enablePVP(enablePVP) { }
-
-    bool Execute(uint64 /*e_time*/, uint32 /*p_time*/) override
-    {
-        if(!_owner)
-            return true;
-
-        Unit* caster = ObjectAccessor::GetUnit(*_owner, _casterGUID);
-        if (!caster)
-            return true;
-
-        // This will only cause combat - the target will engage once the projectile hits (in DoAllEffectOnTarget)
-        if (_enterCombat)
-            _owner->SetInCombatWith(caster);
-
-        if (_enablePVP && caster->ToPlayer())
-            caster->ToPlayer()->UpdatePvP(true);
-
-        return true;
-    }
-
-private:
-    Unit*  _owner;
-    ObjectGuid _casterGUID;
-    bool _enterCombat;
-    bool _enablePVP;
-};
-
 class ProcReflectDelayed : public BasicEvent
 {
     public:
@@ -2144,12 +2113,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
 
     // Calculate hit result
     WorldObject* caster = m_originalCaster ? m_originalCaster : m_caster;
-    Unit* unitCaster = m_caster->ToUnit();
     targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
-
-    // This will only cause combat - the target will engage once the projectile hits (in DoAllEffectOnTarget)
-    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(target) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || target->IsEngaged()))
-        m_originalCaster->SetInCombatWith(target, true);
 
     // Spell have speed - need calculate incoming time
     // Incoming time is zero for self casts. At least I think so.
@@ -2166,15 +2130,6 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
         // Calculate minimum incoming time
         if (!m_delayMoment || m_delayMoment > targetInfo.TimeDelay)
             m_delayMoment = targetInfo.TimeDelay;
-
-        if (unitCaster && targetInfo.MissCondition != SPELL_MISS_EVADE)
-        {
-            bool enterCombat = !caster->IsFriendlyTo(target) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || target->IsEngaged());
-            bool enablePVP = targetInfo.IsPVPEnabling();
-
-            if (enterCombat || enablePVP)
-                target->m_Events.AddEvent(new ProcImpactDelayed(target, m_originalCasterGUID, enterCombat, enablePVP), target->m_Events.CalculateTime(Milliseconds(targetInfo.TimeDelay)));
-        }
     }
     else
         targetInfo.TimeDelay = 0ULL;
@@ -2183,7 +2138,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
     if (targetInfo.MissCondition == SPELL_MISS_REFLECT)
     {
         // Calculate reflected spell result on caster (shouldn't be able to reflect gameobject spells)
-        ASSERT(unitCaster);
+        Unit* unitCaster = ASSERT_NOTNULL(m_caster->ToUnit());
         targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, false); // can't reflect twice
 
         // Proc spell reflect aura when missile hits the original target
@@ -2357,9 +2312,8 @@ void Spell::TargetInfo::PreprocessTarget(Spell* spell)
     else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
         _spellHitTarget = spell->m_caster->ToUnit();
 
-    // Ensure that a player target is put in combat by a taunt, even if they result immune clientside
-    if ((MissCondition == SPELL_MISS_IMMUNE || MissCondition == SPELL_MISS_IMMUNE2) && spell->m_caster->GetTypeId() == TYPEID_PLAYER && unit->GetTypeId() == TYPEID_PLAYER && spell->m_caster->IsValidAttackTarget(unit, spell->GetSpellInfo()))
-        unit->SetInCombatWith(spell->m_caster->ToPlayer());
+    if (spell->m_originalCaster && MissCondition != SPELL_MISS_EVADE && !spell->m_originalCaster->IsFriendlyTo(unit) && (!spell->m_spellInfo->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (spell->m_spellInfo->HasInitialAggro() || unit->IsEngaged()))
+        unit->SetInCombatWith(spell->m_originalCaster);
 
     spell->CallScriptBeforeHitHandlers(MissCondition);
 
@@ -7651,10 +7605,18 @@ void Spell::HandleLaunchPhase()
 
 void Spell::DoEffectOnLaunchTarget(TargetInfo& targetInfo, float multiplier, SpellEffectInfo const& spellEffectInfo)
 {
+    Unit* targetUnit = m_caster->GetGUID() == targetInfo.TargetGUID ? m_caster->ToUnit() : ObjectAccessor::GetUnit(*m_caster, targetInfo.TargetGUID);
+    if (!targetUnit)
+        return;
+
+    // This will only cause combat - the target will engage once the projectile hits (in Spell::TargetInfo::PreprocessTarget)
+    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(targetUnit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || targetUnit->IsEngaged()))
+        m_originalCaster->SetInCombatWith(targetUnit, true);
+
     Unit* unit = nullptr;
     // In case spell hit target, do all effect on that target
     if (targetInfo.MissCondition == SPELL_MISS_NONE)
-        unit = m_caster->GetGUID() == targetInfo.TargetGUID ? m_caster->ToUnit() : ObjectAccessor::GetUnit(*m_caster, targetInfo.TargetGUID);
+        unit = targetUnit;
     // In case spell reflect from target, do all effect on caster (if hit)
     else if (targetInfo.MissCondition == SPELL_MISS_REFLECT && targetInfo.ReflectResult == SPELL_MISS_NONE)
         unit = m_caster->ToUnit();

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2030,6 +2030,37 @@ void Spell::CleanupTargetList()
     m_delayMoment = 0;
 }
 
+class ProcImpactDelayed : public BasicEvent
+{
+public:
+    ProcImpactDelayed(Unit* owner, ObjectGuid casterGUID, const bool enterCombat, bool enablePVP) : _owner(owner), _casterGUID(casterGUID), _enterCombat(enterCombat), _enablePVP(enablePVP) { }
+
+    bool Execute(uint64 /*e_time*/, uint32 /*p_time*/) override
+    {
+        if(!_owner)
+            return true;
+
+        Unit* caster = ObjectAccessor::GetUnit(*_owner, _casterGUID);
+        if (!caster)
+            return true;
+
+        // This will only cause combat - the target will engage once the projectile hits (in DoAllEffectOnTarget)
+        if (_enterCombat)
+            _owner->SetInCombatWith(caster);
+
+        if (_enablePVP && caster->ToPlayer())
+            caster->ToPlayer()->UpdatePvP(true);
+
+        return true;
+    }
+
+private:
+    Unit*  _owner;
+    ObjectGuid _casterGUID;
+    bool _enterCombat;
+    bool _enablePVP;
+};
+
 class ProcReflectDelayed : public BasicEvent
 {
     public:
@@ -2113,7 +2144,12 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
 
     // Calculate hit result
     WorldObject* caster = m_originalCaster ? m_originalCaster : m_caster;
+    Unit* unitCaster = m_caster->ToUnit();
     targetInfo.MissCondition = caster->SpellHitResult(target, m_spellInfo, m_canReflect && !(IsPositive() && m_caster->IsFriendlyTo(target)));
+
+    // This will only cause combat - the target will engage once the projectile hits (in DoAllEffectOnTarget)
+    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(target) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || target->IsEngaged()))
+        m_originalCaster->SetInCombatWith(target, true);
 
     // Spell have speed - need calculate incoming time
     // Incoming time is zero for self casts. At least I think so.
@@ -2130,6 +2166,15 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
         // Calculate minimum incoming time
         if (!m_delayMoment || m_delayMoment > targetInfo.TimeDelay)
             m_delayMoment = targetInfo.TimeDelay;
+
+        if (unitCaster && targetInfo.MissCondition != SPELL_MISS_EVADE)
+        {
+            bool enterCombat = !caster->IsFriendlyTo(target) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || target->IsEngaged());
+            bool enablePVP = targetInfo.IsPVPEnabling();
+
+            if (enterCombat || enablePVP)
+                target->m_Events.AddEvent(new ProcImpactDelayed(target, m_originalCasterGUID, enterCombat, enablePVP), target->m_Events.CalculateTime(Milliseconds(targetInfo.TimeDelay)));
+        }
     }
     else
         targetInfo.TimeDelay = 0ULL;
@@ -2138,7 +2183,7 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
     if (targetInfo.MissCondition == SPELL_MISS_REFLECT)
     {
         // Calculate reflected spell result on caster (shouldn't be able to reflect gameobject spells)
-        Unit* unitCaster = ASSERT_NOTNULL(m_caster->ToUnit());
+        ASSERT(unitCaster);
         targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, false); // can't reflect twice
 
         // Proc spell reflect aura when missile hits the original target
@@ -7616,10 +7661,6 @@ void Spell::DoEffectOnLaunchTarget(TargetInfo& targetInfo, float multiplier, Spe
 
     if (!unit)
         return;
-
-    // This will only cause combat - the target will engage once the projectile hits (in DoAllEffectOnTarget)
-    if (m_originalCaster && targetInfo.MissCondition != SPELL_MISS_EVADE && !m_originalCaster->IsFriendlyTo(unit) && (!m_spellInfo->IsPositive() || m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)) && (m_spellInfo->HasInitialAggro() || unit->IsEngaged()))
-        m_originalCaster->SetInCombatWith(unit);
 
     m_damage = 0;
     m_healing = 0;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -561,6 +561,8 @@ class TC_GAME_API Spell
             void DoTargetSpellHit(Spell* spell, SpellEffectInfo const& spellEffectInfo) override;
             void DoDamageAndTriggers(Spell* spell) override;
 
+            bool IsPVPEnabling() const { return _enablePVP; }
+
             ObjectGuid TargetGUID;
             uint64 TimeDelay = 0ULL;
             int32 Damage = 0;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -561,8 +561,6 @@ class TC_GAME_API Spell
             void DoTargetSpellHit(Spell* spell, SpellEffectInfo const& spellEffectInfo) override;
             void DoDamageAndTriggers(Spell* spell) override;
 
-            bool IsPVPEnabling() const { return _enablePVP; }
-
             ObjectGuid TargetGUID;
             uint64 TimeDelay = 0ULL;
             int32 Damage = 0;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  When the user fires a projectile, immediately enter the caster into combat and do not enter the target into combat until the result of the launch is announced.
-  When a spell misses, place the target in combat

**Issues addressed:**

Closes #28103 

**Tests performed:**
Setup:

1. On one account, create a character with a projectile spell. I went with a warlock for Shadow Bolt, but using Fireball would have been better
2. On another account, create a warrior to be a target for projectiles. Specifically making a warrior to test Spell Reflection in a test case.
3. Log into the characters, and put them in a setup that allows them to attack each other
4. Set up your windows so that you can conveniently watch the combat state of the caster and the target at once. 
5. Place the characters at maximum range for your spell.
6. Each of these tests assumes that the two characters are not in combat at step 1.

Test Cases:

1. Confirm that projectiles don't put the target into combat at launch (Hit).
    1. Cast a projectile at the target.
    2. While the projectile is in the air, observe that the caster is immediately placed into combat.
    3. While the projectile is in the air, observe that the target is not placed into combat.
    4. Confirm that the projectile cast has hit. If it misses, then pivot to Test 2. Test 2 is this test, but for the more unlikely case of non-hits
    5. Observe that the target is now in combat.
2. Confirm that projectiles place the caster in combat and don't put the target into combat at launch (Miss).
    1. Cast a projectile at the target.
    2. While the projectile is in the air, observe that the caster is immediately placed into combat.
    3. While the projectile is in the air, observe that the target is not placed into combat.
    4. Confirm that the projectile cast has missed. If it hits, then repeat until it does not
        * If you don't want to keep rolling the dice on a miss, then you could create a second caster with a large level distance
    6. Observe that the target is now in combat.
3. Confirm that reflected projectiles put the target in combat at time of reflection. Expecting this to act just like Test 2, but adding it here to cover our bases.
	1. Set the warrior up with a shield and teach them spell reflection
        * `.additem 32255`
        * `.learn 23920`
        * `.level 70`
    2. Set up enough Rage on the target, and cast Spell Reflection
    3. While Spell Reflection is active, cast a projectile that can be reflected at the target.
    4. While the projectile is in the air, observe that the caster is immediately placed into combat.
    5. While the projectile is in the air, observe that the target is not placed into combat.
    7. Confirm that the projectile cast has is reflected. If it does not, then repeat until it does
    8. Observe that the target is in combat BEFORE the spell projectile hits the caster.
4. Test pointer paranoia. This is probably an understanding hurdle on my part), but if it doesn't crash things then that can only be good.
    1. Fire a projectile at a target. 
    2. Before the projectile hits, sign that target out
5. Smoke Testing. Spend a session running around the world a bunch with a spellcaster. I'd encourage abusing GM powers to visit more areas and dying in an instance at least once (releasing spirit in an instance is what caused the crash that prompted this test).

Test Results:

1. Success
2. Success
3. Success
4. Success* - When this happens, the caster is told the spell is "interrupted" after the projectile is launched. Bit weird, but I'm classifying this behaviour as out-of-scope for this bug/PR. Nothing's crashing on us on account of that test.
5. Smoke tested with misc in-game play.