### PR TITLE
Core/Creatures: Improved movement interruption while casting spells

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3375,21 +3375,10 @@ void Creature::DoNotReacquireSpellFocusTarget()
 
 bool Creature::IsMovementPreventedByCasting() const
 {
-    // first check if currently a movement allowed channel is active and we're not casting
-    if (Spell* spell = m_currentSpells[CURRENT_CHANNELED_SPELL])
-    {
-        if (spell->getState() != SPELL_STATE_FINISHED && spell->IsChannelActive())
-            if (spell->CheckMovement() != SPELL_CAST_OK)
-                return true;
-    }
+    if (!Unit::IsMovementPreventedByCasting() && !HasSpellFocus())
+        return false;
 
-    if (HasSpellFocus())
-        return true;
-
-    if (HasUnitState(UNIT_STATE_CASTING))
-        return true;
-
-    return false;
+    return true;
 }
 
 void Creature::StartPickPocketRefillTimer()

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -3025,7 +3025,8 @@ bool Unit::IsMovementPreventedByCasting() const
         return false;
 
     if (Spell* spell = m_currentSpells[CURRENT_GENERIC_SPELL])
-        if (CanCastSpellWhileMoving(spell->GetSpellInfo()))
+        if (CanCastSpellWhileMoving(spell->GetSpellInfo()) || spell->getState() == SPELL_STATE_FINISHED ||
+            !spell->m_spellInfo->InterruptFlags.HasFlag(SpellInterruptFlags::Movement))
             return false;
 
     // channeled spells during channel stage (after the initial cast timer) allow movement with a specific spell attribute

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6875,6 +6875,12 @@ SpellCastResult Spell::CheckMovement() const
     if (IsTriggered())
         return SPELL_CAST_OK;
 
+    // Creatures (not controlled) give priority to spell casting over movement.
+    // We assume that the casting is always valid and the current movement
+    // is stopped by Unit:IsmovementPreventedByCasting to prevent casting interruption.
+    if (m_caster->IsCreature() && !m_caster->ToCreature()->IsControlledByPlayer())
+        return SPELL_CAST_OK;
+
     if (Unit* unitCaster = m_caster->ToUnit())
     {
         if (!unitCaster->CanCastSpellWhileMoving(m_spellInfo))


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  The current implementation of Creature::IsMovementPreventedByCasting is incorrect for two reasons:
   - Any channeling will interrupt the creature's current movement if:
      - The spell has SpellAuraInterruptFlags::Moving or SpellAuraInterruptFlags::Turning (Spell::CheckMovement check). This is correct since otherwise the creature will interrupt the cast at the moment it moves (chase during combat).
      - The caster has UNIT_STATE_CASTING (always present for active channeling). This is incorrect and automatically causes any channeling to prevent the creature from moving.
    - The current logic belongs to an old version of Unit::IsMovementPreventedByCasting that was overwritten in Creature to support the SpellFocus system (Creature::SetSpellFocus).
https://github.com/TrinityCore/TrinityCore/commit/522f537048189b40a12d68583485d1de7fcbf1d2 https://github.com/TrinityCore/TrinityCore/commit/5043639c563514c079ba6eb959dd4c1c555fa494 https://github.com/TrinityCore/TrinityCore/commit/3ea46e57afe26778704647084cc6fa55a798e510 https://github.com/TrinityCore/TrinityCore/commit/5a2f0ce29e29d934c200f617fec6dad619fab9a5
-  Creature::IsMovementPreventedByCasting implementation has been modified to use Unit::IsMovementPreventedByCasting validation while maintaining the Creature::HasSpellFocus check
-  Added additional check to Unit::IsMovementPreventedByCasting() to not prevent movement during casting of (non-channeled) spells that don't have SpellInterruptFlags::Movement.
- Modified the logic of CheckMovement() to not prevent moving creatures from casting spells with movement interruption flags. In retail, creatures stop their movement to cast spells that would be interrupted if they are moving (IsMovementPreventedByCasting will stop the movement).

**Issues addressed:**
(Maybe) it could close #17585


**Tests performed:**
Builds, tested in-game.
- Channeling 131992 while the creature (out of combat) is moving: https://gyazo.com/a394ff7de2a0ceeba3a6a3a3bb7bb9ee
- Leymor encounter: https://github.com/TrinityCore/TrinityCore/commit/1baa2f4f3993e7269f72fd143bea36d1a7ffd9f8. Before the PR, if you moved making the boss have to chase you, most of its abilities weren't cast because they had SpellInterruptFlags::Movement. With PR, the boss stops to cast his spells and then continue the chase.

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
