### PR TITLE
Core/Spells: Implement SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -547,6 +547,13 @@ void Unit::AtStartOfEncounter()
 void Unit::AtEndOfEncounter()
 {
     RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::EndOfEncounter);
+
+    GetSpellHistory()->ResetCooldowns([](SpellHistory::CooldownStorageType::iterator itr)
+    {
+        SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(itr->first, DIFFICULTY_NONE);
+
+        return spellInfo->HasAttribute(SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END);
+    }, true);
 }
 
 void Unit::UpdateSplineMovement(uint32 t_diff)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -554,6 +554,13 @@ void Unit::AtEndOfEncounter()
 
         return spellInfo->HasAttribute(SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END);
     }, true);
+
+    GetSpellHistory()->ResetCharges([](SpellHistory::ChargeStorageType::iterator itr)
+    {
+        SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(itr->first, DIFFICULTY_NONE);
+
+        return spellInfo->HasAttribute(SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END);
+    }, true);
 }
 
 void Unit::UpdateSplineMovement(uint32 t_diff)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -554,13 +554,6 @@ void Unit::AtEndOfEncounter()
 
         return spellInfo->HasAttribute(SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END);
     }, true);
-
-    GetSpellHistory()->ResetCharges([](SpellHistory::ChargeStorageType::iterator itr)
-    {
-        SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(itr->first, DIFFICULTY_NONE);
-
-        return spellInfo->HasAttribute(SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END);
-    });
 }
 
 void Unit::UpdateSplineMovement(uint32 t_diff)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -560,7 +560,7 @@ void Unit::AtEndOfEncounter()
         SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(itr->first, DIFFICULTY_NONE);
 
         return spellInfo->HasAttribute(SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END);
-    }, true);
+    });
 }
 
 void Unit::UpdateSplineMovement(uint32 t_diff)

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -163,22 +163,6 @@ public:
     void RestoreCharge(uint32 chargeCategoryId);
     void ResetCharges(uint32 chargeCategoryId);
     void ResetAllCharges();
-    template<typename Predicate>
-    void ResetCharges(Predicate predicate)
-    {
-        std::vector<int32> resetCharges;
-        resetCharges.reserve(_categoryCharges.size());
-        for (auto itr = _categoryCharges.begin(); itr != _categoryCharges.end();)
-        {
-            if (predicate(itr))
-            {
-                resetCharges.push_back(int32(itr->first));
-                ResetCharges(itr, GetCastDifficulty()->ChargeCategoryId);
-            }
-            else
-                ++itr;
-        }
-    }
     bool HasCharge(uint32 chargeCategoryId) const;
     int32 GetMaxCharges(uint32 chargeCategoryId) const;
     int32 GetChargeRecoveryTime(uint32 chargeCategoryId) const;

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -163,6 +163,22 @@ public:
     void RestoreCharge(uint32 chargeCategoryId);
     void ResetCharges(uint32 chargeCategoryId);
     void ResetAllCharges();
+    template<typename Predicate>
+    void ResetCharges(Predicate predicate)
+    {
+        std::vector<int32> resetCharges;
+        resetCharges.reserve(_categoryCharges.size());
+        for (auto itr = _categoryCharges.begin(); itr != _categoryCharges.end();)
+        {
+            if (predicate(itr))
+            {
+                resetCharges.push_back(int32(itr->first));
+                ResetCharges(itr, GetCastDifficulty()->ChargeCategoryId);
+            }
+            else
+                ++itr;
+        }
+    }
     bool HasCharge(uint32 chargeCategoryId) const;
     int32 GetMaxCharges(uint32 chargeCategoryId) const;
     int32 GetChargeRecoveryTime(uint32 chargeCategoryId) const;


### PR DESCRIPTION
**Changes proposed:**

-  Implement SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END in Unit::AtEndOfEncounter().

**Issues addressed:**

None.

**Tests performed:**

None.

**Known issues and TODO list:**

None.