### PR TITLE
Fix cheating attempt

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22953,7 +22953,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
     if (count < 1) count = 1;
 
     // cheating attempt
-    if (slot > MAX_BAG_SIZE && slot != NULL_SLOT)
+    if (bag != NULL_BAG && bag != INVENTORY_SLOT_BAG_0 && slot > MAX_BAG_SIZE && slot != NULL_SLOT)
         return false;
 
     if (!IsAlive())


### PR DESCRIPTION
Player::BuyItemFromVendorSlot


**Changes proposed:**

Fix cheating attempt

**Tests performed:**

In game


**Known issues and TODO list:** (add/remove lines as needed)

The problem was that due to this incorrect check, it was impossible to point to some cells in the backpack.