### PR TITLE
Fix mail leaking

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -18876,8 +18876,6 @@ Item* Player::_LoadMailedItem(ObjectGuid const& playerGuid, Player* player, uint
 void Player::_LoadMail(PreparedQueryResult mailsResult, PreparedQueryResult mailItemsResult, PreparedQueryResult artifactResult, PreparedQueryResult azeriteItemResult,
     PreparedQueryResult azeriteItemMilestonePowersResult, PreparedQueryResult azeriteItemUnlockedEssencesResult, PreparedQueryResult azeriteEmpoweredItemResult)
 {
-    m_mail.clear();
-
     std::unordered_map<uint64, Mail*> mailById;
 
     if (mailsResult)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix Mail leaking during loading


**Issues addressed:**
Do not clear m_mail container inside Player::LoadMail. As described in https://github.com/TrinityCore/TrinityCore/issues/28814 LoadInventory is executed before LoadMail and if any items can't be loaded they will be sent via mail. There are 2 problems

1) MailDraft::SendMailTo will allocate new Mail object and store it in Player::m_mail map. LoadMail will clear that container without deallocating memory.
2) Players would not see this Mail until relog . 

All queries are executed prior to calling Player::LoadFromDB meaning that if we add smth to DB inside LoadFromDB we won't see this changes until we make another query. In a situation with corrupted items player would no see them because they were not there when we queried them. Clearing m_mail leaks Mail object and leaves players without items until he re-loged

Closes # https://github.com/TrinityCore/TrinityCore/issues/28814 


**Tests performed:**

(Does it build, tested in-game, etc.)
Build & in-game testing

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
