### PR TITLE
Core/PacketIO: increase ByteBuffer append limit from ~10mb to ~100mb

### DIFF
--- a/src/server/shared/Packets/ByteBuffer.cpp
+++ b/src/server/shared/Packets/ByteBuffer.cpp
@@ -89,7 +89,7 @@ void ByteBuffer::append(uint8 const* src, size_t cnt)
 {
     ASSERT(src, "Attempted to put a NULL-pointer in ByteBuffer (pos: " SZFMTD " size: " SZFMTD ")", _wpos, size());
     ASSERT(cnt, "Attempted to put a zero-sized value in ByteBuffer (pos: " SZFMTD " size: " SZFMTD ")", _wpos, size());
-    ASSERT(size() < 10000000);
+    ASSERT((size() + cnt) < 100000000);
 
     FlushBits();
 


### PR DESCRIPTION
**Changes proposed:**

-  just increasing the bytebuffer::append limit so we can squeeze larger datasets into it.

**Tests performed:**
- tested for Cata Classic as their hotfixes require that increased limit.
