### PR TITLE
EventMap : Allow to use uint32 as eventId

### DIFF
--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -35,13 +35,15 @@ void EventMap::SetPhase(uint16 phase)
 
 void EventMap::ScheduleEvent(uint32 eventId, Milliseconds time, uint16 group /*= 0*/, uint16 phase /*= 0*/)
 {
+    uint64 internalEventId = uint64(eventId);
+
     if (group && group < 16)
-        eventId |= (1LL << (group + 31));
+        internalEventId |= (1LL << (group + 31));
 
     if (phase && phase < 16)
-        eventId |= (1LL << (phase + 47));
+        internalEventId |= (1LL << (phase + 47));
 
-    _eventMap.insert(EventStore::value_type(_time + time, eventId));
+    _eventMap.insert(EventStore::value_type(_time + time, internalEventId));
 }
 
 void EventMap::ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint16 group /*= 0*/, uint16 phase /*= 0*/)

--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -25,37 +25,37 @@ void EventMap::Reset()
     _phase = 0;
 }
 
-void EventMap::SetPhase(uint8 phase)
+void EventMap::SetPhase(uint16 phase)
 {
     if (!phase)
         _phase = 0;
-    else if (phase <= 8)
-        _phase = uint8(1 << (phase - 1));
+    else if (phase <= 16)
+        _phase = uint16(1 << (phase - 1));
 }
 
-void EventMap::ScheduleEvent(uint32 eventId, Milliseconds time, uint32 group /*= 0*/, uint8 phase /*= 0*/)
+void EventMap::ScheduleEvent(uint32 eventId, Milliseconds time, uint16 group /*= 0*/, uint16 phase /*= 0*/)
 {
-    if (group && group <= 8)
-        eventId |= (1 << (group + 15));
+    if (group && group < 16)
+        eventId |= (1LL << (group + 31));
 
-    if (phase && phase <= 8)
-        eventId |= (1 << (phase + 23));
+    if (phase && phase < 16)
+        eventId |= (1LL << (phase + 47));
 
     _eventMap.insert(EventStore::value_type(_time + time, eventId));
 }
 
-void EventMap::ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group /*= 0*/, uint8 phase /*= 0*/)
+void EventMap::ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint16 group /*= 0*/, uint16 phase /*= 0*/)
 {
     ScheduleEvent(eventId, randtime(minTime, maxTime), group, phase);
 }
 
-void EventMap::RescheduleEvent(uint32 eventId, Milliseconds time, uint32 group /*= 0*/, uint8 phase /*= 0*/)
+void EventMap::RescheduleEvent(uint32 eventId, Milliseconds time, uint16 group /*= 0*/, uint16 phase /*= 0*/)
 {
     CancelEvent(eventId);
     ScheduleEvent(eventId, time, group, phase);
 }
 
-void EventMap::RescheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group /*= 0*/, uint8 phase /*= 0*/)
+void EventMap::RescheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint16 group /*= 0*/, uint16 phase /*= 0*/)
 {
     RescheduleEvent(eventId, randtime(minTime, maxTime), group, phase);
 }
@@ -78,11 +78,11 @@ uint32 EventMap::ExecuteEvent()
 
         if (itr->first > _time)
             return 0;
-        else if (_phase && (itr->second & 0xFF000000) && !((itr->second >> 24) & _phase))
+        else if (_phase && (itr->second & 0xFFFF000000000000) && !((itr->second >> 48) & _phase))
             _eventMap.erase(itr);
         else
         {
-            uint32 eventId = (itr->second & 0x0000FFFF);
+            uint32 eventId = (itr->second & 0x00000000FFFFFFFF);
             _lastEvent = itr->second; // include phase/group
             _eventMap.erase(itr);
             return eventId;
@@ -106,16 +106,16 @@ void EventMap::DelayEvents(Milliseconds delay)
     }
 }
 
