### PR TITLE
Core/Arena: Correctly update the stats of the members of each team when the week ends and the arena points are distributed.

### DIFF
--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -907,7 +907,7 @@ void ArenaTeam::UpdateArenaPointsHelper(std::map<uint32, uint32>& playerPoints)
     }
 }
 
-void ArenaTeam::SaveToDB()
+void ArenaTeam::SaveToDB(bool forceMemberSave)
 {
     // Save team and member stats to db
     // Called after a match has ended or when calculating arena_points
@@ -927,7 +927,7 @@ void ArenaTeam::SaveToDB()
     for (MemberList::const_iterator itr = Members.begin(); itr != Members.end(); ++itr)
     {
         // Save the effort and go
-        if (itr->WeekGames == 0)
+        if (itr->WeekGames == 0 && !forceMemberSave)
             continue;
 
         stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_ARENA_TEAM_MEMBER);

--- a/src/server/game/Battlegrounds/ArenaTeam.h
+++ b/src/server/game/Battlegrounds/ArenaTeam.h
@@ -155,7 +155,7 @@ class TC_GAME_API ArenaTeam
         bool LoadArenaTeamFromDB(QueryResult arenaTeamDataResult);
         bool LoadMembersFromDB(QueryResult arenaTeamMembersResult);
         void LoadStatsFromDB(uint32 ArenaTeamId);
-        void SaveToDB();
+        void SaveToDB(bool forceMemberSave = false);
 
         void BroadcastPacket(WorldPacket* packet);
         void BroadcastEvent(ArenaTeamEvents event, ObjectGuid guid, uint8 strCount, std::string const& str1, std::string const& str2, std::string const& str3);

--- a/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
@@ -178,7 +178,7 @@ void ArenaTeamMgr::DistributeArenaPoints()
     for (auto [teamId, team] : ArenaTeamStore)
     {
         if (team->FinishWeek())
-            team->SaveToDB();
+            team->SaveToDB(true);
 
         team->NotifyStatsChanged();
     }


### PR DESCRIPTION
**Changes proposed:**

-  Correctly update the stats of the members of each team when the week ends and the arena points are distributed.
After this PR: https://github.com/TrinityCore/TrinityCore/pull/17989
When do FinishWeek() all WeekGames and WeekWins are set to 0 (team and members)
after that, do SaveToDB() that have check:
```c++
    for (MemberList::const_iterator itr = Members.begin(); itr != Members.end(); ++itr)
    {
        // Save the effort and go
        if (itr->WeekGames == 0)
            continue;
```
so when arena points distribution is executed, always skip save member stats into DB and that's wrong, because if you restart the server, load stats from db and don't update it before (I am referring to the weekGames and the weekWins of each member)

**Issues addressed:**

None


**Tests performed:**

Tested in game.
