### PR TITLE
Core/Packets: Handle QueryCountdownTimer

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -366,7 +366,7 @@ inline void Battleground::_ProcessJoin(uint32 diff)
         _preparationStartTime = GameTime::GetGameTime();
         for (Group* group : m_BgRaids)
             if (group)
-                group->StartCountdown(WorldPackets::Misc::TimerType::Pvp, Seconds(StartDelayTimes[BG_STARTING_EVENT_FIRST] / 1000), _preparationStartTime);
+                group->StartCountdown(CountdownTimerType::Pvp, Seconds(StartDelayTimes[BG_STARTING_EVENT_FIRST] / 1000), _preparationStartTime);
 
         StartingEventCloseDoors();
         SetStartDelayTime(StartDelayTimes[BG_STARTING_EVENT_FIRST]);
@@ -1096,9 +1096,9 @@ void Battleground::AddOrSetPlayerToCorrectBgGroup(Player* player, Team team)
         group->Create(player);
         Seconds countdownMaxForBGType = Seconds(StartDelayTimes[BG_STARTING_EVENT_FIRST]  / 1000);
         if (_preparationStartTime)
-            group->StartCountdown(WorldPackets::Misc::TimerType::Pvp, countdownMaxForBGType, _preparationStartTime);
+            group->StartCountdown(CountdownTimerType::Pvp, countdownMaxForBGType, _preparationStartTime);
         else
-            group->StartCountdown(WorldPackets::Misc::TimerType::Pvp, countdownMaxForBGType);
+            group->StartCountdown(CountdownTimerType::Pvp, countdownMaxForBGType);
     }
     else                                            // raid already exist
     {

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -563,7 +563,6 @@ class TC_GAME_API Battleground : public ZoneScript
         BattlegroundStatus m_Status;
         uint32 m_ClientInstanceID;                          // the instance-id which is sent to the client and without any other internal use
         uint32 m_StartTime;
-        uint32 m_CountdownTimer;
         uint32 m_ResetStatTimer;
         uint32 m_ValidStartPositionTimer;
         int32 m_EndTime;                                    // it is set to 120000 when bg is ending and it decreases itself

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -606,5 +606,8 @@ class TC_GAME_API Battleground : public ZoneScript
         std::unordered_set<uint32> const* _pvpStatIds;
 
         std::vector<WorldPackets::Battleground::BattlegroundPlayerPosition> _playerPositions;
+
+        // Time when the first message "the battle will begin in 2minutes" is send (or 1m for arenas)
+        time_t _preparationStartTime;
 };
 #endif

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -23,12 +23,14 @@
 #include "DB2Stores.h"
 #include "Formulas.h"
 #include "GameObject.h"
+#include "GameTime.h"
 #include "GroupMgr.h"
 #include "Item.h"
 #include "LFGMgr.h"
 #include "Log.h"
 #include "Loot.h"
 #include "MapManager.h"
+#include "MiscPackets.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "PartyPackets.h"
@@ -36,6 +38,22 @@
 #include "Player.h"
 #include "UpdateData.h"
 #include "WorldSession.h"
+
+Seconds Group::CountdownInfo::GetTimeLeft() const
+{
+    return Seconds(std::max<time_t>(_endTime - GameTime::GetGameTime(), 0));
+}
+
+void Group::CountdownInfo::StartCountdown(Seconds duration, Seconds passedTime)
+{
+    _startTime = GameTime::GetGameTime() - passedTime.count();
+    _endTime = _startTime + duration.count();
+}
+
+bool Group::CountdownInfo::IsRunning() const
+{
+    return _endTime > GameTime::GetGameTime();
+}
 
 Group::Group() : m_leaderGuid(), m_leaderFactionGroup(0), m_leaderName(""), m_groupFlags(GROUP_FLAG_NONE), m_groupCategory(GROUP_CATEGORY_HOME),
 m_dungeonDifficulty(DIFFICULTY_NORMAL), m_raidDifficulty(DIFFICULTY_NORMAL_RAID), m_legacyRaidDifficulty(DIFFICULTY_10_N),
