### PR TITLE
Core/Flags: Allow GMs to target npcs with UNIT_FLAG2_UNTARGETABLE_BY_CLIENT flag

### DIFF
--- a/src/server/game/Entities/Object/Updates/UpdateFields.cpp
+++ b/src/server/game/Entities/Object/Updates/UpdateFields.cpp
@@ -995,7 +995,7 @@ void UnitData::WriteCreate(ByteBuffer& data, EnumFlag<UpdateFieldFlag> fieldVisi
         VirtualItems[i].WriteCreate(data, owner, receiver);
     }
     data << uint32(ViewerDependentValue<FlagsTag>::GetValue(this, owner, receiver));
-    data << uint32(Flags2);
+    data << uint32(ViewerDependentValue<Flags2Tag>::GetValue(this, owner, receiver));
     data << uint32(ViewerDependentValue<Flags3Tag>::GetValue(this, owner, receiver));
     data << uint32(ViewerDependentValue<AuraStateTag>::GetValue(this, owner, receiver));
     for (uint32 i = 0; i < 2; ++i)
@@ -1388,7 +1388,7 @@ void UnitData::WriteUpdate(ByteBuffer& data, Mask const& changesMask, bool ignor
         }
         if (changesMask[43])
         {
-            data << uint32(Flags2);
+            data << uint32(ViewerDependentValue<Flags2Tag>::GetValue(this, owner, receiver));
         }
         if (changesMask[44])
         {

--- a/src/server/game/Entities/Object/Updates/UpdateFields.h
+++ b/src/server/game/Entities/Object/Updates/UpdateFields.h
@@ -304,6 +304,7 @@ struct UnitData : public IsUpdateFieldStructureTag, public HasChangesMask<217>
     UpdateField<uint32, 32, 42> Flags;
     struct FlagsTag : ViewerDependentValueTag<uint32> {};
     UpdateField<uint32, 32, 43> Flags2;
+    struct Flags2Tag : ViewerDependentValueTag<uint32> {};
     UpdateField<uint32, 32, 44> Flags3;
     struct Flags3Tag : ViewerDependentValueTag<uint32> {};
     UpdateField<uint32, 32, 45> AuraState;

--- a/src/server/game/Entities/Object/Updates/ViewerDependentValues.h
+++ b/src/server/game/Entities/Object/Updates/ViewerDependentValues.h
@@ -241,6 +241,23 @@ public:
 };
 
 template<>
+class ViewerDependentValue<UF::UnitData::Flags2Tag>
+{
+public:
+    using value_type = UF::UnitData::Flags2Tag::value_type;
+
+    static value_type GetValue(UF::UnitData const* unitData, Unit const* /*unit*/, Player const* receiver)
+    {
+        value_type flags = unitData->Flags2;
+        // Gamemasters should be always able to interact with units - remove uninteractible flag
+        if (receiver->IsGameMaster())
+            flags &= ~UNIT_FLAG2_UNTARGETABLE_BY_CLIENT;
+
+        return flags;
+    }
+};
+
+template<>
 class ViewerDependentValue<UF::UnitData::Flags3Tag>
 {
 public:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Allow GMs to target units with UNIT_FLAG2: UNIT_FLAG2_UNTARGETABLE_BY_CLIENT 
![image](https://github.com/TrinityCore/TrinityCore/assets/680324/03996d87-dcaa-4e8e-ad6e-b64ac8b9a4c9)

**Issues addressed:**

Closes #  No issue addressed


**Tests performed:**

Build and tested in-game


**Known issues and TODO list:** (add/remove lines as needed)

- No issues known


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
