### PR TITLE
Core/Misc: Store vectors of abilities per skilline

### DIFF
--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -39,8 +39,6 @@ typedef std::map<uint32, uint32> AreaFlagByMapID;
 typedef std::tuple<int16, int8, int32> WMOAreaTableKey;
 typedef std::map<WMOAreaTableKey, WMOAreaTableEntry const*> WMOAreaInfoByTripple;
 
-typedef std::unordered_map<uint32, std::vector<SkillLineAbilityEntry const*>> AbilitiesBySkillLine;
-
 DBCStorage <AreaTableEntry> sAreaTableStore(AreaTableEntryfmt);
 DBCStorage <AreaGroupEntry> sAreaGroupStore(AreaGroupEntryfmt);
 DBCStorage <AreaPOIEntry> sAreaPOIStore(AreaPOIEntryfmt);
@@ -159,13 +157,8 @@ DBCStorage <ScalingStatValuesEntry> sScalingStatValuesStore(ScalingStatValuesfmt
 DBCStorage <SkillLineEntry> sSkillLineStore(SkillLinefmt);
 DBCStorage <SkillLineAbilityEntry> sSkillLineAbilityStore(SkillLineAbilityfmt);
 DBCStorage <SkillRaceClassInfoEntry> sSkillRaceClassInfoStore(SkillRaceClassInfofmt);
+std::unordered_map<uint32, std::vector<SkillLineAbilityEntry const*>> SkillLineAbilitiesBySkill;
 SkillRaceClassInfoMap SkillRaceClassInfoBySkill;
-
-static AbilitiesBySkillLine sAbilitiesBySkillLine;
-std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skillLine)
-{
-    return Trinity::Containers::MapGetValuePtr(sAbilitiesBySkillLine, skillLine);
-}
 
 DBCStorage <SkillTiersEntry> sSkillTiersStore(SkillTiersfmt);
 
@@ -508,7 +501,7 @@ void LoadDBCStores(const std::string& dataPath)
             }
         }
 
-        sAbilitiesBySkillLine[skillLine->SkillLine].push_back(skillLine);
+        SkillLineAbilitiesBySkill[skillLine->SkillLine].push_back(skillLine);
     }
 
     // Create Spelldifficulty searcher
@@ -947,6 +940,11 @@ uint32 GetDefaultMapLight(uint32 mapId)
     }
 
     return 0;
+}
+
+std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skillLine)
+{
+    return Trinity::Containers::MapGetValuePtr(SkillLineAbilitiesBySkill, skillLine);
 }
 
 SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, uint8 class_)

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -18,6 +18,7 @@
 #include "DBCStores.h"
 #include "DBCFileLoader.h"
 #include "DBCfmt.h"
+#include "Containers.h"
 #include "Errors.h"
 #include "IteratorPair.h"
 #include "Log.h"
@@ -163,10 +164,7 @@ SkillRaceClassInfoMap SkillRaceClassInfoBySkill;
 static AbilitiesBySkillLine sAbilitiesBySkillLine;
 std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skillLine)
 {
-    auto i = sAbilitiesBySkillLine.find(skillLine);
-    if (i != sAbilitiesBySkillLine.end())
-        return &i->second;
-    return nullptr;
+    return Trinity::Containers::MapGetValuePtr(sAbilitiesBySkillLine, skillLine);
 }
 
 DBCStorage <SkillTiersEntry> sSkillTiersStore(SkillTiersfmt);
@@ -510,16 +508,7 @@ void LoadDBCStores(const std::string& dataPath)
             }
         }
 
-        auto abilityBySkillLineItr = sAbilitiesBySkillLine.find(skillLine->SkillLine);
-        if (abilityBySkillLineItr == sAbilitiesBySkillLine.end())
-        {
-            (sAbilitiesBySkillLine[skillLine->SkillLine] = std::vector<SkillLineAbilityEntry const*>())
-                .push_back(skillLine);
-        }
-        else
-        {
-            abilityBySkillLineItr->second.push_back(skillLine);
-        }
+        sAbilitiesBySkillLine[skillLine->SkillLine].push_back(skillLine);
     }
 
     // Create Spelldifficulty searcher

--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -38,6 +38,8 @@ typedef std::map<uint32, uint32> AreaFlagByMapID;
 typedef std::tuple<int16, int8, int32> WMOAreaTableKey;
 typedef std::map<WMOAreaTableKey, WMOAreaTableEntry const*> WMOAreaInfoByTripple;
 
+typedef std::unordered_map<uint32, std::vector<SkillLineAbilityEntry const*>> AbilitiesBySkillLine;
+
 DBCStorage <AreaTableEntry> sAreaTableStore(AreaTableEntryfmt);
 DBCStorage <AreaGroupEntry> sAreaGroupStore(AreaGroupEntryfmt);
 DBCStorage <AreaPOIEntry> sAreaPOIStore(AreaPOIEntryfmt);
