### PR TITLE
Spells/Priest: Implement Benediction, Divine Service, and Focused Mending

### DIFF
--- a/sql/updates/world/master/2023_07_22_01_world.sql
+++ b/sql/updates/world/master/2023_07_22_01_world.sql
@@ -1,8 +1,13 @@
 DELETE FROM `spell_proc` WHERE `SpellId` IN (405554);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(405554, 0x00, 6, 0x00000000, 0x00000020, 0x00000000, 0x00400000, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0, 0, 0, 0);
+(405554,0x00,6,0x00000000,0x00000000,0x00000000,0x00400000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0,0,0,0); -- Priest Holy 10.1 Class Set 2pc
 
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (33076, 411097, 41635, 33110, 405554);
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN (
+'spell_pri_prayer_of_mending',        -- reassigned to different spell
+'spell_pri_prayer_of_mending_aura',   -- deleted
+'spell_pri_prayer_of_mending_dummy',  -- new script
+'spell_pri_prayer_of_mending_heal',   -- new script
+'spell_pri_holy_10_1_class_set_2pc'); -- new script
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
 (33076, 'spell_pri_prayer_of_mending_dummy'),
 (411097, 'spell_pri_prayer_of_mending_dummy'),

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,5 +1,11 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (33076, 41635, 33110);
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (33076, 411097, 41635, 33110, 405554);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
 (33076, 'spell_pri_prayer_of_mending_dummy'),
+(411097, 'spell_pri_prayer_of_mending_dummy'),
 (41635, 'spell_pri_prayer_of_mending'),
-(33110, 'spell_pri_prayer_of_mending_heal');
+(33110, 'spell_pri_prayer_of_mending_heal'),
+(405554, 'spell_pri_holy_10_1_class_set_2pc');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN(405554);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(405554, 0x00, 6, 0x00000000, 0x00000020, 0x00000000, 0x00400000, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0, 0, 0, 0); --Priest Holy 10.1 Class Set 2pc

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,3 +1,5 @@
-DELETE FROM `spell_script_names` WHERE `spell_id`=33110 AND `ScriptName`='spell_pri_prayer_of_mending_heal';
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (33076, 41635, 33110);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(33076, 'spell_pri_prayer_of_mending_dummy'),
+(41635, 'spell_pri_prayer_of_mending'),
 (33110, 'spell_pri_prayer_of_mending_heal');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,3 +1,7 @@
+DELETE FROM `spell_proc` WHERE `SpellId` IN (405554);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(405554, 0x00, 6, 0x00000000, 0x00000020, 0x00000000, 0x00400000, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0, 0, 0, 0);
+
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (33076, 411097, 41635, 33110, 405554);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
 (33076, 'spell_pri_prayer_of_mending_dummy'),
@@ -5,7 +9,3 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 (41635, 'spell_pri_prayer_of_mending'),
 (33110, 'spell_pri_prayer_of_mending_heal'),
 (405554, 'spell_pri_holy_10_1_class_set_2pc');
-
-DELETE FROM `spell_proc` WHERE `SpellId` IN(405554);
-INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(405554, 0x00, 6, 0x00000000, 0x00000020, 0x00000000, 0x00400000, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0, 0, 0, 0); --Priest Holy 10.1 Class Set 2pc

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=33110 AND `ScriptName`='spell_pri_prayer_of_mending_heal';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES 
+(33110, 'spell_pri_prayer_of_mending_heal');

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1334,31 +1334,6 @@ class spell_pri_prayer_of_mending_dummy : public spell_pri_prayer_of_mending_Spe
 };
 
 // 41635 - Prayer of Mending (Aura)
-class spell_pri_prayer_of_mending : public SpellScript
-{
-    PrepareSpellScript(spell_pri_prayer_of_mending);
-
-    void HandleDummy(SpellEffIndex /*effIndex*/)
-    {
-        Aura* aura = GetHitAura();
-        if (!aura)
-            return;
-
-        spell_pri_prayer_of_mending_aura* script = aura->GetScript<spell_pri_prayer_of_mending_aura>();
-        if (!script)
-            return;
-
-        bool isEmpoweredByFocusedMending = std::any_cast<bool>(GetSpell()->m_customArg);
-
-        script->SetEmpoweredByFocusedMending(isEmpoweredByFocusedMending);
-    }
-
-    void Register() override
-    {
-        OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending::HandleDummy, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
-    }
-};
-
 class spell_pri_prayer_of_mending_aura : public AuraScript
 {
     PrepareAuraScript(spell_pri_prayer_of_mending_aura);
@@ -1420,6 +1395,31 @@ public:
 
 private:
     bool _isEmpoweredByFocusedMending = false;
+};
+
+class spell_pri_prayer_of_mending : public SpellScript
+{
+    PrepareSpellScript(spell_pri_prayer_of_mending);
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        Aura* aura = GetHitAura();
+        if (!aura)
+            return;
+
+        spell_pri_prayer_of_mending_aura* script = aura->GetScript<spell_pri_prayer_of_mending_aura>();
+        if (!script)
+            return;
+
+        bool isEmpoweredByFocusedMending = std::any_cast<bool>(GetSpell()->m_customArg);
+
+        script->SetEmpoweredByFocusedMending(isEmpoweredByFocusedMending);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending::HandleDummy, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
+    }
 };
 
 // 155793 - Prayer of Mending (Jump)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1443,7 +1443,9 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
             SPELL_PRIEST_RENEW,
             SPELL_PRIEST_DIVINE_SERVICE,
             SPELL_PRIEST_PRAYER_OF_MENDING_AURA
