### PR TITLE
Core/Quests: Ignore update of optional objectives if quest is completed

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16546,7 +16546,7 @@ void Player::UpdateQuestObjectiveProgress(QuestObjectiveType objectiveType, int3
             continue;
 
         // Ignore update of optional objectives if quest is completed
-        if ((GetQuestStatus(quest->GetQuestId()) == QUEST_STATUS_COMPLETE) && (objective.Flags & (QUEST_OBJECTIVE_FLAG_OPTIONAL)))
+        if (GetQuestStatus(quest->GetQuestId()) == QUEST_STATUS_COMPLETE && objective.Flags & QUEST_OBJECTIVE_FLAG_OPTIONAL)
             continue;
 
         if (quest->HasFlagEx(QUEST_FLAGS_EX_NO_CREDIT_FOR_PROXY))

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16545,6 +16545,10 @@ void Player::UpdateQuestObjectiveProgress(QuestObjectiveType objectiveType, int3
         if (!IsQuestObjectiveCompletable(logSlot, quest, objective))
             continue;
 
+        // Ignore update of optional objectives if quest is completed
+        if ((GetQuestStatus(quest->GetQuestId()) == QUEST_STATUS_COMPLETE) && (objective.Flags & (QUEST_OBJECTIVE_FLAG_OPTIONAL)))
+            continue;
+
         if (quest->HasFlagEx(QUEST_FLAGS_EX_NO_CREDIT_FOR_PROXY))
             if (objective.Type == QUEST_OBJECTIVE_MONSTER && victimGuid.IsEmpty())
                 continue;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Ignore update of optional objectives if quest is completed
-  This logic (https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Entities/Player/Player.cpp#L16655) causes that a completed quest is flagged as incomplete when processing an optional objective (Player::CanCompleteQuest returns false as quest is already completed)

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game ([Quest 8488](https://www.wowhead.com/quest=8488/unexpected-results))


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
