### PR TITLE
Core/Spells Fix CheckLocation for nested areas

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -1982,7 +1982,7 @@ SpellCastResult SpellInfo::CheckLocation(uint32 map_id, uint32 zone_id, uint32 a
         std::vector<uint32> areaGroupMembers = sDB2Manager.GetAreasForGroup(RequiredAreasID);
         for (uint32 areaId : areaGroupMembers)
         {
-            if (areaId == zone_id || areaId == area_id)
+            if (DB2Manager::IsInArea(area_id, areaId))
             {
                 found = true;
                 break;


### PR DESCRIPTION
**Changes proposed:**

-  Fix SpellInfo checkLocation for nested areas
-  Example nested area : 14504 (Sapphire Enclave) - 13862 (Valdrakken) - 13647 (Thaldraszus)
-  Example spell : 360954 (Highland Drake) have allowed areas 13647 (Thaldraszus) which should be allowed in Valdrakken sub-areas like the Sapphire Enclave.

**Issues addressed:**

None

**Tests performed:**
Built, tested ingame
