### PR TITLE
Core/Movement: Made fixed ChaseAngle optional and added possibility t…

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -609,7 +609,7 @@ void MotionMaster::MoveRandom(float wanderDistance /*= 0.0f*/, Optional<Millisec
         scriptResult->SetResult(MovementStopReason::Interrupted);
 }
 
-void MotionMaster::MoveFollow(Unit* target, float dist, ChaseAngle angle, Optional<Milliseconds> duration /*= {}*/, MovementSlot slot/* = MOTION_SLOT_ACTIVE*/,
+void MotionMaster::MoveFollow(Unit* target, float dist, Optional<ChaseAngle> angle /*= {}*/, Optional<Milliseconds> duration /*= {}*/, bool ignoreTargetWalk /*= false*/, MovementSlot slot/* = MOTION_SLOT_ACTIVE*/,
     Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult /*= {}*/)
 {
     // Ignore movement request if target not exist
@@ -621,7 +621,7 @@ void MotionMaster::MoveFollow(Unit* target, float dist, ChaseAngle angle, Option
     }
 
     TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::MoveFollow: '{}', starts following '{}'", _owner->GetGUID(), target->GetGUID());
-    Add(new FollowMovementGenerator(target, dist, angle, duration, std::move(scriptResult)), slot);
+    Add(new FollowMovementGenerator(target, dist, angle, duration, ignoreTargetWalk, std::move(scriptResult)), slot);
 }
 
 void MotionMaster::MoveChase(Unit* target, Optional<ChaseRange> dist, Optional<ChaseAngle> angle)

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -158,7 +158,7 @@ class TC_GAME_API MotionMaster
         void MoveTargetedHome();
         void MoveRandom(float wanderDistance = 0.0f, Optional<Milliseconds> duration = {}, MovementSlot slot = MOTION_SLOT_DEFAULT,
             Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});
-        void MoveFollow(Unit* target, float dist, ChaseAngle angle, Optional<Milliseconds> duration = {}, MovementSlot slot = MOTION_SLOT_ACTIVE,
+        void MoveFollow(Unit* target, float dist, Optional<ChaseAngle> angle = {}, Optional<Milliseconds> duration = {}, bool ignoreTargetWalk = false, MovementSlot slot = MOTION_SLOT_ACTIVE,
             Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});
         void MoveChase(Unit* target, Optional<ChaseRange> dist = {}, Optional<ChaseAngle> angle = {});
         void MoveChase(Unit* target, float dist, float angle) { MoveChase(target, ChaseRange(dist), ChaseAngle(angle)); }

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -146,22 +146,17 @@ bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)
             // select angle
             float tAngle;
             float const curAngle = target->GetRelativeAngle(owner);
-            if (_angle)
-            {
-                if (_angle->IsAngleOkay(curAngle))
-                    tAngle = curAngle;
-                else
-                {
-                    float const diffUpper = Position::NormalizeOrientation(curAngle - _angle->UpperBound());
-                    float const diffLower = Position::NormalizeOrientation(_angle->LowerBound() - curAngle);
-                    if (diffUpper < diffLower)
-                        tAngle = _angle->UpperBound();
-                    else
-                        tAngle = _angle->LowerBound();
-                }
-            }
-            else
+            if (!_angle || _angle->IsAngleOkay(curAngle))
                 tAngle = curAngle;
+            else
+            {
+                float const diffUpper = Position::NormalizeOrientation(curAngle - _angle->UpperBound());
+                float const diffLower = Position::NormalizeOrientation(_angle->LowerBound() - curAngle);
+                if (diffUpper < diffLower)
+                    tAngle = _angle->UpperBound();
+                else
+                    tAngle = _angle->LowerBound();
+            }
 
             target->GetNearPoint(owner, x, y, z, range, target->ToAbsoluteAngle(tAngle));
 

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -35,9 +35,9 @@ static void DoMovementInform(Unit* owner, Unit* target)
         AI->MovementInform(FOLLOW_MOTION_TYPE, target->GetGUID().GetCounter());
 }
 
