### PR TITLE
Core/Creatures: Fix IsMovementPreventedByCasting logic

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3371,18 +3371,19 @@ void Creature::DoNotReacquireSpellFocusTarget()
 
 bool Creature::IsMovementPreventedByCasting() const
 {
+    // Can always move when not casting
+    if (!HasUnitState(UNIT_STATE_CASTING))
+        return false;
+
     // first check if currently a movement allowed channel is active and we're not casting
     if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
     {
         if (spell->getState() != SPELL_STATE_FINISHED && spell->IsChannelActive())
             if (spell->CheckMovement() != SPELL_CAST_OK)
-                return false;
+                return true;
     }
 
     if (HasSpellFocus())
-        return true;
-
-    if (HasUnitState(UNIT_STATE_CASTING))
         return true;
 
     return false;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Current implementation was interrupting the creature movement when the channeled spell could be used while moving (inverted logic)
- Example: https://gyazo.com/a394ff7de2a0ceeba3a6a3a3bb7bb9ee (vertical movement was never started before)

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)

- It would be necessary to test this PR with known cases of channeled spells to ensure that nothing is broken


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
