### PR TITLE
Scripts/Spells: Implemented Priest talent Heaven's Wrath

### DIFF
--- a/sql/updates/world/master/2024_02_07_00_world.sql
+++ b/sql/updates/world/master/2024_02_07_00_world.sql
@@ -1,6 +1,6 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` = 421558;
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(421558, 'spell_pri_heavens_wrath');
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_heavens_wrath';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(421558,'spell_pri_heavens_wrath');
 
 DELETE FROM `spell_proc` WHERE `SpellId` IN (421558);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES

--- a/sql/updates/world/master/9999_99_99_99_world_heavens_wrath.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_heavens_wrath.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 421558;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(421558, 'spell_pri_heavens_wrath');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (421558);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(421558,0x02,6,0x00000000,0x00818000,0x00000080,0x00000000,0x0,0x0,0x3,0x2,0x403,0x0,0x0,0,0,0,0); -- Heaven's Wrath

--- a/sql/updates/world/master/9999_99_99_99_world_heavens_wrath.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_heavens_wrath.sql
@@ -4,4 +4,4 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 
 DELETE FROM `spell_proc` WHERE `SpellId` IN (421558);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(421558,0x02,6,0x00000000,0x00818000,0x00000080,0x00000000,0x0,0x0,0x3,0x2,0x403,0x0,0x0,0,0,0,0); -- Heaven's Wrath
+(421558,0x00,6,0x00000000,0x00018000,0x00000000,0x00000000,0x0,0x0,0x3,0x2,0x403,0x0,0x0,0,0,0,0); -- Heaven's Wrath

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1264,9 +1264,16 @@ class spell_pri_heavens_wrath : public AuraScript
     {
         return ValidateSpellInfo
         ({
-            SPELL_PRIEST_HEAVENS_WRATH,
             SPELL_PRIEST_ULTIMATE_PENITENCE
         });
+    }
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        if (eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_ULTIMATE_PENITENCE)
+            return false;
+
+        return true;
     }
 
     void HandleEffectProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -1264,27 +1264,22 @@ class spell_pri_heavens_wrath : public AuraScript
 {
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo
-        ({
-            SPELL_PRIEST_ULTIMATE_PENITENCE
-        });
+        return ValidateSpellInfo({ SPELL_PRIEST_ULTIMATE_PENITENCE });
     }
 
-    bool CheckProc(ProcEventInfo& eventInfo)
+    bool CheckProc(ProcEventInfo const& eventInfo) const
     {
         return !(eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_ULTIMATE_PENITENCE_DAMAGE || eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_ULTIMATE_PENITENCE_HEAL);
     }
 
-    void HandleEffectProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
+    void HandleEffectProc(AuraEffect const* aurEff, ProcEventInfo const& eventInfo) const
     {
         Unit* caster = eventInfo.GetActor();
         if (!caster)
             return;
 
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(SPELL_PRIEST_ULTIMATE_PENITENCE, GetCastDifficulty());
         int32 cdReduction = aurEff->GetAmount();
-
-        caster->GetSpellHistory()->ModifyCooldown(spellInfo, Seconds(-cdReduction), true);
+        caster->GetSpellHistory()->ModifyCooldown(SPELL_PRIEST_ULTIMATE_PENITENCE, Seconds(-cdReduction), true);
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -176,6 +176,8 @@ enum PriestSpells
     SPELL_PRIEST_TRINITY                            = 214205,
     SPELL_PRIEST_TRINITY_EFFECT                     = 214206,
     SPELL_PRIEST_ULTIMATE_PENITENCE                 = 421453,
+    SPELL_PRIEST_ULTIMATE_PENITENCE_DAMAGE          = 421543,
+    SPELL_PRIEST_ULTIMATE_PENITENCE_HEAL            = 421544,
     SPELL_PRIEST_VAMPIRIC_EMBRACE_HEAL              = 15290,
     SPELL_PRIEST_VAMPIRIC_TOUCH_DISPEL              = 64085,
     SPELL_PRIEST_VOID_SHIELD                        = 199144,
@@ -1270,10 +1272,7 @@ class spell_pri_heavens_wrath : public AuraScript
 
     bool CheckProc(ProcEventInfo& eventInfo)
     {
-        if (eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_ULTIMATE_PENITENCE)
-            return false;
-
-        return true;
+        return !(eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_ULTIMATE_PENITENCE_DAMAGE || eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_ULTIMATE_PENITENCE_HEAL);
     }
 
     void HandleEffectProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -99,6 +99,7 @@ enum PriestSpells
     SPELL_PRIEST_HALO_SHADOW_HEAL                   = 390971,
     SPELL_PRIEST_HEAL                               = 2060,
     SPELL_PRIEST_HEALING_LIGHT                      = 196809,
+    SPELL_PRIEST_HEAVENS_WRATH                      = 421558,
     SPELL_PRIEST_HOLY_FIRE                          = 14914,
     SPELL_PRIEST_HOLY_MENDING_HEAL                  = 391156,
     SPELL_PRIEST_HOLY_NOVA                          = 132157,
@@ -174,6 +175,7 @@ enum PriestSpells
     SPELL_PRIEST_TRAIL_OF_LIGHT_HEAL                = 234946,
     SPELL_PRIEST_TRINITY                            = 214205,
     SPELL_PRIEST_TRINITY_EFFECT                     = 214206,
+    SPELL_PRIEST_ULTIMATE_PENITENCE                 = 421453,
     SPELL_PRIEST_VAMPIRIC_EMBRACE_HEAL              = 15290,
     SPELL_PRIEST_VAMPIRIC_TOUCH_DISPEL              = 64085,
     SPELL_PRIEST_VOID_SHIELD                        = 199144,
@@ -1252,6 +1254,36 @@ class spell_pri_guardian_spirit : public AuraScript
     {
         DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_pri_guardian_spirit::CalculateAmount, EFFECT_1, SPELL_AURA_SCHOOL_ABSORB);
         OnEffectAbsorb += AuraEffectAbsorbFn(spell_pri_guardian_spirit::Absorb, EFFECT_1);
+    }
+};
+
+// 421558 - Heaven's Wrath
+class spell_pri_heavens_wrath : public AuraScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo
+        ({
+            SPELL_PRIEST_HEAVENS_WRATH,
+            SPELL_PRIEST_ULTIMATE_PENITENCE
+        });
+    }
+
+    void HandleEffectProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
+    {
+        Unit* caster = eventInfo.GetActor();
+        if (!caster)
+            return;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(SPELL_PRIEST_ULTIMATE_PENITENCE, GetCastDifficulty());
+        int32 cdReduction = aurEff->GetAmount();
+
+        caster->GetSpellHistory()->ModifyCooldown(spellInfo, Seconds(-cdReduction), true);
+    }
+
+    void Register() override
+    {
+        OnEffectProc += AuraEffectProcFn(spell_pri_heavens_wrath::HandleEffectProc, EFFECT_0, SPELL_AURA_DUMMY);
     }
 };
 
@@ -2976,6 +3008,7 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_guardian_spirit);
     RegisterSpellScript(spell_pri_halo_shadow);
     RegisterAreaTriggerAI(areatrigger_pri_halo);
+    RegisterSpellScript(spell_pri_heavens_wrath);
     RegisterSpellScript(spell_pri_holy_mending);
     RegisterSpellScript(spell_pri_holy_words);
     RegisterSpellScript(spell_pri_holy_word_salvation);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

Discipline Priest talent

**Issues addressed:**
[Heaven's Wrath](https://www.wowhead.com/spell=421558/heavens-wrath) doesn't reduce Ultimate Penitence cooldown.

**Tests performed:**
tested ingame
- rank 1 and 4 Penance bolts => 1*4 = 4 sec cdr(from Penanace) + 2 sec cdr(from spell's cd) = 6 sec cdr(e.g.1:50->1:44)
- rank 2 and 4 Penance bolts => 2*4 = 8 sec cdr(from Penance) + 2 sec cdr(from spell's cd) = 10 sec cdr(e.g.1:50->1:40)

build used(for 2nd test): BAQA0Hr2WRGgVq7/s2iQ2HhjlABoFEk0SSIIlkSSikEAAAAAAAAAAAAS7AikEkCRSiIQ5AEJRUIA



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
