### PR TITLE
Core/Game: Fix FlaggedValuesArray32 flags overflow for InvisibilityType because TOTAL_INVISIBILITY_TY…

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1566,7 +1566,7 @@ bool WorldObject::CanDetect(WorldObject const* obj, bool ignoreStealth, bool che
 
 bool WorldObject::CanDetectInvisibilityOf(WorldObject const* obj) const
 {
-    uint32 mask = obj->m_invisibility.GetFlags() & m_invisibilityDetect.GetFlags();
+    uint64 mask = obj->m_invisibility.GetFlags() & m_invisibilityDetect.GetFlags();
 
     // Check for not detected types
     if (mask != obj->m_invisibility.GetFlags())
@@ -1574,7 +1574,7 @@ bool WorldObject::CanDetectInvisibilityOf(WorldObject const* obj) const
 
     for (uint32 i = 0; i < TOTAL_INVISIBILITY_TYPES; ++i)
     {
-        if (!(mask & (1 << i)))
+        if (!(mask & (uint64(1) << i)))
             continue;
 
         int32 objInvisibilityValue = obj->m_invisibility.GetValue(InvisibilityType(i));

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -409,17 +409,19 @@ template <class T_VALUES, class T_FLAGS, class FLAG_TYPE, size_t ARRAY_SIZE>
 class FlaggedValuesArray32
 {
     public:
+        static_assert(sizeof(T_FLAGS) * 8 > ARRAY_SIZE, "Fix T_FLAGS");
+
         FlaggedValuesArray32()
         {
             for (uint32 i = 0; i < ARRAY_SIZE; ++i)
                 m_values[i] = T_VALUES(0);
-            m_flags = 0;
+            m_flags = T_FLAGS(0);
         }
 
         T_FLAGS GetFlags() const { return m_flags; }
-        bool HasFlag(FLAG_TYPE flag) const { return m_flags & (1 << flag); }
-        void AddFlag(FLAG_TYPE flag) { m_flags |= (1 << flag); }
-        void DelFlag(FLAG_TYPE flag) { m_flags &= ~(1 << flag); }
+        bool HasFlag(FLAG_TYPE flag) const { return m_flags & (T_FLAGS(1) << flag); }
+        void AddFlag(FLAG_TYPE flag) { m_flags |= (T_FLAGS(1) << flag); }
+        void DelFlag(FLAG_TYPE flag) { m_flags &= ~(T_FLAGS(1) << flag); }
 
         T_VALUES GetValue(FLAG_TYPE flag) const { return m_values[flag]; }
         void SetValue(FLAG_TYPE flag, T_VALUES value) { m_values[flag] = value; }
@@ -547,8 +549,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         FlaggedValuesArray32<int32, uint32, StealthType, TOTAL_STEALTH_TYPES> m_stealth;
         FlaggedValuesArray32<int32, uint32, StealthType, TOTAL_STEALTH_TYPES> m_stealthDetect;
 
-        FlaggedValuesArray32<int32, uint32, InvisibilityType, TOTAL_INVISIBILITY_TYPES> m_invisibility;
-        FlaggedValuesArray32<int32, uint32, InvisibilityType, TOTAL_INVISIBILITY_TYPES> m_invisibilityDetect;
+        FlaggedValuesArray32<int32, uint64, InvisibilityType, TOTAL_INVISIBILITY_TYPES> m_invisibility;
+        FlaggedValuesArray32<int32, uint64, InvisibilityType, TOTAL_INVISIBILITY_TYPES> m_invisibilityDetect;
 
         FlaggedValuesArray32<int32, uint32, ServerSideVisibilityType, TOTAL_SERVERSIDE_VISIBILITY_TYPES> m_serverSideVisibility;
         FlaggedValuesArray32<int32, uint32, ServerSideVisibilityType, TOTAL_SERVERSIDE_VISIBILITY_TYPES> m_serverSideVisibilityDetect;


### PR DESCRIPTION
…PES (38) can't fit in 32 bits flag

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add an assert to ensure that T_FLAGS type is big enough to fit flags
-  extend T_FLAGS for m_invisibility/m_invisibilityDetect to 64 bits because TOTAL_INVISIBILITY_TYPE is 38
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

build


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
