### PR TITLE
Remove extra online update query when login in world on character

### DIFF
--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -845,12 +845,6 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
 
     CharacterDatabase.Execute(stmt);
 
-    LoginDatabasePreparedStatement* loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_ACCOUNT_ONLINE);
-
-    loginStmt->setUInt32(0, GetAccountId());
-
-    LoginDatabase.Execute(loginStmt);
-
     pCurrChar->SetInGameTime(GameTime::GetGameTimeMS());
 
     // announce group about member online (must be after add to player list to receive announce to self)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Remove extra update query when login in world on character since is there already one sent when you enter credentials

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/26923


**Tests performed:**

(Does it build, tested in-game, tested on db side.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
