### PR TITLE
Core/GroupHander: Check if player is in a group for `CMSG_REQUEST_PARTY_MEMBER_STATS` before providing data.

### DIFF
--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -923,7 +923,7 @@ void WorldSession::HandleRequestPartyMemberStatsOpcode(WorldPacket &recvData)
     recvData >> Guid;
 
     Player* player = ObjectAccessor::FindConnectedPlayer(Guid);
-    if (!player)
+    if (!player || !(player->GetGroup() != GetPlayer()->GetGroup()))
     {
         WorldPacket data(SMSG_PARTY_MEMBER_STATS_FULL, 3+4+2);
         data << uint8(0);                                   // only for SMSG_PARTY_MEMBER_STATS_FULL, probably arena/bg related

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -911,7 +911,7 @@ void WorldSession::HandleRequestPartyMemberStatsOpcode(WorldPacket &recvData)
     recvData >> Guid;
 
     Player* player = ObjectAccessor::FindConnectedPlayer(Guid);
-    if (!player || !GetPlayer()->GetGroup() || !(player->GetGroup()->GetGUID() != GetPlayer()->GetGroup()->GetGUID()))
+    if (!player || !GetPlayer()->GetGroup() || !(player->GetGroup()->GetGUID() == GetPlayer()->GetGroup()->GetGUID()))
     {
         WorldPacket data(SMSG_PARTY_MEMBER_STATS_FULL, 3+4+2);
         data << uint8(0);                                   // only for SMSG_PARTY_MEMBER_STATS_FULL, probably arena/bg related

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -923,7 +923,7 @@ void WorldSession::HandleRequestPartyMemberStatsOpcode(WorldPacket &recvData)
     recvData >> Guid;
 
     Player* player = ObjectAccessor::FindConnectedPlayer(Guid);
-    if (!player || !(player->GetGroup() != GetPlayer()->GetGroup()))
+    if (!player || !GetPlayer()->GetGroup() || !(player->GetGroup()->GetGUID() != GetPlayer()->GetGroup()->GetGUID()))
     {
         WorldPacket data(SMSG_PARTY_MEMBER_STATS_FULL, 3+4+2);
         data << uint8(0);                                   // only for SMSG_PARTY_MEMBER_STATS_FULL, probably arena/bg related

--- a/src/server/game/Handlers/GroupHandler.cpp
+++ b/src/server/game/Handlers/GroupHandler.cpp
@@ -911,7 +911,7 @@ void WorldSession::HandleRequestPartyMemberStatsOpcode(WorldPacket &recvData)
     recvData >> Guid;
 
     Player* player = ObjectAccessor::FindConnectedPlayer(Guid);
-    if (!player || !GetPlayer()->GetGroup() || !(player->GetGroup()->GetGUID() == GetPlayer()->GetGroup()->GetGUID()))
+    if (!player || !player->GetGroup() || !GetPlayer()->GetGroup() || (player->GetGroup() != GetPlayer()->GetGroup()))
     {
         WorldPacket data(SMSG_PARTY_MEMBER_STATS_FULL, 3+4+2);
         data << uint8(0);                                   // only for SMSG_PARTY_MEMBER_STATS_FULL, probably arena/bg related


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Adds a group check to the handling of `CMSG_REQUEST_PARTY_MEMBER_STATS` to ensure players can't request information on other players not in their group.

**Issues addressed:**

Closes #30085

**Tests performed:**

Untested, have no way of spoofing packets like that that I know of.

**Known issues and TODO list:** (add/remove lines as needed)
- This might be the wrong approach, this might be incorrect, but I think it should probably be corrected, so I figured I'd throw my hat in the ring.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
