### PR TITLE
Core/Gameobjects: Changed the highlight logic for GAMEOBJECT_TYPE_GATHERING_NODE

### DIFF
--- a/src/server/game/Entities/Object/Updates/ViewerDependentValues.h
+++ b/src/server/game/Entities/Object/Updates/ViewerDependentValues.h
@@ -132,7 +132,7 @@ public:
                         dynFlags &= ~GO_DYNFLAG_LO_NO_INTERACT;
                     break;
                 case GAMEOBJECT_TYPE_GATHERING_NODE:
-                    if (gameObject->CanActivateForPlayer(receiver))
+                    if (gameObject->GetGOInfo()->GetConditionID1() && gameObject->CanActivateForPlayer(receiver))
                         dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_SPARKLE | GO_DYNFLAG_LO_HIGHLIGHT;
                     if (gameObject->GetGoStateFor(receiver->GetGUID()) == GO_STATE_ACTIVE)
                         dynFlags |= GO_DYNFLAG_LO_DEPLETED;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Changed the highlight logic for GAMEOBJECT_TYPE_GATHERING_NODE

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game:

- Copper Vein (1731): Highlight linked to active tracking aura
- Decay Covered Chest (376583): Highlight linked to WorldEffectID
- Brightly Colored Egg (113768): No highlight (without this PR the GO is permanently highlighted)


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
