### PR TITLE
Core/Bnet: Added missing 'next_url' field to Login.proto

### DIFF
--- a/src/server/proto/Login/Login.pb.cc
+++ b/src/server/proto/Login/Login.pb.cc
@@ -171,13 +171,14 @@ void protobuf_AssignDesc_Login_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SrpLoginChallenge));
   LoginResult_descriptor_ = file->message_type(6);
-  static const int LoginResult_offsets_[6] = {
+  static const int LoginResult_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, authentication_state_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, error_code_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, error_message_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, url_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, login_ticket_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, server_evidence_m2_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(LoginResult, next_url_),
   };
   LoginResult_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -325,22 +326,23 @@ void protobuf_AddDesc_Login_2eproto() {
     "s\030\003 \002(\t\022\021\n\tgenerator\030\004 \002(\t\022\025\n\rhash_funct"
     "ion\030\005 \002(\t\022\020\n\010username\030\006 \002(\t\022\014\n\004salt\030\007 \002("
     "\t\022\020\n\010public_B\030\010 \002(\t\022#\n\033eligible_credenti"
-    "al_upgrade\030\t \001(\010\"\300\001\n\013LoginResult\022G\n\024auth"
+    "al_upgrade\030\t \001(\010\"\322\001\n\013LoginResult\022G\n\024auth"
     "entication_state\030\001 \002(\0162).Battlenet.JSON."
     "Login.AuthenticationState\022\022\n\nerror_code\030"
     "\002 \001(\t\022\025\n\rerror_message\030\003 \001(\t\022\013\n\003url\030\004 \001("
     "\t\022\024\n\014login_ticket\030\005 \001(\t\022\032\n\022server_eviden"
-    "ce_M2\030\006 \001(\t\"E\n\022LoginRefreshResult\022\033\n\023log"
-    "in_ticket_expiry\030\001 \002(\004\022\022\n\nis_expired\030\002 \001"
-    "(\010\"\232\001\n\017GameAccountInfo\022\024\n\014display_name\030\001"
-    " \002(\t\022\021\n\texpansion\030\002 \002(\r\022\024\n\014is_suspended\030"
-    "\003 \001(\010\022\021\n\tis_banned\030\004 \001(\010\022\032\n\022suspension_e"
-    "xpires\030\005 \001(\004\022\031\n\021suspension_reason\030\006 \001(\t\""
-    "O\n\017GameAccountList\022<\n\rgame_accounts\030\001 \003("
-    "\0132%.Battlenet.JSON.Login.GameAccountInfo"
-    "*\032\n\010FormType\022\016\n\nLOGIN_FORM\020\001*H\n\023Authenti"
-    "cationState\022\t\n\005LOGIN\020\001\022\t\n\005LEGAL\020\002\022\021\n\rAUT"
-    "HENTICATOR\020\003\022\010\n\004DONE\020\004B\002H\002", 1266);
+    "ce_M2\030\006 \001(\t\022\020\n\010next_url\030\007 \001(\t\"E\n\022LoginRe"
+    "freshResult\022\033\n\023login_ticket_expiry\030\001 \002(\004"
+    "\022\022\n\nis_expired\030\002 \001(\010\"\232\001\n\017GameAccountInfo"
+    "\022\024\n\014display_name\030\001 \002(\t\022\021\n\texpansion\030\002 \002("
+    "\r\022\024\n\014is_suspended\030\003 \001(\010\022\021\n\tis_banned\030\004 \001"
+    "(\010\022\032\n\022suspension_expires\030\005 \001(\004\022\031\n\021suspen"
+    "sion_reason\030\006 \001(\t\"O\n\017GameAccountList\022<\n\r"
+    "game_accounts\030\001 \003(\0132%.Battlenet.JSON.Log"
+    "in.GameAccountInfo*\032\n\010FormType\022\016\n\nLOGIN_"
+    "FORM\020\001*H\n\023AuthenticationState\022\t\n\005LOGIN\020\001"
+    "\022\t\n\005LEGAL\020\002\022\021\n\rAUTHENTICATOR\020\003\022\010\n\004DONE\020\004"
+    "B\002H\002", 1284);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "Login.proto", &protobuf_RegisterTypes);
   ErrorResponse::default_instance_ = new ErrorResponse();
@@ -927,6 +929,7 @@ const int LoginResult::kErrorMessageFieldNumber;
 const int LoginResult::kUrlFieldNumber;
 const int LoginResult::kLoginTicketFieldNumber;
 const int LoginResult::kServerEvidenceM2FieldNumber;
+const int LoginResult::kNextUrlFieldNumber;
 #endif  // !_MSC_VER
 
 LoginResult::LoginResult()
