### PR TITLE
Core/Battlegrounds: Prevent end Arena when a dead player logout

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1097,8 +1097,8 @@ void Battleground::EventPlayerLoggedOut(Player* player)
         // drop flag and handle other cleanups
         RemovePlayer(player, guid, GetPlayerTeam(guid));
 
-        // 1 player is logging out, if it is the last, then end arena!
-        if (isArena())
+        // 1 player is logging out, if it is the last alive, then end arena!
+        if (isArena() && player->IsAlive())
             if (GetAlivePlayersCountByTeam(player->GetBGTeam()) <= 1 && GetPlayersCountByTeam(GetOtherTeam(player->GetBGTeam())))
                 EndBattleground(GetOtherTeam(player->GetBGTeam()));
     }


### PR DESCRIPTION
**Changes proposed:**

-  Prevent end Arena when a dead player logout.
By example in Arena 2vs2, Team A - player 1 is alive, Team A - player 2 is dead, player 2 lose connection and login again and Arena end losing Team A.
Arena only should end by time or if no player is alive or online.
>The Fight
Players battle it out until all the members of one team are defeated or choose to leave, or until 45 minutes have elapsed.
https://wowwiki-archive.fandom.com/wiki/Arena_PvP_system

**Issues addressed:**

None


**Tests performed:**

tested in-game
