### PR TITLE
[3.3.5] Noth 25 - Curse of the plaguebringer should affect 10 targets

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3445,18 +3445,12 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     ApplySpellFix({
-        54835  // Curse of the Plaguebringer - Noth (H)
-    }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->MaxAffectedTargets = 8;
-    });
-
-    ApplySpellFix({
         40827, // Sinful Beam
         40859, // Sinister Beam
         40860, // Vile Beam
         40861, // Wicked Beam
-        54098  // Poison Bolt Volly - Faerlina (H)
+        54098, // Poison Bolt Volly - Faerlina (H)
+        54835  // Curse of the Plaguebringer - Noth (H)
     }, [](SpellInfo* spellInfo)
     {
         spellInfo->MaxAffectedTargets = 10;


### PR DESCRIPTION
Moving this from merged PR conversation: https://github.com/TrinityCore/TrinityCore/pull/28161#discussion_r933811914

So I was thinking about the max target value for 25 man, I think it should actually be 10.  Not sure what the standard is around here for proof of original mechanics, but one of the people I was running this with said it should be 10, I found this video from 13 years back mentioning it being 10, and wowpedia also says 10.

https://wowpedia.fandom.com/wiki/Noth_the_Plaguebringer
https://www.youtube.com/watch?v=zoQli9GzXW8
