### PR TITLE
Revert "MMAP: Build ADT floor just like WMO floor below liquid"

### DIFF
--- a/src/tools/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/mmaps_generator/TerrainBuilder.cpp
@@ -493,6 +493,10 @@ namespace MMAP
                             minTLevel = h;
                     }
 
+                    // terrain under the liquid?
+                    if (minLLevel > maxTLevel)
+                        useTerrain = false;
+
                     //liquid under the terrain?
                     if (minTLevel > maxLLevel)
                         useLiquid = false;


### PR DESCRIPTION
Reverts TrinityCore/TrinityCore#27503

This commit actually causes issues where the terrain mesh underwater is disconnected from the terrain outside of the water, with creatures not being able to enter/exit water as they used to do.

![image](https://user-images.githubusercontent.com/1153754/197389691-530068c1-9c66-4330-9a75-c519da76e9a8.png)
