### PR TITLE
Core/Misc: Duplicate call to WorldObject::UpdatePositionData

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12337,8 +12337,6 @@ bool Unit::UpdatePosition(float x, float y, float z, float orientation, bool tel
     else if (turn)
         UpdateOrientation(orientation);
 
-    UpdatePositionData();
-
     _positionUpdateInfo.Relocated = relocated;
     _positionUpdateInfo.Turned = turn;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Remove duplicate call to WorldObject::UpdatePositionData, we already have it in Map::XXXRelocation, for creatures in move list UpdatePositionData will be called once relocation happened

**Issues addressed:**

Closes #  (insert issue tracker number)
Discussed and described here https://github.com/TrinityCore/TrinityCore/discussions/28099

**Tests performed:**
Yes it's build, tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
