### PR TITLE
Core/Movement: Implement SetUnlimitedSpeed for MoveJumpWithGravity

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -873,6 +873,7 @@ void MotionMaster::MoveJumpWithGravity(Position const& pos, float speedXY, float
         init.SetParabolicVerticalAcceleration(gravity, 0);
         init.SetUncompressed();
         init.SetVelocity(speedXY);
+        init.SetUnlimitedSpeed();
         if (hasOrientation)
             init.SetFacing(pos.GetOrientation());
         if (effect)

--- a/src/server/game/Movement/Spline/MoveSplineInit.h
+++ b/src/server/game/Movement/Spline/MoveSplineInit.h
@@ -146,6 +146,11 @@ namespace Movement
          */
         void SetOrientationFixed(bool enable);
 
+        /* Enables no-speed limit
+         * if not set, the speed will be limited by certain flags to 50.0f, and otherwise 28.0f
+         */
+        void SetUnlimitedSpeed();
+
         /* Sets the velocity (in case you want to have custom movement velocity)
          * if no set, speed will be selected based on unit's speeds and current movement mode
          * Has no effect if falling mode enabled
@@ -176,6 +181,7 @@ namespace Movement
     inline void MoveSplineInit::SetTransportEnter() { args.flags.EnableTransportEnter(); }
     inline void MoveSplineInit::SetTransportExit() { args.flags.EnableTransportExit(); }
     inline void MoveSplineInit::SetOrientationFixed(bool enable) { args.flags.orientationFixed = enable; }
+    inline void MoveSplineInit::SetUnlimitedSpeed() { args.flags.unlimitedSpeed = true; }
 
     inline void MoveSplineInit::SetParabolic(float amplitude, float time_shift)
     {


### PR DESCRIPTION
According to Sylvanas Windrunner's encounter sniffs, her jump spells using SPELL_EFFECT_JUMP_CHARGE can go past 50.0f speed limitation of the client.

**Changes proposed:**

- Implement SetUnlimitedSpeed that allows speed to surpass 50.0f with certain flags or 28.0f by default.
- Implement SetUnlimitedSpeed inside MoveJumpWithGravity init.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

Not entirely sure yet whether the limitation is only based on creatures or both players and creatures. We could check whether the actor is not a player to set it just in case.