### PR TITLE
Core/GameObjects: Allow certain types to be sent to the client without display

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1799,7 +1799,7 @@ bool GameObject::IsNeverVisibleFor(WorldObject const* seer, bool allowServerside
     if (GetGOInfo()->GetServerOnly() && !allowServersideObjects)
         return true;
 
-    if (!GetDisplayId())
+    if (!GetDisplayId() && GetGOInfo()->IsDisplayMandatory())
         return true;
 
     return false;

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -1238,8 +1238,10 @@ struct GameObjectTemplate
         {
             case GAMEOBJECT_TYPE_SPELL_FOCUS:
             case GAMEOBJECT_TYPE_MULTI:
-            case GAMEOBJECT_TYPE_SIEGEABLE_MULTI: return false;
-            default: return true;
+            case GAMEOBJECT_TYPE_SIEGEABLE_MULTI:
+                return false;
+            default:
+                return true;
         }
     }
 

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -1232,6 +1232,17 @@ struct GameObjectTemplate
         }
     }
 
+    bool IsDisplayMandatory() const
+    {
+        switch (type)
+        {
+            case GAMEOBJECT_TYPE_SPELL_FOCUS:
+            case GAMEOBJECT_TYPE_MULTI:
+            case GAMEOBJECT_TYPE_SIEGEABLE_MULTI: return false;
+            default: return true;
+        }
+    }
+
     void InitializeQueryData();
     WorldPacket BuildQueryData(LocaleConstant loc) const;
 };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Allow certain types to be sent to the client without display (thanks to @Shauren and @mdX7 for confirming/retrieving the list)

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.
- Runeforge in Acherus
![image](https://user-images.githubusercontent.com/2695278/230779725-c7825b3a-03fb-42ab-b74f-cefba68cce08.png)
- .gob add temp 289688 (GAMEOBJECT_TYPE_MULTI and GAMEOBJECT_TYPE_SIEGEABLE_MULTI have a visible model in the client)


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
