### PR TITLE
Core/Achievements: Allow updating criteria trees with a criteria that has correct map id

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -100,9 +100,29 @@ bool AchievementMgr::CanUpdateCriteriaTree(Criteria const* criteria, CriteriaTre
 
     if (achievement->InstanceID != -1 && referencePlayer->GetMapId() != uint32(achievement->InstanceID))
     {
-        TC_LOG_TRACE("criteria.achievement", "AchievementMgr::CanUpdateCriteriaTree: (Id: {} Type {} Achievement {}) Wrong map",
-            criteria->ID, CriteriaMgr::GetCriteriaTypeString(criteria->Entry->Type), achievement->ID);
-        return false;
+        bool isMapCriteria = false;
+        switch (CriteriaType(criteria->Entry->Type))
+        {
+            case CriteriaType::WinBattleground:
+            case CriteriaType::ParticipateInBattleground:
+            case CriteriaType::DieOnMap:
+            case CriteriaType::WinArena:
+            case CriteriaType::ParticipateInArena:
+            case CriteriaType::CompleteChallengeMode:
+                isMapCriteria = true;
+                break;
+            default:
+                break;
+        }
+
+        // if criteria does not have map asset, then there is nothing more to check and we can fail the update criteria tree
+        // if criteria does have map assset, need to check if referencePlayer meets that condition.
+        if (!isMapCriteria || (criteria->Entry->Asset.MapID != -1 && referencePlayer->GetMapId() != uint32(criteria->Entry->Asset.MapID)))
+        {
+            TC_LOG_TRACE("criteria.achievement", "AchievementMgr::CanUpdateCriteriaTree: (Id: {} Type {} Achievement {}) Wrong map",
+                criteria->ID, CriteriaMgr::GetCriteriaTypeString(criteria->Entry->Type), achievement->ID);
+            return false;
+        }
     }
 
     if ((achievement->Faction == ACHIEVEMENT_FACTION_HORDE    && referencePlayer->GetTeam() != HORDE) ||


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Allow criteria tree's that have a criteria with map id to be updated even when achievement instance id check failed
- Previously some achievements had a different map id (example: old arathi, old warsong) which is why some of these achievements wouldn't work

**Issues addressed:**

Closes: none? Achievements in battlegrounds like Warsong Gulch Perfection work now


**Tests performed:**

- Builds
- Tested on Warsong Gulch local branch
  - Warsong Gulch Perfection works now
  -  Warsong Expedience works now


**Known issues and TODO list:**
- This might break some achievements? I'm not sure.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
