### PR TITLE
ZoneScript: Add hook for AreaTrigger creation/deletion

### DIFF
--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -39,6 +39,7 @@
 #include "Transport.h"
 #include "Unit.h"
 #include "UpdateData.h"
+#include "ZoneScript.h"
 #include "advstd.h"
 #include <bit>
 
@@ -63,6 +64,9 @@ void AreaTrigger::AddToWorld()
     ///- Register the AreaTrigger for guid lookup and for caster
     if (!IsInWorld())
     {
+        if (m_zoneScript)
+            m_zoneScript->OnAreaTriggerCreate(this);
+
         GetMap()->GetObjectsStore().Insert<AreaTrigger>(GetGUID(), this);
         if (_spawnId)
             GetMap()->GetAreaTriggerBySpawnIdStore().insert(std::make_pair(_spawnId, this));
@@ -76,6 +80,9 @@ void AreaTrigger::RemoveFromWorld()
     ///- Remove the AreaTrigger from the accessor and from all lists of objects in world
     if (IsInWorld())
     {
+        if (m_zoneScript)
+            m_zoneScript->OnAreaTriggerRemove(this);
+
         _isRemoved = true;
 
         if (Unit* caster = GetCaster())
@@ -113,6 +120,8 @@ bool AreaTrigger::Create(uint32 areaTriggerCreatePropertiesId, Unit* caster, Uni
         TC_LOG_ERROR("entities.areatrigger", "AreaTrigger (areaTriggerCreatePropertiesId {}) not created. Invalid areatrigger create properties id ({})", areaTriggerCreatePropertiesId, areaTriggerCreatePropertiesId);
         return false;
     }
+
+    SetZoneScript();
 
     _areaTriggerTemplate = _areaTriggerCreateProperties->Template;
 
@@ -253,6 +262,8 @@ bool AreaTrigger::CreateServer(Map* map, AreaTriggerTemplate const* areaTriggerT
             areaTriggerTemplate->Id.Id, GetPositionX(), GetPositionY());
         return false;
     }
+
+    SetZoneScript();
 
     _areaTriggerTemplate = areaTriggerTemplate;
 

--- a/src/server/game/Maps/ZoneScript.h
+++ b/src/server/game/Maps/ZoneScript.h
@@ -21,6 +21,7 @@
 #include "Define.h"
 #include "ObjectGuid.h"
 
+class AreaTrigger;
 class Creature;
 class GameObject;
 class Player;
@@ -48,6 +49,9 @@ class TC_GAME_API ZoneScript
 
         virtual void OnGameObjectCreate(GameObject* ) { }
         virtual void OnGameObjectRemove(GameObject* ) { }
+
+        virtual void OnAreaTriggerCreate([[maybe_unused]] AreaTrigger* areaTrigger) { }
+        virtual void OnAreaTriggerRemove([[maybe_unused]] AreaTrigger* areaTrigger) { }
 
         virtual void OnUnitDeath(Unit*) { }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add hook in ZoneScript for AreaTrigger creation/deletion (like there is for GameObject & Creature)

**Issues addressed:**

Closes: none. I need this for Warsong Gulch


**Tests performed:**

- Tested on local warsong gulch (pr soon)
- Breakpoint triggers in zonescript


**Known issues and TODO list:**
- none



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
