### PR TITLE
CreatureAI OnHealthDepleted hook

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -99,7 +99,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         virtual void JustEngagedWith(Unit* /*who*/) { }
 
         // Called when the creature reaches 0 health (or 1 if unkillable).
-        virtual void OnHealthDepleted(Unit* /*attacker*/, bool /*wasKilled*/) { }
+        virtual void OnHealthDepleted(Unit* /*attacker*/, bool /*isKill*/) { }
 
         // Called when the creature is killed
         virtual void JustDied(Unit* /*killer*/) { }

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -98,8 +98,8 @@ class TC_GAME_API CreatureAI : public UnitAI
         // Called for reaction when initially engaged - this will always happen _after_ JustEnteredCombat
         virtual void JustEngagedWith(Unit* /*who*/) { }
 
-        // Called when unkillable creature reached 1 hp for the first time
-        virtual void OnDeathPrevented(Unit* /*attacker*/) { }
+        // Called when the creature reaches 0 health (or 1 if unkillable).
+        virtual void OnHealthDepleted(Unit* /*attacker*/) { }
 
         // Called when the creature is killed
         virtual void JustDied(Unit* /*killer*/) { }

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -98,7 +98,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         // Called for reaction when initially engaged - this will always happen _after_ JustEnteredCombat
         virtual void JustEngagedWith(Unit* /*who*/) { }
 
-        // Called when unit can't die but has reached 1 hp
+        // Called when unkillable creature reached 1 hp for the first time
         virtual void OnDeathPrevented(Unit* /*attacker*/) { }
 
         // Called when the creature is killed

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -98,6 +98,9 @@ class TC_GAME_API CreatureAI : public UnitAI
         // Called for reaction when initially engaged - this will always happen _after_ JustEnteredCombat
         virtual void JustEngagedWith(Unit* /*who*/) { }
 
+        // Called when unit can't die but has reached 1 hp
+        virtual void OnDeathPrevented(Unit* /*attacker*/) { }
+
         // Called when the creature is killed
         virtual void JustDied(Unit* /*killer*/) { }
 

--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -99,7 +99,7 @@ class TC_GAME_API CreatureAI : public UnitAI
         virtual void JustEngagedWith(Unit* /*who*/) { }
 
         // Called when the creature reaches 0 health (or 1 if unkillable).
-        virtual void OnHealthDepleted(Unit* /*attacker*/) { }
+        virtual void OnHealthDepleted(Unit* /*attacker*/, bool /*wasKilled*/) { }
 
         // Called when the creature is killed
         virtual void JustDied(Unit* /*killer*/) { }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -893,6 +893,11 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
     else if (victim->IsCreature() && damageTaken >= health && victim->ToCreature()->HasFlag(CREATURE_STATIC_FLAG_UNKILLABLE))
     {
         damageTaken = health - 1;
+
+        // If we had damage (aka health was not 1 already) trigger DeathPrevented
+        if (damageTaken > 0)
+            if (CreatureAI* victimAI = victim->ToCreature()->AI())
+                victimAI->OnDeathPrevented(attacker);
     }
     else if (victim->IsVehicle() && damageTaken >= (health-1) && victim->GetCharmer() && victim->GetCharmer()->GetTypeId() == TYPEID_PLAYER)
     {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -894,10 +894,10 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
     {
         damageTaken = health - 1;
 
-        // If we had damage (aka health was not 1 already) trigger DeathPrevented
+        // If we had damage (aka health was not 1 already) trigger OnHealthDepleted
         if (damageTaken > 0)
             if (CreatureAI* victimAI = victim->ToCreature()->AI())
-                victimAI->OnDeathPrevented(attacker);
+                victimAI->OnHealthDepleted(attacker);
     }
     else if (victim->IsVehicle() && damageTaken >= (health-1) && victim->GetCharmer() && victim->GetCharmer()->GetTypeId() == TYPEID_PLAYER)
     {
@@ -10907,7 +10907,10 @@ void Unit::SetMeleeAnimKitId(uint16 animKitId)
 
         // Call creature just died function
         if (CreatureAI* ai = creature->AI())
+        {
+            ai->OnHealthDepleted(attacker);
             ai->JustDied(attacker);
+        }
 
         if (TempSummon * summon = creature->ToTempSummon())
         {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -896,8 +896,10 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
 
         // If we had damage (aka health was not 1 already) trigger OnHealthDepleted
         if (damageTaken > 0)
+        {
             if (CreatureAI* victimAI = victim->ToCreature()->AI())
                 victimAI->OnHealthDepleted(attacker, false);
+        }
     }
     else if (victim->IsVehicle() && damageTaken >= (health-1) && victim->GetCharmer() && victim->GetCharmer()->GetTypeId() == TYPEID_PLAYER)
     {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -897,7 +897,7 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
         // If we had damage (aka health was not 1 already) trigger OnHealthDepleted
         if (damageTaken > 0)
             if (CreatureAI* victimAI = victim->ToCreature()->AI())
-                victimAI->OnHealthDepleted(attacker);
+                victimAI->OnHealthDepleted(attacker, false);
     }
     else if (victim->IsVehicle() && damageTaken >= (health-1) && victim->GetCharmer() && victim->GetCharmer()->GetTypeId() == TYPEID_PLAYER)
     {
@@ -10908,7 +10908,7 @@ void Unit::SetMeleeAnimKitId(uint16 animKitId)
         // Call creature just died function
         if (CreatureAI* ai = creature->AI())
         {
-            ai->OnHealthDepleted(attacker);
+            ai->OnHealthDepleted(attacker, true);
             ai->JustDied(attacker);
         }
 


### PR DESCRIPTION
**Changes proposed:**

-  Add "OnHealthDepleted" hook triggered when an unkillable creature reach 1 hp for the first time, or a normal creature reach 0 hp
- Example : npc Nullification Device (196712) should cast a spell when reaching 1 hp then despawn.

**Issues addressed:**


**Tests performed:**

Build, tested ingame

**Known issues and TODO list:**
