### PR TITLE
Core: Add some blizzlike level restrictions while using changefaction

### DIFF
--- a/sql/updates/world/3.3.5/2024_06_27_01_world.sql
+++ b/sql/updates/world/3.3.5/2024_06_27_01_world.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `trinity_string` WHERE `entry` IN (397,398);
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
+(397, "Characters below level 10 are not eligible for faction change."),
+(398, "Death Knights below level 60 are not eligible for faction change.");

--- a/sql/updates/world/3.3.5/2024_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/2024_99_99_99_world.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `trinity_string` WHERE `entry` IN (10056,10057);
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
+(10056, "Characters below level 10 are not eligible for faction change."),
+(10057, "Death Knights below level 60 are not eligible for faction change.");

--- a/sql/updates/world/3.3.5/2024_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/2024_99_99_99_world.sql
@@ -1,5 +1,0 @@
---
-DELETE FROM `trinity_string` WHERE `entry` IN (10056,10057);
-INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
-(10056, "Characters below level 10 are not eligible for faction change."),
-(10057, "Death Knights below level 60 are not eligible for faction change.");

--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -420,7 +420,7 @@ void CharacterDatabaseConnection::DoPrepareStatements()
     PrepareStatement(CHAR_SEL_CHARACTER_AT_LOGIN, "SELECT at_login FROM characters WHERE guid = ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_CHAR_CLASS_LVL_AT_LOGIN, "SELECT class, level, at_login, knownTitles FROM characters WHERE guid = ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_CHAR_CUSTOMIZE_INFO, "SELECT name, race, class, gender, at_login FROM characters WHERE guid = ?", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_SEL_CHAR_RACE_OR_FACTION_CHANGE_INFOS, "SELECT c.at_login, c.knownTitles, gm.guid FROM characters c LEFT JOIN group_member gm ON c.guid = gm.memberGuid WHERE c.guid = ?", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_SEL_CHAR_RACE_OR_FACTION_CHANGE_INFOS, "SELECT c.at_login, c.knownTitles, gm.guid, c.map FROM characters c LEFT JOIN group_member gm ON c.guid = gm.memberGuid WHERE c.guid = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_SEL_INSTANCE, "SELECT data, completedEncounters FROM instance WHERE map = ? AND id = ?", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_PERM_BIND_BY_INSTANCE, "SELECT guid FROM character_instance WHERE instance = ? and permanent = 1", CONNECTION_SYNCH);
     PrepareStatement(CHAR_SEL_CHAR_COD_ITEM_MAIL, "SELECT id, messageType, mailTemplateId, sender, subject, body, money, has_items FROM mail WHERE receiver = ? AND has_items <> 0 AND cod <> 0", CONNECTION_SYNCH);

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1670,11 +1670,24 @@ void WorldSession::HandleCharFactionOrRaceChangeCallback(std::shared_ptr<Charact
     uint32 atLoginFlags        = fields[0].GetUInt16();
     std::string knownTitlesStr = fields[1].GetString();
     uint32 groupId             = !fields[2].IsNull() ? fields[2].GetUInt32() : 0;
+    uint32 mapId               = fields[3].GetUInt16();
 
     uint32 usedLoginFlag = (factionChangeInfo->FactionChange ? AT_LOGIN_CHANGE_FACTION : AT_LOGIN_CHANGE_RACE);
     if (!(atLoginFlags & usedLoginFlag))
     {
         SendCharFactionChange(CHAR_CREATE_ERROR, factionChangeInfo.get());
+        return;
+    }
+
+    if (level < 10)
+    {
+        SendCharFactionChange(CHAR_CREATE_ERROR, factionChangeInfo.get());
+        return;
+    }
+
+    if (playerClass == CLASS_DEATH_KNIGHT && (level < 60 || mapId == 609))
+    {
+        SendCharFactionChange(CHAR_CREATE_RESTRICTED_RACECLASS, factionChangeInfo.get());
         return;
     }
 

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -449,7 +449,9 @@ enum TrinityStrings
     LANG_COMMAND_LEARN_ALL_PETTALENT_HELP = 394,
     LANG_COMMAND_BG_START_HELP            = 395,
     LANG_COMMAND_BG_STOP_HELP             = 396,
-    // Room for more level 2                397-399 not used
+    LANG_CHANGEFACTION_NOT_ELIGIBLE_10    = 397,
+    LANG_CHANGEFACTION_NOT_ELIGIBLE_60    = 398,
+    // Room for more level 2                399 not used
 
     // level 3 chat
     LANG_SCRIPTS_RELOADED                 = 400,
@@ -1209,8 +1211,6 @@ enum TrinityStrings
     LANG_OPVP_ZM_GOSSIP_HORDE             = 10055,
 
     // 10056-10066 - free
-    LANG_CHANGEFACTION_NOT_ELIGIBLE_10    = 10056,
-    LANG_CHANGEFACTION_NOT_ELIGIBLE_60    = 10057,
 
     // Use for custom patches               11000-11999
     LANG_AUTO_BROADCAST                   = 11000,

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1209,6 +1209,8 @@ enum TrinityStrings
     LANG_OPVP_ZM_GOSSIP_HORDE             = 10055,
 
     // 10056-10066 - free
+    LANG_CHANGEFACTION_NOT_ELIGIBLE_10    = 10056,
+    LANG_CHANGEFACTION_NOT_ELIGIBLE_60    = 10057,
 
     // Use for custom patches               11000-11999
     LANG_AUTO_BROADCAST                   = 11000,

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -422,20 +422,24 @@ public:
         if (!player)
             return false;
 
+        CharacterCacheEntry const* characterInfo = sCharacterCache->GetCharacterCacheByGuid(player->GetGUID());
+        if (!characterInfo)
+            return false;
+
+        if (characterInfo->Level < 10)
+        {
+            handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_10);
+            return false;
+        }
+
+        if (characterInfo->Class == CLASS_DEATH_KNIGHT && characterInfo->Level < 60)
+        {
+            handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_60);
+            return false;
+        }
+
         if (Player* target = player->GetConnectedPlayer())
         {
-            if (target->GetLevel() < 10)
-            {
-                handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_10);
-                return false;
-            }
-
-            if (target->GetClass() == CLASS_DEATH_KNIGHT && target->GetLevel() < 60)
-            {
-                handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_60);
-                return false;
-            }
-
             handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER, handler->GetNameLink(target).c_str());
             target->SetAtLoginFlag(AT_LOGIN_CHANGE_FACTION);
         }

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -424,6 +424,20 @@ public:
 
         if (Player* target = player->GetConnectedPlayer())
         {
+            // Check if the player is below level 10
+            if (target->GetLevel() < 10)
+            {
+                handler->PSendSysMessage("Players below level 10 cannot change faction.");
+                return false;
+            }
+
+            // Check if the Death Knight below level 60
+            if (target->GetClass() == CLASS_DEATH_KNIGHT && target->GetLevel() < 60)
+            {
+                handler->PSendSysMessage("Death Knights below level 60 cannot change faction.");
+                return false;
+            }
+
             handler->PSendSysMessage(LANG_CUSTOMIZE_PLAYER, handler->GetNameLink(target).c_str());
             target->SetAtLoginFlag(AT_LOGIN_CHANGE_FACTION);
         }

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -429,12 +429,14 @@ public:
         if (characterInfo->Level < 10)
         {
             handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_10);
