### PR TITLE
Core/Movement: Allow chase movement generator usage without target == victim

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -624,14 +624,14 @@ void MotionMaster::MoveFollow(Unit* target, float dist, ChaseAngle angle, Option
     Add(new FollowMovementGenerator(target, dist, angle, duration, std::move(scriptResult)), slot);
 }
 
-void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle)
+void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle, bool skipLostTargetCheck /*= false*/)
 {
     // Ignore movement request if target not exist
     if (!target || target == _owner)
         return;
 
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveChase: '{}', starts chasing '{}'", _owner->GetGUID(), target->GetGUID());
-    Add(new ChaseMovementGenerator(target, dist, angle));
+    Add(new ChaseMovementGenerator(target, dist, angle, skipLostTargetCheck));
 }
 
 void MotionMaster::MoveConfused()

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -160,8 +160,8 @@ class TC_GAME_API MotionMaster
             Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});
         void MoveFollow(Unit* target, float dist, ChaseAngle angle, Optional<Milliseconds> duration = {}, MovementSlot slot = MOTION_SLOT_ACTIVE,
             Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});
-        void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
-        void MoveChase(Unit* target, float dist, float angle) { MoveChase(target, ChaseRange(dist), ChaseAngle(angle)); }
+        void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {}, bool skipLostTargetCheck = false);
+        void MoveChase(Unit* target, float dist, float angle, bool skipLostTargetCheck = false) { MoveChase(target, ChaseRange(dist), ChaseAngle(angle), skipLostTargetCheck); }
         void MoveConfused();
         void MoveFleeing(Unit* enemy, Milliseconds time = 0ms,
             Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -65,8 +65,8 @@ static void DoMovementInform(Unit* owner, Unit* target)
         AI->MovementInform(CHASE_MOTION_TYPE, target->GetGUID().GetCounter());
 }
 
-ChaseMovementGenerator::ChaseMovementGenerator(Unit *target, Optional<ChaseRange> range, Optional<ChaseAngle> angle) : AbstractFollower(ASSERT_NOTNULL(target)), _range(range),
-    _angle(angle), _rangeCheckTimer(RANGE_CHECK_INTERVAL)
+ChaseMovementGenerator::ChaseMovementGenerator(Unit *target, Optional<ChaseRange> range, Optional<ChaseAngle> angle, bool skipLostTargetCheck /*= false*/) : AbstractFollower(ASSERT_NOTNULL(target)), _range(range),
+    _angle(angle), _rangeCheckTimer(RANGE_CHECK_INTERVAL), _skipLostTargetCheck(skipLostTargetCheck)
 {
     Mode = MOTION_MODE_DEFAULT;
     Priority = MOTION_PRIORITY_NORMAL;
@@ -103,7 +103,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
         return false;
 
     // the owner might be unable to move (rooted or casting), or we have lost the target, pause movement
-    if (owner->HasUnitState(UNIT_STATE_NOT_MOVE) || owner->IsMovementPreventedByCasting() || HasLostTarget(owner, target))
+    if (owner->HasUnitState(UNIT_STATE_NOT_MOVE) || owner->IsMovementPreventedByCasting() || (!_skipLostTargetCheck && HasLostTarget(owner, target)))
     {
         owner->StopMoving();
         _lastTargetPosition.reset();

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.h
@@ -31,7 +31,7 @@ class Unit;
 class ChaseMovementGenerator : public MovementGenerator, public AbstractFollower
 {
     public:
-        explicit ChaseMovementGenerator(Unit* target, Optional<ChaseRange> range = {}, Optional<ChaseAngle> angle = {});
+        explicit ChaseMovementGenerator(Unit* target, Optional<ChaseRange> range = {}, Optional<ChaseAngle> angle = {}, bool skipLostTargetCheck = false);
         ~ChaseMovementGenerator();
 
         void Initialize(Unit*) override;
@@ -54,6 +54,7 @@ class ChaseMovementGenerator : public MovementGenerator, public AbstractFollower
         TimeTracker _rangeCheckTimer;
         bool _movingTowards = true;
         bool _mutualChase = true;
+        bool _skipLostTargetCheck = false;
 };
 
 #endif


### PR DESCRIPTION
**Tests performed:**
tested ingame with creature id 135406 on WIP code of naddley
```cpp
    void SpellHit(WorldObject* /*caster*/, SpellInfo const* spellInfo) override
    {
        if (spellInfo->Id == SPELL_LUCRES_CALL)
        {
            Creature* goldenSerpent = me->GetInstanceScript()->GetCreature(DATA_GOLDEN_SERPENT);
            if (!goldenSerpent)
                return;

            me->GetMotionMaster()->Clear();
            me->GetMotionMaster()->MoveChase(goldenSerpent, 2.0f, {}, true);
        }
    }
```
