### PR TITLE
Build: added support for Unity builds in all projects except for scripts

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -55,6 +55,7 @@ set(WITH_SOURCE_TREE    "hierarchical" CACHE STRING "Build the source tree for I
 set_property(CACHE WITH_SOURCE_TREE PROPERTY STRINGS no flat hierarchical hierarchical-folders)
 option(WITHOUT_GIT      "Disable the GIT testing routines"                            0)
 option(BUILD_TESTING    "Build test suite" 0)
+option(UNITY_BUILDS     "Enables the unity build mode which combines multiple source files into buckets to speed up build time" 0)
 
 if(UNIX)
   option(USE_LD_GOLD    "Use GNU gold linker"                                        0)

--- a/cmake/showoptions.cmake
+++ b/cmake/showoptions.cmake
@@ -45,6 +45,12 @@ else()
   message("* Build unit tests       : No (default)")
 endif()
 
+if(UNITY_BUILDS)
+  message("* Unity build enabled    : Yes")
+else()
+  message("* Unity build enabled    : No (default)")
+endif()
+
 if(USE_COREPCH)
   message("* Build core w/PCH       : Yes (default)")
 else()

--- a/dep/SFMT/CMakeLists.txt
+++ b/dep/SFMT/CMakeLists.txt
@@ -83,3 +83,12 @@ set_target_properties(sfmt
     PROPERTIES
       FOLDER
         "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(sfmt
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(sfmt
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/argon2/CMakeLists.txt
+++ b/dep/argon2/CMakeLists.txt
@@ -39,3 +39,12 @@ set_target_properties(argon2
   PROPERTIES
     FOLDER
       "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(argon2
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(argon2
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/bzip2/CMakeLists.txt
+++ b/dep/bzip2/CMakeLists.txt
@@ -41,3 +41,12 @@ else()
       FOLDER
         "dep")
 endif()
+
+if(UNITY_BUILDS)
+  set_target_properties(bzip2
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(bzip2
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/efsw/CMakeLists.txt
+++ b/dep/efsw/CMakeLists.txt
@@ -88,3 +88,12 @@ if (BUILD_SHARED_LIBS)
 else ()
   add_library(efsw INTERFACE IMPORTED GLOBAL)
 endif ()
+
+if(UNITY_BUILDS)
+  set_target_properties(efsw
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(efsw
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/fmt/CMakeLists.txt
+++ b/dep/fmt/CMakeLists.txt
@@ -43,3 +43,12 @@ set_target_properties(fmt
   PROPERTIES
     FOLDER
       "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(fmt
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(fmt
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/g3dlite/CMakeLists.txt
+++ b/dep/g3dlite/CMakeLists.txt
@@ -71,3 +71,12 @@ set_target_properties(g3dlib
     PROPERTIES
       FOLDER
         "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(g3dlib
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(g3dlib
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/gsoap/CMakeLists.txt
+++ b/dep/gsoap/CMakeLists.txt
@@ -27,6 +27,15 @@ set_target_properties(gsoap
       FOLDER
         "dep")
 
+if(UNITY_BUILDS)
+  set_target_properties(gsoap
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(gsoap
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 7)
+endif()
+
 if (MSVC)
   # Little fix for MSVC / Windows platforms
   target_compile_definitions(gsoap

--- a/dep/jemalloc/CMakeLists.txt
+++ b/dep/jemalloc/CMakeLists.txt
@@ -117,3 +117,12 @@ else()
       valgrind)
 
 endif()
+
+if(UNITY_BUILDS)
+  set_target_properties(jemalloc
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(jemalloc
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()

--- a/dep/libmpq/CMakeLists.txt
+++ b/dep/libmpq/CMakeLists.txt
@@ -36,3 +36,12 @@ set_target_properties(mpq
     PROPERTIES
       FOLDER
         "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(mpq
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(mpq
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 2)
+endif()

--- a/dep/recastnavigation/Detour/CMakeLists.txt
+++ b/dep/recastnavigation/Detour/CMakeLists.txt
@@ -34,3 +34,12 @@ set_target_properties(Detour
     PROPERTIES
       FOLDER
         "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(Detour
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(Detour
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 7)
+endif()

--- a/dep/recastnavigation/Recast/CMakeLists.txt
+++ b/dep/recastnavigation/Recast/CMakeLists.txt
@@ -38,3 +38,12 @@ set_target_properties(Recast
     PROPERTIES
       FOLDER
         "dep")
+
+if(UNITY_BUILDS)
+  set_target_properties(Recast
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(Recast
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 2)
+endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -82,6 +82,15 @@ set_target_properties(common
       FOLDER
         "server")
 
+if(UNITY_BUILDS)
+  set_target_properties(common
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(common
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()
+
 if(BUILD_SHARED_LIBS)
   if(UNIX)
     install(TARGETS common

--- a/src/server/authserver/CMakeLists.txt
+++ b/src/server/authserver/CMakeLists.txt
@@ -63,6 +63,15 @@ set_target_properties(authserver
       FOLDER
         "server")
 
+if(UNITY_BUILDS)
+  set_target_properties(authserver
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(authserver
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 2)
+endif()
+
 if(COPY_CONF AND WIN32)
   if("${CMAKE_MAKE_PROGRAM}" MATCHES "MSBuild")
     add_custom_command(TARGET authserver

--- a/src/server/database/CMakeLists.txt
+++ b/src/server/database/CMakeLists.txt
@@ -59,6 +59,15 @@ set_target_properties(database
       FOLDER
         "server")
 
+if(UNITY_BUILDS)
+  set_target_properties(database
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(database
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()
+
 if(BUILD_SHARED_LIBS)
   if(UNIX)
     install(TARGETS database

--- a/src/server/game/CMakeLists.txt
+++ b/src/server/game/CMakeLists.txt
@@ -60,6 +60,15 @@ set_target_properties(game
       FOLDER
         "server")
 
+if(UNITY_BUILDS)
+  set_target_properties(game
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(game
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()
+
 if(BUILD_SHARED_LIBS)
   if(UNIX)
     install(TARGETS game

--- a/src/server/shared/CMakeLists.txt
+++ b/src/server/shared/CMakeLists.txt
@@ -50,6 +50,15 @@ set_target_properties(shared
       FOLDER
         "server")
 
+if(UNITY_BUILDS)
+  set_target_properties(shared
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(shared
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()
+
 if(BUILD_SHARED_LIBS)
   if(UNIX)
     install(TARGETS shared

--- a/src/server/worldserver/CMakeLists.txt
+++ b/src/server/worldserver/CMakeLists.txt
@@ -70,6 +70,15 @@ set_target_properties(worldserver
       FOLDER
         "server")
 
+if(UNITY_BUILDS)
+  set_target_properties(worldserver
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(worldserver
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()
+
 # Add all dynamic projects as dependency to the worldserver
 if(WORLDSERVER_DYNAMIC_SCRIPT_MODULES_DEPENDENCIES)
   add_dependencies(worldserver ${WORLDSERVER_DYNAMIC_SCRIPT_MODULES_DEPENDENCIES})

--- a/src/tools/map_extractor/CMakeLists.txt
+++ b/src/tools/map_extractor/CMakeLists.txt
@@ -45,6 +45,15 @@ set_target_properties(mapextractor
       FOLDER
         "tools")
 
+if(UNITY_BUILDS)
+  set_target_properties(mapextractor
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(mapextractor
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 6)
+endif()
+
 if(UNIX)
   install(TARGETS mapextractor DESTINATION bin)
 elseif(WIN32)

--- a/src/tools/mmaps_generator/CMakeLists.txt
+++ b/src/tools/mmaps_generator/CMakeLists.txt
@@ -40,6 +40,15 @@ set_target_properties(mmaps_generator
       FOLDER
         "tools")
 
+if(UNITY_BUILDS)
+  set_target_properties(mmaps_generator
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(mmaps_generator
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 4)
+endif()
+
 if(UNIX)
   install(TARGETS mmaps_generator DESTINATION bin)
 elseif(WIN32)

--- a/src/tools/vmap4_extractor/CMakeLists.txt
+++ b/src/tools/vmap4_extractor/CMakeLists.txt
@@ -28,6 +28,15 @@ set_target_properties(vmap4extractor
       FOLDER
         "tools")
 
+if(UNITY_BUILDS)
+  set_target_properties(vmap4extractor
+      PROPERTIES UNITY_BUILD ON)
+  set_target_properties(vmap4extractor
+      PROPERTIES
+        UNITY_BUILD_MODE BATCH
+        UNITY_BUILD_BATCH_SIZE 8)
+endif()
+
 if(UNIX)
   install(TARGETS vmap4extractor DESTINATION bin)
 elseif(WIN32)


### PR DESCRIPTION
**Changes proposed:**

-  enable the unity build functionality via cmake option which allows us to merge multiple source files into a single unity files to speed up build time.


**Tests performed:**
- builds. build time is effectively cut in half

**Todo:**
- the scripts project cannot be built with unity building right now due to its unscoped enum mess which needs a big refactor to work properly