### PR TITLE
Core/Spells: allow players to absorb fire damage from environmental damage spell effects

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -744,8 +744,9 @@ uint32 Player::EnvironmentalDamage(EnviromentalDamage type, uint32 damage)
     {
         case DAMAGE_LAVA:
         case DAMAGE_SLIME:
+        case DAMAGE_FIRE:
         {
-            DamageInfo dmgInfo(this, this, damage, nullptr, type == DAMAGE_LAVA ? SPELL_SCHOOL_MASK_FIRE : SPELL_SCHOOL_MASK_NATURE, DIRECT_DAMAGE, BASE_ATTACK);
+            DamageInfo dmgInfo(this, this, damage, nullptr, type == DAMAGE_SLIME ? SPELL_SCHOOL_MASK_NATURE : SPELL_SCHOOL_MASK_FIRE, DIRECT_DAMAGE, BASE_ATTACK);
             Unit::CalcAbsorbResist(dmgInfo);
             absorb = dmgInfo.GetAbsorb();
             resist = dmgInfo.GetResist();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  CherryPick https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/e87c7ae513be87869b7648a4e83e21bcf7d35ec3 
- Credit goes to [Ovahlord](https://github.com/Ovahlord) since it's his fix

**Issues addressed:**

Update https://github.com/TrinityCore/TrinityCore/issues/29064

**Tests performed:**

Does it build and have been tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)

- [ No issues noticed. ] 
- It still doesn't fix the issue since the environmental damage is currently only respecting absorbtion and resisting mechanics, not total damage taken mechanics as it shoud but is still smth than nothing.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
