### PR TITLE
Core/Maps: Decrement map unload timer by correct (accumulated) time diff

### DIFF
--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -325,7 +325,7 @@ void MapManager::Update(uint32 diff)
     MapMapType::iterator iter = i_maps.begin();
     while (iter != i_maps.end())
     {
-        if (iter->second->CanUnload(i_timer.GetCurrent()))
+        if (iter->second->CanUnload(uint32(i_timer.GetCurrent())))
         {
             if (DestroyMap(iter->second.get()))
                 iter = i_maps.erase(iter);

--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -325,7 +325,7 @@ void MapManager::Update(uint32 diff)
     MapMapType::iterator iter = i_maps.begin();
     while (iter != i_maps.end())
     {
-        if (iter->second->CanUnload(diff))
+        if (iter->second->CanUnload(i_timer.GetCurrent()))
         {
             if (DestroyMap(iter->second.get()))
                 iter = i_maps.erase(iter);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Map unload timer is progressing at approx 1/100th it's intended speed (if using default CONFIG_INTERVAL_MAPUPDATE of 100). Change to use the accumulated diff up to the point the threshold is crossed for the unload timer to be correctly calculated


**Issues addressed:**



**Tests performed:**

-  Compiled successfully.
-  When adding custom logging for the m_unloadTimer, saw that it decremented 1000ms over 1 second rather than between 10ms and 60ms.
-  When tracking OnPlayerLeaveMap() and ~Map() times confirmed that the map unload occurred at expected time.


**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
