### PR TITLE
Core/Config: Implement reading config overrides from subdirectory

### DIFF
--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -33,6 +33,7 @@ public:
     /// Method used only for loading main configuration files (bnetserver.conf and worldserver.conf)
     bool LoadInitial(std::string file, std::vector<std::string> args, std::string& error);
     bool LoadAdditionalFile(std::string file, bool keepOnReload, std::string& error);
+    uint LoadAdditionalDir(std::string dir, bool keepOnReload, std::string& error);
 
     /// Overrides configuration with environment variables and returns overridden keys
     std::vector<std::string> OverrideWithEnvVariablesIfAny();

--- a/src/common/Configuration/Config.h
+++ b/src/common/Configuration/Config.h
@@ -20,6 +20,7 @@
 
 #include "Define.h"
 #include <string>
+#include <string_view>
 #include <vector>
 
 class TC_COMMON_API ConfigMgr
@@ -33,7 +34,7 @@ public:
     /// Method used only for loading main configuration files (bnetserver.conf and worldserver.conf)
     bool LoadInitial(std::string file, std::vector<std::string> args, std::string& error);
     bool LoadAdditionalFile(std::string file, bool keepOnReload, std::string& error);
-    uint LoadAdditionalDir(std::string dir, bool keepOnReload, std::string& error);
+    bool LoadAdditionalDir(std::string const& dir, bool keepOnReload, std::vector<std::string>& loadedFiles, std::vector<std::string>& errors);
 
     /// Overrides configuration with environment variables and returns overridden keys
     std::vector<std::string> OverrideWithEnvVariablesIfAny();

--- a/src/server/bnetserver/CMakeLists.txt
+++ b/src/server/bnetserver/CMakeLists.txt
@@ -35,8 +35,9 @@ add_executable(bnetserver
 )
 
 if (NOT WIN32)
-  set_target_properties(bnetserver PROPERTIES
-    COMPILE_DEFINITIONS _TRINITY_BNET_CONFIG="${CONF_DIR}/bnetserver.conf"
+  target_compile_definitions(bnetserver PRIVATE
+    _TRINITY_BNET_CONFIG="${CONF_DIR}/bnetserver.conf"
+    _TRINITY_BNET_CONFIG_DIR="${CONF_DIR}/bnetserver.conf.d"
   )
 endif()
 

--- a/src/server/bnetserver/Main.cpp
+++ b/src/server/bnetserver/Main.cpp
@@ -58,6 +58,9 @@ namespace fs = boost::filesystem;
 #ifndef _TRINITY_BNET_CONFIG
 # define _TRINITY_BNET_CONFIG  "bnetserver.conf"
 #endif
+#ifndef _TRINITY_BNET_CONFIG_DIR
+    #define _TRINITY_BNET_CONFIG_DIR "bnetserver.conf.d"
+#endif
 
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
 #include "ServiceWin32.h"
@@ -87,6 +90,7 @@ int main(int argc, char** argv)
     signal(SIGABRT, &Trinity::AbortHandler);
 
     auto configFile = fs::absolute(_TRINITY_BNET_CONFIG);
+    auto configDir  = fs::absolute(_TRINITY_BNET_CONFIG_DIR);
     std::string configService;
     auto vm = GetConsoleArguments(argc, argv, configFile, configService);
     // exit if help or version is enabled
@@ -112,6 +116,15 @@ int main(int argc, char** argv)
                                  configError))
     {
         printf("Error in config file: %s\n", configError.c_str());
+        return 1;
+    }
+
+    std::string configDirError;
+    uint configDirFiles = sConfigMgr->LoadAdditionalDir(configDir.generic_string(), true, configDirError);
+    if (configDirError.empty()) {
+        printf("Loaded %u additional config files", configDirFiles);
+    } else {
+        printf("Error in additional config files: %s\n", configDirError.c_str());
         return 1;
     }
 

--- a/src/server/bnetserver/Main.cpp
+++ b/src/server/bnetserver/Main.cpp
@@ -83,7 +83,7 @@ void StopDB();
 void SignalHandler(std::weak_ptr<Trinity::Asio::IoContext> ioContextRef, boost::system::error_code const& error, int signalNumber);
 void KeepDatabaseAliveHandler(std::weak_ptr<Trinity::Asio::DeadlineTimer> dbPingTimerRef, int32 dbPingInterval, boost::system::error_code const& error);
 void BanExpiryHandler(std::weak_ptr<Trinity::Asio::DeadlineTimer> banExpiryCheckTimerRef, int32 banExpiryCheckInterval, boost::system::error_code const& error);
-variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, std::string& configService);
+variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, fs::path& configDir, std::string& winServiceAction);
 
 int main(int argc, char** argv)
 {
@@ -91,8 +91,8 @@ int main(int argc, char** argv)
 
     auto configFile = fs::absolute(_TRINITY_BNET_CONFIG);
     auto configDir  = fs::absolute(_TRINITY_BNET_CONFIG_DIR);
-    std::string configService;
-    auto vm = GetConsoleArguments(argc, argv, configFile, configService);
+    std::string winServiceAction;
+    auto vm = GetConsoleArguments(argc, argv, configFile, configDir, winServiceAction);
     // exit if help or version is enabled
     if (vm.count("help") || vm.count("version"))
         return 0;
@@ -102,11 +102,11 @@ int main(int argc, char** argv)
     std::shared_ptr<void> protobufHandle(nullptr, [](void*) { google::protobuf::ShutdownProtobufLibrary(); });
 
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
-    if (configService.compare("install") == 0)
+    if (winServiceAction == "install")
         return WinServiceInstall() ? 0 : 1;
-    else if (configService.compare("uninstall") == 0)
+    if (winServiceAction == "uninstall")
         return WinServiceUninstall() ? 0 : 1;
-    else if (configService.compare("run") == 0)
+    if (winServiceAction == "run")
         return WinServiceRun() ? 0 : 1;
 #endif
 
@@ -119,12 +119,17 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    std::string configDirError;
-    uint configDirFiles = sConfigMgr->LoadAdditionalDir(configDir.generic_string(), true, configDirError);
-    if (configDirError.empty()) {
-        printf("Loaded %u additional config files", configDirFiles);
-    } else {
-        printf("Error in additional config files: %s\n", configDirError.c_str());
+    std::vector<std::string> loadedConfigFiles;
+    std::vector<std::string> configDirErrors;
+    bool additionalConfigFileLoadSuccess = sConfigMgr->LoadAdditionalDir(configDir.generic_string(), true, loadedConfigFiles, configDirErrors);
+    for (std::string const& loadedConfigFile : loadedConfigFiles)
+        printf("Loaded additional config file %s\n", loadedConfigFile.c_str());
+
+    if (!additionalConfigFileLoadSuccess)
+    {
+        for (std::string const& configDirError : configDirErrors)
+            printf("Error in additional config files: %s\n", configDirError.c_str());
+
         return 1;
     }
 
@@ -350,22 +355,22 @@ void ServiceStatusWatcher(std::weak_ptr<Trinity::Asio::DeadlineTimer> serviceSta
 }
 #endif
 
-variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, std::string& configService)
+variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, fs::path& configDir, [[maybe_unused]] std::string& winServiceAction)
 {
-    (void)configService;
-
     options_description all("Allowed options");
     all.add_options()
         ("help,h", "print usage message")
         ("version,v", "print version build info")
         ("config,c", value<fs::path>(&configFile)->default_value(fs::absolute(_TRINITY_BNET_CONFIG)),
                      "use <arg> as configuration file")
+        ("config-dir,cd", value<fs::path>(&configDir)->default_value(fs::absolute(_TRINITY_BNET_CONFIG_DIR)),
+            "use <arg> as directory with additional config files")
         ("update-databases-only,u", "updates databases only")
         ;
 #if TRINITY_PLATFORM == TRINITY_PLATFORM_WINDOWS
     options_description win("Windows platform specific options");
     win.add_options()
-        ("service,s", value<std::string>(&configService)->default_value(""), "Windows service options: [install | uninstall]")
+        ("service,s", value<std::string>(&winServiceAction)->default_value(""), "Windows service options: [install | uninstall]")
         ;
 
     all.add(win);

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -33,8 +33,9 @@ add_executable(worldserver
 )
 
 if(NOT WIN32)
-  set_target_properties(worldserver PROPERTIES
-    COMPILE_DEFINITIONS _TRINITY_CORE_CONFIG="${CONF_DIR}/worldserver.conf"
+  target_compile_definitions(worldserver PRIVATE
+    _TRINITY_CORE_CONFIG="${CONF_DIR}/worldserver.conf"
+    _TRINITY_CORE_CONFIG_DIR="${CONF_DIR}/worldserver.conf.d"
   )
 endif()
 

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -123,7 +123,7 @@ void WorldUpdateLoop();
 void ClearOnlineAccounts();
 void ShutdownCLIThread(std::thread* cliThread);
 bool LoadRealmInfo();
-variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, std::string& cfg_service);
+variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, fs::path& configDir, std::string& winServiceAction);
 
 /// Launch the Trinity server
 extern int main(int argc, char** argv)
@@ -132,9 +132,9 @@ extern int main(int argc, char** argv)
 
     auto configFile = fs::absolute(_TRINITY_CORE_CONFIG);
     auto configDir  = fs::absolute(_TRINITY_CORE_CONFIG_DIR);
-    std::string configService;
+    std::string winServiceAction;
 
