### PR TITLE
Core/Creatures: Don't remove hovering from creatures that can fly

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2792,7 +2792,7 @@ void Creature::UpdateMovementFlags()
         else
             SetDisableGravity(true);
 
-        if (!HasAuraType(SPELL_AURA_HOVER))
+        if (!HasAuraType(SPELL_AURA_HOVER) && GetMovementTemplate().Ground != CreatureGroundMovementType::Hover)
             SetHover(false);
     }
     else


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't remove the hover of creatures that can fly (IsFlightAllowed() == true) and have CreatureGroundMovementType::Hover in movement template.
- Example:
```
[5] MoverGUID: Full: 0x20315000008A2C00000014000061A137 Creature/0 R3156/S20 Map: 0 (Eastern Kingdoms) Entry: 141488 (Zidormi) Low: 6398263
[5] MovementFlags: 268436992 (DisableGravity, Root, Hover)
```
```sql
DELETE FROM `creature_template_movement` WHERE `CreatureId`=141488;
INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
(141488,2,0,1,1,0,0,NULL); -- Hover, disable gravity & root
```

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
