### PR TITLE
Cherry-pick AreaTrigger conditions and enable Shadow Vault tavern

### DIFF
--- a/sql/updates/world/3.3.5/2024_01_26_00_world.sql
+++ b/sql/updates/world/3.3.5/2024_01_26_00_world.sql
@@ -1,0 +1,7 @@
+--
+DELETE FROM `areatrigger_tavern` WHERE `id` = 5309;
+INSERT INTO `areatrigger_tavern` (`id`, `name`) VALUES (5309, 'Shadow Vault');
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 30 AND `SourceEntry` = 5309;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(30, 0, 5309, 0, 0, 26, 0, 1, 0, 0, 0, 0, 0, '', 'Shadow Vault tavern requires phase 1.');

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1818,6 +1818,15 @@ bool ConditionMgr::isSourceTypeValid(Condition* cond) const
             }
             break;
         }
+        case CONDITION_SOURCE_TYPE_AREATRIGGER_CLIENT_TRIGGERED:
+        {
+            if (!sAreaTriggerStore.LookupEntry(cond->SourceEntry))
+            {
+                TC_LOG_ERROR("sql.sql", "%s SourceEntry in `condition` table, does not exists in AreaTrigger.dbc, ignoring.", cond->ToString().c_str());
+                return false;
+            }
+            break;
+        }
         case CONDITION_SOURCE_TYPE_TERRAIN_SWAP:
         {
             TC_LOG_ERROR("sql.sql", "CONDITION_SOURCE_TYPE_TERRAIN_SWAP: is only for master branch, skipped");

--- a/src/server/game/Conditions/ConditionMgr.h
+++ b/src/server/game/Conditions/ConditionMgr.h
@@ -154,7 +154,7 @@ enum ConditionSourceType
     CONDITION_SOURCE_TYPE_GRAVEYARD                      = 27, // only master
     CONDITION_SOURCE_TYPE_AREATRIGGER                    = 28, // only master (this refers to dynamically spawned areatriggers, not the ones from AreaTrigger.dbc/db2)
     CONDITION_SOURCE_TYPE_CONVERSATION_LINE              = 29, // only master
-    CONDITION_SOURCE_TYPE_AREATRIGGER_CLIENT_TRIGGERED   = 30, // only master (TODO: cherry-pick)
+    CONDITION_SOURCE_TYPE_AREATRIGGER_CLIENT_TRIGGERED   = 30,
     CONDITION_SOURCE_TYPE_TRAINER_SPELL                  = 31, // only master (TODO: cherry-pick)
     CONDITION_SOURCE_TYPE_OBJECT_ID_VISIBILITY           = 32, // only master (TODO: cherry-pick)
     CONDITION_SOURCE_TYPE_SPAWN_GROUP                    = 33, // only master (TODO: cherry-pick)

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -621,6 +621,9 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recvData)
     if (player->isDebugAreaTriggers)
         ChatHandler(player->GetSession()).PSendSysMessage(LANG_DEBUG_AREATRIGGER_REACHED, triggerId);
 
+    if (!sConditionMgr->IsObjectMeetingNotGroupedConditions(CONDITION_SOURCE_TYPE_AREATRIGGER_CLIENT_TRIGGERED, atEntry->ID, player))
+        return;
+
     if (sScriptMgr->OnAreaTrigger(player, atEntry))
         return;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Cherry-pick AreaTrigger conditions from 6ebd592
-  Enable Shadow Vault tavern (should work only in phase 1)

**Issues addressed:**

Closes #26292


**Tests performed:**

tested in-game

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
