### PR TITLE
Core/Map: Implement several difficulty getters

### DIFF
--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -303,6 +303,41 @@ bool ScriptedAI::HealthAbovePct(uint32 pct) const
     return me->HealthAbovePct(pct);
 }
 
+bool ScriptedAI::IsLFR() const
+{
+    return me->GetMap()->IsLFR();
+}
+
+bool ScriptedAI::IsNormal() const
+{
+    return me->GetMap()->IsNormal();
+}
+
+bool ScriptedAI::IsHeroic() const
+{
+    return me->GetMap()->IsHeroic();
+}
+
+bool ScriptedAI::IsMythic() const
+{
+    return me->GetMap()->IsMythic();
+}
+
+bool ScriptedAI::IsMythicPlus() const
+{
+    return me->GetMap()->IsMythicPlus();
+}
+
+bool ScriptedAI::IsHeroicOrHigher() const
+{
+    return me->GetMap()->IsHeroicOrHigher();
+}
+
+bool ScriptedAI::IsTimewalking() const
+{
+    return me->GetMap()->IsTimewalking();
+}
+
 SpellInfo const* ScriptedAI::SelectSpell(Unit* target, uint32 school, uint32 mechanic, SelectTargetType targets, float rangeMin, float rangeMax, SelectEffect effect)
 {
     // No target so we can't cast

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.cpp
@@ -126,7 +126,6 @@ ScriptedAI::ScriptedAI(Creature* creature) : ScriptedAI(creature, creature->GetS
 
 ScriptedAI::ScriptedAI(Creature* creature, uint32 scriptId) : CreatureAI(creature, scriptId), IsFleeing(false), _isCombatMovementAllowed(true)
 {
-    _isHeroic = me->GetMap()->IsHeroic();
     _difficulty = me->GetMap()->GetDifficultyID();
 }
 

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -237,13 +237,13 @@ struct TC_GAME_API ScriptedAI : public CreatureAI
         void SetCombatMovement(bool allowMovement);
         bool IsCombatMovementAllowed() const { return _isCombatMovementAllowed; }
 
-        bool IsLFR() const { return me->GetMap()->IsLFR(); }
-        bool IsNormal() const { return me->GetMap()->IsNormal(); }
-        bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
-        bool IsMythic() const { return me->GetMap()->IsMythic(); }
-        bool IsMythicPlus() const { return me->GetMap()->IsMythicPlus(); }
-        bool IsHeroicOrHigher() const { return me->GetMap()->IsHeroicOrHigher(); }
-        bool IsTimewalking() const { return me->GetMap()->IsTimewalking(); }
+        bool IsLFR() const;
+        bool IsNormal() const;
+        bool IsHeroic() const;
+        bool IsMythic() const;
+        bool IsMythicPlus() const;
+        bool IsHeroicOrHigher() const;
+        bool IsTimewalking() const;
 
         // return the dungeon or raid difficulty
         Difficulty GetDifficulty() const { return _difficulty; }

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -242,6 +242,7 @@ struct TC_GAME_API ScriptedAI : public CreatureAI
         bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
         bool IsMythic() const { return me->GetMap()->IsMythic(); }
         bool IsMythicPlus() const { return me->GetMap()->IsMythicPlus(); }
+        bool IsHeroicOrHigher() const { return me->GetMap()->IsHeroicOrHigher(); }
         bool IsTimewalking() const { return me->GetMap()->IsTimewalking(); }
 
         // return the dungeon or raid difficulty

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -237,12 +237,11 @@ struct TC_GAME_API ScriptedAI : public CreatureAI
         void SetCombatMovement(bool allowMovement);
         bool IsCombatMovementAllowed() const { return _isCombatMovementAllowed; }
 
-        // return true for heroic mode. i.e.
-        //   - for dungeon in mode 10-heroic,
-        //   - for raid in mode 10-Heroic
-        //   - for raid in mode 25-heroic
-        // DO NOT USE to check raid in mode 25-normal.
-        bool IsHeroic() const { return _isHeroic; }
+        bool IsLFR() const { return me->GetMap()->IsLFR(); }
+        bool IsNormal() const { return me->GetMap()->IsNormal(); }
+        bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
+        bool IsMythic() const { return me->GetMap()->IsMythic(); }
+        bool IsTimewalking() const { return me->GetMap()->IsTimewalking(); }
 
         // return the dungeon or raid difficulty
         Difficulty GetDifficulty() const { return _difficulty; }
@@ -305,7 +304,6 @@ struct TC_GAME_API ScriptedAI : public CreatureAI
     private:
         Difficulty _difficulty;
         bool _isCombatMovementAllowed;
-        bool _isHeroic;
 };
 
 class TC_GAME_API BossAI : public ScriptedAI

--- a/src/server/game/AI/ScriptedAI/ScriptedCreature.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedCreature.h
@@ -241,6 +241,7 @@ struct TC_GAME_API ScriptedAI : public CreatureAI
         bool IsNormal() const { return me->GetMap()->IsNormal(); }
         bool IsHeroic() const { return me->GetMap()->IsHeroic(); }
         bool IsMythic() const { return me->GetMap()->IsMythic(); }
+        bool IsMythicPlus() const { return me->GetMap()->IsMythicPlus(); }
         bool IsTimewalking() const { return me->GetMap()->IsTimewalking(); }
 
         // return the dungeon or raid difficulty

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -909,14 +909,14 @@ enum Difficulty : uint8
 
 enum DifficultyFlags
 {
-    DIFFICULTY_FLAG_HEROIC          = 0x01,
-    DIFFICULTY_FLAG_DEFAULT         = 0x02,
-    DIFFICULTY_FLAG_CAN_SELECT      = 0x04, // Player can select this difficulty in dropdown menu
-    DIFFICULTY_FLAG_CHALLENGE_MODE  = 0x08,
-
-    DIFFICULTY_FLAG_LEGACY          = 0x20,
-    DIFFICULTY_FLAG_DISPLAY_HEROIC  = 0x40, // Controls icon displayed on minimap when inside the instance
-    DIFFICULTY_FLAG_DISPLAY_MYTHIC  = 0x80  // Controls icon displayed on minimap when inside the instance
+    DIFFICULTY_FLAG_HEROIC_STYLE_LOCKOUTS   = 0x01,
+    DIFFICULTY_FLAG_DEFAULT                 = 0x02,
+    DIFFICULTY_FLAG_CAN_SELECT              = 0x04, // Player can select this difficulty in dropdown menu
+    //DIFFICULTY_FLAG_CHALLENGE_MODE          = 0x08, // deprecated since Legion expansion
+    DIFFICULTY_FLAG_LFG_ONLY                = 0x10,
+    DIFFICULTY_FLAG_LEGACY                  = 0x20,
+    DIFFICULTY_FLAG_DISPLAY_HEROIC          = 0x40, // Controls icon displayed on minimap when inside the instance
+    DIFFICULTY_FLAG_DISPLAY_MYTHIC          = 0x80  // Controls icon displayed on minimap when inside the instance
 };
 
 enum class ExpectedStatType : uint8

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3255,6 +3255,11 @@ bool Map::IsMythicPlus() const
     return IsDungeon() && i_spawnMode == DIFFICULTY_MYTHIC_KEYSTONE;
 }
 
