### PR TITLE
Core/Conversation: Implemented OnPrivateConversationLineStarted hook

### DIFF
--- a/src/server/game/Entities/Conversation/Conversation.cpp
+++ b/src/server/game/Entities/Conversation/Conversation.cpp
@@ -29,6 +29,7 @@
 #include "Player.h"
 #include "ScriptMgr.h"
 #include "UpdateData.h"
+#include "WorldSession.h"
 
 Conversation::Conversation() : WorldObject(false), _duration(0), _maxDuration(0), _textureKitId(0), _activeLineIdx(-1), _privateOwnerLocale(LOCALE_enUS)
 {

--- a/src/server/game/Entities/Conversation/Conversation.h
+++ b/src/server/game/Entities/Conversation/Conversation.h
@@ -58,6 +58,8 @@ class TC_GAME_API Conversation : public WorldObject, public GridObject<Conversat
         void Update(uint32 diff) override;
         void Remove();
         Milliseconds GetDuration() const { return _duration; }
+        Milliseconds GetMaxDuration() const { return _maxDuration; }
+        Milliseconds GetTimePassed() const { return _maxDuration - _duration; }
         uint32 GetTextureKitId() const { return _textureKitId; }
 
         static Conversation* CreateConversation(uint32 conversationEntry, Unit* creator, Position const& pos, ObjectGuid privateObjectOwner, SpellInfo const* spellInfo = nullptr, bool autoStart = true);
@@ -79,6 +81,9 @@ class TC_GAME_API Conversation : public WorldObject, public GridObject<Conversat
         Milliseconds const* GetLineStartTime(LocaleConstant locale, int32 lineId) const;
         Milliseconds GetLastLineEndTime(LocaleConstant locale) const;
 
+        ObjectGuid GetActorGUID(uint32 actorIndex) const;
+        std::vector<UF::ConversationLine> const& GetConversationLines() const { return m_conversationData->Lines; }
+
         uint32 GetScriptId() const;
 
         UF::UpdateField<UF::ConversationData, 0, TYPEID_CONVERSATION> m_conversationData;
@@ -87,7 +92,10 @@ class TC_GAME_API Conversation : public WorldObject, public GridObject<Conversat
         Position _stationaryPosition;
         ObjectGuid _creatorGuid;
         Milliseconds _duration;
+        Milliseconds _maxDuration;
         uint32 _textureKitId;
+        uint32 _activeLineIdx;
+        LocaleConstant _privateOwnerLocale;
 
         std::unordered_map<std::pair<LocaleConstant /*locale*/, int32 /*lineId*/>, Milliseconds /*startTime*/> _lineStartTimes;
         std::array<Milliseconds /*endTime*/, TOTAL_LOCALES> _lastLineEndTimes;

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2268,6 +2268,13 @@ void ScriptMgr::OnConversationLineStarted(Conversation* conversation, uint32 lin
     tmpscript->OnConversationLineStarted(conversation, lineId, sender);
 }
 
+void ScriptMgr::OnPrivateConversationLineStarted(Conversation* conversation, uint32 lineId, uint8 actorIndex)
+{
+    ASSERT(conversation);
+
+    GET_SCRIPT(ConversationScript, conversation->GetScriptId(), tmpscript);
+    tmpscript->OnPrivateConversationLineStarted(conversation, lineId, actorIndex);
+}
 // Scene
 void ScriptMgr::OnSceneStart(Player* player, uint32 sceneInstanceID, SceneTemplate const* sceneTemplate)
 {
@@ -3126,6 +3133,10 @@ void ConversationScript::OnConversationCreate(Conversation* /*conversation*/, Un
 }
 
 void ConversationScript::OnConversationLineStarted(Conversation* /*conversation*/, uint32 /*lineId*/, Player* /*sender*/)
+{
+}
+
+void ConversationScript::OnPrivateConversationLineStarted(Conversation* /*conversation*/, uint32 /*lineId*/, uint8 /*actorIndex*/)
 {
 }
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -925,6 +925,9 @@ class TC_GAME_API ConversationScript : public ScriptObject
 
         // Called when player sends CMSG_CONVERSATION_LINE_STARTED with valid conversation guid
         virtual void OnConversationLineStarted(Conversation* conversation, uint32 lineId, Player* sender);
+
+        // Called for private conversations when a line starts depending on private owner locale start time
+        virtual void OnPrivateConversationLineStarted(Conversation* conversation, uint32 lineId, uint8 actorIndex);
 };
 
 class TC_GAME_API SceneScript : public ScriptObject
@@ -1270,6 +1273,7 @@ class TC_GAME_API ScriptMgr
 
         void OnConversationCreate(Conversation* conversation, Unit* creator);
         void OnConversationLineStarted(Conversation* conversation, uint32 lineId, Player* sender);
+        void OnPrivateConversationLineStarted(Conversation* conversation, uint32 lineId, uint8 actorIndex);
 
     public: /* SceneScript */
 


### PR DESCRIPTION
**Changes proposed:**
- Implemented hook for private conversations to allow time based triggers based on locale of the private object owner

**Tests performed:**
built, tested ingame

**Example code**
(within ConversationScript)
```c
    void OnPrivateConversationLineStarted(Conversation* conversation, uint32 lineId, uint8 actorIndex) override
    {
        if (lineId != CONV_LINE_VANESSA_TELEPORT) // 53702
            return;

        Unit* privateObjectOwner = ObjectAccessor::GetUnit(*conversation, conversation->GetPrivateObjectOwner());
        if (!privateObjectOwner)
            return;

        Unit* vanessa = ObjectAccessor::GetUnit(*conversation, conversation->GetActorGUID(actorIndex));
        if (!vanessa)
            return;

        vanessa->CastSpell(privateObjectOwner, SPELL_VANESSA_TELEPORT_BEHIND); // 396357
        vanessa->CastSpell(privateObjectOwner, SPELL_VANESSA_CHEAP_SHOT); // 396359
        vanessa->RemoveAurasDueToSpell(SPELL_VANESSA_STEALTH); // 228928
        vanessa->SetEmoteState(EMOTE_STATE_READY1H);
    }
```

**Additional info**
We need it for cases where scripted actions have to align with line starts. In other cases blizz is using `CMSG_CONVERSATION_LINE_STARTED`, but this isn't their generic solution. 
An example for this is <https://youtu.be/XKy9ihJ8pY4?t=56>; the teleport is happening simultaneously with the speechbubble of Vanessa VanCleef. SMSG_UPDATE_OBJECT dump of related conversation is found [here](https://gist.github.com/mdX7/68e1c0eee1d91dcec575ebab484b396a)
