### PR TITLE
Core/Misc: Defined and implemented CHARACTER_FLAG_RESTING

### DIFF
--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -1018,7 +1018,7 @@ enum CharacterFlags
 {
     CHARACTER_FLAG_NONE                 = 0x00000000,
     CHARACTER_FLAG_UNK1                 = 0x00000001,
-    CHARACTER_FLAG_UNK2                 = 0x00000002,
+    CHARACTER_FLAG_RESTING              = 0x00000002,
     CHARACTER_FLAG_LOCKED_FOR_TRANSFER  = 0x00000004,
     CHARACTER_FLAG_UNK4                 = 0x00000008,
     CHARACTER_FLAG_UNK5                 = 0x00000010,

--- a/src/server/game/Server/Packets/CharacterPackets.cpp
+++ b/src/server/game/Server/Packets/CharacterPackets.cpp
@@ -120,6 +120,9 @@ EnumCharactersResult::CharacterInfo::CharacterInfo(Field* fields)
     uint32 playerFlags  = fields[12].GetUInt32();
     uint32 atLoginFlags = fields[13].GetUInt16();
 
+    if (playerFlags & PLAYER_FLAGS_RESTING)
+        Flags |= CHARACTER_FLAG_RESTING;
+
     if (atLoginFlags & AT_LOGIN_RESURRECT)
         playerFlags &= ~PLAYER_FLAGS_GHOST;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Defined a very useless character flag that's set when a character is currently resting/in a rested area.
-  During the 2004 beta, this flag was used for displaying the character as resting on the selection screen. This was removed before live.
-  However, the flag is still set and unset, as can be seen if one compares flags before and after leaving a rested area (like a major city).
- For nearly 20 years there has been no associated behaviour with this flag in the client, but maybe we might see it in use again with 11.0 :)

**Issues addressed:**

Defines a previous unknown flag.

**Tests performed:**

Builds, tested ingame, does visually nothing.

**Known issues and TODO list:** (add/remove lines as needed)

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