+bool Map::IsHeroicOrHigher() const
+{
+    return IsHeroic() || IsMythic() || IsMythicPlus();
+}
+
 bool Map::Is25ManRaid() const
 {
     return IsRaid() && (i_spawnMode == DIFFICULTY_25_N || i_spawnMode == DIFFICULTY_25_HC);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3250,6 +3250,11 @@ bool Map::IsMythic() const
     return false;
 }
 
+bool Map::IsMythicPlus() const
+{
+    return IsDungeon() && i_spawnMode == DIFFICULTY_MYTHIC_KEYSTONE;
+}
+
 bool Map::Is25ManRaid() const
 {
     return IsRaid() && (i_spawnMode == DIFFICULTY_25_N || i_spawnMode == DIFFICULTY_25_HC);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3193,11 +3193,49 @@ bool Map::IsRaid() const
     return i_mapEntry && i_mapEntry->IsRaid();
 }
 
+bool Map::IsLFR() const
+{
+    switch (i_spawnMode)
+    {
+        case DIFFICULTY_LFR:
+        case DIFFICULTY_LFR_NEW:
+        case DIFFICULTY_LFR_15TH_ANNIVERSARY:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool Map::IsNormal() const
+{
+    switch (i_spawnMode)
+    {
+        case DIFFICULTY_NORMAL:
+        case DIFFICULTY_10_N:
+        case DIFFICULTY_25_N:
+        case DIFFICULTY_NORMAL_RAID:
+        case DIFFICULTY_NORMAL_ISLAND:
+        case DIFFICULTY_NORMAL_WARFRONT:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool Map::IsHeroic() const
 {
-    if (DifficultyEntry const* difficulty = sDifficultyStore.LookupEntry(i_spawnMode))
-        return difficulty->Flags & DIFFICULTY_FLAG_HEROIC;
-    return false;
+    switch (i_spawnMode)
+    {
+        case DIFFICULTY_10_HC:
+        case DIFFICULTY_25_HC:
+        case DIFFICULTY_HEROIC:
+        case DIFFICULTY_3_MAN_SCENARIO_HC:
+            return true;
+        default:
+            if (DifficultyEntry const* difficulty = sDifficultyStore.LookupEntry(i_spawnMode))
+                return difficulty->Flags & DIFFICULTY_FLAG_DISPLAY_HEROIC;
+            return false;
+    }
 }
 
 bool Map::IsMythic() const
@@ -3207,11 +3245,6 @@ bool Map::IsMythic() const
     return false;
 }
 
-bool Map::IsHeroicOrMythic() const
-{
-    return IsHeroic() || IsMythic();
-}
-
 bool Map::Is25ManRaid() const
 {
     return IsRaid() && (i_spawnMode == DIFFICULTY_25_N || i_spawnMode == DIFFICULTY_25_HC);
@@ -3219,7 +3252,7 @@ bool Map::Is25ManRaid() const
 
 bool Map::IsTimewalking() const
 {
-    return (IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING)) || (IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID));
+    return (IsDungeon() && i_spawnMode == DIFFICULTY_TIMEWALKING) || (IsRaid() && i_spawnMode == DIFFICULTY_TIMEWALKING_RAID);
 }
 
 bool Map::IsBattleground() const

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3200,9 +3200,26 @@ bool Map::IsHeroic() const
     return false;
 }
 
+bool Map::IsMythic() const
+{
+    if (DifficultyEntry const* difficulty = sDifficultyStore.LookupEntry(i_spawnMode))
+        return difficulty->Flags & DIFFICULTY_FLAG_DISPLAY_MYTHIC;
+    return false;
+}
+
+bool Map::IsHeroicOrMythic() const
+{
+    return IsHeroic() || IsMythic();
+}
+
 bool Map::Is25ManRaid() const
 {
     return IsRaid() && (i_spawnMode == DIFFICULTY_25_N || i_spawnMode == DIFFICULTY_25_HC);
+}
+
+bool Map::IsTimewalking() const
+{
+    return (IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID) || IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING));
 }
 
 bool Map::IsBattleground() const

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3219,7 +3219,7 @@ bool Map::Is25ManRaid() const
 
 bool Map::IsTimewalking() const
 {
-    return (IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING) || IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID));
+    return IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING) || IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID);
 }
 
 bool Map::IsBattleground() const

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3219,7 +3219,7 @@ bool Map::Is25ManRaid() const
 
 bool Map::IsTimewalking() const
 {
-    return IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING) || IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID);
+    return (IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING)) || (IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID));
 }
 
 bool Map::IsBattleground() const

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3219,7 +3219,7 @@ bool Map::Is25ManRaid() const
 
 bool Map::IsTimewalking() const
 {
-    return (IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID) || IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING));
+    return (IsDungeon() && (i_spawnMode == DIFFICULTY_TIMEWALKING) || IsRaid() && (i_spawnMode == DIFFICULTY_TIMEWALKING_RAID));
 }
 
 bool Map::IsBattleground() const

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3224,6 +3224,13 @@ bool Map::IsNormal() const
 
 bool Map::IsHeroic() const
 {
+    if (DifficultyEntry const* difficulty = sDifficultyStore.LookupEntry(i_spawnMode))
+    {
+        if (difficulty->Flags & DIFFICULTY_FLAG_DISPLAY_HEROIC)
+            return true;
+    }
+
+    // compatibility purposes of old difficulties
     switch (i_spawnMode)
     {
         case DIFFICULTY_10_HC:
@@ -3232,8 +3239,6 @@ bool Map::IsHeroic() const
         case DIFFICULTY_3_MAN_SCENARIO_HC:
             return true;
         default:
-            if (DifficultyEntry const* difficulty = sDifficultyStore.LookupEntry(i_spawnMode))
-                return difficulty->Flags & DIFFICULTY_FLAG_DISPLAY_HEROIC;
             return false;
     }
 }

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -315,7 +315,10 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         bool IsNonRaidDungeon() const;
         bool IsRaid() const;
         bool IsHeroic() const;
