### PR TITLE
Core/Disables: Added DISABLE_TYPE_PHASE_AREA

### DIFF
--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -241,7 +241,7 @@ void LoadDisables()
                     TC_LOG_INFO("misc", "Pathfinding disabled for {} map {}.", MapTypeNames[mapEntry->InstanceType], entry);
                 break;
             }
-            case DISABLE_TYPE_PHASE:
+            case DISABLE_TYPE_PHASE_AREA:
             {
                 if (!sPhaseStore.LookupEntry(entry))
                 {
@@ -394,7 +394,7 @@ bool IsDisabledFor(DisableType type, uint32 entry, WorldObject const* ref, uint8
         case DISABLE_TYPE_OUTDOORPVP:
         case DISABLE_TYPE_CRITERIA:
         case DISABLE_TYPE_MMAP:
-        case DISABLE_TYPE_PHASE:
+        case DISABLE_TYPE_PHASE_AREA:
             return true;
         case DISABLE_TYPE_VMAP:
            return (flags & itr->second.flags) != 0;

--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -241,6 +241,17 @@ void LoadDisables()
                     TC_LOG_INFO("misc", "Pathfinding disabled for {} map {}.", MapTypeNames[mapEntry->InstanceType], entry);
                 break;
             }
+            case DISABLE_TYPE_PHASE:
+            {
+                if (!sPhaseStore.LookupEntry(entry))
+                {
+                    TC_LOG_ERROR("sql.sql", "Phase entry {} from `disables` doesn't exist in dbc, skipped.", entry);
+                    continue;
+                }
+                if (flags)
+                    TC_LOG_ERROR("sql.sql", "Disable flags specified for phase {}, useless data.", entry);
+                break;
+            }
             default:
                 break;
         }
@@ -383,6 +394,7 @@ bool IsDisabledFor(DisableType type, uint32 entry, WorldObject const* ref, uint8
         case DISABLE_TYPE_OUTDOORPVP:
         case DISABLE_TYPE_CRITERIA:
         case DISABLE_TYPE_MMAP:
+        case DISABLE_TYPE_PHASE:
             return true;
         case DISABLE_TYPE_VMAP:
            return (flags & itr->second.flags) != 0;

--- a/src/server/game/Conditions/DisableMgr.h
+++ b/src/server/game/Conditions/DisableMgr.h
@@ -33,7 +33,7 @@ enum DisableType
     DISABLE_TYPE_VMAP                   = 6,
     DISABLE_TYPE_MMAP                   = 7,
     DISABLE_TYPE_LFG_MAP                = 8,
-    DISABLE_TYPE_PHASE                  = 9,
+    DISABLE_TYPE_PHASE_AREA             = 9,
 
     MAX_DISABLE_TYPES
 };

--- a/src/server/game/Conditions/DisableMgr.h
+++ b/src/server/game/Conditions/DisableMgr.h
@@ -33,6 +33,7 @@ enum DisableType
     DISABLE_TYPE_VMAP                   = 6,
     DISABLE_TYPE_MMAP                   = 7,
     DISABLE_TYPE_LFG_MAP                = 8,
+    DISABLE_TYPE_PHASE                  = 9,
 
     MAX_DISABLE_TYPES
 };

--- a/src/server/game/Phasing/PhasingHandler.cpp
+++ b/src/server/game/Phasing/PhasingHandler.cpp
@@ -319,7 +319,7 @@ void PhasingHandler::OnAreaChange(WorldObject* object)
                     continue;
 
                 uint32 phaseId = phaseArea.PhaseInfo->Id;
-                if (DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE, phaseId, object))
+                if (DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE_AREA, phaseId, object))
                     continue;
 
                 if (sConditionMgr->IsObjectMeetToConditions(srcInfo, phaseArea.Conditions))
