### PR TITLE
Handle SPELL_ATTR12_CAN_PROC_FROM_IMMUNE

### DIFF
--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -870,7 +870,7 @@ enum SpellAttr11 : uint32
 enum SpellAttr12 : uint32
 {
     SPELL_ATTR12_UNK0                            = 0x00000001, // TITLE Unknown attribute 0@Attr12
-    SPELL_ATTR12_UNK1                            = 0x00000002, // TITLE Unknown attribute 1@Attr12
+    SPELL_ATTR12_CAN_PROC_FROM_IMMUNE            = 0x00000002, // TITLE Can proc from immuned spells
     SPELL_ATTR12_UNK2                            = 0x00000004, // TITLE Unknown attribute 2@Attr12
     SPELL_ATTR12_UNK3                            = 0x00000008, // TITLE Unknown attribute 3@Attr12
     SPELL_ATTR12_UNK4                            = 0x00000010, // TITLE Unknown attribute 4@Attr12

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1830,7 +1830,7 @@ uint32 Aura::GetProcEffectMask(AuraApplication* aurApp, ProcEventInfo& eventInfo
         return 0;
 
     // do checks against db data
-    if (!SpellMgr::CanSpellTriggerProcOnEvent(*procEntry, eventInfo))
+    if (!SpellMgr::CanSpellTriggerProcOnEvent(GetSpellInfo(), *procEntry, eventInfo))
         return 0;
 
     // do checks using conditions table

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -508,7 +508,7 @@ SpellProcEntry const* SpellMgr::GetSpellProcEntry(SpellInfo const* spellInfo) co
     return nullptr;
 }
 
-bool SpellMgr::CanSpellTriggerProcOnEvent(SpellProcEntry const& procEntry, ProcEventInfo& eventInfo)
+bool SpellMgr::CanSpellTriggerProcOnEvent(SpellInfo const* procAuraSpellInfo, SpellProcEntry const& procEntry, ProcEventInfo& eventInfo)
 {
     // proc type doesn't match
     if (!(eventInfo.GetTypeMask() & procEntry.ProcFlags))
@@ -573,6 +573,10 @@ bool SpellMgr::CanSpellTriggerProcOnEvent(SpellProcEntry const& procEntry, ProcE
             else
                 hitMask |= PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB;
         }
+
+        if (procAuraSpellInfo->HasAttribute(SPELL_ATTR12_CAN_PROC_FROM_IMMUNE))
+            hitMask |= PROC_HIT_IMMUNE;
+
         if (!(eventInfo.GetHitMask() & hitMask))
             return false;
     }


### PR DESCRIPTION
**Changes proposed:**

- Handle SPELL_ATTR12_CAN_PROC_FROM_IMMUNE
- Spells like 372600 should proc even through immunity

**Issues addressed:**

None


**Tests performed:**

Built, tested ingame


**Known issues and TODO list:**

- [ ] Attr named by me™️, maybe has a blizz internal name, i'll change if required