### PR TITLE
Core/Spells: OnPrecast should be called before ReSetTimer

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3412,10 +3412,10 @@ SpellCastResult Spell::prepare(SpellCastTargets const& targets, AuraEffect const
             m_caster->ToCreature()->SetSpellFocus(this, nullptr);
     }
 
+    CallScriptOnPrecastHandler();
+
     // set timer base at cast time
     ReSetTimer();
-
-    CallScriptOnPrecastHandler();
 
     TC_LOG_DEBUG("spells", "Spell::prepare: spell id %u source %u caster %d customCastFlags %u mask %u", m_spellInfo->Id, m_caster->GetEntry(), m_originalCaster ? m_originalCaster->GetEntry() : -1, _triggeredCastFlags, m_targets.GetTargetMask());
 


### PR DESCRIPTION
**Changes proposed:**

-  Moved CallScriptOnPrecastHandler() above ReSetTimer() to avoid cases in which setting a custom cast time OnPrecast hook for a certain spell would ignore it. This was a bug initially introduced when @Seyden implemented the hook on https://github.com/TrinityCore/TrinityCore/pull/27632 and missed a line.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] OnPrecast should not be registered at all because it really uses no spell hook. It is suggested virtual void Register() = 0; changes to virtual void Register { }; in SpellScript.h so we can avoid registering a method with no spell hook.