### PR TITLE
Fix AI flee logic: creatures should finish casting any current spells before fleeing

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3365,10 +3365,10 @@ void SmartScript::UpdateTimer(SmartScriptHolder& e, uint32 const diff)
             }
         }
 
-        // Delay flee for assist event if stunned or rooted
+        // Delay flee for assist event if stunned, rooted or casting
         if (e.GetActionType() == SMART_ACTION_FLEE_FOR_ASSIST)
         {
-            if (me && me->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_LOST_CONTROL))
+            if (me && me->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_LOST_CONTROL | UNIT_STATE_CASTING))
             {
                 e.timer = 1;
                 return;

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
@@ -111,6 +111,16 @@ struct npc_blackfathom_deeps_event : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
+        if (me->GetEntry() == NPC_MURKSHALLOW_SOFTSHELL || me->GetEntry() == NPC_BARBED_CRUSTACEAN)
+        {
+            if (!me->HasUnitState(UNIT_STATE_CASTING) && !_flee && me->HealthBelowPct(15))
+            {
+                _flee = true;
+                me->DoFleeToGetAssistance();
+                return;
+            }
+        }
+
         if (!UpdateVictim())
             return;
 
@@ -118,16 +128,6 @@ struct npc_blackfathom_deeps_event : public ScriptedAI
 
         if (me->HasUnitState(UNIT_STATE_CASTING))
             return;
-
-        if (me->GetEntry() == NPC_MURKSHALLOW_SOFTSHELL && me->GetEntry() == NPC_BARBED_CRUSTACEAN)
-        {
-            if (!_flee && me->HealthBelowPct(15))
-            {
-                _flee = true;
-                me->DoFleeToGetAssistance();
-                return;
-            }
-        }
 
         while (uint32 eventId = _events.ExecuteEvent())
         {

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
@@ -109,18 +109,6 @@ struct npc_blackfathom_deeps_event : public ScriptedAI
             _instance->SetData(DATA_EVENT, _instance->GetData(DATA_EVENT) + 1);
     }
 
-    void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
-    {
-        if (me->GetEntry() != NPC_MURKSHALLOW_SOFTSHELL && me->GetEntry() != NPC_BARBED_CRUSTACEAN)
-            return;
-
-        if (!_flee && me->HealthBelowPctDamaged(15, damage))
-        {
-            _flee = true;
-            me->DoFleeToGetAssistance();
-        }
-    }
-
     void UpdateAI(uint32 diff) override
     {
         if (!UpdateVictim())
@@ -130,6 +118,16 @@ struct npc_blackfathom_deeps_event : public ScriptedAI
 
         if (me->HasUnitState(UNIT_STATE_CASTING))
             return;
+
+        if (me->GetEntry() == NPC_MURKSHALLOW_SOFTSHELL && me->GetEntry() == NPC_BARBED_CRUSTACEAN)
+        {
+            if (!_flee && me->HealthBelowPctDamaged(15, damage))
+            {
+                _flee = true;
+                me->DoFleeToGetAssistance();
+                return;
+            }
+        }
 
         while (uint32 eventId = _events.ExecuteEvent())
         {

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
@@ -121,7 +121,7 @@ struct npc_blackfathom_deeps_event : public ScriptedAI
 
         if (me->GetEntry() == NPC_MURKSHALLOW_SOFTSHELL && me->GetEntry() == NPC_BARBED_CRUSTACEAN)
         {
-            if (!_flee && me->HealthBelowPctDamaged(15, damage))
+            if (!_flee && me->HealthBelowPct(15))
             {
                 _flee = true;
                 me->DoFleeToGetAssistance();

--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -513,20 +513,20 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
+            // This check is done at all times, but does not take effect if casting.
+            if (!me->HasUnitState(UNIT_STATE_CASTING) && !has_fled && me->HealthBelowPct(15))
+            {
+                me->DoFleeToGetAssistance();
+                has_fled = true;
+                return;
+            }
+
             if (!UpdateVictim() || !me->GetVictim())
                 return;
 
             interrupt_cooldown += diff;
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;
-
-            // This check is done at all times, but does not take effect if casting.
-            if (!has_fled && me->HealthBelowPct(15))
-            {
-                me->DoFleeToGetAssistance();
-                has_fled = true;
-                return;
-            }
 
             if (me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING) && interrupt_cooldown > 25000)
             {

--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -520,6 +520,14 @@ public:
             if (me->HasUnitState(UNIT_STATE_CASTING))
                 return;
 
+            // This check is done at all times, but does not take effect if casting.
+            if (!has_fled && me->GetHealth() > damage && me->HealthBelowPctDamaged(15, damage))
+            {
+                me->DoFleeToGetAssistance();
+                has_fled = true;
+                return;
+            }
+
             if (me->EnsureVictim()->HasUnitState(UNIT_STATE_CASTING) && interrupt_cooldown > 25000)
             {
                 DoCastVictim(SPELL_COUNTERSPELL);
@@ -530,15 +538,6 @@ public:
             {
                 DoMeleeAttackIfReady();
             });
-        }
-
-        void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
-        {
-            if (!has_fled && me->GetHealth() > damage && me->HealthBelowPctDamaged(15, damage))
-            {
-                me->DoFleeToGetAssistance();
-                has_fled = true;
-            }
         }
 
     private:

--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -521,7 +521,7 @@ public:
                 return;
 
             // This check is done at all times, but does not take effect if casting.
-            if (!has_fled && me->GetHealth() > damage && me->HealthBelowPct(15))
+            if (!has_fled && me->HealthBelowPct(15))
             {
                 me->DoFleeToGetAssistance();
                 has_fled = true;

--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -521,7 +521,7 @@ public:
                 return;
 
             // This check is done at all times, but does not take effect if casting.
-            if (!has_fled && me->GetHealth() > damage && me->HealthBelowPctDamaged(15, damage))
+            if (!has_fled && me->GetHealth() > damage && me->HealthBelowPct(15))
             {
                 me->DoFleeToGetAssistance();
                 has_fled = true;


### PR DESCRIPTION
**Changes proposed:**

- Change flee AI so that creatures finish casting before attempting to flee.

**Issues addressed:**

- Currently, enemies using the standard AI will cancel their cast to flee if taken below a certain health percentage. In the original engine, enemies will finish casting before attempting to flee by default. This PR addresses the difference.

**Tests performed:**

- Deployed to personal server running latest 3.3.5 branch as of 2022-09-02.
- Tested with enemies at Gold Coast Quarry in Westfall, which are notorious for being populated with Defias Pillagers. Get into combat, damage them below 15% health while they are casting, and observe that they wait until finishing fireballs before running for help.
- Tested with Aquamancer in BFD- they will now finish casting water bolts before fleeing < 15% health.
- Tested with casters in Kil'sorrow Fortress (Nagrand), they will now finish casting before fleeing < 15% health.

**Known issues and TODO list:** (add/remove lines as needed)

- None at this time.