### PR TITLE
Core/Spells: Fix Stealth and Prowl cooldown getting stuck

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2029,6 +2029,9 @@ void SpellInfo::_LoadAuraState()
             case 35329: // Vibrant Blood
             case 35331: // Black Blood
             case 49163: // Perpetual Instability
+            case 1543:  // Flare
+            case 13424: // Faerie Fire
+            case 13752: // Faerie Fire
                 return AURA_STATE_FAERIE_FIRE;
             default:
                 break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix Stealth and Prowl cooldown getting stuck after using them while being out of cobat and affected by following auras:
 1543:  // Flare
 13424: // Faerie Fire
 13752: // Faerie Fire
- Fix was suggested by [Rushor](https://github.com/Rushor) [here](https://github.com/TrinityCore/TrinityCore/commit/9e0a343f729eb7e172c447dccb066f4f236aa11e#commitcomment-38375561).

**Issues addressed:**

Closes #21632

Related issues: https://github.com/TrinityCore/TrinityCore/issues/21626 https://github.com/TrinityCore/TrinityCore/issues/6457

**Tests performed:**

Does it build, tested in-game, as you can see below:
<details>
  <summary>Before</summary>

  https://user-images.githubusercontent.com/24683355/214250717-4d55e7c9-54d0-4579-abf1-ca3f563f7184.mp4
</details>
<details>
  <summary>After</summary>
  

https://github.com/TrinityCore/TrinityCore/assets/24683355/4e907bb1-e18f-4e28-ac56-d13f3d6abc95
</details>

**Known issues and TODO list:** (add/remove lines as needed)

- [ As this fix works, not really sure if we shoud revert [https://github.com/TrinityCore/TrinityCore/commit/9e0a343f729eb7e172c447dccb066f4f236aa11e](https://github.com/TrinityCore/TrinityCore/commit/9e0a343f729eb7e172c447dccb066f4f236aa11e) too. ] 

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
