### PR TITLE
Core/Items: Dropped deprecated ItemFlag2 ITEM_FLAG2_DONT_IGNORE_BUY_PRICE

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -81,11 +81,6 @@ std::string CreatureMovementData::ToString() const
 VendorItemCount::VendorItemCount(uint32 _item, uint32 _count)
     : itemId(_item), count(_count), lastIncrementTime(GameTime::GetGameTime()) { }
 
-bool VendorItem::IsGoldRequired(ItemTemplate const* pProto) const
-{
-    return pProto->HasFlag(ITEM_FLAG2_DONT_IGNORE_BUY_PRICE) || !ExtendedCost;
-}
-
 bool VendorItemData::RemoveItem(uint32 item_id, uint8 type)
 {
     auto newEnd = std::remove_if(m_items.begin(), m_items.end(), [=](VendorItem const& vendorItem)

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -667,9 +667,6 @@ struct VendorItem
     std::vector<int32> BonusListIDs;
     uint32 PlayerConditionId;
     bool IgnoreFiltering;
-
-    //helpers
-    bool IsGoldRequired(ItemTemplate const* pProto) const;
 };
 
 struct VendorItemData

--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -211,7 +211,7 @@ enum ItemFlags2 : uint32
 {
     ITEM_FLAG2_FACTION_HORDE                            = 0x00000001,
     ITEM_FLAG2_FACTION_ALLIANCE                         = 0x00000002,
-    ITEM_FLAG2_DONT_IGNORE_BUY_PRICE                    = 0x00000004, // when item uses extended cost, gold is also required
+    ITEM_FLAG2_DONT_IGNORE_BUY_PRICE                    = 0x00000004, // when item uses extended cost, gold is also required // deprecated
     ITEM_FLAG2_CLASSIFY_AS_CASTER                       = 0x00000008,
     ITEM_FLAG2_CLASSIFY_AS_PHYSICAL                     = 0x00000010,
     ITEM_FLAG2_EVERYONE_CAN_ROLL_NEED                   = 0x00000020,

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22372,7 +22372,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
     }
 
     uint64 price = 0;
-    if (!crItem->ExtendedCost && pProto->GetBuyPrice() > 0) //Assume price cannot be negative (do not know why it is int32)
+    if (pProto->GetBuyPrice() > 0) //Assume price cannot be negative (do not know why it is int32)
     {
         double buyPricePerItem = double(pProto->GetBuyPrice()) / pProto->GetBuyCount();
         uint64 maxCount = MAX_MONEY_AMOUNT / buyPricePerItem;
@@ -22386,7 +22386,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
 
         // reputation discount
         price = uint64(floor(price * GetReputationPriceDiscount(creature)));
-        price = pProto->GetBuyPrice() > 0 ? std::max(1ULL, price) : price;
+        price = pProto->GetBuyPrice() > 0 ? std::max(uint64(1), price) : price;
 
         if (int32 priceMod = GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))
             price -= CalculatePct(price, priceMod);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22386,6 +22386,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
 
         // reputation discount
         price = uint64(floor(price * GetReputationPriceDiscount(creature)));
+        price = pProto->GetBuyPrice() > 0 ? std::max(1u, price) : price;
 
         if (int32 priceMod = GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))
             price -= CalculatePct(price, priceMod);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22386,7 +22386,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
 
         // reputation discount
         price = uint64(floor(price * GetReputationPriceDiscount(creature)));
-        price = pProto->GetBuyPrice() > 0 ? std::max(1u, price) : price;
+        price = pProto->GetBuyPrice() > 0 ? std::max(1ULL, price) : price;
 
         if (int32 priceMod = GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))
             price -= CalculatePct(price, priceMod);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22372,7 +22372,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
     }
 
     uint64 price = 0;
-    if (crItem->IsGoldRequired(pProto) && pProto->GetBuyPrice() > 0) //Assume price cannot be negative (do not know why it is int32)
+    if (!crItem->ExtendedCost && pProto->GetBuyPrice() > 0) //Assume price cannot be negative (do not know why it is int32)
     {
         double buyPricePerItem = double(pProto->GetBuyPrice()) / pProto->GetBuyCount();
         uint64 maxCount = MAX_MONEY_AMOUNT / buyPricePerItem;

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -660,7 +660,12 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
                 continue;
             }
 
