### PR TITLE
Core/StatSystem: Fixed missing calls to set negative attack power mods

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2787,7 +2787,7 @@ void Player::InitStatsForLevel(bool reapplyMods)
     SetAttackPowerMultiplier(0.0f);
     SetRangedAttackPower(0);
     SetRangedAttackPowerModPos(0);
-    SetRangedAttackPowerModPos(0);
+    SetRangedAttackPowerModNeg(0);
     SetRangedAttackPowerMultiplier(0.0f);
 
     // Base crit values (will be recalculated in UpdateAllStats() at loading and in _ApplyAllStatBonuses() at reset

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2783,8 +2783,10 @@ void Player::InitStatsForLevel(bool reapplyMods)
 
     SetAttackPower(0);
     SetAttackPowerModPos(0);
+    SetAttackPowerModNeg(0);
     SetAttackPowerMultiplier(0.0f);
     SetRangedAttackPower(0);
+    SetRangedAttackPowerModPos(0);
     SetRangedAttackPowerModPos(0);
     SetRangedAttackPowerMultiplier(0.0f);
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -477,7 +477,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
         SetRangedAttackPower(int32(base_attPower));
         if (attPowerMod >= 0)
             SetRangedAttackPowerModPos(int32(attPowerMod));
-        else
+        if (attPowerMod <= 0)
             SetRangedAttackPowerModNeg(int32(attPowerMod));
         SetRangedAttackPowerMultiplier(attPowerMultiplier);
     }
@@ -486,7 +486,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
         SetAttackPower(int32(base_attPower));
         if (attPowerMod >= 0)
             SetAttackPowerModPos(int32(attPowerMod));
-        else
+        if (attPowerMod <= 0)
             SetAttackPowerModNeg(int32(attPowerMod));
         SetAttackPowerMultiplier(attPowerMultiplier);
     }
@@ -1057,18 +1057,18 @@ void Creature::UpdateAttackPowerAndDamage(bool ranged)
     if (ranged)
     {
         SetRangedAttackPower(int32(baseAttackPower));
-        if (attackPowerMod > 0)
+        if (attackPowerMod >= 0)
             SetRangedAttackPowerModPos(int32(attackPowerMod));
-        else
+        if (attackPowerMod <= 0)
             SetRangedAttackPowerModNeg(int32(attackPowerMod));
         SetRangedAttackPowerMultiplier(attackPowerMultiplier);
     }
     else
     {
         SetAttackPower(int32(baseAttackPower));
-        if (attackPowerMod > 0)
+        if (attackPowerMod >= 0)
             SetAttackPowerModPos(int32(attackPowerMod));
-        else
+        if (attackPowerMod <= 0)
             SetAttackPowerModNeg(int32(attackPowerMod));
         SetAttackPowerMultiplier(attackPowerMultiplier);
     }

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -475,13 +475,19 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     if (ranged)
     {
         SetRangedAttackPower(int32(base_attPower));
-        SetRangedAttackPowerModPos(int32(attPowerMod));
+        if (attPowerMod > 0)
+            SetRangedAttackPowerModPos(int32(attPowerMod));
+        else
+            SetRangedAttackPowerModNeg(int32(attPowerMod));
         SetRangedAttackPowerMultiplier(attPowerMultiplier);
     }
     else
     {
         SetAttackPower(int32(base_attPower));
-        SetAttackPowerModPos(int32(attPowerMod));
+        if (attPowerMod > 0)
+            SetAttackPowerModPos(int32(attPowerMod));
+        else
+            SetAttackPowerModNeg(int32(attPowerMod));
         SetAttackPowerMultiplier(attPowerMultiplier);
     }
 
@@ -1051,13 +1057,19 @@ void Creature::UpdateAttackPowerAndDamage(bool ranged)
     if (ranged)
     {
         SetRangedAttackPower(int32(baseAttackPower));
-        SetRangedAttackPowerModPos(int32(attackPowerMod));
+        if (attackPowerMod > 0)
+            SetRangedAttackPowerModPos(int32(attackPowerMod));
+        else
+            SetRangedAttackPowerModNeg(int32(attackPowerMod));
         SetRangedAttackPowerMultiplier(attackPowerMultiplier);
     }
     else
     {
         SetAttackPower(int32(baseAttackPower));
-        SetAttackPowerModPos(int32(attackPowerMod));
+        if (attackPowerMod > 0)
+            SetAttackPowerModPos(int32(attackPowerMod));
+        else
+            SetAttackPowerModNeg(int32(attackPowerMod));
         SetAttackPowerMultiplier(attackPowerMultiplier);
     }
 

--- a/src/server/game/Entities/Unit/StatSystem.cpp
+++ b/src/server/game/Entities/Unit/StatSystem.cpp
@@ -475,7 +475,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     if (ranged)
     {
         SetRangedAttackPower(int32(base_attPower));
-        if (attPowerMod > 0)
+        if (attPowerMod >= 0)
             SetRangedAttackPowerModPos(int32(attPowerMod));
         else
             SetRangedAttackPowerModNeg(int32(attPowerMod));
@@ -484,7 +484,7 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     else
     {
         SetAttackPower(int32(base_attPower));
-        if (attPowerMod > 0)
+        if (attPowerMod >= 0)
             SetAttackPowerModPos(int32(attPowerMod));
         else
             SetAttackPowerModNeg(int32(attPowerMod));


### PR DESCRIPTION
**Changes proposed:**

-  Added calls to SetAttackPowerModNeg

**Issues addressed:**

All AP mods causes the client API Script_UnitAttackPower to always send posBuff > 0 because of setting the wrong unit field.


**Tests performed:**
https://i.gyazo.com/bb92befe647e29003dc03abbe445fcff.jpg

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
