### PR TITLE
Proper assignment of quest loot for group loot & round robin

### DIFF
--- a/src/server/game/Loot/Loot.cpp
+++ b/src/server/game/Loot/Loot.cpp
@@ -96,7 +96,7 @@ bool LootItem::AllowedForPlayer(Player const* player, bool isGivenByMasterLooter
     if (pProto->Class == ITEM_CLASS_RECIPE && pProto->Bonding == BIND_WHEN_PICKED_UP && pProto->Spells[1].SpellId != 0 && player->HasSpell(pProto->Spells[1].SpellId))
         return false;
 
-    if (needs_quest && !freeforall && player->GetGroup() && (player->GetGroup()->GetLootMethod() == GROUP_LOOT || player->GetGroup()->GetLootMethod() == ROUND_ROBIN) && ownerGuid.IsEmpty() == false && ownerGuid != player->GetGUID())
+    if (needs_quest && !freeforall && player->GetGroup() && (player->GetGroup()->GetLootMethod() == GROUP_LOOT || player->GetGroup()->GetLootMethod() == ROUND_ROBIN) && !ownerGuid.IsEmpty() && ownerGuid != player->GetGUID())
         return false;
 
     // check quest requirements

--- a/src/server/game/Loot/Loot.h
+++ b/src/server/game/Loot/Loot.h
@@ -150,7 +150,9 @@ struct TC_GAME_API LootItem
                  { };
 
     // Basic checks for player/item compatibility - if false no chance to see the item in the loot
+    bool AllowedForPlayer(Player const* player, bool isGivenByMasterLooter, ObjectGuid ownerGuid) const;
     bool AllowedForPlayer(Player const* player, bool isGivenByMasterLooter = false) const;
+    bool AllowedForPlayer(Player const* player, ObjectGuid ownerGuid) const;
     void AddAllowedLooter(Player const* player);
     GuidSet const& GetAllowedLooters() const { return allowedGUIDs; }
 };

--- a/src/server/game/Loot/LootItemStorage.cpp
+++ b/src/server/game/Loot/LootItemStorage.cpp
@@ -266,7 +266,7 @@ void LootItemStorage::AddNewStoredLoot(Loot* loot, Player* player)
         // saved to the DB that the player never should have gotten. This check prevents that, so that only
         // items that the player should get in loot are in the DB.
         // IE: Horde items are not saved to the DB for Ally players.
-        if (!li.AllowedForPlayer(player))
+        if (!li.AllowedForPlayer(player, loot->lootOwnerGUID))
             continue;
 
         // Don't save currency tokens


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Quest items for group loot and round robin loot do not work properly in the current implementation. Party members should be able to take turns looting quest items if using group loot or round robin. Current functionality is that nearly all quest items are free for all. This is not Blizzlike.

The proposed patch makes the following changes:

-  In group loot or round robin, only the person who owns the loot sees and can loot the quest items
-  If the looter releases the loot, the quest items become available to everyone
-  If the quest items are multi-loot (i.e., everyone gets the quest item), then it will appear for everyone as expected
-  If the loot type is any other type (e.g., master looter, free for all), the previous functionality takes effect (i.e., quest loot is free for all in most instances)

**Tests performed:**

Builds. Tested in-game.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
