### PR TITLE
Core/Creature: Update HomePosition upon ExitVehicle only if the creature was inside a vehicle

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3390,8 +3390,8 @@ void Creature::ExitVehicle(Position const* /*exitPosition*/)
     bool const isInVehicle = GetVehicle();
     Unit::ExitVehicle();
 
-    // if the creature exits a vehicle, set it's home position to the
+    // if alive creature exits a vehicle, set it's home position to the
     // exited position so it won't run away (home) and evade if it's hostile
-    if (isInVehicle)
+    if (isInVehicle && IsAlive())
         SetHomePosition(GetPosition());
 }

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3387,9 +3387,11 @@ std::string Creature::GetDebugInfo() const
 
 void Creature::ExitVehicle(Position const* /*exitPosition*/)
 {
+    bool const isInVehicle = GetVehicle();
     Unit::ExitVehicle();
 
     // if the creature exits a vehicle, set it's home position to the
     // exited position so it won't run away (home) and evade if it's hostile
-    SetHomePosition(GetPosition());
+    if (isInVehicle)
+        SetHomePosition(GetPosition());
 }


### PR DESCRIPTION
**Changes proposed:**

-  Check if creature is in vehicle before Unit::ExitVehicle(); and only do SetHomePosition(GetPosition()); if was in vehicle.
After this commit: 3e407c7d1c79cc94bf932880ee0eb68058d139fd creatures do SetHomePosition when ExitVehicle is executed.
When a unit dies do ExitVehicle: https://github.com/TrinityCore/TrinityCore/blob/8a619460e21a9603a45894db88e344a0499c2d0f/src/server/game/Entities/Unit/Unit.cpp#L8725
So SetHomePosition set every time a creature dies.
This can cause also problems by example in Ulduar Flame Leviathan, when two door colossus die Flame Leviathan break door and enter: https://github.com/TrinityCore/TrinityCore/blob/8a619460e21a9603a45894db88e344a0499c2d0f/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp#L941-L945
https://github.com/TrinityCore/TrinityCore/blob/8a619460e21a9603a45894db88e344a0499c2d0f/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp#L742-L748
https://github.com/TrinityCore/TrinityCore/blob/8a619460e21a9603a45894db88e344a0499c2d0f/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp#L1017-L1022
https://github.com/TrinityCore/TrinityCore/blob/8a619460e21a9603a45894db88e344a0499c2d0f/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp#L555-L573

but colossus have check:
```c++
if (me->GetHomePosition().IsInDist(&Center, 50.f))
    instance->SetData(DATA_COLOSSUS, instance->GetData(DATA_COLOSSUS)+1);
```
So in case you aggro colossus and go far away center position, DATA_COLOSSUS is not increased and boss do not execute ACTION_MOVE_TO_CENTER_POSITION


**Issues addressed:**

None


**Tests performed:**

tested in-game
