### PR TITLE
Core/Movement: implement smooth waypoints

### DIFF
--- a/sql/updates/world/master/2022_xx_xx_xx_world.sql
+++ b/sql/updates/world/master/2022_xx_xx_xx_world.sql
@@ -1,2 +1,10 @@
 -- Waypoint Data
-ALTER TABLE `waypoint_data` ADD COLUMN `velocity` FLOAT DEFAULT 0 NOT NULL AFTER `orientation`;
+DROP TABLE IF EXISTS `waypoint_data_addon`;
+CREATE TABLE `waypoint_data_addon` (  
+  `PathID` INT(10) UNSIGNED NOT NULL DEFAULT 0,
+  `PointID` INT(10) UNSIGNED NOT NULL DEFAULT 0,
+  `SplinePointIndex` TINYINT(3) UNSIGNED NOT NULL DEFAULT 0,
+  `PositionX` FLOAT NOT NULL DEFAULT 0,
+  `PositionY` FLOAT NOT NULL DEFAULT 0,
+  `PositionZ` FLOAT NOT NULL DEFAULT 0
+);

--- a/sql/updates/world/master/2022_xx_xx_xx_world.sql
+++ b/sql/updates/world/master/2022_xx_xx_xx_world.sql
@@ -1,0 +1,2 @@
+-- Waypoint Data
+ALTER TABLE `waypoint_data` ADD COLUMN `velocity` FLOAT DEFAULT 0 NOT NULL AFTER `orientation`;

--- a/sql/updates/world/master/2022_xx_xx_xx_world.sql
+++ b/sql/updates/world/master/2022_xx_xx_xx_world.sql
@@ -1,4 +1,13 @@
--- Waypoint Data
+-- waypoints
+ALTER TABLE `waypoints` 
+	ADD COLUMN `smoothTransition` tinyint UNSIGNED NOT NULL DEFAULT 0 AFTER `delay`;
+
+-- waypoint_data
+ALTER TABLE `waypoint_data`
+	ADD COLUMN `velocity` FLOAT NOT NULL DEFAULT 0 AFTER `orientation`,
+	ADD COLUMN `smoothTransition` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `delay`;
+
+-- waypoint_data_addon
 DROP TABLE IF EXISTS `waypoint_data_addon`;
 CREATE TABLE `waypoint_data_addon` (  
   `PathID` INT(10) UNSIGNED NOT NULL DEFAULT 0,

--- a/src/server/database/Database/Implementation/WorldDatabase.cpp
+++ b/src/server/database/Database/Implementation/WorldDatabase.cpp
@@ -52,7 +52,7 @@ void WorldDatabaseConnection::DoPrepareStatements()
     PrepareStatement(WORLD_UPD_WAYPOINT_DATA_WPGUID, "UPDATE waypoint_data SET wpguid = ? WHERE id = ? and point = ?", CONNECTION_ASYNC);
     PrepareStatement(WORLD_SEL_WAYPOINT_DATA_MAX_ID, "SELECT MAX(id) FROM waypoint_data", CONNECTION_SYNCH);
     PrepareStatement(WORLD_SEL_WAYPOINT_DATA_MAX_POINT, "SELECT MAX(point) FROM waypoint_data WHERE id = ?", CONNECTION_SYNCH);
-    PrepareStatement(WORLD_SEL_WAYPOINT_DATA_BY_ID, "SELECT point, position_x, position_y, position_z, orientation, move_type, delay, action, action_chance FROM waypoint_data WHERE id = ? ORDER BY point", CONNECTION_SYNCH);
+    PrepareStatement(WORLD_SEL_WAYPOINT_DATA_BY_ID, "SELECT point, position_x, position_y, position_z, orientation, velocity, move_type, delay, action, action_chance FROM waypoint_data WHERE id = ? ORDER BY point", CONNECTION_SYNCH);
     PrepareStatement(WORLD_SEL_WAYPOINT_DATA_POS_BY_ID, "SELECT point, position_x, position_y, position_z, orientation FROM waypoint_data WHERE id = ?", CONNECTION_SYNCH);
     PrepareStatement(WORLD_SEL_WAYPOINT_DATA_POS_FIRST_BY_ID, "SELECT position_x, position_y, position_z, orientation FROM waypoint_data WHERE point = 1 AND id = ?", CONNECTION_SYNCH);
     PrepareStatement(WORLD_SEL_WAYPOINT_DATA_POS_LAST_BY_ID, "SELECT position_x, position_y, position_z, orientation FROM waypoint_data WHERE id = ? ORDER BY point DESC LIMIT 1", CONNECTION_SYNCH);

--- a/src/server/database/Database/Implementation/WorldDatabase.cpp
+++ b/src/server/database/Database/Implementation/WorldDatabase.cpp
@@ -28,7 +28,7 @@ void WorldDatabaseConnection::DoPrepareStatements()
     PrepareStatement(WORLD_REP_LINKED_RESPAWN, "REPLACE INTO linked_respawn (guid, linkedGuid, linkType) VALUES (?, ?, ?)", CONNECTION_ASYNC);
     PrepareStatement(WORLD_SEL_CREATURE_TEXT, "SELECT CreatureID, GroupID, ID, Text, Type, Language, Probability, Emote, Duration, Sound, SoundPlayType, BroadcastTextId, TextRange FROM creature_text", CONNECTION_SYNCH);
     PrepareStatement(WORLD_SEL_SMART_SCRIPTS, "SELECT entryorguid, source_type, id, link, event_type, event_phase_mask, event_chance, event_flags, event_param1, event_param2, event_param3, event_param4, event_param5, event_param_string, action_type, action_param1, action_param2, action_param3, action_param4, action_param5, action_param6, target_type, target_param1, target_param2, target_param3, target_param4, target_x, target_y, target_z, target_o FROM smart_scripts ORDER BY entryorguid, source_type, id, link", CONNECTION_SYNCH);
-    PrepareStatement(WORLD_SEL_SMARTAI_WP, "SELECT entry, pointid, position_x, position_y, position_z, orientation, delay FROM waypoints ORDER BY entry, pointid", CONNECTION_SYNCH);
+    PrepareStatement(WORLD_SEL_SMARTAI_WP, "SELECT entry, pointid, position_x, position_y, position_z, orientation, velocity, delay, smoothTransition FROM waypoints ORDER BY entry, pointid", CONNECTION_SYNCH);
     PrepareStatement(WORLD_DEL_GAMEOBJECT, "DELETE FROM gameobject WHERE guid = ?", CONNECTION_ASYNC);
     PrepareStatement(WORLD_DEL_EVENT_GAMEOBJECT, "DELETE FROM game_event_gameobject WHERE guid = ?", CONNECTION_ASYNC);
     PrepareStatement(WORLD_INS_GRAVEYARD_ZONE, "INSERT INTO graveyard_zone (ID, GhostZone, Faction) VALUES (?, ?, ?)", CONNECTION_ASYNC);

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -217,6 +217,7 @@ class TC_GAME_API CreatureAI : public UnitAI
 
         /// == Waypoints system =============================
 
+        virtual void WaypointPathStarted(uint32 /*pathId*/) { }
         virtual void WaypointStarted(uint32 /*nodeId*/, uint32 /*pathId*/) { }
         virtual void WaypointReached(uint32 /*nodeId*/, uint32 /*pathId*/) { }
         virtual void WaypointPathEnded(uint32 /*nodeId*/, uint32 /*pathId*/) { }

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -139,13 +139,13 @@ void EscortAI::MovementInform(uint32 type, uint32 id)
     }
     else if (type == WAYPOINT_MOTION_TYPE)
     {
-        ASSERT(id < _path.nodes.size(), "EscortAI::MovementInform: referenced movement id (%u) points to non-existing node in loaded path (%s)", id, me->GetGUID().ToString().c_str());
-        WaypointNode waypoint = _path.nodes[id];
+        ASSERT(id < _path.Nodes.size(), "EscortAI::MovementInform: referenced movement id (%u) points to non-existing node in loaded path (%s)", id, me->GetGUID().ToString().c_str());
+        WaypointNode waypoint = _path.Nodes[id];
 
         TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::MovementInform: waypoint node %u reached (%s)", waypoint.id, me->GetGUID().ToString().c_str());
 
         // last point
-        if (id == _path.nodes.size() - 1)
+        if (id == _path.Nodes.size() - 1)
         {
             _started = false;
             _ended = true;
@@ -258,16 +258,16 @@ void EscortAI::AddWaypoint(uint32 id, float x, float y, float z, float orientati
     Trinity::NormalizeMapCoord(y);
 
     WaypointNode waypoint;
-    waypoint.id = id;
-    waypoint.x = x;
-    waypoint.y = y;
-    waypoint.z = z;
-    waypoint.orientation = orientation;
-    waypoint.moveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
-    waypoint.delay = waitTime.count();
-    waypoint.eventId = 0;
-    waypoint.eventChance = 100;
-    _path.nodes.push_back(std::move(waypoint));
+    waypoint.Id = id;
+    waypoint.X = x;
+    waypoint.Y = y;
+    waypoint.Z = z;
+    waypoint.Orientation = orientation;
+    waypoint.MoveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
+    waypoint.Delay = waitTime.count();
+    waypoint.EventId = 0;
+    waypoint.EventChance = 100;
+    _path.Nodes.push_back(std::move(waypoint));
 
     _manualPath = true;
 }
@@ -299,7 +299,7 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
     if (!_manualPath && resetWaypoints)
         FillPointMovementListForCreature();
 
-    if (_path.nodes.empty())
+    if (_path.Nodes.empty())
     {
         TC_LOG_ERROR("scripts.ai.escortai", "EscortAI::Start: (script: %s) is set to return home after waypoint end and instant respawn at waypoint end. Creature will never despawn (%s)", me->GetScriptName().c_str(), me->GetGUID().ToString().c_str());
         return;
@@ -342,8 +342,8 @@ void EscortAI::SetRun(bool on)
     if (on == _running)
         return;
 
-    for (auto& node : _path.nodes)
-        node.moveType = on ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
+    for (auto& node : _path.Nodes)
+        node.MoveType = on ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
 
     me->SetWalk(!on);
     _running = on;
@@ -440,13 +440,13 @@ void EscortAI::FillPointMovementListForCreature()
     if (!path)
         return;
 
-    for (WaypointNode const& value : path->nodes)
+    for (WaypointNode const& value : path->Nodes)
     {
         WaypointNode node = value;
         Trinity::NormalizeMapCoord(node.x);
         Trinity::NormalizeMapCoord(node.y);
-        node.moveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
+        node.MoveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
 
-        _path.nodes.push_back(std::move(node));
+        _path.Nodes.push_back(std::move(node));
     }
 }

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -142,7 +142,7 @@ void EscortAI::MovementInform(uint32 type, uint32 id)
         ASSERT(id < _path.Nodes.size(), "EscortAI::MovementInform: referenced movement id (%u) points to non-existing node in loaded path (%s)", id, me->GetGUID().ToString().c_str());
         WaypointNode waypoint = _path.Nodes[id];
 
-        TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::MovementInform: waypoint node %u reached (%s)", waypoint.id, me->GetGUID().ToString().c_str());
+        TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::MovementInform: waypoint node %u reached (%s)", waypoint.Id, me->GetGUID().ToString().c_str());
 
         // last point
         if (id == _path.Nodes.size() - 1)
@@ -328,7 +328,7 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
     }
 
     TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::Start: (script: %s) started with %u waypoints. ActiveAttacker = %d, Run = %d, Player = %s (%s)",
-        me->GetScriptName().c_str(), uint32(_path.nodes.size()), _activeAttacker, _running, _playerGUID.ToString().c_str(), me->GetGUID().ToString().c_str());
+        me->GetScriptName().c_str(), uint32(_path.Nodes.size()), _activeAttacker, _running, _playerGUID.ToString().c_str(), me->GetGUID().ToString().c_str());
 
     // set initial speed
     me->SetWalk(!_running);
