### PR TITLE
Core/Creatures: Fix logic in searching nearby creatures by StringId

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1490,7 +1490,7 @@ namespace Trinity
                 if (i_args.CreatureId && u->GetEntry() != i_args.CreatureId)
                     return false;
 
-                if (i_args.StringId && u->HasStringId(*i_args.StringId))
+                if (i_args.StringId && !u->HasStringId(*i_args.StringId))
                     return false;
 
                 if (i_args.IsAlive.has_value() && u->IsAlive() != i_args.IsAlive)


### PR DESCRIPTION
**Changes proposed:**

Makes it so the proper creatures pass or fail the check respectively, as it's currently selecting and ignoring the opposite ones than it should.

**Tests performed:**

Working as intended after the change.


