### PR TITLE
Scripts/Trial of the Crusader: Update Read and Write Save Data

### DIFF
--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -573,57 +573,28 @@ class instance_trial_of_the_crusader : public InstanceMapScript
 
             void Save()
             {
-                OUT_SAVE_INST_DATA;
-
-                std::ostringstream saveStream;
-
-                for (uint8 i = 0; i < EncounterCount; ++i)
-                    saveStream << GetBossState(i) << ' ';
-
-                saveStream << TrialCounter << ' '
-                    << uint32(TributeToImmortalityEligible ? 1 : 0) << ' '
-                    << uint32(TributeToDedicatedInsanity ? 1 : 0);
-                SaveDataBuffer = saveStream.str();
-
                 SaveToDB();
-                OUT_SAVE_INST_DATA_COMPLETE;
                 NeedSave = false;
             }
 
-            std::string GetSaveData() override
+            void WriteSaveDataMore(std::ostringstream& data) override
             {
-                return SaveDataBuffer;
+                data << TrialCounter << ' '
+                    << uint32(TributeToImmortalityEligible ? 1 : 0) << ' '
+                    << uint32(TributeToDedicatedInsanity ? 1 : 0);
             }
 
-            void Load(char const* strIn) override
+            void ReadSaveDataMore(std::istringstream& data) override
             {
-                if (!strIn)
-                {
-                    OUT_LOAD_INST_DATA_FAIL;
-                    return;
-                }
+                uint32 temp = 0;
 
-                OUT_LOAD_INST_DATA(strIn);
+                data >> TrialCounter;
 
-                std::istringstream loadStream(strIn);
+                data >> temp;
+                TributeToImmortalityEligible = temp != 0;
 
-                uint32 tmpState;
-                for (uint8 i = 0; i < EncounterCount; ++i)
-                {
-                    loadStream >> tmpState;
-                    if (tmpState == IN_PROGRESS || tmpState > SPECIAL)
-                        tmpState = NOT_STARTED;
-                    SetBossState(i, EncounterState(tmpState));
-                }
-
-                loadStream >> TrialCounter;
-                loadStream >> tmpState;
-                TributeToImmortalityEligible = tmpState != 0;
-                loadStream >> tmpState;
-                TributeToDedicatedInsanity = tmpState != 0;
-                EventStage = 0;
-
-                OUT_LOAD_INST_DATA_COMPLETE;
+                data >> temp;
+                TributeToDedicatedInsanity = temp != 0;
             }
 
             bool CheckAchievementCriteriaMeet(uint32 criteria_id, Player const* /*source*/, Unit const* /*target*/, uint32 /*miscvalue1*/) override
@@ -671,7 +642,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 uint32 Team;
                 bool NeedSave;
                 bool CrusadersSpecialState;
-                std::string SaveDataBuffer;
                 GuidVector snoboldGUIDS;
 
                 // Achievement stuff


### PR DESCRIPTION
**Changes proposed:**

-  Update Read and Write Save Data
-  Fixes Lord Jaraxxus stuck case described here #24552
When you enter in the instance, boss states are 0 (NOT_STARTED), if you check instance table in char db, data field is empty
If you do a server restart without do anything in the instance and login again and enter in the instance, boss states are 5 (TO_BE_DECIDED)
So when Lord Jaraxxus is summoned, and do Reset(): https://github.com/TrinityCore/TrinityCore/blob/8e7b6c54e469e70d2a3d817e0f9b9d0ae46cbae6/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp#L116-L131
ACTION_JARAXXUS_INTRO can't be executed, so: https://github.com/TrinityCore/TrinityCore/blob/8e7b6c54e469e70d2a3d817e0f9b9d0ae46cbae6/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_lord_jaraxxus.cpp#L156-L160
EVENT_INTRO don't start and stuck.

**Issues addressed:**

Updates #24552

**Tests performed:**

tested in-game
