### PR TITLE
Core/Instances: Fix not being able to resurect at the instance entrance under certain conditions.

### DIFF
--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -152,10 +152,6 @@ Map::EnterState MapManager::PlayerCannotEnter(uint32 mapid, Player* player, bool
     if (player->IsGameMaster())
         return Map::CAN_ENTER;
 
-    //Other requirements
-    if (!player->Satisfy(sObjectMgr->GetAccessRequirement(mapid, targetDifficulty), mapid, true))
-        return Map::CANNOT_ENTER_UNSPECIFIED_REASON;
-
     char const* mapName = entry->MapName[player->GetSession()->GetSessionDbcLocale()];
 
     Group* group = player->GetGroup();
@@ -208,6 +204,10 @@ Map::EnterState MapManager::PlayerCannotEnter(uint32 mapid, Player* player, bool
         if (!player->GetSession()->UpdateAndCheckInstanceCount(instanceIdToCheck) && !player->isDead())
             return Map::CANNOT_ENTER_TOO_MANY_INSTANCES;
     }
+
+    //Other requirements
+    if (!player->Satisfy(sObjectMgr->GetAccessRequirement(mapid, targetDifficulty), mapid, true))
+        return Map::CANNOT_ENTER_UNSPECIFIED_REASON;
 
     return Map::CAN_ENTER;
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix not being able to resurect at the instance entrance under certain conditions.
<details>
  <summary>Because C++ also follows a top-to-bottom execution order, we changed the order of instance requirement check and we got the expected result, shoud most likely not be any problems.</summary>
  

In the other words: If it works, it works.

  
![programmerhumor-io-programming-m](https://github.com/user-attachments/assets/25786375-b4c9-42d9-bffe-58a83a3a9527)
</details>

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/25969

**Tests performed:**

Does it build, tested in-game, as you can see below:

https://youtu.be/ZIrCoBy_nng

**Known issues and TODO list:** (add/remove lines as needed)

- [ Merge. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
