### PR TITLE
Core/PacketIO: Named unknown fields in FeatureSystemStatus

### DIFF
--- a/src/server/game/Server/Packets/SystemPackets.cpp
+++ b/src/server/game/Server/Packets/SystemPackets.cpp
@@ -77,7 +77,7 @@ WorldPacket const* FeatureSystemStatus::Write()
     _worldPacket << uint32(ClubsPresenceUpdateTimer);
     _worldPacket << uint32(HiddenUIClubsPresenceUpdateTimer);
 
-    _worldPacket << int32(GameRuleUnknown1);
+    _worldPacket << int32(ActiveSeason);
     _worldPacket << uint32(GameRuleValues.size());
 
     _worldPacket << int16(MaxPlayerNameQueriesPerPacket);
@@ -189,7 +189,7 @@ WorldPacket const* FeatureSystemStatusGlueScreen::Write()
     _worldPacket.WriteBit(LiveRegionKeyBindingsCopyEnabled);
     _worldPacket.WriteBit(Unknown901CheckoutRelated);
     _worldPacket.WriteBit(EuropaTicketSystemStatus.has_value());
-    _worldPacket.WriteBit(Unused925.has_value());
+    _worldPacket.WriteBit(LaunchETA.has_value());
     _worldPacket.FlushBits();
 
     if (EuropaTicketSystemStatus)
@@ -205,12 +205,12 @@ WorldPacket const* FeatureSystemStatusGlueScreen::Write()
     _worldPacket << int32(ActiveClassTrialBoostType);
     _worldPacket << int32(MinimumExpansionLevel);
     _worldPacket << int32(MaximumExpansionLevel);
-    _worldPacket << int32(GameRuleUnknown1);
+    _worldPacket << int32(ActiveSeason);
     _worldPacket << uint32(GameRuleValues.size());
     _worldPacket << int16(MaxPlayerNameQueriesPerPacket);
 
-    if (Unused925)
-        _worldPacket << int32(*Unused925);
+    if (LaunchETA)
+        _worldPacket << int32(*LaunchETA);
 
     if (!LiveRegionCharacterCopySourceRegions.empty())
         _worldPacket.append(LiveRegionCharacterCopySourceRegions.data(), LiveRegionCharacterCopySourceRegions.size());

--- a/src/server/game/Server/Packets/SystemPackets.h
+++ b/src/server/game/Server/Packets/SystemPackets.h
@@ -128,7 +128,7 @@ namespace WorldPackets
             uint32 ClubsPresenceUpdateTimer              = 0;
             uint32 HiddenUIClubsPresenceUpdateTimer      = 0; ///< Timer for updating club presence when communities ui frame is hidden
             uint32 KioskSessionMinutes                   = 0;
-            int32 GameRuleUnknown1                       = 0;
+            int32 ActiveSeason                           = 0;
             int16 MaxPlayerNameQueriesPerPacket          = 50;
             bool ItemRestorationButtonEnabled        = false;
             bool CharUndeleteEnabled                 = false; ///< Implemented
@@ -200,10 +200,10 @@ namespace WorldPackets
             int32 MinimumExpansionLevel              = 0;
             int32 MaximumExpansionLevel              = 0;
             uint32 KioskSessionMinutes               = 0;
-            int32 GameRuleUnknown1 = 0;
+            int32 ActiveSeason = 0;
             std::vector<GameRuleValuePair> GameRuleValues;
             int16 MaxPlayerNameQueriesPerPacket = 50;
-            Optional<int32> Unused925;
+            Optional<int32> LaunchETA;
         };
 
         class MOTD final : public ServerPacket

--- a/src/server/game/Server/Packets/SystemPackets.h
+++ b/src/server/game/Server/Packets/SystemPackets.h
@@ -128,7 +128,7 @@ namespace WorldPackets
             uint32 ClubsPresenceUpdateTimer              = 0;
             uint32 HiddenUIClubsPresenceUpdateTimer      = 0; ///< Timer for updating club presence when communities ui frame is hidden
             uint32 KioskSessionMinutes                   = 0;
-            int32 ActiveSeason                           = 0;
+            int32 ActiveSeason                           = 0; ///< Currently active Classic season
             int16 MaxPlayerNameQueriesPerPacket          = 50;
             bool ItemRestorationButtonEnabled        = false;
             bool CharUndeleteEnabled                 = false; ///< Implemented
@@ -200,7 +200,7 @@ namespace WorldPackets
             int32 MinimumExpansionLevel              = 0;
             int32 MaximumExpansionLevel              = 0;
             uint32 KioskSessionMinutes               = 0;
-            int32 ActiveSeason = 0;
+            int32 ActiveSeason                       = 0;     // Currently active Classic season                    
             std::vector<GameRuleValuePair> GameRuleValues;
             int16 MaxPlayerNameQueriesPerPacket = 50;
             Optional<int32> LaunchETA;

--- a/src/server/game/Server/Packets/SystemPackets.h
+++ b/src/server/game/Server/Packets/SystemPackets.h
@@ -200,7 +200,7 @@ namespace WorldPackets
             int32 MinimumExpansionLevel              = 0;
             int32 MaximumExpansionLevel              = 0;
             uint32 KioskSessionMinutes               = 0;
-            int32 ActiveSeason                       = 0;     // Currently active Classic season                    
+            int32 ActiveSeason                       = 0;     // Currently active Classic season
             std::vector<GameRuleValuePair> GameRuleValues;
             int16 MaxPlayerNameQueriesPerPacket = 50;
             Optional<int32> LaunchETA;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Named two unknown fields in FeatureSystemStatus and FeatureSystemStatusGlueScreen based on usage in classic client.
-  GameRuleUnknown1/ActiveSeason is accessed by https://wowpedia.fandom.com/wiki/API_C_Seasons.GetActiveSeason
-  Unused925/LaunchETA is accessed by a lua function called 'GetLaunchETA' and shown as below:
![world](https://user-images.githubusercontent.com/11392454/184323756-3badd08c-ade6-4b10-8f44-a496cd9f2f2e.jpg)
- Placement and type of these two fields is identical to classic client. Guess they are starting to merge packet structures between mainline and classic.



**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
