### PR TITLE
Core/Objects: implement internal heartbeat timer for WorldObjects

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -880,7 +880,7 @@ void MovementInfo::OutDebug()
 WorldObject::WorldObject(bool isWorldObject) : Object(), WorldLocation(), LastUsedScriptID(0),
 m_movementInfo(), m_name(), m_isActive(false), m_isFarVisible(false), m_isStoredInWorldObjectGridContainer(isWorldObject), m_zoneScript(nullptr),
 m_transport(nullptr), m_zoneId(0), m_areaId(0), m_staticFloorZ(VMAP_INVALID_HEIGHT), m_outdoors(false), m_liquidStatus(LIQUID_MAP_NO_WATER),
-m_currMap(nullptr), m_InstanceId(0), _dbPhase(0), m_notifyflags(0)
+m_currMap(nullptr), m_InstanceId(0), _dbPhase(0), m_notifyflags(0), _heartbeatTimer(HEARTBEAT_INTERVAL)
 {
     m_serverSideVisibility.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE | GHOST_VISIBILITY_GHOST);
     m_serverSideVisibilityDetect.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_ALIVE);
@@ -905,10 +905,10 @@ void WorldObject::Update(uint32 diff)
 {
     m_Events.Update(diff);
 
-    _heartbeatTimer.Update(diff);
-    while (_heartbeatTimer.Passed())
+    _heartbeatTimer -= Milliseconds(diff);
+    while (_heartbeatTimer <= 0ms)
     {
-        _heartbeatTimer.Reset(_heartbeatTimer.GetExpiry() + HEARTBEAT_INTERVAL);
+        _heartbeatTimer += HEARTBEAT_INTERVAL;
         Heartbeat();
     }
 }

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -904,6 +904,13 @@ WorldObject::~WorldObject()
 void WorldObject::Update(uint32 diff)
 {
     m_Events.Update(diff);
+
+    _heartbeatTimer.Update(diff);
+    while (_heartbeatTimer.Passed())
+    {
+        _heartbeatTimer.Reset(_heartbeatTimer.GetExpiry() + HEARTBEAT_INTERVAL);
+        Heartbeat();
+    }
 }
 
 void WorldObject::SetIsStoredInWorldObjectGridContainer(bool on)

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -32,6 +32,7 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include "SpellDefines.h"
+#include "Timer.h"
 #include "UniqueTrackablePtr.h"
 #include "UpdateFields.h"
 #include <list>
@@ -145,6 +146,7 @@ namespace UF
 }
 
 float const DEFAULT_COLLISION_HEIGHT = 2.03128f; // Most common value in dbc
+static constexpr Seconds const HEARTBEAT_INTERVAL = 5s;
 
 class TC_GAME_API Object
 {
@@ -823,6 +825,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         virtual bool IsInvisibleDueToDespawn([[maybe_unused]] WorldObject const* seer) const { return false; }
         //difference from IsAlwaysVisibleFor: 1. after distance check; 2. use owner or charmer as seer
         virtual bool IsAlwaysDetectableFor([[maybe_unused]] WorldObject const* seer) const { return false; }
+
+        virtual void Heartbeat() { }
     private:
         Map* m_currMap;                                   // current object's Map location
 
@@ -836,6 +840,8 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
         ObjectGuid _privateObjectOwner;
 
         std::unique_ptr<SmoothPhasing> _smoothPhasing;
+
+        TimeTracker _heartbeatTimer;
 
         virtual bool _IsWithinDist(WorldObject const* obj, float dist2compare, bool is3D, bool incOwnRadius = true, bool incTargetRadius = true) const;
 

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -145,7 +145,7 @@ namespace UF
 }
 
 float const DEFAULT_COLLISION_HEIGHT = 2.03128f; // Most common value in dbc
-static constexpr Seconds const HEARTBEAT_INTERVAL = 5s;
+static constexpr Milliseconds const HEARTBEAT_INTERVAL = 5s + 200ms;
 
 class TC_GAME_API Object
 {

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -32,7 +32,6 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include "SpellDefines.h"
-#include "Timer.h"
 #include "UniqueTrackablePtr.h"
 #include "UpdateFields.h"
 #include <list>
@@ -841,7 +840,7 @@ class TC_GAME_API WorldObject : public Object, public WorldLocation
 
         std::unique_ptr<SmoothPhasing> _smoothPhasing;
 
-        TimeTracker _heartbeatTimer;
+        Milliseconds _heartbeatTimer;
 
         virtual bool _IsWithinDist(WorldObject const* obj, float dist2compare, bool is3D, bool incOwnRadius = true, bool incTargetRadius = true) const;
 


### PR DESCRIPTION
... and added a virtual Heartbeat() method for future implementations

This is the first step of porting the functionality of #25822 by cutting each change into a nicely self-contained commit


**Changes proposed:**

-  Added a heartbeat timer that invokes a virtual method within the WorldObject class

**Tests performed:**
- Builds
