### PR TITLE
Core/Spell: Implement Summon Sayaad

### DIFF
--- a/sql/updates/world/master/2023_04_23_00_world.sql
+++ b/sql/updates/world/master/2023_04_23_00_world.sql
@@ -1,0 +1,9 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_warl_strengthen_pact_succubus','spell_warl_strengthen_pact_incubus','spell_warl_random_sayaad','spell_warl_summon_sayaad','spell_warl_sayaad_precast_disorientation');
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES 
+(366323,'spell_warl_strengthen_pact_succubus'),
+(366325,'spell_warl_strengthen_pact_incubus'),
+(366330,'spell_warl_random_sayaad'),
+(366222,'spell_warl_summon_sayaad'),
+(366323,'spell_warl_sayaad_precast_disorientation'),
+(366325,'spell_warl_sayaad_precast_disorientation'),
+(366222,'spell_warl_sayaad_precast_disorientation');

--- a/sql/updates/world/master/2023_99_99_99_world.sql
+++ b/sql/updates/world/master/2023_99_99_99_world.sql
@@ -1,5 +1,6 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (366323, 366325, 366222);
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (366323, 366325, 366330, 366222);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
 (366323, 'spell_warl_strengthen_pact_succubus_incubus'),
 (366325, 'spell_warl_strengthen_pact_succubus_incubus'),
+(366330, 'spell_warl_random_sayaad'),
 (366222, 'spell_warl_summon_sayaad');

--- a/sql/updates/world/master/2023_99_99_99_world.sql
+++ b/sql/updates/world/master/2023_99_99_99_world.sql
@@ -1,9 +1,0 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (366323, 366325, 366330, 366222);
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
-(366323, 'spell_warl_strengthen_pact_succubus'),
-(366325, 'spell_warl_strengthen_pact_incubus'),
-(366330, 'spell_warl_random_sayaad'),
-(366222, 'spell_warl_summon_sayaad'),
-(366323, 'spell_warl_sayaad_precast_disorientation'),
-(366325, 'spell_warl_sayaad_precast_disorientation'),
-(366222, 'spell_warl_sayaad_precast_disorientation');

--- a/sql/updates/world/master/2023_99_99_99_world.sql
+++ b/sql/updates/world/master/2023_99_99_99_world.sql
@@ -1,0 +1,5 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (366323, 366325, 366222);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(366323, 'spell_warl_strengthen_pact_succubus_incubus'),
+(366325, 'spell_warl_strengthen_pact_succubus_incubus'),
+(366222, 'spell_warl_summon_sayaad');

--- a/sql/updates/world/master/2023_99_99_99_world.sql
+++ b/sql/updates/world/master/2023_99_99_99_world.sql
@@ -3,4 +3,7 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (366323, 'spell_warl_strengthen_pact_succubus'),
 (366325, 'spell_warl_strengthen_pact_incubus'),
 (366330, 'spell_warl_random_sayaad'),
-(366222, 'spell_warl_summon_sayaad');
+(366222, 'spell_warl_summon_sayaad'),
+(366323, 'spell_warl_sayaad_precast_disorientation'),
+(366325, 'spell_warl_sayaad_precast_disorientation'),
+(366222, 'spell_warl_sayaad_precast_disorientation');

--- a/sql/updates/world/master/2023_99_99_99_world.sql
+++ b/sql/updates/world/master/2023_99_99_99_world.sql
@@ -1,6 +1,6 @@
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (366323, 366325, 366330, 366222);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
-(366323, 'spell_warl_strengthen_pact_succubus_incubus'),
-(366325, 'spell_warl_strengthen_pact_succubus_incubus'),
+(366323, 'spell_warl_strengthen_pact_succubus'),
+(366325, 'spell_warl_strengthen_pact_incubus'),
 (366330, 'spell_warl_random_sayaad'),
 (366222, 'spell_warl_summon_sayaad');

--- a/src/server/game/Entities/Creature/TemporarySummon.h
+++ b/src/server/game/Entities/Creature/TemporarySummon.h
@@ -29,6 +29,7 @@ enum PetEntry
     PET_SUCCUBUS        = 1863,
     PET_DOOMGUARD       = 18540,
     PET_FELGUARD        = 30146,