+        bool IsMythic() const;
+        bool IsHeroicOrMythic() const;
         bool Is25ManRaid() const;
+        bool IsTimewalking() const;
         bool IsBattleground() const;
         bool IsBattleArena() const;
         bool IsBattlegroundOrArena() const;

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -314,9 +314,10 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         bool IsDungeon() const;
         bool IsNonRaidDungeon() const;
         bool IsRaid() const;
+        bool IsLFR() const;
+        bool IsNormal() const;
         bool IsHeroic() const;
         bool IsMythic() const;
-        bool IsHeroicOrMythic() const;
         bool Is25ManRaid() const;
         bool IsTimewalking() const;
         bool IsBattleground() const;

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -319,6 +319,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         bool IsHeroic() const;
         bool IsMythic() const;
         bool IsMythicPlus() const;
+        bool IsHeroicOrHigher() const;
         bool Is25ManRaid() const;
         bool IsTimewalking() const;
         bool IsBattleground() const;

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -318,6 +318,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         bool IsNormal() const;
         bool IsHeroic() const;
         bool IsMythic() const;
+        bool IsMythicPlus() const;
         bool Is25ManRaid() const;
         bool IsTimewalking() const;
         bool IsBattleground() const;

--- a/src/server/scripts/Argus/AntorusTheBurningThrone/boss_garothi_worldbreaker.cpp
+++ b/src/server/scripts/Argus/AntorusTheBurningThrone/boss_garothi_worldbreaker.cpp
@@ -826,7 +826,7 @@ class spell_garothi_cannon_chooser : public SpellScript
         }
         else if ((lastCannonEntry == NPC_DECIMATOR && annihilator) || (annihilator && !decimator))
         {
-            uint8 count = caster->GetMap()->GetDifficultyID() == DIFFICULTY_MYTHIC_RAID ? MAX_TARGETS_SIZE :
+            uint8 count = caster->GetMap()->IsMythic() ? MAX_TARGETS_SIZE :
                 std::max<uint8>(MIN_TARGETS_SIZE, std::ceil(float(caster->GetMap()->GetPlayersCountExceptGMs()) / 5));
 
             for (uint8 i = 0; i < count; i++)

--- a/src/server/scripts/Argus/AntorusTheBurningThrone/boss_garothi_worldbreaker.cpp
+++ b/src/server/scripts/Argus/AntorusTheBurningThrone/boss_garothi_worldbreaker.cpp
@@ -271,7 +271,7 @@ struct boss_garothi_worldbreaker : public BossAI
             me->SetFacingTo(me->GetHomePosition().GetOrientation());
             events.Reset();
 
-            if (GetDifficulty() == DIFFICULTY_MYTHIC_RAID || GetDifficulty() == DIFFICULTY_HEROIC_RAID)
+            if (IsHeroic() || IsMythic())
                 events.ScheduleEvent(EVENT_SURGING_FEL, 8s);
 
             DoCastSelf(SPELL_APOCALYPSE_DRIVE);

--- a/src/server/scripts/BrokenIsles/TrialOfValor/boss_guarm.cpp
+++ b/src/server/scripts/BrokenIsles/TrialOfValor/boss_guarm.cpp
@@ -214,12 +214,12 @@ struct boss_guarm : public BossAI
         events.ScheduleEvent(EVENT_CHECK_ENERGY, 500ms);
         events.ScheduleEvent(EVENT_OFF_THE_LEASH, 45s);
 
-        if (GetDifficulty() == DIFFICULTY_MYTHIC_RAID)
+        if (IsMythic())
         {
             events.ScheduleEvent(EVENT_VOLATILE_FOAM, 11s);
             events.ScheduleEvent(EVENT_BERSERK, 4min + 4s);
         }
-        else if (GetDifficulty() == DIFFICULTY_HEROIC_RAID)
+        else if (IsHeroic())
             events.ScheduleEvent(EVENT_BERSERK, 5min);
         else if (GetDifficulty() == DIFFICULTY_NORMAL_RAID)
             events.ScheduleEvent(EVENT_BERSERK, 6min);
@@ -300,7 +300,7 @@ struct boss_guarm : public BossAI
         me->SetReactState(REACT_AGGRESSIVE);
         events.ScheduleEvent(EVENT_FLASHING_FANGS, 16s);
         events.ScheduleEvent(EVENT_LICK, 18s);
-        if (GetDifficulty() == DIFFICULTY_MYTHIC_RAID)
+        if (IsMythic())
             events.ScheduleEvent(EVENT_VOLATILE_FOAM, 20s);
 
         // Headlong Charge

--- a/src/server/scripts/DragonIsles/AzureVault/boss_leymor.cpp
+++ b/src/server/scripts/DragonIsles/AzureVault/boss_leymor.cpp
@@ -317,7 +317,7 @@ struct npc_ley_line_sprouts : public ScriptedAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        if (GetDifficulty() == DIFFICULTY_MYTHIC || GetDifficulty() == DIFFICULTY_MYTHIC_KEYSTONE)
+        if (IsMythic())
             DoCastAOE(SPELL_VOLATILE_SAPLING, true);
 
         if (TempSummon* tempSummon = me->ToTempSummon())

--- a/src/server/scripts/DragonIsles/AzureVault/boss_leymor.cpp
+++ b/src/server/scripts/DragonIsles/AzureVault/boss_leymor.cpp
@@ -317,7 +317,7 @@ struct npc_ley_line_sprouts : public ScriptedAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        if (IsMythic())
+        if (IsMythic() || IsMythicPlus())
             DoCastAOE(SPELL_VOLATILE_SAPLING, true);
 
         if (TempSummon* tempSummon = me->ToTempSummon())

--- a/src/server/scripts/Zandalar/Underrot/boss_cragmaw_the_infested.cpp
+++ b/src/server/scripts/Zandalar/Underrot/boss_cragmaw_the_infested.cpp
@@ -148,7 +148,7 @@ struct boss_cragmaw_the_infested : public BossAI
         if (Creature* fetidMaggot = ObjectAccessor::GetCreature(*me, _fetidMaggotGuid))
             fetidMaggot->DespawnOrUnsummon();
 
-        if (IsHeroic() || GetDifficulty() == DIFFICULTY_MYTHIC || GetDifficulty() == DIFFICULTY_MYTHIC_KEYSTONE)
+        if (IsHeroic() || IsMythic())
             DoCast(SPELL_POWER_ENERGIZE_TANTRUM);
     }
 

