### PR TITLE
Fix cripple and curse spells for 25 man Noth

### DIFF
--- a/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
+++ b/src/server/scripts/Northrend/Naxxramas/boss_noth.cpp
@@ -54,8 +54,10 @@ enum Talk
 
 enum Spells
 {
-    SPELL_CURSE         = 29213, // 25-man: 54835
-    SPELL_CRIPPLE       = 29212, // 25-man: 54814
+    SPELL_CURSE         = 29213,
+    SPELL_CRIPPLE       = 29212,
+    SPELL_CURSE_25      = 54835,
+    SPELL_CRIPPLE_25    = 54814,
 
     SPELL_TELEPORT      = 29216, // ground to balcony
     SPELL_TELEPORT_BACK = 29231  // balcony to ground
@@ -210,7 +212,7 @@ struct boss_noth : public BossAI
             {
                 case EVENT_CURSE:
                 {
-                    DoCastAOE(SPELL_CURSE);
+                    DoCastAOE(RAID_MODE(SPELL_CURSE, SPELL_CURSE_25));
                     events.Repeat(randtime(Seconds(50), Seconds(70)));
                     break;
                 }
@@ -223,7 +225,7 @@ struct boss_noth : public BossAI
                     events.Repeat(Seconds(40));
                     break;
                 case EVENT_BLINK:
-                    DoCastAOE(SPELL_CRIPPLE, true);
+                    DoCastAOE(RAID_MODE(SPELL_CRIPPLE, SPELL_CRIPPLE_25), true);
                     DoCastAOE(SPELL_BLINK);
                     ResetThreatList();
                     justBlinked = true;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix spell cast for 25 man Noth of Curse and Cripple
-  The spell ids were labeled in source correctly, but were not taken in consideration when cast
-  

**Issues addressed:**

Closes  #28160 


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
