### PR TITLE
Fix herbalism, mining and skinning failing at low levels

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5664,10 +5664,11 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                 if (res != SPELL_CAST_OK)
                     return res;
 
-                // chance for fail at lockpicking attempt
-                // second check prevent fail at rechecks
-                if (skillId != SKILL_NONE && (!m_selfContainer || ((*m_selfContainer) != this)))
+                // some tradeskills can fail - but herbalism, mining and skinning cannot
+                if (skillId != SKILL_NONE && skillId != SKILL_HERBALISM && skillId != SKILL_MINING && skillId != SKILL_SKINNING && (!m_selfContainer || ((*m_selfContainer) != this)))
                 {
+                    // chance for fail at lockpicking attempt
+                    // second check prevent fail at rechecks
                     bool canFailAtMax = skillId == SKILL_LOCKPICKING;
 
                     // chance for failure in orange lockpick

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5664,11 +5664,11 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                 if (res != SPELL_CAST_OK)
                     return res;
 
-                // some tradeskills can fail - but herbalism, mining and skinning cannot as of patch 3.1.0
-                if (skillId != SKILL_NONE && skillId != SKILL_HERBALISM && skillId != SKILL_MINING && skillId != SKILL_SKINNING && (!m_selfContainer || ((*m_selfContainer) != this)))
+                // chance for fail at lockpicking attempt
+                // second check prevent fail at rechecks
+                // herbalism and mining cannot fail as of patch 3.1.0
+                if (skillId != SKILL_NONE && skillId != SKILL_HERBALISM && skillId != SKILL_MINING && (!m_selfContainer || ((*m_selfContainer) != this)))
                 {
-                    // chance for fail at lockpicking attempt
-                    // second check prevent fail at rechecks
                     bool canFailAtMax = skillId == SKILL_LOCKPICKING;
 
                     // chance for failure in orange lockpick

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5664,7 +5664,7 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                 if (res != SPELL_CAST_OK)
                     return res;
 
-                // some tradeskills can fail - but herbalism, mining and skinning cannot
+                // some tradeskills can fail - but herbalism, mining and skinning cannot as of patch 3.1.0
                 if (skillId != SKILL_NONE && skillId != SKILL_HERBALISM && skillId != SKILL_MINING && skillId != SKILL_SKINNING && (!m_selfContainer || ((*m_selfContainer) != this)))
                 {
                     // chance for fail at lockpicking attempt


### PR DESCRIPTION
**Changes proposed:**

-  Add exceptions for herbalism, mining and skinning to the failure check for SPELL_EFFECT_OPEN_LOCK.

**Issues addressed:**

- Sometimes, when attempting to use herbalism, skinning or mining, the client will receive "Failed attempt" without so much as a cast bar, even though the skill is orange. As of 3.1.0, these attempts should always succeed after the gathering cast.

**Tests performed:**

- Deployed to Kelfor (personal TC deployment) as a patch and tested based on latest 3.3.5 as of 2022-09-02.
- Tested with herbalism, mining and skinning in starting areas with skill 1.

**Known issues and TODO list:** (add/remove lines as needed)

- None.