### PR TITLE
Core/Creatures: Allow interaction with trigger creatures using spellclick

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -655,8 +655,8 @@ bool Creature::UpdateEntry(uint32 entry, CreatureData const* data /*= nullptr*/,
         }
     }
 
-    // trigger creature is always uninteractible and can not be attacked
-    if (IsTrigger())
+    // Trigger creatures without spellclick are always uninteractible and can not be attacked
+    if (IsTrigger() && !HasNpcFlag(UNIT_NPC_FLAG_SPELLCLICK))
         SetUninteractible(true);
 
     InitializeReactState();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Allow interaction with trigger creatures using spellclick. There are a lot of trigger creatures with visual auras to emulate interactive objects (spellclick)

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game

<details>
  <summary>Example</summary>

(.gm on)
![image](https://github.com/TrinityCore/TrinityCore/assets/2695278/4db31ab8-ed63-415f-9f64-e06f8afeecbc)
(.gm off)
![image](https://github.com/TrinityCore/TrinityCore/assets/2695278/a93a059b-a53e-40ac-a289-17d9d7c1836f)

</details>

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
