### PR TITLE
Scripts/Generic: Implemented generic method to cast triggered spells …

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,3 +1,3 @@
 DELETE FROM `spell_script_names` WHERE `spell_id`=387905;
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(387905, 'spell_gen_gob_lock_triggered_cast');
+(387905, 'spell_gen_open_lock_triggered_cast_gob_spell');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=387905;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(387905, 'spell_gen_gob_lock_triggered_cast');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5228,6 +5228,23 @@ class spell_gen_despawn_all_summons_owned_by_caster : public SpellScript
     }
 };
 
+// 387905 - Teleporting
+class spell_gen_gob_lock_triggered_cast : public SpellScript
+{
+    PrepareSpellScript(spell_gen_cast_gob_spell_triggered);
+
+    void HandleOpenLock(SpellEffIndex /*effIndex*/)
+    {
+        uint32 spellId = GetHitGObj()->GetGOInfo()->goober.spell;
+        GetCaster()->CastSpell(nullptr, spellId, true);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_gen_gob_lock_triggered_cast::HandleOpenLock, EFFECT_0, SPELL_EFFECT_OPEN_LOCK);
+    }
+};
+
 void AddSC_generic_spell_scripts()
 {
     RegisterSpellScript(spell_gen_absorb0_hitlimit1);
@@ -5389,4 +5406,5 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_eject_passengers_3_8);
     RegisterSpellScript(spell_gen_reverse_cast_target_to_caster_triggered);
     RegisterSpellScript(spell_gen_despawn_all_summons_owned_by_caster);
+    RegisterSpellScript(spell_gen_gob_lock_triggered_cast);
 }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5229,9 +5229,9 @@ class spell_gen_despawn_all_summons_owned_by_caster : public SpellScript
 };
 
 // 387905 - Teleporting
-class spell_gen_gob_lock_triggered_cast : public SpellScript
+class spell_gen_open_lock_triggered_cast_gob_spell : public SpellScript
 {
-    PrepareSpellScript(spell_gen_cast_gob_spell_triggered);
+    PrepareSpellScript(spell_gen_open_lock_triggered_cast_gob_spell);
 
     void HandleOpenLock(SpellEffIndex /*effIndex*/)
     {
@@ -5241,7 +5241,7 @@ class spell_gen_gob_lock_triggered_cast : public SpellScript
 
     void Register() override
     {
-        OnEffectHitTarget += SpellEffectFn(spell_gen_gob_lock_triggered_cast::HandleOpenLock, EFFECT_0, SPELL_EFFECT_OPEN_LOCK);
+        OnEffectHitTarget += SpellEffectFn(spell_gen_open_lock_triggered_cast_gob_spell::HandleOpenLock, EFFECT_0, SPELL_EFFECT_OPEN_LOCK);
     }
 };
 
@@ -5406,5 +5406,5 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_eject_passengers_3_8);
     RegisterSpellScript(spell_gen_reverse_cast_target_to_caster_triggered);
     RegisterSpellScript(spell_gen_despawn_all_summons_owned_by_caster);
-    RegisterSpellScript(spell_gen_gob_lock_triggered_cast);
+    RegisterSpellScript(spell_gen_open_lock_triggered_cast_gob_spell);
 }


### PR DESCRIPTION
…on open lock effect

* used for Seat of the Aspects teleporter in Valdrakken

**Tests performed:**

(Does it build, tested in-game, etc.)
tested valdrakken seat of the aspects teleporters ingame

**Note:**
could also move it to zone_valdrakken or zone_thaldraszus and rename to spell_xy_seat_of_the_aspects_teleporter; didn't encounter similar gobs yet