### PR TITLE
Core/SAI: Set the trigger player as baseobject when the source type isn't a WorldObject

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1187,28 +1187,28 @@ public:
     void OnSceneStart(Player* player, uint32 /*sceneInstanceID*/, SceneTemplate const* sceneTemplate) override
     {
         SmartScript smartScript;
-        smartScript.OnInitialize(nullptr, nullptr, sceneTemplate);
+        smartScript.OnInitialize(player, nullptr, sceneTemplate);
         smartScript.ProcessEventsFor(SMART_EVENT_SCENE_START, player);
     }
 
     void OnSceneTriggerEvent(Player* player, uint32 /*sceneInstanceID*/, SceneTemplate const* sceneTemplate, std::string const& triggerName) override
     {
         SmartScript smartScript;
-        smartScript.OnInitialize(nullptr, nullptr, sceneTemplate);
+        smartScript.OnInitialize(player, nullptr, sceneTemplate);
         smartScript.ProcessEventsFor(SMART_EVENT_SCENE_TRIGGER, player, 0, 0, false, nullptr, nullptr, triggerName);
     }
 
     void OnSceneCancel(Player* player, uint32 /*sceneInstanceID*/, SceneTemplate const* sceneTemplate) override
     {
         SmartScript smartScript;
-        smartScript.OnInitialize(nullptr, nullptr, sceneTemplate);
+        smartScript.OnInitialize(player, nullptr, sceneTemplate);
         smartScript.ProcessEventsFor(SMART_EVENT_SCENE_CANCEL, player);
     }
 
     void OnSceneComplete(Player* player, uint32 /*sceneInstanceID*/, SceneTemplate const* sceneTemplate) override
     {
         SmartScript smartScript;
-        smartScript.OnInitialize(nullptr, nullptr, sceneTemplate);
+        smartScript.OnInitialize(player, nullptr, sceneTemplate);
         smartScript.ProcessEventsFor(SMART_EVENT_SCENE_COMPLETE, player);
     }
 };
