### PR TITLE
Core/Player: Fix console errors of wrong teamid for neutral pandaren race

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -512,9 +512,20 @@ void PlayerAchievementMgr::CompletedAchievement(AchievementEntry const* achievem
     //! Since no common attributes were found, (not even in titleRewardFlags field)
     //! we explicitly check by ID. Maybe in the future we could move the achievement_reward
     //! condition fields to the condition system.
-    if (uint32 titleId = reward->TitleId[achievement->ID == 1793 ? _owner->GetNativeGender() : (_owner->GetTeam() == ALLIANCE ? 0 : 1)])
-        if (CharTitlesEntry const* titleEntry = sCharTitlesStore.LookupEntry(titleId))
-            _owner->SetTitle(titleEntry);
+    int32 titleId = [&]
+    {
+        if (achievement->ID == 1793)
+            return reward->TitleId[_owner->GetNativeGender()];
+        switch (_owner->GetTeam())
+        {
+            case ALLIANCE: return reward->TitleId[0];
+            case HORDE: return reward->TitleId[1];
+            default: break;
+        }
+        return 0u;
+    }();
+    if (CharTitlesEntry const* titleEntry = sCharTitlesStore.LookupEntry(titleId))
+        _owner->SetTitle(titleEntry);
 
     // mail
     if (reward->SenderCreatureId)

--- a/src/server/game/Battlefield/Battlefield.h
+++ b/src/server/game/Battlefield/Battlefield.h
@@ -218,7 +218,6 @@ class TC_GAME_API Battlefield : public ZoneScript
         // Battlefield - generic methods
         TeamId GetDefenderTeam() const { return m_DefenderTeam; }
         TeamId GetAttackerTeam() const { return TeamId(1 - m_DefenderTeam); }
-        TeamId GetOtherTeam(TeamId team) const { return (team == TEAM_HORDE ? TEAM_ALLIANCE : TEAM_HORDE); }
         void SetDefenderTeam(TeamId team) { m_DefenderTeam = team; }
 
         // Group methods

--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1705,11 +1705,6 @@ Team Battleground::GetPlayerTeam(ObjectGuid guid) const
     return TEAM_OTHER;
 }
 
