### PR TITLE
GameObjects/CapturePoints: Update Map SpawnGroupConditions immediately after UpdateCapturePoint

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -3879,6 +3879,8 @@ void GameObject::UpdateCapturePoint()
             bg->UpdateWorldState(GetGOInfo()->capturePoint.worldState1, AsUnderlyingType(m_goValue.CapturePoint.State));
         }
     }
+
+    GetMap()->UpdateSpawnGroupConditions();
 }
 
 bool GameObject::CanInteractWithCapturePoint(Player const* target) const

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -693,6 +693,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         typedef std::function<void(Map*)> FarSpellCallback;
         void AddFarSpellCallback(FarSpellCallback&& callback);
 
+        void UpdateSpawnGroupConditions();
+
     private:
         // Type specific code for add/remove to/from grid
         template<class T>
@@ -755,7 +757,6 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         }
 
         void SetSpawnGroupActive(uint32 groupId, bool state);
-        void UpdateSpawnGroupConditions();
         std::unordered_set<uint32> _toggledSpawnGroupIds;
 
         uint32 _respawnCheckTimer;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Expose Map::UpdateSpawnGroupConditions
-  Call this function after Capture point has been updated

**Issues addressed:**

Closes: none


**Tests performed:**

- Builds
- Spawngroups appear and dissappear instantly after assaulting/defending/capturing a capture point

**Known issues and TODO list:**

- none

This change is needed because we don't want to wait for `Map::_respawnCheckTimer` to update the spawn conditions. In battlegrounds, when a capture point is assaulted, spirit guides get removed instantly and everyone gets teleported without the delay


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
