### PR TITLE
Core/DataStores: Sort ConditionalContentTuning container by OrderIndex

### DIFF
--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -464,7 +464,7 @@ namespace
     std::unordered_map<uint32 /*chrCustomizationReqId*/, std::vector<std::pair<uint32 /*chrCustomizationOptionId*/, std::vector<uint32>>>> _chrCustomizationRequiredChoices;
     ChrSpecializationByIndexContainer _chrSpecializationsByIndex;
     std::unordered_map<int32, ConditionalChrModelEntry const*> _conditionalChrModelsByChrModelId;
-    std::unordered_multimap<uint32, ConditionalContentTuningEntry const*> _conditionalContentTuning;
+    std::unordered_map<uint32 /*contentTuningId*/, std::vector<ConditionalContentTuningEntry const*>> _conditionalContentTuning;
     std::unordered_set<std::pair<uint32, int32>> _contentTuningLabels;
     std::unordered_multimap<uint32, CurrencyContainerEntry const*> _currencyContainers;
     CurvePointsContainer _curvePoints;
@@ -1220,8 +1220,17 @@ uint32 DB2Manager::LoadStores(std::string const& dataPath, LocaleConstant defaul
     for (ConditionalChrModelEntry const* conditionalChrModel : sConditionalChrModelStore)
         _conditionalChrModelsByChrModelId[conditionalChrModel->ChrModelID] = conditionalChrModel;
 
-    for (ConditionalContentTuningEntry const* conditionalContentTuning : sConditionalContentTuningStore)
-        _conditionalContentTuning.emplace(conditionalContentTuning->ParentContentTuningID, conditionalContentTuning);
+    {
+        for (ConditionalContentTuningEntry const* conditionalContentTuning : sConditionalContentTuningStore)
+            _conditionalContentTuning[conditionalContentTuning->ParentContentTuningID].push_back(conditionalContentTuning);
+
+        for (auto& [parentContentTuningId, conditionalContentTunings] : _conditionalContentTuning)
+        {
+            std::ranges::sort(conditionalContentTunings, [](ConditionalContentTuningEntry const* conditionalContentTuning1, ConditionalContentTuningEntry const* conditionalContentTuning2) {
+                return conditionalContentTuning1->OrderIndex > conditionalContentTuning2->OrderIndex;
+            });
+        }
+    }
 
     for (ContentTuningXExpectedEntry const* contentTuningXExpectedStat : sContentTuningXExpectedStore)
         if (sExpectedStatModStore.LookupEntry(contentTuningXExpectedStat->ExpectedStatModID))
@@ -2112,9 +2121,14 @@ ChrSpecializationEntry const* DB2Manager::GetDefaultChrSpecializationForClass(ui
 
 uint32 DB2Manager::GetRedirectedContentTuningId(uint32 contentTuningId, uint32 redirectFlag) const
 {
-    for (auto [_, conditionalContentTuning] : Trinity::Containers::MapEqualRange(_conditionalContentTuning, contentTuningId))
-        if (conditionalContentTuning->RedirectFlag & redirectFlag)
-            return conditionalContentTuning->RedirectContentTuningID;
+    std::vector<ConditionalContentTuningEntry const*> const* conditionalContentTunings = Trinity::Containers::MapGetValuePtr(_conditionalContentTuning, contentTuningId);
+
+    if (conditionalContentTunings)
+    {
+        for (ConditionalContentTuningEntry const* conditionalContentTuning : *conditionalContentTunings)
+            if (conditionalContentTuning->RedirectFlag & redirectFlag)
+                return conditionalContentTuning->RedirectContentTuningID;
+    }
 
     return contentTuningId;
 }

--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -1225,11 +1225,7 @@ uint32 DB2Manager::LoadStores(std::string const& dataPath, LocaleConstant defaul
             _conditionalContentTuning[conditionalContentTuning->ParentContentTuningID].push_back(conditionalContentTuning);
 
         for (auto& [parentContentTuningId, conditionalContentTunings] : _conditionalContentTuning)
-        {
-            std::ranges::sort(conditionalContentTunings, [](ConditionalContentTuningEntry const* conditionalContentTuning1, ConditionalContentTuningEntry const* conditionalContentTuning2) {
-                return conditionalContentTuning1->OrderIndex > conditionalContentTuning2->OrderIndex;
-            });
-        }
+            std::ranges::sort(conditionalContentTunings, std::greater(), &ConditionalContentTuningEntry::OrderIndex);
     }
 
     for (ContentTuningXExpectedEntry const* contentTuningXExpectedStat : sContentTuningXExpectedStore)
@@ -2121,14 +2117,10 @@ ChrSpecializationEntry const* DB2Manager::GetDefaultChrSpecializationForClass(ui
 
 uint32 DB2Manager::GetRedirectedContentTuningId(uint32 contentTuningId, uint32 redirectFlag) const
 {
-    std::vector<ConditionalContentTuningEntry const*> const* conditionalContentTunings = Trinity::Containers::MapGetValuePtr(_conditionalContentTuning, contentTuningId);
-
-    if (conditionalContentTunings)
-    {
+    if (std::vector<ConditionalContentTuningEntry const*> const* conditionalContentTunings = Trinity::Containers::MapGetValuePtr(_conditionalContentTuning, contentTuningId))
         for (ConditionalContentTuningEntry const* conditionalContentTuning : *conditionalContentTunings)
             if (conditionalContentTuning->RedirectFlag & redirectFlag)
                 return conditionalContentTuning->RedirectContentTuningID;
-    }
 
     return contentTuningId;
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Sort ConditionalContentTuning container by OrderIndex. DB2Manager::GetRedirectedContentTuningId will return the ContentTuningId with the highest OrderIndex in case several valid redirectflags for the ParentContentTuningId are sent by parameter

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game
Before:
```
ContentTuningId: 2385
RedirectFlags: 32 -> 2537
RedirectFlags: 64 + 32 -> 2537
RedirectFlags: 256 + 64 + 32 -> 2537
RedirectFlags: 256 + 32 -> 2537
```
After:
```
ContentTuningId: 2385
RedirectFlags: 32 -> 2537
RedirectFlags: 64 + 32 -> 2533
RedirectFlags: 256 + 64 + 32 -> 2594
RedirectFlags: 256 + 32 -> 2594
```

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
