### PR TITLE
Knock Back Spells with only BasePoints can now Knock Back Units

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3959,6 +3959,9 @@ void Spell::EffectKnockBack()
     if (speedxy < 0.01f && speedz < 0.01f)
         return;
 
+    if (speedxy < 0.01f)
+        speedxy = 0.05f;
+
     Position origin;
     if (effectInfo->Effect == SPELL_EFFECT_KNOCK_BACK_DEST)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Some Spells like 108773 or 93575, 88250 has BasePoint set but no MiscValue.  As a result, we have only given a speedz, but no speedxy. Since the calculation in line 3957 (float speedxy = float(effectInfo->MiscValue) * ratio;) turns speedxy into 0, the KnockBack Effect does not work. 
With this change it will work, even if the unit will move a little bit.




**Tests performed:**

(Does it build, tested in-game, etc.)
Build and work ingame - testet with a few spells.

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