@@ -443,8 +443,8 @@ void EscortAI::FillPointMovementListForCreature()
     for (WaypointNode const& value : path->Nodes)
     {
         WaypointNode node = value;
-        Trinity::NormalizeMapCoord(node.x);
-        Trinity::NormalizeMapCoord(node.y);
+        Trinity::NormalizeMapCoord(node.X);
+        Trinity::NormalizeMapCoord(node.Y);
         node.MoveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
 
         _path.Nodes.push_back(std::move(node));

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -753,7 +753,7 @@ void SmartAI::SetRun(bool run)
     me->SetWalk(!run);
     _run = run;
     for (auto& node : _path.Nodes)
-        node.moveType = run ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
+        node.MoveType = run ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
 }
 
 void SmartAI::SetDisableGravity(bool fly)

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -57,7 +57,7 @@ void SmartAI::StartPath(bool run/* = false*/, uint32 pathId/* = 0*/, bool repeat
             return;
     }
 
-    if (_path.nodes.empty())
+    if (_path.Nodes.empty())
         return;
 
     _currentWaypointNode = nodeId;
@@ -83,19 +83,19 @@ bool SmartAI::LoadPath(uint32 entry)
         return false;
 
     WaypointPath const* path = sSmartWaypointMgr->GetPath(entry);
-    if (!path || path->nodes.empty())
+    if (!path || path->Nodes.empty())
     {
         GetScript()->SetPathId(0);
         return false;
     }
 
-    _path.id = path->id;
-    _path.nodes = path->nodes;
-    for (WaypointNode& waypoint : _path.nodes)
+    _path.Id = path->Id;
+    _path.Nodes = path->Nodes;
+    for (WaypointNode& waypoint : _path.Nodes)
     {
-        Trinity::NormalizeMapCoord(waypoint.x);
-        Trinity::NormalizeMapCoord(waypoint.y);
-        waypoint.moveType = _run ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
+        Trinity::NormalizeMapCoord(waypoint.X);
+        Trinity::NormalizeMapCoord(waypoint.Y);
+        waypoint.MoveType = _run ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
     }
 
     GetScript()->SetPathId(entry);
@@ -190,7 +190,7 @@ void SmartAI::StopPath(uint32 DespawnTime, uint32 quest, bool fail)
 void SmartAI::EndPath(bool fail)
 {
     RemoveEscortState(SMART_ESCORT_ESCORTING | SMART_ESCORT_PAUSED | SMART_ESCORT_RETURNING);
-    _path.nodes.clear();
+    _path.Nodes.clear();
     _waypointPauseTimer = 0;
 
     if (_escortNPCFlags)
@@ -374,7 +374,7 @@ void SmartAI::WaypointReached(uint32 nodeId, uint32 pathId)
     }
     else if (HasEscortState(SMART_ESCORT_ESCORTING) && me->GetMotionMaster()->GetCurrentMovementGeneratorType() == WAYPOINT_MOTION_TYPE)
     {
-        if (_currentWaypointNode == _path.nodes.size())
+        if (_currentWaypointNode == _path.Nodes.size())
             _waypointPathEnded = true;
         else
             SetRun(_run);
@@ -752,7 +752,7 @@ void SmartAI::SetRun(bool run)
 {
     me->SetWalk(!run);
     _run = run;
-    for (auto& node : _path.nodes)
+    for (auto& node : _path.Nodes)
         node.moveType = run ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
 }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2041,17 +2041,17 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                         for (uint32 pathId : waypoints)
                         {
                             WaypointPath const* path = sSmartWaypointMgr->GetPath(pathId);
-                            if (!path || path->nodes.empty())
+                            if (!path || path->Nodes.empty())
                                 continue;
 
-                            for (WaypointNode const& waypoint : path->nodes)
+                            for (WaypointNode const& waypoint : path->Nodes)
                             {
-                                float distamceToThisNode = creature->GetDistance(waypoint.x, waypoint.y, waypoint.z);
+                                float distamceToThisNode = creature->GetDistance(waypoint.X, waypoint.Y, waypoint.Z);
                                 if (distamceToThisNode < distanceToClosest)
                                 {
                                     distanceToClosest = distamceToThisNode;
                                     closest.first = pathId;
-                                    closest.second = waypoint.id;
+                                    closest.second = waypoint.Id;
                                 }
                             }
                         }

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -98,8 +98,8 @@ void SmartWaypointMgr::LoadFromDB()
         ++lastId;
 
         WaypointPath& path = _waypointStore[entry];
-        path.id = entry;
-        path.nodes.emplace_back(id, x, y, z, o, delay);
+        path.Id = entry;
+        path.Nodes.emplace_back(id, x, y, z, o, delay);
 
         lastEntry = entry;
         ++total;
@@ -1849,7 +1849,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_WP_START:
         {
             WaypointPath const* path = sSmartWaypointMgr->GetPath(e.action.wpStart.pathID);
-            if (!path || path->nodes.empty())
+            if (!path || path->Nodes.empty())
             {
                 TC_LOG_ERROR("sql.sql", "SmartAIMgr: Creature " SI64FMTD " Event %u Action %u uses non-existent WaypointPath id %u, skipped.", e.entryOrGuid, e.event_id, e.GetActionType(), e.action.wpStart.pathID);
                 return false;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -81,10 +81,14 @@ void SmartWaypointMgr::LoadFromDB()
         float x = fields[2].GetFloat();
         float y = fields[3].GetFloat();
         float z = fields[4].GetFloat();
+
         Optional<float> o;
         if (!fields[5].IsNull())
             o = fields[5].GetFloat();
-        uint32 delay = fields[6].GetUInt32();
+
+        float velocity = fields[6].GetFloat();
+        uint32 delay = fields[7].GetUInt32();
+        bool smoothTransition = fields[8].GetBool();
 
         if (lastEntry != entry)
         {
@@ -99,7 +103,7 @@ void SmartWaypointMgr::LoadFromDB()
 
         WaypointPath& path = _waypointStore[entry];
         path.Id = entry;
-        path.Nodes.emplace_back(id, x, y, z, o, delay);
+        path.Nodes.emplace_back(id, x, y, z, o, velocity, delay, smoothTransition);
 
         lastEntry = entry;
         ++total;

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -1103,7 +1103,7 @@ void MotionMaster::MovePath(uint32 pathId, bool repeatable)
 
 void MotionMaster::MovePath(WaypointPath& path, bool repeatable)
 {
-    TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MovePath: '%s', starts moving over path Id: %u (repeatable: %s)", _owner->GetGUID().ToString().c_str(), path.id, repeatable ? "YES" : "NO");
+    TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MovePath: '%s', starts moving over path Id: %u (repeatable: %s)", _owner->GetGUID().ToString().c_str(), path.Id, repeatable ? "YES" : "NO");
     Add(new WaypointMovementGenerator<Creature>(path, repeatable), MOTION_SLOT_DEFAULT);
 }
 

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -86,15 +86,15 @@ void WaypointMovementGenerator<Creature>::Resume(uint32 overrideTimer/* = 0*/)
 bool WaypointMovementGenerator<Creature>::GetResetPosition(Unit* /*owner*/, float& x, float& y, float& z)
 {
     // prevent a crash at empty waypoint path.
-    if (!_path || _path->nodes.empty())
+    if (!_path || _path->Nodes.empty())
         return false;
 
-    ASSERT(_currentNode < _path->nodes.size(), "WaypointMovementGenerator::GetResetPosition: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->id);
-    WaypointNode const &waypoint = _path->nodes.at(_currentNode);
+    ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::GetResetPosition: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
+    WaypointNode const &waypoint = _path->Nodes.at(_currentNode);
 
-    x = waypoint.x;
-    y = waypoint.y;
-    z = waypoint.z;
+    x = waypoint.X;
+    y = waypoint.Y;
+    z = waypoint.Z;
     return true;
 }
 
@@ -136,7 +136,7 @@ bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* owner, uint32 diff)
     if (!owner || !owner->IsAlive())
         return true;
 
-    if (HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED | MOVEMENTGENERATOR_FLAG_PAUSED) || !_path || _path->nodes.empty())
+    if (HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED | MOVEMENTGENERATOR_FLAG_PAUSED) || !_path || _path->Nodes.empty())
         return true;
 
     if (owner->HasUnitState(UNIT_STATE_NOT_MOVE | UNIT_STATE_LOST_CONTROL) || owner->IsMovementPreventedByCasting())
@@ -237,38 +237,38 @@ void WaypointMovementGenerator<Creature>::MovementInform(Creature* owner)
 
 void WaypointMovementGenerator<Creature>::OnArrived(Creature* owner)
 {
-    if (!_path || _path->nodes.empty())
+    if (!_path || _path->Nodes.empty())
         return;
 
-    ASSERT(_currentNode < _path->nodes.size(), "WaypointMovementGenerator::OnArrived: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->id);
-    WaypointNode const &waypoint = _path->nodes.at(_currentNode);
-    if (waypoint.delay)
+    ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::OnArrived: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
+    WaypointNode const &waypoint = _path->Nodes.at(_currentNode);
+    if (waypoint.Delay)
     {
         owner->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
-        _nextMoveTime.Reset(waypoint.delay);
+        _nextMoveTime.Reset(waypoint.Delay);
     }
 
-    if (waypoint.eventId && urand(0, 99) < waypoint.eventChance)
+    if (waypoint.EventId && urand(0, 99) < waypoint.EventChance)
     {
-        TC_LOG_DEBUG("maps.script", "Creature movement start script %u at point %u for %s.", waypoint.eventId, _currentNode, owner->GetGUID().ToString().c_str());
+        TC_LOG_DEBUG("maps.script", "Creature movement start script %u at point %u for %s.", waypoint.EventId, _currentNode, owner->GetGUID().ToString().c_str());
         owner->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
-        owner->GetMap()->ScriptsStart(sWaypointScripts, waypoint.eventId, owner, nullptr);
+        owner->GetMap()->ScriptsStart(sWaypointScripts, waypoint.EventId, owner, nullptr);
     }
 
     // inform AI
     if (CreatureAI* AI = owner->AI())
     {
         AI->MovementInform(WAYPOINT_MOTION_TYPE, _currentNode);
-        AI->WaypointReached(waypoint.id, _path->id);
+        AI->WaypointReached(waypoint.Id, _path->Id);
     }
 
-    owner->UpdateCurrentWaypointInfo(waypoint.id, _path->id);
+    owner->UpdateCurrentWaypointInfo(waypoint.Id, _path->Id);
 }
 
 void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaunch/* = false*/)
 {
     // sanity checks
-    if (!owner || !owner->IsAlive() || HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED) || !_path || _path->nodes.empty() || (relaunch && (HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED) || !HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED))))
+    if (!owner || !owner->IsAlive() || HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED) || !_path || _path->Nodes.empty() || (relaunch && (HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED) || !HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED))))
         return;
 
     if (owner->HasUnitState(UNIT_STATE_NOT_MOVE) || owner->IsMovementPreventedByCasting() || (owner->IsFormationLeader() && !owner->IsFormationLeaderMoveAllowed())) // if cannot move OR cannot move because of formation
