### PR TITLE
Core/Spells: Summoned creatures by SPELL_EFFECT_SUMMON should inherit phaseshift of caster

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2079,6 +2079,7 @@ void Spell::EffectSummonType()
 
     if (summon)
     {
+        PhasingHandler::InheritPhaseShift(summon, m_caster);
         summon->SetCreatorGUID(caster->GetGUID());
         ExecuteLogEffectSummonObject(SpellEffectName(effectInfo->Effect), summon);
     }


### PR DESCRIPTION
...phaseshift of caster

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
built, tested in game with #28275 (removed code of adding phase manually)