### PR TITLE
Core/Players: Fixed typo preventing OOC regen

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1708,7 +1708,7 @@ void Player::Regenerate(Powers power)
     float addvalue = 0.0f;
     if (!IsInCombat())
     {
-        if (powerType->GetFlags().HasFlag(PowerTypeFlags::UseRegenInterrupt) && m_regenInterruptTimestamp + Milliseconds(powerType->RegenInterruptTimeMS) < GameTime::Now())
+        if (powerType->GetFlags().HasFlag(PowerTypeFlags::UseRegenInterrupt) && m_regenInterruptTimestamp + Milliseconds(powerType->RegenInterruptTimeMS) >= GameTime::Now())
             return;
 
         addvalue = (powerType->RegenPeace + m_unitData->PowerRegenFlatModifier[powerIndex]) * 0.001f * m_regenTimer;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Evaluation would always result to true after regen interrupt time had passed, resulting in reversed behaviour where OOC regen would no longer occur after m_regenInterruptTimestamp + RegenInterruptTimeMS milliseconds.
- We now only return/prevent regen if our m_regenInterruptTimestamp + RegenInterruptTimeMS is higher than GameTime.

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Works ingame, Holy Power now correctly decays out of combat


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
