### PR TITLE
Core/Spells: Allow get SpellDifficulty on battleground maps

### DIFF
--- a/sql/updates/world/3.3.5/9999_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/9999_99_99_99_world.sql
@@ -1,0 +1,5 @@
+-- 
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_ioc_seaforium_blast_credit' AND `spell_id` IN (67813,67814);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(67813, 'spell_ioc_seaforium_blast_credit'),
+(67814, 'spell_ioc_seaforium_blast_credit');

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -177,7 +177,7 @@ uint32 SpellMgr::GetSpellIdForDifficulty(uint32 spellId, WorldObject const* cast
     if (!GetSpellInfo(spellId))
         return spellId;
 
-    if (!caster || !caster->GetMap() || !caster->GetMap()->IsDungeon())
+    if (!caster || !caster->GetMap() || (!caster->GetMap()->IsDungeon() && !caster->GetMap()->IsBattleground()))
         return spellId;
 
     uint32 mode = uint32(caster->GetMap()->GetSpawnMode());

--- a/src/server/scripts/Northrend/IsleOfConquest/isle_of_conquest.cpp
+++ b/src/server/scripts/Northrend/IsleOfConquest/isle_of_conquest.cpp
@@ -215,10 +215,12 @@ class spell_ioc_launch : public SpellScript
 
 enum SeaforiumBombSpells
 {
-    SPELL_SEAFORIUM_BLAST       = 66676,
-    SPELL_HUGE_SEAFORIUM_BLAST  = 66672,
-    SPELL_A_BOMB_INABLE_CREDIT  = 68366,
-    SPELL_A_BOMB_INATION_CREDIT = 68367
+    SPELL_SEAFORIUM_BLAST         = 66676,
+    SPELL_SEAFORIUM_BLAST_H       = 67814,
+    SPELL_HUGE_SEAFORIUM_BLAST    = 66672,
+    SPELL_HUGE_SEAFORIUM_BLAST_H  = 67813,
+    SPELL_A_BOMB_INABLE_CREDIT    = 68366,
+    SPELL_A_BOMB_INATION_CREDIT   = 68367
 };
 
 // 66672 - Huge Seaforium Blast
@@ -239,9 +241,10 @@ class spell_ioc_seaforium_blast_credit : public SpellScript
         if (!caster)
             return;
 
-        if (GetSpellInfo()->Id == SPELL_SEAFORIUM_BLAST)
+        uint32 spellId = GetSpellInfo()->Id;
+        if (spellId == SPELL_SEAFORIUM_BLAST || spellId == SPELL_SEAFORIUM_BLAST_H)
             _creditSpell = SPELL_A_BOMB_INABLE_CREDIT;
-        else if (GetSpellInfo()->Id == SPELL_HUGE_SEAFORIUM_BLAST)
+        else if (spellId == SPELL_HUGE_SEAFORIUM_BLAST || spellId == SPELL_HUGE_SEAFORIUM_BLAST_H)
             _creditSpell = SPELL_A_BOMB_INATION_CREDIT;
 
         if (GetHitGObj() && GetHitGObj()->IsDestructibleBuilding())


### PR DESCRIPTION
**Changes proposed:**

-  Allow get SpellDifficulty on battleground maps
This is only for Isle of Conquest (Bracket 71-79 is Regular Difficulty, Bracket 80-84 is heroic or 25Man)
Spells of IoC Battleground vehicles, cannons, bombs and bosses have SpellDifficulty in DBC
By example:
https://aowow.trinitycore.info/?spell=67199 - https://aowow.trinitycore.info/?spell=67450
https://aowow.trinitycore.info/?spell=67796 - https://aowow.trinitycore.info/?spell=67816
https://aowow.trinitycore.info/?spell=67280 - https://aowow.trinitycore.info/?spell=67811
https://aowow.trinitycore.info/?spell=66542 - https://aowow.trinitycore.info/?spell=67456

- Also update spellId support for seaforium bombs achievements (the achievement still don't work due to originalCaster and gameobject cast changes, but isn't related to this PR)


**Issues addressed:**

None


**Tests performed:**

tested in-game
