### PR TITLE
Core/Reputation: Implemented renown reputation (Dragonflight)

### DIFF
--- a/src/server/game/Reputation/ReputationMgr.h
+++ b/src/server/game/Reputation/ReputationMgr.h
@@ -54,6 +54,7 @@ struct FactionState
     uint32 ID;
     RepListID ReputationListID;
     int32 Standing;
+    int32 VisualStandingIncrease;
     EnumFlag<ReputationFlags> Flags = ReputationFlags::None;
     bool needSend;
     bool needSave;
@@ -116,8 +117,15 @@ class TC_GAME_API ReputationMgr
             return forceItr != _forcedReactions.end() ? &forceItr->second : nullptr;
         }
 
+        bool IsParagonReputation(FactionEntry const* factionEntry) const;
         int32 GetParagonLevel(uint32 paragonFactionId) const;
         int32 GetParagonLevel(FactionEntry const* paragonFactionEntry) const;
+
+        bool HasMaximumRenownReputation(FactionEntry const* factionEntry) const;
+        bool IsRenownReputation(FactionEntry const* factionEntry) const;
+        int32 GetRenownLevel(FactionEntry const* renownFactionEntry) const;
+        int32 GetRenownLevelThreshold(FactionEntry const* renownFactionEntry) const;
+        int32 GetRenownMaxLevel(FactionEntry const* renownFactionEntry) const;
 
     public:                                                 // modifiers
         bool SetReputation(FactionEntry const* factionEntry, int32 standing)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implemented renown reputations (Dragonflight). Reputation levels can now be earned. All rewards are quests or achievements that have serverside conditions and are not added directly to the player (as opposed to paragon reward quest). 
-  Added paragon reputation support for renown reputations


**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
- I don't know if RenownRewards.QuestID (db2) must be completed when reaching the renown level or has no use
- SMSG_SET_CURRENCY isn't working properly and therefore a chat message is displayed when acquiring the hidden currency. Fixed in (https://github.com/TrinityCore/TrinityCore/pull/28676) (CurrencyGainSource::RenownRepGain missing)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
