### PR TITLE
Scripts/Spells: Implemented Priest talent Train of Thought

### DIFF
--- a/sql/updates/world/master/2024_02_11_00_world.sql
+++ b/sql/updates/world/master/2024_02_11_00_world.sql
@@ -1,7 +1,7 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (390693);
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(390693, 'spell_pri_train_of_thought');
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_train_of_thought';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(390693,'spell_pri_train_of_thought');
 
 DELETE FROM `spell_proc` WHERE `SpellId` IN (390693);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(390693,0x02,6,0x000008C0,0x00000000,0x00000000,0x00000000,0x0,0x0,0x3,0x1,0x403,0x0,0x0,0,0,0,0); -- Train of Thought
+(390693,0x0,6,0x000008C0,0x00000000,0x00000000,0x00000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0,0,0,0); -- Train of Thought

--- a/sql/updates/world/master/9999_99_99_99_world_train_of_thought.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_train_of_thought.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (390693);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(390693, 'spell_pri_train_of_thought');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (390693);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(390693,0x02,6,0x000008C0,0x00000000,0x00000000,0x00000000,0x0,0x0,0x3,0x1,0x403,0x0,0x0,0,0,0,0); -- Train of Thought

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -3004,30 +3004,30 @@ class spell_pri_train_of_thought : public AuraScript
             SPELL_PRIEST_SMITE,
             SPELL_PRIEST_POWER_WORD_SHIELD,
             SPELL_PRIEST_PENANCE
+        }) && ValidateSpellEffect
+        ({
+            { SPELL_PRIEST_TRAIN_OF_THOUGHT, EFFECT_0 },
+            { SPELL_PRIEST_TRAIN_OF_THOUGHT, EFFECT_1 }
         });
     }
 
     void HandleProc(ProcEventInfo& eventInfo)
     {
-        Unit* caster = GetTarget();
-        if (!caster)
-            return;
-
         if (eventInfo.GetSpellInfo()->Id == SPELL_PRIEST_SMITE)
         {
             SpellInfo const* penance = sSpellMgr->GetSpellInfo(SPELL_PRIEST_PENANCE, GetCastDifficulty());
-            AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_PRIEST_TRAIN_OF_THOUGHT, EFFECT_1);
+            AuraEffect const* aurEff = GetTarget()->GetAuraEffect(SPELL_PRIEST_TRAIN_OF_THOUGHT, EFFECT_1);
             int32 cdr = aurEff->GetAmount();
 
-            caster->GetSpellHistory()->ModifyCooldown(penance, Milliseconds(cdr));
+            GetTarget()->GetSpellHistory()->ModifyCooldown(penance, Milliseconds(cdr));
         }
         else
         {
             SpellInfo const* pws = sSpellMgr->GetSpellInfo(SPELL_PRIEST_POWER_WORD_SHIELD, GetCastDifficulty());
-            AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_PRIEST_TRAIN_OF_THOUGHT, EFFECT_0);
+            AuraEffect const* aurEff = GetTarget()->GetAuraEffect(SPELL_PRIEST_TRAIN_OF_THOUGHT, EFFECT_0);
             int32 cdr = aurEff->GetAmount();
 
-            caster->GetSpellHistory()->ModifyCooldown(pws, Milliseconds(cdr));
+            GetTarget()->GetSpellHistory()->ModifyCooldown(pws, Milliseconds(cdr));
         }
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Issues addressed:**

[Train of Thought](https://www.wowhead.com/spell=390693/train-of-thought) doesn't work.
Power Word: Shield's cd should be reduced by 1sec by Flash Heal or Renew.
Penance's cd should be reduced by 0.5sec by Smite.


**Tests performed:**

tested ingame
disc priest
build: BAQA0Hr2WRGgVq7/s2iQ2HhjlABoFEcg0SSIIlkSSikkAAAAAAAAAAAAi0ISSQKEJJiAlDQkERhA


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