@@ -392,7 +392,7 @@ bool PhasingHandler::OnConditionChange(WorldObject* object, bool updateVisibilit
 
     for (auto itr = suppressedPhaseShift.Phases.begin(); itr != suppressedPhaseShift.Phases.end();)
     {
-        if (!DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE, itr->Id, object) && sConditionMgr->IsObjectMeetToConditions(srcInfo, *ASSERT_NOTNULL(itr->AreaConditions)))
+        if (!DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE_AREA, itr->Id, object) && sConditionMgr->IsObjectMeetToConditions(srcInfo, *ASSERT_NOTNULL(itr->AreaConditions)))
         {
             changed = phaseShift.AddPhase(itr->Id, itr->Flags, itr->AreaConditions, itr->References) || changed;
             suppressedPhaseShift.ModifyPhasesReferences(itr, -itr->References);
@@ -646,7 +646,7 @@ void PhasingHandler::PrintToChat(ChatHandler* chat, WorldObject const* target)
                 phases << ' ' << '(' << cosmetic << ')';
             if (phase.Flags.HasFlag(PhaseFlags::Personal))
                 phases << ' ' << '(' << personal << ')';
-            if (DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE, phase.Id, nullptr))
+            if (DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE_AREA, phase.Id, nullptr))
                 phases << " (Disabled)";
         }
 

--- a/src/server/game/Phasing/PhasingHandler.cpp
+++ b/src/server/game/Phasing/PhasingHandler.cpp
@@ -20,6 +20,7 @@
 #include "ConditionMgr.h"
 #include "Creature.h"
 #include "DB2Stores.h"
+#include "DisableMgr.h"
 #include "Language.h"
 #include "Map.h"
 #include "MiscPackets.h"
@@ -318,6 +319,9 @@ void PhasingHandler::OnAreaChange(WorldObject* object)
                     continue;
 
                 uint32 phaseId = phaseArea.PhaseInfo->Id;
+                if (DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE, phaseId, object))
+                    continue;
+
                 if (sConditionMgr->IsObjectMeetToConditions(srcInfo, phaseArea.Conditions))
                     phaseShift.AddPhase(phaseId, GetPhaseFlags(phaseId), &phaseArea.Conditions);
                 else
@@ -388,7 +392,7 @@ bool PhasingHandler::OnConditionChange(WorldObject* object, bool updateVisibilit
 
     for (auto itr = suppressedPhaseShift.Phases.begin(); itr != suppressedPhaseShift.Phases.end();)
     {
-        if (sConditionMgr->IsObjectMeetToConditions(srcInfo, *ASSERT_NOTNULL(itr->AreaConditions)))
+        if (!DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE, itr->Id, object) && sConditionMgr->IsObjectMeetToConditions(srcInfo, *ASSERT_NOTNULL(itr->AreaConditions)))
         {
             changed = phaseShift.AddPhase(itr->Id, itr->Flags, itr->AreaConditions, itr->References) || changed;
             suppressedPhaseShift.ModifyPhasesReferences(itr, -itr->References);
@@ -642,6 +646,8 @@ void PhasingHandler::PrintToChat(ChatHandler* chat, WorldObject const* target)
                 phases << ' ' << '(' << cosmetic << ')';
             if (phase.Flags.HasFlag(PhaseFlags::Personal))
                 phases << ' ' << '(' << personal << ')';
+            if (DisableMgr::IsDisabledFor(DISABLE_TYPE_PHASE, phase.Id, nullptr))
+                phases << " (Disabled)";
         }
 
         chat->PSendSysMessage(LANG_PHASESHIFT_PHASES, phases.str().c_str());


### PR DESCRIPTION
**Tests performed:**
Used the following sql and checked if any of the Refugees are visible in Stormwind harbor while gm off
```sql
DELETE FROM `disables` WHERE `sourceType`=9 AND `entry`=11595;
INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES 
(9, 11595, 0, '', '', 'Disable Darnassian and Gilnean Refugees phase');
```

**Note:**
Also thought about skipping loading of objects with disabled phases entirely, but since this table is reloadable and creature/gameobject isn't i decided to just not apply the phase to the players