### PR TITLE
Core/Locales: Fix crash of uninitialized value for empty texts

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -244,7 +244,7 @@ void ObjectMgr::AddLocaleString(std::string_view value, LocaleConstant localeCon
         data.reserve(TOTAL_LOCALES);
         data.resize(localeConstant + 1);
     }
-    
+
     data[localeConstant] = value.empty() ? "" : value;
 }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -239,16 +239,13 @@ ObjectMgr::~ObjectMgr()
 
 void ObjectMgr::AddLocaleString(std::string_view value, LocaleConstant localeConstant, std::vector<std::string>& data)
 {
-    if (!value.empty())
+    if (data.size() <= size_t(localeConstant))
     {
-        if (data.size() <= size_t(localeConstant))
-        {
-            data.reserve(TOTAL_LOCALES);
-            data.resize(localeConstant + 1);
-        }
-
-        data[localeConstant] = value;
+        data.reserve(TOTAL_LOCALES);
+        data.resize(localeConstant + 1);
     }
+    
+    data[localeConstant] = value.empty() ? "" : value;
 }
 
 void ObjectMgr::LoadCreatureLocales()


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Check `!value.empty()` leaves the value uninitialized when stored text in DB is empty. Any subsequent attempt to access the value such as https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Quests/QuestDef.cpp#L633 crashes the server

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game.
```sql
DELETE FROM `quest_completion_log_conditional` WHERE (`QuestId`=74381 AND `PlayerConditionId`=0 AND `QuestgiverCreatureId`=0 AND `locale`='enUS');
INSERT INTO `quest_completion_log_conditional` (`QuestId`, `PlayerConditionId`, `QuestgiverCreatureId`, `locale`, `Text`, `OrderIndex`, `VerifiedBuild`) VALUES
(74381, 0, 0, 'enUS', '', 0, 53441); -- Hidden Legacies
```


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