--- a/src/server/scripts/Zandalar/Underrot/boss_cragmaw_the_infested.cpp
+++ b/src/server/scripts/Zandalar/Underrot/boss_cragmaw_the_infested.cpp
@@ -148,7 +148,7 @@ struct boss_cragmaw_the_infested : public BossAI
         if (Creature* fetidMaggot = ObjectAccessor::GetCreature(*me, _fetidMaggotGuid))
             fetidMaggot->DespawnOrUnsummon();
 
-        if (IsHeroic() || IsMythic())
+        if (IsHeroicOrHigher())
             DoCast(SPELL_POWER_ENERGIZE_TANTRUM);
     }
 

--- a/src/server/scripts/Zandalar/Underrot/boss_elder_leaxa.cpp
+++ b/src/server/scripts/Zandalar/Underrot/boss_elder_leaxa.cpp
@@ -92,7 +92,7 @@ struct boss_elder_leaxa : public BossAI
         Talk(SAY_AGGRO);
         me->SetAIAnimKitId(0);
         events.ScheduleEvent(EVENT_BLOOD_BOLT, 1s);
-        if (IsHeroic() || IsMythic())
+        if (IsHeroicOrHigher())
             events.ScheduleEvent(EVENT_SANGUINE_FEAST, 8s);
         events.ScheduleEvent(EVENT_CREEPING_ROT, 12s);
         events.ScheduleEvent(EVENT_BLOOD_MIRROR, 17s);

