### PR TITLE
Core/Creatures: Added possibility to set PlayHoverAnim state on spawn

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `creature_template_addon` ADD `PlayHoverAnim` TINYINT UNSIGNED NOT NULL DEFAULT '0' AFTER `meleeAnimKit`;
+ALTER TABLE `creature_addon` ADD `PlayHoverAnim` TINYINT UNSIGNED NOT NULL DEFAULT '0' AFTER `meleeAnimKit`;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2680,6 +2680,8 @@ bool Creature::LoadCreaturesAddon()
     SetMovementAnimKitId(cainfo->movementAnimKit);
     SetMeleeAnimKitId(cainfo->meleeAnimKit);
 
+    SetPlayHoverAnim(cainfo->PlayHoverAnim, false);
+
     // Check if visibility distance different
     if (cainfo->visibilityDistanceType != VisibilityDistanceType::Normal)
         SetVisibilityDistanceOverride(cainfo->visibilityDistanceType);

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -635,8 +635,9 @@ struct CreatureAddon
     uint16 aiAnimKit;
     uint16 movementAnimKit;
     uint16 meleeAnimKit;
-    std::vector<uint32> auras;
+    bool PlayHoverAnim;
     VisibilityDistanceType visibilityDistanceType;
+    std::vector<uint32> auras;
 };
 
 // Vendors

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13196,9 +13196,15 @@ void Unit::UpdateMovementForcesModMagnitude()
     }
 }
 
-void Unit::SetPlayHoverAnim(bool enable)
+void Unit::SetPlayHoverAnim(bool enable, bool sendUpdate /*= true*/)
 {
+    if (_playHoverAnim == enable)
+        return;
+
     _playHoverAnim = enable;
+
+    if (!sendUpdate)
+        return;
 
     WorldPackets::Misc::SetPlayHoverAnim data;
     data.UnitGUID = GetGUID();

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1219,7 +1219,7 @@ class TC_GAME_API Unit : public WorldObject
         void MonsterMoveWithSpeed(float x, float y, float z, float speed, bool generatePath = false, bool forceDestination = false);
 
         bool IsPlayingHoverAnim() const { return _playHoverAnim; }
-        void SetPlayHoverAnim(bool enable);
+        void SetPlayHoverAnim(bool enable, bool sendUpdate = true);
         void SetHoverHeight(float hoverHeight) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::HoverHeight), hoverHeight); }
 
         bool IsGravityDisabled() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY); }

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -713,8 +713,8 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                                 0       1       2      3       4       5        6             7              8                  9              10
-    QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, visibilityDistanceType, auras FROM creature_template_addon");
+    //                                               0      1        2      3       4       5      6          7                8             9              10                      11
+    QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, PlayHoverAnim, visibilityDistanceType, auras FROM creature_template_addon");
 
     if (!result)
     {
@@ -745,9 +745,10 @@ void ObjectMgr::LoadCreatureTemplateAddons()
         creatureAddon.aiAnimKit                 = fields[6].GetUInt16();
         creatureAddon.movementAnimKit           = fields[7].GetUInt16();
         creatureAddon.meleeAnimKit              = fields[8].GetUInt16();
-        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[9].GetUInt8());
+        creatureAddon.PlayHoverAnim             = fields[9].GetBool();
+        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[10].GetUInt8());
 
-        for (std::string_view aura : Trinity::Tokenize(fields[10].GetStringView(), ' ', false))
+        for (std::string_view aura : Trinity::Tokenize(fields[11].GetStringView(), ' ', false))
         {
             SpellInfo const* spellInfo = nullptr;
             if (Optional<uint32> spellId = Trinity::StringTo<uint32>(aura))
@@ -1275,8 +1276,8 @@ void ObjectMgr::LoadCreatureAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                                0       1       2      3       4       5        6             7              8                  9              10
-    QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, visibilityDistanceType, auras FROM creature_addon");
+    //                                               0     1        2      3       4       5      6          7                8             9              10                      11
+    QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, PlayHoverAnim, visibilityDistanceType, auras FROM creature_addon");
 
     if (!result)
     {
@@ -1314,9 +1315,10 @@ void ObjectMgr::LoadCreatureAddons()
         creatureAddon.aiAnimKit                 = fields[6].GetUInt16();
         creatureAddon.movementAnimKit           = fields[7].GetUInt16();
         creatureAddon.meleeAnimKit              = fields[8].GetUInt16();
-        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[9].GetUInt8());
+        creatureAddon.PlayHoverAnim             = fields[9].GetBool();
+        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[10].GetUInt8());
 
-        for (std::string_view aura : Trinity::Tokenize(fields[10].GetStringView(), ' ', false))
+        for (std::string_view aura : Trinity::Tokenize(fields[11].GetStringView(), ' ', false))
         {
             SpellInfo const* spellInfo = nullptr;
             if (Optional<uint32> spellId = Trinity::StringTo<uint32>(aura))
@@ -9687,7 +9689,7 @@ void ObjectMgr::LoadGossipMenuItems()
     TC_LOG_INFO("server.loading", ">> Loaded " SZFMTD " gossip_menu_option entries in %u ms", _gossipMenuItemsStore.size(), GetMSTimeDiffToNow(oldMSTime));
 }
 
-void ObjectMgr::LoadGossipMenuFriendshipFactions()
+void ObjectMgr::LoadGossipMenuAddons()
 {
     uint32 oldMSTime = getMSTime();
 

--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1398,7 +1398,7 @@ class TC_GAME_API ObjectMgr
 
         void LoadGossipMenu();
         void LoadGossipMenuItems();
-        void LoadGossipMenuFriendshipFactions();
+        void LoadGossipMenuAddons();
 
         void LoadVendors();
         void LoadTrainers();

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2248,8 +2248,8 @@ void World::SetInitialWorldSettings()
     TC_LOG_INFO("server.loading", "Loading Gossip menu options...");
     sObjectMgr->LoadGossipMenuItems();
 
-    TC_LOG_INFO("server.loading", "Loading Gossip menu friendship factions...");
-    sObjectMgr->LoadGossipMenuFriendshipFactions();
+    TC_LOG_INFO("server.loading", "Loading Gossip menu addons...");
+    sObjectMgr->LoadGossipMenuAddons();
 
     TC_LOG_INFO("server.loading", "Loading Creature trainers...");
     sObjectMgr->LoadCreatureTrainers();                         // must be after LoadGossipMenuItems


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Added a new field **PlayHoverAnim**  in the table **creature(_template)_addon** to control this state
- Extended function **SetPlayHoverAnim** to avoid sending SMSG_SET_PLAY_HOVER_ANIM in case of spawning

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)

- I'm not sure if the functions **Set*AnimKitId** should also be extended to not send **SMSG_SET_*_ANIM_KIT** in case of spawning


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
