### PR TITLE
Core/Graveyards: Fix graveyards in subzones when there is no valid graveyard in that subzone

### DIFF
--- a/src/server/game/Globals/ObjectMgr.h
+++ b/src/server/game/Globals/ObjectMgr.h
@@ -1230,6 +1230,7 @@ class TC_GAME_API ObjectMgr
 
         WorldSafeLocsEntry const* GetDefaultGraveyard(uint32 team) const;
         WorldSafeLocsEntry const* GetClosestGraveyard(WorldLocation const& location, uint32 team, WorldObject* conditionObject) const;
+        WorldSafeLocsEntry const* GetClosestGraveyardInZone(WorldLocation const& location, uint32 team, WorldObject* conditionObject, uint32 zoneId) const;
         bool AddGraveyardLink(uint32 id, uint32 zoneId, uint32 team, bool persist = true);
         void RemoveGraveyardLink(uint32 id, uint32 zoneId, uint32 team, bool persist = false);
         void LoadGraveyardZones();


### PR DESCRIPTION
Currently, when you die as a horde player in Northshire, your ghost doesn't get teleported to the nearest horde graveyard. This PR makes resolves this issue by looking at the parent area if there is any.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Searching for a correct graveyard through parent area when none is found

**Issues addressed:**

Closes: none?


**Tests performed:**

1. die as horde player in Northshire --> Correctly teleported away now
2. die in the Great Sea between vashjir and stormwind as a Horde player --> teleported to tirisfal glades (yep this is correct).

**Known issues and TODO list:**
- None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
