### PR TITLE
Fix typo in worldstate expression execution

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -3664,7 +3664,7 @@ bool ConditionMgr::IsMeetingWorldStateExpression(Map const* map, WorldStateExpre
                 break;
         }
 
-        if (buffer.rpos() < buffer.size())
+        if (buffer.rpos() >= buffer.size())
             break;
 
         resultLogic = buffer.read<WorldStateExpressionLogic>();


### PR DESCRIPTION
**Issues addressed:**
Solves the issue because of which the worldstate expression was not fully executed

**Tests performed:**

I tested only with 18414 (but i think it works with later expansion too)

