### PR TITLE
Spells/Priest: Protective Light Aura

### DIFF
--- a/sql/updates/world/master/2024_01_28_03_world_priest_protective_light.sql
+++ b/sql/updates/world/master/2024_01_28_03_world_priest_protective_light.sql
@@ -1,0 +1,6 @@
+DELETE FROM `spell_proc` WHERE `SpellId` IN (193063);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(193063,0x02,6,0x00000800,0x00000000,0x00000000,0x00000000,0x0,0x0,0x2,0x2,0x3,0x0,0x0,0,0,0,0); -- Protective Light
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (193063);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (193063, 'spell_pri_protective_light');

--- a/sql/updates/world/master/2024_01_28_03_world_priest_protective_light.sql
+++ b/sql/updates/world/master/2024_01_28_03_world_priest_protective_light.sql
@@ -3,4 +3,5 @@ INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyM
 (193063,0x02,6,0x00000800,0x00000000,0x00000000,0x00000000,0x0,0x0,0x2,0x2,0x3,0x0,0x0,0,0,0,0); -- Protective Light
 
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (193063);
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (193063, 'spell_pri_protective_light');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(193063, 'spell_pri_protective_light');

--- a/sql/updates/world/master/2024_01_29_00_world.sql
+++ b/sql/updates/world/master/2024_01_29_00_world.sql
@@ -1,6 +1,6 @@
 DELETE FROM `spell_proc` WHERE `SpellId` IN (193063);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(193063,0x02,6,0x00000800,0x00000000,0x00000000,0x00000000,0x0,0x0,0x2,0x2,0x3,0x0,0x0,0,0,0,0); -- Protective Light
+(193063,0x02,6,0x00000800,0x00000000,0x00000000,0x00000000,0x0,0x0,0x2,0x2,0x403,0x0,0x0,0,0,0,0); -- Protective Light
 
 DELETE FROM `spell_script_names` WHERE `spell_id` IN (193063);
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2799,7 +2799,7 @@ class spell_pri_protective_light : public AuraScript
         return eventInfo.GetProcTarget() == GetCaster();
     }
 
-    void HandleEffectProc(AuraEffect* auraEff, ProcEventInfo& eventInfo)
+    void HandleEffectProc(AuraEffect* auraEff, ProcEventInfo& /*eventInfo*/)
     {
         GetCaster()->CastSpell(GetCaster(), SPELL_PRIEST_PROTECTIVE_LIGHT_AURA, auraEff);
     }

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -138,6 +138,7 @@ enum PriestSpells
     SPELL_PRIEST_PRAYER_OF_MENDING_AURA             = 41635,
     SPELL_PRIEST_PRAYER_OF_MENDING_HEAL             = 33110,
     SPELL_PRIEST_PRAYER_OF_MENDING_JUMP             = 155793,
+    SPELL_PRIEST_PROTECTIVE_LIGHT_AURA              = 193065,
     SPELL_PRIEST_PURGE_THE_WICKED                   = 204197,
     SPELL_PRIEST_PURGE_THE_WICKED_DUMMY             = 204215,
     SPELL_PRIEST_PURGE_THE_WICKED_PERIODIC          = 204213,
@@ -2788,8 +2789,31 @@ class spell_pri_vampiric_touch : public AuraScript
     }
 };
 