--- a/src/server/scripts/Zandalar/Underrot/boss_elder_leaxa.cpp
+++ b/src/server/scripts/Zandalar/Underrot/boss_elder_leaxa.cpp
@@ -92,7 +92,7 @@ struct boss_elder_leaxa : public BossAI
         Talk(SAY_AGGRO);
         me->SetAIAnimKitId(0);
         events.ScheduleEvent(EVENT_BLOOD_BOLT, 1s);
-        if (IsHeroic() || GetDifficulty() == DIFFICULTY_MYTHIC || GetDifficulty() == DIFFICULTY_MYTHIC_KEYSTONE)
+        if (IsHeroic() || IsMythic())
             events.ScheduleEvent(EVENT_SANGUINE_FEAST, 8s);
         events.ScheduleEvent(EVENT_CREEPING_ROT, 12s);
         events.ScheduleEvent(EVENT_BLOOD_MIRROR, 17s);


### PR DESCRIPTION
**Changes proposed:**

-  Implemented some map mode getters: IsMythic, IsHeroicOrMythic, and IsTimewalking. These are usable both in dungeon, raid, expedition islands, and warfronts maps since parent getters check for map flags directly. Also, these should be helpful to scripters in the future to avoid overcrowding the code with GetDifficultyID and enumerates.
- Updated a script with one of them.

**Issues addressed:**

None.

**Tests performed:**

It was tested and it builds in-game.


**Known issues and TODO list:**

None.