### PR TITLE
Fix angle calculation in Unit::KnockbackFrom

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11910,7 +11910,7 @@ void Unit::KnockbackFrom(Position const& origin, float speedXY, float speedZ, Mo
         GetMotionMaster()->MoveKnockbackFrom(origin, speedXY, speedZ, spellEffectExtraData);
     else
     {
-        float o = GetPosition() == origin ? GetOrientation() + M_PI : origin.GetRelativeAngle(this);
+        float o = GetPosition() == origin ? GetOrientation() + M_PI : origin.GetAbsoluteAngle(this);
         if (speedXY < 0)
         {
             speedXY = -speedXY;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Change unit knockback angle from relative to absolute.
- A relative angle calculation would result in the unit being knocked back in a parabolic curve instead of a straight line from the source.

**Issues addressed:**

- None that I found, #21250 seemed close but wasn't quite it.


**Tests performed:**

- Builds, briefly tested in game, preview available: https://youtu.be/KnkTUS5bMZw
- Video shows current behaviour on master, and then new behaviour after the fix.


**Known issues and TODO list:** (add/remove lines as needed)

- None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