-        });
+            })
+            && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_DIVINE_SERVICE, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1
+            && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_BENEDICTION, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1;
     }
 
     void HandleEffectHitTarget(SpellEffIndex /*effIndex*/)
@@ -1465,8 +1467,7 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
         {
             if (roll_chance_i(benediction->GetAmount()))
                 caster->CastSpell(target, SPELL_PRIEST_RENEW,
-                    CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS))
-                    .SetTriggeringSpell(GetSpell()));
+                    CastSpellExtraArgs(TriggerCastFlags(TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CAST_IN_PROGRESS)));
         }
     }
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1491,26 +1491,26 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
         Unit* caster = GetCaster();
         Unit* target = GetHitUnit();
 
+        bool healBonus = 1.0f;
+
         if (AuraEffect const* focusedMending = caster->GetAuraEffect(SPELL_PRIEST_FOCUSED_MENDING, EFFECT_0))
         {
             bool isEmpoweredByFocusedMending = std::any_cast<bool>(GetSpell()->m_customArg);
-            if (!isEmpoweredByFocusedMending)
-                return;
 
-            _healBonus += focusedMending->GetAmount() / 100.0f;
+            if (isEmpoweredByFocusedMending)
+                healBonus += focusedMending->GetAmount() / 100.0f;
         }
 
         if (AuraEffect const* divineService = caster->GetAuraEffect(SPELL_PRIEST_DIVINE_SERVICE, EFFECT_0))
         {
             Aura* prayerOfMending = target->GetAura(SPELL_PRIEST_PRAYER_OF_MENDING_AURA, caster->GetGUID());
-            if (!prayerOfMending)
-                return;
 
-            _healBonus += divineService->GetAmount() * prayerOfMending->GetStackAmount() / 100.0f;
+            if (prayerOfMending)
+                healBonus += divineService->GetAmount() * prayerOfMending->GetStackAmount() / 100.0f;
 
         }
 
-        SetHitHeal(GetHitHeal() * _healBonus);
+        SetHitHeal(GetHitHeal() * healBonus);
 
         if (AuraEffect* benediction = caster->GetAuraEffect(SPELL_PRIEST_BENEDICTION, EFFECT_0))
         {
@@ -1524,9 +1524,6 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
     {
         OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending_heal::HandleEffectHitTarget, EFFECT_0, SPELL_EFFECT_HEAL);
     }
-
-private:
-    float _healBonus = 1.0f;
 };
 
 // 204197 - Purge the Wicked

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1434,7 +1434,7 @@ class spell_pri_prayer_of_mending_jump : public spell_pri_prayer_of_mending_Spel
 
     void HandleJump(SpellEffIndex /*effIndex*/)
     {
-        Unit* origCaster = GetOriginalCaster(); 
+        Unit* origCaster = GetOriginalCaster();
         Unit* target = GetHitUnit();
 
         if (origCaster)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1443,9 +1443,8 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
             SPELL_PRIEST_RENEW,
             SPELL_PRIEST_DIVINE_SERVICE,
             SPELL_PRIEST_PRAYER_OF_MENDING_AURA
-            })
-            && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_DIVINE_SERVICE, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1
-            && sSpellMgr->AssertSpellInfo(SPELL_PRIEST_BENEDICTION, DIFFICULTY_NONE)->GetEffects().size() > EFFECT_1;
+        })
+            && ValidateSpellEffect({ { SPELL_PRIEST_DIVINE_SERVICE, EFFECT_0 }, { SPELL_PRIEST_BENEDICTION, EFFECT_0 } });
     }
 
     void HandleEffectHitTarget(SpellEffIndex /*effIndex*/)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2125,7 +2125,6 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_prayer_of_mending_jump);
     RegisterSpellScript(spell_pri_prayer_of_mending_heal);
     RegisterSpellScript(spell_pri_holy_10_1_class_set_2pc);
