### PR TITLE
Core/Spells: Implement SPELL_EFFECT_REMOVE_AURA_BY_SPELL_LABEL

### DIFF
--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -506,6 +506,7 @@ namespace
     std::unordered_set<uint8> _spellFamilyNames;
     SpellProcsPerMinuteModContainer _spellProcsPerMinuteMods;
     std::unordered_map<int32, std::vector<SpellVisualMissileEntry const*>> _spellVisualMissilesBySet;
+    std::unordered_map<int32, std::vector<SpellLabelEntry const*>> _spellLabelsByLabelId;
     TalentsByPosition _talentsByPosition;
     std::unordered_map<std::pair<uint32, uint32>, TaxiPathEntry const*> _taxiPaths;
     ToyItemIdsContainer _toys;
@@ -1444,6 +1445,9 @@ uint32 DB2Manager::LoadStores(std::string const& dataPath, LocaleConstant defaul
 
     for (SpellVisualMissileEntry const* spellVisualMissile : sSpellVisualMissileStore)
         _spellVisualMissilesBySet[spellVisualMissile->SpellVisualMissileSetID].push_back(spellVisualMissile);
+
+    for (SpellLabelEntry const* spellLabel : sSpellLabelStore)
+        _spellLabelsByLabelId[spellLabel->LabelID].push_back(spellLabel);
 
     for (TalentEntry const* talentInfo : sTalentStore)
     {
@@ -3062,6 +3066,11 @@ std::vector<SpellProcsPerMinuteModEntry const*> DB2Manager::GetSpellProcsPerMinu
 std::vector<SpellVisualMissileEntry const*> const* DB2Manager::GetSpellVisualMissiles(int32 spellVisualMissileSetId) const
 {
     return Trinity::Containers::MapGetValuePtr(_spellVisualMissilesBySet, spellVisualMissileSetId);
+}
+
+std::vector<SpellLabelEntry const*> const* DB2Manager::GetSpellLabels(uint32 labelId) const
+{
+    return Trinity::Containers::MapGetValuePtr(_spellLabelsByLabelId, labelId);
 }
 
 std::vector<TalentEntry const*> const& DB2Manager::GetTalentsByPosition(uint32 class_, uint32 tier, uint32 column) const

--- a/src/server/game/DataStores/DB2Stores.h
+++ b/src/server/game/DataStores/DB2Stores.h
@@ -477,6 +477,7 @@ public:
     static bool IsValidSpellFamiliyName(SpellFamilyNames family);
     std::vector<SpellProcsPerMinuteModEntry const*> GetSpellProcsPerMinuteMods(uint32 spellprocsPerMinuteId) const;
     std::vector<SpellVisualMissileEntry const*> const* GetSpellVisualMissiles(int32 spellVisualMissileSetId) const;
+    std::vector<SpellLabelEntry const*> const* GetSpellLabels(uint32 labelId) const;
     std::vector<TalentEntry const*> const& GetTalentsByPosition(uint32 class_, uint32 tier, uint32 column) const;
     TaxiPathEntry const* GetTaxiPath(uint32 from, uint32 to) const;
     static bool IsTotemCategoryCompatibleWith(uint32 itemTotemCategoryId, uint32 requiredTotemCategoryId);

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -412,6 +412,7 @@ class TC_GAME_API Spell
         void EffectModifySpellCharges();
         void EffectCreateTraitTreeConfig();
         void EffectChangeActiveCombatTraitConfig();
+        void RemoveAurasBySpellLabel();
 
         typedef std::unordered_set<Aura*> UsedSpellMods;
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -298,7 +298,7 @@ NonDefaultConstructible<SpellEffectHandlerFn> SpellEffectHandlers[TOTAL_SPELL_EF
     &Spell::EffectUnused,                                   //209 SPELL_EFFECT_209
     &Spell::EffectLearnGarrisonBuilding,                    //210 SPELL_EFFECT_LEARN_GARRISON_BUILDING
     &Spell::EffectNULL,                                     //211 SPELL_EFFECT_LEARN_GARRISON_SPECIALIZATION
-    &Spell::EffectNULL,                                     //212 SPELL_EFFECT_REMOVE_AURA_BY_SPELL_LABEL
+    &Spell::RemoveAurasBySpellLabel,                        //212 SPELL_EFFECT_REMOVE_AURA_BY_SPELL_LABEL
     &Spell::EffectJumpDest,                                 //213 SPELL_EFFECT_JUMP_DEST_2
     &Spell::EffectCreateGarrison,                           //214 SPELL_EFFECT_CREATE_GARRISON
     &Spell::EffectNULL,                                     //215 SPELL_EFFECT_UPGRADE_CHARACTER_SPELLS
@@ -5937,4 +5937,21 @@ void Spell::EffectChangeActiveCombatTraitConfig()
         return;
 
     target->UpdateTraitConfig(std::move(*traitConfig), damage, false);
+}
+
+void Spell::RemoveAurasBySpellLabel()
+{
+    if (effectHandleMode != SPELL_EFFECT_HANDLE_HIT_TARGET)
+        return;
+
+    if (!unitTarget)
+        return;
+
+    std::vector<SpellLabelEntry const*> const* spellLabels = sDB2Manager.GetSpellLabels(effectInfo->MiscValue);
+    if (!spellLabels)
+        return;
+
+    // there may be need of specifying casterguid of removed auras
+    for (SpellLabelEntry const* spellLabel : *spellLabels)
+        unitTarget->RemoveAurasDueToSpell(spellLabel->SpellID);
 }


### PR DESCRIPTION
**Changes proposed:**

-  Function to get the spellid's from SpellLabel.db2 by label id
-  Function for the 212 SPELL_EFFECT_REMOVE_AURA_BY_SPELL_LABEL to remove the auras marked by the label

**Tests performed:**

- tested ingame with evoker visage removes hover

![image](https://user-images.githubusercontent.com/25673748/214433611-3cb57902-887b-408f-9785-591ffb2a64ad.png)

![image](https://user-images.githubusercontent.com/25673748/214433746-be70cadd-f79f-4500-84f8-3dce14ea1805.png)

