### PR TITLE
Core/Maps: restored a hack in gridmap liquid status code

### DIFF
--- a/src/server/game/Maps/GridMap.cpp
+++ b/src/server/game/Maps/GridMap.cpp
@@ -593,6 +593,8 @@ float GridMap::getLiquidLevel(float x, float y) const
     return _liquidMap[cx_int*_liquidWidth + cy_int];
 }
 
+constexpr float GROUND_LEVEL_OFFSET_HACK = 0.02f; // due to floating point precision issues, we have to resort to a small hack to fix inconsistencies in liquids
+
 // Get water state on map
 ZLiquidStatus GridMap::GetLiquidStatus(float x, float y, float z, Optional<map_liquidHeaderTypeFlags> ReqLiquidType, LiquidData* data, float collisionHeight) const
 {
@@ -656,8 +658,8 @@ ZLiquidStatus GridMap::GetLiquidStatus(float x, float y, float z, Optional<map_l
 
     // Get water level
     float liquid_level = _liquidMap ? _liquidMap[lx_int*_liquidWidth + ly_int] : _liquidLevel;
-    // Get ground level (sub 0.2 for fix some errors)
-    float ground_level = getHeight(x, y);
+    // Get ground level (sub 0.02 for fix some errors)
+    float ground_level = getHeight(x, y) - GROUND_LEVEL_OFFSET_HACK;
 
     // Check water level and ground level
     if (liquid_level < ground_level || z < ground_level)

--- a/src/server/game/Maps/GridMap.cpp
+++ b/src/server/game/Maps/GridMap.cpp
@@ -662,7 +662,7 @@ ZLiquidStatus GridMap::GetLiquidStatus(float x, float y, float z, Optional<map_l
     float ground_level = getHeight(x, y);
 
     // Check water level and ground level
-    if (liquid_level < (ground_level - GROUND_LEVEL_OFFSET_HACK ) || z < (ground_level - GROUND_LEVEL_OFFSET_HACK ))
+    if (liquid_level < (ground_level - GROUND_LEVEL_OFFSET_HACK) || z < (ground_level - GROUND_LEVEL_OFFSET_HACK))
         return LIQUID_MAP_NO_WATER;
 
     // All ok in water -> store data

--- a/src/server/game/Maps/GridMap.cpp
+++ b/src/server/game/Maps/GridMap.cpp
@@ -659,10 +659,10 @@ ZLiquidStatus GridMap::GetLiquidStatus(float x, float y, float z, Optional<map_l
     // Get water level
     float liquid_level = _liquidMap ? _liquidMap[lx_int*_liquidWidth + ly_int] : _liquidLevel;
     // Get ground level (sub 0.02 for fix some errors)
-    float ground_level = getHeight(x, y) - GROUND_LEVEL_OFFSET_HACK;
+    float ground_level = getHeight(x, y);
 
     // Check water level and ground level
-    if (liquid_level < ground_level || z < ground_level)
+    if (liquid_level < (ground_level - GROUND_LEVEL_OFFSET_HACK ) || z < (ground_level - GROUND_LEVEL_OFFSET_HACK ))
         return LIQUID_MAP_NO_WATER;
 
     // All ok in water -> store data


### PR DESCRIPTION
**Changes proposed:**

-  restored a slightly less impactful hackfix for a precision issue in gridmap liquid code that causes players to be markes as not in water while being underwater.

**Issues addressed:**

Closes
closes #29543
closes #22020

**Tests performed:**
- tested ingame, results are promising