@@ -1222,7 +1222,7 @@ public:
     void OnQuestStatusChange(Player* player, Quest const* quest, QuestStatus /*oldStatus*/, QuestStatus newStatus) override
     {
         SmartScript smartScript;
-        smartScript.OnInitialize(nullptr, nullptr, nullptr, quest);
+        smartScript.OnInitialize(player, nullptr, nullptr, quest);
         switch (newStatus)
         {
             case QUEST_STATUS_INCOMPLETE:
@@ -1250,7 +1250,7 @@ public:
         if (slot < MAX_QUEST_LOG_SIZE && player->IsQuestObjectiveComplete(slot, quest, objective))
         {
             SmartScript smartScript;
-            smartScript.OnInitialize(nullptr, nullptr, nullptr, quest);
+            smartScript.OnInitialize(player, nullptr, nullptr, quest);
             smartScript.ProcessEventsFor(SMART_EVENT_QUEST_OBJ_COMPLETION, player, objective.ID);
         }
     }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -48,8 +48,8 @@ SmartScript::SmartScript()
 {
     go = nullptr;
     me = nullptr;
+    player = nullptr;
     trigger = nullptr;
-    atPlayer = nullptr;
     areaTrigger = nullptr;
     sceneTemplate = nullptr;
     quest = nullptr;
@@ -1232,7 +1232,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             EnumFlag<SmartActionSummonCreatureFlags> flags(static_cast<SmartActionSummonCreatureFlags>(e.action.summonCreature.flags));
             bool preferUnit = flags.HasFlag(SmartActionSummonCreatureFlags::PreferUnit);
-            WorldObject* summoner = preferUnit ? unit : Coalesce<WorldObject>(GetBaseObjectOrPlayerTrigger(), unit);
+            WorldObject* summoner = preferUnit ? unit : GetBaseObjectOrUnitInvoker(unit);
             if (!summoner)
                 break;
 
@@ -1270,7 +1270,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }
         case SMART_ACTION_SUMMON_GO:
         {
-            WorldObject* summoner = GetBaseObjectOrUnit(unit);
+            WorldObject* summoner = GetBaseObjectOrUnitInvoker(unit);
             if (!summoner)
                 break;
 
@@ -2499,7 +2499,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         }
         case SMART_ACTION_TRIGGER_GAME_EVENT:
         {
-            WorldObject* sourceObject = GetBaseObjectOrUnit(unit);
+            WorldObject* sourceObject = GetBaseObjectOrUnitInvoker(unit);
             for (WorldObject* target : targets)
             {
                 if (e.action.triggerGameEvent.useSaiTargetAsGameEventSource)
@@ -2596,7 +2596,7 @@ void SmartScript::GetTargets(ObjectVector& targets, SmartScriptHolder const& e, 
     else if (Unit* tempLastInvoker = GetLastInvoker())
         scriptTrigger = tempLastInvoker;
 
-    WorldObject* baseObject = GetBaseObjectOrPlayerTrigger();
+    WorldObject* baseObject = GetBaseObject();
     switch (e.GetTargetType())
     {
         case SMART_TARGET_SELF:
@@ -3003,7 +3003,7 @@ void SmartScript::GetTargets(ObjectVector& targets, SmartScriptHolder const& e, 
 
 void SmartScript::GetWorldObjectsInDist(ObjectVector& targets, float dist) const
 {
-    WorldObject* obj = GetBaseObjectOrPlayerTrigger();
+    WorldObject* obj = GetBaseObject();
     if (!obj)
         return;
 
@@ -3750,22 +3750,14 @@ WorldObject* SmartScript::GetBaseObject() const
         obj = go;
     else if (areaTrigger)
         obj = areaTrigger;
+    else if (player)
+        obj = player;
     return obj;
 }
 
-WorldObject* SmartScript::GetBaseObjectOrUnit(Unit* unit)
+WorldObject* SmartScript::GetBaseObjectOrUnitInvoker(Unit* invoker)
 {
-    WorldObject* summoner = GetBaseObject();
-
-    if (!summoner && unit)
-        return unit;
-
-    return summoner;
-}
-
-WorldObject* SmartScript::GetBaseObjectOrPlayerTrigger() const
-{
-    return trigger ? atPlayer : GetBaseObject();
+    return Coalesce<WorldObject>(GetBaseObject(), invoker);
 }
 
 bool SmartScript::IsUnit(WorldObject* obj)
@@ -4018,7 +4010,49 @@ void SmartScript::GetScript()
 
 void SmartScript::OnInitialize(WorldObject* obj, AreaTriggerEntry const* at, SceneTemplate const* scene, Quest const* qst)
 {
-    if (obj)//handle object based scripts
+    if (at)
+    {
+        mScriptType = SMART_SCRIPT_TYPE_AREATRIGGER;
+        trigger = at;
+        player = obj->ToPlayer();
+
+        if (!player)
+        {
+            TC_LOG_ERROR("misc", "SmartScript::OnInitialize: source is AreaTrigger with id {}, missing trigger player", trigger->ID);
+            return;
+        }
+
+        TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is AreaTrigger with id {}, triggered by player {}", trigger->ID, player->GetGUID().ToString());
+    }
+    else if (scene)
+    {
+        mScriptType = SMART_SCRIPT_TYPE_SCENE;
+        sceneTemplate = scene;
+        player = obj->ToPlayer();
+
+        if (!player)
+        {
+            TC_LOG_ERROR("misc", "SmartScript::OnInitialize: source is Scene with id {}, missing trigger player", scene->SceneId);
+            return;
+        }
+
+        TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is Scene with id {}, triggered by player {}", scene->SceneId, player->GetGUID().ToString());
+    }
+    else if (qst)
+    {
+        mScriptType = SMART_SCRIPT_TYPE_QUEST;
+        quest = qst;
+        player = obj->ToPlayer();
+
+        if (!player)
+        {
+            TC_LOG_ERROR("misc", "SmartScript::OnInitialize: source is Quest with id {}, missing trigger player", qst->GetQuestId());
+            return;
+        }
+
+        TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is Quest with id {}, triggered by player {}", qst->GetQuestId(), player->GetGUID().ToString());
+    }
+    else if (obj) // Handle object based scripts
     {
         switch (obj->GetTypeId())
         {
@@ -4032,17 +4066,6 @@ void SmartScript::OnInitialize(WorldObject* obj, AreaTriggerEntry const* at, Sce
                 go = obj->ToGameObject();
                 TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is GameObject {}", go->GetEntry());
                 break;
-            case TYPEID_PLAYER:
-                if (at)
-                {
-                    mScriptType = SMART_SCRIPT_TYPE_AREATRIGGER;
-                    trigger = at;
-                    atPlayer = obj->ToPlayer();
-                    TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is AreaTrigger {}, triggered by player {}", trigger->ID, atPlayer->GetGUID().ToString());
-                }
-                else
-                    TC_LOG_ERROR("misc", "SmartScript::OnInitialize: !WARNING! Player TypeID is only allowed for AreaTriggers");
-                break;
             case TYPEID_AREATRIGGER:
                 areaTrigger = obj->ToAreaTrigger();
                 mScriptType = areaTrigger->IsServerSide() ? SMART_SCRIPT_TYPE_AREATRIGGER_ENTITY_SERVERSIDE : SMART_SCRIPT_TYPE_AREATRIGGER_ENTITY;
@@ -4052,18 +4075,6 @@ void SmartScript::OnInitialize(WorldObject* obj, AreaTriggerEntry const* at, Sce
                 TC_LOG_ERROR("misc", "SmartScript::OnInitialize: Unhandled TypeID !WARNING!");
                 return;
         }
-    }
-    else if (scene)
-    {
-        mScriptType = SMART_SCRIPT_TYPE_SCENE;
-        sceneTemplate = scene;
-        TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is Scene with id {}", scene->SceneId);
-    }
-    else if (qst)
-    {
-        mScriptType = SMART_SCRIPT_TYPE_QUEST;
-        quest = qst;
-        TC_LOG_DEBUG("scripts.ai", "SmartScript::OnInitialize: source is Quest with id {}", qst->GetQuestId());
     }
     else
     {

--- a/src/server/game/AI/SmartScripts/SmartScript.h
+++ b/src/server/game/AI/SmartScripts/SmartScript.h
@@ -56,8 +56,7 @@ class TC_GAME_API SmartScript
         void SetPathId(uint32 id) { mPathId = id; }
         uint32 GetPathId() const { return mPathId; }
         WorldObject* GetBaseObject() const;
-        WorldObject* GetBaseObjectOrUnit(Unit* unit);
-        WorldObject* GetBaseObjectOrPlayerTrigger() const;
+        WorldObject* GetBaseObjectOrUnitInvoker(Unit* invoker);
         bool HasAnyEventWithFlag(uint32 flag) const { return mAllEventFlags & flag; }
         static bool IsUnit(WorldObject* obj);
         static bool IsPlayer(WorldObject* obj);
@@ -118,7 +117,7 @@ class TC_GAME_API SmartScript
         ObjectGuid meOrigGUID;
         GameObject* go;
         ObjectGuid goOrigGUID;
-        Player* atPlayer;
+        Player* player;
         AreaTriggerEntry const* trigger;
         AreaTrigger* areaTrigger;
         SceneTemplate const* sceneTemplate;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Set the trigger player as baseobject when the source type isn't a WorldObject. This change affects SMART_SCRIPT_TYPE_AREATRIGGER, SMART_SCRIPT_TYPE_QUEST and SMART_SCRIPT_TYPE_SCENE where the player will be the base object for the actions.

**Issues addressed:**
None

**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
