### PR TITLE
Core/Units: allow self inflicted damage to bypass CREATURE_STATIC_FLAGG_UNKILLABLE

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -883,7 +883,7 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
 
         duel_hasEnded = true;
     }
-    else if (victim->IsCreature() && damageTaken >= health && victim->ToCreature()->HasFlag(CREATURE_STATIC_FLAG_UNKILLABLE))
+    else if (victim->IsCreature() && victim != attacker && damageTaken >= health && victim->ToCreature()->HasFlag(CREATURE_STATIC_FLAG_UNKILLABLE))
     {
         damageTaken = health - 1;
 


### PR DESCRIPTION

There are several bosses which are set as unkillable and use suicide spells to kill themselves instead (Magmaw in Blackwing Descent and HC Cho'Gall in Bastion of Twilight)

**Changes proposed:**

-  creatures that deal damage to themselves will now be able to bypass the unkillable static flag, which means they can now kill themselves (like with instakill spell effects)

**Tests performed:**
- tested on 4.x