@@ -954,6 +957,7 @@ void LoginResult::SharedCtor() {
   url_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   login_ticket_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   server_evidence_m2_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  next_url_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -977,6 +981,9 @@ void LoginResult::SharedDtor() {
   }
   if (server_evidence_m2_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
     delete server_evidence_m2_;
+  }
+  if (next_url_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete next_url_;
   }
   if (this != default_instance_) {
   }

--- a/src/server/proto/Login/Login.pb.h
+++ b/src/server/proto/Login/Login.pb.h
@@ -848,6 +848,18 @@ class TC_PROTO_API LoginResult : public ::google::protobuf::Message {
   inline ::std::string* release_server_evidence_m2();
   inline void set_allocated_server_evidence_m2(::std::string* server_evidence_m2);
 
+  // optional string next_url = 7;
+  inline bool has_next_url() const;
+  inline void clear_next_url();
+  static const int kNextUrlFieldNumber = 7;
+  inline const ::std::string& next_url() const;
+  inline void set_next_url(const ::std::string& value);
+  inline void set_next_url(const char* value);
+  inline void set_next_url(const char* value, size_t size);
+  inline ::std::string* mutable_next_url();
+  inline ::std::string* release_next_url();
+  inline void set_allocated_next_url(::std::string* next_url);
+
   // @@protoc_insertion_point(class_scope:Battlenet.JSON.Login.LoginResult)
  private:
   inline void set_has_authentication_state();
@@ -862,6 +874,8 @@ class TC_PROTO_API LoginResult : public ::google::protobuf::Message {
   inline void clear_has_login_ticket();
   inline void set_has_server_evidence_m2();
   inline void clear_has_server_evidence_m2();
+  inline void set_has_next_url();
+  inline void clear_has_next_url();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -872,6 +886,7 @@ class TC_PROTO_API LoginResult : public ::google::protobuf::Message {
   ::std::string* url_;
   ::std::string* login_ticket_;
   ::std::string* server_evidence_m2_;
+  ::std::string* next_url_;
   int authentication_state_;
   friend void TC_PROTO_API protobuf_AddDesc_Login_2eproto();
   friend void protobuf_AssignDesc_Login_2eproto();
@@ -2983,6 +2998,82 @@ inline void LoginResult::set_allocated_server_evidence_m2(::std::string* server_
     server_evidence_m2_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   }
   // @@protoc_insertion_point(field_set_allocated:Battlenet.JSON.Login.LoginResult.server_evidence_M2)
+}
+
+// optional string next_url = 7;
+inline bool LoginResult::has_next_url() const {
+  return (_has_bits_[0] & 0x00000040u) != 0;
+}
+inline void LoginResult::set_has_next_url() {
+  _has_bits_[0] |= 0x00000040u;
+}
+inline void LoginResult::clear_has_next_url() {
+  _has_bits_[0] &= ~0x00000040u;
+}
+inline void LoginResult::clear_next_url() {
+  if (next_url_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    next_url_->clear();
+  }
+  clear_has_next_url();
+}
+inline const ::std::string& LoginResult::next_url() const {
+  // @@protoc_insertion_point(field_get:Battlenet.JSON.Login.LoginResult.next_url)
+  return *next_url_;
+}
+inline void LoginResult::set_next_url(const ::std::string& value) {
+  set_has_next_url();
+  if (next_url_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    next_url_ = new ::std::string;
+  }
+  next_url_->assign(value);
+  // @@protoc_insertion_point(field_set:Battlenet.JSON.Login.LoginResult.next_url)
+}
+inline void LoginResult::set_next_url(const char* value) {
+  set_has_next_url();
+  if (next_url_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    next_url_ = new ::std::string;
+  }
+  next_url_->assign(value);
+  // @@protoc_insertion_point(field_set_char:Battlenet.JSON.Login.LoginResult.next_url)
+}
+inline void LoginResult::set_next_url(const char* value, size_t size) {
+  set_has_next_url();
+  if (next_url_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    next_url_ = new ::std::string;
+  }
+  next_url_->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:Battlenet.JSON.Login.LoginResult.next_url)
+}
+inline ::std::string* LoginResult::mutable_next_url() {
+  set_has_next_url();
+  if (next_url_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    next_url_ = new ::std::string;
+  }
+  // @@protoc_insertion_point(field_mutable:Battlenet.JSON.Login.LoginResult.next_url)
+  return next_url_;
+}
+inline ::std::string* LoginResult::release_next_url() {
+  clear_has_next_url();
+  if (next_url_ == &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    return NULL;
+  } else {
+    ::std::string* temp = next_url_;
+    next_url_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+    return temp;
+  }
+}
+inline void LoginResult::set_allocated_next_url(::std::string* next_url) {
+  if (next_url_ != &::google::protobuf::internal::GetEmptyStringAlreadyInited()) {
+    delete next_url_;
+  }
+  if (next_url) {
+    set_has_next_url();
+    next_url_ = next_url;
+  } else {
+    clear_has_next_url();
+    next_url_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  }
+  // @@protoc_insertion_point(field_set_allocated:Battlenet.JSON.Login.LoginResult.next_url)
 }
 
 // -------------------------------------------------------------------

--- a/src/server/proto/Login/Login.proto
+++ b/src/server/proto/Login/Login.proto
@@ -63,6 +63,7 @@ message LoginResult {
   optional string url = 4;
   optional string login_ticket = 5;
   optional string server_evidence_M2 = 6;
+  optional string next_url = 7;
 }
 
 message LoginRefreshResult {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

This PR modifies the Login.proto file to add a string field `next_url` to `LoginResult`.

This is required if we want to implement TOTP authenticator support in master branch as well as in 3.3.5, as issue #17366 suggests.

When `LoginResult.authentication_state` is equal to `AUTHENTICATOR` after the POST request to `/bnetserver/login`, the client looks for a `next_url` field to know where to submit the authentication code.

The presence of this field will trigger the client to display a text input menu for the authenticator code.

One the client submits this code, a POST request is made to the URL in `next_url`. The body of this request is a `LoginForm`, and the response is a `LoginResult`. This form contains two input fields: a text value, `authenticator_input` which is the user's text input,
and `remember_authenticator` which the client sets to `"true"`.

The client expects the result from this last request to be the same as if the the authenticator was not required; the authenticator URL response should contain `server_evidence_M2` and `login_ticket`.

**Issues addressed:**

This PR alone does not implement #17366, but may help.

**Tests performed:**

Verified the basic process of requesting authenticator code from the client.

**Known issues and TODO list:** (add/remove lines as needed)

- TODO: An actual implementation of TOTP in Bnet that will make use of this

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
