### PR TITLE
Fixed soulbound tradeable items not being properly updated once every second

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1045,13 +1045,12 @@ void Player::Update(uint32 p_time)
 
     Unit::AIUpdateTick(p_time);
 
-    // Update items that have just a limited lifetime
+    // Once per second, update items that have just a limited lifetime
     if (now > m_Last_tick)
+    {
         UpdateItemDuration(uint32(now - m_Last_tick));
-
-    // check every second
-    if (now > m_Last_tick + 1)
         UpdateSoulboundTradeItems();
+    }
 
     // If mute expired, remove it from the DB
     if (GetSession()->m_muteTime && GetSession()->m_muteTime < now)


### PR DESCRIPTION
In the current code they were updated only if the difftime went above 1 second.

**Changes proposed:**

-  Change time check logic before calling UpdateSoulboundTradeItems

**Issues addressed:**

Fixes soulbound item timer never being updated.

**Tests performed:**

From debugger, function is being called as intended once per second now.