@@ -48,6 +66,8 @@ m_readyCheckStarted(false), m_readyCheckTimer(Milliseconds::zero()), m_activeMar
 
     for (uint8 i = 0; i < RAID_MARKERS_COUNT; ++i)
         m_markers[i] = nullptr;
+
+    _countdowns = { nullptr, nullptr, nullptr };
 }
 
 Group::~Group()
@@ -1401,6 +1421,19 @@ void Group::BroadcastGroupUpdate(void)
             TC_LOG_DEBUG("misc", "-- Forced group value update for '{}'", pp->GetName());
         }
     }
+}
+
+void Group::StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Seconds passedTime)
+{
+    if (!_countdowns[AsUnderlyingType(timerType)])
+        _countdowns[AsUnderlyingType(timerType)] = std::make_unique<CountdownInfo>();
+
+    _countdowns[AsUnderlyingType(timerType)]->StartCountdown(duration, passedTime);
+}
+
+Group::CountdownInfo const* Group::GetCountdownInfo(WorldPackets::Misc::TimerType timerType) const
+{
+    return _countdowns[AsUnderlyingType(timerType)].get();
 }
 
 void Group::SetLootMethod(LootMethod method)

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -44,9 +44,9 @@ Seconds Group::CountdownInfo::GetTimeLeft() const
     return Seconds(std::max<time_t>(_endTime - GameTime::GetGameTime(), 0));
 }
 
-void Group::CountdownInfo::StartCountdown(Seconds duration, Seconds passedTime)
+void Group::CountdownInfo::StartCountdown(Seconds duration, Optional<time_t> startTime)
 {
-    _startTime = GameTime::GetGameTime() - passedTime.count();
+    _startTime = startTime ? *startTime : GameTime::GetGameTime();
     _endTime = _startTime + duration.count();
 }
 
@@ -1423,12 +1423,12 @@ void Group::BroadcastGroupUpdate(void)
     }
 }
 
-void Group::StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Seconds passedTime)
+void Group::StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Optional<time_t> startTime)
 {
     if (!_countdowns[AsUnderlyingType(timerType)])
         _countdowns[AsUnderlyingType(timerType)] = std::make_unique<CountdownInfo>();
 
-    _countdowns[AsUnderlyingType(timerType)]->StartCountdown(duration, passedTime);
+    _countdowns[AsUnderlyingType(timerType)]->StartCountdown(duration, startTime);
 }
 
 Group::CountdownInfo const* Group::GetCountdownInfo(WorldPackets::Misc::TimerType timerType) const

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1423,16 +1423,22 @@ void Group::BroadcastGroupUpdate(void)
     }
 }
 
-void Group::StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Optional<time_t> startTime)
+void Group::StartCountdown(CountdownTimerType timerType, Seconds duration, Optional<time_t> startTime)
 {
+    if (AsUnderlyingType(timerType) < 0 || AsUnderlyingType(timerType) >= std::ssize(_countdowns))
+        return;
+
     if (!_countdowns[AsUnderlyingType(timerType)])
         _countdowns[AsUnderlyingType(timerType)] = std::make_unique<CountdownInfo>();
 
     _countdowns[AsUnderlyingType(timerType)]->StartCountdown(duration, startTime);
 }
 
-Group::CountdownInfo const* Group::GetCountdownInfo(WorldPackets::Misc::TimerType timerType) const
+Group::CountdownInfo const* Group::GetCountdownInfo(CountdownTimerType timerType) const
 {
+    if (AsUnderlyingType(timerType) < 0 || AsUnderlyingType(timerType) >= std::ssize(_countdowns))
+        return nullptr;
+
     return _countdowns[AsUnderlyingType(timerType)].get();
 }
 

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -46,6 +46,14 @@ enum class InstanceResetMethod : uint8;
 enum class InstanceResetResult : uint8;
 enum LootMethod : uint8;
 
