### PR TITLE
Core/Packets: Fix quest title length for NPC packets

### DIFF
--- a/src/server/game/Server/Packets/NPCPackets.cpp
+++ b/src/server/game/Server/Packets/NPCPackets.cpp
@@ -77,7 +77,7 @@ ByteBuffer& operator<<(ByteBuffer& data, ClientGossipText const& gossipText)
     data << int32(gossipText.QuestFlags[1]);
 
     data.WriteBit(gossipText.Repeatable);
-    data.WriteBits(gossipText.QuestTitle.size(), 9);
+    data.WriteBits(gossipText.QuestTitle.size(), 10);
     data.FlushBits();
 
     data.WriteString(gossipText.QuestTitle);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix quest title length for NPC packets


**Issues addressed:**
Closes #29161


**Tests performed:**
Builds. Tested in-game


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
