### PR TITLE
Core/Spells: Allow Spells with SPELL_EFFECT_KNOCK_BACK to knockback stunned targets

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4305,8 +4305,8 @@ void Spell::EffectKnockBack()
             if (creatureTarget->isWorldBoss() || creatureTarget->IsDungeonBoss())
                 return;
 
-    // Spells with SPELL_EFFECT_KNOCK_BACK (like Thunderstorm) can't knockback target if target has ROOT/STUN
-    if (unitTarget->HasUnitState(UNIT_STATE_ROOT | UNIT_STATE_STUNNED))
+    // Spells with SPELL_EFFECT_KNOCK_BACK (like Thunderstorm) can't knockback target if target has ROOT
+    if (unitTarget->HasUnitState(UNIT_STATE_ROOT))
         return;
 
     // Instantly interrupt non melee spells being cast


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Allow Spells with SPELL_EFFECT_KNOCK_BACK to knockback stunned targets as you can see here (select lower playback speed) https://youtu.be/eyPStPXUHqo?t=188
-  Fix suggested by [Fimbulveter](https://github.com/Fimbulveter) in the issue comment

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/18180


**Tests performed:**

<details>
  <summary>Before</summary>

https://github.com/TrinityCore/TrinityCore/assets/24683355/4a770f85-b710-496b-b736-cee7afc6bed2


</details>

<details>
  <summary>After</summary>

https://github.com/TrinityCore/TrinityCore/assets/24683355/d330031e-0496-4976-bce5-dce3a7163e2b


</details>


**Known issues and TODO list:** (add/remove lines as needed)

- [ Merge ] 

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
