### PR TITLE
Core/Spells: Fix SPELLVALUE_CRIT_CHANCE

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7780,7 +7780,7 @@ void Spell::SetSpellValue(SpellValueMod mod, int32 value)
             m_spellValue->AuraStackAmount = uint8(value);
             break;
         case SPELLVALUE_CRIT_CHANCE:
-            m_spellValue->CriticalChance = value / 100.0f; // @todo ugly /100 remove when basepoints are double
+            m_spellValue->CriticalChance = value;
             break;
     }
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Why do we need this division here?

![image](https://github.com/TrinityCore/TrinityCore/assets/13364438/79c94bcd-93f9-419d-9419-616305778987)

roll_chance_f takes a pure percentage value.
