### PR TITLE
Scripts/Spells: Implemented Priest talent Divine Aegis/ Fixed PW:S Crit

### DIFF
--- a/sql/updates/world/master/2024_02_10_04_world.sql
+++ b/sql/updates/world/master/2024_02_10_04_world.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_proc` WHERE `SpellId` IN (47515);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(47515,0x00,6,0x00000000,0x00000000,0x00000000,0x00000000,0x0,0x0,0x2,0x2,0x402,0x0,0x0,0,0,0,0); -- Divine Aegis
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_pri_divine_aegis';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(47515,'spell_pri_divine_aegis');

--- a/sql/updates/world/master/9999_99_99_99_world_divine_aegis.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_divine_aegis.sql
@@ -1,3 +1,0 @@
-DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_pri_divine_aegis');
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(47515, 'spell_pri_divine_aegis');

--- a/sql/updates/world/master/9999_99_99_99_world_divine_aegis.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_divine_aegis.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_pri_divine_aegis');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(47515, 'spell_pri_divine_aegis');

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -67,6 +67,8 @@ enum PriestSpells
     SPELL_PRIEST_DARK_REPRIMAND_DAMAGE              = 373130,
     SPELL_PRIEST_DARK_REPRIMAND_HEALING             = 400187,
     SPELL_PRIEST_DAZZLING_LIGHT                     = 196810,
+    SPELL_PRIEST_DIVINE_AEGIS                       = 47515,
+    SPELL_PRIEST_DIVINE_AEGIS_ABSORB                = 47753,
     SPELL_PRIEST_DIVINE_BLESSING                    = 40440,
     SPELL_PRIEST_DIVINE_HYMN_HEAL                   = 64844,
     SPELL_PRIEST_DIVINE_IMAGE_SUMMON                = 392990,
@@ -1995,11 +1997,12 @@ class spell_pri_power_word_shield : public AuraScript
         }) && ValidateSpellEffect({
             { SPELL_PRIEST_MASTERY_GRACE, EFFECT_0 },
             { SPELL_PRIEST_RAPTURE, EFFECT_1 },
-            { SPELL_PRIEST_BENEVOLENCE, EFFECT_0 }
+            { SPELL_PRIEST_BENEVOLENCE, EFFECT_0 },
+            { SPELL_PRIEST_DIVINE_AEGIS, EFFECT_1}
         });
     }
 
-    void CalculateAmount(AuraEffect const* /*auraEffect*/, int32& amount, bool& canBeRecalculated) const
+    void CalculateAmount(AuraEffect const* auraEffect, int32& amount, bool& canBeRecalculated) const
     {
         canBeRecalculated = false;
 
@@ -2022,6 +2025,18 @@ class spell_pri_power_word_shield : public AuraScript
                     if (caster->HasAura(SPELL_PVP_RULES_ENABLED_HARDCODED))
                         modifiedAmount *= 0.8f;
                 }
+            }
+
+            float critChanceDone = caster->SpellCritChanceDone(nullptr, auraEffect, GetSpellInfo()->GetSchoolMask(), GetSpellInfo()->GetAttackType());
+            float critChanceTaken = caster->SpellCritChanceTaken(caster, nullptr, auraEffect, GetSpellInfo()->GetSchoolMask(), critChanceDone, GetSpellInfo()->GetAttackType());
+
+            if (roll_chance_f(critChanceTaken))
+            {
+                modifiedAmount *= 2;
+
+                // Divine Aegis
+                if (AuraEffect const* divineEff = caster->GetAuraEffect(SPELL_PRIEST_DIVINE_AEGIS, EFFECT_1))
+                    AddPct(modifiedAmount, divineEff->GetAmount());
             }
 
             // Rapture talent (TBD: move into DoEffectCalcDamageAndHealing hook).
@@ -2062,6 +2077,45 @@ class spell_pri_power_word_shield : public AuraScript
         DoEffectCalcAmount += AuraEffectCalcAmountFn(spell_pri_power_word_shield::CalculateAmount, EFFECT_0, SPELL_AURA_SCHOOL_ABSORB);
         AfterEffectApply += AuraEffectApplyFn(spell_pri_power_word_shield::HandleOnApply, EFFECT_0, SPELL_AURA_SCHOOL_ABSORB, AURA_EFFECT_HANDLE_REAL_OR_REAPPLY_MASK);
         AfterEffectRemove += AuraEffectRemoveFn(spell_pri_power_word_shield::HandleOnRemove, EFFECT_0, SPELL_AURA_SCHOOL_ABSORB, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
+// 47515 - Divine Aegis
+class spell_pri_divine_aegis : public AuraScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo ({ SPELL_PRIEST_DIVINE_AEGIS_ABSORB })
+            && ValidateSpellEffect({ { SPELL_PRIEST_DIVINE_AEGIS, EFFECT_0} });
+    }
+
+    bool CheckProc(ProcEventInfo& eventInfo)
+    {
+        if (eventInfo.GetHealInfo() && eventInfo.GetHitMask() & PROC_HIT_CRITICAL)
+            return true;
+
+        return false;
+    }
+
+    void HandleProc(ProcEventInfo& eventInfo)
+    {
+        Unit* caster = eventInfo.GetActor();
+        if (!caster)
+            return;
+        
+        uint32 healing = eventInfo.GetHealInfo()->GetHeal();
+        AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_PRIEST_DIVINE_AEGIS, EFFECT_0);
+
+        CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
+        args.AddSpellBP0(CalculatePct(healing, aurEff->GetAmount()));
+
+        caster->CastSpell(GetTarget(), SPELL_PRIEST_DIVINE_AEGIS_ABSORB, args);
+    }
+
+    void Register() override
+    {
+        DoCheckProc += AuraCheckProcFn(spell_pri_divine_aegis::CheckProc);
+        OnProc += AuraProcFn(spell_pri_divine_aegis::HandleProc);
     }
 };
 
@@ -3008,6 +3062,7 @@ void AddSC_priest_spell_scripts()
     RegisterSpellScript(spell_pri_blaze_of_light);
     RegisterSpellScript(spell_pri_circle_of_healing);
     RegisterSpellScript(spell_pri_dark_indulgence);
+    RegisterSpellScript(spell_pri_divine_aegis);
     RegisterSpellScript(spell_pri_divine_image);
     RegisterSpellScript(spell_pri_divine_image_spell_triggered);
     RegisterSpellScript(spell_pri_divine_image_stack_timer);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2102,7 +2102,6 @@ class spell_pri_divine_aegis : public AuraScript
         Unit* caster = eventInfo.GetActor();
         if (!caster)
             return;
-        
         uint32 healing = eventInfo.GetHealInfo()->GetHeal();
         AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_PRIEST_DIVINE_AEGIS, EFFECT_0);
         CastSpellExtraArgs args(TRIGGERED_FULL_MASK);

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2105,7 +2105,6 @@ class spell_pri_divine_aegis : public AuraScript
         
         uint32 healing = eventInfo.GetHealInfo()->GetHeal();
         AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_PRIEST_DIVINE_AEGIS, EFFECT_0);
-
         CastSpellExtraArgs args(TRIGGERED_FULL_MASK);
         args.AddSpellBP0(CalculatePct(healing, aurEff->GetAmount()));
 

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2027,10 +2027,8 @@ class spell_pri_power_word_shield : public AuraScript
                 }
             }
 
-            float critChanceDone = caster->SpellCritChanceDone(nullptr, auraEffect, GetSpellInfo()->GetSchoolMask(), GetSpellInfo()->GetAttackType());
-            float critChanceTaken = caster->SpellCritChanceTaken(caster, nullptr, auraEffect, GetSpellInfo()->GetSchoolMask(), critChanceDone, GetSpellInfo()->GetAttackType());
-
-            if (roll_chance_f(critChanceTaken))
+            float critChance = caster->SpellCritChanceDone(nullptr, auraEffect, GetSpellInfo()->GetSchoolMask(), GetSpellInfo()->GetAttackType());
+            if (roll_chance_f(critChance))
             {
                 modifiedAmount *= 2;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Issues addressed:**

[Divine Aegis](https://www.wowhead.com/spell=47515/divine-aegis) talent doesn't work.
Crit heals should give you an absorb of 5% from healing recieved.
Crit heals with PW:S should increase the PW:S absorb by 10%.


**Tests performed:**

tested ingame
discipline priest talent
build: BAQA0Hr2WRGgVq7/s2iQ2HhjlABolCCSLBiIlkSSCJJBAAAAAAAAAAAItgkEkCRSiIQJEJRUIA

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