+namespace WorldPackets
+{
+    namespace Misc
+    {
+        enum TimerType : int32;
+    }
+}
+
 #define MAX_GROUP_SIZE      5
 #define MAX_RAID_SIZE       40
 #define MAX_RAID_SUBGROUPS  MAX_RAID_SIZE / MAX_GROUP_SIZE
@@ -201,6 +209,26 @@ class TC_GAME_API Group
         };
         typedef std::list<MemberSlot> MemberSlotList;
         typedef MemberSlotList::const_iterator member_citerator;
+
+        class CountdownInfo
+        {
+        public:
+            CountdownInfo() : _startTime(0), _endTime(0) { }
+
+            Seconds GetTimeLeft() const;
+
+            Seconds GetTotalTime() const
+            {
+                return Seconds(_endTime - _startTime);
+            }
+
+            void StartCountdown(Seconds duration, Seconds passedTime = 0s);
+            bool IsRunning() const;
+
+        private:
+            time_t _startTime;
+            time_t _endTime;
+        };
 
     protected:
         typedef MemberSlotList::iterator member_witerator;
@@ -379,6 +407,9 @@ class TC_GAME_API Group
         // FG: evil hacks
         void BroadcastGroupUpdate(void);
 
+        void StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Seconds passedTime = 0s);
+        CountdownInfo const* GetCountdownInfo(WorldPackets::Misc::TimerType timerType) const;
+
     protected:
         bool _setMembersGroup(ObjectGuid guid, uint8 group);
         void _homebindIfInstance(Player* player);
@@ -423,5 +454,7 @@ class TC_GAME_API Group
         // Raid markers
         std::array<std::unique_ptr<RaidMarker>, RAID_MARKERS_COUNT> m_markers;
         uint32              m_activeMarkers;
+
+        std::array<std::unique_ptr<CountdownInfo>, 3> _countdowns;
 };
 #endif

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -222,7 +222,7 @@ class TC_GAME_API Group
                 return Seconds(_endTime - _startTime);
             }
 
-            void StartCountdown(Seconds duration, Seconds passedTime = 0s);
+            void StartCountdown(Seconds duration, Optional<time_t> startTime = { });
             bool IsRunning() const;
 
         private:
@@ -407,7 +407,7 @@ class TC_GAME_API Group
         // FG: evil hacks
         void BroadcastGroupUpdate(void);
 
-        void StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Seconds passedTime = 0s);
+        void StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Optional<time_t> startTime = { });
         CountdownInfo const* GetCountdownInfo(WorldPackets::Misc::TimerType timerType) const;
 
     protected:

--- a/src/server/game/Groups/Group.h
+++ b/src/server/game/Groups/Group.h
@@ -46,14 +46,6 @@ enum class InstanceResetMethod : uint8;
 enum class InstanceResetResult : uint8;
 enum LootMethod : uint8;
 
-namespace WorldPackets
-{
-    namespace Misc
-    {
-        enum TimerType : int32;
-    }
-}
-
 #define MAX_GROUP_SIZE      5
 #define MAX_RAID_SIZE       40
 #define MAX_RAID_SUBGROUPS  MAX_RAID_SIZE / MAX_GROUP_SIZE
@@ -177,6 +169,13 @@ struct RaidMarker
         Location.WorldRelocate(mapId, positionX, positionY, positionZ);
         TransportGUID = transportGuid;
     }
+};
+
+enum class CountdownTimerType : int32
+{
+    Pvp             = 0,
+    ChallengeMode   = 1,
+    PlayerCountdown = 2
 };
 
 enum class PingSubjectType : uint8
@@ -407,8 +406,8 @@ class TC_GAME_API Group
         // FG: evil hacks
         void BroadcastGroupUpdate(void);
 
