### PR TITLE
Core/Spells: Implement SpellAuraInterruptFlags2::EnteringInstance

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -457,13 +457,11 @@ bool Map::AddPlayerToMap(Player* player, bool initPlayer /*= true*/)
     player->UpdateObjectVisibility(false);
     PhasingHandler::SendToPlayer(player);
 
-    if (player->IsAlive())
-    {
-        ConvertCorpseToBones(player->GetGUID());
+    if (Instanceable())
+        player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EnteringInstance);
 
-        if (Instanceable())
-            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EnteringInstance);
-    }
+    if (player->IsAlive())
+        ConvertCorpseToBones(player->GetGUID());
 
     sScriptMgr->OnPlayerEnterMap(this, player);
     return true;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -458,7 +458,12 @@ bool Map::AddPlayerToMap(Player* player, bool initPlayer /*= true*/)
     PhasingHandler::SendToPlayer(player);
 
     if (player->IsAlive())
+    {
         ConvertCorpseToBones(player->GetGUID());
+
+        if (Instanceable())
+            player->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EnteringInstance);
+    }
 
     sScriptMgr->OnPlayerEnterMap(this, player);
     return true;

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -127,7 +127,7 @@ enum class SpellAuraInterruptFlags2 : uint32
     StartOfEncounter            = 0x00000100, // NYI
     EndOfEncounter              = 0x00000200, // NYI
     Disconnect                  = 0x00000400, // NYI
-    EnteringInstance            = 0x00000800, // NYI
+    EnteringInstance            = 0x00000800, // Implemented in Map::AddPlayerToMap
     DuelEnd                     = 0x00001000, // NYI
     LeaveArenaOrBattleground    = 0x00002000, // NYI
     ChangeTalent                = 0x00004000,


### PR DESCRIPTION
**Changes proposed:**

- Implement SpellAuraInterruptFlags2::EnteringInstance. Instanceable returns true if MAP_INSTANCE, MAP_RAID, MAP_BATTLEGROUND, MAP_ARENA and MAP_SCENARIO.
- EnteringInstance either implies:
1. there's some sort of middle ground where the transfer is in process, but not completed yet. Map::AddPlayerToMap handles it post-transfer, so it should be fine either way. In any case, let me know if there's a better handler for it.
2. or they decided to use -ing form to refer to the gerund as in "EnterInstance" and it should just happen when you're added to the map itself.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.
