### PR TITLE
Improvements for power regeneration.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2100,7 +2100,7 @@ void Player::Regenerate(Powers power)
             m_powerFraction[power] = addvalue - integerValue;
     }
     if (m_regenTimerCount >= 2000 || curValue == maxValue || curValue == 0)
-        SetPower(power, curValue);
+        SetPower(power, curValue, true, true);
     else
         UpdateUInt32Value(UNIT_FIELD_POWER1 + AsUnderlyingType(power), curValue);
 }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2099,7 +2099,7 @@ void Player::Regenerate(Powers power)
         else
             m_powerFraction[power] = addvalue - integerValue;
     }
-    if (m_regenTimerCount >= 2000)
+    if (m_regenTimerCount >= 2000 || curValue == maxValue || curValue == 0)
         SetPower(power, curValue);
     else
         UpdateUInt32Value(UNIT_FIELD_POWER1 + AsUnderlyingType(power), curValue);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9404,9 +9404,6 @@ void Unit::SetMaxHealth(uint32 val)
 
 void Unit::SetPower(Powers power, uint32 val, bool withPowerUpdate /*= true*/)
 {
-    if (GetPower(power) == val)
-        return;
-
     uint32 maxPower = GetMaxPower(power);
     if (maxPower < val)
         val = maxPower;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9402,8 +9402,11 @@ void Unit::SetMaxHealth(uint32 val)
         SetHealth(val);
 }
 
-void Unit::SetPower(Powers power, uint32 val, bool withPowerUpdate /*= true*/)
+void Unit::SetPower(Powers power, uint32 val, bool withPowerUpdate /*= true*/, bool force /*= false*/)
 {
+    if (!force && GetPower(power) == val)
+        return;
+
     uint32 maxPower = GetMaxPower(power);
     if (maxPower < val)
         val = maxPower;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -934,7 +934,7 @@ class TC_GAME_API Unit : public WorldObject
         uint32 GetMaxPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_MAXPOWER1 + int32(power)); }
         float GetPowerPct(Powers power) const { return GetMaxPower(power) ? 100.f * GetPower(power) / GetMaxPower(power) : 0.0f; }
         int32 CountPctFromMaxPower(Powers power, int32 pct) const { return CalculatePct(GetMaxPower(power), pct); }
-        void SetPower(Powers power, uint32 val, bool withPowerUpdate = true);
+        void SetPower(Powers power, uint32 val, bool withPowerUpdate = true, bool force = false);
         void SetMaxPower(Powers power, uint32 val);
         inline void SetFullPower(Powers power) { SetPower(power, GetMaxPower(power)); }
         // returns the change in power


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

The first commit simply fixes some cases where the server fails to send power updates whenever necessary.

The second commit fixes rage and runic power out-of-combat decay. Firstly, now the server will calculate rage and runic power every tick (but send packet once per 2 sec as it was before), similar to energy. This helps avoid client-server desynchronization issues.

Secondly, the amount of resource loss has been adjusted. Currently, Warriors and Bear Druids lose rage slower than they should (losing 2 rage every 2 seconds, or 1 rage per second. They should lose 1.25 rage per second), and Death Knights lose runic power faster than intended (losing 3 runic power every 2 seconds, or 1.5 runic power per second. They should lose 1.25 runic power per second).

The proposed changes make rage and runic power out-of-combat decay much smoother and better synchronized with client prediction. The result can be seen in the video:

<details>
  <summary>Before</summary>
  
  https://github.com/TrinityCore/TrinityCore/assets/13364438/3b104475-d3ac-4511-b5ec-dcb2cdec4232

  https://github.com/TrinityCore/TrinityCore/assets/13364438/8d5d4d41-d710-428c-bb6a-21e1e6b570eb

</details>

<details>
  <summary>After</summary>
  
  https://github.com/TrinityCore/TrinityCore/assets/13364438/31839c46-8def-4dd9-bb2f-130a672038aa

  https://github.com/TrinityCore/TrinityCore/assets/13364438/58b0ad36-a44a-4ed3-a1da-ec071632fe99

</details>

The third commit relates to energy regeneration for Rogues and Cat Druids. Currently, any auras that alter the energy regeneration rate do not affect client prediction. In other words, visually in the game client, the energy regeneration rate never changes and remains constantly at 10 energy per second.

For example, if you're playing a Rogue and have the Vitality talent (61329), which increases energy regeneration speed by 25%, the server restores 12.5 energy per second. Now, if you use Adrenaline Rush (13750), doubling your energy regeneration speed, the server now restores 25 energy per second. HOWEVER, the game client still continues to regenerate your energy at a rate of 10 energy per second. This means you'll only receive the correct amount of energy once every 2 seconds from the server. This results in jerky energy bar movements, and more frustratingly, the client will keep your spells locked for longer than necessary, thinking you lack the required energy for their use. This can lead to significant discomfort when playing as a Rogue.

The proposed changes implement the correct adjustment of energy regeneration speed on both the server and the client and makes playing as a Rogue or a Cat Druid more enjoyable The result can be seen in the video:

<details>
  <summary>Before</summary>
  
  https://github.com/TrinityCore/TrinityCore/assets/13364438/44a38826-bbd6-45c0-9858-143b57d5948b

</details>

<details>
  <summary>After</summary>
  
  https://github.com/TrinityCore/TrinityCore/assets/13364438/75096b45-80fb-4f6c-8c89-4da4e8ead386

</details>

**Issues addressed:**

Closes #28299

**Tests performed:**

Builded and tested in-game.