@@ -283,18 +283,18 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
     {
         if (ComputeNextNode())
         {
-            ASSERT(_currentNode < _path->nodes.size(), "WaypointMovementGenerator::StartMove: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->id);
+            ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::StartMove: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
 
             // inform AI
             if (CreatureAI* AI = owner->AI())
-                AI->WaypointStarted(_path->nodes[_currentNode].id, _path->id);
+                AI->WaypointStarted(_path->Nodes[_currentNode].Id, _path->Id);
         }
         else
         {
-            WaypointNode const &waypoint = _path->nodes[_currentNode];
-            float x = waypoint.x;
-            float y = waypoint.y;
-            float z = waypoint.z;
+            WaypointNode const &waypoint = _path->Nodes[_currentNode];
+            float x = waypoint.X;
+            float y = waypoint.Y;
+            float z = waypoint.Z;
             float o = owner->GetOrientation();
 
             if (!transportPath)
@@ -315,7 +315,7 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
 
             // inform AI
             if (CreatureAI* AI = owner->AI())
-                AI->WaypointPathEnded(waypoint.id, _path->id);
+                AI->WaypointPathEnded(waypoint.Id, _path->Id);
             return;
         }
     }
@@ -325,11 +325,11 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
 
         // inform AI
         if (CreatureAI* AI = owner->AI())
-            AI->WaypointStarted(_path->nodes[_currentNode].id, _path->id);
+            AI->WaypointStarted(_path->Nodes[_currentNode].Id, _path->Id);
     }
 
-    ASSERT(_currentNode < _path->nodes.size(), "WaypointMovementGenerator::StartMove: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->id);
-    WaypointNode const &waypoint = _path->nodes[_currentNode];
+    ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::StartMove: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
+    WaypointNode const &waypoint = _path->Nodes[_currentNode];
 
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED | MOVEMENTGENERATOR_FLAG_TIMED_PAUSED);
 
@@ -343,12 +343,12 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
 
     //! Do not use formationDest here, MoveTo requires transport offsets due to DisableTransportPathTransformations() call
     //! but formationDest contains global coordinates
-    init.MoveTo(waypoint.x, waypoint.y, waypoint.z);
+    init.MoveTo(waypoint.X, waypoint.Y, waypoint.Z);
 
-    if (waypoint.orientation.has_value() && waypoint.delay > 0)
-        init.SetFacing(*waypoint.orientation);
+    if (waypoint.Orientation.has_value() && waypoint.Delay > 0)
+        init.SetFacing(*waypoint.Orientation);
 
-    switch (waypoint.moveType)
+    switch (waypoint.MoveType)
     {
         case WAYPOINT_MOVE_TYPE_LAND:
             init.SetAnimation(AnimTier::Ground);
@@ -366,6 +366,9 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
             break;
     }
 
+    if (waypoint.Velocity > 0.f)
+        init.SetVelocity(waypoint.Velocity);
+
     init.Launch();
 
     // inform formation
@@ -374,10 +377,10 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
 
 bool WaypointMovementGenerator<Creature>::ComputeNextNode()
 {
-    if ((_currentNode == _path->nodes.size() - 1) && !_repeating)
+    if ((_currentNode == _path->Nodes.size() - 1) && !_repeating)
         return false;
 
-    _currentNode = (_currentNode + 1) % _path->nodes.size();
+    _currentNode = (_currentNode + 1) % _path->Nodes.size();
     return true;
 }
 

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -19,6 +19,7 @@
 #include "Creature.h"
 #include "CreatureAI.h"
 #include "Errors.h"
+#include "G3DPosition.hpp"
 #include "Log.h"
 #include "Map.h"
 #include "MovementDefines.h"
@@ -29,7 +30,8 @@
 #include "WaypointManager.h"
 #include <sstream>
 
-WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bool repeating) : _nextMoveTime(0), _pathId(pathId), _repeating(repeating), _loadedFromDB(true)
+WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bool repeating) : _lastSplineId(0), _pathId(pathId), _waypointDelay(0), _pauseTime(0),
+_waypointReached(true), _recalculateSpeed(false), _repeating(repeating), _loadedFromDB(true), _stalled(false), _hasBeenStalled(false), _done(false)
 {
     Mode = MOTION_MODE_DEFAULT;
     Priority = MOTION_PRIORITY_NORMAL;
@@ -37,7 +39,8 @@ WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bo
     BaseUnitState = UNIT_STATE_ROAMING;
 }
 
-WaypointMovementGenerator<Creature>::WaypointMovementGenerator(WaypointPath& path, bool repeating) : _nextMoveTime(0), _pathId(0), _repeating(repeating), _loadedFromDB(false)
+WaypointMovementGenerator<Creature>::WaypointMovementGenerator(WaypointPath& path, bool repeating) : _lastSplineId(0), _pathId(0), _waypointDelay(0), _pauseTime(0),
+_waypointReached(true), _recalculateSpeed(false), _repeating(repeating), _loadedFromDB(false), _stalled(false), _hasBeenStalled(false), _done(false)
 {
     _path = &path;
 
@@ -52,45 +55,14 @@ MovementGeneratorType WaypointMovementGenerator<Creature>::GetMovementGeneratorT
     return WAYPOINT_MOTION_TYPE;
 }
 
