### PR TITLE
SendTrainerList on PrepareGossipMenu for trainers with gossip flag

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13755,6 +13755,11 @@ void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId, bool showQues
                 case GossipOptionNpc::None:
                 case GossipOptionNpc::Vendor:
                 case GossipOptionNpc::Trainer:
+					if (uint32 trainerId = sObjectMgr->GetCreatureTrainerForGossipOption(creature->GetEntry(), gossipMenuItem.MenuID, gossipMenuItem.OrderIndex))
+                        GetSession()->SendTrainerList(creature, trainerId);
+                    else
+                        TC_LOG_DEBUG("network", "Player::PrepareGossipMenu - Creature id %u was trying to SendTrainerList without trainer data.", creature->GetEntry());
+                    break;
                 case GossipOptionNpc::Binder:
                 case GossipOptionNpc::Banker:
                 case GossipOptionNpc::PetitionVendor:

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13754,6 +13754,7 @@ void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId, bool showQues
                     break;
                 case GossipOptionNpc::None:
                 case GossipOptionNpc::Vendor:
+					break;
                 case GossipOptionNpc::Trainer:
 					if (uint32 trainerId = sObjectMgr->GetCreatureTrainerForGossipOption(creature->GetEntry(), gossipMenuItem.MenuID, gossipMenuItem.OrderIndex))
                         GetSession()->SendTrainerList(creature, trainerId);


### PR DESCRIPTION
**Changes proposed:**

-  SendTrainerList on Player::PrepareGossipMenu case GossipOptionNpc::Trainer

**Issues addressed:**
[28642](https://github.com/TrinityCore/TrinityCore/issues/28642)

Closes #  (insert issue tracker number)
28642

**Tests performed:**
Builds & tested ingame.

Known issues and TODO list: (add/remove lines as needed)

Does not show gossip text when the player clicks on the npc. 
I checked some on retail and it works in the same way (only trainer window).

![image](https://user-images.githubusercontent.com/25673748/210184213-80f7f561-1757-4077-87fd-ffb5feec8ce6.png)
