### PR TITLE
Spells/Priest: Implement Purge the Wicked

### DIFF
--- a/sql/updates/world/master/2023_05_07_06_world.sql
+++ b/sql/updates/world/master/2023_05_07_06_world.sql
@@ -1,0 +1,8 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_purge_the_wicked';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES 
+(47540,'spell_pri_purge_the_wicked'),
+(400169,'spell_pri_purge_the_wicked');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_purge_the_wicked_dummy';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES 
+(204215,'spell_pri_purge_the_wicked_dummy');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,8 +1,0 @@
-DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_purge_the_wicked';
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
-(47540, 'spell_pri_purge_the_wicked'),
-(400169, 'spell_pri_purge_the_wicked');
-
-DELETE FROM `spell_script_names` WHERE `spell_id`=204215 AND `ScriptName`='spell_pri_purge_the_wicked_dummy';
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
-(204215, 'spell_pri_purge_the_wicked_dummy');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,8 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_purge_the_wicked';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(47540, 'spell_pri_purge_the_wicked'),
+(400169, 'spell_pri_purge_the_wicked');
+
+DELETE FROM `spell_script_names` WHERE `spell_id`=204215 AND `ScriptName`='spell_pri_purge_the_wicked_dummy';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(204215, 'spell_pri_purge_the_wicked_dummy');

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -99,6 +99,7 @@ enum PriestSpells
     SPELL_PRIEST_RENEW                              = 139,
     SPELL_PRIEST_RENEWED_HOPE                       = 197469,
     SPELL_PRIEST_RENEWED_HOPE_EFFECT                = 197470,
+    SPELL_PRIEST_REVEL_IN_PURITY                    = 373003,
     SPELL_PRIEST_SHADOW_MEND_DAMAGE                 = 186439,
     SPELL_PRIEST_SHADOW_MEND_PERIODIC_DUMMY         = 187464,
     SPELL_PRIEST_SHIELD_DISCIPLINE_ENERGIZE         = 47755,
@@ -118,11 +119,6 @@ enum PriestSpells
     SPELL_PRIEST_PRAYER_OF_MENDING_HEAL             = 33110,
     SPELL_PRIEST_PRAYER_OF_MENDING_JUMP             = 155793,
     SPELL_PRIEST_WEAKENED_SOUL                      = 6788
-};
-
-enum PriestTalents
-{
-    SPELL_PRIEST_TALENT_REVEL_IN_PURITY             = 373003
 };
 
 enum MiscSpells
@@ -1329,8 +1325,8 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC, SPELL_PRIEST_TALENT_REVEL_IN_PURITY })
-            && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_TALENT_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1;
+        return ValidateSpellInfo({ SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC, SPELL_PRIEST_REVEL_IN_PURITY })
+            && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1;
     }
 
     void FilterTargets(std::list<WorldObject*>& targets)
@@ -1349,7 +1345,7 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
             return;
 
         // Note: there's no SPELL_EFFECT_DUMMY with BasePoints 1 in any of the spells related to use as reference so we hardcode the value.
-        int32 spreadCount = 1;
+        uint32 spreadCount = 1;
 
         // Note: we must sort our list of targets whose priority is 1) aura, 2) distance, and 3) duration.
         targets.sort([&](WorldObject const* lhs, WorldObject const* rhs) -> bool
@@ -1373,8 +1369,8 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
         });
 
         // Note: Revel in Purity talent.
-        if (caster->HasAura(SPELL_PRIEST_TALENT_REVEL_IN_PURITY))
-            spreadCount += sSpellMgr->AssertSpellInfo(SPELL_PRIEST_TALENT_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffect(EFFECT_1).CalcValue(GetCaster());
+        if (caster->HasAura(SPELL_PRIEST_REVEL_IN_PURITY))
+            spreadCount += sSpellMgr->AssertSpellInfo(SPELL_PRIEST_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffect(EFFECT_1).CalcValue(GetCaster());
 
         if (targets.size() > spreadCount)
             targets.resize(spreadCount);
@@ -1393,8 +1389,6 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
         OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_pri_purge_the_wicked_dummy::FilterTargets, EFFECT_1, TARGET_UNIT_DEST_AREA_ENEMY);
         OnEffectHitTarget += SpellEffectFn(spell_pri_purge_the_wicked_dummy::HandleDummy, EFFECT_1, SPELL_EFFECT_DUMMY);
     }
-
-private:
 };
 
 // 47536 - Rapture

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1313,7 +1313,7 @@ class spell_pri_purge_the_wicked : public SpellScript
         Unit* target = GetHitUnit();
 
         if (target->HasAura(SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC, caster->GetGUID()))
-            caster->CastSpell(target, SPELL_PRIEST_PURGE_THE_WICKED_DUMMY, CastSpellExtraArgs(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS));
+            caster->CastSpell(target, SPELL_PRIEST_PURGE_THE_WICKED_DUMMY, CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
     }
 
     void Register() override
@@ -1329,7 +1329,7 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC })
+        return ValidateSpellInfo({ SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC, SPELL_PRIEST_TALENT_REVEL_IN_PURITY })
             && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_TALENT_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1;
     }
 
@@ -1341,7 +1341,8 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
         targets.remove_if([&](WorldObject* object) -> bool
         {
             // Note: we must remove any non-unit target, the explicit target and any other target that may be under any crowd control aura.
-            return (!object->ToUnit() || object->ToUnit() == explTarget || object->ToUnit()->HasBreakableByDamageCrowdControlAura());
+            Unit* target = object->ToUnit();
+            return !target || target == explTarget || target->HasBreakableByDamageCrowdControlAura();
         });
 
         if (!targets.empty())
@@ -1370,7 +1371,7 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
 
             // Note: Revel in Purity talent.
             if (caster->HasAura(SPELL_PRIEST_TALENT_REVEL_IN_PURITY))
-                _spreadCount += sSpellMgr->GetSpellInfo(SPELL_PRIEST_TALENT_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffect(EFFECT_1).CalcValue(GetCaster());
+                _spreadCount += sSpellMgr->AssertSpellInfo(SPELL_PRIEST_TALENT_REVEL_IN_PURITY, DIFFICULTY_NONE)->GetEffect(EFFECT_1).CalcValue(GetCaster());
         }
 
         targets.resize(std::min<uint32>(targets.size(), _spreadCount));
@@ -1381,7 +1382,7 @@ class spell_pri_purge_the_wicked_dummy : public SpellScript
         Unit* caster = GetCaster();
         Unit* target = GetHitUnit();
 
-        caster->CastSpell(target, SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC, CastSpellExtraArgs(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS));
+        caster->CastSpell(target, SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC, CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
     }
 
     void Register() override
@@ -1818,6 +1819,8 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_prayer_of_mending);
     RegisterSpellScript(spell_pri_prayer_of_mending_aura);
     RegisterSpellScript(spell_pri_prayer_of_mending_jump);
+    RegisterSpellScript(spell_pri_purge_the_wicked);
+    RegisterSpellScript(spell_pri_purge_the_wicked_dummy);
     RegisterSpellScript(spell_pri_rapture);
     RegisterSpellScript(spell_pri_sins_of_the_many);
     RegisterSpellScript(spell_pri_spirit_of_redemption);


### PR DESCRIPTION
**Changes proposed:**

- Implement Purge the Wicked (spellId: 204197). The list of targets is sorted by comparing each possible target:

1. If any of the targets don't have the aura, it chooses the given target, which is sorted by the distance closest to the explicit target. If both targets have the aura, it chooses the target whose aura has the lower duration.

- Implement Revel in Purity (spellId: 373003) talent which modifies Purge of the Wicked's spread count.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.