### PR TITLE
Pools/GameObjects: Allow traps to be pooled and not respawn instantly

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1440,7 +1440,11 @@ void GameObject::Delete()
     if (GameObjectOverride const* goOverride = GetGameObjectOverride())
         ReplaceAllFlags(GameObjectFlags(goOverride->Flags));
 
-    AddObjectToRemoveList();
+    uint32 poolid = GetGameObjectData() ? GetGameObjectData()->poolId : 0;
+    if (poolid && m_goInfo->type != GAMEOBJECT_TYPE_TRAP)
+        sPoolMgr->UpdatePool<GameObject>(GetMap()->GetPoolData(), poolid, GetSpawnId());
+    else
+        AddObjectToRemoveList();
 }
 
 void GameObject::SendGameObjectDespawn()

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1440,11 +1440,7 @@ void GameObject::Delete()
     if (GameObjectOverride const* goOverride = GetGameObjectOverride())
         ReplaceAllFlags(GameObjectFlags(goOverride->Flags));
 
-    uint32 poolid = GetGameObjectData() ? GetGameObjectData()->poolId : 0;
-    if (poolid)
-        sPoolMgr->UpdatePool<GameObject>(GetMap()->GetPoolData(), poolid, GetSpawnId());
-    else
-        AddObjectToRemoveList();
+    AddObjectToRemoveList();
 }
 
 void GameObject::SendGameObjectDespawn()

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -573,7 +573,8 @@ void PoolMgr::LoadFromDB()
                 if (goinfo->type != GAMEOBJECT_TYPE_CHEST &&
                     goinfo->type != GAMEOBJECT_TYPE_FISHINGHOLE &&
                     goinfo->type != GAMEOBJECT_TYPE_GATHERING_NODE &&
-                    goinfo->type != GAMEOBJECT_TYPE_GOOBER)
+                    goinfo->type != GAMEOBJECT_TYPE_GOOBER &&
+                    goinfo->type != GAMEOBJECT_TYPE_TRAP)
                 {
                     TC_LOG_ERROR("sql.sql", "`pool_gameobject` has a not lootable gameobject spawn (GUID: {}, type: {}) defined for pool id ({}), skipped.", guid, goinfo->type, pool_id);
                     continue;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

While trying to make battleground buffs work with pooling I noticed a behavior I was not expecting. Read more on it here: https://github.com/TrinityCore/TrinityCore/discussions/28475

**Changes proposed:**

-  Remove updatepool call in gameobject::Delete.

**Issues addressed:**

Closes: none that I know of.


**Tests performed:**

- Builds
- Battleground buffs that work with pooling (given the SQL in the discussion) work like I wanted it to work


**Known issues and TODO list:**

- I have no idea why that piece of code is here, the creature counter part does not seem to have that code. 
- I *might* have broken a lot of pooling with this. I am unsure about what to test and what results are expected

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
