### PR TITLE
Core/loot: Check itemCount also in bank when CanRollOnItem

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1020,7 +1020,7 @@ bool CanRollOnItem(const LootItem& item, Player const* player)
     if (!proto)
         return false;
 
-    uint32 itemCount = player->GetItemCount(item.itemid);
+    uint32 itemCount = player->GetItemCount(item.itemid, true);
     if (proto->MaxCount > 0 && static_cast<int32>(itemCount) >= proto->MaxCount)
         return false;
 


### PR DESCRIPTION
**Changes proposed:**

-  Check itemCount also in bank when CanRollOnItem
Added here: 00fdf6e99a2516095889e13d4638efa049782ce5, set inBankAlso true in GetItemCount is needed here.

**Issues addressed:**

None


**Tests performed:**

tested in-game
