### PR TITLE
Core/Spells: make Spell::CheckMovement respect the current spell state

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6860,13 +6860,13 @@ SpellCastResult Spell::CheckMovement() const
     {
         if (!unitCaster->CanCastSpellWhileMoving(m_spellInfo))
         {
-            if (unitCaster->GetCurrentSpell(CURRENT_GENERIC_SPELL) == this)
+            if (getState() == SPELL_STATE_PREPARING)
             {
                 if (m_casttime > 0)
                     if (m_spellInfo->InterruptFlags.HasFlag(SpellInterruptFlags::Movement))
                         return SPELL_FAILED_MOVING;
             }
-            else if (unitCaster->GetCurrentSpell(CURRENT_CHANNELED_SPELL) == this)
+            else if (getState() == SPELL_STATE_CASTING)
                 if (!m_spellInfo->IsMoveAllowedChannel())
                     return SPELL_FAILED_MOVING;
         }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6860,17 +6860,15 @@ SpellCastResult Spell::CheckMovement() const
     {
         if (!unitCaster->CanCastSpellWhileMoving(m_spellInfo))
         {
-            if (m_casttime)
+            if (unitCaster->GetCurrentSpell(CURRENT_GENERIC_SPELL) == this)
             {
-                if (m_spellInfo->InterruptFlags.HasFlag(SpellInterruptFlags::Movement))
-                    return SPELL_FAILED_MOVING;
+                if (m_casttime > 0)
+                    if (m_spellInfo->InterruptFlags.HasFlag(SpellInterruptFlags::Movement))
+                        return SPELL_FAILED_MOVING;
             }
-            else
-            {
-                // only fail channeled casts if they are instant but cannot be channeled while moving
-                if (m_spellInfo->IsChanneled() && !m_spellInfo->IsMoveAllowedChannel())
+            else if (unitCaster->GetCurrentSpell(CURRENT_CHANNELED_SPELL) == this)
+                if (!m_spellInfo->IsMoveAllowedChannel())
                     return SPELL_FAILED_MOVING;
-            }
         }
     }
 


### PR DESCRIPTION
**Changes proposed:**

-  there are spells, such as Erudax' Shadow Gale which have a cast time AND a channel time. The spell allows movement while casting but not while channeling. Hence, the reason why we need to respect the spell's current state and switch between the checked interrupt flags accordingly.

**Tests performed:**
- tested on 4.x
