### PR TITLE
Core/Creatures: split creature_addon and creature_template_addon's byte fields

### DIFF
--- a/sql/updates/world/3.3.5/2023_01_09_00_world.sql
+++ b/sql/updates/world/3.3.5/2023_01_09_00_world.sql
@@ -1,26 +1,26 @@
 ALTER TABLE `creature_template_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
 	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
-	ADD COLUMN `VisibilityFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `AnimTier`,
-	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `VisibilityFlags`,
+	ADD COLUMN `VisFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `AnimTier`,
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `VisFlags`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
 UPDATE `creature_template_addon` SET `StandState`=`bytes1` & 0xFF;
 UPDATE `creature_template_addon` SET `AnimTier`=(`bytes1` >> 24) & 0xFF;
-UPDATE `creature_template_addon` SET `VisibilityFlags`=(`bytes1` >> 16) & 0xFF;
+UPDATE `creature_template_addon` SET `VisFlags`=(`bytes1` >> 16) & 0xFF;
 UPDATE `creature_template_addon` SET `SheathState`=`bytes2` & 0xFF;
 UPDATE `creature_template_addon` SET `PvPFlags`=(`bytes2` >> 8) & 0xFF;
 
 ALTER TABLE `creature_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
 	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
-	ADD COLUMN `VisibilityFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `AnimTier`,
-	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `VisibilityFlags`,
+	ADD COLUMN `VisFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `AnimTier`,
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `VisFlags`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
 UPDATE `creature_addon` SET `StandState`=`bytes1` & 0xFF;
 UPDATE `creature_addon` SET `AnimTier`=(`bytes1` >> 24) & 0xFF;
-UPDATE `creature_addon` SET `VisibilityFlags`=(`bytes1` >> 16) & 0xFF;
+UPDATE `creature_addon` SET `VisFlags`=(`bytes1` >> 16) & 0xFF;
 UPDATE `creature_addon` SET `SheathState`=`bytes2` & 0xFF;
 UPDATE `creature_addon` SET `PvPFlags`=(`bytes2` >> 8) & 0xFF;
 