-void WaypointMovementGenerator<Creature>::Pause(uint32 timer/* = 0*/)
-{
-    if (timer)
-    {
-        // Don't try to paused an already paused generator
-        if (HasFlag(MOVEMENTGENERATOR_FLAG_PAUSED))
-            return;
-
-        AddFlag(MOVEMENTGENERATOR_FLAG_TIMED_PAUSED);
-        _nextMoveTime.Reset(timer);
-        RemoveFlag(MOVEMENTGENERATOR_FLAG_PAUSED);
-    }
-    else
-    {
-        AddFlag(MOVEMENTGENERATOR_FLAG_PAUSED);
-        _nextMoveTime.Reset(1); // Needed so that Update does not behave as if node was reached
-        RemoveFlag(MOVEMENTGENERATOR_FLAG_TIMED_PAUSED);
-    }
-}
-
-void WaypointMovementGenerator<Creature>::Resume(uint32 overrideTimer/* = 0*/)
-{
-    if (overrideTimer)
-        _nextMoveTime.Reset(overrideTimer);
-
-    if (_nextMoveTime.Passed())
-        _nextMoveTime.Reset(1); // Needed so that Update does not behave as if node was reached
-
-    RemoveFlag(MOVEMENTGENERATOR_FLAG_PAUSED);
-}
-
 bool WaypointMovementGenerator<Creature>::GetResetPosition(Unit* /*owner*/, float& x, float& y, float& z)
 {
-    // prevent a crash at empty waypoint path.
+    // Prevent a crash at empty waypoint path.
     if (!_path || _path->Nodes.empty())
         return false;
 
     ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::GetResetPosition: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
-    WaypointNode const &waypoint = _path->Nodes.at(_currentNode);
+    WaypointNode const& waypoint = _path->Nodes.at(_currentNode);
 
     x = waypoint.X;
     y = waypoint.Y;
@@ -100,6 +72,8 @@ bool WaypointMovementGenerator<Creature>::GetResetPosition(Unit* /*owner*/, floa
 
 void WaypointMovementGenerator<Creature>::DoInitialize(Creature* owner)
 {
+    _done = false;
+
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
     if (_loadedFromDB)
@@ -112,101 +86,107 @@ void WaypointMovementGenerator<Creature>::DoInitialize(Creature* owner)
 
     if (!_path)
     {
+        // No path id found for entry.
         TC_LOG_ERROR("sql.sql", "WaypointMovementGenerator::DoInitialize: couldn't load path for creature (%s) (_pathId: %u)", owner->GetGUID().ToString().c_str(), _pathId);
         return;
     }
 
-    owner->StopMoving();
+    // Determine our first waypoint that we want to approach.
+    if (CreatureData const* creatureData = owner->GetCreatureData())
+    {
+        if (_path->Nodes.size() > creatureData->currentwaypoint)
+        {
+            owner->UpdateCurrentWaypointInfo(creatureData->currentwaypoint, _path->Id);
+            _currentNode = creatureData->currentwaypoint;
+        }
+    }
 
-    _nextMoveTime.Reset(1000);
+    // Inform AI.
+    if (CreatureAI* AI = owner->AI())
+        AI->WaypointPathStarted(_path->Id);
 }
 
 void WaypointMovementGenerator<Creature>::DoReset(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    owner->StopMoving();
-
-    if (!HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED) && _nextMoveTime.Passed())
-        _nextMoveTime.Reset(1); // Needed so that Update does not behave as if node was reached
+    // We did not reach our last waypoint before reset, treat this scenario as resuming movement.
+    if (!_done && !_waypointReached)
+        _hasBeenStalled = true;
+    else if (_done)
+    {
+        // Mimic IdleMovementGenerator.
+        if (!owner->IsStopped())
+            owner->StopMoving();
+    }
 }
 
 bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* owner, uint32 diff)
 {
+    // Creature has died. Do not update anymore.
     if (!owner || !owner->IsAlive())
         return true;
 
-    if (HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED | MOVEMENTGENERATOR_FLAG_PAUSED) || !_path || _path->Nodes.empty())
+    // The creature has completed its waypoint path or the path is no longer available.
+    if (_done || !_path || _path->Nodes.empty())
         return true;
 
-    if (owner->HasUnitState(UNIT_STATE_NOT_MOVE | UNIT_STATE_LOST_CONTROL) || owner->IsMovementPreventedByCasting())
+    // Creature is not moving but has a delay between the current and the next delay.
+    if (owner->movespline->Finalized())
+        if (_waypointDelay > 0)
+            _waypointDelay -= diff;
+
+    // Creature's movement has been paused.
+    if (_pauseTime > 0)
+        _pauseTime -= diff;
+
+    // Creature cannot move at the moment. Stop movement and hold further updates until the creature can move again.
+    if (!IsAllowedToMove(owner))
     {
-        AddFlag(MOVEMENTGENERATOR_FLAG_INTERRUPTED);
+        _hasBeenStalled = !_waypointReached;
         owner->StopMoving();
         return true;
     }
 
-    if (HasFlag(MOVEMENTGENERATOR_FLAG_INTERRUPTED))
+    // There is no way that this should ever happen, but just in case.
+    if (_path->Nodes.size() - 1 < _currentNode)
+        return true;
+
+    WaypointNode const& waypoint = _path->Nodes.at(_currentNode);
+
+    // Basic check for launching a new spline. Creature is no longer moving or is about to smoothly transition from one spline to another.
+    bool shouldLaunchNextSpline = [&]()
     {
-        /*
-         *  relaunch only if
-         *  - has a tiner? -> was it interrupted while not waiting aka moving? need to check both:
-         *      -> has a timer - is it because its waiting to start next node?
-         *      -> has a timer - is it because something set it while moving (like timed pause)?
-         *
-         *  - doesnt have a timer? -> is movement valid?
-         *
-         *  TODO: ((_nextMoveTime.Passed() && VALID_MOVEMENT) || (!_nextMoveTime.Passed() && !HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED)))
-         */
-        if (HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED) && (_nextMoveTime.Passed() || !HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED)))
-        {
-            StartMove(owner, true);
+        if (owner->movespline->Finalized())
             return true;
-        }
 
-        RemoveFlag(MOVEMENTGENERATOR_FLAG_INTERRUPTED);
-    }
+        if (waypoint.SmoothTransition && owner->movespline->MaxPathIdx() >= 1 && owner->movespline->currentPathIdx() >= owner->movespline->MaxPathIdx() - 1)
+            return true;
 
-    // if it's moving
+        return false;
+    }();
+
+    // Inform AI hooks that we have arrived at our transition point.
+    if (shouldLaunchNextSpline && !_waypointReached && !_hasBeenStalled)
+        ProcessWaypointArrival(owner, waypoint);
+
+    // Waypoint is a one-way path and has been completed. No further actions needed.
+    if (_done)
+        return true;
+
+    bool hasToRelaunchSpline = _hasBeenStalled || _recalculateSpeed;
+
+    // Creature cannot launch a new spline yet. There is still a delay that needs to expire.
+    if (!hasToRelaunchSpline && _waypointDelay > 0)
+        return true;
+
+    if (shouldLaunchNextSpline || hasToRelaunchSpline)
+        StartMove(owner, hasToRelaunchSpline);
+
+    // Set home position to current position.
     if (!owner->movespline->Finalized())
-    {
-        // set home position at place (every MotionMaster::UpdateMotion)
         if (owner->GetTransGUID().IsEmpty())
             owner->SetHomePosition(owner->GetPosition());
-
-        // relaunch movement if its speed has changed
-        if (HasFlag(MOVEMENTGENERATOR_FLAG_SPEED_UPDATE_PENDING))
-            StartMove(owner, true);
-    }
-    else if (!_nextMoveTime.Passed()) // it's not moving, is there a timer?
-    {
-        if (UpdateTimer(diff))
-        {
-            if (!HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED)) // initial movement call
-            {
-                StartMove(owner);
-                return true;
-            }
-            else if (!HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED)) // timer set before node was reached, resume now
-            {
-                StartMove(owner, true);
-                return true;
-            }
-        }
-        else
-            return true; // keep waiting
-    }
-    else // not moving, no timer
-    {
-        if (HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED) && !HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED))
-        {
-            OnArrived(owner); // hooks and wait timer reset (if necessary)
-            AddFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED); // signals to future StartMove that it reached a node
-        }
-
-        if (_nextMoveTime.Passed()) // OnArrived might have set a timer
-            StartMove(owner); // check path status, get next point and move if necessary & can
-    }
 
     return true;
 }
@@ -217,35 +197,74 @@ void WaypointMovementGenerator<Creature>::DoDeactivate(Creature* owner)
     owner->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
 }
 
-void WaypointMovementGenerator<Creature>::DoFinalize(Creature* owner, bool active, bool/* movementInform*/)
+void WaypointMovementGenerator<Creature>::DoFinalize(Creature* owner, bool active, bool /*movementInform*/)
 {
     AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
     if (active)
     {
         owner->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
-
-        // TODO: Research if this modification is needed, which most likely isnt
         owner->SetWalk(false);
     }
 }
 
-void WaypointMovementGenerator<Creature>::MovementInform(Creature* owner)
+void WaypointMovementGenerator<Creature>::Pause(uint32 timer /*= 0*/)
 {
-    if (owner->AI())
-        owner->AI()->MovementInform(WAYPOINT_MOTION_TYPE, _currentNode);
+    _stalled = timer ? false : true;
+    _hasBeenStalled = !_waypointReached;
+    _pauseTime = timer;
 }
 
