### PR TITLE
Core/Player: Remove name check when logging in

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -17183,17 +17183,6 @@ bool Player::LoadFromDB(ObjectGuid guid, CharacterDatabaseQueryHolder const& hol
 
     m_name = fields[2].GetString();
 
-    // check name limitations
-    if (ObjectMgr::CheckPlayerName(m_name, GetSession()->GetSessionDbcLocale()) != CHAR_NAME_SUCCESS ||
-        (!GetSession()->HasPermission(rbac::RBAC_PERM_SKIP_CHECK_CHARACTER_CREATION_RESERVEDNAME) && sObjectMgr->IsReservedName(m_name)))
-    {
-        CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ADD_AT_LOGIN_FLAG);
-        stmt->setUInt16(0, uint16(AT_LOGIN_RENAME));
-        stmt->setUInt32(1, guid.GetCounter());
-        CharacterDatabase.Execute(stmt);
-        return false;
-    }
-
     Gender gender = Gender(fields[5].GetUInt8());
     if (!IsValidGender(gender))
     {


### PR DESCRIPTION
**Changes proposed:**
Remove the name check that fires when players are just logging in. 

**Issues addressed:**
Name checks run in the main thread and are very expensive, but the same checks run whenever someone creates or modifies a character anyways so it never does anything unless `reserved_name` or the profanity/reserved dbcs are changed. This hits very hard when many players log in after a restart or crash.

Almost 30ms on my machine in release mode for a single player:
![image](https://user-images.githubusercontent.com/76849026/184627547-11705a7e-9d8f-4649-a36b-22d225d9bfdd.png)

**Tests performed:**

- Creating new characters with profane/reserved names
- Renaming a character with profane/reserved names (AT_LOGIN_RENAME)
- Recustomizing a character with profane/reserved names (AT_LOGIN_CUSTOMIZE)

**Possible adjustments**
- Make this configurable in .conf to allow modifying those dbcs after initial server launch
- Keep the `reserved_name` check to allow adding things like admin names after the fact, since it's almost always next to free to do anyways.