### PR TITLE
Core/Mail: Fix error handling with empty bag.

### DIFF
--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -190,7 +190,7 @@ void WorldSession::HandleSendMail(WorldPackets::Mail::SendMail& sendMail)
                 player->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);
                 return;
             }
-            
+
             // handle empty bag before CanBeTraded, since that func already has that check
             if (item->IsNotEmptyBag())
             {

--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -190,6 +190,13 @@ void WorldSession::HandleSendMail(WorldPackets::Mail::SendMail& sendMail)
                 player->SendMailResult(0, MAIL_SEND, MAIL_ERR_MAIL_ATTACHMENT_INVALID);
                 return;
             }
+            
+            // handle empty bag before CanBeTraded, since that func already has that check
+            if (item->IsNotEmptyBag())
+            {
+                player->SendMailResult(0, MAIL_SEND, MAIL_ERR_EQUIP_ERROR, EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS);
+                return;
+            }
 
             if (!item->CanBeTraded(true))
             {
@@ -212,12 +219,6 @@ void WorldSession::HandleSendMail(WorldPackets::Mail::SendMail& sendMail)
             if (mailInfo.Cod && item->IsWrapped())
             {
                 player->SendMailResult(0, MAIL_SEND, MAIL_ERR_CANT_SEND_WRAPPED_COD);
-                return;
-            }
-
-            if (item->IsNotEmptyBag())
-            {
-                player->SendMailResult(0, MAIL_SEND, MAIL_ERR_EQUIP_ERROR, EQUIP_ERR_CAN_ONLY_DO_WITH_EMPTY_BAGS);
                 return;
             }
 


### PR DESCRIPTION
It looks like `item->IsNotEmptyBag()` case would be never executed since we already have similar check [here](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Entities/Item/Item.cpp#L729) and player will have `EQUIP_ERR_MAIL_BOUND_ITEM` error for this case.