### PR TITLE
Core/Gossips: Don't send NpcInteraction for GossipOptionNpc::None

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -14180,6 +14180,8 @@ void Player::OnGossipSelect(WorldObject* source, int32 gossipOptionId, uint32 me
     bool handled = true;
     switch (gossipOptionNpc)
     {
+        case GossipOptionNpc::None:
+            break;
         case GossipOptionNpc::Vendor:
             GetSession()->SendListInventory(guid);
             break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Don't send NpcInteraction opcode for GossipOptionNpc::None. If another gossip menu is sent, the client is left in an invalid state and closes the gossip menu without finishing the interaction with the source (worldobject)

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.

Tested with Trading Post Post (386352) in Stormwind (GossipOptionIDs are present in db2)


**Known issues and TODO list:** (add/remove lines as needed)
None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
