### PR TITLE
License: Restore long lost OpenSSL exception

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -337,3 +337,14 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+                            OpenSSL exception
+In addition, as a special exception, the TrinityCore project
+gives permission to link the code of its release of Trinity Core with
+the OpenSSL project's "OpenSSL" library (or with modified versions of
+it that use the same license as the "OpenSSL" library), and distribute
+the linked executables.  You must obey the GNU General Public License
+in all respects for all of the code used other than "OpenSSL".  If you
+modify this file, you may extend this exception to your version of the
+file, but you are not obligated to do so.  If you do not wish to do
+so, delete this exception statement from your version.


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Restore long lost OpenSSL exception accidentally removed in 4559e99e0d0c87f6a13fd018d1de624fa350446f and include it in the COPYING license file.

**Issues addressed:**

None


**Tests performed:**

None

**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