-Team Battleground::GetOtherTeam(Team team) const
-{
-    return team ? ((team == ALLIANCE) ? HORDE : ALLIANCE) : TEAM_OTHER;
-}
-
 bool Battleground::IsPlayerInBattleground(ObjectGuid guid) const
 {
     BattlegroundPlayerMap::const_iterator itr = m_Players.find(guid);

--- a/src/server/game/Battlegrounds/Battleground.h
+++ b/src/server/game/Battlegrounds/Battleground.h
@@ -461,7 +461,6 @@ class TC_GAME_API Battleground : public ZoneScript
 
         // since arenas can be AvA or Hvh, we have to get the "temporary" team of a player
         Team GetPlayerTeam(ObjectGuid guid) const;
-        Team GetOtherTeam(Team team) const;
         bool IsPlayerInBattleground(ObjectGuid guid) const;
         bool IsPlayerMercenaryInBattleground(ObjectGuid guid) const;
 

--- a/src/server/game/Chat/Channels/ChannelMgr.cpp
+++ b/src/server/game/Chat/Channels/ChannelMgr.cpp
@@ -69,7 +69,7 @@ ChannelMgr::~ChannelMgr()
     {
         Field* fields = result->Fetch();
         std::string dbName = fields[0].GetString();
-        uint32 team = fields[1].GetUInt32();
+        Team team = Team(fields[1].GetUInt32());
         bool dbAnnounce = fields[2].GetBool();
         bool dbOwnership = fields[3].GetBool();
         std::string dbPass = fields[4].GetString();
@@ -111,19 +111,26 @@ ChannelMgr::~ChannelMgr()
     TC_LOG_INFO("server.loading", ">> Loaded {} custom chat channels in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
 }
 
-/*static*/ ChannelMgr* ChannelMgr::ForTeam(uint32 team)
+/*static*/ ChannelMgr* ChannelMgr::ForTeam(Team team)
 {
     static ChannelMgr allianceChannelMgr(ALLIANCE);
     static ChannelMgr hordeChannelMgr(HORDE);
+    static ChannelMgr neutralChannelMgr(PANDARIA_NEUTRAL);
 
     if (sWorld->getBoolConfig(CONFIG_ALLOW_TWO_SIDE_INTERACTION_CHANNEL))
-        return &allianceChannelMgr;        // cross-faction
+        return &neutralChannelMgr;         // cross-faction
 
-    if (team == ALLIANCE)
-        return &allianceChannelMgr;
-
-    if (team == HORDE)
-        return &hordeChannelMgr;
+    switch (team)
+    {
+        case HORDE:
+            return &hordeChannelMgr;
+        case ALLIANCE:
+            return &allianceChannelMgr;
+        case PANDARIA_NEUTRAL:
+            return &neutralChannelMgr;
+        default:
+            break;
+    }
 
     return nullptr;
 }

--- a/src/server/game/Chat/Channels/ChannelMgr.h
+++ b/src/server/game/Chat/Channels/ChannelMgr.h
@@ -19,6 +19,7 @@
 
 #include "Define.h"
 #include "ObjectGuid.h"
+#include "SharedDefines.h"
 #include <string>
 #include <unordered_map>
 
@@ -32,7 +33,7 @@ class TC_GAME_API ChannelMgr
     typedef std::unordered_map<ObjectGuid, Channel*> BuiltinChannelContainer;
 
     protected:
-        explicit ChannelMgr(uint32 team) : _team(team), _guidGenerator(HighGuid::ChatChannel) { }
+        explicit ChannelMgr(Team team) : _team(team), _guidGenerator(HighGuid::ChatChannel) { }
         ~ChannelMgr();
 
     public:
@@ -42,7 +43,7 @@ class TC_GAME_API ChannelMgr
         ChannelMgr& operator=(ChannelMgr&& right) = delete;
 
         static void LoadFromDB();
-        static ChannelMgr* ForTeam(uint32 team);
+        static ChannelMgr* ForTeam(Team team);
         static Channel* GetChannelForPlayerByNamePart(std::string const& namePart, Player* playerSearcher);
         static Channel* GetChannelForPlayerByGuid(ObjectGuid channelGuid, Player* playerSearcher);
         static AreaTableEntry const* SpecialLinkedArea;
@@ -57,7 +58,7 @@ class TC_GAME_API ChannelMgr
     private:
         CustomChannelContainer _customChannels;
         BuiltinChannelContainer _channels;
-        uint32 const _team;
+        Team const _team;
         ObjectGuidGenerator _guidGenerator;
 
         static void SendNotOnChannelNotify(Player const* player, std::string const& name);

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2813,10 +2813,15 @@ void Creature::LoadCreaturesSparringHealth(bool force /*= false*/)
 /// Send a message to LocalDefense channel for players opposition team in the zone
 void Creature::SendZoneUnderAttackMessage(Player* attacker)
 {
-    uint32 enemy_team = attacker->GetTeam();
     WorldPackets::Misc::ZoneUnderAttack packet;
     packet.AreaID = GetAreaId();
-    sWorld->SendGlobalMessage(packet.Write(), nullptr, (enemy_team == ALLIANCE ? HORDE : ALLIANCE));
+    packet.Write();
+
+    Team enemyTeam = attacker->GetTeam();
+    if (enemyTeam != ALLIANCE)
+        sWorld->SendGlobalMessage(packet.GetRawPacket(), nullptr, ALLIANCE);
+    if (enemyTeam != HORDE)
+        sWorld->SendGlobalMessage(packet.GetRawPacket(), nullptr, HORDE);
 }
 
 void Creature::SetCanMelee(bool canMelee, bool fleeFromMelee /*= false*/)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2145,7 +2145,7 @@ bool Player::IsGroupVisibleFor(Player const* p) const
     {
         default: return IsInSameGroupWith(p);
         case 1:  return IsInSameRaidWith(p);
-        case 2:  return GetTeam() == p->GetTeam();
+        case 2:  return GetEffectiveTeam() == p->GetEffectiveTeam();
         case 3:  return false;
     }
 }
@@ -7784,7 +7784,7 @@ void Player::DuelComplete(DuelCompleteType type)
         case DUEL_FLED:
             // if initiator and opponent are on the same team
             // or initiator and opponent are not PvP enabled, forcibly stop attacking
-            if (GetTeam() == opponent->GetTeam())
+            if (GetEffectiveTeam() == opponent->GetEffectiveTeam())
             {
                 AttackStop();
                 opponent->AttackStop();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6459,6 +6459,7 @@ Team Player::TeamForRace(uint8 race)
         {
             case 0: return ALLIANCE;
             case 1: return HORDE;
+            case 2: return PANDARIA_NEUTRAL;
         }
         TC_LOG_ERROR("entities.player", "Race ({}) has wrong teamid ({}) in DBC: wrong DBC files?", uint32(race), rEntry->Alliance);
     }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2234,11 +2234,11 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         static TeamId TeamIdForRace(uint8 race);
         static uint8 GetFactionGroupForRace(uint8 race);
         Team GetTeam() const { return m_team; }
-        TeamId GetTeamId() const { return m_team == ALLIANCE ? TEAM_ALLIANCE : TEAM_HORDE; }
+        TeamId GetTeamId() const { return GetTeamIdForTeam(m_team); }
         void SetFactionForRace(uint8 race);
 
-        Team GetEffectiveTeam() const { return HasPlayerFlagEx(PLAYER_FLAGS_EX_MERCENARY_MODE) ? (GetTeam() == ALLIANCE ? HORDE : ALLIANCE) : Team(GetTeam()); }
-        TeamId GetEffectiveTeamId() const { return GetEffectiveTeam() == ALLIANCE ? TEAM_ALLIANCE : TEAM_HORDE; }
+        Team GetEffectiveTeam() const { return HasPlayerFlagEx(PLAYER_FLAGS_EX_MERCENARY_MODE) ? GetOtherTeam(GetTeam()) : GetTeam(); }
+        TeamId GetEffectiveTeamId() const { return GetTeamIdForTeam(GetEffectiveTeam()); }
 
         void InitDisplayIds();
 

--- a/src/server/game/Entities/Taxi/TaxiPathGraph.cpp
+++ b/src/server/game/Entities/Taxi/TaxiPathGraph.cpp
@@ -33,8 +33,17 @@ struct EdgeCost
     uint32 Distance;
     uint32 EvaluateDistance(Player const* player) const
     {
-        TaxiNodeFlags requireFlag = (player->GetTeam() == ALLIANCE) ? TaxiNodeFlags::ShowOnAllianceMap : TaxiNodeFlags::ShowOnHordeMap;
-        if (!To->GetFlags().HasFlag(requireFlag))
+        bool isVisibleForFaction = [&]
+        {
+            switch (player->GetTeam())
+            {
+                case HORDE: return To->GetFlags().HasFlag(TaxiNodeFlags::ShowOnHordeMap);
+                case ALLIANCE: return To->GetFlags().HasFlag(TaxiNodeFlags::ShowOnAllianceMap);
+                default: break;
+            }
+            return false;
+        }();
+        if (!isVisibleForFaction)
             return std::numeric_limits<uint16>::max();
 
         if (PlayerConditionEntry const* condition = sPlayerConditionStore.LookupEntry(To->ConditionID))

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -6656,10 +6656,20 @@ uint32 ObjectMgr::GetNearestTaxiNode(float x, float y, float z, uint32 mapid, ui
     float dist = 10000;
     uint32 id = 0;
 
-    TaxiNodeFlags requireFlag = (team == ALLIANCE) ? TaxiNodeFlags::ShowOnAllianceMap : TaxiNodeFlags::ShowOnHordeMap;
+    auto isVisibleForFaction = [&](TaxiNodesEntry const* node)
+    {
+        switch (team)
+        {
+            case HORDE: return node->GetFlags().HasFlag(TaxiNodeFlags::ShowOnHordeMap);
+            case ALLIANCE: return node->GetFlags().HasFlag(TaxiNodeFlags::ShowOnAllianceMap);
+            default: break;
+        }
+        return false;
+    };
+
     for (TaxiNodesEntry const* node : sTaxiNodesStore)
     {
-        if (!node || node->ContinentID != mapid || !node->GetFlags().HasFlag(requireFlag) || node->GetFlags().HasFlag(TaxiNodeFlags::IgnoreForFindNearest))
+        if (!node || node->ContinentID != mapid || !isVisibleForFaction(node) || node->GetFlags().HasFlag(TaxiNodeFlags::IgnoreForFindNearest))
             continue;
 
         uint32 field   = uint32((node->ID - 1) / 8);

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -1127,18 +1127,57 @@ enum TeamId
     TEAM_NEUTRAL
 };
 
+constexpr TeamId GetOtherTeam(TeamId team)
+{
+    switch (team)
+    {
+        case TEAM_ALLIANCE:
+            return TEAM_HORDE;
+        case TEAM_HORDE:
+            return TEAM_ALLIANCE;
+        default:
+            break;
+    }
+    return TEAM_NEUTRAL;
+}
+
 enum Team
 {
     HORDE               = 67,
     ALLIANCE            = 469,
-    //TEAM_STEAMWHEEDLE_CARTEL = 169,                       // not used in code
-    //TEAM_ALLIANCE_FORCES     = 891,
-    //TEAM_HORDE_FORCES        = 892,
-    //TEAM_SANCTUARY           = 936,
-    //TEAM_OUTLAND             = 980,
     PANDARIA_NEUTRAL    = 1249,                             // Starting pandas should have this team
-    TEAM_OTHER               = 0                            // if ReputationListId > 0 && Flags != FACTION_FLAG_TEAM_HEADER
+    TEAM_OTHER          = 0                                 // if ReputationListId > 0 && Flags != FACTION_FLAG_TEAM_HEADER
 };
+
+constexpr Team GetOtherTeam(Team team)
+{
+    switch (team)
+    {
+        case HORDE:
+            return ALLIANCE;
+        case ALLIANCE:
+            return HORDE;
+        case PANDARIA_NEUTRAL:
+            return PANDARIA_NEUTRAL;
+        default:
+            break;
+    }
+    return TEAM_OTHER;
+}
+
+constexpr TeamId GetTeamIdForTeam(Team team)
+{
+    switch (team)
+    {
+        case HORDE:
+            return TEAM_HORDE;
+        case ALLIANCE:
+            return TEAM_ALLIANCE;
+        default:
+            break;
+    }
+    return TEAM_NEUTRAL;
+}
 
 enum SpellEffectName
 {

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -1136,6 +1136,7 @@ enum Team
     //TEAM_HORDE_FORCES        = 892,
     //TEAM_SANCTUARY           = 936,
     //TEAM_OUTLAND             = 980,
+    PANDARIA_NEUTRAL    = 1249,                             // Starting pandas should have this team
     TEAM_OTHER               = 0                            // if ReputationListId > 0 && Flags != FACTION_FLAG_TEAM_HEADER
 };
 

--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -2602,11 +2602,14 @@ void World::Update(uint32 diff)
         if (getBoolConfig(CONFIG_PRESERVE_CUSTOM_CHANNELS))
         {
             TC_METRIC_TIMER("world_update_time", TC_METRIC_TAG("type", "Save custom channels"));
-            ChannelMgr* mgr1 = ASSERT_NOTNULL(ChannelMgr::ForTeam(ALLIANCE));
+            ChannelMgr* mgr1 = ASSERT_NOTNULL(ChannelMgr::ForTeam(PANDARIA_NEUTRAL));
             mgr1->SaveToDB();
-            ChannelMgr* mgr2 = ASSERT_NOTNULL(ChannelMgr::ForTeam(HORDE));
+            ChannelMgr* mgr2 = ASSERT_NOTNULL(ChannelMgr::ForTeam(ALLIANCE));
             if (mgr1 != mgr2)
                 mgr2->SaveToDB();
+            ChannelMgr* mgr3 = ASSERT_NOTNULL(ChannelMgr::ForTeam(HORDE));
+            if (mgr1 != mgr3)
+                mgr3->SaveToDB();
         }
     }
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/instance_trial_of_the_champion.cpp
@@ -28,7 +28,6 @@ EndScriptData */
 #include "InstanceScript.h"
 #include "Map.h"
 #include "MotionMaster.h"
-#include "Player.h"
 #include "trial_of_the_champion.h"
 
 constexpr uint32 ToCEncounterCount = 4;
@@ -60,12 +59,10 @@ public:
             SetBossNumber(ToCEncounterCount);
             LoadDungeonEncounterData(encounters);
             uiArgentSoldierDeaths = 0;
-            teamInInstance = 0;
 
             bDone = false;
         }
 
-        uint32 teamInInstance;
         PersistentInstanceScriptValue<uint16> uiMovementDone;
         PersistentInstanceScriptValue<uint16> uiGrandChampionsDeaths;
         uint8 uiArgentSoldierDeaths;
@@ -84,12 +81,6 @@ public:
         GuidList VehicleList;
 
         bool bDone;
-
-        void OnPlayerEnter(Player* player) override
-        {
-            if (!teamInInstance)
-                teamInInstance = player->GetTeam();
-        }
 
         void OnCreatureCreate(Creature* creature) override
         {
@@ -114,29 +105,21 @@ public:
 
         uint32 GetCreatureEntry(ObjectGuid::LowType /*guidLow*/, CreatureData const* data) override
         {
-            if (!teamInInstance)
-            {
-                Map::PlayerList const& players = instance->GetPlayers();
-                if (!players.isEmpty())
-                    if (Player* player = players.begin()->GetSource())
-                        teamInInstance = player->GetTeam();
-            }
-
             uint32 entry = data->id;
             switch (entry)
             {
                 case VEHICLE_MOKRA_SKILLCRUSHER_MOUNT:
-                    return teamInInstance == HORDE ? VEHICLE_MARSHAL_JACOB_ALERIUS_MOUNT : VEHICLE_MOKRA_SKILLCRUSHER_MOUNT;
+                    return instance->GetTeamInInstance() == HORDE ? VEHICLE_MARSHAL_JACOB_ALERIUS_MOUNT : VEHICLE_MOKRA_SKILLCRUSHER_MOUNT;
                 case VEHICLE_ERESSEA_DAWNSINGER_MOUNT:
-                    return teamInInstance == HORDE ? VEHICLE_AMBROSE_BOLTSPARK_MOUNT : VEHICLE_ERESSEA_DAWNSINGER_MOUNT;
+                    return instance->GetTeamInInstance() == HORDE ? VEHICLE_AMBROSE_BOLTSPARK_MOUNT : VEHICLE_ERESSEA_DAWNSINGER_MOUNT;
                 case VEHICLE_RUNOK_WILDMANE_MOUNT:
-                    return teamInInstance == HORDE ? VEHICLE_COLOSOS_MOUNT : VEHICLE_RUNOK_WILDMANE_MOUNT;
+                    return instance->GetTeamInInstance() == HORDE ? VEHICLE_COLOSOS_MOUNT : VEHICLE_RUNOK_WILDMANE_MOUNT;
                 case VEHICLE_ZUL_TORE_MOUNT:
-                    return teamInInstance == HORDE ? VEHICLE_EVENSONG_MOUNT : VEHICLE_ZUL_TORE_MOUNT;
+                    return instance->GetTeamInInstance() == HORDE ? VEHICLE_EVENSONG_MOUNT : VEHICLE_ZUL_TORE_MOUNT;
                 case VEHICLE_DEATHSTALKER_VESCERI_MOUNT:
-                    return teamInInstance == HORDE ? VEHICLE_LANA_STOUTHAMMER_MOUNT : VEHICLE_DEATHSTALKER_VESCERI_MOUNT;
+                    return instance->GetTeamInInstance() == HORDE ? VEHICLE_LANA_STOUTHAMMER_MOUNT : VEHICLE_DEATHSTALKER_VESCERI_MOUNT;
                 case NPC_JAEREN:
-                    return teamInInstance == HORDE ? NPC_ARELAS : NPC_JAEREN;
+                    return instance->GetTeamInInstance() == HORDE ? NPC_ARELAS : NPC_JAEREN;
                 default:
                     return entry;
             }

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/instance_trial_of_the_crusader.cpp
@@ -119,7 +119,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 EventStage = 0;
                 NorthrendBeasts = NOT_STARTED;
                 NorthrendBeastsCount = 4;
-                Team = TEAM_OTHER;
                 EventTimer = 1000;
                 NotOneButTwoJormungarsTimer = 0;
                 ResilienceWillFixItTimer = 0;
@@ -133,9 +132,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
 
             void OnPlayerEnter(Player* player) override
             {
-                if (Team == TEAM_OTHER)
-                    Team = player->GetTeam();
-
                 if (NorthrendBeasts == GORMOK_IN_PROGRESS)
                     player->CreateVehicleKit(PLAYER_VEHICLE_ID, 0);
             }
@@ -524,7 +520,6 @@ class instance_trial_of_the_crusader : public InstanceMapScript
                 uint32 EventStage;
                 uint32 EventTimer;
                 uint32 NorthrendBeasts;
-                uint32 Team;
                 bool CrusadersSpecialState;
                 GuidVector snoboldGUIDS;
 

--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/instance_forge_of_souls.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/instance_forge_of_souls.cpp
@@ -21,7 +21,6 @@
 #include "forge_of_souls.h"
 #include "InstanceScript.h"
 #include "Map.h"
-#include "Player.h"
 
 BossBoundaryData const boundaries =
 {
@@ -48,14 +47,6 @@ class instance_forge_of_souls : public InstanceMapScript
                 SetBossNumber(EncounterCount);
                 LoadBossBoundaries(boundaries);
                 LoadDungeonEncounterData(encounters);
-
-                teamInInstance = 0;
-            }
-
-            void OnPlayerEnter(Player* player) override
-            {
-                if (!teamInInstance)
-                    teamInInstance = player->GetTeam();
             }
 
             void OnCreatureCreate(Creature* creature) override
@@ -73,23 +64,15 @@ class instance_forge_of_souls : public InstanceMapScript
 
             uint32 GetCreatureEntry(ObjectGuid::LowType /*guidLow*/, CreatureData const* data) override
             {
-                if (!teamInInstance)
-                {
-                    Map::PlayerList const& players = instance->GetPlayers();
-                    if (!players.isEmpty())
-                        if (Player* player = players.begin()->GetSource())
-                            teamInInstance = player->GetTeam();
-                }
-
                 uint32 entry = data->id;
                 switch (entry)
                 {
                     case NPC_SYLVANAS_PART1:
-                        return teamInInstance == ALLIANCE ? NPC_JAINA_PART1 : NPC_SYLVANAS_PART1;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_JAINA_PART1 : NPC_SYLVANAS_PART1;
                     case NPC_LORALEN:
-                        return teamInInstance == ALLIANCE ? NPC_ELANDRA : NPC_LORALEN;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_ELANDRA : NPC_LORALEN;
                     case NPC_KALIRA:
-                        return teamInInstance == ALLIANCE ? NPC_KORELN : NPC_KALIRA;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_KORELN : NPC_KALIRA;
                     default:
                         return entry;
                 }
@@ -100,7 +83,7 @@ class instance_forge_of_souls : public InstanceMapScript
                 switch (type)
                 {
                     case DATA_TEAM_IN_INSTANCE:
-                        return teamInInstance;
+                        return instance->GetTeamInInstance();
                     default:
                         break;
                 }
@@ -126,8 +109,6 @@ class instance_forge_of_souls : public InstanceMapScript
         private:
             ObjectGuid bronjahm;
             ObjectGuid devourerOfSouls;
-
-            uint32 teamInInstance;
         };
 
         InstanceScript* GetInstanceScript(InstanceMap* map) const override

--- a/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/HallsOfReflection/halls_of_reflection.cpp
@@ -2739,7 +2739,7 @@ class spell_hor_start_halls_of_reflection_quest_ae : public SpellScriptLoader
                     // CanTakeQuest and CanAddQuest checks done in spell effect execution
                     if (target->GetTeam() == ALLIANCE)
                         target->CastSpell(target, SPELL_START_HALLS_OF_REFLECTION_QUEST_A, true);
-                    else
+                    else if (target->GetTeam() == HORDE)
                         target->CastSpell(target, SPELL_START_HALLS_OF_REFLECTION_QUEST_H, true);
                 }
             }

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/instance_pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/instance_pit_of_saron.cpp
@@ -20,7 +20,6 @@
 #include "InstanceScript.h"
 #include "Map.h"
 #include "pit_of_saron.h"
-#include "Player.h"
 #include "TemporarySummon.h"
 
 // positions for Martin Victus (37591) and Gorkun Ironskull (37592)
@@ -56,27 +55,12 @@ class instance_pit_of_saron : public InstanceMapScript
                 SetBossNumber(EncounterCount);
                 LoadDoorData(Doors);
                 LoadDungeonEncounterData(encounters);
-                _teamInInstance = 0;
                 _cavernActive = 0;
                 _shardsHit = 0;
             }
 
