### PR TITLE
Core/Pets: Avoid loading creature_addon/creature_template_addon

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2040,7 +2040,9 @@ void Creature::setDeathState(DeathState s)
 
         Motion_Initialize();
         Unit::setDeathState(ALIVE);
-        LoadCreaturesAddon();
+
+        if (!IsPet())
+            LoadCreaturesAddon();
     }
 }
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1874,7 +1874,6 @@ bool Pet::Create(ObjectGuid::LowType guidlow, Map* map, uint32 phaseMask, uint32
     SetPhaseMask(phaseMask, false);
     Object::_Create(guidlow, petId, HighGuid::Pet);
 
-    m_spawnId = guidlow;
     m_originalEntry = Entry;
 
     if (!InitEntry(Entry))


### PR DESCRIPTION
**Changes proposed:**

-  Avoid loading creature_addon/creature_template_addon on Pets when JUST_RESPAWNED
-  Also removed m_spawnId when the pet is created

After this commit: https://github.com/TrinityCore/TrinityCore/commit/74a0d579eef07c013cc8deff930a975cf19c487f
when a hunter with his dead pet is revived by the BG or BF spirit guide, he casts spell 6962 to revive the pet.
The SpellScript is executed and the pet goes to JUST_RESPAWNED, then it executes: https://github.com/TrinityCore/TrinityCore/blob/6b9899e907a8ee7f6686419e67aaabb62d8d3a5a/src/server/game/Entities/Pet/Pet.cpp#L585

https://github.com/TrinityCore/TrinityCore/blob/6b9899e907a8ee7f6686419e67aaabb62d8d3a5a/src/server/game/Entities/Creature/Creature.cpp#L2009-L2046

https://github.com/TrinityCore/TrinityCore/blob/6b9899e907a8ee7f6686419e67aaabb62d8d3a5a/src/server/game/Entities/Creature/Creature.cpp#L2514

Finally it searches for m_spawnId and in case and if it matches load creature_addon data, otherwise, try searching creature_template_addon for the pet entry.
https://github.com/TrinityCore/TrinityCore/blob/6b9899e907a8ee7f6686419e67aaabb62d8d3a5a/src/server/game/Entities/Creature/Creature.cpp#L2499-L2506
This leads to a situation where a hunter's pet can obtain the creature_addon of an NPC if their m_spawnId matches, potentially gaining auras defined in the database with that guid
Also with creature_template_addon.

So I add check to prevent it from loading creature_template_addon/creature_addon when JUST_RESPAWNED in case it is a pet.

And about m_spawnId: https://github.com/TrinityCore/TrinityCore/blob/6b9899e907a8ee7f6686419e67aaabb62d8d3a5a/src/server/game/Entities/Pet/Pet.cpp#L1877
Previously known as m_DBTableGuid (inherited from mangos I think), it was renamed to m_spawnId here: https://github.com/TrinityCore/TrinityCore/commit/dcb7082277447c21b11c4a1d59f105fa342c172e
Creatures and Gameobjects supposedly use it to determine their spawn in the database.
I'm curious as to why this is set when creating a pet, as it seems to only cause issues, I have decided to remove it because I don't see the point and so you can assess if it is appropriate to remove it or we should keep it for some reason that I don't know.


**Issues addressed:**

None


**Tests performed:**

For creature_template_addon case:
- Get a hunter and tame by example npc 684 that have aura 22766 in creature_template_addon
- enter in a battleground, wait until preparation ends
- check pet auras using command .list aura
- kill pet, kill self, Release Spirit and wait until spirit guide resurrect
- check pet auras using command .list aura, now pet should have aura 22766
Example: https://imgur.com/a/sPbNtmQ

For creature_addon case:
- Execute this query in world BD:
```sql
-- This is only for test, don't execute it
-- Empty creature_addon table and give all existing spawns the same creature_addon to have all the aura 43910
DELETE FROM `creature_addon`;
INSERT INTO `creature_addon` (`guid`, `auras`)
SELECT guid, '43910' FROM creature;
```
- Get a hunter and enter in a battleground, wait until preparation ends
- check pet auras using command .list aura
- kill pet, kill self, Release Spirit and wait until spirit guide resurrect
- check pet auras using command .list aura, now pet should have aura 43910
Example: https://imgur.com/a/xWgNtk3
