### PR TITLE
fix (event): Hourly Bell Correction

### DIFF
--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -1181,6 +1181,12 @@ public:
                     _rings = 12;
                 }
 
+                // Dwarf hourly horn should only play a single time, each time the next hour begins.
+                if (_soundId == BELLTOLLDWARFGNOME)
+                {
+                    _rings = 1;
+                }
+
                 for (auto i = 0; i < _rings; ++i)
                     _events.ScheduleEvent(EVENT_RING_BELL, Seconds(i * 4 + 1));
             }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed**:

- Changes go_bells script to play the BellTollDwarfGnome once at every hour.

**Issues addressed**: Fixes #NONE REPORTED

**References**:
- https://www.reddit.com/r/classicwow/comments/ou0rw5/question_what_is_that_super_loud_bellowing/
- cherry-pick commit (https://github.com/vmangos/core/pull/1569)
- Co-Authored-By: Schell244 <9536270+schell244@users.noreply.github.com>

**Tests performed**: (Does it build, tested in-game, etc)
-  Builds on win 11 with VS 2022
- Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