+    PET_INCUBUS         = 184600,
 
     // Death Knight pets
     PET_GHOUL           = 26125,
@@ -97,6 +98,7 @@ class TC_GAME_API Minion : public TempSummon
         bool IsPetSuccubus() const { return GetEntry() == PET_SUCCUBUS; }
         bool IsPetDoomguard() const { return GetEntry() == PET_DOOMGUARD; }
         bool IsPetFelguard() const { return GetEntry() == PET_FELGUARD; }
+        bool IsPetIncubus() const { return GetEntry() == PET_INCUBUS; }
 
         // Death Knight pets
         bool IsPetGhoul() const { return GetEntry() == PET_GHOUL; } // Ghoul may be guardian or pet

--- a/src/server/game/Entities/Creature/TemporarySummon.h
+++ b/src/server/game/Entities/Creature/TemporarySummon.h
@@ -95,10 +95,10 @@ class TC_GAME_API Minion : public TempSummon
         bool IsPetImp() const { return GetEntry() == PET_IMP; }
         bool IsPetFelhunter() const { return GetEntry() == PET_FEL_HUNTER; }
         bool IsPetVoidwalker() const { return GetEntry() == PET_VOID_WALKER; }
-        bool IsPetSuccubus() const { return GetEntry() == PET_SUCCUBUS; }
+        bool IsPetSayaad() const { return GetEntry() == PET_SUCCUBUS || GetEntry() == PET_INCUBUS; }
         bool IsPetDoomguard() const { return GetEntry() == PET_DOOMGUARD; }
         bool IsPetFelguard() const { return GetEntry() == PET_FELGUARD; }
-        bool IsPetIncubus() const { return GetEntry() == PET_INCUBUS; }
+        bool IsWarlockPet() const { return IsPetImp() || IsPetFelhunter() || IsPetVoidwalker() || IsPetSayaad() || IsPetDoomguard() || IsPetFelguard(); }
 
         // Death Knight pets
         bool IsPetGhoul() const { return GetEntry() == PET_GHOUL; } // Ghoul may be guardian or pet

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -931,7 +931,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
         SetPowerType(POWER_ENERGY);
         SetFullPower(POWER_ENERGY);
     }
-    else if (IsPetImp() || IsPetFelhunter() || IsPetVoidwalker() || IsPetSuccubus() || IsPetIncubus() || IsPetDoomguard() || IsPetFelguard()) // Warlock pets have energy (since 5.x)
+    else if (IsWarlockPet()) // Warlock pets have energy (since 5.x)
         SetPowerType(POWER_ENERGY);
     else
         SetPowerType(POWER_MANA);

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -931,7 +931,7 @@ bool Guardian::InitStatsForLevel(uint8 petlevel)
         SetPowerType(POWER_ENERGY);
         SetFullPower(POWER_ENERGY);
     }
-    else if (IsPetImp() || IsPetFelhunter() || IsPetVoidwalker() || IsPetSuccubus() || IsPetDoomguard() || IsPetFelguard()) // Warlock pets have energy (since 5.x)
+    else if (IsPetImp() || IsPetFelhunter() || IsPetVoidwalker() || IsPetSuccubus() || IsPetIncubus() || IsPetDoomguard() || IsPetFelguard()) // Warlock pets have energy (since 5.x)
         SetPowerType(POWER_ENERGY);
     else
         SetPowerType(POWER_MANA);

--- a/src/server/game/Entities/Pet/PetDefines.h
+++ b/src/server/game/Entities/Pet/PetDefines.h
@@ -112,6 +112,11 @@ enum class PetTameResult : uint8
 
 constexpr uint32 CALL_PET_SPELL_ID = 883;
 
+enum PetSpells
+{
+    PET_SUMMONING_DESORIENTATION = 32752
+};
+
 class PetStable
 {
 public:

--- a/src/server/game/Entities/Pet/PetDefines.h
+++ b/src/server/game/Entities/Pet/PetDefines.h
@@ -114,7 +114,7 @@ constexpr uint32 CALL_PET_SPELL_ID = 883;
 
 enum PetSpells
 {
-    PET_SUMMONING_DESORIENTATION = 32752
+    PET_SUMMONING_DISORIENTATION = 32752
 };
 
 class PetStable

--- a/src/server/game/Entities/Pet/PetDefines.h
+++ b/src/server/game/Entities/Pet/PetDefines.h
@@ -111,11 +111,7 @@ enum class PetTameResult : uint8
 };
 
 constexpr uint32 CALL_PET_SPELL_ID = 883;
