### PR TITLE
Core/Vehicle: Only interrupt spells with SpellAuraInterruptFlags::Mount on entering a vehicle

### DIFF
--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -834,7 +834,9 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
         }
     }
 
-    Passenger->InterruptNonMeleeSpells(false);
+    Passenger->InterruptSpell(CURRENT_GENERIC_SPELL);
+    Passenger->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+    Passenger->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags::Mount);
     Passenger->RemoveAurasByType(SPELL_AURA_MOUNTED);
 
     VehicleSeatEntry const* veSeat = Seat->second.SeatInfo;


### PR DESCRIPTION
**Changes proposed:**
- Only interrupt channels/auras with SpellAuraInterruptFlags::Mount, it's required for Lords of Dread Swarm ability(spell id: 360300), which channel is started before entering vehicle (spell id: 46598)

**Tests performed:**
tested ingame
