### PR TITLE
Core/Creatures: fixed an inverted logic that was falsely causing creatures without any loot to despawn instantly

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2971,7 +2971,6 @@ void Creature::AllLootRemovedFromCorpse()
                     return false;
 
                 hasSkinningLoot = true;
-                break;
             }
         }
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2962,11 +2962,20 @@ void Creature::AllLootRemovedFromCorpse()
         if (m_loot && m_loot->loot_type == LOOT_SKINNING && m_loot->isLooted())
             return true;
 
+        bool hasSkinningLoot = false;
         for (auto const& [_, loot] : m_personalLoot)
-            if (loot->loot_type != LOOT_SKINNING || !loot->isLooted())
-                return false;
+        {
+            if (loot->loot_type == LOOT_SKINNING)
+            {
+                if (!loot->isLooted())
+                    return false;
 
-        return true;
+                hasSkinningLoot = true;
+                break;
+            }
+        }
+
+        return hasSkinningLoot;
     }();
 
     if (isFullySkinned)


### PR DESCRIPTION

**Changes proposed:**

-  the skinning loot check had an inverted logic which was causing lootless-creatures to be falsely marked as skinned and thus despawned instantly.



**Tests performed:**
- tested ingame

