### PR TITLE
GameObjects: Mark some pvp related gameobjects as active

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -844,7 +844,7 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
             break;
         case GAMEOBJECT_TYPE_NEW_FLAG:
             m_goTypeImpl = std::make_unique<GameObjectType::NewFlag>(*this);
-            if (map->Instanceable()) 
+            if (map->Instanceable())
                 setActive(true);
             break;
         case GAMEOBJECT_TYPE_NEW_FLAG_DROP:

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -844,6 +844,10 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
             break;
         case GAMEOBJECT_TYPE_NEW_FLAG:
             m_goTypeImpl = std::make_unique<GameObjectType::NewFlag>(*this);
+            setActive(true);
+            break;
+        case GAMEOBJECT_TYPE_NEW_FLAG_DROP:
+            setActive(true);
             break;
         case GAMEOBJECT_TYPE_PHASEABLE_MO:
             RemoveFlag(GameObjectFlags(0xF00));
@@ -855,6 +859,7 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
             m_goValue.CapturePoint.LastTeamCapture = TEAM_NEUTRAL;
             m_goValue.CapturePoint.State = WorldPackets::Battleground::BattlegroundCapturePointState::Neutral;
             UpdateCapturePoint();
+            setActive(true);
             break;
         default:
             SetGoAnimProgress(animProgress);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -844,10 +844,12 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
             break;
         case GAMEOBJECT_TYPE_NEW_FLAG:
             m_goTypeImpl = std::make_unique<GameObjectType::NewFlag>(*this);
-            setActive(true);
+            if (map->Instanceable()) 
+                setActive(true);
             break;
         case GAMEOBJECT_TYPE_NEW_FLAG_DROP:
-            setActive(true);
+            if (map->Instanceable())
+                setActive(true);
             break;
         case GAMEOBJECT_TYPE_PHASEABLE_MO:
             RemoveFlag(GameObjectFlags(0xF00));
@@ -859,7 +861,8 @@ bool GameObject::Create(uint32 entry, Map* map, Position const& pos, QuaternionD
             m_goValue.CapturePoint.LastTeamCapture = TEAM_NEUTRAL;
             m_goValue.CapturePoint.State = WorldPackets::Battleground::BattlegroundCapturePointState::Neutral;
             UpdateCapturePoint();
-            setActive(true);
+            if (map->Instanceable())
+                setActive(true);
             break;
         default:
             SetGoAnimProgress(animProgress);


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Make some GameObject types as active
- Lots of timers depend on their Update ticks

**Issues addressed:**

Closes: none


**Tests performed:**

- Tested on https://github.com/TrinityCore/TrinityCore/pull/29247


**Known issues and TODO list:**

- none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
