### PR TITLE
Core/Movement: Don't compute orientation for vertical splines

### DIFF
--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -58,7 +58,8 @@ Location MoveSpline::computePosition(int32 time_point, int32 point_index) const
         {
             Vector3 hermite;
             spline.evaluate_derivative(point_Idx, u, hermite);
-            c.orientation = std::atan2(hermite.y, hermite.x);
+            if (hermite.x != 0.f || hermite.y != 0.f)
+                c.orientation = std::atan2(hermite.y, hermite.x);
         }
 
         if (splineflags.backward)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  If the position of a vertical spline is computed, the hermite interpolation returns a value (x,y) equal to (0,0) which causes the orientation to be zero serverside (arctan).

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