-    auto vm = GetConsoleArguments(argc, argv, configFile, configService);
+    auto vm = GetConsoleArguments(argc, argv, configFile, configDir, winServiceAction);
     // exit if help or version is enabled
     if (vm.count("help") || vm.count("version"))
         return 0;
@@ -144,12 +144,12 @@ extern int main(int argc, char** argv)
     std::shared_ptr<void> protobufHandle(nullptr, [](void*) { google::protobuf::ShutdownProtobufLibrary(); });
 
 #ifdef _WIN32
-    if (configService.compare("install") == 0)
+    if (winServiceAction == "install")
         return WinServiceInstall() ? 0 : 1;
-    else if (configService.compare("uninstall") == 0)
+    if (winServiceAction == "uninstall")
         return WinServiceUninstall() ? 0 : 1;
-    else if (configService.compare("run") == 0)
-        return WinServiceRun() ? 0 : 0;
+    if (winServiceAction == "run")
+        return WinServiceRun() ? 0 : 1;
 
     Optional<UINT> newTimerResolution;
     boost::system::error_code dllError;
@@ -199,12 +199,17 @@ extern int main(int argc, char** argv)
         return 1;
     }
 
-    std::string configDirError;
-    uint configDirFiles = sConfigMgr->LoadAdditionalDir(configDir.generic_string(), true, configDirError);
-    if (configDirError.empty()) {
-        printf("Loaded %u additional config files\n", configDirFiles);
-    } else {
-        printf("Error in additional config files: %s\n", configDirError.c_str());
+    std::vector<std::string> loadedConfigFiles;
+    std::vector<std::string> configDirErrors;
+    bool additionalConfigFileLoadSuccess = sConfigMgr->LoadAdditionalDir(configDir.generic_string(), true, loadedConfigFiles, configDirErrors);
+    for (std::string const& loadedConfigFile : loadedConfigFiles)
+        printf("Loaded additional config file %s\n", loadedConfigFile.c_str());
+
+    if (!additionalConfigFileLoadSuccess)
+    {
+        for (std::string const& configDirError : configDirErrors)
+            printf("Error in additional config files: %s\n", configDirError.c_str());
+
         return 1;
     }
 
@@ -691,23 +696,22 @@ void ClearOnlineAccounts()
 
 /// @}
 
-variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, std::string& configService)
+variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, fs::path& configDir, [[maybe_unused]] std::string& winServiceAction)
 {
-    // Silences warning about configService not be used if the OS is not Windows
-    (void)configService;
-
     options_description all("Allowed options");
     all.add_options()
         ("help,h", "print usage message")
         ("version,v", "print version build info")
         ("config,c", value<fs::path>(&configFile)->default_value(fs::absolute(_TRINITY_CORE_CONFIG)),
                      "use <arg> as configuration file")
+        ("config-dir,cd", value<fs::path>(&configDir)->default_value(fs::absolute(_TRINITY_CORE_CONFIG_DIR)),
+                     "use <arg> as directory with additional config files")
         ("update-databases-only,u", "updates databases only")
         ;
 #ifdef _WIN32
     options_description win("Windows platform specific options");
     win.add_options()
-        ("service,s", value<std::string>(&configService)->default_value(""), "Windows service options: [install | uninstall]")
+        ("service,s", value<std::string>(&winServiceAction)->default_value(""), "Windows service options: [install | uninstall]")
         ;
 
     all.add(win);

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -73,6 +73,10 @@ namespace fs = boost::filesystem;
     #define _TRINITY_CORE_CONFIG  "worldserver.conf"
 #endif
 
+#ifndef _TRINITY_CORE_CONFIG_DIR
+    #define _TRINITY_CORE_CONFIG_DIR "worldserver.conf.d"
+#endif
+
 #ifdef _WIN32
 #include "ServiceWin32.h"
 char serviceName[] = "worldserver";
@@ -127,6 +131,7 @@ extern int main(int argc, char** argv)
     signal(SIGABRT, &Trinity::AbortHandler);
 
     auto configFile = fs::absolute(_TRINITY_CORE_CONFIG);
+    auto configDir  = fs::absolute(_TRINITY_CORE_CONFIG_DIR);
     std::string configService;
 
     auto vm = GetConsoleArguments(argc, argv, configFile, configService);
@@ -191,6 +196,15 @@ extern int main(int argc, char** argv)
                                  configError))
     {
         printf("Error in config file: %s\n", configError.c_str());
+        return 1;
+    }
+
+    std::string configDirError;
+    uint configDirFiles = sConfigMgr->LoadAdditionalDir(configDir.generic_string(), true, configDirError);
+    if (configDirError.empty()) {
+        printf("Loaded %u additional config files\n", configDirFiles);
+    } else {
+        printf("Error in additional config files: %s\n", configDirError.c_str());
         return 1;
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Read additional config files from bnetserver.conf.d and worldserver.conf.d if provided

**Tests performed:**

Builds, works as expected.