-            int32 price = vendorItem->IsGoldRequired(itemTemplate) ? uint32(floor(itemTemplate->GetBuyPrice() * discountMod)) : 0;
+            float price = 0;
+            if (!vendorItem->ExtendedCost)
+            {
+                price = floor(itemTemplate->GetBuyPrice() * discountMod);
+                price = itemTemplate->GetBuyPrice() > 0 ? std::max(1.00f, price) : price;
+            }
 
             if (int32 priceMod = _player->GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))
                 price -= CalculatePct(price, priceMod);
@@ -671,7 +676,7 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
             item.Type = vendorItem->Type;
             item.Quantity = leftInStock;
             item.StackCount = itemTemplate->GetBuyCount();
-            item.Price = price;
+            item.Price = uint32(price);
             item.DoNotFilterOnVendor = vendorItem->IgnoreFiltering;
             item.Refundable = itemTemplate->HasFlag(ITEM_FLAG_ITEM_PURCHASE_RECORD) && vendorItem->ExtendedCost && itemTemplate->GetMaxStackSize() == 1;
 

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -660,12 +660,8 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
                 continue;
             }
 
-            uint64 price = 0;
-            if (!vendorItem->ExtendedCost)
-            {
-                price = uint64(floor(itemTemplate->GetBuyPrice() * discountMod));
-                price = itemTemplate->GetBuyPrice() > 0 ? std::max(1ULL, price) : price;
-            }
+            uint64 price = uint64(floor(itemTemplate->GetBuyPrice() * discountMod));
+            price = itemTemplate->GetBuyPrice() > 0 ? std::max(uint64(1), price) : price;
 
             if (int32 priceMod = _player->GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))
                 price -= CalculatePct(price, priceMod);

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -664,7 +664,7 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
             if (!vendorItem->ExtendedCost)
             {
                 price = uint64(floor(itemTemplate->GetBuyPrice() * discountMod));
-                price = itemTemplate->GetBuyPrice() > 0 ? std::max(1u, price) : price;
+                price = itemTemplate->GetBuyPrice() > 0 ? std::max(1ULL, price) : price;
             }
 
             if (int32 priceMod = _player->GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -660,11 +660,11 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
                 continue;
             }
 
-            float price = 0;
+            uint64 price = 0;
             if (!vendorItem->ExtendedCost)
             {
-                price = floor(itemTemplate->GetBuyPrice() * discountMod);
-                price = itemTemplate->GetBuyPrice() > 0 ? std::max(1.00f, price) : price;
+                price = uint64(floor(itemTemplate->GetBuyPrice() * discountMod));
+                price = itemTemplate->GetBuyPrice() > 0 ? std::max(1u, price) : price;
             }
 
             if (int32 priceMod = _player->GetTotalAuraModifier(SPELL_AURA_MOD_VENDOR_ITEMS_PRICES))
@@ -676,7 +676,7 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
             item.Type = vendorItem->Type;
             item.Quantity = leftInStock;
             item.StackCount = itemTemplate->GetBuyCount();
-            item.Price = uint32(price);
+            item.Price = price;
             item.DoNotFilterOnVendor = vendorItem->IgnoreFiltering;
             item.Refundable = itemTemplate->HasFlag(ITEM_FLAG_ITEM_PURCHASE_RECORD) && vendorItem->ExtendedCost && itemTemplate->GetMaxStackSize() == 1;
 


### PR DESCRIPTION
**Changes proposed:**

- dropped deprecated item flag (ref EnumeratedStrings.db2: `(deprecated) Don't ignore buy prices when extended cost is specified`)
- use `std::max(1, price)` if buyprice is > 0

**Tests performed:**
(Does it build, tested in-game, etc.)
tested with npc entry 45490, blacksmith hammer and fishing rod now have proper pricing and aren't given away for free anymore
