### PR TITLE
Fixed the quest dialog could not be closed automatically after getting the quest reward when the quest giver has no other follow-up quests.

### DIFF
--- a/src/server/game/AI/CoreAI/GameObjectAI.cpp
+++ b/src/server/game/AI/CoreAI/GameObjectAI.cpp
@@ -31,7 +31,7 @@ GameObjectAI::GameObjectAI(GameObject* go, uint32 scriptId) : _scriptId(scriptId
     ASSERT(_scriptId, "A GameObjectAI was initialized with an invalid scriptId!");
 }
 
-Optional<QuestGiverStatus> GameObjectAI::GetDialogStatus(Player* /*player*/)
+Optional<QuestGiverStatus> GameObjectAI::GetDialogStatus(Player const* /*player*/)
 {
     return {};
 }

--- a/src/server/game/AI/CoreAI/GameObjectAI.h
+++ b/src/server/game/AI/CoreAI/GameObjectAI.h
@@ -70,7 +70,7 @@ class TC_GAME_API GameObjectAI
         static int32 Permissible(GameObject const* go);
 
         // Called when the dialog status between a player and the gameobject is requested.
-        virtual Optional<QuestGiverStatus> GetDialogStatus(Player* player);
+        virtual Optional<QuestGiverStatus> GetDialogStatus(Player const* player);
 
         // Called when a player opens a gossip dialog with the gameobject.
         virtual bool OnGossipHello(Player* /*player*/) { return false; }

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -324,7 +324,7 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     return true;
 }
 
-Optional<QuestGiverStatus> CreatureAI::GetDialogStatus(Player* /*player*/)
+Optional<QuestGiverStatus> CreatureAI::GetDialogStatus(Player const* /*player*/)
 {
     return {};
 }

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -189,7 +189,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         /// == Gossip system ================================
 
         // Called when the dialog status between a player and the creature is requested.
-        virtual Optional<QuestGiverStatus> GetDialogStatus(Player* player);
+        virtual Optional<QuestGiverStatus> GetDialogStatus(Player const* player);
 
         // Called when a player opens a gossip dialog with the creature.
         virtual bool OnGossipHello(Player* /*player*/) { return false; }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16968,7 +16968,7 @@ void Player::SendQuestReward(Quest const* quest, Creature const* questGiver, uin
         if (questGiver->IsGossip())
             packet.LaunchGossip = true;
         else if (questGiver->IsQuestGiver())
-            packet.LaunchQuest = true;
+            packet.LaunchQuest = (GetQuestDialogStatus(questGiver) & ~QuestGiverStatus::Future) != QuestGiverStatus::None;
         else if (quest->GetNextQuestInChain() && !quest->HasFlag(QUEST_FLAGS_AUTOCOMPLETE))
             if (Quest const* rewardQuest = sObjectMgr->GetQuestTemplate(quest->GetNextQuestInChain()))
                 packet.UseQuestReward = CanTakeQuest(rewardQuest, false);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16113,7 +16113,7 @@ bool Player::SendQuestUpdate(uint32 questId, bool updateVisiblity /*= true*/)
     return PhasingHandler::OnConditionChange(this, updateVisiblity);
 }
 
-QuestGiverStatus Player::GetQuestDialogStatus(Object* questgiver)
+QuestGiverStatus Player::GetQuestDialogStatus(Object const* questgiver) const
 {
     QuestRelationResult qr, qir;
 

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1566,7 +1566,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void PrepareQuestMenu(ObjectGuid guid);
         void SendPreparedQuest(WorldObject* source);
         bool IsActiveQuest(uint32 quest_id) const;
-        Quest const* GetNextQuest(ObjectGuid guid, Quest const* quest) const;
+        Quest const* GetNextQuest(Object const* questGiver, Quest const* quest) const;
         bool CanSeeStartQuest(Quest const* quest) const;
         bool CanTakeQuest(Quest const* quest, bool msg) const;
         bool CanAddQuest(Quest const* quest, bool msg) const;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1616,7 +1616,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         void RemoveActiveQuest(uint32 questId, bool update = true);
         void RemoveRewardedQuest(uint32 questId, bool update = true);
         bool SendQuestUpdate(uint32 questId, bool updateVisiblity = true);
-        QuestGiverStatus GetQuestDialogStatus(Object* questGiver);
+        QuestGiverStatus GetQuestDialogStatus(Object const* questGiver) const;
 
         void SetDailyQuestStatus(uint32 quest_id);
         bool IsDailyQuestDone(uint32 quest_id) const;


### PR DESCRIPTION
**Changes proposed:**

- Fixed the quest dialog could not be closed automatically after getting the quest reward when the quest giver has no other follow-up quests.
- Add the `const` keyword to functions and arguments that are semantically read-only.

**Issues addressed:**

discussion: https://github.com/TrinityCore/TrinityCore/discussions/28971#discussion-5188356

**Tests performed:**

build completed, tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

None.