### PR TITLE
Core/Battlegrounds: Capture flag immediately when standing on capture point and your team's flag return due to drop timer ended

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -292,6 +292,8 @@ void BattlegroundWS::RespawnFlagAfterDrop(uint32 team)
 
     SetDroppedFlagGUID(ObjectGuid::Empty, GetTeamIndexByTeamId(team));
     _bothFlagsKept = false;
+    // Check opposing flag if it is in capture zone; if so, capture it
+    HandleFlagRoomCapturePoint(team == ALLIANCE ? TEAM_HORDE : TEAM_ALLIANCE);
 }
 
 void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
@@ -380,6 +382,13 @@ void BattlegroundWS::EventPlayerCapturedFlag(Player* player)
     {
         _flagsTimer[GetTeamIndexByTeamId(player->GetTeam()) ? 0 : 1] = BG_WS_FLAG_RESPAWN_TIME;
     }
+}
+void BattlegroundWS::HandleFlagRoomCapturePoint(int32 team)
+{
+    Player* flagCarrier = ObjectAccessor::GetPlayer(GetBgMap(), GetFlagPickerGUID(team));
+    uint32 areaTrigger = team == TEAM_ALLIANCE ? 3647 : 3646;
+    if (flagCarrier && flagCarrier->IsInAreaTriggerRadius(sAreaTriggerStore.LookupEntry(areaTrigger)))
+        EventPlayerCapturedFlag(flagCarrier);
 }
 
 void BattlegroundWS::EventPlayerDroppedFlag(Player* player)
@@ -534,11 +543,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
             _bothFlagsKept = false;
-
-            // Check Horde flag if it is in capture zone; if so, capture it
-            if (Player* hordeFlagCarrier = ObjectAccessor::GetPlayer(GetBgMap(), GetFlagPickerGUID(TEAM_HORDE)))
-                if (hordeFlagCarrier->IsInAreaTriggerRadius(sAreaTriggerStore.LookupEntry(3646)))
-                    EventPlayerCapturedFlag(hordeFlagCarrier);
+            HandleFlagRoomCapturePoint(TEAM_HORDE); // Check Horde flag if it is in capture zone; if so, capture it
         }
         else
         {
@@ -572,11 +577,7 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
             _bothFlagsKept = false;
-
-            // Check Alliance flag if it is in capture zone; if so, capture it
-            if (Player* allianceFlagCarrier = ObjectAccessor::GetPlayer(GetBgMap(), GetFlagPickerGUID(TEAM_ALLIANCE)))
-                if (allianceFlagCarrier->IsInAreaTriggerRadius(sAreaTriggerStore.LookupEntry(3647)))
-                    EventPlayerCapturedFlag(allianceFlagCarrier);
+            HandleFlagRoomCapturePoint(TEAM_ALLIANCE); // Check Alliance flag if it is in capture zone; if so, capture it
         }
         else
         {

--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.h
@@ -226,6 +226,7 @@ class BattlegroundWS : public Battleground
         void EventPlayerDroppedFlag(Player* player) override;
         void EventPlayerClickedOnFlag(Player* player, GameObject* target_obj) override;
         void EventPlayerCapturedFlag(Player* player);
+        void HandleFlagRoomCapturePoint(int32 team);
 
         void RemovePlayer(Player* player, ObjectGuid guid, uint32 team) override;
         void HandleAreaTrigger(Player* player, uint32 trigger) override;


### PR DESCRIPTION
**Changes proposed:**

-  Capture flag immediately when standing on capture point and your team's flag return due to drop timer ended
>When the flag is dropped, it becomes a clickable object where it was dropped. A capturing team member can pick it up again and keep running, but the player who dropped it will not be able to personally pick it up again for 3 seconds. Or, a defending team member can click on it and it will instantly teleport back to their base (this is called "returning" the flag). If no player picks up or returns the flag for about five seconds, it will return itself.
https://wowwiki-archive.fandom.com/wiki/Warsong_Gulch

Flag can return to the base clicking on it or after a few seconds if no one click it.

first case was fixed here: https://github.com/TrinityCore/TrinityCore/pull/28087
but second case need fix it.

**Issues addressed:**

None


**Tests performed:**

tested in-game
