### PR TITLE
Core/DataStores: Fixed loading CommonData when IdTable is present

### DIFF
--- a/src/common/DataStores/DB2FileLoader.cpp
+++ b/src/common/DataStores/DB2FileLoader.cpp
@@ -809,7 +809,7 @@ T DB2FileLoaderRegularImpl::RecordGetVarInt(uint8 const* record, uint32 field, u
         }
         case DB2ColumnCompression::CommonData:
         {
-            uint32 id = RecordGetId(record, (_data.get() - record) / _header->RecordSize);
+            uint32 id = RecordGetId(record, (record - _data.get()) / _header->RecordSize);
             T value;
             auto valueItr = _commonValues[field].find(id);
             if (valueItr != _commonValues[field].end())


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixed an edge case where CommonData columns would subtract record address from data offset, resulting in very large values being used to index into idTable in RecordGetId.
-  This should only affect cases where a DB2 has both a column with CommonData compression and uses non-inline IDs (IdTable). AFAIK, no currently loaded DB2s has this, but SpellVisual does in 7.3.5 and future/other DB2s might aswell.

**Issues addressed:**

Properly fixes #22002


**Tests performed:**

(Does it build, tested in-game, etc.)
Not tested with master branch but current logic looks like a typo.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
