### PR TITLE
Change Map::Visit to not call EnsureGridLoaded if cell.NoCreate is true

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -534,11 +534,11 @@ bool Map::EnsureGridLoaded(Cell const& cell)
     NGridType *grid = getNGrid(cell.GridX(), cell.GridY());
 
     ASSERT(grid != nullptr);
-    if (!isGridObjectDataLoaded(cell.GridX(), cell.GridY()))
+    if (!grid->isGridObjectDataLoaded())
     {
         TC_LOG_DEBUG("maps", "Loading grid[%u, %u] for map %u instance %u", cell.GridX(), cell.GridY(), GetId(), i_InstanceId);
 
-        setGridObjectDataLoaded(true, cell.GridX(), cell.GridY());
+        grid->setGridObjectDataLoaded(true);
 
         ObjectGridLoader loader(*grid, this, cell);
         loader.LoadN();
@@ -709,7 +709,8 @@ bool Map::AddToMap(Transport* obj)
 
 bool Map::IsGridLoaded(GridCoord const& p) const
 {
-    return (getNGrid(p.x_coord, p.y_coord) && isGridObjectDataLoaded(p.x_coord, p.y_coord));
+    NGridType* grid = getNGrid(p.x_coord, p.y_coord);
+    return grid && grid->isGridObjectDataLoaded();
 }
 
 void Map::VisitNearbyCellsOf(WorldObject* obj, TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &gridVisitor, TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor)

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -696,9 +696,6 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
             return i_grids[x][y];
         }
 
-        bool isGridObjectDataLoaded(uint32 x, uint32 y) const { return getNGrid(x, y)->isGridObjectDataLoaded(); }
-        void setGridObjectDataLoaded(bool pLoaded, uint32 x, uint32 y) { getNGrid(x, y)->setGridObjectDataLoaded(pLoaded); }
-
         void setNGrid(NGridType* grid, uint32 x, uint32 y);
         void ScriptsProcess();
 
@@ -985,10 +982,11 @@ inline void Map::Visit(Cell const& cell, TypeContainerVisitor<T, CONTAINER>& vis
     const uint32 cell_x = cell.CellX();
     const uint32 cell_y = cell.CellY();
 
-    if (!cell.NoCreate() || IsGridLoaded(GridCoord(x, y)))
-    {
+    if (!cell.NoCreate())
         EnsureGridLoaded(cell);
-        getNGrid(x, y)->VisitGrid(cell_x, cell_y, visitor);
-    }
+
+    NGridType* grid = getNGrid(x, y);
+    if (grid && grid->isGridObjectDataLoaded())
+        grid->VisitGrid(cell_x, cell_y, visitor);
 }
 #endif


### PR DESCRIPTION
Was discussed with @jackpoz in discord. He proposed to test & make a PR to see where discussion would take us. Maybe there were a good reason to call EnsureGridCreated after IsGridLoaded or it just was and oversight. The motivation behind this changes is to reduce locking, for some reason MSVC in debug/releasewithdebug mode showed that this was a pretty time consuming lock with thousands of active creatures moving around and constantly using Map::Visit

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  When Map::Visit is called with Cell::NoCreate set to true we check that grid exists by calling IsGridLoaded(GridCoord(x, y)) and still call EnsureGridLoaded which will call EnsureGridCreated and use locking. Sure that this call is redundant because IsGridLoaded tells us that grid is created (!= null) and loaded (isGridObjectDataLoaded is set to true)
- I also cleaned up Map::isGridObjectDataLoaded/setGridObjectDataLoaded functions. Almost everywhere we had NGridType or a sequence of getNGrid calls that was reduced to just 1 call


**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Build and tested localy on a fork


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 

I also would love to know why Cell structure uses bitpacking into 4-bytes field. Does anyone remember what was the motivation for this back then? Is this some optimization technic?

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
