### PR TITLE
Save enter/exit areatrigger info in Unit

### DIFF
--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -641,6 +641,8 @@ void AreaTrigger::HandleUnitEnterExit(std::vector<Unit*> const& newTargetList)
         DoActions(unit);
 
         _ai->OnUnitEnter(unit);
+
+        unit->EnterAreaTrigger(GetEntry(), GetGUID());
     }
 
     for (ObjectGuid const& exitUnitGuid : exitUnits)
@@ -654,6 +656,8 @@ void AreaTrigger::HandleUnitEnterExit(std::vector<Unit*> const& newTargetList)
 
                 player->UpdateQuestObjectiveProgress(QUEST_OBJECTIVE_AREA_TRIGGER_EXIT, GetEntry(), 1);
             }
+
+            leavingUnit->ExitAreaTrigger(GetEntry(), GetGUID());
 
             UndoActions(leavingUnit);
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5265,6 +5265,24 @@ void Unit::RemoveAllAreaTriggers()
         m_areaTrigger.front()->Remove();
 }
 
+void Unit::EnterAreaTrigger(uint32 areaTriggerId, ObjectGuid areaTriggerGUID)
+{
+    _insideAreaTriggers[areaTriggerId].insert(areaTriggerGUID);
+}
+
+void Unit::ExitAreaTrigger(uint32 areaTriggerId, ObjectGuid areaTriggerGUID)
+{
+    _insideAreaTriggers[areaTriggerId].erase(areaTriggerGUID);
+
+    if (_insideAreaTriggers[areaTriggerId].size() == 0)
+        _insideAreaTriggers.erase(areaTriggerId);
+}
+
+bool Unit::IsInAreaTrigger(uint32 areaTriggerId)
+{
+    return _insideAreaTriggers.find(areaTriggerId) != _insideAreaTriggers.end();
+}
+
 void Unit::SendSpellNonMeleeDamageLog(SpellNonMeleeDamage const* log)
 {
     WorldPackets::CombatLog::SpellNonMeleeDamageLog packet;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1702,6 +1702,10 @@ class TC_GAME_API Unit : public WorldObject
         void RemoveAreaTrigger(AuraEffect const* aurEff);
         void RemoveAllAreaTriggers();
 
+        void EnterAreaTrigger(uint32 areaTriggerId, ObjectGuid areaTriggerGUID);
+        void ExitAreaTrigger(uint32 areaTriggerId, ObjectGuid areaTriggerGUID);
+        bool IsInAreaTrigger(uint32 areaTriggerId);
+
         void ModifyAuraState(AuraStateType flag, bool apply);
         uint32 BuildAuraStateUpdateForTarget(Unit const* target) const;
         bool HasAuraState(AuraStateType flag, SpellInfo const* spellProto = nullptr, Unit const* Caster = nullptr) const;
@@ -1963,6 +1967,8 @@ class TC_GAME_API Unit : public WorldObject
 
         typedef std::vector<AreaTrigger*> AreaTriggerList;
         AreaTriggerList m_areaTrigger;
+
+        std::unordered_map<uint32 /*areaTriggerId*/, std::set<ObjectGuid>> _insideAreaTriggers;
 
         uint32 m_transformSpell;
 


### PR DESCRIPTION
**Changes proposed:**

We currently have a flaw in the AT enter/exit implementation, because if two same AT overlap and a player exit one while still being in the other, we still call OnUnitExit and potentialy remove an aura that the player should still have because he's still in the second AT. 

This PR allow to check in OnUnitEnter/Exit if the player was already in, or still in, an identical AT before applying/removing the corresponding aura (or any other action).

It also allow to easily check if an Unit is inside an AT, which is used by Blizzard on fights like Dargrul The Underking in the Neltharion's Lair. An AT is spawned behind the crystal pillars and rotate following Dargrul, if you're inside when he cast his magmawave you're safe.

**Issues addressed:**

None

**Tests performed:**

Build, tested ingame


**Known issues and TODO list:**

- Currently scripters would have to manually check in OnUnitExit if the unit is still in an identical AT, we could set a parameter in the hook but that would be a major breaking change.