### PR TITLE
Battlegrounds: Add hook for gameobject/creature create/remove

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -500,6 +500,12 @@ class TC_GAME_API Battleground
         void AddPlayerPosition(WorldPackets::Battleground::BattlegroundPlayerPosition const& position);
         void RemovePlayerPosition(ObjectGuid guid);
 
+        virtual void OnCreatureCreate(Creature* /*creature*/) { }
+        virtual void OnCreatureRemove(Creature* /*creature*/) { }
+
+        virtual void OnGameObjectCreate(GameObject* /*gameObject*/) { }
+        virtual void OnGameObjectRemove(GameObject* /*gameObject*/) { }
+
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends Battleground
         void EndNow();

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -343,6 +343,10 @@ void Creature::AddToWorld()
 
         if (GetZoneScript())
             GetZoneScript()->OnCreatureCreate(this);
+
+        if (BattlegroundMap* bgMap = GetMap()->ToBattlegroundMap())
+            if (Battleground* bg = bgMap->GetBG())
+                bg->OnCreatureCreate(this);
     }
 }
 
@@ -352,6 +356,10 @@ void Creature::RemoveFromWorld()
     {
         if (GetZoneScript())
             GetZoneScript()->OnCreatureRemove(this);
+
+        if (BattlegroundMap* bgMap = GetMap()->ToBattlegroundMap())
+            if (Battleground* bg = bgMap->GetBG())
+                bg->OnCreatureRemove(this);
 
         if (m_formation)
             sFormationMgr->RemoveCreatureFromGroup(m_formation, this);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -588,6 +588,10 @@ void GameObject::AddToWorld()
         if (m_zoneScript)
             m_zoneScript->OnGameObjectCreate(this);
 
+        if (BattlegroundMap* bgMap = GetMap()->ToBattlegroundMap())
+            if (Battleground* bg = bgMap->GetBG())
+                bg->OnGameObjectCreate(this);
+
         GetMap()->GetObjectsStore().Insert<GameObject>(GetGUID(), this);
         if (m_spawnId)
             GetMap()->GetGameObjectBySpawnIdStore().insert(std::make_pair(m_spawnId, this));
@@ -614,6 +618,10 @@ void GameObject::RemoveFromWorld()
     {
         if (m_zoneScript)
             m_zoneScript->OnGameObjectRemove(this);
+
+        if (BattlegroundMap* bgMap = GetMap()->ToBattlegroundMap())
+            if (Battleground* bg = bgMap->GetBG())
+                bg->OnGameObjectRemove(this);
 
         RemoveFromOwner();
         if (m_model)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

Add some hooks from zonescript to battlegrounds. I want to easily access Creatures/GameObjects when they are spawned in database.

**Changes proposed:**

-  Add hook for creature create
-  Add hook for creature remove
-  Add hook for gameobject create
-  Add hook for gameobject remove

**Issues addressed:**

Closes: none, but will be required for future changes in #28369


**Tests performed:**

- Builds
- Breakpoints trigger

**Known issues and TODO list:**

- none

I think the proper fix would be to have ZoneScripts in battlegrounds working


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
