### PR TITLE
Core/Debugging: Improve SymInitialize fail message

### DIFF
--- a/src/common/Debugging/WheatyExceptionReport.cpp
+++ b/src/common/Debugging/WheatyExceptionReport.cpp
@@ -718,7 +718,7 @@ PEXCEPTION_POINTERS pExceptionInfo)
             Log(_T("SYMBOL HANDLER ERROR (THIS IS NOT THE CRASH ERROR)\r\n\r\n"));
             Log(_T("Couldn't initialize symbol handler for process when generating crash report\r\n"));
             Log(_T("Error: %s\r\n"), ErrorMessage(GetLastError()));
-            Log(_T("THE BELOW CALL STACKS MAY NOW HAVE MISSING OR INACCURATE FILE/FUNCTION NAMES\r\n\r\n"));
+            Log(_T("THE BELOW CALL STACKS MIGHT HAVE MISSING OR INACCURATE FILE/FUNCTION NAMES\r\n\r\n"));
             Log(_T("END OF SYMBOL HANDLER ERROR\r\n"));
             Log(_T("----\r\n"));
         }

--- a/src/common/Debugging/WheatyExceptionReport.cpp
+++ b/src/common/Debugging/WheatyExceptionReport.cpp
@@ -713,8 +713,14 @@ PEXCEPTION_POINTERS pExceptionInfo)
         // Initialize DbgHelp
         if (!SymInitialize(GetCurrentProcess(), nullptr, TRUE))
         {
-            Log(_T("\n\rCRITICAL ERROR.\n\r Couldn't initialize the symbol handler for process.\n\rError [%s].\n\r\n\r"),
-                ErrorMessage(GetLastError()));
+            Log(_T("\r\n"));
+            Log(_T("----\r\n"));
+            Log(_T("SYMBOL HANDLER ERROR (THIS IS NOT THE CRASH ERROR)\r\n\r\n"));
+            Log(_T("Couldn't initialize symbol handler for process when generating crash report\r\n"));
+            Log(_T("Error: %s\r\n"), ErrorMessage(GetLastError()));
+            Log(_T("THE BELOW CALL STACKS MAY NOW HAVE MISSING OR INACCURATE FILE/FUNCTION NAMES\r\n\r\n"));
+            Log(_T("END OF SYMBOL HANDLER ERROR\r\n"));
+            Log(_T("----\r\n"));
         }
 
         if (pExceptionRecord->ExceptionCode == 0xE06D7363 && pExceptionRecord->NumberParameters >= 2)

--- a/src/common/Debugging/WheatyExceptionReport.cpp
+++ b/src/common/Debugging/WheatyExceptionReport.cpp
@@ -719,7 +719,6 @@ PEXCEPTION_POINTERS pExceptionInfo)
             Log(_T("Couldn't initialize symbol handler for process when generating crash report\r\n"));
             Log(_T("Error: %s\r\n"), ErrorMessage(GetLastError()));
             Log(_T("THE BELOW CALL STACKS MIGHT HAVE MISSING OR INACCURATE FILE/FUNCTION NAMES\r\n\r\n"));
-            Log(_T("END OF SYMBOL HANDLER ERROR\r\n"));
             Log(_T("----\r\n"));
         }
 


### PR DESCRIPTION
**Changes proposed:**

-  Improve DbgHelp SymInitialize error message to be less confusing

**Issues addressed:**
None, but i've seen lots of confusion about this error.

**Tests performed:**
This is how new output looks (well, with a real error message of course, I just copied it out of the if clause locally to test formatting)

```
----
SYMBOL HANDLER ERROR (THIS IS NOT THE CRASH ERROR)

Couldn't initialize symbol handler for process when generating crash report
Error: The operation completed successfully.

THE BELOW CALL STACKS MIGHT HAVE INACCURATE FILE/FUNCTION NAMES

----
```

**Known issues and TODO list:** (add/remove lines as needed)

- This is all I know about the error, there might be something else we should let the user know.