### PR TITLE
Core/GameEvent: Fix game event end time duration overwriting

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -139,7 +139,7 @@ bool GameEventMgr::StartEvent(uint16 event_id, bool overwrite)
         {
             mGameEvent[event_id].start = GameTime::GetGameTime();
             if (data.end <= data.start)
-                data.end = data.start + data.length;
+                data.end = data.start + data.length * MINUTE;
         }
 
         // When event is started, set its worldstate to current time
@@ -186,7 +186,7 @@ void GameEventMgr::StopEvent(uint16 event_id, bool overwrite)
     {
         data.start = GameTime::GetGameTime() - data.length * MINUTE;
         if (data.end <= data.start)
-            data.end = data.start + data.length;
+            data.end = data.start + data.length * MINUTE;
     }
     else if (serverwide_evt)
     {


### PR DESCRIPTION
**Changes proposed:**

-  Convert length to seconds to get the right end date
When a event with end_time date oldest than current time date is started with overwrite (command event start, arena season event at startup or smart_scripts) the duration was being set in minutes, so if it is not changed to seconds, end time values ​​lower than expected will appear.

**Issues addressed:**

None


**Tests performed:**

can be checked arena season with command .event info 60
before fix:
```
Event 60: Arena Season 8 [active]
Start: 2024-08-13_12-40-07 End: 2024-09-12_12-40-07 Occurence: 3600 Days  Length: 1800 Days 
Next state change: -
```
after fix:
```
Event 60: Arena Season 8 [active]
Start: 2024-08-13_13-29-57 End: 2029-07-18_13-29-57 Occurence: 3600 Days  Length: 1800 Days 
Next state change: -
```

