### PR TITLE
Core/Transports: Fixed event timestamps for edge cases

### DIFF
--- a/src/server/game/Maps/TransportMgr.cpp
+++ b/src/server/game/Maps/TransportMgr.cpp
@@ -406,14 +406,14 @@ static void InitializeLeg(TransportPathLeg* leg, std::vector<TransportPathEvent>
                 if ((*eventPointItr)->ArrivalEventID)
                 {
                     TransportPathEvent& event = outEvents->emplace_back();
-                    event.Timestamp = totalTime + splineTime + leg->Duration;
+                    event.Timestamp = totalTime + splineTime + leg->Duration + delaySum;
                     event.EventId = (*eventPointItr)->ArrivalEventID;
                 }
 
                 if ((*eventPointItr)->DepartureEventID)
                 {
                     TransportPathEvent& event = outEvents->emplace_back();
-                    event.Timestamp = totalTime + splineTime + leg->Duration + (pausePointItr == eventPointItr ? (*eventPointItr)->Delay * IN_MILLISECONDS : 0);
+                    event.Timestamp = totalTime + splineTime + leg->Duration + delaySum + (pausePointItr == eventPointItr ? (*eventPointItr)->Delay * IN_MILLISECONDS : 0);
                     event.EventId = (*eventPointItr)->DepartureEventID;
                 }
             }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixed desync in the arrival/departure event for transports with several pause nodes in the same TransportPathLeg (for example, The Zephyr's arrival/departure event for the second pause node (Orgrimmar))

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
