### PR TITLE
Core/Auras: implemented PROC_FLAG_HEARTBEAT and moved food/drink emote mechanic into heartbeat handling

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2884,7 +2884,6 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         GuidList WhisperList;
         TimePoint m_regenInterruptTimestamp;
         uint32 m_regenTimerCount;
-        uint32 m_foodEmoteTimerCount;
         std::array<float, MAX_POWERS_PER_CLASS> m_powerFraction;
         uint32 m_contestedPvPTimer;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -501,6 +501,19 @@ void Unit::Heartbeat()
 
     // SMSG_FLIGHT_SPLINE_SYNC for cyclic splines
     SendFlightSplineSyncUpdate();
+
+    // Aura Heartbeat
+    TriggerAuraHeartbeat();
+}
+
+void Unit::TriggerAuraHeartbeat()
+{
+    // There are some auras which do invoke generic behavior on heartbeat
+    for (auto const& [_, auraApplication] : m_appliedAuras)
+        auraApplication->GetBase()->Heartbeat();
+
+    // PROC_FLAG_HEARTBEAT
+    Unit::ProcSkillsAndAuras(this, nullptr, PROC_FLAG_HEARTBEAT, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
 }
 
 bool Unit::haveOffhandWeapon() const

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -502,17 +502,15 @@ void Unit::Heartbeat()
     // SMSG_FLIGHT_SPLINE_SYNC for cyclic splines
     SendFlightSplineSyncUpdate();
 
-    // Aura Heartbeat
+    // Trigger heartbeat procs and generic aura behavior such as food emotes
     TriggerAuraHeartbeat();
 }
 
 void Unit::TriggerAuraHeartbeat()
 {
-    // There are some auras which do invoke generic behavior on heartbeat
     for (auto const& [_, auraApplication] : m_appliedAuras)
         auraApplication->GetBase()->Heartbeat();
 
-    // PROC_FLAG_HEARTBEAT
     Unit::ProcSkillsAndAuras(this, nullptr, PROC_FLAG_HEARTBEAT, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_NONE, PROC_HIT_NONE, nullptr, nullptr, nullptr);
 }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -685,6 +685,7 @@ class TC_GAME_API Unit : public WorldObject
         virtual void Update(uint32 time) override;
 
         void Heartbeat() override;
+        void TriggerAuraHeartbeat();
 
         void setAttackTimer(WeaponAttackType type, uint32 time) { m_attackTimer[type] = time; }
         void resetAttackTimer(WeaponAttackType type = BASE_ATTACK);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2614,6 +2614,28 @@ void UnitAura::AddStaticApplication(Unit* target, uint32 effMask)
     _staticApplications[target->GetGUID()] |= effMask;
 }
 
+void UnitAura::Heartbeat()
+{
+    Aura::Heartbeat();
+
+    // Periodic food and drink emote animation
+    HandlePeriodicFoodSpellVisualKit();
+}
+
+void UnitAura::HandlePeriodicFoodSpellVisualKit()
+{
+    SpellSpecificType specificType = GetSpellInfo()->GetSpellSpecific();
+
+    bool food = specificType == SPELL_SPECIFIC_FOOD || specificType == SPELL_SPECIFIC_FOOD_AND_DRINK;
+    bool drink = specificType == SPELL_SPECIFIC_DRINK || specificType == SPELL_SPECIFIC_FOOD_AND_DRINK;
+
+    if (food)
+        GetUnitOwner()->SendPlaySpellVisualKit(SPELL_VISUAL_KIT_FOOD, 0, 0);
+
+    if (drink)
+        GetUnitOwner()->SendPlaySpellVisualKit(SPELL_VISUAL_KIT_DRINK, 0, 0);
+}
+
 DynObjAura::DynObjAura(AuraCreateInfo const& createInfo)
     : Aura(createInfo)
 {

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -257,6 +257,7 @@ class TC_GAME_API Aura
         float CalcPPMProcChance(Unit* actor) const;
         void SetLastProcAttemptTime(TimePoint lastProcAttemptTime) { m_lastProcAttemptTime = lastProcAttemptTime; }
         void SetLastProcSuccessTime(TimePoint lastProcSuccessTime) { m_lastProcSuccessTime = lastProcSuccessTime; }
+        virtual void Heartbeat() { }
 
         // AuraScript
         void LoadScripts();
@@ -382,6 +383,9 @@ class TC_GAME_API UnitAura : public Aura
         DiminishingGroup GetDiminishGroup() const { return m_AuraDRGroup; }
 
         void AddStaticApplication(Unit* target, uint32 effMask);
+
+        void Heartbeat() override;
+        void HandlePeriodicFoodSpellVisualKit();
 
     private:
         DiminishingGroup m_AuraDRGroup;                 // Diminishing

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -134,7 +134,7 @@ enum ProcFlags : uint32
 {
     PROC_FLAG_NONE                              = 0x00000000,
 
-    PROC_FLAG_HEARTBEAT                         = 0x00000001,    // 00 Killed by agressor - not sure about this flag
+    PROC_FLAG_HEARTBEAT                         = 0x00000001,    // 00 Heartbeat
     PROC_FLAG_KILL                              = 0x00000002,    // 01 Kill target (in most cases need XP/Honor reward)
 
     PROC_FLAG_DEAL_MELEE_SWING                  = 0x00000004,    // 02 Done melee auto attack


### PR DESCRIPTION
**Changes proposed:**

-  PROC_FLAG_HEARTBEAT does now fire on every heartbeat
-  moved periodic food and drink emote handling into unitAura and use spellspecifctype to determine its type


**Tests performed:**
- tested ingame
