### PR TITLE
Core/Player: fix incorrect Warrior Block Value calculations

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -5092,7 +5092,7 @@ void Player::ApplyBaseModPctValue(BaseModGroup modGroup, float pct)
         return;
     }
 
-    AddPct(m_auraBasePctMod[modGroup], pct);
+    m_auraBasePctMod[modGroup] += CalculatePct(1.0f, pct);
     UpdateBaseModGroup(modGroup);
 }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Most likely current warrior block value formula is wrong because it does calculate from already increased percentage.
-  All the credit goes to [Keader](https://github.com/Keader) since it's his fix.

560 base value (with shield)

Before: https://youtu.be/2vOxTWngijg
560 + Rank 1 Shield Mastery (15%) 84 + Rank 2 Shield Mastery (15%) 84 = 
560 + 84 = 644 -- Rank 1 Shield Mastery (15%)
644 + 84 = 728 -- Rank 2 Shield Mastery (15%)

728 + 728 Shield Block (100% from already increased value)  = 1456 (wrong value)

After: https://youtu.be/O-bPyQbA85M
560 + 84 Rank 1 Shield Mastery (15%) + 84 Rank 2 Shield Mastery (15%) = 
560 + 84 = 644 -- Rank 1 Shield Mastery (15%)
644 + 84 = 728 -- Rank 2 Shield Mastery (15%)

728 + 560 Shield Block (100% from base value)  = 1288 (correct value)

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/25482

**Tests performed:**

Does it build, tested in-game as you can see above, etc.

**Known issues and TODO list:** (add/remove lines as needed)

- [ None ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
