### PR TITLE
Core/Spells: Fix a double-mount bug with Magic Rooster

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3477,7 +3477,7 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->_GetEffect(EFFECT_1).Effect = SPELL_EFFECT_NONE;
     });
 
-    // // Magic Rooster
+    // Magic Rooster
     ApplySpellFix({ 65917 }, [](SpellInfo* spellInfo)
     {
         spellInfo->Attributes &= ~SPELL_ATTR0_CASTABLE_WHILE_MOUNTED;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3477,6 +3477,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->_GetEffect(EFFECT_1).Effect = SPELL_EFFECT_NONE;
     });
 
+    // // Magic Rooster
+    ApplySpellFix({ 65917 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Attributes &= ~SPELL_ATTR0_CASTABLE_WHILE_MOUNTED;
+    });
+
     // Lock and Load (Rank 1)
     ApplySpellFix({ 56342 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Remove SPELL_ATTR0_CASTABLE_WHILE_MOUNTED attribute from Magic Rooster (65917) spell.

Usually, if you try to mount while sitting on another mount, the client will automatically send a dismount opcode. Unfortunately, the Magic Rooster has the attribute SPELL_ATTR0_CASTABLE_WHILE_MOUNTED, most likely by mistake. If you try to mount the Magic Rooster while sitting on another mount, you will have both mounts in your buff list. The only thing we can do is remove this attribute on the server. Auto-dismount will still not work, but at least the player will receive an error if they try to mount the Magic Rooster while sitting on another mount.

**Tests performed:**

Builded and tested.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
