### PR TITLE
Core/Players: moved zone and area updating from a standalone timer into Heartbeat handling

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1994,6 +1994,7 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         void UpdatePvPState(bool onlyFFA = false);
         void SetPvP(bool state) override;
         void UpdatePvP(bool state, bool override = false);
+        void UpdateZoneAndArea();
         void UpdateZone(uint32 newZone, uint32 newArea);
         void UpdateArea(uint32 newArea);
         void UpdateHostileAreaState(AreaTableEntry const* area);
@@ -3128,7 +3129,6 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         uint32 m_weaponChangeTimer;
 
         uint32 m_zoneUpdateId;
-        uint32 m_zoneUpdateTimer;
         uint32 m_areaUpdateId;
 
         uint32 m_deathTimer;


### PR DESCRIPTION
**Changes proposed:**

-  turns out that retail and classic update their zone data on a per-heartbeat basis as well so we move the zone and area id handling over there

**Tests performed:**
- tested ingame

Is is worth noting that because of this relocation of the updating, zones, areas and consequently phasing and spell_area may take a bit longer as the old zone update timer was ticking every second while the heartbeat only fires once every 5200ms or on certain movement actions.