### PR TITLE
Core/Creatures: Fix level scaling for summons without SummonPropertiesFlags::UseCreatureLevel

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -232,7 +232,12 @@ void TempSummon::InitStats(WorldObject* summoner, Milliseconds duration)
         }
 
         if (!m_Properties->GetFlags().HasFlag(SummonPropertiesFlags::UseCreatureLevel))
-            SetLevel(unitSummoner->GetLevel());
+        {
+            int32 minLevel = m_unitData->ScalingLevelMin + m_unitData->ScalingLevelDelta;
+            int32 maxLevel = m_unitData->ScalingLevelMax + m_unitData->ScalingLevelDelta;
+            uint8 level = std::clamp<int32>(unitSummoner->GetLevel(), minLevel, maxLevel);
+            SetLevel(level);
+        }
     }
 
     uint32 faction = m_Properties->Faction;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix level scaling for summons without SummonPropertiesFlags::UseCreatureLevel. Creature levels only scale between ContentTuning levels

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
