### PR TITLE
Core/Spells: Implement SpellAuraInterruptFlags2::AbandonVehicle

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12280,8 +12280,6 @@ void Unit::ExitVehicle(Position const* /*exitPosition*/)
     //! init spline movement based on those coordinates in unapply handlers, and
     //! relocate exiting passengers based on Unit::moveSpline data. Either way,
     //! Coming Soon(TM)
-
-    RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::AbandonVehicle);
 }
 
 void Unit::_ExitVehicle(Position const* exitPosition)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12280,6 +12280,8 @@ void Unit::ExitVehicle(Position const* /*exitPosition*/)
     //! init spline movement based on those coordinates in unapply handlers, and
     //! relocate exiting passengers based on Unit::moveSpline data. Either way,
     //! Coming Soon(TM)
+
+    RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::AbandonVehicle);
 }
 
 void Unit::_ExitVehicle(Position const* exitPosition)
@@ -12363,6 +12365,8 @@ void Unit::_ExitVehicle(Position const* exitPosition)
         else
             ToTempSummon()->UnSummon(2000); // Approximation
     }
+
+    RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::AbandonVehicle);
 }
 
 bool Unit::IsFalling() const

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -123,7 +123,7 @@ enum class SpellAuraInterruptFlags2 : uint32
     Transform                   = 0x00000010, // NYI
     Jump                        = 0x00000020,
     ChangeSpec                  = 0x00000040,
-    AbandonVehicle              = 0x00000080, // NYI
+    AbandonVehicle              = 0x00000080, // Implemented in Unit::ExitVehicle and Unit::_ExitVehicle
     StartOfEncounter            = 0x00000100, // NYI
     EndOfEncounter              = 0x00000200, // NYI
     Disconnect                  = 0x00000400, // NYI

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -123,7 +123,7 @@ enum class SpellAuraInterruptFlags2 : uint32
     Transform                   = 0x00000010, // NYI
     Jump                        = 0x00000020,
     ChangeSpec                  = 0x00000040,
-    AbandonVehicle              = 0x00000080, // Implemented in Unit::ExitVehicle and Unit::_ExitVehicle
+    AbandonVehicle              = 0x00000080, // Implemented in Unit::_ExitVehicle
     StartOfEncounter            = 0x00000100, // NYI
     EndOfEncounter              = 0x00000200, // NYI
     Disconnect                  = 0x00000400, // NYI


### PR DESCRIPTION
**Changes proposed:**

- Implement SpellAuraInterruptFlags2::AbandonVehicle. Added on both Unit::ExitVehicle and Unit::_ExitVehicle since the later uses special handling for AuraEffect::HandleAuraControlVehicle.

**Issues addressed:**

None.

**Tests performed:**

It builds and it was tested in-game.

**Known issues and TODO list:**

None.