### PR TITLE
Core/Misc: Improve missing class health/mana data error message

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4352,7 +4352,7 @@ void ObjectMgr::LoadPlayerInfo()
             auto& pClassInfo = _playerClassInfo[class_];
 
             // fatal error if no level 1 data
-            if (!pClassInfo->levelInfo || pClassInfo->levelInfo[0].basehealth == 0)
+            if (!pClassInfo || !pClassInfo->levelInfo || pClassInfo->levelInfo[0].basehealth == 0)
             {
                 TC_LOG_ERROR("sql.sql", "Class %i Level 1 does not have health/mana data!", class_);
                 ABORT();


### PR DESCRIPTION
If the class lacks health/mana data entirely, pClassInfo is null and crashes without reaching the error message if we don't check it first.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Null check pClassInfo itself when loading player create level hp/mana data

**Issues addressed:**

None

**Tests performed:**

It builds and fixes the issue. 