### PR TITLE
Scripts/Spells: Implemented Priest talent Crystalline Reflection

### DIFF
--- a/sql/updates/world/master/2024_02_10_05_world.sql
+++ b/sql/updates/world/master/2024_02_10_05_world.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_crystalline_reflection';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(17,'spell_pri_crystalline_reflection');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3487,7 +3487,8 @@ void SpellMgr::LoadSpellInfoCorrections()
         71607, // Item - Bauble of True Blood 10m
         71646, // Item - Bauble of True Blood 25m
         71610, // Item - Althor's Abacus trigger 10m
-        71641  // Item - Althor's Abacus trigger 25m
+        71641, // Item - Althor's Abacus trigger 25m
+        373462 // Crystalline Reflection HEAL
     }, [](SpellInfo* spellInfo)
     {
         // We need more spells to find a general way (if there is any)

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2090,9 +2090,13 @@ class spell_pri_power_word_shield : public AuraScript
                 caster->CastSpell(caster, SPELL_PRIEST_SHIELD_DISCIPLINE_EFFECT, aurEff);
     }
 
-    void HandleAfterAbsorb(AuraEffect* /*aurEff*/, DamageInfo& dmgInfo, uint32& /*absorbAmount*/)
+    void HandleAfterAbsorb(AuraEffect* /*aurEff*/, DamageInfo& dmgInfo, uint32& absorbAmount)
     {
-        AuraEffect const* auraEff = GetCaster()->GetAuraEffect(SPELL_PRIEST_CRYSTALLINE_REFLECTION, EFFECT_0);
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        AuraEffect const* auraEff = caster->GetAuraEffect(SPELL_PRIEST_CRYSTALLINE_REFLECTION, EFFECT_0);
         if (!auraEff)
             return;
 
@@ -2101,7 +2105,7 @@ class spell_pri_power_word_shield : public AuraScript
             return;
 
         CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
-        args.AddSpellBP0(CalculatePct(dmgInfo.GetDamage(), auraEff->GetAmount()));
+        args.AddSpellBP0(CalculatePct(absorbAmount, auraEff->GetAmount()));
 
         GetTarget()->CastSpell(attacker, SPELL_PRIEST_CRYSTALLINE_REFLECTION_REFLECT, args);
     }
@@ -2111,7 +2115,7 @@ class spell_pri_power_word_shield : public AuraScript
         DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_pri_power_word_shield::CalculateAmount, EFFECT_0, SPELL_AURA_SCHOOL_ABSORB);
         AfterEffectApply += AuraEffectApplyFn(spell_pri_power_word_shield::HandleOnApply, EFFECT_0, SPELL_AURA_SCHOOL_ABSORB, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
         AfterEffectRemove += AuraEffectRemoveFn(spell_pri_power_word_shield::HandleOnRemove, EFFECT_0, SPELL_AURA_SCHOOL_ABSORB, AURA_EFFECT_HANDLE_REAL);
-        OnEffectAbsorb += AuraEffectAbsorbFn(spell_pri_power_word_shield::HandleAfterAbsorb, EFFECT_0);
+        AfterEffectAbsorb += AuraEffectAbsorbFn(spell_pri_power_word_shield::HandleAfterAbsorb, EFFECT_0);
     }
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Issues addressed:**

[Crystalline Reflection](https://www.wowhead.com/spell=373457/crystalline-reflection) not working at all.
Should make Power Word: Shield do heal on target and reflect 6%/12% of damage absorbed. 


**Tests performed:**

tested ingame
priest general talent
build: BAQA0Hr2WRGgVq7/s2iQ2HhjlABoFEItkECSJpkkIJJBAAAAAAAAAAAINikEkCRSiIQJEJRUIA


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
