### PR TITLE
Core/Spells: resurrection after raise ally

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -2414,6 +2414,7 @@ public:
                 ghoul->DespawnOrUnsummon(1s);
             }
 
+            player->ClearResurrectRequestData();
             player->RemoveAura(SPELL_GHOUL_FRENZY);
         }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  add _resurrectionData object resetting, to the spell_dk_raise_ally_AuraScript(along 
with aura removing)
-  Problem in next function have being called for resurrection spells by players:
```
Spell::EffectResurrectNew()
{
  ...
  if (player->IsResurrectRequested()) // already have one active request, even after raise_ally removing
        return;
  ...
  SendResurrectRequest(..) // so we dont hit here
}
```

-  

**Issues addressed:**

Closes #26296


**Tests performed:**

Tested in game


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