@@ -157,6 +159,16 @@ DBCStorage <SkillLineEntry> sSkillLineStore(SkillLinefmt);
 DBCStorage <SkillLineAbilityEntry> sSkillLineAbilityStore(SkillLineAbilityfmt);
 DBCStorage <SkillRaceClassInfoEntry> sSkillRaceClassInfoStore(SkillRaceClassInfofmt);
 SkillRaceClassInfoMap SkillRaceClassInfoBySkill;
+
+static AbilitiesBySkillLine sAbilitiesBySkillLine;
+std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skillLine)
+{
+    auto i = sAbilitiesBySkillLine.find(skillLine);
+    if (i != sAbilitiesBySkillLine.end())
+        return &i->second;
+    return nullptr;
+}
+
 DBCStorage <SkillTiersEntry> sSkillTiersStore(SkillTiersfmt);
 
 DBCStorage <SoundEntriesEntry> sSoundEntriesStore(SoundEntriesfmt);
@@ -496,6 +508,17 @@ void LoadDBCStores(const std::string& dataPath)
 
                 sPetFamilySpellsStore[cFamily->ID].insert(spellInfo->ID);
             }
+        }
+
+        auto abilityBySkillLineItr = sAbilitiesBySkillLine.find(skillLine->SkillLine);
+        if (abilityBySkillLineItr == sAbilitiesBySkillLine.end())
+        {
+            (sAbilitiesBySkillLine[skillLine->SkillLine] = std::vector<SkillLineAbilityEntry const*>())
+                .push_back(skillLine);
+        }
+        else
+        {
+            abilityBySkillLineItr->second.push_back(skillLine);
         }
     }
 

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -81,8 +81,8 @@ TC_GAME_API uint32 GetDefaultMapLight(uint32 mapId);
 
 typedef std::unordered_multimap<uint32, SkillRaceClassInfoEntry const*> SkillRaceClassInfoMap;
 typedef std::pair<SkillRaceClassInfoMap::iterator, SkillRaceClassInfoMap::iterator> SkillRaceClassInfoBounds;
-TC_GAME_API SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, uint8 class_);
 TC_GAME_API std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skill);
+TC_GAME_API SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, uint8 class_);
 
 TC_GAME_API ResponseCodes ValidateName(std::wstring const& name, LocaleConstant locale);
 

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -82,6 +82,7 @@ TC_GAME_API uint32 GetDefaultMapLight(uint32 mapId);
 typedef std::unordered_multimap<uint32, SkillRaceClassInfoEntry const*> SkillRaceClassInfoMap;
 typedef std::pair<SkillRaceClassInfoMap::iterator, SkillRaceClassInfoMap::iterator> SkillRaceClassInfoBounds;
 TC_GAME_API SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, uint8 class_);
+TC_GAME_API std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skill);
 
 TC_GAME_API ResponseCodes ValidateName(std::wstring const& name, LocaleConstant locale);
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6021,9 +6021,9 @@ void Player::SetSkill(uint32 id, uint16 step, uint16 newVal, uint16 maxVal)
                 mSkillStatus.erase(itr);
 
             // remove all spells that related to this skill
-            if (std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(id))
-                for (SkillLineAbilityEntry const* pAbility : *abilities)
-                    RemoveSpell(sSpellMgr->GetFirstSpellInChain(pAbility->Spell));
+            if (std::vector<SkillLineAbilityEntry const*> const* skillLineAbilities = GetSkillLineAbilitiesBySkill(id))
+                for (SkillLineAbilityEntry const* skillLineAbility : *skillLineAbilities)
+                    RemoveSpell(sSpellMgr->GetFirstSpellInChain(skillLineAbility->Spell));
         }
     }
     else if (newVal)                                        //add
@@ -23152,12 +23152,11 @@ void Player::LearnSkillRewardedSpells(uint32 skillId, uint32 skillValue)
 {
     uint32 raceMask  = GetRaceMask();
     uint32 classMask = GetClassMask();
-
-    std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(skillId);
-    if (!abilities)
+    std::vector<SkillLineAbilityEntry const*> const* skillLineAbilities = GetSkillLineAbilitiesBySkill(skillId);
+    if (!skillLineAbilities)
         return;
 
-    for (SkillLineAbilityEntry const* ability : *abilities)
+    for (SkillLineAbilityEntry const* ability : *skillLineAbilities)
     {
         if (!sSpellMgr->GetSpellInfo(ability->Spell))
             continue;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6021,10 +6021,9 @@ void Player::SetSkill(uint32 id, uint16 step, uint16 newVal, uint16 maxVal)
                 mSkillStatus.erase(itr);
 
             // remove all spells that related to this skill
-            for (uint32 j = 0; j < sSkillLineAbilityStore.GetNumRows(); ++j)
-                if (SkillLineAbilityEntry const* pAbility = sSkillLineAbilityStore.LookupEntry(j))
-                    if (pAbility->SkillLine == id)
-                        RemoveSpell(sSpellMgr->GetFirstSpellInChain(pAbility->Spell));
+            if (std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(id))
+                for (SkillLineAbilityEntry const* pAbility : *abilities)
+                    RemoveSpell(sSpellMgr->GetFirstSpellInChain(pAbility->Spell));
         }
     }
     else if (newVal)                                        //add
