### PR TITLE
Spells/Priest: Update Halo

### DIFF
--- a/sql/updates/world/master/2023_05_07_04_world.sql
+++ b/sql/updates/world/master/2023_05_07_04_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_halo_shadow';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES 
+(120644,'spell_pri_halo_shadow');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,3 +1,0 @@
-DELETE FROM `spell_script_names` WHERE `spell_id`=120644 AND `ScriptName`='spell_pri_halo_shadow';
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
-(120644, 'spell_pri_halo_shadow');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=120644 AND `ScriptName`='spell_pri_halo_shadow';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(120644, 'spell_pri_halo_shadow');

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -59,8 +59,12 @@ enum PriestSpells
     SPELL_PRIEST_DIVINE_WRATH                       = 40441,
     SPELL_PRIEST_FLASH_HEAL                         = 2061,
     SPELL_PRIEST_GUARDIAN_SPIRIT_HEAL               = 48153,
-    SPELL_PRIEST_HALO_DAMAGE                        = 120696,
-    SPELL_PRIEST_HALO_HEAL                          = 120692,
+    SPELL_PRIEST_HALO_HOLY                          = 120517,
+    SPELL_PRIEST_HALO_SHADOW                        = 120644,
+    SPELL_PRIEST_HALO_HOLY_DAMAGE                   = 120696,
+    SPELL_PRIEST_HALO_HOLY_HEAL                     = 120692,
+    SPELL_PRIEST_HALO_SHADOW_DAMAGE                 = 390964,
+    SPELL_PRIEST_HALO_SHADOW_HEAL                   = 390971,
     SPELL_PRIEST_HEAL                               = 2060,
     SPELL_PRIEST_HOLY_WORD_CHASTISE                 = 88625,
     SPELL_PRIEST_HOLY_WORD_SANCTIFY                 = 34861,
@@ -541,7 +545,8 @@ class spell_pri_guardian_spirit : public AuraScript
     }
 };
 
-// 120517 - Halo
+// 120517 - Halo (Holy)
+// 120644 - Halo (Shadow)
 struct areatrigger_pri_halo : AreaTriggerAI
 {
     areatrigger_pri_halo(AreaTrigger* areatrigger) : AreaTriggerAI(areatrigger) {}
@@ -551,9 +556,11 @@ struct areatrigger_pri_halo : AreaTriggerAI
         if (Unit* caster = at->GetCaster())
         {
             if (caster->IsValidAttackTarget(unit))
-                caster->CastSpell(unit, SPELL_PRIEST_HALO_DAMAGE, CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
+                caster->CastSpell(unit, at->GetSpellId() == SPELL_PRIEST_HALO_SHADOW ? SPELL_PRIEST_HALO_SHADOW_DAMAGE : SPELL_PRIEST_HALO_HOLY_DAMAGE,
+                    CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
             else if (caster->IsValidAssistTarget(unit))
-                caster->CastSpell(unit, SPELL_PRIEST_HALO_HEAL, CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
+                caster->CastSpell(unit, at->GetSpellId() == SPELL_PRIEST_HALO_SHADOW ? SPELL_PRIEST_HALO_SHADOW_HEAL : SPELL_PRIEST_HALO_HOLY_HEAL,
+                    CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
         }
     }
 };

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -545,6 +545,25 @@ class spell_pri_guardian_spirit : public AuraScript
     }
 };
 
+// 120644 - Halo (Shadow)
+class spell_pri_halo_shadow : public SpellScript
+{
+    PrepareSpellScript(spell_pri_halo_shadow);
+
+    void HandleHitTarget(SpellEffIndex effIndex)
+    {
+        Unit* caster = GetCaster();
+
+        if (caster->GetPowerType() != GetEffectInfo().MiscValue)
+            PreventHitDefaultEffect(effIndex);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_pri_halo_shadow::HandleHitTarget, EFFECT_1, SPELL_EFFECT_ENERGIZE);
+    }
+};
+
 // 120517 - Halo (Holy)
 // 120644 - Halo (Shadow)
 struct areatrigger_pri_halo : AreaTriggerAI
@@ -1654,6 +1673,7 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_divine_star_shadow);
     RegisterAreaTriggerAI(areatrigger_pri_divine_star);
     RegisterSpellScript(spell_pri_guardian_spirit);
+    RegisterSpellScript(spell_pri_halo_shadow);
     RegisterAreaTriggerAI(areatrigger_pri_halo);
     RegisterSpellScript(spell_pri_holy_words);
     RegisterSpellScript(spell_pri_item_t6_trinket);


### PR DESCRIPTION
**Changes proposed:**

-  Update Halo's trigger spells to properly support both Halo for Shadow and Holy/Discipline specs. It also offers support during Shadow Covenant aura for Discipline since it uses SPELL_AURA_OVERRIDE_ACTIONBAR_SPELLS to override the spells cast.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.