-        void StartCountdown(WorldPackets::Misc::TimerType timerType, Seconds duration, Optional<time_t> startTime = { });
-        CountdownInfo const* GetCountdownInfo(WorldPackets::Misc::TimerType timerType) const;
+        void StartCountdown(CountdownTimerType timerType, Seconds duration, Optional<time_t> startTime = { });
+        CountdownInfo const* GetCountdownInfo(CountdownTimerType timerType) const;
 
     protected:
         bool _setMembersGroup(ObjectGuid guid, uint8 group);

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1181,3 +1181,21 @@ void WorldSession::HandleRequestLatestSplashScreen(WorldPackets::Misc::RequestLa
     splashScreenShowLatest.UISplashScreenID = splashScreen ? splashScreen->ID : 0;
     SendPacket(splashScreenShowLatest.Write());
 }
+
+void WorldSession::HandleQueryCountdownTimer(WorldPackets::Misc::QueryCountdownTimer& queryCountdownTimer)
+{
+    Group const* group = _player->GetGroup();
+    if (!group)
+        return;
+
+    Group::CountdownInfo const* info = group->GetCountdownInfo(queryCountdownTimer.TimerType);
+    if (!info)
+        return;
+
+    WorldPackets::Misc::StartTimer startTimer;
+    startTimer.Type = queryCountdownTimer.TimerType;
+    startTimer.TimeLeft = info->GetTimeLeft();
+    startTimer.TotalTime = info->GetTotalTime();
+
+    _player->SendDirectMessage(startTimer.Write());
+}

--- a/src/server/game/Server/Packets/MiscPackets.cpp
+++ b/src/server/game/Server/Packets/MiscPackets.cpp
@@ -760,6 +760,13 @@ WorldPacket const* WorldPackets::Misc::StartTimer::Write()
     return &_worldPacket;
 }
 
+void WorldPackets::Misc::QueryCountdownTimer::Read()
+{
+    uint32 timerType = 0;
+    _worldPacket >> timerType;
+    TimerType = WorldPackets::Misc::TimerType(timerType);
+}
+
 void WorldPackets::Misc::ConversationLineStarted::Read()
 {
     _worldPacket >> ConversationGUID;

--- a/src/server/game/Server/Packets/MiscPackets.cpp
+++ b/src/server/game/Server/Packets/MiscPackets.cpp
@@ -762,9 +762,7 @@ WorldPacket const* WorldPackets::Misc::StartTimer::Write()
 
 void WorldPackets::Misc::QueryCountdownTimer::Read()
 {
-    uint32 timerType = 0;
-    _worldPacket >> timerType;
-    TimerType = WorldPackets::Misc::TimerType(timerType);
+    TimerType = _worldPacket.read<CountdownTimerType, int32>();
 }
 
 void WorldPackets::Misc::ConversationLineStarted::Read()

--- a/src/server/game/Server/Packets/MiscPackets.h
+++ b/src/server/game/Server/Packets/MiscPackets.h
@@ -32,6 +32,7 @@
 #include <array>
 #include <map>
 
+enum class CountdownTimerType : int32;
 enum UnitStandStateType : uint8;
 enum WeatherState : uint32;
 
@@ -926,13 +927,6 @@ namespace WorldPackets
             ObjectGuid SourceGuid;
         };
 
-        enum TimerType : int32
-        {
-            Pvp = 0,
-            ChallengeMode = 1,
-            PlayerCountdown = 2
-        };
-
         class StartTimer final : public ServerPacket
         {
         public:
@@ -942,7 +936,7 @@ namespace WorldPackets
 
             Duration<Seconds> TotalTime;
             Duration<Seconds> TimeLeft;
-            TimerType Type = Pvp;
+            CountdownTimerType Type = {};
         };
 
         class QueryCountdownTimer final : public ClientPacket
@@ -952,7 +946,7 @@ namespace WorldPackets
 
             void Read() override;
 
-            WorldPackets::Misc::TimerType TimerType = Pvp;
+            CountdownTimerType TimerType = {};
         };
 
         class ConversationLineStarted final : public ClientPacket