@@ -23153,12 +23152,13 @@ void Player::LearnSkillRewardedSpells(uint32 skillId, uint32 skillValue)
 {
     uint32 raceMask  = GetRaceMask();
     uint32 classMask = GetClassMask();
-    for (uint32 j = 0; j < sSkillLineAbilityStore.GetNumRows(); ++j)
-    {
-        SkillLineAbilityEntry const* ability = sSkillLineAbilityStore.LookupEntry(j);
-        if (!ability || ability->SkillLine != skillId)
-            continue;
 
+    std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(skillId);
+    if (!abilities)
+        return;
+
+    for (SkillLineAbilityEntry const* ability : *abilities)
+    {
         if (!sSpellMgr->GetSpellInfo(ability->Spell))
             continue;
 

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2197,11 +2197,11 @@ void SpellMgr::LoadPetLevelupSpellMap()
             if (!creatureFamily->SkillLine[j])
                 continue;
 
-            std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(creatureFamily->SkillLine[j]);
-            if (!abilities)
+            std::vector<SkillLineAbilityEntry const*> const* skillLineAbilities = GetSkillLineAbilitiesBySkill(creatureFamily->SkillLine[j]);
+            if (!skillLineAbilities)
                 continue;
 
-            for (SkillLineAbilityEntry const* skillLine: *abilities)
+            for (SkillLineAbilityEntry const* skillLine : *skillLineAbilities)
             {
                 if (skillLine->AcquireMethod != SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN)
                     continue;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2197,19 +2197,12 @@ void SpellMgr::LoadPetLevelupSpellMap()
             if (!creatureFamily->SkillLine[j])
                 continue;
 
-            for (uint32 k = 0; k < sSkillLineAbilityStore.GetNumRows(); ++k)
+            std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(creatureFamily->SkillLine[j]);
+            if (!abilities)
+                continue;
+
+            for (SkillLineAbilityEntry const* skillLine: *abilities)
             {
-                SkillLineAbilityEntry const* skillLine = sSkillLineAbilityStore.LookupEntry(k);
-                if (!skillLine)
-                    continue;
-
-                //if (skillLine->skillId != creatureFamily->SkillLine[0] &&
-                //    (!creatureFamily->SkillLine[1] || skillLine->skillId != creatureFamily->SkillLine[1]))
-                //    continue;
-
-                if (skillLine->SkillLine != creatureFamily->SkillLine[j])
-                    continue;
-
                 if (skillLine->AcquireMethod != SKILL_LINE_ABILITY_LEARNED_ON_SKILL_LEARN)
                     continue;
 

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -435,16 +435,12 @@ public:
     {
         uint32 classmask = player->GetClassMask();
 
-        for (uint32 j = 0; j < sSkillLineAbilityStore.GetNumRows(); ++j)
+        std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(skillId);
+        if (!abilities)
+            return;
+
+        for(SkillLineAbilityEntry const* skillLine : *abilities)
         {
-            SkillLineAbilityEntry const* skillLine = sSkillLineAbilityStore.LookupEntry(j);
-            if (!skillLine)
-                continue;
-
-            // wrong skill
-            if (skillLine->SkillLine != skillId)
-                continue;
-
             // not high rank
             if (skillLine->SupercededBySpell)
                 continue;

--- a/src/server/scripts/Commands/cs_learn.cpp
+++ b/src/server/scripts/Commands/cs_learn.cpp
@@ -435,11 +435,11 @@ public:
     {
         uint32 classmask = player->GetClassMask();
 
-        std::vector<SkillLineAbilityEntry const*> const* abilities = GetSkillLineAbilitiesBySkill(skillId);
-        if (!abilities)
+        std::vector<SkillLineAbilityEntry const*> const* skillLineAbilities = GetSkillLineAbilitiesBySkill(skillId);
+        if (!skillLineAbilities)
             return;
 
-        for(SkillLineAbilityEntry const* skillLine : *abilities)
+        for (SkillLineAbilityEntry const* skillLine : *skillLineAbilities)
         {
             // not high rank
             if (skillLine->SupercededBySpell)


### PR DESCRIPTION
Used the same names and types as master to keep it simple.

**Changes proposed:**

-  Store vectors of abilities per skilline instead of searching through all of them every time

**Issues addressed:**
Slightly improves `Player::LoadFromDB` performance, but also makes searching prettier.

**Tests performed:**
- Tried .learn all recipes blacksmithing
- Tried unlearning a skill
- Tried leveling up a pet
- Tried logging in and printing out the loaded skills, identical to old version