### PR TITLE
Core/Players: Fix SPELLMOD_PCT on login

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22577,13 +22577,13 @@ void Player::SendSpellModifiers() const
             case SPELLMOD_PCT:
                 if (!pctModifier || pctModifier->ModIndex != uint8(mod->op))
                 {
-                    pctModifier = &flatMods.Modifiers.emplace_back();
+                    pctModifier = &pctMods.Modifiers.emplace_back();
                     pctModifier->ModIndex = uint8(mod->op);
                 }
                 boost::from_block_range(&static_cast<SpellModifierByClassMask const*>(mod)->mask[0], &static_cast<SpellModifierByClassMask const*>(mod)->mask[0] + 4, mask);
                 for (std::size_t classIndex = mask.find_first(); classIndex != decltype(mask)::npos; classIndex = mask.find_next(classIndex))
                 {
-                    float& modifierValue = getOrCreateModifierData(pctModifier->ModifierData, classIndex, 0.0f);
+                    float& modifierValue = getOrCreateModifierData(pctModifier->ModifierData, classIndex, 1.0f);
                     modifierValue *= 1.0f + CalculatePct(1.0f, static_cast<SpellModifierByClassMask const*>(mod)->value);
                 }
                 break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixed some copy/paste typos wherein percentage spell mods would:
-  A: incorrectly added to SMSG_SET_FLAT_SPELL_MODIFIER rather than SMSG_SET_PCT_SPELL_MODIFIER
-  B: using a wrong default value, resulting in all calculated values to be zero.

**Issues addressed:**

Fixes many spells ingame displaying zero in tooltips.


**Tests performed:**

Builds, tested ingame before/after.


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
