### PR TITLE
AreaTrigger: Extend SearchUnitInSphere radius calculation

### DIFF
--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -364,7 +364,7 @@ float AreaTrigger::GetOverrideScaleCurveProgress() const
 {
     auto const overrideScale = m_areaTriggerData->OverrideScaleCurve;
     ASSERT(overrideScale->OverrideActive, "OverrideScaleCurve must be active to evaluate it");
-    
+
     if (!GetTimeToTargetScale())
         return 1.0f;
 

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -470,7 +470,7 @@ void AreaTrigger::SetOverrideScaleCurve(uint32 startTimeOffSet, std::array<DBCPo
     curveTemplate.StartTimeOffset = startTimeOffSet;
 
     AreaTriggerScaleCurvePointsTemplate curve;
-    curve.Mode = CurveInterpolationMode::Linear;
+    curve.Mode = mode;
     curve.Points = points;
     curveTemplate.Curve = curve;
 

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.h
@@ -91,9 +91,16 @@ class TC_GAME_API AreaTrigger : public WorldObject, public GridObject<AreaTrigge
         bool IsRemoved() const { return _isRemoved; }
         uint32 GetSpellId() const { return m_areaTriggerData->SpellID; }
         AuraEffect const* GetAuraEffect() const { return _aurEff; }
+
         uint32 GetTimeSinceCreated() const { return _timeSinceCreated; }
         uint32 GetTimeToTarget() const { return m_areaTriggerData->TimeToTarget; }
         uint32 GetTimeToTargetScale() const { return m_areaTriggerData->TimeToTargetScale; }
+        uint32 GetTimeToTargetExtraScale() const { return m_areaTriggerData->TimeToTargetExtraScale; }
+
+        void SetTimeToTarget(uint32 timeToTarget) { SetUpdateFieldValue(m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::TimeToTarget), timeToTarget); }
+        void SetTimeToTargetScale(uint32 timeToTargetScale) { SetUpdateFieldValue(m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::TimeToTargetScale), timeToTargetScale); }
+        void SetTimeToTargetExtraScale(uint32 timeToTargetExtraScale) { SetUpdateFieldValue(m_values.ModifyValue(&AreaTrigger::m_areaTriggerData).ModifyValue(&UF::AreaTriggerData::TimeToTargetExtraScale), timeToTargetExtraScale); }
+
         int32 GetDuration() const { return _duration; }
         int32 GetTotalDuration() const { return _totalDuration; }
         void SetDuration(int32 newDuration);
@@ -130,9 +137,15 @@ class TC_GAME_API AreaTrigger : public WorldObject, public GridObject<AreaTrigge
 
         UF::UpdateField<UF::AreaTriggerData, 0, TYPEID_AREATRIGGER> m_areaTriggerData;
 
+        void SetOverrideScaleCurve(uint32 startTimeOffSet, std::array<DBCPosition2D, 2> points, CurveInterpolationMode mode = CurveInterpolationMode::Linear);
+        float GetOverrideScaleCurveValue() const;
+
     protected:
         void _UpdateDuration(int32 newDuration);
         float GetProgress() const;
+
+        float GetOverrideScaleCurveProgress() const;
+        float GetExtraScaleCurveProgress() const;
 
         float GetScaleCurveValue(UF::ScaleCurve const& scaleCurve, float x) const;
         void SetScaleCurve(UF::MutableFieldReference<UF::ScaleCurve, false>&& scaleCurveMutator, Optional<AreaTriggerScaleCurveTemplate> const& curve);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implement core handling for OverrideScaleCurve and make it possible to manipulate it via AreaTrigger::SetOverrideScaleCurve
-  Implement ScaleCurveId for Spheres
-  Implement SpellMod::Radius for Spheres

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
- [x] Tested in-game with Anduin Befouled Barrier
- [x] Builds

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Find out if OverrideScaleCurve actually needs AREATRIGGER_FLAG_HAS_DYNAMIC_SHAPE, the reason here is that the AT gets sent with an UPDATE_OBJECT create without the flag and afterwards the OverrideScaleCurve is sent in another packet without the flag being applied, it could be that the flag gets set on activating the overrideScaleCurve but the update being not sent as packet to the client
- [ ] Database support is missing for initial data (wont be handled in this PR)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
