### PR TITLE
Core/PacketIO: Implemented CMSG_BUSY_TRADE and CMSG_IGNORE_TRADE

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13502,17 +13502,16 @@ bool Player::IsUsingTwoHandedWeaponInOneHand() const
     return true;
 }
 
-void Player::TradeCancel(bool sendback)
+void Player::TradeCancel(bool sendback, TradeStatus status /*= TRADE_STATUS_TRADE_CANCELED*/)
 {
     if (m_trade)
     {
         Player* trader = m_trade->GetTrader();
 
-        // send yellow "Trade canceled" message to both traders
         if (sendback)
-            GetSession()->SendCancelTrade();
+            GetSession()->SendCancelTrade(status);
 
-        trader->GetSession()->SendCancelTrade();
+        trader->GetSession()->SendCancelTrade(status);
 
         // cleanup
         delete m_trade;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1167,7 +1167,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
 
         Player* GetTrader() const;
         TradeData* GetTradeData() const { return m_trade; }
-        void TradeCancel(bool sendback);
+        void TradeCancel(bool sendback, TradeStatus status = TRADE_STATUS_TRADE_CANCELED);
 
         CinematicMgr* GetCinematicMgr() const { return _cinematicMgr; }
 

--- a/src/server/game/Handlers/TradeHandler.cpp
+++ b/src/server/game/Handlers/TradeHandler.cpp
@@ -62,14 +62,12 @@ void WorldSession::SendTradeStatus(TradeStatusInfo const& info)
 
 void WorldSession::HandleIgnoreTradeOpcode(WorldPacket& /*recvPacket*/)
 {
-    TC_LOG_DEBUG("network", "WORLD: Ignore Trade {}", _player->GetGUID().ToString());
-    // recvPacket.print_storage();
+    _player->TradeCancel(true, TRADE_STATUS_IGNORE_YOU);
 }
 
 void WorldSession::HandleBusyTradeOpcode(WorldPacket& /*recvPacket*/)
 {
-    TC_LOG_DEBUG("network", "WORLD: Busy Trade {}", _player->GetGUID().ToString());
-    // recvPacket.print_storage();
+    _player->TradeCancel(true, TRADE_STATUS_BUSY);
 }
 
 void WorldSession::SendUpdateTrade(bool trader_data /*= true*/)
@@ -570,13 +568,13 @@ void WorldSession::HandleBeginTradeOpcode(WorldPacket& /*recvPacket*/)
     SendTradeStatus(info);
 }
 
-void WorldSession::SendCancelTrade()
+void WorldSession::SendCancelTrade(TradeStatus status)
 {
     if (PlayerRecentlyLoggedOut() || PlayerLogout())
         return;
 
     TradeStatusInfo info;
-    info.Status = TRADE_STATUS_TRADE_CANCELED;
+    info.Status = status;
     SendTradeStatus(info);
 }
 
@@ -672,13 +670,6 @@ void WorldSession::HandleInitiateTradeOpcode(WorldPacket& recvPacket)
     if (pOther->GetSession()->isLogingOut())
     {
         info.Status = TRADE_STATUS_TARGET_LOGOUT;
-        SendTradeStatus(info);
-        return;
-    }
-
-    if (pOther->GetSocial()->HasIgnore(GetPlayer()->GetGUID()))
-    {
-        info.Status = TRADE_STATUS_IGNORE_YOU;
         SendTradeStatus(info);
         return;
     }

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -529,7 +529,7 @@ class TC_GAME_API WorldSession
 
         void SendTradeStatus(TradeStatusInfo const& status);
         void SendUpdateTrade(bool trader_data = true);
-        void SendCancelTrade();
+        void SendCancelTrade(TradeStatus status);
 
         void SendPetitionQueryOpcode(ObjectGuid petitionguid);
 


### PR DESCRIPTION
**Changes proposed:**

When a player's game client receives a message that another player wants to initiate a trade, the client can send various responses:

`CMSG_BEGIN_TRADE` - Agree to trade.
`CMSG_BUSY_TRADE` - Refusal to trade and the message "$n is busy right now" for the player initiating the trade. This occurs if you are busy in trading at the AH or have enabled automatic trade rejection in the client settings.
`CMSG_IGNORE_TRADE` - Refusal to trade and a message to the initiating player that their target is ignoring them.

Currently, `CMSG_BUSY_TRADE` is not processed by the server. This means that the trade window will not open if you offer it to a player who is busy trading at the AH. Meanwhile, the server will consider that the trade has already started and will not allow both players to initiate it further until they log out. The proposed changes implement `CMSG_BUSY_TRADE` and now everything works as shown in @CraftedRO video (see #29308). This also fixes the functionality of the automatic trade rejection option in the game client settings.

As for `CMSG_IGNORE_TRADE`, it is not processed by the server, but the server does not allow the initiation of a trade if you are being ignored (`WorldSession::HandleInitiateTradeOpcode`). The proposed changes remove the old check for ignoring and allow the client to make the decision using `CMSG_IGNORE_TRADE`, as it was probably originally intended.

**Issues addressed:**

Closes #29308


**Tests performed:**

Builded and tested in-game.