### PR TITLE
Cherrypick Core/Instance: Prevent possible crash on boss minion despawn

### DIFF
--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -374,7 +374,8 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
                 if (GameObject* door = instance->GetGameObject(*i))
                     UpdateDoorState(door);
 
-        for (GuidSet::iterator i = bossInfo->minion.begin(); i != bossInfo->minion.end(); ++i)
+        GuidSet minions = bossInfo->minion; // Copy to prevent iterator invalidation (minion might be unsummoned in UpdateMinionState)
+        for (GuidSet::iterator i = minions.begin(); i != minions.end(); ++i)
             if (Creature* minion = instance->GetCreature(*i))
                 UpdateMinionState(minion, state);
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Well I'm not sure if it's needed but I had to try.
- https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/pull/169/commits/043fd6ffcbf0ff94dcb9dc5e4e693500af6edcb4
-  Credit goes to original authors.

**Issues addressed:**

Closes None as I know


**Tests performed:**

Does it build, not really sure how shoud be properly tested.


**Known issues and TODO list:** (add/remove lines as needed)

- [ Decide if it's needed or not. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
