### PR TITLE
Scripts/HoL: Fix a crash caused by iterator invalidating in Ionar boss script

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfLightning/boss_ionar.cpp
@@ -145,9 +145,12 @@ struct boss_ionar : public BossAI
 
         Position pos = me->GetPosition();
 
-        for (ObjectGuid guid : summons)
+        for (SummonList::const_iterator itr = summons.begin(); itr != summons.end();)
         {
-            if (Creature* pSpark = ObjectAccessor::GetCreature(*me, guid))
+            Creature* pSpark = ObjectAccessor::GetCreature(*me, *itr);
+            ++itr;
+
+            if (pSpark)
             {
                 if (pSpark->IsAlive())
                 {


### PR DESCRIPTION
**Changes proposed:**

The crash occurs in `boss_ionar::CallBackSparks`. We are calling `Creature::DespawnOrUnsummon` for iterable creatures directly within the loop, which leads to call `boss_ionar::SummonedCreatureDespawn`, followed by `SummonList::Despawn`. The iterator becomes invalidated, resulting in a core crash.

Steps to reproduce the crash:

1. `.tele hallsoflightning`
2. Enter the dungeon and pull the boss Ionar.
3. Target Ionar and use `.damage 200000`
4. When sparks appear, kill at least one of them.
5. After a few seconds, the server crashes.

This PR fixes the issue.

**Tests performed:**

Builded and tested in-game.
