### PR TITLE
Core/Unit: Implement SetNameplateAttachToGUID from UpdateField

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -962,6 +962,8 @@ class TC_GAME_API Unit : public WorldObject
 
         void SetCreatedBySpell(int32 spellId) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::CreatedBySpell), spellId); }
 
+        void SetNameplateAttachToGUID(ObjectGuid guid) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::NameplateAttachToGUID), guid); }
+
         Emote GetEmoteState() const { return Emote(*m_unitData->EmoteState); }
         void SetEmoteState(Emote emote) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::EmoteState), emote); }
 


### PR DESCRIPTION
This field was not currently being handled anywhere besides packets inside UpdateObject on several creatures (Sylvanas Windrunner during her encounter in Sanctum of Domination e.g.)

**Changes proposed:**

It sets the current unit's nameplate on top of a different creature using its GUID. To return it back, we just set it to 0 as packets show.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

None.