### PR TITLE
Core/Vehicle: Fix an assertion when installing a vehicle through aura

### DIFF
--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -52,7 +52,7 @@ UsableSeatNum(0), _me(unit), _vehicleInfo(vehInfo), _creatureEntry(creatureEntry
     // Set or remove correct flags based on available seats. Will overwrite db data (if wrong).
     if (UsableSeatNum)
         _me->SetNpcFlag((_me->GetTypeId() == TYPEID_PLAYER ? UNIT_NPC_FLAG_PLAYER_VEHICLE : UNIT_NPC_FLAG_SPELLCLICK));
-    else
+    else if (!unit->m_unitData->InteractSpellID)
         _me->RemoveNpcFlag((_me->GetTypeId() == TYPEID_PLAYER ? UNIT_NPC_FLAG_PLAYER_VEHICLE : UNIT_NPC_FLAG_SPELLCLICK));
 
     InitMovementInfoForBase();

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5311,11 +5311,18 @@ void AuraEffect::HandleAuraSetVehicle(AuraApplication const* aurApp, uint8 mode,
 
     if (apply)
     {
+        // remove current vehicle kit before creating a new one
+        target->RemoveVehicleKit();
         if (!target->CreateVehicleKit(vehicleId, 0))
             return;
     }
     else if (target->GetVehicleKit())
+    {
         target->RemoveVehicleKit();
+        if (Creature* creature = target->ToCreature())
+            if (creature->GetCreatureTemplate()->VehicleId)
+                creature->CreateVehicleKit(creature->GetCreatureTemplate()->VehicleId, creature->GetEntry());
+    }
 
     if (target->GetTypeId() != TYPEID_PLAYER)
         return;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5309,19 +5309,18 @@ void AuraEffect::HandleAuraSetVehicle(AuraApplication const* aurApp, uint8 mode,
 
     uint32 vehicleId = GetMiscValue();
 
+    target->RemoveVehicleKit();
+
     if (apply)
     {
-        // remove current vehicle kit before creating a new one
-        target->RemoveVehicleKit();
         if (!target->CreateVehicleKit(vehicleId, 0))
             return;
     }
     else if (target->GetVehicleKit())
     {
-        target->RemoveVehicleKit();
         if (Creature* creature = target->ToCreature())
-            if (creature->GetCreatureTemplate()->VehicleId)
-                creature->CreateVehicleKit(creature->GetCreatureTemplate()->VehicleId, creature->GetEntry());
+            if (uint32 originalVehicleId = creature->GetCreatureTemplate()->VehicleId)
+                creature->CreateVehicleKit(originalVehicleId, creature->GetEntry());
     }
 
     if (target->GetTypeId() != TYPEID_PLAYER)

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -5316,7 +5316,7 @@ void AuraEffect::HandleAuraSetVehicle(AuraApplication const* aurApp, uint8 mode,
         if (!target->CreateVehicleKit(vehicleId, 0))
             return;
     }
-    else if (target->GetVehicleKit())
+    else
     {
         if (Creature* creature = target->ToCreature())
             if (uint32 originalVehicleId = creature->GetCreatureTemplate()->VehicleId)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Uninstall current vehicle when applying aura that creates a vehicle
-  Reapply creature_template vehicle when one was present (on aura removal)
-  Make sure the NPCFlags are not removed when an interactspell is present but no vehicle seats are

**Issues addressed:**

Closes: none? This is needed for the track switches & Mine Carts in Silvershard Mines

**Tests performed:**

- Builds Locally
- Tested with Silveshard mines (pr soon tm)


**Known issues and TODO list:**

- None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
