### PR TITLE
Scripts/Druid: Sudden Ambush

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_proc` WHERE `SpellId` IN (384667);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(384667,0x01,7,0x00000000,0x00000080,0x00200000,0x00001000,0x10,0x0,0x5,0x2,0x3,0x0,0x0,0,0,0,0); -- Sudden Ambush

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,3 +1,10 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_dru_sudden_ambush'; 
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_dru_shred'; 
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_dru_rake'; 
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES('384667','spell_dru_sudden_ambush');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES('5221','spell_dru_shred');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES('1822','spell_dru_rake');
+
 DELETE FROM `spell_proc` WHERE `SpellId` IN (384667);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(384667,0x01,7,0x00000000,0x00000080,0x00200000,0x00001000,0x10,0x0,0x5,0x2,0x3,0x0,0x0,0,0,0,0); -- Sudden Ambush
+(384667,0x01,7,0x00000000,0x00000080,0x00200000,0x00001000,0x10,0x0,0x5,0x2,0x3,0x0,0x0,0,0,0,0);

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -93,7 +93,10 @@ enum DruidSpells
     SPELL_DRUID_THRASH_BEAR                    = 77758,
     SPELL_DRUID_THRASH_BEAR_AURA               = 192090,
     SPELL_DRUID_THRASH_CAT                     = 106830,
-    SPELL_DRUID_SUDDEN_AMBUSH                  = 384667
+    SPELL_DRUID_SUDDEN_AMBUSH                  = 384667,
+    SPELL_DRUID_SUDDEN_AMBUSH_AURA             = 391974,
+    SPELL_DRUID_RAKE                           = 1822,
+    SPELL_DRUID_SHRED                          = 5221,
 };
 
 class RaidCheck
@@ -1634,12 +1637,52 @@ class spell_dru_sudden_ambush : public AuraScript
         if (!*comboPointsAmount)
             return false;
 
-        return roll_chance_f(*comboPointsAmount * 5);;
+        return roll_chance_f(*comboPointsAmount * 5);
     }
 
     void Register() override
     {
         DoCheckEffectProc += AuraCheckEffectProcFn(spell_dru_sudden_ambush::CheckProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+    }
+};
+
+class spell_dru_rake : public SpellScript
+{
+    PrepareSpellScript(spell_dru_rake);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({SPELL_DRUID_SUDDEN_AMBUSH});
+    }
+
+    void AfterHitHandle() {
+        if (GetCaster()->HasAura(SPELL_DRUID_SUDDEN_AMBUSH_AURA))
+            GetCaster()->RemoveAura(SPELL_DRUID_SUDDEN_AMBUSH_AURA);
+    }
+
+    void Register() override
+    {
+        AfterHit += SpellHitFn(spell_dru_rake::AfterHitHandle);
+    }
+};
+
+class spell_dru_shred : public SpellScript
+{
+    PrepareSpellScript(spell_dru_shred);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_DRUID_SUDDEN_AMBUSH });
+    }
+
+    void AfterHitHandle() {
+        if (GetCaster()->HasAura(SPELL_DRUID_SUDDEN_AMBUSH_AURA))
+            GetCaster()->RemoveAura(SPELL_DRUID_SUDDEN_AMBUSH_AURA);
+    }
+
+    void Register() override
+    {
+        AfterHit += SpellHitFn(spell_dru_shred::AfterHitHandle);
     }
 };
 
@@ -1689,4 +1732,6 @@ void AddSC_druid_spell_scripts()
     RegisterSpellAndAuraScriptPair(spell_dru_tiger_dash, spell_dru_tiger_dash_aura);
     RegisterSpellAndAuraScriptPair(spell_dru_wild_growth, spell_dru_wild_growth_aura);
     RegisterSpellScript(spell_dru_sudden_ambush);
+    RegisterSpellScript(spell_dru_rake);
+    RegisterSpellScript(spell_dru_shred);
 }

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1624,7 +1624,7 @@ class spell_dru_sudden_ambush : public AuraScript
 
     bool CheckProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
     {
-        // Get the Combo Points 
+        // Get the Combo Points
         Spell const* procSpell = eventInfo.GetProcSpell();
         std::optional<int32_t> comboPointsAmount = procSpell->GetPowerTypeCostAmount(POWER_COMBO_POINTS);
 

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -30,6 +30,7 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
+#include <string> 
 
 enum DruidSpells
 {
@@ -92,7 +93,8 @@ enum DruidSpells
     SPELL_DRUID_TRAVEL_FORM                    = 783,
     SPELL_DRUID_THRASH_BEAR                    = 77758,
     SPELL_DRUID_THRASH_BEAR_AURA               = 192090,
-    SPELL_DRUID_THRASH_CAT                     = 106830
+    SPELL_DRUID_THRASH_CAT                     = 106830,
+    SPELL_DRUID_SUDDEN_AMBUSH                  = 384667
 };
 
 class RaidCheck
@@ -1611,6 +1613,37 @@ class spell_dru_wild_growth_aura : public AuraScript
     }
 };
 
+// 384667 - Sudden Ambush Talent
+class spell_dru_sudden_ambush : public AuraScript
+{
+    PrepareAuraScript(spell_dru_sudden_ambush);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_DRUID_SUDDEN_AMBUSH });
+    }
+
+    bool CheckProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+    {
+        // Get the Combo Points 
+        Spell const* procSpell = eventInfo.GetProcSpell();
+        std::optional<int32_t> comboPointsAmount = procSpell->GetPowerTypeCostAmount(POWER_COMBO_POINTS);
+
+        if (!*comboPointsAmount) {
+            return false;
+        }
+
+        uint8 chances = roll_chance_f(*comboPointsAmount * 5);
+      
+        return chances;
+    }
+
+    void Register() override
+    {
+        DoCheckEffectProc += AuraCheckEffectProcFn(spell_dru_sudden_ambush::CheckProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
+    }
+};
+
 void AddSC_druid_spell_scripts()
 {
     RegisterSpellScript(spell_dru_barkskin);
@@ -1656,4 +1689,5 @@ void AddSC_druid_spell_scripts()
     RegisterSpellAndAuraScriptPair(spell_dru_travel_form_dummy, spell_dru_travel_form_dummy_aura);
     RegisterSpellAndAuraScriptPair(spell_dru_tiger_dash, spell_dru_tiger_dash_aura);
     RegisterSpellAndAuraScriptPair(spell_dru_wild_growth, spell_dru_wild_growth_aura);
+    RegisterSpellScript(spell_dru_sudden_ambush);
 }

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -30,7 +30,6 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
-#include <string> 
 
 enum DruidSpells
 {

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1626,15 +1626,15 @@ class spell_dru_sudden_ambush : public AuraScript
     {
         // Get the Combo Points
         Spell const* procSpell = eventInfo.GetProcSpell();
+        if (!procSpell)
+            return false;
+
         std::optional<int32_t> comboPointsAmount = procSpell->GetPowerTypeCostAmount(POWER_COMBO_POINTS);
 
-        if (!*comboPointsAmount) {
+        if (!*comboPointsAmount)
             return false;
-        }
 
-        uint8 chances = roll_chance_f(*comboPointsAmount * 5);
-      
-        return chances;
+        return roll_chance_f(*comboPointsAmount * 5);;
     }
 
     void Register() override


### PR DESCRIPTION
**Changes proposed:**
-  Fixed Default proc of Sudden Ambush (SQL)
-  5% Chance of proc per combo point spent (Script)
- Add remove effect when cast rake/shred

**Issues addressed:**
Fix #28689 


**Tests performed:**
Tested in Game

**We cant count the Rake/Shred behavior under Stealth here because is from another spell, and that cover much other spells than just Sudden Ambush**

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
