### PR TITLE
Core/Maps: Update SpawnGroup Conditions when loading all cells

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2487,6 +2487,22 @@ void Map::UpdateSpawnGroupConditions()
     }
 }
 
+void Map::InitSpawnGroupState()
+{
+    std::vector<uint32> const* spawnGroups = sObjectMgr->GetSpawnGroupsForMap(GetId());
+    if (!spawnGroups)
+        return;
+
+    for (uint32 spawnGroupId : *spawnGroups)
+    {
+        bool shouldBeActive = sConditionMgr->IsMapMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_SPAWN_GROUP, spawnGroupId, this);
+        if (shouldBeActive)
+            SetSpawnGroupActive(spawnGroupId, true);
+        else
+            SetSpawnGroupInactive(spawnGroupId);
+    }
+}
+
 ObjectGuidGenerator& Map::GetGuidSequenceGenerator(HighGuid high)
 {
     auto itr = _guidGenerators.find(high);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2452,6 +2452,16 @@ bool Map::IsSpawnGroupActive(uint32 groupId) const
     return (_toggledSpawnGroupIds.find(groupId) != _toggledSpawnGroupIds.end()) != !(data->flags & SPAWNGROUP_FLAG_MANUAL_SPAWN);
 }
 
+void Map::InitSpawnGroupState()
+{
+    std::vector<uint32> const* spawnGroups = sObjectMgr->GetSpawnGroupsForMap(GetId());
+    if (!spawnGroups)
+        return;
+
+    for (uint32 spawnGroupId : *spawnGroups)
+        SetSpawnGroupActive(spawnGroupId, sConditionMgr->IsMapMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_SPAWN_GROUP, spawnGroupId, this));
+}
+
 void Map::UpdateSpawnGroupConditions()
 {
     std::vector<uint32> const* spawnGroups = sObjectMgr->GetSpawnGroupsForMap(GetId());
@@ -2481,22 +2491,6 @@ void Map::UpdateSpawnGroupConditions()
             SpawnGroupSpawn(spawnGroupId);
         else if (spawnGroupTemplate->flags & SPAWNGROUP_FLAG_DESPAWN_ON_CONDITION_FAILURE)
             SpawnGroupDespawn(spawnGroupId, true);
-        else
-            SetSpawnGroupInactive(spawnGroupId);
-    }
-}
-
-void Map::InitSpawnGroupState()
-{
-    std::vector<uint32> const* spawnGroups = sObjectMgr->GetSpawnGroupsForMap(GetId());
-    if (!spawnGroups)
-        return;
-
-    for (uint32 spawnGroupId : *spawnGroups)
-    {
-        bool shouldBeActive = sConditionMgr->IsMapMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_SPAWN_GROUP, spawnGroupId, this);
-        if (shouldBeActive)
-            SetSpawnGroupActive(spawnGroupId, true);
         else
             SetSpawnGroupInactive(spawnGroupId);
     }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -116,6 +116,7 @@ Map::~Map()
 
 void Map::LoadAllCells()
 {
+    UpdateSpawnGroupConditions();
     for (uint32 cellX = 0; cellX < TOTAL_NUMBER_OF_CELLS_PER_MAP; cellX++)
         for (uint32 cellY = 0; cellY < TOTAL_NUMBER_OF_CELLS_PER_MAP; cellY++)
             LoadGrid((cellX + 0.5f - CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL, (cellY + 0.5f - CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL);

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -116,7 +116,6 @@ Map::~Map()
 
 void Map::LoadAllCells()
 {
-    UpdateSpawnGroupConditions();
     for (uint32 cellX = 0; cellX < TOTAL_NUMBER_OF_CELLS_PER_MAP; cellX++)
         for (uint32 cellY = 0; cellY < TOTAL_NUMBER_OF_CELLS_PER_MAP; cellY++)
             LoadGrid((cellX + 0.5f - CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL, (cellY + 0.5f - CENTER_GRID_CELL_ID) * SIZE_OF_GRID_CELL);

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -713,8 +713,8 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         typedef std::function<void(Map*)> FarSpellCallback;
         void AddFarSpellCallback(FarSpellCallback&& callback);
 
-        void UpdateSpawnGroupConditions();
         void InitSpawnGroupState();
+        void UpdateSpawnGroupConditions();
 
     private:
         // Type specific code for add/remove to/from grid

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -714,6 +714,7 @@ class TC_GAME_API Map : public GridRefManager<NGridType>
         void AddFarSpellCallback(FarSpellCallback&& callback);
 
         void UpdateSpawnGroupConditions();
+        void InitSpawnGroupState();
 
     private:
         // Type specific code for add/remove to/from grid

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -136,6 +136,7 @@ GarrisonMap* MapManager::CreateGarrison(uint32 mapId, uint32 instanceId, Player*
 {
     GarrisonMap* map = new GarrisonMap(mapId, i_gridCleanUpDelay, instanceId, owner->GetGUID());
     ASSERT(map->IsGarrison());
+    map->InitSpawnGroupState();
     return map;
 }
 

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -74,12 +74,10 @@ Map* MapManager::CreateWorldMap(uint32 mapId, uint32 instanceId)
     Map* map = new Map(mapId, i_gridCleanUpDelay, instanceId, DIFFICULTY_NONE);
     map->LoadRespawnTimes();
     map->LoadCorpseData();
+    map->InitSpawnGroupState();
 
     if (sWorld->getBoolConfig(CONFIG_BASEMAP_LOAD_GRIDS))
-    {
-        map->InitSpawnGroupState();
         map->LoadAllCells();
-    }
 
     return map;
 }
@@ -110,12 +108,10 @@ InstanceMap* MapManager::CreateInstance(uint32 mapId, uint32 instanceId, Instanc
 
     map->CreateInstanceData();
     map->SetInstanceScenario(sScenarioMgr->CreateInstanceScenario(map, team));
+    map->InitSpawnGroupState();
 
     if (sWorld->getBoolConfig(CONFIG_INSTANCEMAP_LOAD_GRIDS))
-    {
-        map->InitSpawnGroupState();
         map->LoadAllCells();
-    }
 
     return map;
 }
@@ -128,12 +124,10 @@ BattlegroundMap* MapManager::CreateBattleground(uint32 mapId, uint32 instanceId,
     ASSERT(map->IsBattlegroundOrArena());
     map->SetBG(bg);
     bg->SetBgMap(map);
+    map->InitSpawnGroupState();
 
     if (sWorld->getBoolConfig(CONFIG_BATTLEGROUNDMAP_LOAD_GRIDS))
-    {
-        map->InitSpawnGroupState();
         map->LoadAllCells();
-    }
 
     return map;
 }

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -76,7 +76,10 @@ Map* MapManager::CreateWorldMap(uint32 mapId, uint32 instanceId)
     map->LoadCorpseData();
 
     if (sWorld->getBoolConfig(CONFIG_BASEMAP_LOAD_GRIDS))
+    {
+        map->InitSpawnGroupState();
         map->LoadAllCells();
+    }
 
     return map;
 }
@@ -109,7 +112,10 @@ InstanceMap* MapManager::CreateInstance(uint32 mapId, uint32 instanceId, Instanc
     map->SetInstanceScenario(sScenarioMgr->CreateInstanceScenario(map, team));
 
     if (sWorld->getBoolConfig(CONFIG_INSTANCEMAP_LOAD_GRIDS))
+    {
+        map->InitSpawnGroupState();
         map->LoadAllCells();
+    }
 
     return map;
 }
@@ -124,7 +130,10 @@ BattlegroundMap* MapManager::CreateBattleground(uint32 mapId, uint32 instanceId,
     bg->SetBgMap(map);
 
     if (sWorld->getBoolConfig(CONFIG_BATTLEGROUNDMAP_LOAD_GRIDS))
+    {
+        map->InitSpawnGroupState();
         map->LoadAllCells();
+    }
 
     return map;
 }

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -1300,6 +1300,7 @@ public:
         {
             handler->PSendSysMessage("Loading all cells (mapId: %u). Current GameObjects " SZFMTD ", Creatures " SZFMTD, map->GetId(), map->GetObjectsStore().Size<GameObject>(), map->GetObjectsStore().Size<Creature>());
 
+            map->InitSpawnGroupState();
             map->LoadAllCells();
 
             handler->PSendSysMessage("Cells loaded (mapId: %u) After load - GameObject " SZFMTD ", Creatures " SZFMTD, map->GetId(), map->GetObjectsStore().Size<GameObject>(), map->GetObjectsStore().Size<Creature>());

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -1300,7 +1300,6 @@ public:
         {
             handler->PSendSysMessage("Loading all cells (mapId: %u). Current GameObjects " SZFMTD ", Creatures " SZFMTD, map->GetId(), map->GetObjectsStore().Size<GameObject>(), map->GetObjectsStore().Size<Creature>());
 
-            map->InitSpawnGroupState();
             map->LoadAllCells();
 
             handler->PSendSysMessage("Cells loaded (mapId: %u) After load - GameObject " SZFMTD ", Creatures " SZFMTD, map->GetId(), map->GetObjectsStore().Size<GameObject>(), map->GetObjectsStore().Size<Creature>());


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Update SpawnGroup Conditions when loading cells

**Issues addressed:**

Closes: none

Current issue: SpawnGroups that don't despawn on condition failure are being spawned even tho the condition to spawn has never been met.


**Tests performed:**

- Builds
- Tested in game while reworking alterac valley


**Known issues and TODO list:**

- This might not be the proper fix


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