-            void OnPlayerEnter(Player* player) override
-            {
-                if (!_teamInInstance)
-                    _teamInInstance = player->GetTeam();
-            }
-
             void OnCreatureCreate(Creature* creature) override
             {
-                if (!_teamInInstance)
-                {
-                    Map::PlayerList const& players = instance->GetPlayers();
-                    if (!players.isEmpty())
-                        if (Player* player = players.begin()->GetSource())
-                            _teamInInstance = player->GetTeam();
-                }
-
                 switch (creature->GetEntry())
                 {
                     case NPC_GARFROST:
@@ -117,39 +101,39 @@ class instance_pit_of_saron : public InstanceMapScript
                 switch (entry)
                 {
                     case NPC_SYLVANAS_PART1:
-                        return _teamInInstance == ALLIANCE ? NPC_JAINA_PART1 : NPC_SYLVANAS_PART1;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_JAINA_PART1 : NPC_SYLVANAS_PART1;
                     case NPC_SYLVANAS_PART2:
-                        return _teamInInstance == ALLIANCE ? NPC_JAINA_PART2 : NPC_SYLVANAS_PART2;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_JAINA_PART2 : NPC_SYLVANAS_PART2;
                     case NPC_KILARA:
-                        return _teamInInstance == ALLIANCE ? NPC_ELANDRA : NPC_KILARA;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_ELANDRA : NPC_KILARA;
                     case NPC_KORALEN:
-                        return _teamInInstance == ALLIANCE ? NPC_KORLAEN : NPC_KORALEN;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_KORLAEN : NPC_KORALEN;
                     case NPC_CHAMPION_1_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_CHAMPION_1_ALLIANCE : NPC_CHAMPION_1_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_CHAMPION_1_ALLIANCE : NPC_CHAMPION_1_HORDE;
                     case NPC_CHAMPION_2_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_CHAMPION_2_ALLIANCE : NPC_CHAMPION_2_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_CHAMPION_2_ALLIANCE : NPC_CHAMPION_2_HORDE;
                     case NPC_CHAMPION_3_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_CHAMPION_2_ALLIANCE : NPC_CHAMPION_3_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_CHAMPION_2_ALLIANCE : NPC_CHAMPION_3_HORDE;
                     case NPC_HORDE_SLAVE_1:
-                        return _teamInInstance == ALLIANCE ? NPC_ALLIANCE_SLAVE_1 : NPC_HORDE_SLAVE_1;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_ALLIANCE_SLAVE_1 : NPC_HORDE_SLAVE_1;
                     case NPC_HORDE_SLAVE_2:
-                        return _teamInInstance == ALLIANCE ? NPC_ALLIANCE_SLAVE_2 : NPC_HORDE_SLAVE_2;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_ALLIANCE_SLAVE_2 : NPC_HORDE_SLAVE_2;
                     case NPC_HORDE_SLAVE_3:
-                        return _teamInInstance == ALLIANCE ? NPC_ALLIANCE_SLAVE_3 : NPC_HORDE_SLAVE_3;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_ALLIANCE_SLAVE_3 : NPC_HORDE_SLAVE_3;
                     case NPC_HORDE_SLAVE_4:
-                        return _teamInInstance == ALLIANCE ? NPC_ALLIANCE_SLAVE_4 : NPC_HORDE_SLAVE_4;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_ALLIANCE_SLAVE_4 : NPC_HORDE_SLAVE_4;
                     case NPC_FREED_SLAVE_1_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_FREED_SLAVE_1_ALLIANCE : NPC_FREED_SLAVE_1_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_FREED_SLAVE_1_ALLIANCE : NPC_FREED_SLAVE_1_HORDE;
                     case NPC_FREED_SLAVE_2_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_FREED_SLAVE_2_ALLIANCE : NPC_FREED_SLAVE_2_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_FREED_SLAVE_2_ALLIANCE : NPC_FREED_SLAVE_2_HORDE;
                     case NPC_FREED_SLAVE_3_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_FREED_SLAVE_3_ALLIANCE : NPC_FREED_SLAVE_3_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_FREED_SLAVE_3_ALLIANCE : NPC_FREED_SLAVE_3_HORDE;
                     case NPC_RESCUED_SLAVE_HORDE:
-                        return _teamInInstance == ALLIANCE ? NPC_RESCUED_SLAVE_ALLIANCE : NPC_RESCUED_SLAVE_HORDE;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_RESCUED_SLAVE_ALLIANCE : NPC_RESCUED_SLAVE_HORDE;
                     case NPC_GORKUN_IRONSKULL_1:
-                        return _teamInInstance == ALLIANCE ? NPC_MARTIN_VICTUS_1 : NPC_GORKUN_IRONSKULL_1;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_MARTIN_VICTUS_1 : NPC_GORKUN_IRONSKULL_1;
                     case NPC_GORKUN_IRONSKULL_2:
-                        return _teamInInstance == ALLIANCE ? NPC_MARTIN_VICTUS_2 : NPC_GORKUN_IRONSKULL_2;
+                        return instance->GetTeamInInstance() == ALLIANCE ? NPC_MARTIN_VICTUS_2 : NPC_GORKUN_IRONSKULL_2;
                     default:
                         return entry;
                 }
@@ -167,7 +151,7 @@ class instance_pit_of_saron : public InstanceMapScript
                         {
                             if (instance->GetCreature(_garfrostGUID))
                             {
-                                if (_teamInInstance == ALLIANCE)
+                                if (instance->GetTeamInInstance() == ALLIANCE)
                                 {
                                     if (TempSummon* summon = instance->SummonCreature(NPC_MARTIN_VICTUS_1, SlaveLeaderPos))
                                         summon->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
@@ -185,7 +169,7 @@ class instance_pit_of_saron : public InstanceMapScript
                         {
                             if (instance->GetCreature(_tyrannusGUID))
                             {
-                                if (_teamInInstance == ALLIANCE)
+                                if (instance->GetTeamInInstance() == ALLIANCE)
                                 {
                                     if (TempSummon * summon = instance->SummonCreature(NPC_JAINA_PART2, EventLeaderPos2))
                                         summon->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
@@ -210,7 +194,7 @@ class instance_pit_of_saron : public InstanceMapScript
                 switch (type)
                 {
                     case DATA_TEAM_IN_INSTANCE:
-                        return _teamInInstance;
+                        return instance->GetTeamInInstance();
                     case DATA_ICE_SHARDS_HIT:
                         return _shardsHit;
                     case DATA_CAVERN_ACTIVE:
@@ -294,7 +278,6 @@ class instance_pit_of_saron : public InstanceMapScript
             ObjectGuid _jainaOrSylvanas2GUID;
             GuidVector _cavernstriggersVector;
 
-            uint32 _teamInInstance;
             uint8 _shardsHit;
             uint8 _cavernActive;
         };

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -191,7 +191,6 @@ class instance_ulduar : public InstanceMapScript
 
                 _maxArmorItemLevel = 0;
                 _maxWeaponItemLevel = 0;
-                TeamInInstance = 0;
                 HodirRareCacheData = 0;
                 ColossusData = 0;
                 elderCount = 0;
@@ -234,7 +233,6 @@ class instance_ulduar : public InstanceMapScript
             ObjectGuid BrainRoomDoorGUIDs[3];
 
             // Miscellaneous
-            uint32 TeamInInstance;
             uint32 HodirRareCacheData;
             uint32 ColossusData;
             uint8 elderCount;
@@ -245,11 +243,8 @@ class instance_ulduar : public InstanceMapScript
             bool Unbroken;
             bool IsDriveMeCrazyEligible;
 
-            void OnPlayerEnter(Player* player) override
+            void OnPlayerEnter(Player* /*player*/) override
             {
-                if (!TeamInInstance)
-                    TeamInInstance = player->GetTeam();
-
                 if (_summonAlgalon)
                 {
                     _summonAlgalon = false;
@@ -412,37 +407,29 @@ class instance_ulduar : public InstanceMapScript
 
             uint32 GetCreatureEntry(ObjectGuid::LowType /*guidLow*/, CreatureData const* data) override
             {
-                if (!TeamInInstance)
-                {
-                    Map::PlayerList const& Players = instance->GetPlayers();
-                    if (!Players.isEmpty())
-                        if (Player* player = Players.begin()->GetSource())
-                            TeamInInstance = player->GetTeam();
-                }
-
                 uint32 entry = data->id;
                 switch (entry)
                 {
                     case NPC_EIVI_NIGHTFEATHER:
-                        return TeamInInstance == HORDE ? NPC_TOR_GREYCLOUD : NPC_EIVI_NIGHTFEATHER;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_TOR_GREYCLOUD : NPC_EIVI_NIGHTFEATHER;
                     case NPC_ELLIE_NIGHTFEATHER:
-                        return TeamInInstance == HORDE ? NPC_KAR_GREYCLOUD : NPC_ELLIE_NIGHTFEATHER;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_KAR_GREYCLOUD : NPC_ELLIE_NIGHTFEATHER;
                     case NPC_ELEMENTALIST_MAHFUUN:
-                        return TeamInInstance == HORDE ? NPC_SPIRITWALKER_TARA : NPC_ELEMENTALIST_MAHFUUN;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_SPIRITWALKER_TARA : NPC_ELEMENTALIST_MAHFUUN;
                     case NPC_ELEMENTALIST_AVUUN:
-                        return TeamInInstance == HORDE ? NPC_SPIRITWALKER_YONA : NPC_ELEMENTALIST_AVUUN;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_SPIRITWALKER_YONA : NPC_ELEMENTALIST_AVUUN;
                     case NPC_MISSY_FLAMECUFFS:
-                        return TeamInInstance == HORDE ? NPC_AMIRA_BLAZEWEAVER : NPC_MISSY_FLAMECUFFS;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_AMIRA_BLAZEWEAVER : NPC_MISSY_FLAMECUFFS;
                     case NPC_SISSY_FLAMECUFFS:
-                        return TeamInInstance == HORDE ? NPC_VEESHA_BLAZEWEAVER : NPC_SISSY_FLAMECUFFS;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_VEESHA_BLAZEWEAVER : NPC_SISSY_FLAMECUFFS;
                     case NPC_FIELD_MEDIC_PENNY:
-                        return TeamInInstance == HORDE ? NPC_BATTLE_PRIEST_ELIZA : NPC_FIELD_MEDIC_PENNY;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_BATTLE_PRIEST_ELIZA : NPC_FIELD_MEDIC_PENNY;
                     case NPC_FIELD_MEDIC_JESSI:
-                        return TeamInInstance == HORDE ? NPC_BATTLE_PRIEST_GINA : NPC_FIELD_MEDIC_JESSI;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_BATTLE_PRIEST_GINA : NPC_FIELD_MEDIC_JESSI;
                     case NPC_MERCENARY_CAPTAIN_H:
-                        return TeamInInstance == HORDE ? NPC_MERCENARY_CAPTAIN_A : NPC_MERCENARY_CAPTAIN_H;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_MERCENARY_CAPTAIN_A : NPC_MERCENARY_CAPTAIN_H;
                     case NPC_MERCENARY_SOLDIER_H:
-                        return TeamInInstance == HORDE ? NPC_MERCENARY_SOLDIER_A : NPC_MERCENARY_SOLDIER_H;
+                        return instance->GetTeamInInstance() == HORDE ? NPC_MERCENARY_SOLDIER_A : NPC_MERCENARY_SOLDIER_H;
                     default:
                         return entry;
                 }

--- a/src/server/scripts/OutdoorPvP/OutdoorPvPHP.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPHP.cpp
@@ -109,7 +109,7 @@ void OutdoorPvPHP::HandlePlayerEnterZone(Player* player, uint32 zone)
         if (m_AllianceTowersControlled >=3)
             player->CastSpell(player, AllianceBuff, true);
     }
-    else
+    else if (player->GetTeam() == HORDE)
     {
         if (m_HordeTowersControlled >=3)
             player->CastSpell(player, HordeBuff, true);
@@ -124,7 +124,7 @@ void OutdoorPvPHP::HandlePlayerLeaveZone(Player* player, uint32 zone)
     {
         player->RemoveAurasDueToSpell(AllianceBuff);
     }
-    else
+    else if (player->GetTeam() == HORDE)
     {
         player->RemoveAurasDueToSpell(HordeBuff);
     }

--- a/src/server/scripts/OutdoorPvP/OutdoorPvPNA.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPNA.cpp
@@ -62,7 +62,7 @@ void OutdoorPvPNA::HandleKillImpl(Player* player, Unit* killed)
         player->KilledMonsterCredit(NA_CREDIT_MARKER); // 0 guid, btw it isn't even used in killedmonster function :S
         if (player->GetTeam() == ALLIANCE)
             player->CastSpell(player, NA_KILL_TOKEN_ALLIANCE, true);
-        else
+        else if (player->GetTeam() == HORDE)
             player->CastSpell(player, NA_KILL_TOKEN_HORDE, true);
     }
 }

--- a/src/server/scripts/OutdoorPvP/OutdoorPvPTF.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPTF.cpp
@@ -148,7 +148,7 @@ void OutdoorPvPTF::HandlePlayerEnterZone(Player* player, uint32 zone)
         if (m_AllianceTowersControlled >= TF_TOWER_NUM)
             player->CastSpell(player, TF_CAPTURE_BUFF, true);
     }
-    else
+    else if (player->GetTeam() == HORDE)
     {
         if (m_HordeTowersControlled >= TF_TOWER_NUM)
             player->CastSpell(player, TF_CAPTURE_BUFF, true);

--- a/src/server/scripts/OutdoorPvP/OutdoorPvPZM.cpp
+++ b/src/server/scripts/OutdoorPvP/OutdoorPvPZM.cpp
@@ -119,7 +119,7 @@ void OutdoorPvPZM::HandlePlayerEnterZone(Player* player, uint32 zone)
         if (m_Graveyard->GetGraveyardState() & ZM_GRAVEYARD_A)
             player->CastSpell(player, ZM_CAPTURE_BUFF, true);
     }
-    else
+    else if (player->GetTeam() == HORDE)
     {
         if (m_Graveyard->GetGraveyardState() & ZM_GRAVEYARD_H)
             player->CastSpell(player, ZM_CAPTURE_BUFF, true);

--- a/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/instance_shattered_halls.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/ShatteredHalls/instance_shattered_halls.cpp
@@ -66,15 +66,11 @@ class instance_shattered_halls : public InstanceMapScript
                 LoadDungeonEncounterData(encounters);
                 executionTimer = 0;
                 executed = 0;
-                _team = 0;
             }
 
             void OnPlayerEnter(Player* player) override
             {
                 Aura* ex = nullptr;
-
-                if (!_team)
-                    _team = player->GetTeam();
 
                 player->CastSpell(player, SPELL_REMOVE_KARGATH_EXECUTIONER, true);
 
@@ -102,14 +98,6 @@ class instance_shattered_halls : public InstanceMapScript
 
             void OnCreatureCreate(Creature* creature) override
             {
-                if (!_team)
-                {
-                    Map::PlayerList const& players = instance->GetPlayers();
-                    if (!players.isEmpty())
-                        if (Player* player = players.begin()->GetSource())
-                            _team = player->GetTeam();
-                }
-
                 switch (creature->GetEntry())
                 {
                     case NPC_GRAND_WARLOCK_NETHEKURSE:
@@ -119,7 +107,7 @@ class instance_shattered_halls : public InstanceMapScript
                         kargathGUID = creature->GetGUID();
                         break;
                     case NPC_RANDY_WHIZZLESPROCKET:
-                        if (_team == HORDE)
+                        if (instance->GetTeamInInstance() == HORDE)
                             creature->UpdateEntry(NPC_DRISELLA);
                         break;
                     case NPC_SHATTERED_EXECUTIONER:
@@ -205,7 +193,7 @@ class instance_shattered_halls : public InstanceMapScript
                     case DATA_PRISONERS_EXECUTED:
                         return executed;
                     case DATA_TEAM_IN_INSTANCE:
-                        return _team;
+                        return instance->GetTeamInInstance();
                     default:
                         return 0;
                 }
@@ -249,7 +237,6 @@ class instance_shattered_halls : public InstanceMapScript
 
             uint8 executed;
             uint32 executionTimer;
-            uint32 _team;
         };
 };
 

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1093,7 +1093,7 @@ class spell_gen_create_lance : public SpellScript
         {
             if (target->GetTeam() == ALLIANCE)
                 GetCaster()->CastSpell(target, SPELL_CREATE_LANCE_ALLIANCE, true);
-            else
+            else if (target->GetTeam() == HORDE)
                 GetCaster()->CastSpell(target, SPELL_CREATE_LANCE_HORDE, true);
         }
     }
@@ -4704,7 +4704,7 @@ class spell_defender_of_azeroth_death_gate_selector : public SpellScript
         if (player->GetQuestStatus(QUEST_DEFENDER_OF_AZEROTH_ALLIANCE) == QUEST_STATUS_NONE && player->GetQuestStatus(QUEST_DEFENDER_OF_AZEROTH_HORDE) == QUEST_STATUS_NONE)
             return;
 
-        BindLocation bindLoc = player->GetTeam() == ALLIANCE ? StormwindInnLoc : OrgrimmarInnLoc;
+        BindLocation const& bindLoc = player->GetTeam() == ALLIANCE ? StormwindInnLoc : OrgrimmarInnLoc;
         player->SetHomebind(bindLoc.Loc, bindLoc.AreaId);
         player->SendBindPointUpdate();
         player->SendPlayerBound(player->GetGUID(), bindLoc.AreaId);
@@ -5018,7 +5018,7 @@ class spell_gen_skinning : public SpellScript
                 case SKILL_CATACLYSM_SKINNING:    return SPELL_CATACLYSM_SKINNING;
                 case SKILL_PANDARIA_SKINNING:     return SPELL_PANDARIA_SKINNING;
                 case SKILL_DRAENOR_SKINNING:      return SPELL_DRAENOR_SKINNING;
-                case SKILL_KUL_TIRAN_SKINNING:    return player->GetTeam() == ALLIANCE ? SPELL_KUL_TIRAN_SKINNING : SPELL_ZANDALARI_SKINNING;
+                case SKILL_KUL_TIRAN_SKINNING:    return player->GetTeam() == ALLIANCE ? SPELL_KUL_TIRAN_SKINNING : (player->GetTeam() == HORDE ? SPELL_ZANDALARI_SKINNING : 0);
                 case SKILL_SHADOWLANDS_SKINNING:  return SPELL_SHADOWLANDS_SKINNING;
                 case SKILL_DRAGON_ISLES_SKINNING: return SPELL_DRAGON_ISLES_SKINNING;
                 case SKILL_CLASSIC_SKINNING:      // Trainer only


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix console errors of wrong teamid for neutral pandaren race

**Tests performed:**

Tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
