### PR TITLE
Core/Combat: reset the ThreatManager update interval upon engaging thee creature and move ThreatClear packet sending into the update cycle to mimic retail behavior

### DIFF
--- a/src/server/game/Combat/ThreatManager.h
+++ b/src/server/game/Combat/ThreatManager.h
@@ -95,6 +95,9 @@ class TC_GAME_API ThreatManager
         // called from Creature::Update (only creatures can have their own threat list)
         // should not be called from anywhere else
         void Update(uint32 tdiff);
+        // called from Creature::AtEngage
+        // should not be called from anywhere else
+        void ResetUpdateTimer();
 
         // never nullptr
         Unit* GetOwner() const { return _owner; }
@@ -197,6 +200,7 @@ class TC_GAME_API ThreatManager
         void PurgeThreatListRef(ObjectGuid const& guid);
 
         bool _needClientUpdate;
+        bool _needThreatClearUpdate;
         uint32 _updateTimer;
         std::unique_ptr<Heap> _sortedThreatList;
         std::unordered_map<ObjectGuid, ThreatReference*> _myThreatListEntries;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -742,6 +742,8 @@ void Creature::Update(uint32 diff)
 
     UpdateMovementCapabilities();
 
+    GetThreatManager().Update(diff);
+
     switch (m_deathState)
     {
         case JUST_RESPAWNED:
@@ -828,7 +830,6 @@ void Creature::Update(uint32 diff)
             if (!IsAlive())
                 break;
 
-            GetThreatManager().Update(diff);
             if (_spellFocusInfo.Delay)
             {
                 if (_spellFocusInfo.Delay <= diff)
@@ -3593,6 +3594,8 @@ bool Creature::IsEngaged() const
 void Creature::AtEngage(Unit* target)
 {
     Unit::AtEngage(target);
+
+    GetThreatManager().ResetUpdateTimer();
 
     if (!HasFlag(CREATURE_STATIC_FLAG_2_ALLOW_MOUNTED_COMBAT))
         Dismount();


### PR DESCRIPTION
**Changes proposed:**

-  the threatmanager will now continue to update even when dead to support sending pending packets when dead
-  TheatClear is now put behind the threat update interval to mimic retail
-  This fixes an inconsistency in the client where HighestThreatUpdate and ClearTheat would be sent at the same time, resulting in the creature retaining the threat display, causing the client to glitch out and being stuck in this red'ish state

**Tests performed:**
- tested ingame

**Known issues and TODO list:** (add/remove lines as needed)
- This treatment should also be applied for the CombatManager as the combat and threat update but should happen at the same time.