### PR TITLE
Core/GameObjects: Added check to avoid using GAMEOBJECT_TYPE_CHAIR if already in use by a creature

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2225,17 +2225,18 @@ void GameObject::Use(Unit* user)
 
                 float x_i = GetPositionX() + relativeDistance * std::cos(orthogonalOrientation);
                 float y_i = GetPositionY() + relativeDistance * std::sin(orthogonalOrientation);
+                Position const slotPos(x_i, y_i, GetPositionZ());
 
                 // Check if seat is "occupied" by creature
-                if (Creature* creature = FindNearestCreatureInRange(INTERACTION_DISTANCE))
-                    if (creature->IsSitState() && creature->GetStandState() != UNIT_STAND_STATE_SIT && creature->GetExactDist2d(x_i, y_i) < 0.1f)
+                if (Creature* creature = FindNearestCreatureToPosition(&slotPos, CONTACT_DISTANCE))
+                    if (creature->IsSitState() && creature->GetStandState() != UNIT_STAND_STATE_SIT && creature->GetExactDist2d(slotPos) < 0.1f)
                         continue;
 
                 if (!itr->second.IsEmpty())
                 {
                     if (Player* ChairUser = ObjectAccessor::GetPlayer(*this, itr->second))
                     {
-                        if (ChairUser->IsSitState() && ChairUser->GetStandState() != UNIT_STAND_STATE_SIT && ChairUser->GetExactDist2d(x_i, y_i) < 0.1f)
+                        if (ChairUser->IsSitState() && ChairUser->GetStandState() != UNIT_STAND_STATE_SIT && ChairUser->GetExactDist2d(slotPos) < 0.1f)
                             continue;        // This seat is already occupied by ChairUser. NOTE: Not sure if the ChairUser->GetStandState() != UNIT_STAND_STATE_SIT check is required.
                         else
                             itr->second.Clear(); // This seat is unoccupied.

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2226,6 +2226,11 @@ void GameObject::Use(Unit* user)
                 float x_i = GetPositionX() + relativeDistance * std::cos(orthogonalOrientation);
                 float y_i = GetPositionY() + relativeDistance * std::sin(orthogonalOrientation);
 
+                // Check if seat is "occupied" by creature
+                if (Creature* creature = FindNearestCreatureInRange(INTERACTION_DISTANCE))
+                    if (creature->IsSitState() && creature->GetStandState() != UNIT_STAND_STATE_SIT && creature->GetExactDist2d(x_i, y_i) < 0.1f)
+                        return;
+
                 if (!itr->second.IsEmpty())
                 {
                     if (Player* ChairUser = ObjectAccessor::GetPlayer(*this, itr->second))

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2229,7 +2229,7 @@ void GameObject::Use(Unit* user)
                 // Check if seat is "occupied" by creature
                 if (Creature* creature = FindNearestCreatureInRange(INTERACTION_DISTANCE))
                     if (creature->IsSitState() && creature->GetStandState() != UNIT_STAND_STATE_SIT && creature->GetExactDist2d(x_i, y_i) < 0.1f)
-                        return;
+                        continue;
 
                 if (!itr->second.IsEmpty())
                 {

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2056,6 +2056,15 @@ Creature* WorldObject::FindNearestCreature(uint32 entry, float range, bool alive
     return creature;
 }
 
+Creature* WorldObject::FindNearestCreatureInRange(float range, bool alive) const
+{
+    Creature* creature = nullptr;
+    Trinity::NearestCreatureWithLiveStateInObjectRangeCheck checker(*this, alive, range);
+    Trinity::CreatureLastSearcher<Trinity::NearestCreatureWithLiveStateInObjectRangeCheck> searcher(this, creature, checker);
+    Cell::VisitAllObjects(this, searcher, range);
+    return creature;
+}
+
 GameObject* WorldObject::FindNearestGameObject(uint32 entry, float range, bool spawnedOnly) const
 {
     GameObject* go = nullptr;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2056,11 +2056,11 @@ Creature* WorldObject::FindNearestCreature(uint32 entry, float range, bool alive
     return creature;
 }
 
-Creature* WorldObject::FindNearestCreatureInRange(float range, bool alive) const
+Creature* WorldObject::FindNearestCreatureToPosition(Position const* pos, float range, bool alive) const
 {
     Creature* creature = nullptr;
-    Trinity::NearestCreatureWithLiveStateInObjectRangeCheck checker(*this, alive, range);
-    Trinity::CreatureLastSearcher<Trinity::NearestCreatureWithLiveStateInObjectRangeCheck> searcher(this, creature, checker);
+    Trinity::NearestCreatureWithLiveStateToPositionCheck checker(pos, alive, range);
+    Trinity::CreatureLastSearcher<Trinity::NearestCreatureWithLiveStateToPositionCheck> searcher(this, creature, checker);
     Cell::VisitAllObjects(this, searcher, range);
     return creature;
 }

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -574,6 +574,7 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         void SummonCreatureGroup(uint8 group, std::list<TempSummon*>* list = nullptr);
 
         Creature*   FindNearestCreature(uint32 entry, float range, bool alive = true) const;
+        Creature*   FindNearestCreatureInRange(float range, bool alive = true) const;
         GameObject* FindNearestGameObject(uint32 entry, float range, bool spawnedOnly = true) const;
         GameObject* FindNearestUnspawnedGameObject(uint32 entry, float range) const;
         GameObject* FindNearestGameObjectOfType(GameobjectTypes type, float range) const;

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -574,7 +574,7 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         void SummonCreatureGroup(uint8 group, std::list<TempSummon*>* list = nullptr);
 
         Creature*   FindNearestCreature(uint32 entry, float range, bool alive = true) const;
-        Creature*   FindNearestCreatureInRange(float range, bool alive = true) const;
+        Creature*   FindNearestCreatureToPosition(Position const* pos, float range, bool alive = true) const;
         GameObject* FindNearestGameObject(uint32 entry, float range, bool spawnedOnly = true) const;
         GameObject* FindNearestUnspawnedGameObject(uint32 entry, float range) const;
         GameObject* FindNearestGameObjectOfType(GameobjectTypes type, float range) const;

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1402,6 +1402,32 @@ namespace Trinity
             NearestAssistCreatureInCreatureRangeCheck(NearestAssistCreatureInCreatureRangeCheck const&) = delete;
     };
 
+    class NearestCreatureWithLiveStateToPositionCheck
+    {
+        public:
+            NearestCreatureWithLiveStateToPositionCheck(Position const* pos, bool alive, float range) : i_pos(pos), i_alive(alive), i_range(range) { }
+
+            bool operator()(Creature* u)
+            {
+                if (u->getDeathState() != DEAD
+                    && u->IsAlive() == i_alive
+                    && u->IsWithinDist3d(i_pos, i_range))
+                {
+                    i_range = u->GetDistance(*i_pos);        // use found unit range as new range limit for next check
+                    return true;
+                }
+                return false;
+            }
+
+        private:
+            Position const* i_pos;
+            bool   i_alive;
+            float  i_range;
+
+            // prevent clone this object
+            NearestCreatureWithLiveStateToPositionCheck(NearestCreatureWithLiveStateToPositionCheck const&) = delete;
+    };
+
     // Success at unit in range, range update for next check (this can be use with CreatureLastSearcher to find nearest creature)
     class NearestCreatureEntryWithLiveStateInObjectRangeCheck
     {
@@ -1432,35 +1458,6 @@ namespace Trinity
 
             // prevent clone this object
             NearestCreatureEntryWithLiveStateInObjectRangeCheck(NearestCreatureEntryWithLiveStateInObjectRangeCheck const&) = delete;
-    };
-
-    class NearestCreatureWithLiveStateInObjectRangeCheck
-    {
-        public:
-            NearestCreatureWithLiveStateInObjectRangeCheck(WorldObject const& obj, bool alive, float range)
-                : i_obj(obj), i_alive(alive), i_range(range) { }
-
-            bool operator()(Creature* u)
-            {
-                if (u->getDeathState() != DEAD
-                    && u->IsAlive() == i_alive
-                    && u->GetGUID() != i_obj.GetGUID()
-                    && i_obj.IsWithinDistInMap(u, i_range)
-                    && u->CheckPrivateObjectOwnerVisibility(&i_obj))
-                {
-                    i_range = i_obj.GetDistance(u);         // use found unit range as new range limit for next check
-                    return true;
-                }
-                return false;
-            }
-
-        private:
-            WorldObject const& i_obj;
-            bool   i_alive;
-            float  i_range;
-
-            // prevent clone this object
-            NearestCreatureWithLiveStateInObjectRangeCheck(NearestCreatureWithLiveStateInObjectRangeCheck const&) = delete;
     };
 
     class AnyPlayerInObjectRangeCheck

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1434,6 +1434,35 @@ namespace Trinity
             NearestCreatureEntryWithLiveStateInObjectRangeCheck(NearestCreatureEntryWithLiveStateInObjectRangeCheck const&) = delete;
     };
 
+    class NearestCreatureWithLiveStateInObjectRangeCheck
+    {
+        public:
+            NearestCreatureWithLiveStateInObjectRangeCheck(WorldObject const& obj, bool alive, float range)
+                : i_obj(obj), i_alive(alive), i_range(range) { }
+
+            bool operator()(Creature* u)
+            {
+                if (u->getDeathState() != DEAD
+                    && u->IsAlive() == i_alive
+                    && u->GetGUID() != i_obj.GetGUID()
+                    && i_obj.IsWithinDistInMap(u, i_range)
+                    && u->CheckPrivateObjectOwnerVisibility(&i_obj))
+                {
+                    i_range = i_obj.GetDistance(u);         // use found unit range as new range limit for next check
+                    return true;
+                }
+                return false;
+            }
+
+        private:
+            WorldObject const& i_obj;
+            bool   i_alive;
+            float  i_range;
+
+            // prevent clone this object
+            NearestCreatureWithLiveStateInObjectRangeCheck(NearestCreatureWithLiveStateInObjectRangeCheck const&) = delete;
+    };
+
     class AnyPlayerInObjectRangeCheck
     {
         public:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Added check to avoid using GAMEOBJECT_TYPE_CHAIR if already in use by a creature. In retail, the chairs have no special flag and the client sends CMSG_GAME_OBJ_USE and CMSG_GAME_OBJ_REPORT_USE on click. The only difference with empty chairs is that the server doesn't send SMSG_MOVE_TELEPORT.

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
