### PR TITLE
Core/Conversation: Implemented OnConversationStart and OnConversation…

### DIFF
--- a/src/server/game/Entities/Conversation/Conversation.cpp
+++ b/src/server/game/Entities/Conversation/Conversation.cpp
@@ -64,6 +64,8 @@ void Conversation::RemoveFromWorld()
 
 void Conversation::Update(uint32 diff)
 {
+    sScriptMgr->OnConversationUpdate(this, diff);
+
     if (GetDuration() > Milliseconds(diff))
     {
         _duration -= Milliseconds(diff);
@@ -239,6 +241,7 @@ bool Conversation::Start()
     if (!GetMap()->AddToMap(this))
         return false;
 
+    sScriptMgr->OnConversationStart(this);
     return true;
 }
 

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -2259,6 +2259,14 @@ void ScriptMgr::OnConversationCreate(Conversation* conversation, Unit* creator)
     tmpscript->OnConversationCreate(conversation, creator);
 }
 
+void ScriptMgr::OnConversationStart(Conversation* conversation)
+{
+    ASSERT(conversation);
+
+    GET_SCRIPT(ConversationScript, conversation->GetScriptId(), tmpscript);
+    tmpscript->OnConversationStart(conversation);
+}
+
 void ScriptMgr::OnConversationLineStarted(Conversation* conversation, uint32 lineId, Player* sender)
 {
     ASSERT(conversation);
@@ -2266,6 +2274,14 @@ void ScriptMgr::OnConversationLineStarted(Conversation* conversation, uint32 lin
 
     GET_SCRIPT(ConversationScript, conversation->GetScriptId(), tmpscript);
     tmpscript->OnConversationLineStarted(conversation, lineId, sender);
+}
+
+void ScriptMgr::OnConversationUpdate(Conversation* conversation, uint32 diff)
+{
+    ASSERT(conversation);
+
+    GET_SCRIPT(ConversationScript, conversation->GetScriptId(), tmpscript);
+    tmpscript->OnConversationUpdate(conversation, diff);
 }
 
 // Scene
@@ -3125,7 +3141,15 @@ void ConversationScript::OnConversationCreate(Conversation* /*conversation*/, Un
 {
 }
 
+void ConversationScript::OnConversationStart(Conversation* /*conversation*/ )
+{
+}
+
 void ConversationScript::OnConversationLineStarted(Conversation* /*conversation*/, uint32 /*lineId*/, Player* /*sender*/)
+{
+}
+
+void ConversationScript::OnConversationUpdate(Conversation* /*conversation*/, uint32 /*diff*/)
 {
 }
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -923,8 +923,14 @@ class TC_GAME_API ConversationScript : public ScriptObject
         // Called when Conversation is created but not added to Map yet.
         virtual void OnConversationCreate(Conversation* conversation, Unit* creator);
 
+        // Called when Conversation is started
+        virtual void OnConversationStart(Conversation* conversation);
+
         // Called when player sends CMSG_CONVERSATION_LINE_STARTED with valid conversation guid
         virtual void OnConversationLineStarted(Conversation* conversation, uint32 lineId, Player* sender);
+
+        // Called for each update tick
+        virtual void OnConversationUpdate(Conversation* conversation, uint32 diff);
 };
 
 class TC_GAME_API SceneScript : public ScriptObject
@@ -1269,7 +1275,9 @@ class TC_GAME_API ScriptMgr
     public: /* ConversationScript */
 
         void OnConversationCreate(Conversation* conversation, Unit* creator);
+        void OnConversationStart(Conversation* conversation);
         void OnConversationLineStarted(Conversation* conversation, uint32 lineId, Player* sender);
+        void OnConversationUpdate(Conversation* conversation, uint32 diff);
 
     public: /* SceneScript */
 


### PR DESCRIPTION
…Update hooks

**Tests performed:**
built, tested ingame

**Example usage:**
(within ConversationScript)
```cpp

    void OnConversationStart(Conversation* conversation) override
    {
        LocaleConstant privateOwnerLocale = LOCALE_enUS;
        if (Player* owner = ObjectAccessor::GetPlayer(*conversation, conversation->GetPrivateObjectOwner()))
            privateOwnerLocale = owner->GetSession()->GetSessionDbLocaleIndex();

        if (Milliseconds const* teleportLineStartTime = conversation->GetLineStartTime(privateOwnerLocale, CONV_LINE_VANESSA_TELEPORT))
            _events.ScheduleEvent(EVENT_VANESSA_TELEPORT, *teleportLineStartTime);
    }

    void OnConversationUpdate(Conversation* conversation, uint32 diff) override
    {
        _events.Update(diff);

        switch (_events.ExecuteEvent())
        {
            case EVENT_VANESSA_TELEPORT:
            {
                Unit* privateObjectOwner = ObjectAccessor::GetUnit(*conversation, conversation->GetPrivateObjectOwner());
                if (!privateObjectOwner)
                    return;

                Creature* vanessaClone = ObjectAccessor::GetCreature(*conversation, _vanessaCloneGUID);
                if (!vanessaClone)
                    return;

                vanessaClone->CastSpell(privateObjectOwner, SPELL_VANESSA_TELEPORT_BEHIND, true);
                vanessaClone->CastSpell(privateObjectOwner, SPELL_VANESSA_CHEAP_SHOT, true);
                vanessaClone->RemoveAurasDueToSpell(SPELL_VANESSA_STEALTH);
                vanessaClone->SetEmoteState(EMOTE_STATE_READY1H);
                break;
            }
            default:
                break;
        }
    }
```
