### PR TITLE
* DB: Fix spell 18960 Teleport: Moonglade

### DIFF
--- a/sql/updates/world/master/2023_02_03_00_world.sql
+++ b/sql/updates/world/master/2023_02_03_00_world.sql
@@ -1,0 +1,1 @@
+UPDATE spell_target_position SET EffectIndex = 1 WHERE ID = 18960;


### PR DESCRIPTION
**Changes proposed:**

-  Added Effect 1: ID 252 (SPELL_EFFECT_TELEPORT_UNITS) in db for the operation of the Spell in teleportation

**Issues addressed:**

Closes #28702