--- a/src/server/game/Server/Packets/MiscPackets.h
+++ b/src/server/game/Server/Packets/MiscPackets.h
@@ -926,16 +926,16 @@ namespace WorldPackets
             ObjectGuid SourceGuid;
         };
 
+        enum TimerType : int32
+        {
+            Pvp = 0,
+            ChallengeMode = 1,
+            PlayerCountdown = 2
+        };
+
         class StartTimer final : public ServerPacket
         {
         public:
-            enum TimerType : int32
-            {
-                Pvp             = 0,
-                ChallengeMode   = 1,
-                PlayerCountdown = 2
-            };
-
             StartTimer() : ServerPacket(SMSG_START_TIMER, 12) { }
 
             WorldPacket const* Write() override;
@@ -943,6 +943,16 @@ namespace WorldPackets
             Duration<Seconds> TotalTime;
             Duration<Seconds> TimeLeft;
             TimerType Type = Pvp;
+        };
+
+        class QueryCountdownTimer final : public ClientPacket
+        {
+        public:
+            QueryCountdownTimer(WorldPacket&& packet) : ClientPacket(CMSG_QUERY_COUNTDOWN_TIMER, std::move(packet)) { }
+
+            void Read() override;
+
+            WorldPackets::Misc::TimerType TimerType = Pvp;
         };
 
         class ConversationLineStarted final : public ClientPacket

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -729,7 +729,7 @@ void OpcodeTable::Initialize()
     DEFINE_HANDLER(CMSG_QUERY_BATTLE_PET_NAME,                              STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleQueryBattlePetName);
     DEFINE_HANDLER(CMSG_QUERY_CORPSE_LOCATION_FROM_CLIENT,                  STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQueryCorpseLocation);
     DEFINE_HANDLER(CMSG_QUERY_CORPSE_TRANSPORT,                             STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQueryCorpseTransport);
-    DEFINE_HANDLER(CMSG_QUERY_COUNTDOWN_TIMER,                              STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL);
+    DEFINE_HANDLER(CMSG_QUERY_COUNTDOWN_TIMER,                              STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleQueryCountdownTimer);
     DEFINE_HANDLER(CMSG_QUERY_CREATURE,                                     STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleCreatureQuery);
     DEFINE_HANDLER(CMSG_QUERY_GAME_OBJECT,                                  STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleGameObjectQueryOpcode);
     DEFINE_HANDLER(CMSG_QUERY_GARRISON_PET_NAME,                            STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL);

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -522,6 +522,7 @@ namespace WorldPackets
         class CloseInteraction;
         class ConversationLineStarted;
         class RequestLatestSplashScreen;
+        class QueryCountdownTimer;
     }
 
     namespace Movement
@@ -1751,6 +1752,7 @@ class TC_GAME_API WorldSession
         void HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& closeInteraction);
         void HandleConversationLineStarted(WorldPackets::Misc::ConversationLineStarted& conversationLineStarted);
         void HandleKeyboundOverride(WorldPackets::Spells::KeyboundOverride& keyboundOverride);
+        void HandleQueryCountdownTimer(WorldPackets::Misc::QueryCountdownTimer& queryCountdownTimer);
 
         // Adventure Journal
         void HandleAdventureJournalOpenQuest(WorldPackets::AdventureJournal::AdventureJournalOpenQuest& openQuest);


### PR DESCRIPTION
- Add it to battleground
- Base implementation countdowns in Group

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add base implementation of countdowns in Group
    - This is done in an array that supports all TimerTypes. 
-  Use said implementation for a more blizzlike approach to the countdowns in battlegrounds
-  Handle CMSG_QUERY_COUNTDOWN_TIMER

**Issues addressed:**

Closes: none?


**Tests performed:**

- Builds
- Tested in battlegrounds


**Known issues and TODO list:**

- [x] The timers between horde & alliance can be out of sync up to 2 seconds. Resolving this issue would bloat the PR a lot, its only cosmetic.
- [ ] Maybe we could add the /countdown X command in here as well, TBD


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
