### PR TITLE
Core/Spells: Implement SpellAuraInterruptFlags2::TouchingGround

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12483,6 +12483,9 @@ bool Unit::UpdatePosition(float x, float y, float z, float orientation, bool tel
     if (isInWater)
         RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::Swimming);
 
+    if (!IsFlying() && !IsFalling())
+        RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::TouchingGround);
+
     return (relocated || turn);
 }
 

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -134,7 +134,7 @@ enum class SpellAuraInterruptFlags2 : uint32
     ChangeGlyph                 = 0x00008000,
     SeamlessTransfer            = 0x00010000, // NYI
     WarModeLeave                = 0x00020000, // NYI
-    TouchingGround              = 0x00040000, // NYI
+    TouchingGround              = 0x00040000, // Implemented in Unit::UpdatePosition
     ChromieTime                 = 0x00080000, // NYI
     SplineFlightOrFreeFlight    = 0x00100000, // NYI
     ProcOrPeriodicAttacking     = 0x00200000  // NYI


### PR DESCRIPTION
**Changes proposed:**

- Implement SpellAuraInterruptFlags2::TouchingGround. If the unit is not flying (DisableGravity or Flying) or falling, you're left with touching the ground which covers both solid ground, solid water (while waterwalking), or in the water (submerged or not).

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.