### PR TITLE
Core/Spells: Update IsPrimaryProfessionSkill filtering

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -104,7 +104,7 @@ PetFamilySpellsStore sPetFamilySpellsStore;
 bool IsPrimaryProfessionSkill(uint32 skill)
 {
     SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
-    return pSkill && pSkill->CategoryID == SKILL_CATEGORY_PROFESSION;
+    return pSkill && pSkill->CategoryID == SKILL_CATEGORY_PROFESSION && !pSkill->ParentSkillLineID;
 }
 
 bool IsWeaponSkill(uint32 skill)


### PR DESCRIPTION
**Changes proposed:**

-  Check for Unique Bitfield flag in IsPrimaryProfessionSkill function

**Proof:**
[Skills with unique bitfield shows only primary proffs first spell](https://wow.tools/dbc/?dbc=skillline&build=10.0.5.47215#page=1&colFilter[11]=0x1080)

**Issues addressed:**
28649

**Closes** 
#28649

**Tests performed:**
Builds & tested.
[Test video](https://youtu.be/bg09sXX4rjI)


![profbug](https://user-images.githubusercontent.com/25673748/210218666-efa73b18-a648-46f9-8c1b-60d87073a377.png)