### PR TITLE
Core/Movement: fix air state condition

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2653,7 +2653,8 @@ void Creature::UpdateMovementFlags()
     float ground = GetFloorZ();
 
     bool canHover = CanHover();
-    bool isInAir = (G3D::fuzzyGt(GetPositionZ(), ground + (canHover ? GetFloatValue(UNIT_FIELD_HOVERHEIGHT) : 0.0f) + GROUND_HEIGHT_TOLERANCE) || G3D::fuzzyLt(GetPositionZ(), ground - GROUND_HEIGHT_TOLERANCE)); // Can be underground too, prevent the falling
+    float collisionHeight = GetCollisionHeight() / 2.0f;
+    bool isInAir = (G3D::fuzzyGt(GetPositionZ(), ground + (canHover ? GetFloatValue(UNIT_FIELD_HOVERHEIGHT) : 0.0f) + collisionHeight) || G3D::fuzzyLt(GetPositionZ(), ground - collisionHeight)); // Can be underground too, prevent the falling
 
     if (GetMovementTemplate().IsFlightAllowed() && isInAir && !IsFalling())
     {


### PR DESCRIPTION
**Changes proposed:**
Problem is that calculation to detect `isInAir` has been made only using the strict calculation of `ground Z + 0.5` value which animation doesn't work for most of the flying creatures(mostly dragons) , they should change the animation type depends on the size of their model which is unique per model and distance from the ground, e.g. sindragosa during the attack has difference about 0.8f between ground and her position which leads to the flying state since it's bigger than 0.5

![1](https://github.com/TrinityCore/TrinityCore/assets/52127050/79cf59da-10e4-4f44-8b59-5d0b5c1bcf2e)

After the change it takes the `collisionHeight` which is 6 for sindragosa and since we need to set it to flying state when half of the model goes up we divide it by 2

![1](https://github.com/TrinityCore/TrinityCore/assets/52127050/88bcd9bb-acb8-4996-a3c4-c81539ff3013)

and it automatically will go up as soon as it reach pos + colission > ground Z 

![1](https://github.com/TrinityCore/TrinityCore/assets/52127050/2ff18d79-0d4c-4aef-8f92-b9545ae7885f)

Closes #29819 #29121


**Tests performed:**
tested in game

