### PR TITLE
Core/Player: Proper search for trainerId in the trainer gossips

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13895,7 +13895,7 @@ void Player::OnGossipSelect(WorldObject* source, int32 gossipOptionId, uint32 me
             GetSession()->SendTaxiMenu(source->ToCreature());
             break;
         case GossipOptionNpc::Trainer:
-            GetSession()->SendTrainerList(source->ToCreature(), sObjectMgr->GetCreatureTrainerForGossipOption(source->GetEntry(), menuId, gossipOptionId));
+            GetSession()->SendTrainerList(source->ToCreature(), sObjectMgr->GetCreatureTrainerForGossipOption(source->GetEntry(), menuId, item->OrderIndex));
             break;
         case GossipOptionNpc::SpiritHealer:
             source->CastSpell(source->ToCreature(), 17251, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(GetGUID()));


### PR DESCRIPTION
**Changes proposed:**

-  Player::OnGossipSelect can't find the trainerId at  case GossipOptionNpc::Trainer because GetCreatureTrainerForGossipOption always failed.

**Issues addressed:**
[28642](https://github.com/TrinityCore/TrinityCore/issues/28642)

Closes #  (insert issue tracker number)
28642

**Tests performed:**
Builds & tested ingame.

![image](https://user-images.githubusercontent.com/25673748/210184213-80f7f561-1757-4077-87fd-ffb5feec8ce6.png)