-void WaypointMovementGenerator<Creature>::OnArrived(Creature* owner)
+void WaypointMovementGenerator<Creature>::Resume(uint32 overrideTimer /*= 0*/)
+{
+    _hasBeenStalled = !_waypointReached;
+    _stalled = false;
+    if (overrideTimer)
+        _pauseTime = overrideTimer;
+}
+
+bool WaypointMovementGenerator<Creature>::IsAllowedToMove(Creature* owner)
+{
+    return (!_stalled && _pauseTime <= 0 && !owner->HasUnitState(UNIT_STATE_NOT_MOVE) && !owner->IsMovementPreventedByCasting());
+}
+
+void WaypointMovementGenerator<Creature>::ProcessWaypointArrival(Creature* owner, WaypointNode const& waypoint)
 {
     if (!_path || _path->Nodes.empty())
         return;
 
-    ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::OnArrived: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
-    WaypointNode const &waypoint = _path->Nodes.at(_currentNode);
-    if (waypoint.Delay)
-    {
+    if (waypoint.Delay > 0)
         owner->ClearUnitState(UNIT_STATE_ROAMING_MOVE);
-        _nextMoveTime.Reset(waypoint.Delay);
+
+    bool const useTransportPath = !owner->GetTransGUID().IsEmpty();
+
+    // Check if the waypoint path has reached its end and may not repeat. Inform AI and update home position.
+    if ((_currentNode == _path->Nodes.size() - 1) && !_repeating && !_done)
+    {
+        WaypointNode const& waypoint = _path->Nodes.at(_currentNode);
+        float x = waypoint.X;
+        float y = waypoint.Y;
+        float z = waypoint.Z;
+        float o = owner->GetOrientation();
+
+        if (!useTransportPath)
+            owner->SetHomePosition(x, y, z, o);
+        else
+        {
+            if (TransportBase* trans = owner->GetTransport())
+            {
+                o -= trans->GetTransportOrientation();
+                owner->SetTransportHomePosition(x, y, z, o);
+                trans->CalculatePassengerPosition(x, y, z, &o);
+                owner->SetHomePosition(x, y, z, o);
+            }
+        }
+
+        _done = true;
+        owner->UpdateCurrentWaypointInfo(0, 0);
+
+        // Inform AI that the path has ended.
+        if (CreatureAI* AI = owner->AI())
+            AI->WaypointPathEnded(waypoint.Id, _path->Id);
     }
 
     if (waypoint.EventId && urand(0, 99) < waypoint.EventChance)
@@ -255,95 +274,74 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature* owner)
         owner->GetMap()->ScriptsStart(sWaypointScripts, waypoint.EventId, owner, nullptr);
     }
 
-    // inform AI
+    owner->UpdateCurrentWaypointInfo(waypoint.Id, _path->Id);
+
+    // Inform AI.
     if (CreatureAI* AI = owner->AI())
     {
         AI->MovementInform(WAYPOINT_MOTION_TYPE, _currentNode);
         AI->WaypointReached(waypoint.Id, _path->Id);
     }
 
-    owner->UpdateCurrentWaypointInfo(waypoint.Id, _path->Id);
+    // All hooks called and infos updated. Time to increment the waypoint nodeId.
+    if (_path && !_path->Nodes.empty()) // Ensure that the path has not been changed in one of the hooks.
+        _currentNode = (_currentNode + 1) % _path->Nodes.size();
+
+    _waypointReached = true;
 }
 
-void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaunch/* = false*/)
+void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaunch /*= false*/)
 {
-    // sanity checks
-    if (!owner || !owner->IsAlive() || HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED) || !_path || _path->Nodes.empty() || (relaunch && (HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED) || !HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED))))
-        return;
-
-    if (owner->HasUnitState(UNIT_STATE_NOT_MOVE) || owner->IsMovementPreventedByCasting() || (owner->IsFormationLeader() && !owner->IsFormationLeaderMoveAllowed())) // if cannot move OR cannot move because of formation
+    // Formation checks. Do not launch a new spline when one of our formation members is currently in combat.
+    if (!relaunch)
     {
-        _nextMoveTime.Reset(1000); // delay 1s
-        return;
-    }
-
-    bool const transportPath = !owner->GetTransGUID().IsEmpty();
-
-    if (HasFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED) && HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED))
-    {
-        if (ComputeNextNode())
+        if (!IsAllowedToMove(owner) || (owner->IsFormationLeader() && !owner->IsFormationLeaderMoveAllowed()))
         {
-            ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::StartMove: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
-
-            // inform AI
-            if (CreatureAI* AI = owner->AI())
-                AI->WaypointStarted(_path->Nodes[_currentNode].Id, _path->Id);
-        }
-        else
-        {
-            WaypointNode const &waypoint = _path->Nodes[_currentNode];
-            float x = waypoint.X;
-            float y = waypoint.Y;
-            float z = waypoint.Z;
-            float o = owner->GetOrientation();
-
-            if (!transportPath)
-                owner->SetHomePosition(x, y, z, o);
-            else
-            {
-                if (TransportBase* trans = owner->GetTransport())
-                {
-                    o -= trans->GetTransportOrientation();
-                    owner->SetTransportHomePosition(x, y, z, o);
-                    trans->CalculatePassengerPosition(x, y, z, &o);
-                    owner->SetHomePosition(x, y, z, o);
-                }
-                // else if (vehicle) - this should never happen, vehicle offsets are const
-            }
-            AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
-            owner->UpdateCurrentWaypointInfo(0, 0);
-
-            // inform AI
-            if (CreatureAI* AI = owner->AI())
-                AI->WaypointPathEnded(waypoint.Id, _path->Id);
+            _waypointDelay = 1000;
             return;
         }
     }
-    else if (!HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED))
-    {
-        AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
-        // inform AI
-        if (CreatureAI* AI = owner->AI())
-            AI->WaypointStarted(_path->Nodes[_currentNode].Id, _path->Id);
-    }
-
-    ASSERT(_currentNode < _path->Nodes.size(), "WaypointMovementGenerator::StartMove: tried to reference a node id (%u) which is not included in path (%u)", _currentNode, _path->Id);
-    WaypointNode const &waypoint = _path->Nodes[_currentNode];
-
-    RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED | MOVEMENTGENERATOR_FLAG_TIMED_PAUSED);
-
+    // Now that node selection is done, we build spline data.
     owner->AddUnitState(UNIT_STATE_ROAMING_MOVE);
+    WaypointNode const& waypoint = _path->Nodes.at(_currentNode);
+    bool const useTransportPath = !owner->GetTransGUID().IsEmpty();
 
     Movement::MoveSplineInit init(owner);
-
-    //! If creature is on transport, we assume waypoints set in DB are already transport offsets
-    if (transportPath)
+    // If the creature is on transport, we assume waypoints set in DB are already transport offsets.
+    if (useTransportPath)
         init.DisableTransportPathTransformations();
 
-    //! Do not use formationDest here, MoveTo requires transport offsets due to DisableTransportPathTransformations() call
-    //! but formationDest contains global coordinates
-    init.MoveTo(waypoint.X, waypoint.Y, waypoint.Z);
+    // Determining if we have pre-set spline points in database. Use database data when present, otherwise do own calculations (custom and legacy support).
+    if (!waypoint.SplinePoints.empty())
+    {
+        // We have spline points in waypoint_data_addon table so instead of calculating a path, we append the db side spline points and run that one instead.
+        int32 splineIndex = 0;
+
+        std::vector<G3D::Vector3>::const_iterator itr = waypoint.SplinePoints.begin();
+        if (splineIndex)
+            std::advance(itr, splineIndex);
+
+        init.Path().reserve(waypoint.SplinePoints.size() - splineIndex);
+        std::copy(itr, waypoint.SplinePoints.end(), std::back_inserter(init.Path()));
+
+        // Spline points are appended. Now add our starting vertex and destination to the path and we're good to go.
+        init.Path().insert(init.Path().begin(), PositionToVector3(owner->GetPosition()));
+        init.Path().insert(init.Path().end(), PositionToVector3({ waypoint.X, waypoint.Y, waypoint.Z }));
+    }
+    else
+    {
+        // We have no db spline points, so we are going to fall back to default waypoint behaivior.
+        if (waypoint.SmoothTransition && !owner->movespline->Finalized() && _lastSplineId == owner->movespline->GetId())
+        {
+            // We are still running our previous waypoint spline. Use its final destination as starting point for our next path.
+            init.MoveTo(owner->movespline->FinalDestination(), PositionToVector3({ waypoint.X, waypoint.Y, waypoint.Z }));
+            if (!init.Path().empty())
+                init.Path().insert(init.Path().begin(), PositionToVector3(owner->GetPosition()));
+        }
+        else
+            init.MoveTo(waypoint.X, waypoint.Y, waypoint.Z);
+    }
 
     if (waypoint.Orientation.has_value() && waypoint.Delay > 0)
         init.SetFacing(*waypoint.Orientation);
@@ -366,22 +364,33 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* owner, bool relaun
             break;
     }
 
+    if (owner->CanFly())
+    {
+        init.SetFly();
+        init.SetSmooth();
+        init.SetUncompressed();
+    }
+
     if (waypoint.Velocity > 0.f)
         init.SetVelocity(waypoint.Velocity);
 
     init.Launch();
+    _waypointDelay = waypoint.Delay;
 
-    // inform formation
+    if (!owner->movespline->Finalized())
+        _lastSplineId = owner->movespline->GetId();
+
+    // Inform formation.
     owner->SignalFormationMovement();
-}
 
