### PR TITLE
Core/Auras: Implement caster selection of SPELL_AURA_TRIGGER_SPELL_ON_EXPIRE (stored in MiscValue)

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5138,7 +5138,18 @@ void AuraEffect::HandleTriggerSpellOnExpire(AuraApplication const* aurApp, uint8
     if (!(mode & AURA_EFFECT_HANDLE_REAL) || apply || aurApp->GetRemoveMode() != AURA_REMOVE_BY_EXPIRE)
         return;
 
-    aurApp->GetTarget()->CastSpell(aurApp->GetTarget(), GetSpellEffectInfo().TriggerSpell, this);
+    Unit* caster = aurApp->GetTarget();
+
+    // MiscValue (Caster):
+    // 0 - Aura target
+    // 1 - Aura caster
+    // 2 - ? Aura target is always TARGET_UNIT_CASTER so we consider the same behavior as MiscValue 1
+    uint32 casterType = uint32(GetMiscValue());
+    if (casterType > 0)
+        caster = GetCaster();
+
+    if (caster)
+        caster->CastSpell(aurApp->GetTarget(), GetSpellEffectInfo().TriggerSpell, this);
 }
 
 void AuraEffect::HandleAuraOpenStable(AuraApplication const* aurApp, uint8 mode, bool apply) const


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implement caster selection of SPELL_AURA_TRIGGER_SPELL_ON_EXPIRE (stored in MiscValue):
   -  0 - Aura target
   -  1 - Aura caster
   -  2 - ? Aura target is always TARGET_UNIT_CASTER so I considered the same behavior as MiscValue 1

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.
- 372484 (Dissecting...): Explicit target. Triggered spell targets caster and the effect is SPELL_EFFECT_KILL_CREDIT2 (https://www.youtube.com/watch?v=qD83Lwl3Meo)
- 375596 (Erratic Growth): https://www.wowhead.com/npc=196115/arcane-tender

**Known issues and TODO list:** (add/remove lines as needed)
None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
