### PR TITLE
Attempt to fix Flame Shield no target error on The Eye of Eternity, Malygos encounter

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -803,7 +803,9 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPacket& recvPacket)
     spell->m_cast_count = castCount; // probably pending spell cast
     spell->m_targets = targets;
 
-    SpellCastResult result = spell->CheckPetCast(nullptr);
+    bool const needsExplicit = !targets.GetUnitTarget() && spellInfo->NeedsExplicitUnitTarget();
+    Unit* target = needsExplicit ? _player->GetSelectedUnit() : nullptr;
+    SpellCastResult result = spell->CheckPetCast(target);
 
     if (result == SPELL_CAST_OK)
     {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Attempt to fix an old issue on The Eye of Eternity > Malygos encounter where when you are on Wyrmrest Skytalon you are unable to cast Flame Shield
-  All the credit goes to [Riztazz](https://github.com/Riztazz) since it's his fix.

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/11566


**Tests performed:**

Does it build, tested in-game as you can see below:

Before: https://youtu.be/I4hxHfYxQSI

After: https://youtu.be/Oi9dIb9qGYg

**Known issues and TODO list:** (add/remove lines as needed)

- [ None as far I coud check. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
