### PR TITLE
Core/GameObjects: Fixed the behavior for GAMEOBJECT_TYPE_FISHINGNODE

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -770,7 +770,7 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
             break;
         }
         case GAMEOBJECT_TYPE_FISHINGNODE:
-            SetLevel(1);
+            SetLevel(0);
             SetGoAnimProgress(255);
             break;
         case GAMEOBJECT_TYPE_TRAP:
@@ -971,18 +971,7 @@ void GameObject::Update(uint32 diff)
                         // splash bobber (bobber ready now)
                         Unit* caster = GetOwner();
                         if (caster && caster->GetTypeId() == TYPEID_PLAYER)
-                        {
-                            SetGoState(GO_STATE_ACTIVE);
-                            ReplaceAllFlags(GO_FLAG_NODESPAWN);
-
-                            UpdateData udata(caster->GetMapId());
-                            WorldPacket packet;
-                            BuildValuesUpdateBlockForPlayer(&udata, caster->ToPlayer());
-                            udata.BuildPacket(&packet);
-                            caster->ToPlayer()->SendDirectMessage(&packet);
-
-                            SendCustomAnim(GetGoAnimProgress());
-                        }
+                            SendCustomAnim(0);
 
                         m_lootState = GO_READY;                 // can be successfully open with some chance
                     }
@@ -2521,6 +2510,17 @@ void GameObject::Use(Unit* user)
             {
                 case GO_READY:                              // ready for loot
                 {
+                    SetLootState(GO_ACTIVATED, player);
+
+                    SetGoState(GO_STATE_ACTIVE);
+                    ReplaceAllFlags(GO_FLAG_IN_MULTI_USE);
+
+                    UpdateData udata(player->GetMapId());
+                    WorldPacket packet;
+                    BuildValuesUpdateBlockForPlayer(&udata, player);
+                    udata.BuildPacket(&packet);
+                    player->SendDirectMessage(&packet);
+
                     uint32 zone, subzone;
                     GetZoneAndAreaId(zone, subzone);
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2515,11 +2515,7 @@ void GameObject::Use(Unit* user)
                     SetGoState(GO_STATE_ACTIVE);
                     ReplaceAllFlags(GO_FLAG_IN_MULTI_USE);
 
-                    UpdateData udata(player->GetMapId());
-                    WorldPacket packet;
-                    BuildValuesUpdateBlockForPlayer(&udata, player);
-                    udata.BuildPacket(&packet);
-                    player->SendDirectMessage(&packet);
+                    SendUpdateToPlayer(player);
 
                     uint32 zone, subzone;
                     GetZoneAndAreaId(zone, subzone);

--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -288,7 +288,11 @@ void WorldSession::DoLootRelease(Loot* loot)
 
         if (loot->isLooted() || go->GetGoType() == GAMEOBJECT_TYPE_FISHINGNODE || go->GetGoType() == GAMEOBJECT_TYPE_FISHINGHOLE)
         {
-            if (go->GetGoType() == GAMEOBJECT_TYPE_FISHINGHOLE)
+            if (go->GetGoType() == GAMEOBJECT_TYPE_FISHINGNODE)
+            {
+                go->SetLootState(GO_JUST_DEACTIVATED);
+            }
+            else if (go->GetGoType() == GAMEOBJECT_TYPE_FISHINGHOLE)
             {                                               // The fishing hole used once more
                 go->AddUse();                               // if the max usage is reached, will be despawned in next tick
                 if (go->GetUseCount() >= go->GetGOValue()->FishingHole.MaxOpens)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixed splash animation
-  Fixed a bug where you received the message for escaped fish and the loot was lost when you have already opened the loot window

**Issues addressed:**

Closes #22228
Updates #26676


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
- In retail the flag GO_FLAG_IN_MULTI_USE is sent and I don't know if it makes much sense


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
