### PR TITLE
Quest: Implement CONDITION_SOURCE_TYPE_OBJECT_ID_VISIBILITY being che…

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1227,7 +1227,7 @@ std::vector<std::pair<ConditionsObjectVisibilityIdKey, bool /*conditionMet*/>> C
     {
         for (auto const& [objectVisibilityIdKey, conditions] : *conditionEntriesByObjectVisibilityMap)
         {
-            TC_LOG_DEBUG("condition", "CountQuestObjectiveMeetingVisibilityByObjectIdConditions: found conditions for quest objective {}", questObjectiveId);
+            TC_LOG_DEBUG("condition", "GetQuestObjectiveMeetingVisibilityByObjectIdConditionsResult: found conditions for quest objective {}", questObjectiveId);
             result.emplace_back(objectVisibilityIdKey, IsObjectMeetToConditions(seer, conditions));
         }
     }

--- a/src/server/game/Conditions/ConditionMgr.h
+++ b/src/server/game/Conditions/ConditionMgr.h
@@ -270,6 +270,8 @@ typedef std::unordered_map<uint32, ConditionsByEntryMap> ConditionEntriesByCreat
 typedef std::unordered_map<std::pair<int32, uint32 /*SAI source_type*/>, ConditionsByEntryMap> SmartEventConditionContainer;
 typedef std::unordered_map<uint32, ConditionContainer> ConditionReferenceContainer;//only used for references
 typedef std::unordered_map<std::pair<int32, bool>, ConditionContainer> ConditionEntriesByAreaTriggerIdMap;
+typedef std::pair<uint32 /*object type*/, uint32 /*object id*/> ConditionsObjectVisibilityIdKey;
+typedef std::unordered_map<ConditionsObjectVisibilityIdKey, ConditionContainer> ConditionEntriesByObjectVisibilityMap;
 
 class TC_GAME_API ConditionMgr
 {
@@ -305,6 +307,7 @@ class TC_GAME_API ConditionMgr
         ConditionContainer const* GetConditionsForAreaTrigger(uint32 areaTriggerId, bool isServerSide) const;
         bool IsObjectMeetingTrainerSpellConditions(uint32 trainerId, uint32 spellId, Player* player) const;
         bool IsObjectMeetingVisibilityByObjectIdConditions(uint32 objectType, uint32 entry, WorldObject const* seer) const;
+        std::vector<std::pair<ConditionsObjectVisibilityIdKey, bool /*conditionMet*/>> GetQuestObjectiveMeetingVisibilityByObjectIdConditionsResult(uint32 questObjectiveId, WorldObject const* seer) const;
 
         static uint32 GetPlayerConditionLfgValue(Player const* player, PlayerConditionLfgStatus status);
         static bool IsPlayerMeetingCondition(Player const* player, PlayerConditionEntry const* condition);
@@ -346,7 +349,8 @@ class TC_GAME_API ConditionMgr
         std::unordered_set<uint32> SpellsUsedInSpellClickConditions;
         ConditionEntriesByAreaTriggerIdMap AreaTriggerConditionContainerStore;
         ConditionEntriesByCreatureIdMap TrainerSpellConditionContainerStore;
-        std::unordered_map<std::pair<uint32 /*object type*/, uint32 /*object id*/>, ConditionContainer> ObjectVisibilityConditionStore;
+        ConditionEntriesByObjectVisibilityMap ObjectVisibilityConditionStore;
+        std::unordered_map<uint32, ConditionEntriesByObjectVisibilityMap> QuestObjectiveUsedInObjectIdVisibilityConditions;
 };
 
 #define sConditionMgr ConditionMgr::instance()


### PR DESCRIPTION
…cked when a Quest Objective Progress is updated and update the visiblity if the condition changed

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  When a quest objective progress is updated, compare the conditions for CONDITION_SOURCE_TYPE_OBJECT_ID_VISIBILITY for the objective BEFORE the objective was updated, with the conditions AFTER the progress was updated.. in that case we can decide if a visibility update is needed for the player
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
- [x] Builds
- [x] Tested ingame

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
