### PR TITLE
Core/Spells: Implement SpellAuraInterruptFlags2::EndOfEncounter

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -912,7 +912,7 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         player->RemoveAura(SPELL_MERCENARY_SHAPESHIFT);
         player->RemovePlayerFlagEx(PLAYER_FLAGS_EX_MERCENARY_MODE);
 
-        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+        player->AtEndOfEncounter();
 
         player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::LeaveArenaOrBattleground);
 

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -912,6 +912,8 @@ void Battleground::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
         player->RemoveAura(SPELL_MERCENARY_SHAPESHIFT);
         player->RemovePlayerFlagEx(PLAYER_FLAGS_EX_MERCENARY_MODE);
 
+        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+
         player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::LeaveArenaOrBattleground);
 
         if (!player->IsAlive())                              // resurrect on exit

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -420,7 +420,7 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
 
                     instance->DoOnPlayers([](Player* player)
                     {
-                        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+                        player->AtEndOfEncounter();
                     });
                     break;
                 }
@@ -437,7 +437,7 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
 
                     instance->DoOnPlayers([](Player* player)
                     {
-                        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+                        player->AtEndOfEncounter();
                     });
                     break;
                 }

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -414,10 +414,19 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
                     break;
                 }
                 case FAIL:
+                {
                     ResetCombatResurrections();
                     SendEncounterEnd();
+
+                    instance->DoOnPlayers([](Player* player)
+                    {
+                        if (player->IsAlive())
+                            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+                    });
                     break;
+                }
                 case DONE:
+                {
                     ResetCombatResurrections();
                     SendEncounterEnd();
                     dungeonEncounter = bossInfo->GetDungeonEncounterForDifficulty(instance->GetDifficultyID());
@@ -426,7 +435,14 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
                         DoUpdateCriteria(CriteriaType::DefeatDungeonEncounter, dungeonEncounter->ID);
                         SendBossKillCredit(dungeonEncounter->ID);
                     }
+
+                    instance->DoOnPlayers([](Player* player)
+                    {
+                        if (player->IsAlive())
+                            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+                    });
                     break;
+                }
                 default:
                     break;
             }

--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -420,8 +420,7 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
 
                     instance->DoOnPlayers([](Player* player)
                     {
-                        if (player->IsAlive())
-                            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+                        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
                     });
                     break;
                 }
@@ -438,8 +437,7 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
 
                     instance->DoOnPlayers([](Player* player)
                     {
-                        if (player->IsAlive())
-                            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+                        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
                     });
                     break;
                 }

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -125,7 +125,7 @@ enum class SpellAuraInterruptFlags2 : uint32
     ChangeSpec                  = 0x00000040,
     AbandonVehicle              = 0x00000080, // Implemented in Unit::_ExitVehicle
     StartOfEncounter            = 0x00000100, // Implemented in InstanceScript::SetBossState and Battleground::_ProcessJoin
-    EndOfEncounter              = 0x00000200, // NYI
+    EndOfEncounter              = 0x00000200, // Implemented in InstanceScript::SetBossState and Battleground::RemovePlayerAtLeave
     Disconnect                  = 0x00000400, // NYI
     EnteringInstance            = 0x00000800, // Implemented in Map::AddPlayerToMap
     DuelEnd                     = 0x00001000, // Implemented in Player::DuelComplete

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -124,8 +124,8 @@ enum class SpellAuraInterruptFlags2 : uint32
     Jump                        = 0x00000020,
     ChangeSpec                  = 0x00000040,
     AbandonVehicle              = 0x00000080, // Implemented in Unit::_ExitVehicle
-    StartOfEncounter            = 0x00000100, // Implemented in InstanceScript::SetBossState and Battleground::_ProcessJoin
-    EndOfEncounter              = 0x00000200, // Implemented in InstanceScript::SetBossState and Battleground::RemovePlayerAtLeave
+    StartOfEncounter            = 0x00000100, // Implemented in Unit::AtStartOfEncounter
+    EndOfEncounter              = 0x00000200, // Implemented in Unit::AtEndOfEncounter
     Disconnect                  = 0x00000400, // NYI
     EnteringInstance            = 0x00000800, // Implemented in Map::AddPlayerToMap
     DuelEnd                     = 0x00001000, // Implemented in Player::DuelComplete


### PR DESCRIPTION
**Changes proposed:**

- Implement SpellAuraInterruptFlags2::EndOfEncounter. Yes, battlegrounds (including arenas) are considered PvP encounters. If Solo Shuffle queue is ever implemented, it will be covered by this.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.