### PR TITLE
Core/Vmaps: Fix inconsistency of hitInstance and hitModel to cause wr…

### DIFF
--- a/src/common/Collision/Maps/MapTree.h
+++ b/src/common/Collision/Maps/MapTree.h
@@ -30,6 +30,12 @@ namespace VMAP
     enum class LoadResult : uint8;
     enum class ModelIgnoreFlags : uint32;
 
+    struct GroupLocationInfo
+    {
+        const GroupModel* hitModel = nullptr;
+        int32 rootId = -1;
+    };
+
     struct TC_COMMON_API LocationInfo
     {
         LocationInfo(): rootId(-1), hitInstance(nullptr), hitModel(nullptr), ground_Z(-G3D::finf()) { }

--- a/src/common/Collision/Models/GameObjectModel.cpp
+++ b/src/common/Collision/Models/GameObjectModel.cpp
@@ -227,7 +227,9 @@ bool GameObjectModel::GetLocationInfo(G3D::Vector3 const& point, VMAP::LocationI
     Vector3 pModel = iInvRot * (point - iPos) * iInvScale;
     Vector3 zDirModel = iInvRot * Vector3(0.f, 0.f, -1.f);
     float zDist;
-    if (iModel->GetLocationInfo(pModel, zDirModel, zDist, info))
+
+    VMAP::GroupLocationInfo groupInfo;
+    if (iModel->GetLocationInfo(pModel, zDirModel, zDist, groupInfo))
     {
         Vector3 modelGround = pModel + zDist * zDirModel;
         float world_Z = ((modelGround * iInvRot) * iScale + iPos).z;

--- a/src/common/Collision/Models/ModelInstance.cpp
+++ b/src/common/Collision/Models/ModelInstance.cpp
@@ -116,7 +116,9 @@ namespace VMAP
         Vector3 pModel = iInvRot * (p - iPos) * iInvScale;
         Vector3 zDirModel = iInvRot * Vector3(0.f, 0.f, -1.f);
         float zDist;
-        if (iModel->GetLocationInfo(pModel, zDirModel, zDist, info))
+
+        GroupLocationInfo groupInfo;
+        if (iModel->GetLocationInfo(pModel, zDirModel, zDist, groupInfo))
         {
             Vector3 modelGround = pModel + zDist * zDirModel;
             // Transform back to world space. Note that:
@@ -125,6 +127,8 @@ namespace VMAP
             float world_Z = ((modelGround * iInvRot) * iScale + iPos).z;
             if (info.ground_Z < world_Z) // hm...could it be handled automatically with zDist at intersection?
             {
+                info.rootId = groupInfo.rootId;
+                info.hitModel = groupInfo.hitModel;
                 info.ground_Z = world_Z;
                 info.hitInstance = this;
                 return true;

--- a/src/common/Collision/Models/WorldModel.cpp
+++ b/src/common/Collision/Models/WorldModel.cpp
@@ -548,7 +548,7 @@ namespace VMAP
         return false;
     }
 
-    bool WorldModel::GetLocationInfo(const G3D::Vector3& p, const G3D::Vector3& down, float& dist, LocationInfo& info) const
+    bool WorldModel::GetLocationInfo(const G3D::Vector3& p, const G3D::Vector3& down, float& dist, GroupLocationInfo& info) const
     {
         if (groupModels.empty())
             return false;

--- a/src/common/Collision/Models/WorldModel.h
+++ b/src/common/Collision/Models/WorldModel.h
@@ -30,6 +30,7 @@ namespace VMAP
     class TreeNode;
     struct AreaInfo;
     struct LocationInfo;
+    struct GroupLocationInfo;
     enum class ModelIgnoreFlags : uint32;
 
     class TC_COMMON_API MeshTriangle
@@ -112,7 +113,7 @@ namespace VMAP
             void setRootWmoID(uint32 id) { RootWMOID = id; }
             bool IntersectRay(const G3D::Ray &ray, float &distance, bool stopAtFirstHit, ModelIgnoreFlags ignoreFlags) const;
             bool IntersectPoint(const G3D::Vector3 &p, const G3D::Vector3 &down, float &dist, AreaInfo &info) const;
-            bool GetLocationInfo(const G3D::Vector3 &p, const G3D::Vector3 &down, float &dist, LocationInfo &info) const;
+            bool GetLocationInfo(const G3D::Vector3 &p, const G3D::Vector3 &down, float &dist, GroupLocationInfo& info) const;
             bool writeFile(const std::string &filename);
             bool readFile(const std::string &filename);
             void getGroupModels(std::vector<GroupModel>& outGroupModels);


### PR DESCRIPTION
…ong area ids

**Issues addressed:**

Closes #28326


**Tests performed:**
tested ingame at:
- `.go xyz 1515 -4413 22 1136` (ref issue/siege of orgrimmar)
- regular orgrimmar (around same position as above)
- `.go xyz 1548.641 -4403.93 18.122 2212` (horrific vision of orgrimmar)

