### PR TITLE
Core/Players: Fix inactive reward quests on faction change

### DIFF
--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -519,7 +519,7 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_DEL_CHAR_QUESTSTATUS_REWARDED_BY_QUEST, "DELETE FROM character_queststatus_rewarded WHERE guid = ? AND quest = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_UPD_CHAR_QUESTSTATUS_REWARDED_FACTION_CHANGE, "UPDATE character_queststatus_rewarded SET quest = ? WHERE quest = ? AND guid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_UPD_CHAR_QUESTSTATUS_REWARDED_ACTIVE, "UPDATE character_queststatus_rewarded SET active = 1 WHERE guid = ?", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_UPD_CHAR_QUESTSTATUS_REWARDED_ACTIVE_BY_QUEST, "UPDATE character_queststatus_rewarded SET active = 0 WHERE quest = ? AND guid = ?", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_UPD_CHAR_QUESTSTATUS_REWARDED_ACTIVE_BY_QUEST, "UPDATE character_queststatus_rewarded SET active = 0 WHERE guid = ? AND quest = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_CHAR_SKILL_BY_SKILL, "DELETE FROM character_skills WHERE guid = ? AND skill = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_INS_CHAR_SKILLS, "INSERT INTO character_skills (guid, skill, value, max) VALUES (?, ?, ?, ?)", CONNECTION_ASYNC);
     PrepareStatement(CHAR_UPD_CHAR_SKILLS, "UPDATE character_skills SET value = ?, max = ? WHERE guid = ? AND skill = ?", CONNECTION_ASYNC);

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1996,7 +1996,7 @@ void WorldSession::HandleCharFactionOrRaceChangeCallback(std::shared_ptr<Charact
                 for (auto const& questTemplatePair : questTemplates)
                 {
                     uint32 newRaceMask = (newTeam == ALLIANCE) ? RACEMASK_ALLIANCE : RACEMASK_HORDE;
-                    if (!(questTemplatePair.second.GetAllowableRaces() & newRaceMask))
+                    if (questTemplatePair.second.GetAllowableRaces() && !(questTemplatePair.second.GetAllowableRaces() & newRaceMask))
                     {
                         stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_QUESTSTATUS_REWARDED_ACTIVE_BY_QUEST);
                         stmt->setUInt32(0, lowGuid);


### PR DESCRIPTION
**Changes proposed:**
-  Fix query order (inverted quest and guid)
-  Quest with AllowableRace 0 shouldn't be inactive on faction change

in this commit:  f37e0ee838fbebee80303b2ee915a6696c124bec the order of query CHAR_UPD_CHAR_QUESTSTATUS_REWARDED_ACTIVE_BY_QUEST is wrong.
Also quests with AllowableRace 0 are checked as old faction quest, AllowableRace 0 means both faction.

So before this PR, when a player change faction can update to 0 (inactive) wrong player/quests on character_queststatus_rewarded active column or skip update to 0 old faction quests.

**Issues addressed:**

None


**Tests performed:**

tested in-game.


**Additional info:**

There are probably users who have bad data in character_queststatus_rewarded (active = 0), I have made this query for character database to fix that problem:
```sql
-- Replace world_db_name with the name of your world database
-- Set inactive rewarded quests to active status if AllowableRaces is available for actual player
UPDATE character_queststatus_rewarded AS cqsr
INNER JOIN characters AS c ON cqsr.guid=c.guid
SET active=1
WHERE cqsr.active = 0 AND 
((c.race IN (2,5,6,8,10) AND cqsr.quest NOT IN (SELECT ID FROM world_db_name.quest_template WHERE AllowableRaces > 0 AND AllowableRaces=AllowableRaces & 1101))
OR (c.race IN (1,3,4,7,11) AND cqsr.quest NOT IN (SELECT ID FROM world_db_name.quest_template WHERE AllowableRaces > 0 AND AllowableRaces=AllowableRaces & 690)));

-- Replace world_db_name with the name of your world database
-- Set active rewarded quests to inactive status if AllowableRaces not available for actual player
UPDATE character_queststatus_rewarded AS cqsr
INNER JOIN characters AS c ON cqsr.guid=c.guid
SET active=0
WHERE cqsr.active = 1 AND 
((c.race IN (2,5,6,8,10) AND cqsr.quest IN (SELECT ID FROM world_db_name.quest_template WHERE AllowableRaces > 0 AND AllowableRaces=AllowableRaces & 1101))
OR (c.race IN (1,3,4,7,11) AND cqsr.quest IN (SELECT ID FROM world_db_name.quest_template WHERE AllowableRaces > 0 AND AllowableRaces=AllowableRaces & 690)));
```
Unfortunately I can't include the sql in the PR because it is a cross-database query, so I leave it here as an example for whoever needs it to run it.