### PR TITLE
Core/Spells: Implement SpellAuraInterruptFlags2::StartOfEncounter

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -481,11 +481,9 @@ inline void Battleground::_ProcessJoin(uint32 diff)
         SetStatus(STATUS_IN_PROGRESS);
         SetStartDelayTime(StartDelayTimes[BG_STARTING_EVENT_FOURTH]);
 
-        for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
-        {
-            if (Player* player = ObjectAccessor::FindPlayer(itr->first))
-                player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
-        }
+        for (auto const& [guid, _] : GetPlayers())
+            if (Player* player = ObjectAccessor::FindPlayer(guid))
+                player->AtStartOfEncounter();
 
         // Remove preparation
         if (isArena())

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -481,6 +481,12 @@ inline void Battleground::_ProcessJoin(uint32 diff)
         SetStatus(STATUS_IN_PROGRESS);
         SetStartDelayTime(StartDelayTimes[BG_STARTING_EVENT_FOURTH]);
 
+        for (BattlegroundPlayerMap::const_iterator itr = GetPlayers().begin(); itr != GetPlayers().end(); ++itr)
+        {
+            if (Player* player = ObjectAccessor::FindPlayer(itr->first))
+                player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
+        }
+
         // Remove preparation
         if (isArena())
         {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -536,6 +536,14 @@ void Unit::MonsterMoveWithSpeed(float x, float y, float z, float speed, bool gen
     GetMotionMaster()->LaunchMoveSpline(std::move(initializer), 0, MOTION_PRIORITY_NORMAL, POINT_MOTION_TYPE);
 }
 
+void Unit::AtStartOfEncounter()
+{
+    RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
+
+    if (IsAlive())
+        Unit::ProcSkillsAndAuras(this, nullptr, PROC_FLAG_ENCOUNTER_START, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
+}
+
 void Unit::UpdateSplineMovement(uint32 t_diff)
 {
     if (movespline->Finalized())

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -2017,6 +2017,9 @@ class TC_GAME_API Unit : public WorldObject
         virtual void AtEngage(Unit* /*target*/) {}
         virtual void AtDisengage() {}
 
+    public:
+        void AtStartOfEncounter();
+
     private:
 
         void UpdateSplineMovement(uint32 t_diff);

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -410,7 +410,11 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
                     instance->DoOnPlayers([](Player* player)
                     {
                         if (player->IsAlive())
+                        {
                             Unit::ProcSkillsAndAuras(player, nullptr, PROC_FLAG_ENCOUNTER_START, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
+
+                            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
+                        }
                     });
                     break;
                 }

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -409,12 +409,10 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
 
                     instance->DoOnPlayers([](Player* player)
                     {
-                        if (player->IsAlive())
-                        {
-                            Unit::ProcSkillsAndAuras(player, nullptr, PROC_FLAG_ENCOUNTER_START, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
+                        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
 
-                            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
-                        }
+                        if (player->IsAlive())
+                            Unit::ProcSkillsAndAuras(player, nullptr, PROC_FLAG_ENCOUNTER_START, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
                     });
                     break;
                 }

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -409,10 +409,7 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
 
                     instance->DoOnPlayers([](Player* player)
                     {
-                        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::StartOfEncounter);
-
-                        if (player->IsAlive())
-                            Unit::ProcSkillsAndAuras(player, nullptr, PROC_FLAG_ENCOUNTER_START, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
+                        player->AtStartOfEncounter();
                     });
                     break;
                 }

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -124,7 +124,7 @@ enum class SpellAuraInterruptFlags2 : uint32
     Jump                        = 0x00000020,
     ChangeSpec                  = 0x00000040,
     AbandonVehicle              = 0x00000080, // Implemented in Unit::_ExitVehicle
-    StartOfEncounter            = 0x00000100, // NYI
+    StartOfEncounter            = 0x00000100, // Implemented in InstanceScript::SetBossState and Battleground::_ProcessJoin
     EndOfEncounter              = 0x00000200, // NYI
     Disconnect                  = 0x00000400, // NYI
     EnteringInstance            = 0x00000800, // Implemented in Map::AddPlayerToMap


### PR DESCRIPTION
**Changes proposed:**

- Implement SpellAuraInterruptFlags2::StartOfEncounter. Yes, battlegrounds (including arenas) are considered PvP encounters. If Solo Shuffle queue is ever implemented, it will be covered by this.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.