### PR TITLE
Core/Gameobjects: Fixed GO_DYNFLAG_LO_HIGHLIGHT application

### DIFF
--- a/src/server/game/Entities/Object/Updates/ViewerDependentValues.h
+++ b/src/server/game/Entities/Object/Updates/ViewerDependentValues.h
@@ -94,7 +94,7 @@ public:
                 case GAMEOBJECT_TYPE_GOOBER:
                     if (gameObject->HasConditionalInteraction() && gameObject->CanActivateForPlayer(receiver))
                         if (gameObject->GetGoStateFor(receiver->GetGUID()) != GO_STATE_ACTIVE)
-                            dynFlags |= GO_DYNFLAG_LO_ACTIVATE;
+                            dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_HIGHLIGHT;
                     break;
                 case GAMEOBJECT_TYPE_QUESTGIVER:
                     if (gameObject->CanActivateForPlayer(receiver))
@@ -102,7 +102,7 @@ public:
                     break;
                 case GAMEOBJECT_TYPE_CHEST:
                     if (gameObject->HasConditionalInteraction() && gameObject->CanActivateForPlayer(receiver))
-                        dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_SPARKLE;
+                        dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_SPARKLE | GO_DYNFLAG_LO_HIGHLIGHT;
                     else if (receiver->IsGameMaster())
                         dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_SPARKLE;
                     break;
@@ -126,7 +126,7 @@ public:
                     break;
                 case GAMEOBJECT_TYPE_GATHERING_NODE:
                     if (gameObject->HasConditionalInteraction() && gameObject->CanActivateForPlayer(receiver))
-                        dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_SPARKLE;
+                        dynFlags |= GO_DYNFLAG_LO_ACTIVATE | GO_DYNFLAG_LO_SPARKLE | GO_DYNFLAG_LO_HIGHLIGHT;
                     if (gameObject->GetGoStateFor(receiver->GetGUID()) == GO_STATE_ACTIVE)
                         dynFlags |= GO_DYNFLAG_LO_DEPLETED;
                     break;
@@ -136,11 +136,11 @@ public:
 
             if (!receiver->IsGameMaster())
             {
-                // GO_DYNFLAG_LO_HIGHLIGHT should be applied to GOs with conditional interaction (without GO_FLAG_INTERACT_COND) to disable interaction
+                // GO_DYNFLAG_LO_INTERACT_COND should be applied to GOs with conditional interaction (without GO_FLAG_INTERACT_COND) to disable interaction
                 // (Ignore GAMEOBJECT_TYPE_GATHERING_NODE as some profession-related GOs may include quest loot and can always be interacted with)
                 if (gameObject->GetGoType() != GAMEOBJECT_TYPE_GATHERING_NODE)
                     if (gameObject->HasConditionalInteraction() && !gameObject->HasFlag(GO_FLAG_INTERACT_COND))
-                        dynFlags |= GO_DYNFLAG_LO_HIGHLIGHT;
+                        dynFlags |= GO_DYNFLAG_LO_INTERACT_COND;
 
                 if (!gameObject->MeetsInteractCondition(receiver))
                     dynFlags |= GO_DYNFLAG_LO_NO_INTERACT;

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -3032,7 +3032,8 @@ enum GameObjectDynamicLowFlags : uint16
     GO_DYNFLAG_LO_STOPPED           = 0x0040,               // Transport is stopped
     GO_DYNFLAG_LO_NO_INTERACT       = 0x0080,
     GO_DYNFLAG_LO_INVERTED_MOVEMENT = 0x0100,               // GAMEOBJECT_TYPE_TRANSPORT only
-    GO_DYNFLAG_LO_HIGHLIGHT         = 0x0200,               // Allows object highlight when GO_DYNFLAG_LO_ACTIVATE or GO_DYNFLAG_LO_SPARKLE are set, not only when player is on quest determined by Data fields
+    GO_DYNFLAG_LO_INTERACT_COND     = 0x0200,               // Cannot interact (requires GO_DYNFLAG_LO_ACTIVATE to enable interaction clientside)
+    GO_DYNFLAG_LO_HIGHLIGHT         = 0x4000,               // Allows object highlight when GO_DYNFLAG_LO_ACTIVATE are set, not only when player is on quest determined by Data fields
 };
 
 // client side GO show states


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Renamed GO_DYNFLAG_LO_HIGHLIGHT to GO_DYNFLAG_LO_INTERACT_COND
-  Highlight is now controlled by a new flag GO_DYNFLAG_LO_HIGHLIGHT (0x4000)
- Fixed the interaction for GOs using GO_DYNFLAG_LO_INTERACT_COND to disable interaction. The flag is permanently applied and not only when the player has taken the related quest

**Issues addressed:**

Closes #27374
Closes #30213

**Tests performed:**
Builds, tested in-game:

Goobers
- Harpy Totem (327146): Highlight and interaction with quest 55881 taken (without this PR you can always interact with the GO)
- Northern Firestone (202765): Highlight and interaction with quest 25412 taken (without this PR you can always interact with the GO)

Chests
- River Reeds (376152): Highlight and interaction with quest 65805 taken (without this PR you can always interact with the GO)
- Blood Nettle (209059): Highlight and interaction with quest 29426 taken (go flags 4)
- Bass Blaster (240568): Highlight with quest 37961 taken (no interaction as loot is currently empty)

Gathering nodes
- Copper Vein (1731): No highlight and interaction (quest loot)
- Brightly Colored Egg (113771): No highlight and interaction

**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