-bool WaypointMovementGenerator<Creature>::ComputeNextNode()
-{
-    if ((_currentNode == _path->Nodes.size() - 1) && !_repeating)
-        return false;
+    // Inform AI.
+    if (!relaunch)
+        if (CreatureAI* AI = owner->AI())
+            AI->WaypointStarted(waypoint.Id, _path->Id);
 
-    _currentNode = (_currentNode + 1) % _path->Nodes.size();
-    return true;
+    _waypointReached = false;
+    _recalculateSpeed = false;
+    _hasBeenStalled = false;
 }
 
 std::string WaypointMovementGenerator<Creature>::GetDebugInfo() const

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
@@ -24,6 +24,7 @@
 
 class Creature;
 class Unit;
+struct WaypointNode;
 struct WaypointPath;
 
 template<class T>
@@ -35,6 +36,7 @@ class WaypointMovementGenerator<Creature> : public MovementGeneratorMedium<Creat
     public:
         explicit WaypointMovementGenerator(uint32 pathId = 0, bool repeating = true);
         explicit WaypointMovementGenerator(WaypointPath& path, bool repeating = true);
+
         ~WaypointMovementGenerator() { _path = nullptr; }
 
         MovementGeneratorType GetMovementGeneratorType() const override;
@@ -53,25 +55,21 @@ class WaypointMovementGenerator<Creature> : public MovementGeneratorMedium<Creat
         std::string GetDebugInfo() const override;
 
     private:
-        void MovementInform(Creature*);
-        void OnArrived(Creature*);
+        void ProcessWaypointArrival(Creature*, WaypointNode const&);
         void StartMove(Creature*, bool relaunch = false);
-        bool ComputeNextNode();
-        bool UpdateTimer(uint32 diff)
-        {
-            _nextMoveTime.Update(diff);
-            if (_nextMoveTime.Passed())
-            {
-                _nextMoveTime.Reset(0);
-                return true;
-            }
-            return false;
-        }
+        bool IsAllowedToMove(Creature*);
 
-        TimeTracker _nextMoveTime;
+        uint32 _lastSplineId;
         uint32 _pathId;
+        int32 _waypointDelay;
+        int32 _pauseTime;
+        bool _waypointReached;
+        bool _recalculateSpeed;
         bool _repeating;
         bool _loadedFromDB;
