### PR TITLE
Core/Spells: Don't return immune to reflected spells due to target aurastate

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -2198,7 +2198,8 @@ void Spell::AddUnitTarget(Unit* target, uint32 effectMask, bool checkIfValid /*=
         Unit* unitCaster = ASSERT_NOTNULL(m_caster->ToUnit());
 
         // Calculate reflected spell result on caster
-        if (m_spellInfo->CheckTarget(target, unitCaster, implicit) == SPELL_CAST_OK)
+        SpellCastResult castResult = m_spellInfo->CheckTarget(target, unitCaster, implicit);
+        if (castResult == SPELL_CAST_OK || castResult == SPELL_FAILED_TARGET_AURASTATE)
             targetInfo.ReflectResult = unitCaster->SpellHitResult(unitCaster, m_spellInfo, false); // can't reflect twice
         else
             targetInfo.ReflectResult = SPELL_MISS_IMMUNE;


### PR DESCRIPTION
**Changes proposed:**

-  After this PR: https://github.com/TrinityCore/TrinityCore/pull/29645 all reflected spell that return != SPELL_CAST_OK the result is immune.
-  But I found that in case of Mage Deep Freeze (https://aowow.trinitycore.info/?spell=44572) has TargetAuraState = 4 (AURA_STATE_FROZEN), so when is reflected return immune.
In this video: https://www.youtube.com/watch?v=BHY49tfE2VE -> 8:57
we can see how the warrior affected by mage's Frost Nova (https://aowow.trinitycore.info/?spell=42917) cast Spell Reflection (https://aowow.trinitycore.info/?spell=23920) and Mage cast to warrior Deep Freeze, Deep Freeze is reflected and Mage is afflicted by reflected Deep Freeze
- Because I don't know exactly which cases should return immune and which cases shouldn't, I decided to avoid return result immune in case of castresult target aurastate, since in those cases seems shouldn't return immune

**Issues addressed:**

None


**Tests performed:**

tested in-game

