### PR TITLE
Core/AreaTriggers: Added areatrigger_polygon_vertex table to allow sp…

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,15 @@
+-- 
+DROP TABLE IF EXISTS `areatrigger_polygon_vertex`;
+CREATE TABLE `areatrigger_polygon_vertex`  (
+  `SpawnId` bigint UNSIGNED NOT NULL,
+  `Idx` int UNSIGNED NOT NULL,
+  `VerticeX` float NOT NULL DEFAULT 0,
+  `VerticeY` float NOT NULL DEFAULT 0,
+  `VerticeTargetX` float NULL DEFAULT NULL,
+  `VerticeTargetY` float NULL DEFAULT NULL,
+  `VerifiedBuild` int UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`SpawnId`, `Idx`) USING BTREE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
+
+
+ALTER TABLE `areatrigger` ADD COLUMN `VerifiedBuild` int UNSIGNED NOT NULL AFTER `Comment`;

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -10,6 +10,3 @@ CREATE TABLE `areatrigger_polygon_vertex`  (
   `VerifiedBuild` int UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`SpawnId`, `Idx`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = Dynamic;
-
-
-ALTER TABLE `areatrigger` ADD COLUMN `VerifiedBuild` int UNSIGNED NOT NULL AFTER `Comment`;

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -274,7 +274,6 @@ bool AreaTrigger::CreateServer(Map* map, AreaTriggerTemplate const* areaTriggerT
     SetObjectScale(1.0f);
 
     auto areaTriggerData = m_values.ModifyValue(&AreaTrigger::m_areaTriggerData);
-    SetUpdateFieldValue(areaTriggerData.ModifyValue(&UF::AreaTriggerData::BoundsRadius2D), GetMaxSearchRadius());
     SetUpdateFieldValue(areaTriggerData.ModifyValue(&UF::AreaTriggerData::DecalPropertiesID), 24); // blue decal, for .debug areatrigger visibility
 
     float tmp = 1.0000001f;
@@ -284,6 +283,8 @@ bool AreaTrigger::CreateServer(Map* map, AreaTriggerTemplate const* areaTriggerT
     SetUpdateFieldValue(areaTriggerData.ModifyValue(&UF::AreaTriggerData::ExtraScaleCurve).ModifyValue(&UF::ScaleCurve::ParameterCurve), tmp2);
     SetUpdateFieldValue(areaTriggerData.ModifyValue(&UF::AreaTriggerData::ExtraScaleCurve).ModifyValue(&UF::ScaleCurve::OverrideActive), true);
 
+    SetDuration(-1);
+
     _shape = position.Shape;
     _maxSearchRadius = _shape.GetMaxSearchRadius();
 
@@ -291,6 +292,8 @@ bool AreaTrigger::CreateServer(Map* map, AreaTriggerTemplate const* areaTriggerT
         PhasingHandler::InitDbPhaseShift(GetPhaseShift(), position.phaseUseFlags, position.phaseId, position.phaseGroup);
 
     UpdateShape();
+
+    SetUpdateFieldValue(areaTriggerData.ModifyValue(&UF::AreaTriggerData::BoundsRadius2D), GetMaxSearchRadius());
 
     AI_Initialize();
 
@@ -708,7 +711,7 @@ void AreaTrigger::UpdatePolygonOrientation()
     if (G3D::fuzzyEq(_previousCheckOrientation, newOrientation))
         return;
 
-    _polygonVertices.assign(GetCreateProperties()->PolygonVertices.begin(), GetCreateProperties()->PolygonVertices.end());
+    _polygonVertices.assign(GetShape().PolygonVertices.begin(), GetShape().PolygonVertices.end());
 
     float angleSin = std::sin(newOrientation);
     float angleCos = std::cos(newOrientation);

--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -135,7 +135,7 @@ bool AreaTrigger::Create(uint32 areaTriggerCreatePropertiesId, Unit* caster, Uni
     SetObjectScale(1.0f);
 
     _shape = GetCreateProperties()->Shape;
-    _maxSearchRadius = GetCreateProperties()->GetMaxSearchRadius();
+    _maxSearchRadius = _shape.GetMaxSearchRadius();
 
     auto areaTriggerData = m_values.ModifyValue(&AreaTrigger::m_areaTriggerData);
     SetUpdateFieldValue(areaTriggerData.ModifyValue(&UF::AreaTriggerData::Caster), caster->GetGUID());

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.cpp
@@ -49,6 +49,20 @@ float AreaTriggerShapeInfo::GetMaxSearchRadius() const
             return std::max(DiskDatas.OuterRadius, DiskDatas.OuterRadiusTarget);
         case AREATRIGGER_TYPE_BOUNDED_PLANE:
             return std::sqrt(BoundedPlaneDatas.Extents[0] * BoundedPlaneDatas.Extents[0] / 4 + BoundedPlaneDatas.Extents[1] * BoundedPlaneDatas.Extents[1] / 4);
+        case AREATRIGGER_TYPE_POLYGON:
+        {
+            Position center(0.0f, 0.0f);
+            float maxSearchRadius = 0.0f;
+
+            for (TaggedPosition<Position::XY> const& vertice : PolygonVertices)
+            {
+                float pointDist = center.GetExactDist2d(vertice);
+
+                if (pointDist > maxSearchRadius)
+                    maxSearchRadius = pointDist;
+            }
+            return maxSearchRadius;
+        }
         default:
             break;
     }
@@ -97,21 +111,5 @@ bool AreaTriggerCreateProperties::HasSplines() const
 
 float AreaTriggerCreateProperties::GetMaxSearchRadius() const
 {
-    if (Shape.Type == AREATRIGGER_TYPE_POLYGON)
-    {
-        Position center(0.0f, 0.0f);
-        float maxSearchRadius = 0.0f;
-
-        for (TaggedPosition<Position::XY> const& vertice : PolygonVertices)
-        {
-            float pointDist = center.GetExactDist2d(vertice);
-
-            if (pointDist > maxSearchRadius)
-                maxSearchRadius = pointDist;
-        }
-
-        return maxSearchRadius;
-    }
-
     return Shape.GetMaxSearchRadius();
 }

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.cpp
@@ -108,8 +108,3 @@ bool AreaTriggerCreateProperties::HasSplines() const
 {
     return SplinePoints.size() >= 2;
 }
-
-float AreaTriggerCreateProperties::GetMaxSearchRadius() const
-{
-    return Shape.GetMaxSearchRadius();
-}

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -216,7 +216,6 @@ public:
     ~AreaTriggerCreateProperties();
 
     bool HasSplines() const;
-    float GetMaxSearchRadius() const;
 
     uint32 Id;
     AreaTriggerTemplate const* Template;

--- a/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
+++ b/src/server/game/Entities/AreaTrigger/AreaTriggerTemplate.h
@@ -117,6 +117,8 @@ struct AreaTriggerShapeInfo
     float GetMaxSearchRadius() const;
 
     AreaTriggerTypes Type;
+    std::vector<TaggedPosition<Position::XY>> PolygonVertices;
+    std::vector<TaggedPosition<Position::XY>> PolygonVerticesTarget;
 
     union
     {
@@ -236,8 +238,6 @@ public:
     Optional<AreaTriggerScaleCurveTemplate> ExtraScale;
 
     AreaTriggerShapeInfo Shape;
-    std::vector<TaggedPosition<Position::XY>> PolygonVertices;
-    std::vector<TaggedPosition<Position::XY>> PolygonVerticesTarget;
 
     std::vector<Position> SplinePoints;
     Optional<AreaTriggerOrbitInfo> OrbitInfo;

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Object.h"
+#include "AreaTriggerDataStore.h"
 #include "AreaTriggerPackets.h"
 #include "AreaTriggerTemplate.h"
 #include "BattlefieldMgr.h"
@@ -461,7 +462,7 @@ void Object::BuildMovementUpdate(ByteBuffer* data, CreateObjectBits flags, Playe
         bool hasMoveCurveID         = createProperties && createProperties->MoveCurveId != 0;
         bool hasAreaTriggerSphere   = shape.IsSphere();
         bool hasAreaTriggerBox      = shape.IsBox();
-        bool hasAreaTriggerPolygon  = createProperties && shape.IsPolygon();
+        bool hasAreaTriggerPolygon  = shape.IsPolygon();
         bool hasAreaTriggerCylinder = shape.IsCylinder();
         bool hasDisk                = shape.IsDisk();
         bool hasBoundedPlane        = shape.IsBoudedPlane();
@@ -533,15 +534,16 @@ void Object::BuildMovementUpdate(ByteBuffer* data, CreateObjectBits flags, Playe
 
         if (hasAreaTriggerPolygon)
         {
-            *data << int32(createProperties->PolygonVertices.size());
-            *data << int32(createProperties->PolygonVerticesTarget.size());
+            *data << int32(shape.PolygonVertices.size());
+            *data << int32(shape.PolygonVerticesTarget.size());
+
             *data << float(shape.PolygonDatas.Height);
             *data << float(shape.PolygonDatas.HeightTarget);
 
-            for (TaggedPosition<Position::XY> const& vertice : createProperties->PolygonVertices)
+            for (TaggedPosition<Position::XY> const& vertice : shape.PolygonVertices)
                 *data << vertice;
 
-            for (TaggedPosition<Position::XY> const& vertice : createProperties->PolygonVerticesTarget)
+            for (TaggedPosition<Position::XY> const& vertice : shape.PolygonVerticesTarget)
                 *data << vertice;
         }
 

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "Object.h"
-#include "AreaTriggerDataStore.h"
 #include "AreaTriggerPackets.h"
 #include "AreaTriggerTemplate.h"
 #include "BattlefieldMgr.h"


### PR DESCRIPTION
…awned areatriggers with polygon shape

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)
built, tested ingame with

```sql
SET @ATSPAWNID := 400000;

DELETE FROM `areatrigger_template` WHERE (`IsServerSide`=0 AND `Id` IN (30222));
INSERT INTO `areatrigger_template` (`Id`, `IsServerSide`, `Type`, `Flags`, `Data0`, `Data1`, `Data2`, `Data3`, `Data4`, `Data5`, `Data6`, `Data7`, `VerifiedBuild`) VALUES
(30222, 0, 3, 0, 50.00000381469726562, 50.00000381469726562, 0, 0, 0, 0, 0, 0, 50469);

DELETE FROM `areatrigger` WHERE `SpawnId`=@ATSPAWNID+0;
INSERT INTO `areatrigger` (`SpawnId`, `AreaTriggerId`, `IsServerSide`, `MapId`, `PosX`, `PosY`, `PosZ`, `Orientation`, `PhaseUseFlags`, `PhaseId`, `PhaseGroup`, `Shape`, `ShapeData0`, `ShapeData1`, `ShapeData2`, `ShapeData3`, `ShapeData4`, `ShapeData5`, `ShapeData6`, `ShapeData7`, `Comment`, `VerifiedBuild`) VALUES
(@ATSPAWNID+0, 30222, 0, 2520, -3335.80908203125, 3656.329833984375, 110.8305435180664062, 0, 0, '0', 0, 3, 50.00000381469726562, 50.00000381469726562, 0, 0, 0, 0, 0, 0, '', 50469); -- 0 (Area: 0 - Difficulty: Normal)

DELETE FROM `areatrigger_polygon_vertex` WHERE `SpawnId`=@ATSPAWNID+0;
INSERT INTO `areatrigger_polygon_vertex` (`SpawnId`, `Idx`, `VerticeX`, `VerticeY`, `VerticeTargetX`, `VerticeTargetY`, `VerifiedBuild`) VALUES
(@ATSPAWNID+0, 0, -14.875, -27.498291015625, NULL, NULL, 50469),
(@ATSPAWNID+0, 1, -18.560791015625, -27.23779296875, NULL, NULL, 50469),
(@ATSPAWNID+0, 2, -21.01904296875, -23.427001953125, NULL, NULL, 50469),
(@ATSPAWNID+0, 3, -22.55029296875, -19.69775390625, NULL, NULL, 50469),
(@ATSPAWNID+0, 4, -25.25341796875, -17.7724609375, NULL, NULL, 50469),
(@ATSPAWNID+0, 5, -38.873291015625, -14.162353515625, NULL, NULL, 50469),
(@ATSPAWNID+0, 6, -53.617919921875, -25.576416015625, NULL, NULL, 50469),
(@ATSPAWNID+0, 7, -48.34716796875, -30.020751953125, NULL, NULL, 50469),
(@ATSPAWNID+0, 8, -2.564208984375, -57.7724609375, NULL, NULL, 50469),
(@ATSPAWNID+0, 9, 21.4619140625, -62.91748046875, NULL, NULL, 50469),
(@ATSPAWNID+0, 10, 50.552001953125, -62.6787109375, NULL, NULL, 50469),
(@ATSPAWNID+0, 11, 53.6181640625, -29.5927734375, NULL, NULL, 50469),
(@ATSPAWNID+0, 12, 49.29345703125, 12.471435546875, NULL, NULL, 50469),
(@ATSPAWNID+0, 13, 31.12158203125, 62.91748046875, NULL, NULL, 50469),
(@ATSPAWNID+0, 14, 5.84716796875, 41.8046875, NULL, NULL, 50469),
(@ATSPAWNID+0, 15, 15.348876953125, 31.609375, NULL, NULL, 50469),
(@ATSPAWNID+0, 16, 26.888916015625, 4.31689453125, NULL, NULL, 50469),
(@ATSPAWNID+0, 17, 25.046875, 1.756103515625, NULL, NULL, 50469),
(@ATSPAWNID+0, 18, 26.138916015625, -2.848876953125, NULL, NULL, 50469),
(@ATSPAWNID+0, 19, 22.029541015625, -5.12158203125, NULL, NULL, 50469),
(@ATSPAWNID+0, 20, 22.84033203125, -12.383544921875, NULL, NULL, 50469),
(@ATSPAWNID+0, 21, 20.8369140625, -14.572021484375, NULL, NULL, 50469),
(@ATSPAWNID+0, 22, 15.20654296875, -17.921875, NULL, NULL, 50469),
(@ATSPAWNID+0, 23, 13.15625, -20.111083984375, NULL, NULL, 50469),
(@ATSPAWNID+0, 24, 5.7275390625, -20.47998046875, NULL, NULL, 50469),
(@ATSPAWNID+0, 25, -2.489501953125, -22.403564453125, NULL, NULL, 50469);
```
(brackenhide hollow silence polygon effect at endboss, note: the visible cloud is a different areatrigger)
```sql
-- cloud would be this one
DELETE FROM `areatrigger` WHERE `SpawnId`=@ATSPAWNID+1;
INSERT INTO `areatrigger` (`SpawnId`, `AreaTriggerId`, `IsServerSide`, `MapId`, `PosX`, `PosY`, `PosZ`, `Orientation`, `PhaseUseFlags`, `PhaseId`, `PhaseGroup`, `Shape`, `ShapeData0`, `ShapeData1`, `ShapeData2`, `ShapeData3`, `ShapeData4`, `ShapeData5`, `ShapeData6`, `ShapeData7`, `SpellForVisuals`, `Comment`, `VerifiedBuild`) VALUES
(@ATSPAWNID+1, 6197, 0, 2520, -3304.897705078125, 3614.693603515625, 132.4971466064453125, 4.876865386962890625, 0, '0', 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 397750, '', 50469), -- 397750 ([DNT] OOB Visual) (Area: Den of Decay - Difficulty: Normal)
-- SpellForVisuals, will be added in a different pr
```

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Areatriggers with >= 5 vertices are not shown with `.debug areatrigger`, seems to be client bug
