### PR TITLE
Core/Scripts: Fix EventScript assert for GameObject::SetDestructibleState

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -3226,7 +3226,7 @@ void GameObject::SetDestructibleState(GameObjectDestructibleState state, WorldOb
             break;
         case GO_DESTRUCTIBLE_DAMAGED:
         {
-            if (GetGOInfo()->destructibleBuilding.DamagedEvent)
+            if (GetGOInfo()->destructibleBuilding.DamagedEvent && attackerOrHealer)
                 GameEvents::Trigger(GetGOInfo()->destructibleBuilding.DamagedEvent, attackerOrHealer, this);
             AI()->Damaged(attackerOrHealer, m_goInfo->destructibleBuilding.DamagedEvent);
 
@@ -3252,7 +3252,7 @@ void GameObject::SetDestructibleState(GameObjectDestructibleState state, WorldOb
         }
         case GO_DESTRUCTIBLE_DESTROYED:
         {
-            if (GetGOInfo()->destructibleBuilding.DestroyedEvent)
+            if (GetGOInfo()->destructibleBuilding.DestroyedEvent && attackerOrHealer)
                 GameEvents::Trigger(GetGOInfo()->destructibleBuilding.DestroyedEvent, attackerOrHealer, this);
             AI()->Destroyed(attackerOrHealer, m_goInfo->destructibleBuilding.DestroyedEvent);
 
@@ -3279,7 +3279,7 @@ void GameObject::SetDestructibleState(GameObjectDestructibleState state, WorldOb
         }
         case GO_DESTRUCTIBLE_REBUILDING:
         {
-            if (GetGOInfo()->destructibleBuilding.RebuildingEvent)
+            if (GetGOInfo()->destructibleBuilding.RebuildingEvent && attackerOrHealer)
                 GameEvents::Trigger(GetGOInfo()->destructibleBuilding.RebuildingEvent, attackerOrHealer, this);
             RemoveFlag(GO_FLAG_DAMAGED | GO_FLAG_DESTROYED);
 

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -1093,17 +1093,78 @@ struct GameObjectTemplate
         }
     }
 
-    uint32 GetEventScriptId() const
+    std::set<uint32> GetEventScriptSet() const
     {
+        std::set<uint32> eventSet;
         switch (type)
         {
-            case GAMEOBJECT_TYPE_GOOBER:            return goober.eventID;
-            case GAMEOBJECT_TYPE_CHEST:             return chest.triggeredEvent;
-            case GAMEOBJECT_TYPE_CHAIR:             return chair.triggeredEvent;
-            case GAMEOBJECT_TYPE_CAMERA:            return camera.eventID;
-            case GAMEOBJECT_TYPE_GATHERING_NODE:    return gatheringNode.triggeredEvent;
-            default: return 0;
+            case GAMEOBJECT_TYPE_CHEST:
+                eventSet.insert(chest.triggeredEvent);
+                break;
+            case GAMEOBJECT_TYPE_CHAIR:
+                eventSet.insert(chair.triggeredEvent);
+                break;
+            case GAMEOBJECT_TYPE_GOOBER:
+                eventSet.insert(goober.eventID);
+                break;
+            case GAMEOBJECT_TYPE_TRANSPORT:
+                eventSet.insert(transport.Reached1stfloor);
+                eventSet.insert(transport.Reached2ndfloor);
+                eventSet.insert(transport.Reached3rdfloor);
+                eventSet.insert(transport.Reached4thfloor);
+                eventSet.insert(transport.Reached5thfloor);
+                eventSet.insert(transport.Reached6thfloor);
+                eventSet.insert(transport.Reached7thfloor);
+                eventSet.insert(transport.Reached8thfloor);
+                eventSet.insert(transport.Reached9thfloor);
+                eventSet.insert(transport.Reached10thfloor);
+                break;
+            case GAMEOBJECT_TYPE_CAMERA:
+                eventSet.insert(camera.eventID);
+                break;
+            case GAMEOBJECT_TYPE_MAP_OBJ_TRANSPORT:
+                eventSet.insert(moTransport.startEventID);
+                eventSet.insert(moTransport.stopEventID);
+                break;
+            case GAMEOBJECT_TYPE_FLAGDROP:
+                eventSet.insert(flagDrop.eventID);
+                break;
+            case GAMEOBJECT_TYPE_CONTROL_ZONE:
+                eventSet.insert(controlZone.CaptureEventHorde);
+                eventSet.insert(controlZone.CaptureEventAlliance);
+                eventSet.insert(controlZone.ContestedEventHorde);
+                eventSet.insert(controlZone.ContestedEventAlliance);
+                eventSet.insert(controlZone.ProgressEventHorde);
+                eventSet.insert(controlZone.ProgressEventAlliance);
+                eventSet.insert(controlZone.NeutralEventHorde);
+                eventSet.insert(controlZone.NeutralEventAlliance);
+                break;
+            case GAMEOBJECT_TYPE_DESTRUCTIBLE_BUILDING:
+                eventSet.insert(destructibleBuilding.IntactEvent);
+                eventSet.insert(destructibleBuilding.DamagedEvent);
+                eventSet.insert(destructibleBuilding.DestroyedEvent);
+                eventSet.insert(destructibleBuilding.RebuildingEvent);
+                eventSet.insert(destructibleBuilding.DamageEvent);
+                break;
+            case GAMEOBJECT_TYPE_CAPTURE_POINT:
+                eventSet.insert(capturePoint.ContestedEventHorde);
+                eventSet.insert(capturePoint.CaptureEventHorde);
+                eventSet.insert(capturePoint.DefendedEventHorde);
+                eventSet.insert(capturePoint.ContestedEventAlliance);
+                eventSet.insert(capturePoint.CaptureEventAlliance);
+                eventSet.insert(capturePoint.DefendedEventAlliance);
+                break;
+            case GAMEOBJECT_TYPE_GATHERING_NODE:
+                eventSet.insert(gatheringNode.triggeredEvent);
+                break;
+            default:
+                break;
         }
+
+        // Erase invalid value added from unused GameEvents data fields
+        eventSet.erase(0);
+
+        return eventSet;
     }
 
     uint32 GetTrivialSkillHigh() const

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -24,6 +24,7 @@
 #include "SpawnData.h"
 #include "WorldPacket.h"
 #include <array>
+#include <set>
 #include <string>
 
 // from `gameobject_template`

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -5838,8 +5838,10 @@ void ObjectMgr::LoadEventSet()
 
     // Load all possible event ids from gameobjects
     for (auto const& gameObjectTemplatePair : _gameObjectTemplateStore)
-        if (uint32 eventId = gameObjectTemplatePair.second.GetEventScriptId())
-            _eventStore.insert(eventId);
+    {
+        EventContainer eventSet = gameObjectTemplatePair.second.GetEventScriptSet();
+        _eventStore.insert(eventSet.begin(), eventSet.end());
+    }
 
     // Load all possible event ids from spells
     for (SpellNameEntry const* spellNameEntry : sSpellNameStore)
@@ -5877,7 +5879,7 @@ void ObjectMgr::LoadEventScripts()
     for (ScriptMapMap::const_iterator itr = sEventScripts.begin(); itr != sEventScripts.end(); ++itr)
     {
         if (!IsValidEvent(itr->first))
-            TC_LOG_ERROR("sql.sql", "Table `event_scripts` has script (Id: {}) not referring to any gameobject_template (type 3 data6 field, type 7 data3 field, type 10 data2 field, type 13 data2 field, type 50 data7 field), any taxi path node or any spell effect {}",
+            TC_LOG_ERROR("sql.sql", "Table `event_scripts` has script (Id: {}) not referring to any gameobject_template (data field referencing GameEvent), any taxi path node or any spell effect {}",
                 itr->first, SPELL_EFFECT_SEND_EVENT);
     }
 
@@ -5901,7 +5903,7 @@ void ObjectMgr::LoadEventScripts()
 
         if (!IsValidEvent(eventId))
         {
-            TC_LOG_ERROR("sql.sql", "Event (ID: {}) not referring to any gameobject_template (type 3 data6 field, type 7 data3 field, type 10 data2 field, type 13 data2 field, type 50 data7 field), any taxi path node or any spell effect {}",
+            TC_LOG_ERROR("sql.sql", "Event (ID: {}) not referring to any gameobject_template (data field referencing GameEvent), any taxi path node or any spell effect {}",
                 eventId, SPELL_EFFECT_SEND_EVENT);
             continue;
         }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix EventScript assert for GameObject::SetDestructibleState. SetDestructibleState is used to initialize or rebuild Wintergrasp with the param attackerOrHealer as nullptr (invoker for ScriptMgr::OnEventTrigger).
-  Changed GameObjectTemplate::GetEventScriptId to GameObjectTemplate::GetEventScriptSet to list all GameEvents defined for certain types of gameobjects

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