-FollowMovementGenerator::FollowMovementGenerator(Unit* target, float range, ChaseAngle angle, Optional<Milliseconds> duration,
-    Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult /*= {}*/)
-    : AbstractFollower(ASSERT_NOTNULL(target)), _range(range), _angle(angle), _checkTimer(CHECK_INTERVAL)
+FollowMovementGenerator::FollowMovementGenerator(Unit* target, float range, Optional<ChaseAngle> angle, Optional<Milliseconds> duration,
+    bool ignoreTargetWalk /*= false*/, Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult /*= {}*/)
+    : AbstractFollower(ASSERT_NOTNULL(target)), _range(range), _angle(angle), _ignoreTargetWalk(ignoreTargetWalk), _checkTimer(CHECK_INTERVAL)
 {
     Mode = MOTION_MODE_DEFAULT;
     Priority = MOTION_PRIORITY_NORMAL;
@@ -146,17 +146,22 @@ bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)
             // select angle
             float tAngle;
             float const curAngle = target->GetRelativeAngle(owner);
-            if (_angle.IsAngleOkay(curAngle))
-                tAngle = curAngle;
-            else
+            if (_angle)
             {
-                float const diffUpper = Position::NormalizeOrientation(curAngle - _angle.UpperBound());
-                float const diffLower = Position::NormalizeOrientation(_angle.LowerBound() - curAngle);
-                if (diffUpper < diffLower)
-                    tAngle = _angle.UpperBound();
+                if (_angle->IsAngleOkay(curAngle))
+                    tAngle = curAngle;
                 else
-                    tAngle = _angle.LowerBound();
+                {
+                    float const diffUpper = Position::NormalizeOrientation(curAngle - _angle->UpperBound());
+                    float const diffLower = Position::NormalizeOrientation(_angle->LowerBound() - curAngle);
+                    if (diffUpper < diffLower)
+                        tAngle = _angle->UpperBound();
+                    else
+                        tAngle = _angle->LowerBound();
+                }
             }
+            else
+                tAngle = curAngle;
 
             target->GetNearPoint(owner, x, y, z, range, target->ToAbsoluteAngle(tAngle));
 
@@ -183,7 +188,8 @@ bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)
 
             Movement::MoveSplineInit init(owner);
             init.MovebyPath(_path->GetPath());
-            init.SetWalk(target->IsWalking());
+            if (!_ignoreTargetWalk)
+                init.SetWalk(target->IsWalking());
             init.SetFacing(target->GetOrientation());
             init.Launch();
         }

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.h
@@ -32,8 +32,8 @@ class Unit;
 class FollowMovementGenerator : public MovementGenerator, public AbstractFollower
 {
     public:
-        explicit FollowMovementGenerator(Unit* target, float range, ChaseAngle angle, Optional<Milliseconds> duration,
-            Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});
+        explicit FollowMovementGenerator(Unit* target, float range, Optional<ChaseAngle> angle, Optional<Milliseconds> duration,
+            bool ignoreTargetWalk = false, Optional<Scripting::v2::ActionResultSetter<MovementStopReason>>&& scriptResult = {});
         ~FollowMovementGenerator();
 
         void Initialize(Unit*) override;
@@ -51,7 +51,8 @@ class FollowMovementGenerator : public MovementGenerator, public AbstractFollowe
         void UpdatePetSpeed(Unit* owner);
 
         float const _range;
-        ChaseAngle const _angle;
+        Optional<ChaseAngle const> _angle;
+        bool _ignoreTargetWalk;
 
         TimeTracker _checkTimer;
         Optional<TimeTracker> _duration;


### PR DESCRIPTION
…o ignore setting walk/run depending on target

**Changes proposed:**
-  allow always using direct angle to target instead of using a fixed angle
-  allow ignoring walk/run setting based on target

**Tests performed:**
tested ingame in #30100 with 
```cpp
me->GetMotionMaster()->MoveFollow(goldenSerpent, 2.0f, {}, {}, true);
```
in `npc_animated_gold::SpellHit`
