### PR TITLE
Core/Spells: add SetCastTime for spells

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -579,6 +579,7 @@ class TC_GAME_API Spell
         UsedSpellMods m_appliedMods;
 
         int32 GetCastTime() const { return m_casttime; }
+        void SetCastTime(uint32 time) { m_casttime = time; }
         bool IsAutoRepeat() const { return m_autoRepeat; }
         void SetAutoRepeat(bool rep) { m_autoRepeat = rep; }
         void ReSetTimer() { m_timer = m_casttime > 0 ? m_casttime : 0; }


### PR DESCRIPTION
**Changes proposed:**

-  Implement an additional method to allow spells to have a given cast time set OnPrecast hook. Sylvanas Windrunner encounter modifies Wailing's Arrow cast time to 1.5s on phase 3, being the original 3s on phase 1 with no aura involved or different spell as well, e.g.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

None.