-void EventMap::DelayEvents(Milliseconds delay, uint32 group)
+void EventMap::DelayEvents(Milliseconds delay, uint16 group)
 {
-    if (!group || group > 8 || Empty())
+    if (!group || group > 16 || Empty())
         return;
 
     EventStore delayed;
 
     for (EventStore::iterator itr = _eventMap.begin(); itr != _eventMap.end();)
     {
-        if (itr->second & (1 << (group + 15)))
+        if (itr->second & (1ULL << (group + 31)))
         {
             delayed.insert(EventStore::value_type(itr->first + delay, itr->second));
             _eventMap.erase(itr++);
@@ -134,21 +134,21 @@ void EventMap::CancelEvent(uint32 eventId)
 
     for (EventStore::iterator itr = _eventMap.begin(); itr != _eventMap.end();)
     {
-        if (eventId == (itr->second & 0x0000FFFF))
+        if (eventId == (itr->second & 0x00000000FFFFFFFF))
             _eventMap.erase(itr++);
         else
             ++itr;
     }
 }
 
-void EventMap::CancelEventGroup(uint32 group)
+void EventMap::CancelEventGroup(uint16 group)
 {
-    if (!group || group > 8 || Empty())
+    if (!group || group > 16 || Empty())
         return;
 
     for (EventStore::iterator itr = _eventMap.begin(); itr != _eventMap.end();)
     {
-        if (itr->second & (1 << (group + 15)))
+        if (itr->second & (1ULL << (group + 31)))
             _eventMap.erase(itr++);
         else
             ++itr;
@@ -158,7 +158,7 @@ void EventMap::CancelEventGroup(uint32 group)
 Milliseconds EventMap::GetTimeUntilEvent(uint32 eventId) const
 {
     for (std::pair<TimePoint const, uint32> const& itr : _eventMap)
-        if (eventId == (itr.second & 0x0000FFFF))
+        if (eventId == (itr.second & 0x00000000FFFFFFFF))
             return std::chrono::duration_cast<Milliseconds>(itr.first - _time);
 
     return Milliseconds::max();

--- a/src/common/Utilities/EventMap.cpp
+++ b/src/common/Utilities/EventMap.cpp
@@ -157,7 +157,7 @@ void EventMap::CancelEventGroup(uint16 group)
 
 Milliseconds EventMap::GetTimeUntilEvent(uint32 eventId) const
 {
-    for (std::pair<TimePoint const, uint32> const& itr : _eventMap)
+    for (std::pair<TimePoint const, uint64> const& itr : _eventMap)
         if (eventId == (itr.second & 0x00000000FFFFFFFF))
             return std::chrono::duration_cast<Milliseconds>(itr.first - _time);
 

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -27,15 +27,15 @@ class TC_COMMON_API EventMap
     /**
     * Internal storage type.
     * Key: Time as TimePoint when the event should occur.
-    * Value: The event data as uint32.
+    * Value: The event data as uint64.
     *
     * Structure of event data:
-    * - Bit  0 - 15: Event Id.
-    * - Bit 16 - 23: Group
-    * - Bit 24 - 31: Phase
-    * - Pattern: 0xPPGGEEEE
+    * - Bit  0 - 31: Event Id.
+    * - Bit 32 - 47: Group
+    * - Bit 48 - 63: Phase
+    * - Pattern: 0xPPPPGGGGEEEEEEEE
     */
-    typedef std::multimap<TimePoint, uint32> EventStore;
+    typedef std::multimap<TimePoint, uint64> EventStore;
 
 public:
     EventMap() : _time(TimePoint::min()), _phase(0), _lastEvent(0) { }
@@ -70,7 +70,7 @@ public:
     * @name GetPhaseMask
     * @return Active phases as mask.
     */
-    uint8 GetPhaseMask() const
+    uint16 GetPhaseMask() const
     {
         return _phase;
     }
@@ -89,17 +89,17 @@ public:
     * @brief Sets the phase of the map (absolute).
     * @param phase Phase which should be set. Values: 1 - 8. 0 resets phase.
     */
-    void SetPhase(uint8 phase);
+    void SetPhase(uint16 phase);
 
     /**
     * @name AddPhase
     * @brief Activates the given phase (bitwise).
     * @param phase Phase which should be activated. Values: 1 - 8
     */
-    void AddPhase(uint8 phase)
+    void AddPhase(uint16 phase)
     {
-        if (phase && phase <= 8)
-            _phase |= uint8(1 << (phase - 1));
+        if (phase && phase <= 16)
+            _phase |= uint16(1 << (phase - 1));
     }
 
     /**
@@ -109,8 +109,8 @@ public:
     */
     void RemovePhase(uint8 phase)
     {
-        if (phase && phase <= 8)
-            _phase &= uint8(~(1 << (phase - 1)));
+        if (phase && phase <= 16)
+            _phase &= uint16(~(1 << (phase - 1)));
     }
 
     /**
@@ -121,7 +121,7 @@ public:
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
     * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
     */
-    void ScheduleEvent(uint32 eventId, Milliseconds time, uint32 group = 0, uint8 phase = 0);
+    void ScheduleEvent(uint32 eventId, Milliseconds time, uint16 group = 0, uint16 phase = 0);
 
     /**
     * @name ScheduleEvent
@@ -132,7 +132,7 @@ public:
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
     * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
     */
-    void ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group = 0, uint8 phase = 0);
+    void ScheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint16 group = 0, uint16 phase = 0);
 
     /**
     * @name RescheduleEvent
@@ -142,7 +142,7 @@ public:
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
     * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
     */
-    void RescheduleEvent(uint32 eventId, Milliseconds time, uint32 group = 0, uint8 phase = 0);
+    void RescheduleEvent(uint32 eventId, Milliseconds time, uint16 group = 0, uint16 phase = 0);
 
     /**
     * @name RescheduleEvent
@@ -153,7 +153,7 @@ public:
     * @param group The group which the event is associated to. Has to be between 1 and 8. 0 means it has no group.
     * @param phase The phase in which the event can occur. Has to be between 1 and 8. 0 means it can occur in all phases.
     */
-    void RescheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint32 group = 0, uint8 phase = 0);
+    void RescheduleEvent(uint32 eventId, Milliseconds minTime, Milliseconds maxTime, uint16 group = 0, uint16 phase = 0);
 
     /**
     * @name RepeatEvent
@@ -190,7 +190,7 @@ public:
     * @param delay Amount of delay as std::chrono type.
     * @param group Group of the events.
     */
-    void DelayEvents(Milliseconds delay, uint32 group);
+    void DelayEvents(Milliseconds delay, uint16 group);
 
     /**
     * @name CancelEvent
@@ -204,7 +204,7 @@ public:
     * @brief Cancel events belonging to specified group.
     * @param group Group to cancel.
     */
-    void CancelEventGroup(uint32 group);
+    void CancelEventGroup(uint16 group);
 
     /**
     * @name IsInPhase
@@ -212,9 +212,9 @@ public:
     * @param phase Wanted phase.
     * @return True, if phase of event map contains specified phase.
     */
-    bool IsInPhase(uint8 phase) const
+    bool IsInPhase(uint16 phase) const
     {
-        return phase <= 8 && (!phase || _phase & (1 << (phase - 1)));
+        return phase <= 16 && (!phase || _phase & (1 << (phase - 1)));
     }
 
     /**
@@ -246,7 +246,7 @@ private:
     * phases from 1 to 8 can be set with SetPhase or
     * AddPhase. RemovePhase deactives a phase.
     */
-    uint8 _phase;
+    uint16 _phase;
 
     /**
     * @name _eventMap
@@ -261,7 +261,7 @@ private:
     * @name _lastEvent
     * @brief Stores information on the most recently executed event
     */
-    uint32 _lastEvent;
+    uint64 _lastEvent;
 };
 
 #endif // _EVENT_MAP_H_

--- a/src/common/Utilities/EventMap.h
+++ b/src/common/Utilities/EventMap.h
@@ -107,7 +107,7 @@ public:
     * @brief Deactivates the given phase (bitwise).
     * @param phase Phase which should be deactivated. Values: 1 - 8.
     */
-    void RemovePhase(uint8 phase)
+    void RemovePhase(uint16 phase)
     {
         if (phase && phase <= 16)
             _phase &= uint16(~(1 << (phase - 1)));


### PR DESCRIPTION
**Changes proposed:**

- Currently the ScheduleEvent method allow a uint32 eventId but store it internally as uint16, which lead to issues if the user pass a value greater than 65535.
- Update the EventMap to really allow uint32 eventId. It allow to simplify some scripts by removing the need to declare a spell, then the event triggering it. You can now directly do events.ScheduleEvent(SPELL_MY_SPELL_ID, 10s);
- Because storing eventId as uint32 force us to switch to uint64 (we store eventId, phase & group in the same property), i used the extra space to allow 16 bits groups & 16 bits phases instead of 8 each.

**Issues addressed:**

None that i saw

**Tests performed:**

Built, test ingame


**Known issues and TODO list:**

- [ ] Don't know if switching phase&group in methods to uint16 was the right move, i preferred it that way to indicate that they will be stored on 16 bits. I can revert this change and switch groups to uint8 instead of original uint32.