### PR TITLE
Core/Players: Improve reset spell cooldowns when entering arenas

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -3752,27 +3752,10 @@ void Player::RemoveArenaSpellCooldowns(bool removeActivePetCooldowns)
     GetSpellHistory()->ResetCooldowns([](SpellHistory::CooldownStorageType::iterator itr) -> bool
     {
         SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(itr->first);
-        uint32 maxCooldown = std::max(spellInfo->RecoveryTime, spellInfo->CategoryRecoveryTime);
-        if (Milliseconds(maxCooldown) < Minutes(10))
-        {
-            // Also check item spell cooldowns
-            if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(itr->second.ItemId))
-            {
-                for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
-                {
-                    if (int32(spellInfo->Id) != itemTemplate->Spells[i].SpellId)
-                        continue;
-
-                    int32 itemMaxCooldown = std::max(itemTemplate->Spells[i].SpellCooldown, itemTemplate->Spells[i].SpellCategoryCooldown);
-                    if (itemMaxCooldown > 0 && Milliseconds(itemMaxCooldown) >= Minutes(10))
-                        return false;
-                }
-            }
-
-            return true;
-        }
-
-        return false;
+        int32 cooldown = -1;
+        int32 categoryCooldown = -1;
+        SpellHistory::GetCooldownDurations(spellInfo, itr->second.ItemId, &cooldown, nullptr, &categoryCooldown);
+        return cooldown < 10 * MINUTE * IN_MILLISECONDS && categoryCooldown < 10 * MINUTE * IN_MILLISECONDS;
     }, true);
 
     // pet cooldowns

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -130,6 +130,8 @@ public:
 
     void BuildCooldownPacket(WorldPacket& data, uint8 flags, uint32 spellId, uint32 cooldown) const;
 
+    static void GetCooldownDurations(SpellInfo const* spellInfo, uint32 itemId, int32* cooldown, uint32* categoryId, int32* categoryCooldown);
+
     CooldownStorageType::size_type GetCooldownsSizeForPacket() const { return _spellCooldowns.size(); }
     void SaveCooldownStateBeforeDuel();
     void RestoreCooldownStateAfterDuel();
@@ -145,8 +147,6 @@ private:
 
     typedef std::unordered_map<uint32, uint32> PacketCooldowns;
     void BuildCooldownPacket(WorldPacket& data, uint8 flags, PacketCooldowns const& cooldowns) const;
-
-    static void GetCooldownDurations(SpellInfo const* spellInfo, uint32 itemId, int32* cooldown, uint32* categoryId, int32* categoryCooldown);
 
     Unit* _owner;
     CooldownStorageType _spellCooldowns;


### PR DESCRIPTION
**Changes proposed:**

-  Some spells of items don't have recoverytime or categoryrecoverytime in DBC but item_template has specific cooldown, those cases are not checked when player enters in arena, so reset cooldown of items like:
https://aowow.trinitycore.info/?item=27388 (2 day cooldown) or https://aowow.trinitycore.info/?item=46874 (30 min cooldown)


**Issues addressed:**

None


**Tests performed:**

tested in-game
