### PR TITLE
Core/Movement: require a minimum wander_distance value of 0.1

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2277,6 +2277,11 @@ void ObjectMgr::LoadCreatures()
             TC_LOG_ERROR("sql.sql", "Table `creature` has creature (GUID: {} Entry: {}) with `wander_distance`< 0, set to 0.", guid, data.id);
             data.wander_distance = 0.0f;
         }
+        else if (data.wander_distance > 0.0f && data.wander_distance < 0.1f)
+        {
+            TC_LOG_ERROR("sql.sql", "Table `creature` has creature (GUID: {} Entry: {}) with `wander_distance` below the allowed minimum distance of 0.1, set to 0.", guid, data.id);
+            data.wander_distance = 0.0f;
+        }
         else if (data.movementType == RANDOM_MOTION_TYPE)
         {
             if (G3D::fuzzyEq(data.wander_distance, 0.0f))

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -124,8 +124,8 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
     }
 
     Position position(_reference);
-    float distance = frand(0.f, _wanderDistance);
-    float angle = frand(0.f, float(M_PI * 2));
+    float distance = _wanderDistance > 0.1f ? frand(0.1f, _wanderDistance) : _wanderDistance;
+    float angle = frand(0.f, static_cast<float>(M_PI * 2));
     owner->MovePositionToFirstCollision(position, distance, angle);
 
     // Check if the destination is in LOS
@@ -149,6 +149,13 @@ void RandomMovementGenerator<Creature>::SetRandomLocation(Creature* owner)
                 /*|| (_path->GetPathType() & PATHFIND_FARFROMPOLY)*/)
     {
         _timer.Reset(100);
+        return;
+    }
+
+    if (_path->GetPathLength() < 0.1f)
+    {
+        // the path is too short for the spline system to be accepted. Let's try again soon.
+        _timer.Reset(500);
         return;
     }
 


### PR DESCRIPTION
**Changes proposed:**

-  this is just a small extra step that should help to launch fewer too short splines to reduce console spam

**Tests performed:**
- long term tested on 4.x