-    RegisterSpellScript(spell_pri_holy_10_1_class_set_2pc_chooser);
     RegisterSpellScript(spell_pri_purge_the_wicked);
     RegisterSpellScript(spell_pri_purge_the_wicked_dummy);
     RegisterSpellScript(spell_pri_rapture);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1522,7 +1522,7 @@ class spell_pri_holy_10_1_class_set_2pc : public AuraScript
         return roll_chance_i(aurEff->GetAmount());
     }
 
-    void HandleProc(AuraEffect* aurEff, ProcEventInfo& eventInfo)
+    void HandleProc(AuraEffect* /*aurEff*/, ProcEventInfo& eventInfo)
     {
         GetTarget()->CastSpell(GetTarget(), SPELL_PRIEST_HOLY_10_1_CLASS_SET_2P_CHOOSER,
             CastSpellExtraArgs(TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1491,7 +1491,7 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
         Unit* caster = GetCaster();
         Unit* target = GetHitUnit();
 
-        bool healBonus = 1.0f;
+        float healBonus = 1.0f;
 
         if (AuraEffect const* focusedMending = caster->GetAuraEffect(SPELL_PRIEST_FOCUSED_MENDING, EFFECT_0))
         {

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1400,7 +1400,7 @@ class spell_pri_prayer_of_mending : public SpellScript
 {
     PrepareSpellScript(spell_pri_prayer_of_mending);
 
-    void HandleDummy(SpellEffIndex /*effIndex*/)
+    void HandleEffectDummy(SpellEffIndex /*effIndex*/)
     {
         Aura* aura = GetHitAura();
         if (!aura)
@@ -1417,7 +1417,7 @@ class spell_pri_prayer_of_mending : public SpellScript
 
     void Register() override
     {
-        OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending::HandleDummy, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
+        OnEffectHitTarget += SpellEffectFn(spell_pri_prayer_of_mending::HandleEffectDummy, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
     }
 };
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -56,6 +56,7 @@ enum PriestSpells
     SPELL_PRIEST_DARK_REPRIMAND_DAMAGE              = 373130,
     SPELL_PRIEST_DARK_REPRIMAND_HEALING             = 400187,
     SPELL_PRIEST_DIVINE_BLESSING                    = 40440,
+    SPELL_PRIEST_DIVINE_SERVICE                     = 391233,
     SPELL_PRIEST_DIVINE_STAR_HOLY                   = 110744,
     SPELL_PRIEST_DIVINE_STAR_SHADOW                 = 122121,
     SPELL_PRIEST_DIVINE_STAR_HOLY_DAMAGE            = 122128,
@@ -1436,13 +1437,29 @@ class spell_pri_prayer_of_mending_heal : public spell_pri_prayer_of_mending_Spel
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_PRIEST_BENEDICTION, SPELL_PRIEST_RENEW });
+        return ValidateSpellInfo
+        ({
+            SPELL_PRIEST_BENEDICTION,
+            SPELL_PRIEST_RENEW,
+            SPELL_PRIEST_DIVINE_SERVICE,
+            SPELL_PRIEST_PRAYER_OF_MENDING_AURA
+        });
     }
 
     void HandleEffectHitTarget(SpellEffIndex /*effIndex*/)
     {
         Unit* caster = GetCaster();
         Unit* target = GetHitUnit();
+
+        if (AuraEffect const* divineService = caster->GetAuraEffect(SPELL_PRIEST_DIVINE_SERVICE, EFFECT_0))
+        {
+            if (Aura* prayerOfMending = target->GetAura(SPELL_PRIEST_PRAYER_OF_MENDING_AURA, caster->GetGUID()))
+            {
+                float healBonus = 1.0f + (divineService->GetAmount() * prayerOfMending->GetStackAmount() / 100.0f);
+
+                SetHitHeal(GetHitHeal() * healBonus);
+            }
+        }
 
         if (AuraEffect* benediction = caster->GetAuraEffect(SPELL_PRIEST_BENEDICTION, EFFECT_0))
         {

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1331,7 +1331,8 @@ class spell_pri_prayer_of_mending_dummy : public spell_pri_prayer_of_mending_Spe
 
     void HandleEffectDummy(SpellEffIndex /*effIndex*/)
     {
-        CastPrayerOfMendingAura(GetCaster(), GetHitUnit(), GetEffectValue(), true);
+        // Note: we need to increase BasePoints by 1 since it's 4 as default.
+        CastPrayerOfMendingAura(GetCaster(), GetHitUnit(), GetEffectValue() + 1, true);
     }
 
     void Register() override


### PR DESCRIPTION
**Changes proposed:**

- Implement Benediction talent.
- Implement Divine Service talent.
- Implement Focused Mending talent.
- Implement Priest Holy 10.1 Class Set 2pc.
- Clean-up for Prayer of Mending spell-related scripts. Also, 155793 - Prayer of Mending (Jump) is now using smartheal logic as of 6.0.1 patch.

**Issues addressed:**

None.

**Tests performed:**

Tested.

**Known issues and TODO list:** (add/remove lines as needed)

None.