### PR TITLE
fix(Common/Crypto): correct headers guard

### DIFF
--- a/src/common/Cryptography/SessionKeyGenerator.h
+++ b/src/common/Cryptography/SessionKeyGenerator.h
@@ -15,11 +15,11 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <cstring>
-#include "CryptoHash.h"
-
 #ifndef TRINITY_SESSIONKEYGENERATOR_HPP
 #define TRINITY_SESSIONKEYGENERATOR_HPP
+
+#include <cstring>
+#include "CryptoHash.h"
 
 template <typename Hash>
 class SessionKeyGenerator


### PR DESCRIPTION
**Changes proposed:**
- Correct headers guard in file `SessionKeyGenerator.h`