### PR TITLE
Feature(Smart Scripts/SMART_EVENT_RANGE): Prevent Initial timer 

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2819,7 +2819,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             else
             {
                 if (!e.event.minMaxRepeat.controller)
-                    RecalcTimer(e, 500, 500); //  // make it predictable "This seems to be done to standardize min, max start rather than using the range values for the timer."
+                    RecalcTimer(e, 500, 500); // make it predictable "This seems to be done to standardize min, max start rather than using the range values for the timer."
                 else
                     RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // if param5 value is greater than 0 first action will not happen until after repeat timer fires.
             }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2816,13 +2816,8 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
 
             if (me->IsInRange(me->GetVictim(), (float)e.event.minMaxRepeat.min, (float)e.event.minMaxRepeat.max))
                 ProcessTimedAction(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax, me->GetVictim());
-            else
-            {
-                if (!e.event.minMaxRepeat.controller)
-                    RecalcTimer(e, 500, 500); //  // make it predictable "This seems to be done to standardize min, max start rather than using the range values for the timer."
-                else
-                    RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // if param5 value is greater than 0 first action will not happen until after repeat timer fires.
-            }
+            else // make it predictable
+                RecalcTimer(e, 500, 500);
             break;
         }
         case SMART_EVENT_VICTIM_CASTING:

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2819,7 +2819,7 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             else
             {
                 if (!e.event.minMaxRepeat.controller)
-                    RecalcTimer(e, 500, 500); // make it predictable "This seems to be done to standardize min, max start rather than using the range values for the timer."
+                    RecalcTimer(e, 500, 500); //  // make it predictable "This seems to be done to standardize min, max start rather than using the range values for the timer."
                 else
                     RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // if param5 value is greater than 0 first action will not happen until after repeat timer fires.
             }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2816,8 +2816,13 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
 
             if (me->IsInRange(me->GetVictim(), (float)e.event.minMaxRepeat.min, (float)e.event.minMaxRepeat.max))
                 ProcessTimedAction(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax, me->GetVictim());
-            else // make it predictable
-                RecalcTimer(e, 500, 500);
+            else
+            {
+                if (!e.event.minMaxRepeat.controller)
+                    RecalcTimer(e, 500, 500); //  // make it predictable "This seems to be done to standardize min, max start rather than using the range values for the timer."
+                else
+                    RecalcTimer(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax); // if param5 value is greater than 0 first action will not happen until after repeat timer fires.
+            }
             break;
         }
         case SMART_EVENT_VICTIM_CASTING:

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2814,10 +2814,19 @@ void SmartScript::ProcessEvent(SmartScriptHolder& e, Unit* unit, uint32 var0, ui
             if (!me || !me->IsEngaged() || !me->GetVictim())
                 return;
 
-            if (me->IsInRange(me->GetVictim(), (float)e.event.minMaxRepeat.min, (float)e.event.minMaxRepeat.max))
-                ProcessTimedAction(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax, me->GetVictim());
-            else // make it predictable
-                RecalcTimer(e, 500, 500);
+            if (me->IsInRange(me->GetVictim(), (float)e.event.rangeRepeat.minRange, (float)e.event.rangeRepeat.maxRange))
+            {
+                if (e.event.rangeRepeat.onlyFireOnRepeat == 2)
+                {
+                    e.event.rangeRepeat.onlyFireOnRepeat = 1;
+                    RecalcTimer(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax);
+                }
+                else
+                    ProcessTimedAction(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax, me->GetVictim());
+            }
+            else
+                RecalcTimer(e, 500, 500); // make it predictable
+
             break;
         }
         case SMART_EVENT_VICTIM_CASTING:

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -3315,6 +3315,13 @@ void SmartScript::InitTimer(SmartScriptHolder& e)
     switch (e.GetEventType())
     {
         //set only events which have initial timers
+        case SMART_EVENT_RANGE:
+            // If onlyFireOnRepeat is true set to 2 before entering combat. Will be set back to 1 after entering combat to ignore initial firing.
+            if (e.event.rangeRepeat.onlyFireOnRepeat == 1)
+                e.event.rangeRepeat.onlyFireOnRepeat = 2;
+            // make it predictable
+            RecalcTimer(e, 500, 500);
+            break;
         case SMART_EVENT_UPDATE:
         case SMART_EVENT_UPDATE_IC:
         case SMART_EVENT_UPDATE_OOC:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -314,7 +314,6 @@ void SmartAIMgr::LoadSmartAIFromDB()
             case SMART_EVENT_UPDATE_IC:
             case SMART_EVENT_HEALTH_PCT:
             case SMART_EVENT_MANA_PCT:
-            case SMART_EVENT_RANGE:
             case SMART_EVENT_FRIENDLY_HEALTH_PCT:
             case SMART_EVENT_FRIENDLY_MISSING_BUFF:
             case SMART_EVENT_HAS_AURA:
@@ -325,6 +324,13 @@ void SmartAIMgr::LoadSmartAIFromDB()
                     TC_LOG_ERROR("sql.sql", "SmartAIMgr::LoadSmartAIFromDB: Entry %d SourceType %u, Event %u, Missing Repeat flag.",
                         temp.entryOrGuid, temp.GetScriptType(), temp.event_id);
                 }
