### PR TITLE
Core/Player: Fixed crossmap access when checking access  requirements for SPELL_EFFECT_SUMMON_PLAYER

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1845,6 +1845,11 @@ void WorldObject::ResetMap()
     //m_InstanceId = 0;
 }
 
+Difficulty WorldObject::GetMapDifficulty() const
+{
+    return m_currMap ? m_currMap->GetDifficulty() : REGULAR_DIFFICULTY;
+}
+
 void WorldObject::AddObjectToRemoveList()
 {
     ASSERT(m_uint32Values);

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -414,6 +414,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         Map* FindMap() const { return m_currMap; }
         //used to check all object's GetMap() calls when object is not in world!
 
+        Difficulty GetMapDifficulty() const;
+
         void SetZoneScript();
         void ClearZoneScript();
         ZoneScript* GetZoneScript() const { return m_zoneScript; }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2430,6 +2430,7 @@ class TC_GAME_API Player : public Unit, public GridObject<Player>
         // Player summoning
         time_t m_summon_expire;
         WorldLocation m_summon_location;
+        Difficulty m_summon_difficulty;
 
         // Recall position
         WorldLocation m_recall_location;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5864,8 +5864,6 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                     InstanceTemplate const* instance = sObjectMgr->GetInstanceTemplate(mapId);
                     if (!instance)
                         return SPELL_FAILED_TARGET_NOT_IN_INSTANCE;
-                    if (!target->Satisfy(sObjectMgr->GetAccessRequirement(mapId, difficulty), mapId))
-                        return SPELL_FAILED_BAD_TARGETS;
                 }
                 break;
             }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix proposed by [robinsch](https://github.com/robinsch) in addressed issue comment section.

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/26877

**Tests performed:**

Does it build I'm not sure how shoud be properly tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)

- [ more tests ] 

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
