### PR TITLE
Attempt to fix an old issue where the new arena group leader can't talk on party chat

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -381,6 +381,13 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recvData)
                     return;
             }
 
+            if (sender->InArena())
+            {
+                group = sender->GetGroup();
+                if (!group)
+                    return;
+            }
+
             if (type == CHAT_MSG_PARTY_LEADER && !group->IsLeader(sender->GetGUID()))
                 return;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix the targeted issue where the new group leader can't talk on party chat (/p) if switch has been made while in arena.
-  Credit goes to @Raydor since it's his fix, I only tested and it seems it does the job.

**Issues addressed:**

Closes #14868

**Tests performed:**

Does it build, tested in-game as you can see below, etc.

Before: https://youtu.be/SGJIBz4bHlQ
After: https://youtu.be/fQixV51uq1A

**Known issues and TODO list:** (add/remove lines as needed)

- In my tests I didn't notice issues so I guess is fine.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
