### PR TITLE
Update boss_cthun.cpp

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -342,7 +342,7 @@ public:
                         if (DarkGlareTickTimer <= diff)
                         {
                             //Set angle and cast
-                            float angle = (ClockWise) ? DarkGlareAngle + DarkGlareTick * float(M_PI) / 35 : DarkGlareAngle - DarkGlareTick * float(M_PI) / 35;
+                            float angle = ClockWise ? DarkGlareAngle + DarkGlareTick * float(M_PI) / 35 : DarkGlareAngle - DarkGlareTick * float(M_PI) / 35;
 
                             me->SetOrientation(angle);
                             me->SetFacingTo(angle);

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_cthun.cpp
@@ -342,10 +342,10 @@ public:
                         if (DarkGlareTickTimer <= diff)
                         {
                             //Set angle and cast
-                            if (ClockWise)
-                                me->SetOrientation(DarkGlareAngle + DarkGlareTick * float(M_PI) / 35);
-                            else
-                                me->SetOrientation(DarkGlareAngle - DarkGlareTick * float(M_PI) / 35);
+                            float angle = (ClockWise) ? DarkGlareAngle + DarkGlareTick * float(M_PI) / 35 : DarkGlareAngle - DarkGlareTick * float(M_PI) / 35;
+
+                            me->SetOrientation(angle);
+                            me->SetFacingTo(angle);
 
                             me->StopMoving();
 


### PR DESCRIPTION
**Changes proposed:**
-  if/else changed to a ternary
-  add 'SetFacingTo()'

**Issues addressed:**
The Eye of C'thun and the spell Dark Glare were not visually moving, but the spell was still hitting/casting in the correct direction. This fix now reflects the correct orientation visually.

**Tests performed:**
Builds, and tested in-game. The Eye of C'thun now moves and deals damage in the correct location(s).