### PR TITLE
Core/Player: Fix BuyItemFromVendorSlot slot validation

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21717,7 +21717,7 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
 
     // cheating attempt
     if (slot != NULL_SLOT)
-        if (bag != INVENTORY_SLOT_BAG_0 && slot > MAX_BAG_SIZE || bag == INVENTORY_SLOT_BAG_0 && slot >= INVENTORY_SLOT_ITEM_END)
+        if ((bag != INVENTORY_SLOT_BAG_0 && slot > MAX_BAG_SIZE) || (bag == INVENTORY_SLOT_BAG_0 && slot >= INVENTORY_SLOT_ITEM_END))
             return false;
 
     if (!IsAlive())

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21716,8 +21716,9 @@ bool Player::BuyItemFromVendorSlot(ObjectGuid vendorguid, uint32 vendorslot, uin
     if (count < 1) count = 1;
 
     // cheating attempt
-    if (slot > MAX_BAG_SIZE && slot != NULL_SLOT)
-        return false;
+    if (slot != NULL_SLOT)
+        if (bag != INVENTORY_SLOT_BAG_0 && slot > MAX_BAG_SIZE || bag == INVENTORY_SLOT_BAG_0 && slot >= INVENTORY_SLOT_ITEM_END)
+            return false;
 
     if (!IsAlive())
         return false;


### PR DESCRIPTION
This validation logic may not actually even be needed but to avoid any negative impacts a minimal change is proposed to fix: https://github.com/TrinityCore/TrinityCore/issues/29510

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fix "cheat" validation for Player::BuyItemFromVendorSlot

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/29510


**Tests performed:**

Builds, fixes the issue tested.


**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
