### PR TITLE
Core/Movement: fixed an edge case between hover offsets and polygon selection during pathfinding

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -209,8 +209,13 @@ void PathGenerator::BuildPolyPath(G3D::Vector3 const& startPos, G3D::Vector3 con
     }
 
     // we may need a better number here
-    bool startFarFromPoly = distToStartPoly > 7.0f;
-    bool endFarFromPoly = distToEndPoly > 7.0f;
+    float allowedPolyDist = 7.0f;
+    if (Unit const* unit = _source->ToUnit())
+        if (unit->IsHovering()) // some hovering units hover above the original 7.0f threshold so we have to take their hover offset into consideration
+            allowedPolyDist = std::max(allowedPolyDist, unit->GetHoverOffset());
+
+    bool startFarFromPoly = distToStartPoly > allowedPolyDist;
+    bool endFarFromPoly = distToEndPoly > allowedPolyDist;
     if (startFarFromPoly || endFarFromPoly)
     {
         TC_LOG_DEBUG("maps.mmaps", "++ BuildPolyPath :: farFromPoly distToStartPoly={:.3f} distToEndPoly={:.3f}", distToStartPoly, distToEndPoly);


### PR DESCRIPTION
**Changes proposed:**

-  some units are moving above the ground by using hover movement. This can cause the unit to hover above 7.0yards which is the hardcoded distance limit at which the path generator determines that our path is incomplete due to being too far away from a polgyon. However, hovering units are technically still grounded so we are going to treat them like this and take their hover offset into consideration when checking for the distance between start point and polygon.

- this fixes all edge cases which lead to PATHFIND_INCOMPLETE being disabled in the ChaseMovementGenerator so it can be eneabled as well.

**Tests performed:**
- tested on 4.x

