### PR TITLE
Core/Network: Optimize CPU consumption by decreasing heap allocations.

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -81,40 +81,44 @@ void WorldSocket::CheckIpCallback(PreparedQueryResult result)
 bool WorldSocket::Update()
 {
     EncryptablePacket* queued;
-    MessageBuffer buffer(_sendBufferSize);
-    while (_bufferQueue.Dequeue(queued))
+    if (_bufferQueue.Dequeue(queued))
     {
-        ServerPktHeader header(queued->size() + 2, queued->GetOpcode());
-        if (queued->NeedsEncryption())
-            _authCrypt.EncryptSend(header.header, header.getHeaderLength());
-
-        if (buffer.GetRemainingSpace() < queued->size() + header.getHeaderLength())
+        // Allocate buffer only when it's needed but not on every Update() call.
+        MessageBuffer buffer(_sendBufferSize);
+        do
         {
+            ServerPktHeader header(queued->size() + 2, queued->GetOpcode());
+            if (queued->NeedsEncryption())
+                _authCrypt.EncryptSend(header.header, header.getHeaderLength());
+
+            if (buffer.GetRemainingSpace() < queued->size() + header.getHeaderLength())
+            {
+                QueuePacket(std::move(buffer));
+                buffer.Resize(_sendBufferSize);
+            }
+
+            if (buffer.GetRemainingSpace() >= queued->size() + header.getHeaderLength())
+            {
+                buffer.Write(header.header, header.getHeaderLength());
+                if (!queued->empty())
+                    buffer.Write(queued->contents(), queued->size());
+            }
+            else    // single packet larger than buffer size
+            {
+                MessageBuffer packetBuffer(queued->size() + header.getHeaderLength());
+                packetBuffer.Write(header.header, header.getHeaderLength());
+                if (!queued->empty())
+                    packetBuffer.Write(queued->contents(), queued->size());
+
+                QueuePacket(std::move(packetBuffer));
+            }
+
+            delete queued;
+        } while (_bufferQueue.Dequeue(queued));
+
+        if (buffer.GetActiveSize() > 0)
             QueuePacket(std::move(buffer));
-            buffer.Resize(_sendBufferSize);
-        }
-
-        if (buffer.GetRemainingSpace() >= queued->size() + header.getHeaderLength())
-        {
-            buffer.Write(header.header, header.getHeaderLength());
-            if (!queued->empty())
-                buffer.Write(queued->contents(), queued->size());
-        }
-        else    // single packet larger than 4096 bytes
-        {
-            MessageBuffer packetBuffer(queued->size() + header.getHeaderLength());
-            packetBuffer.Write(header.header, header.getHeaderLength());
-            if (!queued->empty())
-                packetBuffer.Write(queued->contents(), queued->size());
-
-            QueuePacket(std::move(packetBuffer));
-        }
-
-        delete queued;
     }
-
-    if (buffer.GetActiveSize() > 0)
-        QueuePacket(std::move(buffer));
 
     if (!BaseSocket::Update())
         return false;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
We have a network thread that makes approximately 1k invocations per second of this function for every socket:
https://github.com/TrinityCore/TrinityCore/blob/d8240fb513fc18ee9bac067f8333aab1d96005d9/src/server/game/Server/WorldSocket.cpp#L81-L86

Most of the time, `_bufferQueue` remains empty, and we should do nothing inside this function.
However, for each call, we allocate a 64KB buffer even when it is unnecessary.
As a result, a significant portion of CPU time is dedicated to the allocation and deallocation on heap of this buffer.

Below, you can observe the reduction in CPU consumption (with one player online) after implementing this change.
Before:
<img width="400" alt="Screenshot 2024-05-25 at 11 00 22" src="https://github.com/TrinityCore/TrinityCore/assets/444158/e4cce79c-12c1-4790-b61b-ae83ee984e2a">

After:
<img width="400" alt="Screenshot 2024-05-25 at 11 01 30" src="https://github.com/TrinityCore/TrinityCore/assets/444158/e8af2b28-4748-4631-939a-bcff7f048be5">

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
