### PR TITLE
Core/Auras: updated spell aura flags and implemented AFLAG_CANCELABLE and AFLAG_PASSIVE

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -32,14 +32,15 @@ enum AURA_FLAGS
 {
     AFLAG_NONE                   = 0x0000,
     AFLAG_NOCASTER               = 0x0001,
-    AFLAG_POSITIVE               = 0x0002,
+    AFLAG_CANCELABLE             = 0x0002,
     AFLAG_DURATION               = 0x0004,
     AFLAG_SCALABLE               = 0x0008,
     AFLAG_NEGATIVE               = 0x0010,
     AFLAG_UNK20                  = 0x0020,
     AFLAG_UNK40                  = 0x0040,
     AFLAG_UNK80                  = 0x0080,
-    AFLAG_MAW_POWER              = 0x0100,
+    AFLAG_POSITIVE               = 0x0100,
+    AFLAG_PASSIVE                = 0x0200
 };
 
 // these are modes, in which aura effect handler may be called

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -151,6 +151,13 @@ void AuraApplication::_InitFlags(Unit* caster, uint32 effMask)
     if (GetBase()->GetSpellInfo()->HasAttribute(SPELL_ATTR8_AURA_POINTS_ON_CLIENT)
         || std::find_if(GetBase()->GetAuraEffects().begin(), GetBase()->GetAuraEffects().end(), std::cref(effectNeedsAmount)) != GetBase()->GetAuraEffects().end())
         _flags |= AFLAG_SCALABLE;
+
+    if ((_flags & AFLAG_POSITIVE))
+        if (!GetBase()->GetSpellInfo()->IsPassive() && !GetBase()->GetSpellInfo()->HasAttribute(SPELL_ATTR1_NO_AURA_ICON) && GetBase()->GetOwner()->GetGUID() == GetTarget()->GetGUID())
+            _flags |= AFLAG_CANCELABLE;
+
+    if (GetBase()->GetSpellInfo()->IsPassive())
+        _flags |= AFLAG_PASSIVE;
 }
 
 void AuraApplication::_HandleEffect(uint8 effIndex, bool apply)


### PR DESCRIPTION

**Changes proposed:**

-  based on discord discussions it appears that the classic aura flags are different from retail. After comparing the information with sniffs, it seems that these informations are legit.
-  
**Tests performed:**
- tested ingame

However, we could need a reversing guy digging into the depths of the client to verify that classic uses other flags than retail does