--- a/sql/updates/world/3.3.5/2099_99_99_00_world.sql
+++ b/sql/updates/world/3.3.5/2099_99_99_00_world.sql
@@ -23,14 +23,14 @@ UPDATE `creature_template_addon` SET `SheathState`= 0 WHERE (`bytes2` & 0x1 | 0x
 UPDATE `creature_template_addon` SET `SheathState`= 1 WHERE (`bytes2` & 0x1) != 0;
 UPDATE `creature_template_addon` SET `SheathState`= 2 WHERE (`bytes2` & 0x2) != 0;
 
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x1 WHERE (`bytes2` & 0x100) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x2 WHERE (`bytes2` & 0x200) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x4 WHERE (`bytes2` & 0x400) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x8 WHERE (`bytes2` & 0x800) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x10 WHERE (`bytes2` & 0x1000) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x20 WHERE (`bytes2` & 0x2000) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x40 WHERE (`bytes2` & 0x4000) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= 0x80 WHERE (`bytes2` & 0x8000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x1 WHERE (`bytes2` & 0x100) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x2 WHERE (`bytes2` & 0x200) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x4 WHERE (`bytes2` & 0x400) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x8 WHERE (`bytes2` & 0x800) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x10 WHERE (`bytes2` & 0x1000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x20 WHERE (`bytes2` & 0x2000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x40 WHERE (`bytes2` & 0x4000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x80 WHERE (`bytes2` & 0x8000) != 0;
 
 ALTER TABLE `creature_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
@@ -57,14 +57,14 @@ UPDATE `creature_addon` SET `SheathState`= 0 WHERE (`bytes2` & 0x1 | 0x2) = 0;
 UPDATE `creature_addon` SET `SheathState`= 1 WHERE (`bytes2` & 0x1) != 0;
 UPDATE `creature_addon` SET `SheathState`= 2 WHERE (`bytes2` & 0x2) != 0;
 
-UPDATE `creature_addon` SET `PvPFlags`= 0x1 WHERE (`bytes2` & 0x100) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x2 WHERE (`bytes2` & 0x200) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x4 WHERE (`bytes2` & 0x400) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x8 WHERE (`bytes2` & 0x800) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x10 WHERE (`bytes2` & 0x1000) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x20 WHERE (`bytes2` & 0x2000) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x40 WHERE (`bytes2` & 0x4000) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= 0x80 WHERE (`bytes2` & 0x8000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x1 WHERE (`bytes2` & 0x100) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x2 WHERE (`bytes2` & 0x200) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x4 WHERE (`bytes2` & 0x400) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x8 WHERE (`bytes2` & 0x800) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x10 WHERE (`bytes2` & 0x1000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x20 WHERE (`bytes2` & 0x2000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x40 WHERE (`bytes2` & 0x4000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x80 WHERE (`bytes2` & 0x8000) != 0;
 
 -- Conversion done, drop old columns
 ALTER TABLE `creature_template_addon`  

--- a/sql/updates/world/3.3.5/2099_99_99_00_world.sql
+++ b/sql/updates/world/3.3.5/2099_99_99_00_world.sql
@@ -1,22 +1,26 @@
 ALTER TABLE `creature_template_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
 	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
-	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`,
+	ADD COLUMN `VisibilityFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `AnimTier`,
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `VisibilityFlags`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
 UPDATE `creature_template_addon` SET `StandState`=`bytes1` & 0xFF;
 UPDATE `creature_template_addon` SET `AnimTier`=(`bytes1` >> 24) & 0xFF;
+UPDATE `creature_template_addon` SET `VisibilityFlags`=(`bytes1` >> 16) & 0xFF;
 UPDATE `creature_template_addon` SET `SheathState`=`bytes2` & 0xFF;
 UPDATE `creature_template_addon` SET `PvPFlags`=(`bytes2` >> 8) & 0xFF;
 
 ALTER TABLE `creature_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
 	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
-	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`,
+	ADD COLUMN `VisibilityFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `AnimTier`,
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `VisibilityFlags`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
 UPDATE `creature_addon` SET `StandState`=`bytes1` & 0xFF;
 UPDATE `creature_addon` SET `AnimTier`=(`bytes1` >> 24) & 0xFF;
+UPDATE `creature_addon` SET `VisibilityFlags`=(`bytes1` >> 16) & 0xFF;
 UPDATE `creature_addon` SET `SheathState`=`bytes2` & 0xFF;
 UPDATE `creature_addon` SET `PvPFlags`=(`bytes2` >> 8) & 0xFF;
 

--- a/sql/updates/world/3.3.5/2099_99_99_00_world.sql
+++ b/sql/updates/world/3.3.5/2099_99_99_00_world.sql
@@ -1,7 +1,7 @@
 ALTER TABLE `creature_template_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
 	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
-	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`;
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
 UPDATE `creature_template_addon` SET `StandState`= 1 WHERE (`bytes1` & 0x1) != 0;
@@ -35,7 +35,7 @@ UPDATE `creature_template_addon` SET `PvPFlags`= 0x80 WHERE (`bytes2` & 0x8000) 
 ALTER TABLE `creature_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
 	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
-	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`;
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
 UPDATE `creature_addon` SET `StandState`= 1 WHERE (`bytes1` & 0x1) != 0;

--- a/sql/updates/world/3.3.5/2099_99_99_00_world.sql
+++ b/sql/updates/world/3.3.5/2099_99_99_00_world.sql
@@ -1,0 +1,76 @@
+ALTER TABLE `creature_template_addon`   
+	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
+	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`;
+	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
+	
+UPDATE `creature_template_addon` SET `StandState`= 1 WHERE (`bytes1` & 0x1) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 2 WHERE (`bytes1` & 0x2) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 3 WHERE (`bytes1` & 0x3) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 4 WHERE (`bytes1` & 0x4) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 5 WHERE (`bytes1` & 0x5) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 6 WHERE (`bytes1` & 0x6) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 7 WHERE (`bytes1` & 0x7) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 8 WHERE (`bytes1` & 0x8) != 0;
+UPDATE `creature_template_addon` SET `StandState`= 9 WHERE (`bytes1` & 0x9) != 0;
+
+UPDATE `creature_template_addon` SET `AnimTier`= 1 WHERE (`bytes1` & 0x1000000) != 0;
+UPDATE `creature_template_addon` SET `AnimTier`= 2 WHERE (`bytes1` & 0x2000000) != 0;
+UPDATE `creature_template_addon` SET `AnimTier`= 3 WHERE (`bytes1` & 0x3000000) != 0;
+UPDATE `creature_template_addon` SET `AnimTier`= 4 WHERE (`bytes1` & 0x4000000) != 0;
+
+UPDATE `creature_template_addon` SET `SheathState`= 0 WHERE (`bytes2` & 0x1 | 0x2) = 0;
+UPDATE `creature_template_addon` SET `SheathState`= 1 WHERE (`bytes2` & 0x1) != 0;
+UPDATE `creature_template_addon` SET `SheathState`= 2 WHERE (`bytes2` & 0x2) != 0;
+
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x1 WHERE (`bytes2` & 0x100) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x2 WHERE (`bytes2` & 0x200) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x4 WHERE (`bytes2` & 0x400) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x8 WHERE (`bytes2` & 0x800) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x10 WHERE (`bytes2` & 0x1000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x20 WHERE (`bytes2` & 0x2000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x40 WHERE (`bytes2` & 0x4000) != 0;
+UPDATE `creature_template_addon` SET `PvPFlags`= 0x80 WHERE (`bytes2` & 0x8000) != 0;
+
+ALTER TABLE `creature_addon`   
+	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
+	ADD COLUMN `AnimTier` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `StandState`,
+	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`;
+	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
+	
+UPDATE `creature_addon` SET `StandState`= 1 WHERE (`bytes1` & 0x1) != 0;
+UPDATE `creature_addon` SET `StandState`= 2 WHERE (`bytes1` & 0x2) != 0;
+UPDATE `creature_addon` SET `StandState`= 3 WHERE (`bytes1` & 0x3) != 0;
+UPDATE `creature_addon` SET `StandState`= 4 WHERE (`bytes1` & 0x4) != 0;
+UPDATE `creature_addon` SET `StandState`= 5 WHERE (`bytes1` & 0x5) != 0;
+UPDATE `creature_addon` SET `StandState`= 6 WHERE (`bytes1` & 0x6) != 0;
+UPDATE `creature_addon` SET `StandState`= 7 WHERE (`bytes1` & 0x7) != 0;
+UPDATE `creature_addon` SET `StandState`= 8 WHERE (`bytes1` & 0x8) != 0;
+UPDATE `creature_addon` SET `StandState`= 9 WHERE (`bytes1` & 0x9) != 0;
+
+UPDATE `creature_addon` SET `AnimTier`= 1 WHERE (`bytes1` & 0x1000000) != 0;
+UPDATE `creature_addon` SET `AnimTier`= 2 WHERE (`bytes1` & 0x2000000) != 0;
+UPDATE `creature_addon` SET `AnimTier`= 3 WHERE (`bytes1` & 0x3000000) != 0;
+UPDATE `creature_addon` SET `AnimTier`= 4 WHERE (`bytes1` & 0x4000000) != 0;
+
+UPDATE `creature_addon` SET `SheathState`= 0 WHERE (`bytes2` & 0x1 | 0x2) = 0;
+UPDATE `creature_addon` SET `SheathState`= 1 WHERE (`bytes2` & 0x1) != 0;
+UPDATE `creature_addon` SET `SheathState`= 2 WHERE (`bytes2` & 0x2) != 0;
+
+UPDATE `creature_addon` SET `PvPFlags`= 0x1 WHERE (`bytes2` & 0x100) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x2 WHERE (`bytes2` & 0x200) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x4 WHERE (`bytes2` & 0x400) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x8 WHERE (`bytes2` & 0x800) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x10 WHERE (`bytes2` & 0x1000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x20 WHERE (`bytes2` & 0x2000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x40 WHERE (`bytes2` & 0x4000) != 0;
+UPDATE `creature_addon` SET `PvPFlags`= 0x80 WHERE (`bytes2` & 0x8000) != 0;
+
+-- Conversion done, drop old columns
+ALTER TABLE `creature_template_addon`  
+	DROP COLUMN `bytes1`, 
+	DROP COLUMN `bytes2`;
+	
+ALTER TABLE `creature_addon`  
+	DROP COLUMN `bytes1`, 
+	DROP COLUMN `bytes2`;

--- a/sql/updates/world/3.3.5/2099_99_99_00_world.sql
+++ b/sql/updates/world/3.3.5/2099_99_99_00_world.sql
@@ -4,33 +4,10 @@ ALTER TABLE `creature_template_addon`
 	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
-UPDATE `creature_template_addon` SET `StandState`= 1 WHERE (`bytes1` & 0x1) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 2 WHERE (`bytes1` & 0x2) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 3 WHERE (`bytes1` & 0x3) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 4 WHERE (`bytes1` & 0x4) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 5 WHERE (`bytes1` & 0x5) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 6 WHERE (`bytes1` & 0x6) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 7 WHERE (`bytes1` & 0x7) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 8 WHERE (`bytes1` & 0x8) != 0;
-UPDATE `creature_template_addon` SET `StandState`= 9 WHERE (`bytes1` & 0x9) != 0;
-
-UPDATE `creature_template_addon` SET `AnimTier`= 1 WHERE (`bytes1` & 0x1000000) != 0;
-UPDATE `creature_template_addon` SET `AnimTier`= 2 WHERE (`bytes1` & 0x2000000) != 0;
-UPDATE `creature_template_addon` SET `AnimTier`= 3 WHERE (`bytes1` & 0x3000000) != 0;
-UPDATE `creature_template_addon` SET `AnimTier`= 4 WHERE (`bytes1` & 0x4000000) != 0;
-
-UPDATE `creature_template_addon` SET `SheathState`= 0 WHERE (`bytes2` & 0x1 | 0x2) = 0;
-UPDATE `creature_template_addon` SET `SheathState`= 1 WHERE (`bytes2` & 0x1) != 0;
-UPDATE `creature_template_addon` SET `SheathState`= 2 WHERE (`bytes2` & 0x2) != 0;
-
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x1 WHERE (`bytes2` & 0x100) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x2 WHERE (`bytes2` & 0x200) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x4 WHERE (`bytes2` & 0x400) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x8 WHERE (`bytes2` & 0x800) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x10 WHERE (`bytes2` & 0x1000) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x20 WHERE (`bytes2` & 0x2000) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x40 WHERE (`bytes2` & 0x4000) != 0;
-UPDATE `creature_template_addon` SET `PvPFlags`= `PvPFlags`|0x80 WHERE (`bytes2` & 0x8000) != 0;
+UPDATE `creature_template_addon` SET `StandState`=`bytes1` & 0xFF;
+UPDATE `creature_template_addon` SET `AnimTier`=(`bytes1` >> 24) & 0xFF;
+UPDATE `creature_template_addon` SET `SheathState`=`bytes2` & 0xFF;
+UPDATE `creature_template_addon` SET `PvPFlags`=(`bytes2` >> 8) & 0xFF;
 
 ALTER TABLE `creature_addon`   
 	ADD COLUMN `StandState` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `MountCreatureID`,
@@ -38,33 +15,10 @@ ALTER TABLE `creature_addon`
 	ADD COLUMN `SheathState` TINYINT UNSIGNED DEFAULT 1 NOT NULL AFTER `AnimTier`,
 	ADD COLUMN `PvPFlags` TINYINT UNSIGNED DEFAULT 0 NOT NULL AFTER `SheathState`;
 	
-UPDATE `creature_addon` SET `StandState`= 1 WHERE (`bytes1` & 0x1) != 0;
-UPDATE `creature_addon` SET `StandState`= 2 WHERE (`bytes1` & 0x2) != 0;
-UPDATE `creature_addon` SET `StandState`= 3 WHERE (`bytes1` & 0x3) != 0;
-UPDATE `creature_addon` SET `StandState`= 4 WHERE (`bytes1` & 0x4) != 0;
-UPDATE `creature_addon` SET `StandState`= 5 WHERE (`bytes1` & 0x5) != 0;
-UPDATE `creature_addon` SET `StandState`= 6 WHERE (`bytes1` & 0x6) != 0;
-UPDATE `creature_addon` SET `StandState`= 7 WHERE (`bytes1` & 0x7) != 0;
-UPDATE `creature_addon` SET `StandState`= 8 WHERE (`bytes1` & 0x8) != 0;
-UPDATE `creature_addon` SET `StandState`= 9 WHERE (`bytes1` & 0x9) != 0;
-
-UPDATE `creature_addon` SET `AnimTier`= 1 WHERE (`bytes1` & 0x1000000) != 0;
-UPDATE `creature_addon` SET `AnimTier`= 2 WHERE (`bytes1` & 0x2000000) != 0;
-UPDATE `creature_addon` SET `AnimTier`= 3 WHERE (`bytes1` & 0x3000000) != 0;
-UPDATE `creature_addon` SET `AnimTier`= 4 WHERE (`bytes1` & 0x4000000) != 0;
-
-UPDATE `creature_addon` SET `SheathState`= 0 WHERE (`bytes2` & 0x1 | 0x2) = 0;
-UPDATE `creature_addon` SET `SheathState`= 1 WHERE (`bytes2` & 0x1) != 0;
-UPDATE `creature_addon` SET `SheathState`= 2 WHERE (`bytes2` & 0x2) != 0;
-
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x1 WHERE (`bytes2` & 0x100) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x2 WHERE (`bytes2` & 0x200) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x4 WHERE (`bytes2` & 0x400) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x8 WHERE (`bytes2` & 0x800) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x10 WHERE (`bytes2` & 0x1000) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x20 WHERE (`bytes2` & 0x2000) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x40 WHERE (`bytes2` & 0x4000) != 0;
-UPDATE `creature_addon` SET `PvPFlags`= `PvPFlags`|0x80 WHERE (`bytes2` & 0x8000) != 0;
+UPDATE `creature_addon` SET `StandState`=`bytes1` & 0xFF;
+UPDATE `creature_addon` SET `AnimTier`=(`bytes1` >> 24) & 0xFF;
+UPDATE `creature_addon` SET `SheathState`=`bytes2` & 0xFF;
+UPDATE `creature_addon` SET `PvPFlags`=(`bytes2` >> 8) & 0xFF;
 
 -- Conversion done, drop old columns
 ALTER TABLE `creature_template_addon`  

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2510,60 +2510,47 @@ CreatureAddon const* Creature::GetCreatureAddon() const
 //creature_addon table
 bool Creature::LoadCreaturesAddon()
 {
-    CreatureAddon const* cainfo = GetCreatureAddon();
-    if (!cainfo)
+    CreatureAddon const* creatureAddon = GetCreatureAddon();
+    if (!creatureAddon)
         return false;
 
-    if (cainfo->mount != 0)
-        Mount(cainfo->mount);
+    if (creatureAddon->mount != 0)
+        Mount(creatureAddon->mount);
 
-    if (cainfo->bytes1 != 0)
-    {
-        // 0 StandState
-        // 1 FreeTalentPoints   Pet only, so always 0 for default creature
-        // 2 StandFlags
-        // 3 StandMiscFlags
+    // UNIT_FIELD_BYTES_1 values
+    SetStandState(UnitStandStateType(creatureAddon->standState));
+    SetAnimTier(AnimTier(creatureAddon->animTier));
 
-        SetStandState(UnitStandStateType(cainfo->bytes1 & 0xFF));
-        ReplaceAllVisFlags(UnitVisFlags((cainfo->bytes1 >> 16) & 0xFF));
-        SetAnimTier(AnimTier((cainfo->bytes1 >> 24) & 0xFF));
+    //! Suspected correlation between UNIT_FIELD_BYTES_1, offset 3, value 0x2:
+    //! If no inhabittype_fly (if no MovementFlag_DisableGravity or MovementFlag_CanFly flag found in sniffs)
+    //! Check using InhabitType as movement flags are assigned dynamically
+    //! basing on whether the creature is in air or not
+    //! Set MovementFlag_Hover. Otherwise do nothing.
+    if (CanHover())
+        AddUnitMovementFlag(MOVEMENTFLAG_HOVER);
 
-        //! Suspected correlation between UNIT_FIELD_BYTES_1, offset 3, value 0x2:
-        //! If no inhabittype_fly (if no MovementFlag_DisableGravity or MovementFlag_CanFly flag found in sniffs)
-        //! Check using InhabitType as movement flags are assigned dynamically
-        //! basing on whether the creature is in air or not
-        //! Set MovementFlag_Hover. Otherwise do nothing.
-        if (CanHover())
-            AddUnitMovementFlag(MOVEMENTFLAG_HOVER);
-    }
+    // UNIT_FIELD_BYTES_2 values
+    SetSheath(SheathState(creatureAddon->sheathState));
+    ReplaceAllPvpFlags(UnitPVPStateFlags(creatureAddon->pvpFlags));
 
-    if (cainfo->bytes2 != 0)
-    {
-        // 0 SheathState
-        // 1 PvpFlags
-        // 2 PetFlags           Pet only, so always 0 for default creature
-        // 3 ShapeshiftForm     Must be determined/set by shapeshift spell/aura
+    // These fields must only be handled by core internals and must not be modified via scripts/DB data
+    ReplaceAllPetFlags(UNIT_PET_FLAG_NONE);
+    SetShapeshiftForm(FORM_NONE);
 
-        SetSheath(SheathState(cainfo->bytes2 & 0xFF));
-        ReplaceAllPvpFlags(UnitPVPStateFlags((cainfo->bytes2 >> 8) & 0xFF));
-        ReplaceAllPetFlags(UNIT_PET_FLAG_NONE);
-        SetShapeshiftForm(FORM_NONE);
-    }
-
-    if (cainfo->emote != 0)
-        SetEmoteState(Emote(cainfo->emote));
+    if (creatureAddon->emote != 0)
+        SetEmoteState(Emote(creatureAddon->emote));
 
     // Check if visibility distance different
-    if (cainfo->visibilityDistanceType != VisibilityDistanceType::Normal)
-        SetVisibilityDistanceOverride(cainfo->visibilityDistanceType);
+    if (creatureAddon->visibilityDistanceType != VisibilityDistanceType::Normal)
+        SetVisibilityDistanceOverride(creatureAddon->visibilityDistanceType);
 
     // Load Path
-    if (cainfo->path_id != 0)
-        _waypointPathId = cainfo->path_id;
+    if (creatureAddon->path_id != 0)
+        _waypointPathId = creatureAddon->path_id;
 
-    if (!cainfo->auras.empty())
+    if (!creatureAddon->auras.empty())
     {
-        for (std::vector<uint32>::const_iterator itr = cainfo->auras.begin(); itr != cainfo->auras.end(); ++itr)
+        for (std::vector<uint32>::const_iterator itr = creatureAddon->auras.begin(); itr != creatureAddon->auras.end(); ++itr)
         {
             SpellInfo const* AdditionalSpellInfo = sSpellMgr->GetSpellInfo(*itr);
             if (!AdditionalSpellInfo)

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2520,7 +2520,7 @@ bool Creature::LoadCreaturesAddon()
     // UNIT_FIELD_BYTES_1 values
     SetStandState(UnitStandStateType(creatureAddon->standState));
     SetAnimTier(AnimTier(creatureAddon->animTier));
-    ReplaceAllVisFlags(UnitVisFlags(creatureAddon->visibilityFlags));
+    ReplaceAllVisFlags(UnitVisFlags(creatureAddon->visFlags));
 
     //! Suspected correlation between UNIT_FIELD_BYTES_1, offset 3, value 0x2:
     //! If no inhabittype_fly (if no MovementFlag_DisableGravity or MovementFlag_CanFly flag found in sniffs)

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2520,6 +2520,7 @@ bool Creature::LoadCreaturesAddon()
     // UNIT_FIELD_BYTES_1 values
     SetStandState(UnitStandStateType(creatureAddon->standState));
     SetAnimTier(AnimTier(creatureAddon->animTier));
+    ReplaceAllVisFlags(UnitVisFlags(creatureAddon->visibilityFlags));
 
     //! Suspected correlation between UNIT_FIELD_BYTES_1, offset 3, value 0x2:
     //! If no inhabittype_fly (if no MovementFlag_DisableGravity or MovementFlag_CanFly flag found in sniffs)

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -479,8 +479,10 @@ struct CreatureAddon
 {
     uint32 path_id;
     uint32 mount;
-    uint32 bytes1;
-    uint32 bytes2;
+    uint8 standState;
+    uint8 animTier;
+    uint8 sheathState;
+    uint8 pvpFlags;
     uint32 emote;
     std::vector<uint32> auras;
     VisibilityDistanceType visibilityDistanceType;

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -483,6 +483,7 @@ struct CreatureAddon
     uint8 animTier;
     uint8 sheathState;
     uint8 pvpFlags;
+    uint8 visibilityFlags;
     uint32 emote;
     std::vector<uint32> auras;
     VisibilityDistanceType visibilityDistanceType;

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -483,7 +483,7 @@ struct CreatureAddon
     uint8 animTier;
     uint8 sheathState;
     uint8 pvpFlags;
-    uint8 visibilityFlags;
+    uint8 visFlags;
     uint32 emote;
     std::vector<uint32> auras;
     VisibilityDistanceType visibilityDistanceType;

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -40,7 +40,9 @@ enum UnitStandStateType : uint8
     UNIT_STAND_STATE_SIT_HIGH_CHAIR    = 6,
     UNIT_STAND_STATE_DEAD              = 7,
     UNIT_STAND_STATE_KNEEL             = 8,
-    UNIT_STAND_STATE_SUBMERGED         = 9
+    UNIT_STAND_STATE_SUBMERGED         = 9,
+
+    MAX_UNIT_STAND_STATE
 };
 
 // byte flag value (UNIT_FIELD_BYTES_1, 2)
@@ -85,7 +87,9 @@ enum class AnimTier : uint8
     Swim        = 1, // falls back to ground tier animations, not handled by the client, should never appear in sniffs, will prevent tier change animations from playing correctly if used
     Hover       = 2, // plays flying tier animations or falls back to ground tier animations, automatically enables hover clientside when entering visibility with this value
     Fly         = 3, // plays flying tier animations
-    Submerged   = 4
+    Submerged   = 4,
+
+    Max
 };
 
 // low byte (0 from 0..3) of UNIT_FIELD_BYTES_2
@@ -93,10 +97,10 @@ enum SheathState : uint8
 {
     SHEATH_STATE_UNARMED  = 0,                              // non prepared weapon
     SHEATH_STATE_MELEE    = 1,                              // prepared melee weapon
-    SHEATH_STATE_RANGED   = 2                               // prepared ranged weapon
-};
+    SHEATH_STATE_RANGED   = 2,                              // prepared ranged weapon
 
-#define MAX_SHEATH_STATE    3
+    MAX_SHEATH_STATE
+};
 
 // byte (1 from 0..3) of UNIT_FIELD_BYTES_2
 enum UnitPVPStateFlags : uint8

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -787,19 +787,19 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 
         if (creatureAddon.standState >= MAX_UNIT_STAND_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0", entry, creatureAddon.standState);
+            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0.", entry, creatureAddon.standState);
             creatureAddon.standState = 0;
         }
 
         if (AnimTier(creatureAddon.animTier) >= AnimTier::Max)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0", entry, creatureAddon.animTier);
+            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0.", entry, creatureAddon.animTier);
             creatureAddon.animTier = 0;
         }
 
         if (creatureAddon.sheathState >= MAX_SHEATH_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0", entry, creatureAddon.standState);
+            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0.", entry, creatureAddon.sheathState);
             creatureAddon.sheathState = 0;
         }
 
@@ -1364,19 +1364,19 @@ void ObjectMgr::LoadCreatureAddons()
 
         if (creatureAddon.standState >= MAX_UNIT_STAND_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0", guid, creatureAddon.standState);
+            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0.", guid, creatureAddon.standState);
             creatureAddon.standState = 0;
         }
 
         if (AnimTier(creatureAddon.animTier) >= AnimTier::Max)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0", guid, creatureAddon.animTier);
+            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0.", guid, creatureAddon.animTier);
             creatureAddon.animTier = 0;
         }
 
         if (creatureAddon.sheathState >= MAX_SHEATH_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0", guid, creatureAddon.standState);
+            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0.", guid, creatureAddon.sheathState);
             creatureAddon.sheathState = 0;
         }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -711,8 +711,8 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                               0      1        2      3           4         5            6         7      8                       9
-    QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, StandState, AnimTier, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_template_addon");
+    //                                               0      1        2      3           4         5                6            7         8      9                       10
+    QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, StandState, AnimTier, VisibilityFlags, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_template_addon");
 
     if (!result)
     {
@@ -739,12 +739,13 @@ void ObjectMgr::LoadCreatureTemplateAddons()
         creatureAddon.mount                     = fields[2].GetUInt32();
         creatureAddon.standState                = fields[3].GetUInt8();
         creatureAddon.animTier                  = fields[4].GetUInt8();
-        creatureAddon.sheathState               = fields[5].GetUInt8();
-        creatureAddon.pvpFlags                  = fields[6].GetUInt8();
-        creatureAddon.emote                     = fields[7].GetUInt32();
-        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[8].GetUInt8());
+        creatureAddon.visibilityFlags           = fields[5].GetUInt8();
+        creatureAddon.sheathState               = fields[6].GetUInt8();
+        creatureAddon.pvpFlags                  = fields[7].GetUInt8();
+        creatureAddon.emote                     = fields[8].GetUInt32();
+        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[9].GetUInt8());
 
-        for (std::string_view aura : Trinity::Tokenize(fields[9].GetStringView(), ' ', false))
+        for (std::string_view aura : Trinity::Tokenize(fields[10].GetStringView(), ' ', false))
         {
 
             SpellInfo const* spellInfo = nullptr;
@@ -1281,8 +1282,8 @@ void ObjectMgr::LoadCreatureAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                               0     1        2      3           4         5            6         7      8                       9
-    QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, StandState, AnimTier, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_addon");
+    //                                               0     1        2      3           4         5                6            7         8      9                       10
+    QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, StandState, AnimTier, VisibilityFlags, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_addon");
 
     if (!result)
     {
@@ -1316,12 +1317,13 @@ void ObjectMgr::LoadCreatureAddons()
         creatureAddon.mount                     = fields[2].GetUInt32();
         creatureAddon.standState                = fields[3].GetUInt8();
         creatureAddon.animTier                  = fields[4].GetUInt8();
-        creatureAddon.sheathState               = fields[5].GetUInt8();
-        creatureAddon.pvpFlags                  = fields[6].GetUInt8();
-        creatureAddon.emote                     = fields[7].GetUInt32();
-        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[8].GetUInt8());
+        creatureAddon.visibilityFlags           = fields[5].GetUInt8();
+        creatureAddon.sheathState               = fields[6].GetUInt8();
+        creatureAddon.pvpFlags                  = fields[7].GetUInt8();
+        creatureAddon.emote                     = fields[8].GetUInt32();
+        creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[9].GetUInt8());
 
-        for (std::string_view aura : Trinity::Tokenize(fields[9].GetStringView(), ' ', false))
+        for (std::string_view aura : Trinity::Tokenize(fields[10].GetStringView(), ' ', false))
         {
             SpellInfo const* spellInfo = nullptr;
             if (Optional<uint32> spellId = Trinity::StringTo<uint32>(aura))

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -737,10 +737,10 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 
         creatureAddon.path_id                   = fields[1].GetUInt32();
         creatureAddon.mount                     = fields[2].GetUInt32();
-        uint8 standState                        = fields[3].GetUInt8();
-        uint8 animTier                          = fields[4].GetUInt8();
-        uint8 sheathState                       = fields[5].GetUInt8();
-        uint8 pvpFlags                          = fields[6].GetUInt8();
+        creatureAddon.standState                = fields[3].GetUInt8();
+        creatureAddon.animTier                  = fields[4].GetUInt8();
+        creatureAddon.sheathState               = fields[5].GetUInt8();
+        creatureAddon.pvpFlags                  = fields[6].GetUInt8();
         creatureAddon.emote                     = fields[7].GetUInt32();
         creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[8].GetUInt8());
 
@@ -784,29 +784,25 @@ void ObjectMgr::LoadCreatureTemplateAddons()
             }
         }
 
-        if (standState >= MAX_UNIT_STAND_STATE)
+        if (creatureAddon.standState >= MAX_UNIT_STAND_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0", entry, standState);
-            standState = 0;
+            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0", entry, creatureAddon.standState);
+            creatureAddon.standState = 0;
         }
-        creatureAddon.bytes1 |= uint32(uint32(standState) << (UNIT_BYTES_1_OFFSET_STAND_STATE * 8));
 
-        if (AnimTier(animTier) >= AnimTier::Max)
+        if (AnimTier(creatureAddon.animTier) >= AnimTier::Max)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0", entry, standState);
-            animTier = 0;
+            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0", entry, creatureAddon.animTier);
+            creatureAddon.animTier = 0;
         }
-        creatureAddon.bytes1 |= uint32(uint32(animTier) << (UNIT_BYTES_1_OFFSET_ANIM_TIER * 8));
 
-        if (sheathState >= MAX_SHEATH_STATE)
+        if (creatureAddon.sheathState >= MAX_SHEATH_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0", entry, standState);
-            sheathState = 0;
+            TC_LOG_ERROR("sql.sql", "Creature (Entry: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0", entry, creatureAddon.standState);
+            creatureAddon.sheathState = 0;
         }
-        creatureAddon.bytes2 |= uint32(uint32(sheathState) << (UNIT_BYTES_2_OFFSET_SHEATH_STATE * 8));
 
         // PvPFlags don't need any checking for the time being since they cover the entire range of a byte
-        creatureAddon.bytes2 |= uint32(uint32(pvpFlags) << (UNIT_BYTES_2_OFFSET_PVP_FLAG * 8));
 
         if (!sEmotesStore.LookupEntry(creatureAddon.emote))
         {
@@ -1318,10 +1314,10 @@ void ObjectMgr::LoadCreatureAddons()
         }
 
         creatureAddon.mount                     = fields[2].GetUInt32();
-        uint8 standState                        = fields[3].GetUInt8();
-        uint8 animTier                          = fields[4].GetUInt8();
-        uint8 sheathState                       = fields[5].GetUInt8();
-        uint8 pvpFlags                          = fields[6].GetUInt8();
+        creatureAddon.standState                = fields[3].GetUInt8();
+        creatureAddon.animTier                  = fields[4].GetUInt8();
+        creatureAddon.sheathState               = fields[5].GetUInt8();
+        creatureAddon.pvpFlags                  = fields[6].GetUInt8();
         creatureAddon.emote                     = fields[7].GetUInt32();
         creatureAddon.visibilityDistanceType    = VisibilityDistanceType(fields[8].GetUInt8());
 
@@ -1364,29 +1360,25 @@ void ObjectMgr::LoadCreatureAddons()
             }
         }
 
-        if (standState >= MAX_UNIT_STAND_STATE)
+        if (creatureAddon.standState >= MAX_UNIT_STAND_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0", guid, standState);
-            standState = 0;
+            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid unit stand state (%u) defined in `creature_addon`. Truncated to 0", guid, creatureAddon.standState);
+            creatureAddon.standState = 0;
         }
-        creatureAddon.bytes1 |= uint32(uint32(standState) << (UNIT_BYTES_1_OFFSET_STAND_STATE * 8));
 
-        if (AnimTier(animTier) >= AnimTier::Max)
+        if (AnimTier(creatureAddon.animTier) >= AnimTier::Max)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0", guid, standState);
-            animTier = 0;
+            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid animation tier (%u) defined in `creature_addon`. Truncated to 0", guid, creatureAddon.animTier);
+            creatureAddon.animTier = 0;
         }
-        creatureAddon.bytes1 |= uint32(uint32(animTier) << (UNIT_BYTES_1_OFFSET_ANIM_TIER * 8));
 
-        if (sheathState >= MAX_SHEATH_STATE)
+        if (creatureAddon.sheathState >= MAX_SHEATH_STATE)
         {
-            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0", guid, standState);
-            sheathState = 0;
+            TC_LOG_ERROR("sql.sql", "Creature (GUID: %u) has invalid sheath state (%u) defined in `creature_addon`. Truncated to 0", guid, creatureAddon.standState);
+            creatureAddon.sheathState = 0;
         }
-        creatureAddon.bytes2 |= uint32(uint32(sheathState) << (UNIT_BYTES_2_OFFSET_SHEATH_STATE * 8));
 
         // PvPFlags don't need any checking for the time being since they cover the entire range of a byte
-        creatureAddon.bytes2 |= uint32(uint32(pvpFlags) << (UNIT_BYTES_2_OFFSET_PVP_FLAG * 8));
 
         if (!sEmotesStore.LookupEntry(creatureAddon.emote))
         {

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -711,8 +711,8 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                               0      1        2      3           4         5                6            7         8      9                       10
-    QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, StandState, AnimTier, VisibilityFlags, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_template_addon");
+    //                                               0      1        2      3           4         5         6            7         8      9                       10
+    QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, StandState, AnimTier, VisFlags, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_template_addon");
 
     if (!result)
     {
@@ -739,7 +739,7 @@ void ObjectMgr::LoadCreatureTemplateAddons()
         creatureAddon.mount                     = fields[2].GetUInt32();
         creatureAddon.standState                = fields[3].GetUInt8();
         creatureAddon.animTier                  = fields[4].GetUInt8();
-        creatureAddon.visibilityFlags           = fields[5].GetUInt8();
+        creatureAddon.visFlags                  = fields[5].GetUInt8();
         creatureAddon.sheathState               = fields[6].GetUInt8();
         creatureAddon.pvpFlags                  = fields[7].GetUInt8();
         creatureAddon.emote                     = fields[8].GetUInt32();
@@ -1282,8 +1282,8 @@ void ObjectMgr::LoadCreatureAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                               0     1        2      3           4         5                6            7         8      9                       10
-    QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, StandState, AnimTier, VisibilityFlags, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_addon");
+    //                                               0     1        2      3           4         5         6            7         8      9                       10
+    QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, StandState, AnimTier, VisFlags, SheathState, PvPFlags, emote, visibilityDistanceType, auras FROM creature_addon");
 
     if (!result)
     {
@@ -1317,7 +1317,7 @@ void ObjectMgr::LoadCreatureAddons()
         creatureAddon.mount                     = fields[2].GetUInt32();
         creatureAddon.standState                = fields[3].GetUInt8();
         creatureAddon.animTier                  = fields[4].GetUInt8();
-        creatureAddon.visibilityFlags           = fields[5].GetUInt8();
+        creatureAddon.visFlags                  = fields[5].GetUInt8();
         creatureAddon.sheathState               = fields[6].GetUInt8();
         creatureAddon.pvpFlags                  = fields[7].GetUInt8();
         creatureAddon.emote                     = fields[8].GetUInt32();


### PR DESCRIPTION
**Changes proposed:**

-  the times of just dumping raw sniff values into creature_addon tables are over at last. We now have clear and readable fields which will replace bytes1 and bytes2. Existing data will be converted and the old columns dropped afterwards.
- This will make addons much more enjoyable to work with while also blocking access to fields which should have never been set in the DB in the first place, such as pet talents/flags and shapeshift data

**Tests performed:**
- tested ingame
- 