+// 193063 - Protective Light (Aura)
+class spell_pri_protective_light : public AuraScript
+{
+    PrepareAuraScript(spell_pri_protective_light);
+
+    bool CheckEffectProc(const AuraEffect* /*aurEff*/, ProcEventInfo& eventInfo)
+    {
+        return eventInfo.GetProcTarget() == GetCaster();
+    }
+
+    void HandleEffectProc(AuraEffect* auraEff, ProcEventInfo& eventInfo)
+    {
+        eventInfo.GetProcTarget()->CastSpell(GetCaster(), SPELL_PRIEST_PROTECTIVE_LIGHT_AURA, auraEff);
+    }
+
+    void Register() override
+    {
+        DoCheckEffectProc += AuraCheckEffectProcFn(spell_pri_protective_light::CheckEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
+        OnEffectProc += AuraEffectProcFn(spell_pri_protective_light::HandleEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
+    }
+};
+
 void AddSC_priest_spell_scripts()
 {
+    RegisterSpellScript(spell_pri_protective_light);
     RegisterSpellScript(spell_pri_angelic_feather_trigger);
     RegisterAreaTriggerAI(areatrigger_pri_angelic_feather);
     RegisterSpellScript(spell_pri_abyssal_reverie);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2794,7 +2794,7 @@ class spell_pri_protective_light : public AuraScript
 {
     PrepareAuraScript(spell_pri_protective_light);
 
-    bool CheckEffectProc(const AuraEffect* /*aurEff*/, ProcEventInfo& eventInfo)
+    bool CheckEffectProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
     {
         return eventInfo.GetProcTarget() == GetCaster();
     }

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2801,7 +2801,7 @@ class spell_pri_protective_light : public AuraScript
 
     void HandleEffectProc(AuraEffect* auraEff, ProcEventInfo& eventInfo)
     {
-        eventInfo.GetProcTarget()->CastSpell(GetCaster(), SPELL_PRIEST_PROTECTIVE_LIGHT_AURA, auraEff);
+        GetCaster()->CastSpell(GetCaster(), SPELL_PRIEST_PROTECTIVE_LIGHT_AURA, auraEff);
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2137,6 +2137,26 @@ class spell_pri_prayer_of_mending_jump : public spell_pri_prayer_of_mending_Spel
     }
 };
 
+// 193063 - Protective Light (Aura)
+class spell_pri_protective_light : public AuraScript
+{
+    bool CheckEffectProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+    {
+        return eventInfo.GetProcTarget() == GetCaster();
+    }
+
+    void HandleEffectProc(AuraEffect* aurEff, ProcEventInfo& /*eventInfo*/)
+    {
+        GetCaster()->CastSpell(GetCaster(), SPELL_PRIEST_PROTECTIVE_LIGHT_AURA, aurEff);
+    }
+
+    void Register() override
+    {
+        DoCheckEffectProc += AuraCheckEffectProcFn(spell_pri_protective_light::CheckEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
+        OnEffectProc += AuraEffectProcFn(spell_pri_protective_light::HandleEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
+    }
+};
+
 // 405554 - Priest Holy 10.1 Class Set 2pc
 class spell_pri_holy_10_1_class_set_2pc : public AuraScript
 {
@@ -2789,29 +2809,8 @@ class spell_pri_vampiric_touch : public AuraScript
     }
 };
 
-// 193063 - Protective Light (Aura)
-class spell_pri_protective_light : public AuraScript
-{
-    bool CheckEffectProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
-    {
-        return eventInfo.GetProcTarget() == GetCaster();
-    }
-
-    void HandleEffectProc(AuraEffect* auraEff, ProcEventInfo& /*eventInfo*/)
-    {
-        GetCaster()->CastSpell(GetCaster(), SPELL_PRIEST_PROTECTIVE_LIGHT_AURA, auraEff);
-    }
-
-    void Register() override
-    {
-        DoCheckEffectProc += AuraCheckEffectProcFn(spell_pri_protective_light::CheckEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
-        OnEffectProc += AuraEffectProcFn(spell_pri_protective_light::HandleEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
-    }
-};
-
 void AddSC_priest_spell_scripts()
 {
-    RegisterSpellScript(spell_pri_protective_light);
     RegisterSpellScript(spell_pri_angelic_feather_trigger);
     RegisterAreaTriggerAI(areatrigger_pri_angelic_feather);
     RegisterSpellScript(spell_pri_abyssal_reverie);
@@ -2860,6 +2859,7 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_prayer_of_mending_dummy);
     RegisterSpellAndAuraScriptPair(spell_pri_prayer_of_mending, spell_pri_prayer_of_mending_aura);
     RegisterSpellScript(spell_pri_prayer_of_mending_jump);
+    RegisterSpellScript(spell_pri_protective_light);
     RegisterSpellScript(spell_pri_holy_10_1_class_set_2pc);
     RegisterSpellScript(spell_pri_holy_10_1_class_set_2pc_chooser);
     RegisterSpellScript(spell_pri_holy_10_1_class_set_4pc);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2792,8 +2792,6 @@ class spell_pri_vampiric_touch : public AuraScript
 // 193063 - Protective Light (Aura)
 class spell_pri_protective_light : public AuraScript
 {
-    PrepareAuraScript(spell_pri_protective_light);
-
     bool CheckEffectProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
     {
         return eventInfo.GetProcTarget() == GetCaster();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Issues addressed:**

[Protective Light](https://www.wowhead.com/spell=193063/protective-light) aura doesnt proc at all. It should proc from Flash Heal only.

**Tests performed:**
tested ingame
1. make a Priest.
2. have Protective Light selected in the talent tree.
3. use Flash Heal.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
