### PR TITLE
Core/Spells: fixed Howling Blast

### DIFF
--- a/sql/updates/world/master/2022_99_99_99_world.sql
+++ b/sql/updates/world/master/2022_99_99_99_world.sql
@@ -1,0 +1,5 @@
+-- Howling Blast
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_dk_howling_blast';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(49184, 'spell_dk_howling_blast'),
+(237680, 'spell_dk_howling_blast');


### PR DESCRIPTION

**Changes proposed:**

-  handle damage for non-primary targets
-  handle visuals

**Tests performed:**
- tested ingame

**Known issues and TODO list:** (add/remove lines as needed)
- [ ] the spell proc system currently does not properly support two spell casts of the same family being executed at the same time resulting in spell mods being consumed at wrong stages which in this case results in Rime only modifying either the primary or secondary spell damage
