### PR TITLE
Add EventMap to AreaTriggerAI

### DIFF
--- a/src/server/game/AI/CoreAI/AreaTriggerAI.cpp
+++ b/src/server/game/AI/CoreAI/AreaTriggerAI.cpp
@@ -26,3 +26,11 @@ AreaTriggerAI::AreaTriggerAI(AreaTrigger* a, uint32 scriptId) : _scriptId(script
 AreaTriggerAI::~AreaTriggerAI()
 {
 }
+
+void AreaTriggerAI::OnUpdate(uint32 diff)
+{
+    events.Update(diff);
+
+    while (uint32 eventId = events.ExecuteEvent())
+        ExecuteEvent(eventId);
+}

--- a/src/server/game/AI/CoreAI/AreaTriggerAI.h
+++ b/src/server/game/AI/CoreAI/AreaTriggerAI.h
@@ -19,6 +19,7 @@
 #define TRINITY_AREATRIGGERAI_H
 
 #include "Define.h"
+#include "EventMap.h"
 
 class AreaTrigger;
 class Spell;
@@ -30,6 +31,8 @@ class TC_GAME_API AreaTriggerAI
 
     protected:
         AreaTrigger* const at;
+        EventMap events;
+
     public:
         explicit AreaTriggerAI(AreaTrigger* a, uint32 scriptId = {});
         virtual ~AreaTriggerAI();
@@ -41,7 +44,13 @@ class TC_GAME_API AreaTriggerAI
         virtual void OnCreate([[maybe_unused]] Spell const* creatingSpell) { }
 
         // Called on each AreaTrigger update
-        virtual void OnUpdate([[maybe_unused]] uint32 diff) { }
+        virtual void OnUpdate(uint32 diff);
+
+        // Hook used to execute events scheduled into EventMap without the need
+        // to override OnUpdate
+        // note: You must re-schedule the event within this method if the event
+        // is supposed to run more than once
+        virtual void ExecuteEvent(uint32 /*eventId*/) { }
 
         // Called when the AreaTrigger reach splineIndex
         virtual void OnSplineIndexReached([[maybe_unused]] int32 splineIndex) { }
@@ -57,6 +66,13 @@ class TC_GAME_API AreaTriggerAI
 
         // Called when the AreaTrigger is removed
         virtual void OnRemove() { }
+
+        // Pass parameters between AI
+        virtual void DoAction(int32 /*param*/) { }
+        virtual uint32 GetData(uint32 /*id = 0*/) const { return 0; }
+        virtual void SetData(uint32 /*id*/, uint32 /*value*/) { }
+        virtual void SetGUID(ObjectGuid const& /*guid*/, int32 /*id*/ = 0) { }
+        virtual ObjectGuid GetGUID(int32 /*id*/ = 0) const { return ObjectGuid::Empty; }
 
         // Gets the id of the AI (script id)
         uint32 GetId() { return _scriptId; }

--- a/src/server/game/AI/CoreAI/AreaTriggerAI.h
+++ b/src/server/game/AI/CoreAI/AreaTriggerAI.h
@@ -20,6 +20,7 @@
 
 #include "Define.h"
 #include "EventMap.h"
+#include "ObjectGuid.h"
 
 class AreaTrigger;
 class Spell;
@@ -68,11 +69,11 @@ class TC_GAME_API AreaTriggerAI
         virtual void OnRemove() { }
 
         // Pass parameters between AI
-        virtual void DoAction(int32 /*param*/) { }
-        virtual uint32 GetData(uint32 /*id = 0*/) const { return 0; }
-        virtual void SetData(uint32 /*id*/, uint32 /*value*/) { }
-        virtual void SetGUID(ObjectGuid const& /*guid*/, int32 /*id*/ = 0) { }
-        virtual ObjectGuid GetGUID(int32 /*id*/ = 0) const { return ObjectGuid::Empty; }
+        virtual void DoAction([[maybe_unused]] int32 param) { }
+        virtual uint32 GetData([[maybe_unused]] uint32 id = 0) const { return 0; }
+        virtual void SetData([[maybe_unused]] uint32 id, [[maybe_unused]] uint32 value) { }
+        virtual void SetGUID([[maybe_unused]] ObjectGuid const& guid, [[maybe_unused]] int32 id = 0) { }
+        virtual ObjectGuid GetGUID([[maybe_unused]] int32 id = 0) const { return ObjectGuid::Empty; }
 
         // Gets the id of the AI (script id)
         uint32 GetId() { return _scriptId; }


### PR DESCRIPTION
**Changes proposed:**

-  Add EventMap & multiple "Pass parameters between AI" methods on AreatriggerAI
-  Main use would be for AT with overrideCurve who need to update every x ms (example : at_anduin_wrynn_befouled_barrier  in  [#28540](https://github.com/TrinityCore/TrinityCore/pull/28540)) to avoid relying on old-school timers
- Some (rare) AT also pulse spell periodically which would be easier with EventMap

**Issues addressed:**

None

**Tests performed:**

Build, tested ingame


**Known issues and TODO list:** (add/remove lines as needed)
