### PR TITLE
Core/Achievements: Fix typo in criterias with start events

### DIFF
--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -4714,7 +4714,7 @@ void CriteriaMgr::LoadCriteriaList()
             _questObjectiveCriteriasByType[criteriaEntry->Type].push_back(criteria);
         }
 
-        if (criteriaEntry->StartTimer)
+        if (criteriaEntry->StartEvent)
             _criteriasByStartEvent[criteriaEntry->StartEvent][criteriaEntry->StartAsset].push_back(criteria);
 
         if (criteriaEntry->FailEvent)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix typo for starting criterias

**Issues addressed:**

Closes: https://github.com/TrinityCore/TrinityCore/issues/29347


**Tests performed:**

- Buidls locally
- Tested the issue described, achievement works now

**Known issues and TODO list:**

- None



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