+            handler->SetSentErrorMessage(true);
             return false;
         }
 
         if (characterInfo->Class == CLASS_DEATH_KNIGHT && characterInfo->Level < 60)
         {
             handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_60);
+            handler->SetSentErrorMessage(true);
             return false;
         }
 

--- a/src/server/scripts/Commands/cs_character.cpp
+++ b/src/server/scripts/Commands/cs_character.cpp
@@ -424,17 +424,15 @@ public:
 
         if (Player* target = player->GetConnectedPlayer())
         {
-            // Check if the player is below level 10
             if (target->GetLevel() < 10)
             {
-                handler->PSendSysMessage("Players below level 10 cannot change faction.");
+                handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_10);
                 return false;
             }
 
-            // Check if the Death Knight below level 60
             if (target->GetClass() == CLASS_DEATH_KNIGHT && target->GetLevel() < 60)
             {
-                handler->PSendSysMessage("Death Knights below level 60 cannot change faction.");
+                handler->PSendSysMessage(LANG_CHANGEFACTION_NOT_ELIGIBLE_60);
                 return false;
             }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Adding minim required level 10 for players and 60 for Death Knights while using .character changefaction
-  https://www.bluetracker.gg/wow/topic/us-en/19717691770-helpful-faction-change-resources/

![Captură de ecran 2024-06-25 035112](https://github.com/TrinityCore/TrinityCore/assets/24683355/d71630c5-fe8e-4d22-896a-4cb8bf6e7633)


**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/30054


**Tests performed:**

Does it build, tested in-game as can be seen below:

https://youtu.be/w0uOkyq7dgM

**Known issues and TODO list:** (add/remove lines as needed)

- [ Find a way to make this condition work while used directly in server console too, I guess... ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