+        bool _stalled;
+        bool _hasBeenStalled;
+        bool _done;
 };
 
 #endif

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -72,7 +72,7 @@ bool PathGenerator::CalculatePath(G3D::Vector3 const& startPoint, G3D::Vector3 c
 
     _forceDestination = forceDest;
 
-    TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::CalculatePath() for %u", _source->GetGUID().GetCounter());
+    TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::CalculatePath() for %u", _source->GetGUID().ToString().c_str());
     // Let's make sure navMesh works. We can run on map without mmaps.
     // Check if the start and end point have a .mmtile loaded (can we pass via not loaded tile on the way?).
     const Unit* _sourceUnit = _source->ToUnit();

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -72,7 +72,7 @@ bool PathGenerator::CalculatePath(G3D::Vector3 const& startPoint, G3D::Vector3 c
 
     _forceDestination = forceDest;
 
-    TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::CalculatePath() for %u", _source->GetGUID().ToString().c_str());
+    TC_LOG_DEBUG("maps.mmaps", "++ PathGenerator::CalculatePath() for %s", _source->GetGUID().ToString().c_str());
     // Let's make sure navMesh works. We can run on map without mmaps.
     // Check if the start and end point have a .mmtile loaded (can we pass via not loaded tile on the way?).
     const Unit* _sourceUnit = _source->ToUnit();

--- a/src/server/game/Movement/PathGenerator.h
+++ b/src/server/game/Movement/PathGenerator.h
@@ -66,7 +66,7 @@ class TC_GAME_API PathGenerator
         // Calculate the path from owner to given destination
         // return: true if new path was calculated, false otherwise (no change needed)
         bool CalculatePath(float destX, float destY, float destZ, bool forceDest = false);
-        // Calculates the path from start point to given destination
+        // Calculates the path from start point to given destination.
         bool CalculatePath(G3D::Vector3 const& startPoint, G3D::Vector3 const& endPoint, bool forceDest = false);
         bool IsInvalidDestinationZ(WorldObject const* target) const;
 

--- a/src/server/game/Movement/PathGenerator.h
+++ b/src/server/game/Movement/PathGenerator.h
@@ -66,6 +66,8 @@ class TC_GAME_API PathGenerator
         // Calculate the path from owner to given destination
         // return: true if new path was calculated, false otherwise (no change needed)
         bool CalculatePath(float destX, float destY, float destZ, bool forceDest = false);
+        // Calculates the path from start point to given destination
+        bool CalculatePath(G3D::Vector3 const& startPoint, G3D::Vector3 const& endPoint, bool forceDest = false);
         bool IsInvalidDestinationZ(WorldObject const* target) const;
 
         // option setters - use optional

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -140,6 +140,7 @@ namespace Movement
         Vector3 const& FinalDestination() const { return Initialized() ? spline.getPoint(spline.last()) : Vector3::zero(); }
         Vector3 const& CurrentDestination() const { return Initialized() ? spline.getPoint(point_Idx + 1) : Vector3::zero(); }
         int32 currentPathIdx() const;
+        int32 MaxPathIdx() const { return spline.last() - 1; }
 
         Optional<AnimTier> GetAnimation() const { return anim_tier ? anim_tier->AnimTier : Optional<AnimTier>{}; }
 

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -17,6 +17,7 @@
 
 #include "MoveSplineInit.h"
 #include "Creature.h"
+#include "G3DPosition.hpp"
 #include "MovementPackets.h"
 #include "MoveSpline.h"
 #include "PathGenerator.h"
@@ -248,28 +249,32 @@ namespace Movement
         std::transform(controls.begin(), controls.end(), std::back_inserter(args.path), TransportPathTransform(unit, args.TransformForTransport));
     }
 
-    void MoveSplineInit::MoveTo(float x, float y, float z, bool generatePath, bool forceDestination)
-    {
-        MoveTo(G3D::Vector3(x, y, z), generatePath, forceDestination);
-    }
-
-    void MoveSplineInit::MoveTo(Vector3 const& dest, bool generatePath, bool forceDestination)
+    void MoveSplineInit::MoveTo(Vector3 const& start, Vector3 const& dest, bool generatePath, bool forceDestination)
     {
         if (generatePath)
         {
             PathGenerator path(unit);
-            bool result = path.CalculatePath(dest.x, dest.y, dest.z, forceDestination);
+            bool result = path.CalculatePath(start, dest, forceDestination);
             if (result && !(path.GetPathType() & PATHFIND_NOPATH))
             {
                 MovebyPath(path.GetPath());
                 return;
             }
         }
-
         args.path_Idx_offset = 0;
         args.path.resize(2);
         TransportPathTransform transform(unit, args.TransformForTransport);
         args.path[1] = transform(dest);
+    }
+
+    void MoveSplineInit::MoveTo(float x, float y, float z, bool generatePath, bool forceDestination)
+    {
+        MoveTo(PositionToVector3(unit->GetPosition()), G3D::Vector3(x, y, z), generatePath, forceDestination);
+    }
+
+    void MoveSplineInit::MoveTo(Vector3 const& dest, bool generatePath, bool forceDestination)
+    {
+        MoveTo(PositionToVector3(unit->GetPosition()), dest, generatePath, forceDestination);
     }
 
     void MoveSplineInit::SetFall()

--- a/src/server/game/Movement/Spline/MoveSplineInit.h
+++ b/src/server/game/Movement/Spline/MoveSplineInit.h
@@ -97,6 +97,7 @@ namespace Movement
 
         /* Initializes simple A to B motion, A is current unit's position, B is destination
          */
+        void MoveTo(Vector3 const& start, Vector3 const& destination, bool generatePath = true, bool forceDestination = false);
         void MoveTo(Vector3 const& destination, bool generatePath = true, bool forceDestination = false);
         void MoveTo(float x, float y, float z, bool generatePath = true, bool forceDestination = false);
 

--- a/src/server/game/Movement/Waypoints/WaypointDefines.h
+++ b/src/server/game/Movement/Waypoints/WaypointDefines.h
@@ -34,8 +34,8 @@ enum WaypointMoveType
 
 struct WaypointNode
 {
-    WaypointNode() : Id(0), X(0.f), Y(0.f), Z(0.f), Orientation(0.f), Velocity(0.f), Delay(0), EventId(0), MoveType(WAYPOINT_MOVE_TYPE_RUN), EventChance(0) { }
-    WaypointNode(uint32 id, float x, float y, float z, float orientation = 0.f, float velocity = 0.f, uint32 delay = 0) :
+    WaypointNode() : Id(0), X(0.f), Y(0.f), Z(0.f), Velocity(0.f), Delay(0), EventId(0), MoveType(WAYPOINT_MOVE_TYPE_RUN), EventChance(0) { }
+    WaypointNode(uint32 id, float x, float y, float z, Optional<float> orientation = { }, float velocity = 0.f, uint32 delay = 0) :
         Id(id), X(x), Y(y), Z(z), Orientation(orientation), Velocity(velocity), Delay(delay)
     {
         EventId = 0;

--- a/src/server/game/Movement/Waypoints/WaypointDefines.h
+++ b/src/server/game/Movement/Waypoints/WaypointDefines.h
@@ -19,6 +19,7 @@
 #define TRINITY_WAYPOINTDEFINES_H
 
 #include "Define.h"
+#include "G3D/Vector3.h"
 #include "Optional.h"
 #include <vector>
 
@@ -34,9 +35,9 @@ enum WaypointMoveType
 
 struct WaypointNode
 {
-    WaypointNode() : Id(0), X(0.f), Y(0.f), Z(0.f), Velocity(0.f), Delay(0), EventId(0), MoveType(WAYPOINT_MOVE_TYPE_RUN), EventChance(0) { }
-    WaypointNode(uint32 id, float x, float y, float z, Optional<float> orientation = { }, float velocity = 0.f, uint32 delay = 0) :
-        Id(id), X(x), Y(y), Z(z), Orientation(orientation), Velocity(velocity), Delay(delay)
+    WaypointNode() : Id(0), X(0.f), Y(0.f), Z(0.f), Velocity(0.f), Delay(0), EventId(0), MoveType(WAYPOINT_MOVE_TYPE_RUN), EventChance(0), SmoothTransition(false) { }
+    WaypointNode(uint32 id, float x, float y, float z, Optional<float> orientation = { }, float velocity = 0.f, uint32 delay = 0, bool smoothTransition = false) :
+        Id(id), X(x), Y(y), Z(z), Orientation(orientation), Velocity(velocity), Delay(delay), SmoothTransition(smoothTransition)
     {
         EventId = 0;
         MoveType = WAYPOINT_MOVE_TYPE_WALK;
@@ -51,6 +52,8 @@ struct WaypointNode
     uint32 EventId;
     uint32 MoveType;
     uint8 EventChance;
+    bool SmoothTransition;
+    std::vector<G3D::Vector3> SplinePoints;
 };
 
 struct WaypointPath

--- a/src/server/game/Movement/Waypoints/WaypointDefines.h
+++ b/src/server/game/Movement/Waypoints/WaypointDefines.h
@@ -34,40 +34,36 @@ enum WaypointMoveType
 
 struct WaypointNode
 {
-    WaypointNode() : id(0), x(0.f), y(0.f), z(0.f), delay(0), eventId(0), moveType(WAYPOINT_MOVE_TYPE_RUN), eventChance(0) { }
-    WaypointNode(uint32 _id, float _x, float _y, float _z, Optional<float> _orientation = { }, uint32 _delay = 0)
+    WaypointNode() : Id(0), X(0.f), Y(0.f), Z(0.f), Orientation(0.f), Velocity(0.f), Delay(0), EventId(0), MoveType(WAYPOINT_MOVE_TYPE_RUN), EventChance(0) { }
+    WaypointNode(uint32 id, float x, float y, float z, float orientation = 0.f, float velocity = 0.f, uint32 delay = 0) :
+        Id(id), X(x), Y(y), Z(z), Orientation(orientation), Velocity(velocity), Delay(delay)
     {
-        id = _id;
-        x = _x;
-        y = _y;
-        z = _z;
-        orientation = _orientation;
-        delay = _delay;
-        eventId = 0;
-        moveType = WAYPOINT_MOVE_TYPE_WALK;
-        eventChance = 100;
+        EventId = 0;
+        MoveType = WAYPOINT_MOVE_TYPE_WALK;
+        EventChance = 100;
     }
 
-    uint32 id;
-    float x, y, z;
-    Optional<float> orientation;
-    uint32 delay;
-    uint32 eventId;
-    uint32 moveType;
-    uint8 eventChance;
+    uint32 Id;
+    float X, Y, Z;
+    Optional<float> Orientation;
+    float Velocity;
+    uint32 Delay;
+    uint32 EventId;
+    uint32 MoveType;
+    uint8 EventChance;
 };
 
 struct WaypointPath
 {
-    WaypointPath() : id(0) { }
+    WaypointPath() : Id(0) { }
     WaypointPath(uint32 _id, std::vector<WaypointNode>&& _nodes)
     {
-        id = _id;
-        nodes = _nodes;
+        Id = _id;
+        Nodes = _nodes;
     }
 
-    std::vector<WaypointNode> nodes;
-    uint32 id;
+    std::vector<WaypointNode> Nodes;
+    uint32 Id;
 };
 
 #endif

--- a/src/server/game/Movement/Waypoints/WaypointManager.cpp
+++ b/src/server/game/Movement/Waypoints/WaypointManager.cpp
@@ -24,8 +24,8 @@ void WaypointMgr::Load()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                                0    1         2           3          4            5           6        7        8       9        10
-    QueryResult result = WorldDatabase.Query("SELECT id, point, position_x, position_y, position_z, orientation, velocity, move_type, delay, action, action_chance FROM waypoint_data ORDER BY id, point");
+    //                                                0  1      2           3           4           5            6         7          8      9                 10      11
+    QueryResult result = WorldDatabase.Query("SELECT id, point, position_x, position_y, position_z, orientation, velocity, move_type, delay, smoothTransition, action, action_chance FROM waypoint_data ORDER BY id, point");
 
     if (!result)
     {
@@ -67,8 +67,9 @@ void WaypointMgr::Load()
         }
 
         waypoint.Delay = fields[8].GetUInt32();
-        waypoint.EventId = fields[9].GetUInt32();
-        waypoint.EventChance = fields[10].GetInt16();
+        waypoint.SmoothTransition = fields[9].GetBool();
+        waypoint.EventId = fields[10].GetUInt32();
+        waypoint.EventChance = fields[11].GetInt16();
 
         WaypointPath& path = _waypointStore[pathId];
         path.Id = pathId;
@@ -78,6 +79,63 @@ void WaypointMgr::Load()
     while (result->NextRow());
 
     TC_LOG_INFO("server.loading", ">> Loaded %u waypoints in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
+}
+
+void WaypointMgr::LoadWaypointAddons()
+{
+    uint32 oldMSTime = getMSTime();
+
+    //                                               0       1        2                 3          4          5
+    QueryResult result = WorldDatabase.Query("SELECT PathID, PointID, SplinePointIndex, PositionX, PositionY, PositionZ FROM waypoint_data_addon ORDER BY PathID, PointID, SplinePointIndex");
+
+    if (!result)
+    {
+        TC_LOG_INFO("server.loading", ">> Loaded 0 waypoints. DB table `waypoint_data_addon` is empty!");
+        return;
+    }
+
+    uint32 count = 0;
+
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 pathId = fields[0].GetUInt32();
+
+        std::unordered_map<uint32, WaypointPath>::iterator it = _waypointStore.find(pathId);
+        if (it == _waypointStore.end())
+        {
+            TC_LOG_ERROR("sql.sql", "Tried to load waypoint_data_addon data for PathID %u but there is no such path in waypoint_data. Ignoring.", pathId);
+            continue;
+        }
+
+        WaypointPath& path = it->second;
+        uint32 pointId = fields[1].GetUInt32();
+
+
+        std::vector<WaypointNode>::iterator itr = std::find_if(path.Nodes.begin(), path.Nodes.end(), [pointId](WaypointNode const& node)
+            {
+                return node.Id == pointId;
+            });
+
+        if (itr == path.Nodes.end())
+        {
+            TC_LOG_ERROR("sql.sql", "Tried to load waypoint_data_addon data for PointID %u of PathID %u but there is no such point in waypoint_data. Ignoring.", pointId, pathId);
+            continue;
+        }
+
+        float x = fields[3].GetFloat();
+        float y = fields[4].GetFloat();
+        float z = fields[5].GetFloat();
+
+        Trinity::NormalizeMapCoord(x);
+        Trinity::NormalizeMapCoord(y);
+
+        itr->SplinePoints.push_back(G3D::Vector3(x, y, z));
+
+        ++count;
+    } while (result->NextRow());
+
+    TC_LOG_INFO("server.loading", ">> Loaded %u waypoint addon data in %u ms", count, GetMSTimeDiffToNow(oldMSTime));
 }
 
 WaypointMgr* WaypointMgr::instance()

--- a/src/server/game/Movement/Waypoints/WaypointManager.cpp
+++ b/src/server/game/Movement/Waypoints/WaypointManager.cpp
@@ -24,8 +24,8 @@ void WaypointMgr::Load()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                                0    1         2           3          4            5           6        7      8           9
-    QueryResult result = WorldDatabase.Query("SELECT id, point, position_x, position_y, position_z, orientation, move_type, delay, action, action_chance FROM waypoint_data ORDER BY id, point");
+    //                                                0    1         2           3          4            5           6        7        8       9        10
+    QueryResult result = WorldDatabase.Query("SELECT id, point, position_x, position_y, position_z, orientation, velocity, move_type, delay, action, action_chance FROM waypoint_data ORDER BY id, point");
 
     if (!result)
     {
@@ -45,31 +45,33 @@ void WaypointMgr::Load()
         Optional<float> o;
         if (!fields[5].IsNull())
             o = fields[5].GetFloat();
+        float velocity = fields[6].GetFloat();
 
         Trinity::NormalizeMapCoord(x);
         Trinity::NormalizeMapCoord(y);
 
         WaypointNode waypoint;
-        waypoint.id = fields[1].GetUInt32();
-        waypoint.x = x;
-        waypoint.y = y;
-        waypoint.z = z;
-        waypoint.orientation = o;
-        waypoint.moveType = fields[6].GetUInt32();
+        waypoint.Id = fields[1].GetUInt32();
+        waypoint.X = x;
+        waypoint.Y = y;
+        waypoint.Z = z;
+        waypoint.Orientation = o;
+        waypoint.Velocity = velocity;
+        waypoint.MoveType = fields[7].GetUInt32();
 
-        if (waypoint.moveType >= WAYPOINT_MOVE_TYPE_MAX)
+        if (waypoint.MoveType >= WAYPOINT_MOVE_TYPE_MAX)
         {
-            TC_LOG_ERROR("sql.sql", "Waypoint %u in waypoint_data has invalid move_type, ignoring", waypoint.id);
+            TC_LOG_ERROR("sql.sql", "Waypoint %u in waypoint_data has invalid move_type, ignoring", waypoint.Id);
             continue;
         }
 
-        waypoint.delay = fields[7].GetUInt32();
-        waypoint.eventId = fields[8].GetUInt32();
-        waypoint.eventChance = fields[9].GetInt16();
+        waypoint.Delay = fields[8].GetUInt32();
+        waypoint.EventId = fields[9].GetUInt32();
+        waypoint.EventChance = fields[10].GetInt16();
 
         WaypointPath& path = _waypointStore[pathId];
-        path.id = pathId;
-        path.nodes.push_back(std::move(waypoint));
+        path.Id = pathId;
+        path.Nodes.push_back(std::move(waypoint));
         ++count;
     }
     while (result->NextRow());
@@ -104,35 +106,37 @@ void WaypointMgr::ReloadPath(uint32 id)
         Optional<float> o;
         if (!fields[4].IsNull())
             o = fields[4].GetFloat();
+        float velocity = fields[5].GetFloat();
 
         Trinity::NormalizeMapCoord(x);
         Trinity::NormalizeMapCoord(y);
 
         WaypointNode waypoint;
-        waypoint.id = fields[0].GetUInt32();
-        waypoint.x = x;
-        waypoint.y = y;
-        waypoint.z = z;
-        waypoint.orientation = o;
-        waypoint.moveType = fields[5].GetUInt32();
+        waypoint.Id = fields[0].GetUInt32();
+        waypoint.X = x;
+        waypoint.Y = y;
+        waypoint.Z = z;
+        waypoint.Orientation = o;
+        waypoint.Velocity = velocity;
+        waypoint.MoveType = fields[6].GetUInt32();
 
-        if (waypoint.moveType >= WAYPOINT_MOVE_TYPE_MAX)
+        if (waypoint.MoveType >= WAYPOINT_MOVE_TYPE_MAX)
         {
-            TC_LOG_ERROR("sql.sql", "Waypoint %u in waypoint_data has invalid move_type, ignoring", waypoint.id);
+            TC_LOG_ERROR("sql.sql", "Waypoint %u in waypoint_data has invalid move_type, ignoring", waypoint.Id);
             continue;
         }
 
-        waypoint.delay = fields[6].GetUInt32();
-        waypoint.eventId = fields[7].GetUInt32();
-        waypoint.eventChance = fields[8].GetUInt8();
+        waypoint.Delay = fields[7].GetUInt32();
+        waypoint.EventId = fields[8].GetUInt32();
+        waypoint.EventChance = fields[9].GetUInt8();
 
         values.push_back(std::move(waypoint));
     }
     while (result->NextRow());
 
     WaypointPath& path = _waypointStore[id];
-    path.id = id;
-    path.nodes = std::move(values);
+    path.Id = id;
+    path.Nodes = std::move(values);
 }
 
 WaypointPath const* WaypointMgr::GetPath(uint32 id) const

--- a/src/server/game/Movement/Waypoints/WaypointManager.cpp
+++ b/src/server/game/Movement/Waypoints/WaypointManager.cpp
@@ -45,6 +45,7 @@ void WaypointMgr::Load()
         Optional<float> o;
         if (!fields[5].IsNull())
             o = fields[5].GetFloat();
+
         float velocity = fields[6].GetFloat();
 
         Trinity::NormalizeMapCoord(x);
@@ -106,6 +107,7 @@ void WaypointMgr::ReloadPath(uint32 id)
         Optional<float> o;
         if (!fields[4].IsNull())
             o = fields[4].GetFloat();
+
         float velocity = fields[5].GetFloat();
 
         Trinity::NormalizeMapCoord(x);

--- a/src/server/game/Movement/Waypoints/WaypointManager.cpp
+++ b/src/server/game/Movement/Waypoints/WaypointManager.cpp
@@ -42,6 +42,7 @@ void WaypointMgr::Load()
         float x = fields[2].GetFloat();
         float y = fields[3].GetFloat();
         float z = fields[4].GetFloat();
+
         Optional<float> o;
         if (!fields[5].IsNull())
             o = fields[5].GetFloat();
@@ -111,7 +112,6 @@ void WaypointMgr::LoadWaypointAddons()
         WaypointPath& path = it->second;
         uint32 pointId = fields[1].GetUInt32();
 
-
         std::vector<WaypointNode>::iterator itr = std::find_if(path.Nodes.begin(), path.Nodes.end(), [pointId](WaypointNode const& node)
             {
                 return node.Id == pointId;
@@ -162,6 +162,7 @@ void WaypointMgr::ReloadPath(uint32 id)
         float x = fields[1].GetFloat();
         float y = fields[2].GetFloat();
         float z = fields[3].GetFloat();
+
         Optional<float> o;
         if (!fields[4].IsNull())
             o = fields[4].GetFloat();

--- a/src/server/game/Movement/Waypoints/WaypointManager.h
+++ b/src/server/game/Movement/Waypoints/WaypointManager.h
@@ -27,13 +27,16 @@ class TC_GAME_API WaypointMgr
     public:
         static WaypointMgr* instance();
 
-        // Attempts to reload a single path from database
+        // Attempts to reload a single path from database.
         void ReloadPath(uint32 id);
 
-        // Loads all paths from database, should only run on startup
+        // Loads all base waypoint data from database. Should only be called on startup.
         void Load();
 
-        // Returns the path from a given id
+        // Loads additional path data for waypoints from database. Should only be called on startup.
+        void LoadWaypointAddons();
+
+        // Returns the path from a given Id.
         WaypointPath const* GetPath(uint32 id) const;
 
     private:

--- a/src/server/game/Scripting/ScriptSystem.cpp
+++ b/src/server/game/Scripting/ScriptSystem.cpp
@@ -79,8 +79,8 @@ void SystemMgr::LoadScriptWaypoints()
             TC_LOG_ERROR("sql.sql", "SystemMgr: DB table script_waypoint has waypoint for creature entry %u, but creature does not have ScriptName defined and then useless.", entry);
 
         WaypointPath& path = _waypointStore[entry];
-        path.id = entry;
-        path.nodes.emplace_back(id, x, y, z, std::nullopt, waitTime);
+        path.Id = entry;
+        path.Nodes.emplace_back(id, x, y, z, std::nullopt, waitTime);
 
         ++count;
     } while (result->NextRow());

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2262,6 +2262,9 @@ void World::SetInitialWorldSettings()
     TC_LOG_INFO("server.loading", "Loading Waypoints...");
     sWaypointMgr->Load();
 
+    TC_LOG_INFO("server.loading", "Loading Waypoint Addons...");
+    sWaypointMgr->LoadWaypointAddons();
+
     TC_LOG_INFO("server.loading", "Loading SmartAI Waypoints...");
     sSmartWaypointMgr->LoadFromDB();
 


### PR DESCRIPTION
This implementation is completely cherrypicked from https://github.com/The-Cataclysm-Preservation-Project/TrinityCore branch, meaning I'm not the original author, all credits go to @Ovahlord. You may find the commits used as reference right below:

https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/361ac2292be1f36cc84f674d0079b9d81b372017, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/c20838ceaa5bb5fecda8de332fbe3dfcc09d5224, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/d5f9b8c26f50e2fa085de28d8da1cc4c169ea2ae, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/7f04fb8137e827cdb0c26f0446fc68284a49331e, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/9687131c65585116fa993c708d39989cda42a5d4, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/c7540fc930744f9db2a9e1cc82e606d3307dfed7, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/c20838ceaa5bb5fecda8de332fbe3dfcc09d5224, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/087e7e961aaa7988bacd545797494b290a561add, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/317bc49501b694b04a16dbb1dfb94d24cc6aebe,  https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/82714dfa59cffd0b231c44eb639fd617beeee891, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/c7540fc930744f9db2a9e1cc82e606d3307dfed7, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/317bc49501b694b04a16dbb1dfb94d24cc6aebea, https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/bd3ca6e98aaff9a457a82a98c896e78711ebb289

**Changes proposed:**

* Standardized member naming in WaypointNode and WaypointPath struct.
* Added velocity field to waypoint_data to allow specifying custom speed value for waypoints.
* WaypointMovementGenerator decides when to transition if allowed via a new boolean value (smoothTransition).
* Early transitions will now pick up the ongoing spline destination and start calculating their path from that point on.
* Waypoints may now use DB side-spline pathings in a new DB table to support special spline shapes that are not generated by normal pathfinding (e.g. scripted flight paths).
* WaypointMovementGenerator will now respect the current waypoint field in the creature table.
* WaypointMovementGenerator will not ignore pause timers and interaction pause time.
* WaypointMovementGenerator will not pick up ongoing spline destinations when the spline path is being stored in DB.
* Flight waypoint movement is now correctly using catmullrom and uncompressed splines.
* Updated SmartAI's waypoint support to use the new smoothTransition field.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)
- [ ] I should not be dropping MOVEMENTGENERATOR_FLAGS at all, at least that's what my instinct tells me. After confirmation from a first review, I will add the ones I removed back into place.
- [ ] Missing implementation for creature_movement_info table that overrides creatures' movement speeds with Blizzard's movementIds. Cherrypick from: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/c3e98617237a9852a19f502a4666d3ac2c186c98