### PR TITLE
Handlers/Group: Fix possible nullptr issue

### DIFF
--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -315,7 +315,6 @@ void WorldSession::HandleSetRoleOpcode(WorldPackets::Party::SetRole& packet)
     if (oldRole == packet.Role)
         return;
 
-    roleChangedInform.PartyIndex = group->GetGroupCategory();
     roleChangedInform.From = GetPlayer()->GetGUID();
     roleChangedInform.ChangedUnit = packet.TargetGUID;
     roleChangedInform.OldRole = oldRole;
@@ -323,6 +322,7 @@ void WorldSession::HandleSetRoleOpcode(WorldPackets::Party::SetRole& packet)
 
     if (group)
     {
+        roleChangedInform.PartyIndex = group->GetGroupCategory();
         group->BroadcastPacket(roleChangedInform.Write(), false);
         group->SetLfgRoles(packet.TargetGUID, packet.Role);
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix crash in GroupHandler::HandleSetRoleOpcode


**Issues addressed:**

Closes: none?


**Tests performed:**

- Builds

**Known issues and TODO list:** (add/remove lines as needed)

- None

Had this crash when being afk in battleground -> afk into character selection -> reconnecting on battleground map.

PartyIndex is optional so we can just safely ignore it if there is no group
```
Address   Frame     Function      SourceFile
00007FF650D78B5B  0000009768CFC840  Group::GetGroupCategory+B  E:\Trinity\master.source\src\server\game\Groups\Group.h line 267
00007FF651CBC547  0000009768CFC9C0  WorldSession::HandleSetRoleOpcode+127  E:\Trinity\master.source\src\server\game\Handlers\GroupHandler.cpp line 318
```

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
