### PR TITLE
Fix *BSD compile errors

### DIFF
--- a/dep/g3dlite/G3D-v9.0 hotfix16.diff
+++ b/dep/g3dlite/G3D-v9.0 hotfix16.diff
@@ -1,0 +1,14 @@
+diff --git a/dep/g3dlite/source/FileSystem.cpp b/dep/g3dlite/source/FileSystem.cpp
+index 06e6ff00a5e3..0898af795348 100644
+--- a/dep/g3dlite/source/FileSystem.cpp
++++ b/dep/g3dlite/source/FileSystem.cpp
+@@ -35,6 +35,9 @@
+ #   include <fnmatch.h>
+ #   include <unistd.h>
+ #   define _getcwd getcwd
++#   if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
++#     define stat64 stat
++#   endif
+ #   define _stat stat
+ #   define stricmp strcasecmp 
+ #   define strnicmp strncasecmp 

--- a/dep/g3dlite/source/FileSystem.cpp
+++ b/dep/g3dlite/source/FileSystem.cpp
@@ -35,6 +35,9 @@
 #   include <fnmatch.h>
 #   include <unistd.h>
 #   define _getcwd getcwd
+#   if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#     define stat64 stat
+#   endif
 #   define _stat stat
 #   define stricmp strcasecmp 
 #   define strnicmp strncasecmp 

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -74,6 +74,8 @@ time_t LocalTimeToUTCTime(time_t time)
 {
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
     return time + _timezone;
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    return timegm(gmtime(&time));
 #else
     return time + timezone;
 #endif

--- a/src/tools/vmap4_extractor/vmapexport.cpp
+++ b/src/tools/vmap4_extractor/vmapexport.cpp
@@ -434,7 +434,7 @@ int main(int argc, char ** argv)
     //xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     // Create the working directory
     if (mkdir(szWorkDirWmo
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
                     , 0711
 #endif
                     ))


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Set `stat64` to `stat` in g3dlite `Filesystem.cpp` while building under any of the BSDs. `stat64()` does not exist on FreeBSD for example.
- `timezone` is defined as a `long` on Linux. On the BSDs, `timezone()` is a function:
```c
char *timezone(int zone, int dst);
```
`time + timezone` will not work in this context. To work around this difference, the `time` data passed to `LocalTimeToUTCTime()` gets converted to UTC time using `gmtime()`. This function returns a pointer to a `struct tm` object which needs to be converted to `time_t`. This is handled by the BSD function `timegm()`.
- As with Linux and macOS, also use `mkdir(const char *path, mode_t mode)` while building under the BSDs.

**Issues addressed:**
No open issues associated with this pull request.


**Tests performed:**
After implementing the proposed fixes, building was successful under FreeBSD 13.1-RELEASE-p2 using Clang 13.0.0. The produced `authserver` and `worldserver` binaries also work as expected -- clients are able to connect to the services. Lastly, `vmap4extractor` works as intended.


**Known issues and TODO list:** (add/remove lines as needed)
None at the time this pull request was created.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
