### PR TITLE
Update High Interrogator Gerstahn spell entries

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_high_interrogator_gerstahn.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/boss_high_interrogator_gerstahn.cpp
@@ -21,10 +21,10 @@
 
 enum Spells
 {
-    SPELL_SHADOWWORDPAIN                                   = 10894,
-    SPELL_MANABURN                                         = 10876,
-    SPELL_PSYCHICSCREAM                                    = 8122,
-    SPELL_SHADOWSHIELD                                     = 22417
+    SPELL_SHADOWWORDPAIN                                   = 14032,
+    SPELL_MANABURN                                         = 14033,
+    SPELL_PSYCHICSCREAM                                    = 13704,
+    SPELL_SHADOWSHIELD                                     = 12040
 };
 
 enum Events


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Update High Interrogator Gerstahn spell entries with [wowhead values](https://www.wowhead.com/wotlk/npc=9018/high-interrogator-gerstahn#abilities) since the current ones does trow some errors like:

> CastSpell: unknown spell 10876 by caster GUID Full: 0xf13000233a00000a Type: Creature Entry: 9018  Low: 10


**Issues addressed:**

None


**Tests performed:**

Does it build and have been tested in-game.


**Known issues and TODO list:**

- Well if this is correct, a lot of bosses does use similar wrong abilities in enum it seems.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
