### PR TITLE
Core/Spells: Add new script for spells with feign death with all flag…

### DIFF
--- a/sql/updates/world/master/2024_04_21_00_world.sql
+++ b/sql/updates/world/master/2024_04_21_00_world.sql
@@ -1,0 +1,5 @@
+-- Spells
+DELETE FROM `spell_script_names` WHERE `spell_id`=96733 AND `ScriptName` LIKE 'spell_gen_feign_death_%';
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_gen_feign_death_all_flags_no_uninteractible';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(96733, 'spell_gen_feign_death_all_flags_no_uninteractible');

--- a/sql/updates/world/master/2024_99_99_99_spell_96733.sql
+++ b/sql/updates/world/master/2024_99_99_99_spell_96733.sql
@@ -1,0 +1,4 @@
+-- Spells
+DELETE FROM `spell_script_names` WHERE `spell_id`=96733;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(96733, 'spell_gen_feign_death_all_flags_except_uninteractible');

--- a/sql/updates/world/master/2024_99_99_99_spell_96733.sql
+++ b/sql/updates/world/master/2024_99_99_99_spell_96733.sql
@@ -1,4 +1,0 @@
--- Spells
-DELETE FROM `spell_script_names` WHERE `spell_id`=96733;
-INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(96733, 'spell_gen_feign_death_all_flags_except_uninteractible');

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1644,6 +1644,40 @@ class spell_gen_feign_death_all_flags_uninteractible : public AuraScript
     }
 };
 
+// 96733 - Permanent Feign Death (Stun)
+class spell_gen_feign_death_all_flags_except_uninteractible : public AuraScript
+{
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->SetUnitFlag3(UNIT_FLAG3_FAKE_DEAD);
+        target->SetUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
+        target->SetUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+        target->SetImmuneToAll(true);
+
+        if (Creature* creature = target->ToCreature())
+            creature->SetReactState(REACT_PASSIVE);
+    }
+
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        target->RemoveUnitFlag3(UNIT_FLAG3_FAKE_DEAD);
+        target->RemoveUnitFlag2(UNIT_FLAG2_FEIGN_DEATH);
+        target->RemoveUnitFlag(UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
+        target->SetImmuneToAll(false);
+
+        if (Creature* creature = target->ToCreature())
+            creature->InitializeReactState();
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_gen_feign_death_all_flags_except_uninteractible::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_gen_feign_death_all_flags_except_uninteractible::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 // 35357 - Spawn Feign Death
 // 51329 - Feign Death
 class spell_gen_feign_death_no_dyn_flag : public AuraScript
@@ -5388,6 +5422,7 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_feast);
     RegisterSpellScript(spell_gen_feign_death_all_flags);
     RegisterSpellScript(spell_gen_feign_death_all_flags_uninteractible);
+    RegisterSpellScript(spell_gen_feign_death_all_flags_except_uninteractible);
     RegisterSpellScript(spell_gen_feign_death_no_dyn_flag);
     RegisterSpellScript(spell_gen_feign_death_no_prevent_emotes);
     RegisterSpellScript(spell_gen_furious_rage);

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1570,6 +1570,7 @@ and UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT. Some auras can apply only 2 flags
 
 spell_gen_feign_death_all_flags applies all 3 flags
 spell_gen_feign_death_all_flags_uninteractible applies all 3 flags and additionally sets UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_UNINTERACTIBLE
+spell_gen_feign_death_all_flags_no_uninteractible applies all 3 flags and additionally sets UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC
 spell_gen_feign_death_no_dyn_flag applies no UNIT_DYNFLAG_DEAD (does not make the creature appear dead)
 spell_gen_feign_death_no_prevent_emotes applies no UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT
 
@@ -1645,9 +1646,9 @@ class spell_gen_feign_death_all_flags_uninteractible : public AuraScript
 };
 
 // 96733 - Permanent Feign Death (Stun)
-class spell_gen_feign_death_all_flags_except_uninteractible : public AuraScript
+class spell_gen_feign_death_all_flags_no_uninteractible : public AuraScript
 {
-    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/) const
     {
         Unit* target = GetTarget();
         target->SetUnitFlag3(UNIT_FLAG3_FAKE_DEAD);
@@ -1659,7 +1660,7 @@ class spell_gen_feign_death_all_flags_except_uninteractible : public AuraScript
             creature->SetReactState(REACT_PASSIVE);
     }
 
-    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/) const
     {
         Unit* target = GetTarget();
         target->RemoveUnitFlag3(UNIT_FLAG3_FAKE_DEAD);
@@ -1673,8 +1674,8 @@ class spell_gen_feign_death_all_flags_except_uninteractible : public AuraScript
 
     void Register() override
     {
-        OnEffectApply += AuraEffectApplyFn(spell_gen_feign_death_all_flags_except_uninteractible::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
-        OnEffectRemove += AuraEffectRemoveFn(spell_gen_feign_death_all_flags_except_uninteractible::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectApply += AuraEffectApplyFn(spell_gen_feign_death_all_flags_no_uninteractible::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_gen_feign_death_all_flags_no_uninteractible::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -5422,7 +5423,7 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_feast);
     RegisterSpellScript(spell_gen_feign_death_all_flags);
     RegisterSpellScript(spell_gen_feign_death_all_flags_uninteractible);
-    RegisterSpellScript(spell_gen_feign_death_all_flags_except_uninteractible);
+    RegisterSpellScript(spell_gen_feign_death_all_flags_no_uninteractible);
     RegisterSpellScript(spell_gen_feign_death_no_dyn_flag);
     RegisterSpellScript(spell_gen_feign_death_no_prevent_emotes);
     RegisterSpellScript(spell_gen_furious_rage);


### PR DESCRIPTION
…s except uninteractible (like 96733)

Merge with #29921

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  I found this spell is adding all feign death auras except uninteractible (maybe more spells do the same)

**Tests performed:**

Tested in-game



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