+                break;
+            case SMART_EVENT_RANGE:
+                if (temp.event.rangeRepeat.repeatMin == 0 && temp.event.rangeRepeat.repeatMax == 0)
+                    temp.event.event_flags |= SMART_EVENT_FLAG_NOT_REPEATABLE;
+                // Will only work properly if value is 0 or 1
+                if (temp.event.rangeRepeat.onlyFireOnRepeat > 1)
+                    temp.event.rangeRepeat.onlyFireOnRepeat = 1;
                 break;
             case SMART_EVENT_VICTIM_CASTING:
                 if (temp.event.minMaxRepeat.min == 0 && temp.event.minMaxRepeat.max == 0 && !(temp.event.event_flags & SMART_EVENT_FLAG_NOT_REPEATABLE) && temp.source_type != SMART_SCRIPT_TYPE_TIMED_ACTIONLIST)
@@ -704,7 +710,7 @@ bool SmartAIMgr::CheckUnusedEventParams(SmartScriptHolder const& e)
             case SMART_EVENT_DEATH: return NO_PARAMS;
             case SMART_EVENT_EVADE: return NO_PARAMS;
             case SMART_EVENT_SPELLHIT: return sizeof(SmartEvent::spellHit);
-            case SMART_EVENT_RANGE: return sizeof(SmartEvent::minMaxRepeat);
+            case SMART_EVENT_RANGE: return sizeof(SmartEvent::rangeRepeat);
             case SMART_EVENT_OOC_LOS: return sizeof(SmartEvent::los);
             case SMART_EVENT_RESPAWN: return sizeof(SmartEvent::respawn);
             case SMART_EVENT_VICTIM_CASTING: return sizeof(SmartEvent::targetCasting);
@@ -1076,7 +1082,6 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             case SMART_EVENT_UPDATE_OOC:
             case SMART_EVENT_HEALTH_PCT:
             case SMART_EVENT_MANA_PCT:
-            case SMART_EVENT_RANGE:
             case SMART_EVENT_DAMAGED:
             case SMART_EVENT_DAMAGED_TARGET:
             case SMART_EVENT_RECEIVE_HEAL:
@@ -1084,6 +1089,13 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
                     return false;
 
                 if (!IsMinMaxValid(e, e.event.minMaxRepeat.repeatMin, e.event.minMaxRepeat.repeatMax))
+                    return false;
+                break;
+            case SMART_EVENT_RANGE:
+                if (!IsMinMaxValid(e, e.event.rangeRepeat.minRange, e.event.rangeRepeat.maxRange))
+                    return false;
+
+                if (!IsMinMaxValid(e, e.event.rangeRepeat.repeatMin, e.event.rangeRepeat.repeatMax))
                     return false;
                 break;
             case SMART_EVENT_SPELLHIT:

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -204,7 +204,6 @@ struct SmartEvent
             uint32 max;
             uint32 repeatMin;
             uint32 repeatMax;
-            uint32 controller;
         } minMaxRepeat;
 
         struct

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -208,6 +208,15 @@ struct SmartEvent
 
         struct
         {
+            uint32 minRange;
+            uint32 maxRange;
+            uint32 repeatMin;
+            uint32 repeatMax;
+            uint32 onlyFireOnRepeat;
+        } rangeRepeat;
+
+        struct
+        {
             uint32 cooldownMin;
             uint32 cooldownMax;
             SAIBool playerOnly;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -204,6 +204,7 @@ struct SmartEvent
             uint32 max;
             uint32 repeatMin;
             uint32 repeatMax;
+            uint32 controller;
         } minMaxRepeat;
 
         struct


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  prevent initial firing of ranged event and will not fire until repeat time has expired.

**Issues addressed:**

Prevent initial firing of ranged event and will not fire until repeat time has expired.

Currently the event will cast the spell in entering combat which is not desirable.

Closes #  (insert issue tracker number)


**Tests performed:**

Tested in game with and without flag

## How to Test the Changes:
1. Recompile with changes
2. Test without flag
3. Insert in to world
```
UPDATE `smart_scripts` SET `event_type`=9, `event_chance`=75, `event_param1`=0, `event_param2`=8, `event_param3`=10000, `event_param4`=15000, `event_param5`=0, `action_param2`=1, `target_type`=1, `comment`="Boulderfist Magus - Within 0-8 Range - Cast 'Frost Nova'" WHERE `entryorguid`=2567 AND `source_type`=0 AND `id`=3;
``` 
4. .go c 14665
5. enter combat
6. Test with flag
7. Insert in to world
```
UPDATE `smart_scripts` SET `event_type`=9, `event_chance`=75, `event_param1`=0, `event_param2`=8, `event_param3`=10000, `event_param4`=15000, `event_param5`=1, `action_param2`=1, `target_type`=1, `comment`="Boulderfist Magus - Within 0-8 Range - Cast 'Frost Nova'" WHERE `entryorguid`=2567 AND `source_type`=0 AND `id`=3;
``` 

After testing you should see the Frost Nova is cast in entering combat without flag and not until repeat timer occurs with flag.

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
