### PR TITLE
switch to pkg.trinitycore.org as the docker registry

### DIFF
--- a/contrib/Docker/Dockerfile
+++ b/contrib/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM trinitycore/circle-ci:master-base-22.04
+FROM pkg.trinitycore.org/trinitycore/circle-ci:master-base-22.04
 
 #Setup
 WORKDIR /home/circleci

--- a/contrib/Docker/README.md
+++ b/contrib/Docker/README.md
@@ -1,6 +1,6 @@
 # Docker
 
-The Circle CI Linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for Linux, and stores that in the job artifacts. For the 3.3.5 and master branches, it also pushes the images to https://hub.docker.com/r/trinitycore/trinitycore .
+The Circle CI Linux pch job uses the Dockerfile contained in the same folder as this README to create an image with the binaries built for Linux, and stores that in the job artifacts. For the 3.3.5 and master branches, it also pushes the images to pkg.trinitycore.org/trinitycore/trinitycore .
 
 The instructions below expect a basic knowledge of how to configure TrinityCore and how to use Docker.
 
@@ -8,15 +8,15 @@ The instructions below expect a basic knowledge of how to configure TrinityCore 
 For the 3.3.5 and master branches, it's possible to pull the images from DockerHub.
 - For latest 3.3.5, use the following command:
   ```
-  docker pull trinitycore/trinitycore:3.3.5
+  docker pull pkg.trinitycore.org/trinitycore/trinitycore:3.3.5
   ```
 - For latest master, use the following command:
   ```
-  docker pull trinitycore/trinitycore:master
+  docker pull pkg.trinitycore.org/trinitycore/trinitycore:master
   ```
 - For a specific 3.3.5 or master commit, use the following command, replacing "commit_hash" with the hash of the commit:
   ```
-  docker pull trinitycore/trinitycore:commit_hash
+  docker pull pkg.trinitycore.org/trinitycore/trinitycore:commit_hash
   ```
 
 For Pull Requests or branches other than 3.3.5 or master, follow the steps below to load the image from Circle CI:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  switch to pkg.trinitycore.org as the docker registry in Dockerfile & readme for Docker

**Issues addressed:**

N/A


**Tests performed:**

Docker pull


**Known issues and TODO list:** (add/remove lines as needed)

- None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
