### PR TITLE
Core/Spells: allow to get mover for feared/confused/possessed players

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1163,6 +1163,7 @@ class TC_GAME_API Unit : public WorldObject
         bool HasStealthAura()      const { return HasAuraType(SPELL_AURA_MOD_STEALTH); }
         bool HasInvisibilityAura() const { return HasAuraType(SPELL_AURA_MOD_INVISIBILITY); }
         bool IsFeared()  const { return HasAuraType(SPELL_AURA_MOD_FEAR); }
+        bool IsConfused()  const { return HasAuraType(SPELL_AURA_MOD_CONFUSE); }
         bool IsRooted() const { return HasAuraType(SPELL_AURA_MOD_ROOT); }
         bool IsPolymorphed() const;
         bool IsFrozen() const { return HasAuraState(AURA_STATE_FROZEN); }

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -338,7 +338,18 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
 
     // ignore for remote control state (for player case)
     Unit* mover = GetGameClient()->GetActivelyMovedUnit();
-    if (!mover || (mover != _player && mover->GetTypeId() == TYPEID_PLAYER))
+    if(!mover)
+    {
+        //there is no ActivelyMovedUnit if player is under fear, confuse or possession
+        if(_player->IsFeared() || _player->IsConfused() || _player->isPossessed())
+            mover = _player;
+        else
+        {
+            recvPacket.rfinish(); // prevent spam at ignore packet
+            return;
+        }
+    }
+    else if (mover != _player && mover->GetTypeId() == TYPEID_PLAYER)
     {
         recvPacket.rfinish(); // prevent spam at ignore packet
         return;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  add check for feared, confused or possessed players in WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket) because `GetGameClient()->GetActivelyMovedUnit()` returns nullptr for players under these effects.
It caused by this:
https://github.com/TrinityCore/TrinityCore/blob/128339730cafefba04ca8b1b6c72ed4ea9315bd3/src/server/game/Entities/Unit/Unit.cpp#L11436-L11442
same thing in Unit::SetConfused Unit::SetCharmedBy
-  
-  

**Issues addressed:**

Closes #27863


**Tests performed:**

built. tested in game


**Known issues and TODO list:** (add/remove lines as needed)

- Still, there is a kind of related issue. problem with cooldown packet. #26510 https://github.com/TrinityCore/TrinityCore/blob/128339730cafefba04ca8b1b6c72ed4ea9315bd3/src/server/game/Spells/Spell.cpp#L4321-L4324
maybe somebody can explain can we call here `m_caster->ToPlayer()` instead `m_caster->GetAffectingPlayer()) `.
now player can dispell Mind control by trinket, but cant see cooldown
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
