### PR TITLE
Update ItemTemplate.cpp Include Fishing Poles FeralBonus

### DIFF
--- a/src/server/game/Entities/Item/ItemTemplate.cpp
+++ b/src/server/game/Entities/Item/ItemTemplate.cpp
@@ -67,7 +67,8 @@ float ItemTemplate::getDPS() const
 int32 ItemTemplate::getFeralBonus(int32 extraDPS /*= 0*/) const
 {
     // 0x02A5F3 - is mask for Melee weapon from ItemSubClassMask.dbc
-    if (Class == ITEM_CLASS_WEAPON && (1 << SubClass) & 0x02A5F3)
+    // or Fishing Poles (ITEM_SUBCLASS_WEAPON_FISHING_POLE) included in subclass
+    if (Class == ITEM_CLASS_WEAPON && (1 << SubClass || SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE) & 0x02A5F3)
     {
         int32 bonus = int32((extraDPS + getDPS()) * 14.0f) - 767;
         if (bonus < 0)

--- a/src/server/game/Entities/Item/ItemTemplate.cpp
+++ b/src/server/game/Entities/Item/ItemTemplate.cpp
@@ -68,7 +68,7 @@ int32 ItemTemplate::getFeralBonus(int32 extraDPS /*= 0*/) const
 {
     // 0x02A5F3 - is mask for Melee weapon from ItemSubClassMask.dbc
     // or Fishing Poles (ITEM_SUBCLASS_WEAPON_FISHING_POLE) included in subclass
-    if (Class == ITEM_CLASS_WEAPON && (1 << SubClass || SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE) & 0x02A5F3)
+    if (Class == ITEM_CLASS_WEAPON && (((1 << SubClass) & 0x02A5F3) != 0 || SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE))
     {
         int32 bonus = int32((extraDPS + getDPS()) * 14.0f) - 767;
         if (bonus < 0)


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

Changes proposed:
change line 70 to
if (Class == ITEM_CLASS_WEAPON && (((1 << SubClass) & 0x02A5F3) != 0 || SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE))

includes fishing poles as a subclass

Issues addressed:

Closes #28674

Tests performed:

(Does it build, tested in-game)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
