### PR TITLE
Core/Entities: Added possibility to inherit StringIds from other entities

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3137,12 +3137,12 @@ uint32 Creature::GetScriptId() const
     return ASSERT_NOTNULL(sObjectMgr->GetCreatureTemplate(GetEntry()))->ScriptID;
 }
 
-void Creature::InheritStringIds(Creature* parent)
+void Creature::InheritStringIds(Creature const* parent)
 {
-    if (CreatureTemplate const* parentTemplateInfo = GetCreatureTemplate())
-        m_stringIds[AsUnderlyingType(StringIdType::Template)] = parentTemplateInfo->StringId;
-    if (CreatureData const* spawnData = sObjectMgr->GetCreatureData(parent->GetSpawnId()))
-        m_stringIds[AsUnderlyingType(StringIdType::Spawn)] = spawnData->StringId;
+    // copy references to stringIds from template and spawn
+    m_stringIds = parent->m_stringIds;
+
+    // then copy script stringId, not just its reference
     SetScriptStringId(std::string(parent->GetStringId(StringIdType::Script)));
 }
 

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3137,6 +3137,15 @@ uint32 Creature::GetScriptId() const
     return ASSERT_NOTNULL(sObjectMgr->GetCreatureTemplate(GetEntry()))->ScriptID;
 }
 
+void Creature::InheritStringIds(Creature* parent)
+{
+    if (CreatureTemplate const* parentTemplateInfo = GetCreatureTemplate())
+        m_stringIds[AsUnderlyingType(StringIdType::Template)] = parentTemplateInfo->StringId;
+    if (CreatureData const* spawnData = sObjectMgr->GetCreatureData(parent->GetSpawnId()))
+        m_stringIds[AsUnderlyingType(StringIdType::Spawn)] = spawnData->StringId;
+    SetScriptStringId(std::string(parent->GetStringId(StringIdType::Script)));
+}
+
 bool Creature::HasStringId(std::string_view id) const
 {
     return std::find(m_stringIds.begin(), m_stringIds.end(), id) != m_stringIds.end();

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -255,7 +255,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         std::string const& GetAIName() const;
         std::string GetScriptName() const;
         uint32 GetScriptId() const;
-        void InheritStringIds(Creature* parent);
+        void InheritStringIds(Creature const* parent);
         bool HasStringId(std::string_view id) const;
         void SetScriptStringId(std::string id);
         std::array<std::string_view, 3> const& GetStringIds() const { return m_stringIds; }

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -255,6 +255,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         std::string const& GetAIName() const;
         std::string GetScriptName() const;
         uint32 GetScriptId() const;
+        void InheritStringIds(Creature* parent);
         bool HasStringId(std::string_view id) const;
         void SetScriptStringId(std::string id);
         std::array<std::string_view, 3> const& GetStringIds() const { return m_stringIds; }

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -3497,12 +3497,12 @@ uint32 GameObject::GetScriptId() const
     return GetGOInfo()->ScriptId;
 }
 
-void GameObject::InheritStringIds(GameObject* parent)
+void GameObject::InheritStringIds(GameObject const* parent)
 {
-    if (GameObjectTemplate const* parentTemplateInfo = sObjectMgr->GetGameObjectTemplate(parent->GetEntry()))
-        m_stringIds[AsUnderlyingType(StringIdType::Template)] = parentTemplateInfo->StringId;
-    if (GameObjectData const* spawnData = sObjectMgr->GetGameObjectData(parent->GetSpawnId()))
-        m_stringIds[AsUnderlyingType(StringIdType::Spawn)] = spawnData->StringId;
+    // copy references to stringIds from template and spawn
+    m_stringIds = parent->m_stringIds;
+
+    // then copy script stringId, not just its reference
     SetScriptStringId(std::string(parent->GetStringId(StringIdType::Script)));
 }
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -3497,6 +3497,15 @@ uint32 GameObject::GetScriptId() const
     return GetGOInfo()->ScriptId;
 }
 
+void GameObject::InheritStringIds(GameObject* parent)
+{
+    if (GameObjectTemplate const* parentTemplateInfo = sObjectMgr->GetGameObjectTemplate(parent->GetEntry()))
+        m_stringIds[AsUnderlyingType(StringIdType::Template)] = parentTemplateInfo->StringId;
+    if (GameObjectData const* spawnData = sObjectMgr->GetGameObjectData(parent->GetSpawnId()))
+        m_stringIds[AsUnderlyingType(StringIdType::Spawn)] = spawnData->StringId;
+    SetScriptStringId(std::string(parent->GetStringId(StringIdType::Script)));
+}
+
 bool GameObject::HasStringId(std::string_view id) const
 {
     return std::find(m_stringIds.begin(), m_stringIds.end(), id) != m_stringIds.end();

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -378,7 +378,7 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         uint32 GetScriptId() const;
         GameObjectAI* AI() const { return m_AI; }
 
-        void InheritStringIds(GameObject* parent);
+        void InheritStringIds(GameObject const* parent);
         bool HasStringId(std::string_view id) const;
         void SetScriptStringId(std::string id);
         std::array<std::string_view, 3> const& GetStringIds() const { return m_stringIds; }

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -378,6 +378,7 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         uint32 GetScriptId() const;
         GameObjectAI* AI() const { return m_AI; }
 
+        void InheritStringIds(GameObject* parent);
         bool HasStringId(std::string_view id) const;
         void SetScriptStringId(std::string id);
         std::array<std::string_view, 3> const& GetStringIds() const { return m_stringIds; }

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2060,6 +2060,9 @@ TempSummon* WorldObject::SummonPersonalClone(Position const& pos, TempSummonType
         if (TempSummon* summon = map->SummonCreature(GetEntry(), pos, nullptr, despawnTime, privateObjectOwner, spellId, vehId, privateObjectOwner->GetGUID(), &smoothPhasingInfo))
         {
             summon->SetTempSummonType(despawnType);
+
+            if (Creature* thisCreature = ToCreature())
+                summon->InheritStringIds(thisCreature);
             return summon;
         }
     }


### PR DESCRIPTION
* also implicitly do so for personal summons


**Tests performed:**
tested ingame with npc Kayn Sunfury (Entry: 98229) on quest accept of 40378:
```sql
UPDATE `creature_template` SET `StringId`='foo' WHERE `entry`=98229;
UPDATE `creature` SET `StringId`='bar' WHERE `guid`=6000548;
```
and
```diff
 src/server/scripts/BrokenIsles/zone_mardum.cpp | 5 +++++
 1 file changed, 5 insertions(+)

diff --git a/src/server/scripts/BrokenIsles/zone_mardum.cpp b/src/server/scripts/BrokenIsles/zone_mardum.cpp
index 7ed591d195..2ad9d4c2a2 100644
--- a/src/server/scripts/BrokenIsles/zone_mardum.cpp
+++ b/src/server/scripts/BrokenIsles/zone_mardum.cpp
@@ -658,6 +658,11 @@ struct npc_kayn_sunfury_ashtongue_intro : public ScriptedAI
 {
     npc_kayn_sunfury_ashtongue_intro(Creature* creature) : ScriptedAI(creature) { }
 
+    void JustAppeared() override
+    {
+        me->SetScriptStringId("foobar");
+    }
+
     void OnQuestAccept(Player* player, Quest const* quest) override
     {
         if (quest->GetQuestId() == QUEST_ENTER_THE_ILLIDARI_ASHTONGUE)
```