-
-enum PetSpellEntry
-{
-    PET_SUMMONING_DISORIENTATION = 32752
-};
+constexpr uint32 PET_SUMMONING_DISORIENTATION = 32752;
 
 class PetStable
 {

--- a/src/server/game/Entities/Pet/PetDefines.h
+++ b/src/server/game/Entities/Pet/PetDefines.h
@@ -112,7 +112,7 @@ enum class PetTameResult : uint8
 
 constexpr uint32 CALL_PET_SPELL_ID = 883;
 
-enum PetSpells
+enum PetSpellEntry
 {
     PET_SUMMONING_DISORIENTATION = 32752
 };

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6174,7 +6174,7 @@ SpellCastResult Spell::CheckCast(bool strict, int32* param1 /*= nullptr*/, int32
                     {
                         if (strict)                         //starting cast, trigger pet stun (cast by pet so it doesn't attack player)
                             if (Pet* pet = unitCaster->ToPlayer()->GetPet())
-                                pet->CastSpell(pet, PetSpellEntry::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
+                                pet->CastSpell(pet, PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
                                     .SetOriginalCaster(pet->GetGUID())
                                     .SetTriggeringSpell(this));
                     }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6174,7 +6174,7 @@ SpellCastResult Spell::CheckCast(bool strict, int32* param1 /*= nullptr*/, int32
                     {
                         if (strict)                         //starting cast, trigger pet stun (cast by pet so it doesn't attack player)
                             if (Pet* pet = unitCaster->ToPlayer()->GetPet())
-                                pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
+                                pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
                                     .SetOriginalCaster(pet->GetGUID())
                                     .SetTriggeringSpell(this));
                     }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6174,7 +6174,7 @@ SpellCastResult Spell::CheckCast(bool strict, int32* param1 /*= nullptr*/, int32
                     {
                         if (strict)                         //starting cast, trigger pet stun (cast by pet so it doesn't attack player)
                             if (Pet* pet = unitCaster->ToPlayer()->GetPet())
-                                pet->CastSpell(pet, 32752, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
+                                pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
                                     .SetOriginalCaster(pet->GetGUID())
                                     .SetTriggeringSpell(this));
                     }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6174,7 +6174,7 @@ SpellCastResult Spell::CheckCast(bool strict, int32* param1 /*= nullptr*/, int32
                     {
                         if (strict)                         //starting cast, trigger pet stun (cast by pet so it doesn't attack player)
                             if (Pet* pet = unitCaster->ToPlayer()->GetPet())
-                                pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
+                                pet->CastSpell(pet, PetSpellEntry::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
                                     .SetOriginalCaster(pet->GetGUID())
                                     .SetTriggeringSpell(this));
                     }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -852,7 +852,7 @@ class spell_warl_strengthen_pact_succubus : public SpellScript
     {
         return ValidateSpellInfo
         ({
-            PetSpells::PET_SUMMONING_DISORIENTATION,
+            PetSpellEntry::PET_SUMMONING_DISORIENTATION,
             SPELL_WARLOCK_SUCCUBUS_PACT,
             SPELL_WARLOCK_SUMMON_SUCCUBUS
         });
@@ -864,7 +864,7 @@ class spell_warl_strengthen_pact_succubus : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpellEntry::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
@@ -890,7 +890,7 @@ class spell_warl_strengthen_pact_incubus : public SpellScript
     {
         return ValidateSpellInfo
         ({
-            PetSpells::PET_SUMMONING_DISORIENTATION,
+            PetSpellEntry::PET_SUMMONING_DISORIENTATION,
             SPELL_WARLOCK_INCUBUS_PACT,
             SPELL_WARLOCK_SUMMON_INCUBUS
         });
@@ -902,7 +902,7 @@ class spell_warl_strengthen_pact_incubus : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpellEntry::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
@@ -962,7 +962,7 @@ class spell_warl_summon_sayaad : public SpellScript
     {
         return ValidateSpellInfo
         ({
-            PetSpells::PET_SUMMONING_DISORIENTATION,
+            PetSpellEntry::PET_SUMMONING_DISORIENTATION,
             SPELL_WARLOCK_SUMMON_SUCCUBUS,
             SPELL_WARLOCK_SUMMON_INCUBUS
         });
@@ -974,7 +974,7 @@ class spell_warl_summon_sayaad : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpellEntry::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleAfterCast()

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -898,6 +898,45 @@ class spell_warl_strengthen_pact_succubus_incubus : public SpellScript
     }
 };
 
+// 366330 - Random Sayaad 
+class spell_warl_random_sayaad : public SpellScript
+{
+    PrepareSpellScript(spell_warl_random_sayaad);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo
+        ({
+            SPELL_WARLOCK_SUCCUBUS_PACT,
+            SPELL_WARLOCK_INCUBUS_PACT
+        });
+    }
+
+    bool Load() override
+    {
+        return GetCaster()->GetTypeId() == TYPEID_PLAYER;
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+
+        caster->RemoveAura(SPELL_WARLOCK_SUCCUBUS_PACT);
+        caster->RemoveAura(SPELL_WARLOCK_INCUBUS_PACT);
+
+        if (Pet* pet = caster->ToPlayer()->GetPet())
+        {
+            if (pet->IsPetSuccubus() || pet->IsPetIncubus())
+                pet->DespawnOrUnsummon();
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_warl_random_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
 // 366222 - Summon Sayaad
 class spell_warl_summon_sayaad : public SpellScript
 {
@@ -945,5 +984,6 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScript(spell_warl_unstable_affliction);
     RegisterSpellScript(spell_warl_rain_of_fire);
     RegisterSpellScript(spell_warl_strengthen_pact_succubus_incubus);
+    RegisterSpellScript(spell_warl_random_sayaad);
     RegisterSpellScript(spell_warl_summon_sayaad);
 }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -476,10 +476,7 @@ class spell_warl_sayaad_precast_disorientation : public SpellScript
             pet->CastSpell(pet, PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
-    void Register()
-    {
-
-    }
+    void Register() override { }
 };
 
 // 6358 - Seduction (Special Ability)

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -898,7 +898,7 @@ class spell_warl_strengthen_pact_succubus_incubus : public SpellScript
     }
 };
 
-// 366330 - Random Sayaad 
+// 366330 - Random Sayaad
 class spell_warl_random_sayaad : public SpellScript
 {
     PrepareSpellScript(spell_warl_random_sayaad);

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -852,7 +852,7 @@ class spell_warl_strengthen_pact_succubus : public SpellScript
     {
         return ValidateSpellInfo
         ({
-            PetSpells::PET_SUMMONING_DESORIENTATION,
+            PetSpells::PET_SUMMONING_DISORIENTATION,
             SPELL_WARLOCK_SUCCUBUS_PACT,
             SPELL_WARLOCK_SUMMON_SUCCUBUS
         });
@@ -864,7 +864,7 @@ class spell_warl_strengthen_pact_succubus : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
@@ -890,7 +890,7 @@ class spell_warl_strengthen_pact_incubus : public SpellScript
     {
         return ValidateSpellInfo
         ({
-            PetSpells::PET_SUMMONING_DESORIENTATION,
+            PetSpells::PET_SUMMONING_DISORIENTATION,
             SPELL_WARLOCK_INCUBUS_PACT,
             SPELL_WARLOCK_SUMMON_INCUBUS
         });
@@ -902,7 +902,7 @@ class spell_warl_strengthen_pact_incubus : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
@@ -962,7 +962,7 @@ class spell_warl_summon_sayaad : public SpellScript
     {
         return ValidateSpellInfo
         ({
-            PetSpells::PET_SUMMONING_DESORIENTATION,
+            PetSpells::PET_SUMMONING_DISORIENTATION,
             SPELL_WARLOCK_SUMMON_SUCCUBUS,
             SPELL_WARLOCK_SUMMON_INCUBUS
         });
@@ -974,7 +974,7 @@ class spell_warl_summon_sayaad : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleAfterCast()

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -955,7 +955,7 @@ class spell_warl_summon_sayaad : public SpellScript
     {
         Unit* caster = GetCaster();
 
-        caster->CastSpell(caster, roll_chance_i(50) ? SPELL_WARLOCK_SUMMON_SUCCUBUS : SPELL_WARLOCK_SUMMON_INCUBUS, true);
+        caster->CastSpell(caster, roll_chance_i(50) ? SPELL_WARLOCK_SUMMON_SUCCUBUS : SPELL_WARLOCK_SUMMON_INCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -63,6 +63,12 @@ enum WarlockSpells
     SPELL_WARLOCK_UNSTABLE_AFFLICTION_DISPEL        = 31117,
     SPELL_WARLOCK_SHADOWFLAME                       = 37378,
     SPELL_WARLOCK_FLAMESHADOW                       = 37379,
+    SPELL_WARLOCK_SUMMON_SUCCUBUS                   = 712,
+    SPELL_WARLOCK_SUMMON_INCUBUS                    = 365349,
+    SPELL_WARLOCK_STRENGTHEN_PACT_SUCCUBUS          = 366323,
+    SPELL_WARLOCK_STRENGTHEN_PACT_INCUBUS           = 366325,
+    SPELL_WARLOCK_SUCCUBUS_PACT                     = 365360,
+    SPELL_WARLOCK_INCUBUS_PACT                      = 365355
 };
 
 enum MiscSpells
@@ -836,6 +842,63 @@ class spell_warl_rain_of_fire : public AuraScript
     }
 };
 
+// 366323 - Strengthen Pact - Succubus
+// 366325 - Strengthen Pact - Incubus
+class spell_warl_strengthen_pact_succubus_incubus : public SpellScript
+{
+    PrepareSpellScript(spell_warl_strengthen_pact_succubus_incubus);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo
+        ({
+            SPELL_WARLOCK_SUCCUBUS_PACT,
+            SPELL_WARLOCK_INCUBUS_PACT,
+            SPELL_WARLOCK_SUMMON_SUCCUBUS,
+            SPELL_WARLOCK_SUMMON_INCUBUS
+        });
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+
+        if (GetSpellInfo()->Id == SPELL_WARLOCK_STRENGTHEN_PACT_SUCCUBUS)
+        {
+            caster->CastSpell(caster, SPELL_WARLOCK_SUCCUBUS_PACT, true);
+            caster->CastSpell(caster, SPELL_WARLOCK_SUMMON_SUCCUBUS, true);
+        }
+        else
+        {
+            caster->CastSpell(caster, SPELL_WARLOCK_INCUBUS_PACT, true);
+            caster->CastSpell(caster, SPELL_WARLOCK_SUMMON_INCUBUS, true);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_warl_strengthen_pact_succubus_incubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
+// 366222 - Summon Sayaad
+class spell_warl_summon_sayaad : public SpellScript
+{
+    PrepareSpellScript(spell_warl_summon_sayaad);
+
+    void HandleAfterCast()
+    {
+        Unit* caster = GetCaster();
+
+        caster->CastSpell(caster, roll_chance_i(50) ? SPELL_WARLOCK_SUMMON_SUCCUBUS : SPELL_WARLOCK_SUMMON_INCUBUS, true);
+    }
+
+    void Register() override
+    {
+        AfterCast += SpellCastFn(spell_warl_summon_sayaad::HandleAfterCast);
+    }
+};
+
 void AddSC_warlock_spell_scripts()
 {
     RegisterSpellScript(spell_warl_banish);
@@ -864,4 +927,6 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScriptWithArgs(spell_warl_t4_2p_bonus<SPELL_WARLOCK_SHADOWFLAME>, "spell_warl_t4_2p_bonus_fire");
     RegisterSpellScript(spell_warl_unstable_affliction);
     RegisterSpellScript(spell_warl_rain_of_fire);
+    RegisterSpellScript(spell_warl_strengthen_pact_succubus_incubus);
+    RegisterSpellScript(spell_warl_summon_sayaad);
 }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -69,8 +69,7 @@ enum WarlockSpells
     SPELL_WARLOCK_STRENGTHEN_PACT_SUCCUBUS          = 366323,
     SPELL_WARLOCK_STRENGTHEN_PACT_INCUBUS           = 366325,
     SPELL_WARLOCK_SUCCUBUS_PACT                     = 365360,
-    SPELL_WARLOCK_INCUBUS_PACT                      = 365355,
-    SPELL_SUMMONING_DISORIENTATION                  = 32752
+    SPELL_WARLOCK_INCUBUS_PACT                      = 365355
 };
 
 enum MiscSpells
@@ -845,26 +844,18 @@ class spell_warl_rain_of_fire : public AuraScript
 };
 
 // 366323 - Strengthen Pact - Succubus
-// 366325 - Strengthen Pact - Incubus
-class spell_warl_strengthen_pact_succubus_incubus : public SpellScript
+class spell_warl_strengthen_pact_succubus : public SpellScript
 {
-    PrepareSpellScript(spell_warl_strengthen_pact_succubus_incubus);
+    PrepareSpellScript(spell_warl_strengthen_pact_succubus);
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
         return ValidateSpellInfo
         ({
-            SPELL_SUMMONING_DISORIENTATION,
+            PetSpells::PET_SUMMONING_DESORIENTATION,
             SPELL_WARLOCK_SUCCUBUS_PACT,
-            SPELL_WARLOCK_INCUBUS_PACT,
-            SPELL_WARLOCK_SUMMON_SUCCUBUS,
-            SPELL_WARLOCK_SUMMON_INCUBUS
+            SPELL_WARLOCK_SUMMON_SUCCUBUS
         });
-    }
-
-    bool Load() override
-    {
-        return GetCaster()->GetTypeId() == TYPEID_PLAYER;
     }
 
     void OnPrecast() override
@@ -873,28 +864,58 @@ class spell_warl_strengthen_pact_succubus_incubus : public SpellScript
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, SPELL_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
 
-        if (GetSpellInfo()->Id == SPELL_WARLOCK_STRENGTHEN_PACT_SUCCUBUS)
-        {
-            caster->CastSpell(caster, SPELL_WARLOCK_SUCCUBUS_PACT, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
-            caster->CastSpell(caster, SPELL_WARLOCK_SUMMON_SUCCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
-        }
-        else
-        {
-            caster->CastSpell(caster, SPELL_WARLOCK_INCUBUS_PACT, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
-            caster->CastSpell(caster, SPELL_WARLOCK_SUMMON_INCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
-        }
+        caster->CastSpell(caster, SPELL_WARLOCK_SUCCUBUS_PACT, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+        caster->CastSpell(caster, SPELL_WARLOCK_SUMMON_SUCCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
     }
 
     void Register() override
     {
-        OnEffectHitTarget += SpellEffectFn(spell_warl_strengthen_pact_succubus_incubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnEffectLaunch += SpellEffectFn(spell_warl_strengthen_pact_succubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
+// 366325 - Strengthen Pact - Incubus
+class spell_warl_strengthen_pact_incubus : public SpellScript
+{
+    PrepareSpellScript(spell_warl_strengthen_pact_incubus);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo
+        ({
+            PetSpells::PET_SUMMONING_DESORIENTATION,
+            SPELL_WARLOCK_INCUBUS_PACT,
+            SPELL_WARLOCK_SUMMON_INCUBUS
+        });
+    }
+
+    void OnPrecast() override
+    {
+        Unit* caster = GetCaster();
+
+        // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
+        if (Pet* pet = caster->ToPlayer()->GetPet())
+            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+
+        caster->CastSpell(caster, SPELL_WARLOCK_INCUBUS_PACT, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+        caster->CastSpell(caster, SPELL_WARLOCK_SUMMON_INCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+    }
+
+    void Register() override
+    {
+        OnEffectLaunch += SpellEffectFn(spell_warl_strengthen_pact_incubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 
@@ -910,11 +931,6 @@ class spell_warl_random_sayaad : public SpellScript
             SPELL_WARLOCK_SUCCUBUS_PACT,
             SPELL_WARLOCK_INCUBUS_PACT
         });
-    }
-
-    bool Load() override
-    {
-        return GetCaster()->GetTypeId() == TYPEID_PLAYER;
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
@@ -942,13 +958,23 @@ class spell_warl_summon_sayaad : public SpellScript
 {
     PrepareSpellScript(spell_warl_summon_sayaad);
 
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo
+        ({
+            PetSpells::PET_SUMMONING_DESORIENTATION,
+            SPELL_WARLOCK_SUMMON_SUCCUBUS,
+            SPELL_WARLOCK_SUMMON_INCUBUS
+        });
+    }
+
     void OnPrecast() override
     {
         Unit* caster = GetCaster();
 
         // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
         if (Pet* pet = caster->ToPlayer()->GetPet())
-            pet->CastSpell(pet, SPELL_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PetSpells::PET_SUMMONING_DESORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
     }
 
     void HandleAfterCast()
@@ -992,7 +1018,8 @@ void AddSC_warlock_spell_scripts()
     RegisterSpellScriptWithArgs(spell_warl_t4_2p_bonus<SPELL_WARLOCK_SHADOWFLAME>, "spell_warl_t4_2p_bonus_fire");
     RegisterSpellScript(spell_warl_unstable_affliction);
     RegisterSpellScript(spell_warl_rain_of_fire);
-    RegisterSpellScript(spell_warl_strengthen_pact_succubus_incubus);
+    RegisterSpellScript(spell_warl_strengthen_pact_succubus);
+    RegisterSpellScript(spell_warl_strengthen_pact_incubus);
     RegisterSpellScript(spell_warl_random_sayaad);
     RegisterSpellScript(spell_warl_summon_sayaad);
 }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -449,7 +449,7 @@ class spell_warl_random_sayaad : public SpellScript
 
     void Register() override
     {
-        OnEffectLaunch += SpellEffectFn(spell_warl_random_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnEffectHit += SpellEffectFn(spell_warl_random_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 
@@ -473,10 +473,14 @@ class spell_warl_sayaad_precast_disorientation : public SpellScript
             return;
 
         if (Pet* pet = player->GetPet())
-            pet->CastSpell(pet, PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+            pet->CastSpell(pet, PET_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK)
+                .SetOriginalCaster(pet->GetGUID())
+                .SetTriggeringSpell(GetSpell()));
     }
 
-    void Register() override { }
+    void Register() override
+    {
+    }
 };
 
 // 6358 - Seduction (Special Ability)
@@ -834,13 +838,13 @@ class spell_warl_strengthen_pact_succubus : public SpellScript
     {
         Unit* caster = GetCaster();
 
-        caster->CastSpell(nullptr, SPELL_WARLOCK_SUCCUBUS_PACT, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
-        caster->CastSpell(nullptr, SPELL_WARLOCK_SUMMON_SUCCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+        caster->CastSpell(nullptr, SPELL_WARLOCK_SUCCUBUS_PACT, TRIGGERED_FULL_MASK);
+        caster->CastSpell(nullptr, SPELL_WARLOCK_SUMMON_SUCCUBUS, TRIGGERED_FULL_MASK);
     }
 
     void Register() override
     {
-        OnEffectLaunch += SpellEffectFn(spell_warl_strengthen_pact_succubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnEffectHit += SpellEffectFn(spell_warl_strengthen_pact_succubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 
@@ -862,13 +866,13 @@ class spell_warl_strengthen_pact_incubus : public SpellScript
     {
         Unit* caster = GetCaster();
 
-        caster->CastSpell(nullptr, SPELL_WARLOCK_INCUBUS_PACT, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
-        caster->CastSpell(nullptr, SPELL_WARLOCK_SUMMON_INCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+        caster->CastSpell(nullptr, SPELL_WARLOCK_INCUBUS_PACT, TRIGGERED_FULL_MASK);
+        caster->CastSpell(nullptr, SPELL_WARLOCK_SUMMON_INCUBUS, TRIGGERED_FULL_MASK);
     }
 
     void Register() override
     {
-        OnEffectLaunch += SpellEffectFn(spell_warl_strengthen_pact_incubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnEffectHit += SpellEffectFn(spell_warl_strengthen_pact_incubus::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 
@@ -888,12 +892,12 @@ class spell_warl_summon_sayaad : public SpellScript
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        GetCaster()->CastSpell(nullptr, roll_chance_i(50) ? SPELL_WARLOCK_SUMMON_SUCCUBUS : SPELL_WARLOCK_SUMMON_INCUBUS, CastSpellExtraArgs(TRIGGERED_FULL_MASK));
+        GetCaster()->CastSpell(nullptr, roll_chance_i(50) ? SPELL_WARLOCK_SUMMON_SUCCUBUS : SPELL_WARLOCK_SUMMON_INCUBUS, TRIGGERED_FULL_MASK);
     }
 
     void Register() override
     {
-        OnEffectLaunch += SpellEffectFn(spell_warl_summon_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnEffectHit += SpellEffectFn(spell_warl_summon_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -926,7 +926,7 @@ class spell_warl_random_sayaad : public SpellScript
 
         if (Pet* pet = caster->ToPlayer()->GetPet())
         {
-            if (pet->IsPetSuccubus() || pet->IsPetIncubus())
+            if (pet->IsPetSayaad())
                 pet->DespawnOrUnsummon();
         }
     }

--- a/src/server/scripts/Spells/spell_warlock.cpp
+++ b/src/server/scripts/Spells/spell_warlock.cpp
@@ -933,7 +933,7 @@ class spell_warl_random_sayaad : public SpellScript
 
     void Register() override
     {
-        OnEffectHitTarget += SpellEffectFn(spell_warl_random_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnEffectLaunch += SpellEffectFn(spell_warl_random_sayaad::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
 };
 
@@ -941,6 +941,15 @@ class spell_warl_random_sayaad : public SpellScript
 class spell_warl_summon_sayaad : public SpellScript
 {
     PrepareSpellScript(spell_warl_summon_sayaad);
+
+    void OnPrecast() override
+    {
+        Unit* caster = GetCaster();
+
+        // Note: this is a special case in which the warlock's minion pet must also cast Summon Disorientation at the beginning since this is only handled by SPELL_EFFECT_SUMMON_PET in Spell::CheckCast.
+        if (Pet* pet = caster->ToPlayer()->GetPet())
+            pet->CastSpell(pet, SPELL_SUMMONING_DISORIENTATION, CastSpellExtraArgs(TRIGGERED_FULL_MASK).SetOriginalCaster(pet->GetGUID()).SetTriggeringSpell(GetSpell()));
+    }
 
     void HandleAfterCast()
     {


### PR DESCRIPTION
**Changes proposed:**

- Implement Summon Sayaad (spellId: 366222) which has a 50% chance to use Summon Succubus or Summon Incubus.
- Implement Strengthen Pact - Succubus (spellId: 366323) and Strengthen Pact - Incubus (spellId: 366325) which are the item spells related to the player's choosing on the trainer. (Any existing minion pet must trigger Summoning Disorientation (spellId: 32752) OnPrecast since these spells are a SPELL_EFFECT_DUMMY and not a SPELL_EFFECT_SUMMON_PET handled in Spell::CheckCast). 
- Succubus Pact (spellId: 365360) or Incubus Pact (spellId: 365355) do not need implementation since they're a SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS which overrides Summon Sayaad (spellId: 366222) with Summon Succubus (spellId: 712) or Summon Incubus (spellId: 365349). **These auras have an unlimited duration and ALLOW_AURA_WHILE_DEAD and ALLOW_ENTERING_ARENA attributes, though I'm not sure if this is enough to keep them forever until the player decides to change their choice in the trainer again.**
- Implement a new bool TempSummon::IsSayaad which replaces TempSummon::IsSuccubus and includes Incubus now to set its power.

**Issues addressed:**

None.

**Tests performed:**

No testing is needed.

**Known issues and TODO list:** (add/remove lines as needed)
 
- [ ] Maybe implement the trainer's GossipOptions after the initial quest is completed which allows the warlock to:
1. If neither of the SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS is present, show the GossipOption to choose either succubus or incubus. If the first is chosen, the player casts Create Barbed Collar of the Succubus (spellId: 366398) which creates Barbed Collar of the Succubus (itemId: 189720) and destroys Barbed Collar of the Incubus (itemId: 189719); or if the later is chosen, the player casts Create Barbed Collar of the Incubus (spellId: 366384) which creates Barbed Collar of the Incubus (itemId: 189719) and destroys Barbed Collar of the Succubus (itemId: 189720).
3. If any of the SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS is present, show the GossipOption to go back to the default option (Summon Sayaad). Choosing this option forces the player to cast Random Sayaad (spellId: 366330), which removes any of the override auras from the player and if the succubus or the incubus (not any other minion pet) is summoned, they're despawned.
