### PR TITLE
Core/Utgarde Pinacle: Paralyze Removes On Map Change

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3850,6 +3850,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->_GetEffect(EFFECT_0).ApplyAuraName = SPELL_AURA_ADD_PCT_MODIFIER;
     });
 
+    // Utgarde Pinnacle - Paralyze(48278) Removal on change of map
+    ApplySpellFix({ 48278 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AuraInterruptFlags |= AURA_INTERRUPT_FLAG_CHANGE_MAP;
+    });
+
     ApplySpellFix({
         6789,  // Warlock - Death Coil (Rank 1)
         17925, // Warlock - Death Coil (Rank 2)


### PR DESCRIPTION
1. Added flags for removing Paralyze from player if they're moved from instance.
2. This fixes issue tracker: https://github.com/TrinityCore/TrinityCore/issues/28777

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**



**Issues addressed:**

Closes #28777


**Tests performed:**

1. Builds successfully
2. Removes debuff if the player is removed from/leaves the instance during the channel of Paralyze.


**Known issues and TODO list:** (add/remove lines as needed)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
