### PR TITLE
Core/AreaTriggerActions: Define actions and provide function to call them

### DIFF
--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -1383,6 +1383,54 @@ bool AreaTrigger::IsNeverVisibleFor(WorldObject const* seer, bool allowServersid
     return false;
 }
 
+void AreaTrigger::DoAction(AreaTriggerActions action, Unit* unit, AreaTriggerActionParam const& param)
+{
+    switch (action)
+    {
+        case AreaTriggerActions::CastSpell:
+        case AreaTriggerActions::CastSpellOnAreaTriggerCreator:
+        case AreaTriggerActions::AreaTriggerCreatorCastSpell:
+        case AreaTriggerActions::CancelAura:
+        case AreaTriggerActions::SendGameEvent:
+        case AreaTriggerActions::StartQuest:
+        case AreaTriggerActions::RunRandomActionSet:
+        case AreaTriggerActions::Teleport:
+        case AreaTriggerActions::Deprecated:
+        case AreaTriggerActions::ActivateGameObject:
+        case AreaTriggerActions::StartResting:
+        case AreaTriggerActions::StopResting:
+        case AreaTriggerActions::DiscoverArea:
+        case AreaTriggerActions::DeathRegion:
+        case AreaTriggerActions::DespawnAreaTrigger:
+        case AreaTriggerActions::AddMovementForce:
+        case AreaTriggerActions::RemoveMovementForce:
+        case AreaTriggerActions::AreaTriggerCreatorCancelsAuraOnTriggeringUnit:
+        case AreaTriggerActions::RunScript:
+        case AreaTriggerActions::CaptureFlag:
+        case AreaTriggerActions::SetScale:
+        case AreaTriggerActions::IncrementScale:
+        case AreaTriggerActions::DecrementScale:
+        case AreaTriggerActions::SeamlessWarmup:
+        case AreaTriggerActions::SeamlessTransfer:
+        case AreaTriggerActions::KillCredit:
+        case AreaTriggerActions::KillCreditToPlayerOnly:
+        case AreaTriggerActions::CancelAuraOneApplication:
+        case AreaTriggerActions::AreaTriggerCreatorCancelsAuraOnTriggeringUnitOneApplication:
+        case AreaTriggerActions::ApplyAuraAndKeepRetrying:
+        case AreaTriggerActions::CreatorApplyAuraAndKeepRetrying:
+        case AreaTriggerActions::ConversationBegin:
+        case AreaTriggerActions::AnimationSetForSpellVisual:
+        case AreaTriggerActions::AnimationSetForSpellVisualAllowDecay:
+        case AreaTriggerActions::AnimationClearForSpellVisual:
+        case AreaTriggerActions::AllowGhostInInstance:
+        case AreaTriggerActions::DissalowGhostInInstance:
+        case AreaTriggerActions::SendGeneralTrigger:
+        default:
+            TC_LOG_WARN("entities.areatrigger", "AreaTrigger {} tried to execute unsupported action {}", GetGUID(), action);
+            break;
+    }
+}
+
 void AreaTrigger::BuildValuesCreate(ByteBuffer* data, Player const* target) const
 {
     UF::UpdateFieldFlag flags = GetUpdateFieldFlagsFor(target);

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -1383,7 +1383,7 @@ bool AreaTrigger::IsNeverVisibleFor(WorldObject const* seer, bool allowServersid
     return false;
 }
 
-void AreaTrigger::DoAction(AreaTriggerActions action, Unit* unit, AreaTriggerActionParam const& param)
+void AreaTrigger::DoAction(AreaTriggerActions action, Unit* /*triggeringUnit*/, AreaTriggerActionParam const& /*param*/)
 {
     switch (action)
     {
@@ -1426,7 +1426,7 @@ void AreaTrigger::DoAction(AreaTriggerActions action, Unit* unit, AreaTriggerAct
         case AreaTriggerActions::DissalowGhostInInstance:
         case AreaTriggerActions::SendGeneralTrigger:
         default:
-            TC_LOG_WARN("entities.areatrigger", "AreaTrigger {} tried to execute unsupported action {}", GetGUID(), action);
+            TC_LOG_WARN("entities.areatrigger", "AreaTrigger {} tried to execute unsupported action {}", GetEntry(), AsUnderlyingType(action));
             break;
     }
 }

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.h
@@ -79,6 +79,8 @@ class TC_GAME_API AreaTrigger : public WorldObject, public GridObject<AreaTrigge
 
         bool IsNeverVisibleFor(WorldObject const* seer, bool allowServersideObjects = false) const override;
 
+        void DoAction(AreaTriggerActions action, Unit* unit, AreaTriggerActionParam const& param);
+
         float GetStationaryX() const override { return _stationaryPosition.GetPositionX(); }
         float GetStationaryY() const override { return _stationaryPosition.GetPositionY(); }
         float GetStationaryZ() const override { return _stationaryPosition.GetPositionZ(); }

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.h
@@ -79,7 +79,7 @@ class TC_GAME_API AreaTrigger : public WorldObject, public GridObject<AreaTrigge
 
         bool IsNeverVisibleFor(WorldObject const* seer, bool allowServersideObjects = false) const override;
 
-        void DoAction(AreaTriggerActions action, Unit* unit, AreaTriggerActionParam const& param);
+        void DoAction(AreaTriggerActions action, Unit* triggeringUnit, AreaTriggerActionParam const& param);
 
         float GetStationaryX() const override { return _stationaryPosition.GetPositionX(); }
         float GetStationaryY() const override { return _stationaryPosition.GetPositionY(); }

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -22,6 +22,7 @@
 #include "EnumFlag.h"
 #include "ObjectGuid.h"
 #include "Optional.h"
+#include "SharedDefines.h"
 #include "SpawnData.h"
 #include <variant>
 #include <vector>
@@ -30,8 +31,6 @@
 #define MAX_AREATRIGGER_SCALE 7
 
 enum class AreaTriggerFlag : uint32
-enum TeamId;
-
 {
     None                           = 0x00,
     IsServerSide                   = 0x01

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -30,6 +30,8 @@
 #define MAX_AREATRIGGER_SCALE 7
 
 enum class AreaTriggerFlag : uint32
+enum TeamId;
+
 {
     None                           = 0x00,
     IsServerSide                   = 0x01

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -120,7 +120,7 @@ struct AreaTriggerActionParam
     Optional<ObjectGuid> Guid;
 
     // CaptureFlag
-    Optional<TeamId> TeamId;
+    Optional<::TeamId> TeamId;
 };
 
 enum AreaTriggerActionUserTypes

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -119,6 +119,7 @@ struct AreaTriggerActionParam
 
     // ActivateGameObject
     Optional<ObjectGuid> Guid;
+    Optional<std::string_view> StringId;
 
     // CaptureFlag
     Optional<::TeamId> TeamId;

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -57,6 +57,72 @@ enum AreaTriggerActionTypes
     AREATRIGGER_ACTION_MAX         = 3
 };
 
+enum class AreaTriggerActions : uint8
+{
+    CastSpell,
+    CastSpellOnAreaTriggerCreator,
+    AreaTriggerCreatorCastSpell,
+    CancelAura,
+    SendGameEvent,
+    StartQuest, // player only
+    RunRandomActionSet,
+    Teleport,
+    Deprecated,
+    ActivateGameObject,
+    StartResting,
+    StopResting,
+    DiscoverArea,
+    DeathRegion, // player only
+    DespawnAreaTrigger,
+    AddMovementForce,
+    RemoveMovementForce,
+    AreaTriggerCreatorCancelsAuraOnTriggeringUnit,
+    RunScript,
+    CaptureFlag,
+    SetScale,
+    IncrementScale,
+    DecrementScale,
+    SeamlessWarmup,
+    SeamlessTransfer,
+    KillCredit,
+    KillCreditToPlayerOnly,
+    CancelAuraOneApplication,
+    AreaTriggerCreatorCancelsAuraOnTriggeringUnitOneApplication,
+    ApplyAuraAndKeepRetrying,
+    CreatorApplyAuraAndKeepRetrying,
+    ConversationBegin,
+    AnimationSetForSpellVisual,
+    AnimationSetForSpellVisualAllowDecay,
+    AnimationClearForSpellVisual,
+    AllowGhostInInstance,
+    DissalowGhostInInstance,
+    SendGeneralTrigger
+};
+
+struct AreaTriggerActionParam
+{
+    // CastSpell
+    // CastSpellOnAreaTriggerCreator
+    // AreaTriggerCreatorCastSpell
+    // CancelAura
+    // AreaTriggerCreatorCancelsAuraOnTriggeringUnit
+    // CancelAuraOneApplication
+    // AreaTriggerCreatorCancelsAuraOnTriggeringUnitOneApplication
+    // ApplyAuraAndKeepRetrying
+    Optional<uint32> SpellID;
+
+    // SetScale
+    // IncrementScale
+    // DecrementScale
+    Optional<float> Scale;
+
+    // ActivateGameObject
+    Optional<ObjectGuid> Guid;
+
+    // CaptureFlag
+    Optional<TeamId> TeamId;
+};
+
 enum AreaTriggerActionUserTypes
 {
     AREATRIGGER_ACTION_USER_ANY    = 0,


### PR DESCRIPTION
The idea is to provide a function that is the entry point for every area trigger action. This could later be used for example in smart_scripts. But also c++ scripts (see my [capture flag pr](https://github.com/TrinityCore/TrinityCore/pull/29237) and [wsg pr](https://github.com/TrinityCore/TrinityCore/pull/29247))

Actions will not have any implementation in this PR. That should be done in different ones.

**Changes proposed:**

-  Define AreaTriggerActions from [enumerated strings](https://wow.tools/dbc/?dbc=enumeratedstring&build=2.5.1.39640#page=1&colFilter[4]=746%20)
-  Provide function that can be called

**Issues addressed:**

Closes: None


**Tests performed:**

- Builds locally


**Known issues and TODO list:**

- [ ] Maybe we could define a better way to pass down the params.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
