### PR TITLE
Add automation around database dumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           password: $DOCKERHUB_PASSWORD
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: ''
+          MYSQL_ROOT_PASSWORD: ""
           MYSQL_DATABASE: test_mysql
     steps:
       - run:
@@ -24,24 +24,6 @@ jobs:
           command: |
             chmod +x contrib/check_codestyle.sh
             ./contrib/check_codestyle.sh
-      - run:
-          name: SQL checks
-          command: |
-            chmod +x contrib/check_updates.sh
-            dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
-            mysql -h 127.0.0.1 -uroot < sql/create/create_mysql.sql
-            mysql -h 127.0.0.1 -uroot auth < sql/base/auth_database.sql
-            ./contrib/check_updates.sh auth master auth 127.0.0.1
-            mysql -h 127.0.0.1 -uroot characters < sql/base/characters_database.sql
-            ./contrib/check_updates.sh characters master characters 127.0.0.1
-            echo "Importing world database structure"
-            mysql -h 127.0.0.1 -uroot world < sql/base/dev/world_database.sql
-            echo "Importing hotfixes database structure"
-            mysql -h 127.0.0.1 -uroot hotfixes < sql/base/dev/hotfixes_database.sql
-            echo "Importing world database updates"
-            cat sql/updates/world/master/*.sql | mysql -h 127.0.0.1 -uroot world
-            echo "Importing hotfixes database updates"
-            cat sql/updates/hotfixes/master/*.sql | mysql -h 127.0.0.1 -uroot hotfixes
   pch:
     docker:
       - image: trinitycore/circle-ci:master-base-22.04

--- a/.github/workflows/gcc-build.yml
+++ b/.github/workflows/gcc-build.yml
@@ -8,36 +8,50 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
-    - name: Set reusable strings
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/bin" >> "$GITHUB_OUTPUT"
-    - name: Dependencies
-      run: |
-        sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
-    - name: Setup
-      env:
-        CFLAGS: -Werror
-        CXXFLAGS: -Werror
-        CMAKE_BUILD_TYPE: Debug
-      run: >
-        cmake -S ${{ github.workspace }} -B ${{ steps.strings.outputs.build-output-dir }}
-        -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0
-        -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG"
-        -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
-    - name: Build
-      run: |
-        cd bin
-        make -j 4 -k && make install
-    - name: Unit tests
-      run: |
-        cd bin
-        make test
-    - name: Check executables
-      run: |
-        cd ${{ github.workspace }}/check_install/bin
-        ./bnetserver --version
-        ./worldserver --version
+      - uses: actions/checkout@v4
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/bin" >> "$GITHUB_OUTPUT"
+      - name: Dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
+      - name: Setup
+        env:
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
+          CMAKE_BUILD_TYPE: Debug
+        run: >
+          cmake -S ${{ github.workspace }} -B ${{ steps.strings.outputs.build-output-dir }}
+          -DWITH_WARNINGS=1 -DWITH_COREDEBUG=0 -DUSE_COREPCH=1 -DUSE_SCRIPTPCH=1 -DTOOLS=1 -DSCRIPTS=dynamic -DSERVERS=1 -DNOJEM=0
+          -DCMAKE_C_FLAGS_DEBUG="-DNDEBUG" -DCMAKE_CXX_FLAGS_DEBUG="-DNDEBUG"
+          -DCMAKE_INSTALL_PREFIX=check_install -DBUILD_TESTING=1
+      - name: Build
+        run: |
+          cd bin
+          make -j 4 -k && make install
+      - name: Unit tests
+        run: |
+          cd bin
+          make test
+      - name: Check executables
+        run: |
+          cd ${{ github.workspace }}/check_install/bin
+          ./bnetserver --version
+          ./worldserver --version
+
+      - name: Archive
+        if: github.ref == 'refs/heads/master'
+        run: |
+          cd ${{ github.workspace }}/check_install
+          tar -zcvf ${{ github.workspace }}/trinitycore.tar.gz .
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        if: github.ref == 'refs/heads/master'
+        with:
+          name: trinitycore.tar.gz
+          path: ${{ github.workspace }}/trinitycore.tar.gz
+          retention-days: 8

--- a/.github/workflows/update-db-dumps.yml
+++ b/.github/workflows/update-db-dumps.yml
@@ -1,0 +1,120 @@
+on:
+  workflow_dispatch:
+  schedule:
+    # every sunday at midnight UTC
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate_db_dumps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -yq libboost-all-dev g++-11 p7zip-full
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
+
+      - name: Download Artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: gcc-build.yml
+          workflow_conclusion: success
+          branch: master
+          name: trinitycore.tar.gz
+
+      - name: Extract Artifact
+        run: |
+          mkdir -p ${{ github.workspace }}/check_install
+          cd ${{ github.workspace }}/check_install
+          tar -xvf ${{ github.workspace }}/trinitycore.tar.gz .
+
+      - name: Configure
+        run: |
+          cd ${{ github.workspace }}/check_install
+          sudo systemctl start mysql.service
+          cp etc/worldserver.conf.dist etc/worldserver.conf
+
+          sed -i 's/Updates.EnableDatabases.*/Updates.EnableDatabases = 15/g' etc/worldserver.conf
+          sed -i 's|SourceDirectory.*|SourceDirectory = "${{ github.workspace }}"|g' etc/worldserver.conf
+
+      - name: Create empty databases
+        run: |
+          mysql -uroot -proot < sql/create/create_mysql.sql
+          mysql -uroot -proot world < sql/base/dev/world_database.sql
+          mysql -uroot -proot hotfixes < sql/base/dev/hotfixes_database.sql
+
+          # these files are missing from the dev dumps which prevent us from loading updates
+          mysql -uroot -proot world -e "INSERT INTO updates_include VALUES ('$/sql/updates/world', 'RELEASED');" || echo "already has world updates_include"
+          mysql -uroot -proot hotfixes -e "INSERT INTO updates_include VALUES ('$/sql/updates/hotfixes', 'RELEASED');" || echo "already has hotfixes updates_include"
+
+      - name: Start servers
+        run: |
+          cd ${{ github.workspace }}/check_install/bin/
+          ./worldserver --update-databases-only -c ${{ github.workspace }}/check_install/etc/worldserver.conf
+
+      - name: Sanitize Updates
+        run: |
+          for db in auth characters world hotfixes; do
+            mysql -uroot -proot $db -e "UPDATE updates SET speed = 0;"
+          done
+      - name: Dump Databases
+        run: |
+          cd ${{ github.workspace }}
+          mysqldump -h localhost -u root -proot --hex-blob auth --routines | \
+          sed -e 's$VALUES ($VALUES\n($g' | \
+          sed -e 's$),($),\n($g' | \
+          sed -e 's/DEFINER=[^*]*\*/\*/' | \
+          sed -e 's/utf8mb4_0900_ai_ci/utf8mb4_unicode_ci/g' \
+          > sql/base/auth_database.sql
+
+          mysqldump -h localhost -u root -proot --hex-blob characters --routines | \
+          sed -e 's$VALUES ($VALUES\n($g' | \
+          sed -e 's$),($),\n($g' | \
+          sed -e 's/DEFINER=[^*]*\*/\*/' | \
+          sed -e 's/utf8mb4_0900_ai_ci/utf8mb4_unicode_ci/g' \
+          > sql/base/characters_database.sql
+
+          mysqldump -h localhost -u root -proot --hex-blob world --routines | \
+          sed -e 's$VALUES ($VALUES\n($g' | \
+          sed -e 's$),($),\n($g' | \
+          sed -e 's/DEFINER=[^*]*\*/\*/' | \
+          sed -e 's/utf8mb4_0900_ai_ci/utf8mb4_unicode_ci/g' \
+          > sql/base/dev/world_database.sql
+
+          mysqldump -h localhost -u root -proot --hex-blob hotfixes --routines | \
+          sed -e 's$VALUES ($VALUES\n($g' | \
+          sed -e 's$),($),\n($g' | \
+          sed -e 's/DEFINER=[^*]*\*/\*/' | \
+          sed -e 's/utf8mb4_0900_ai_ci/utf8mb4_unicode_ci/g' \
+          > sql/base/dev/hotfixes_database.sql
+
+          # set the date to a fixed value, which will help make an empty diff if there are no changes
+          sed -i -e 's/Dump completed on.*/Dump completed on 2024-05-11  3:06:54/g' sql/base/auth_database.sql
+          sed -i -e 's/Dump completed on.*/Dump completed on 2024-05-11  3:06:54/g' sql/base/characters_database.sql
+          sed -i -e 's/Dump completed on.*/Dump completed on 2024-05-11  3:06:54/g' sql/base/dev/world_database.sql
+          sed -i -e 's/Dump completed on.*/Dump completed on 2024-05-11  3:06:54/g' sql/base/dev/hotfixes_database.sql
+
+      - name: Update Gitignore
+        run: |
+          # initial diff includes changes to workflows, this suppresses them for the demo
+          echo '.github' >> ${{ github.workspace }}/.gitignore
+
+          # restore the sql/base/dev folders, we don't presently use world/hotfixes updates to regen dump
+          git checkout -- sql/base/dev/world_database.sql sql/base/dev/hotfixes_database.sql
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "DB: Update base database dumps"
+          title: Update DB dumps
+          body: |
+            Update database dumps with any changes in the last week.
+
+            This PR has been automatically generated.
+          add-paths: "sql/base/*.sql"
+          branch: db-dump-updates


### PR DESCRIPTION
**THIS IS NOT READY FOR MERGE, BUT NEEDS FEEDBACK**

# Background
This PR proposes changes to the way that TrinityCore accepts database schema changes and solicits feedback for how to reduce developer friction.

In a recent [example PR](https://github.com/TrinityCore/TrinityCore/pull/30204/files), I wanted to make a one-line insert change to the `updates/auth/master` folder. In an ideal world, I'd be able to just submit the single SQL file, but we also require that the auth DB dump be updated.

This process is manual at the moment and a bit painful to ensure that the file excludes commentary that isn't useful. In addition to this, if someone else were to merge a database change in the intervening period between review and merge, then it necessitates regeneration again. Ideally, the worst case here would be someone else stealing my update file name and my needing to update the PR to rename a single file. 

# Implementation
These changes will automate the steps to generate the auth and characters database dumps. Developers would be expected to ONLY update the `sql/updates/.../master` folder, and a periodic database dump PR would be automatically opened once a week. This is, of course, tune-able, and even the PR could be merged automatically if desired. The workflow can also be triggered on-demand.

Here's an example of what the update PR looks like on my fork: https://github.com/motivewc/TrinityCore/pull/3

The process as written also generates the world and hotfixes dumps from the dev dump, however, these don't make it into the PR. This can be changed if there's ever the desire in the future.

# Concerns
## 1. This eliminates the SQL update check in `contrib/check_updates.sh` but additional tooling may be desired in its place.
I'd suggest that in place of that step, we:
1.  run the build and verify that any updates can be executed when the daemon runs with the `----update-databases-only` flag. This would ensure that someone has ultimately written valid SQL that can run against the state of the DB.
2. optionally add a linter to enforce good SQL hygiene such as quoting column names (perhaps [SQLFluff](https://github.com/sqlfluff/sqlfluff)?)


## 2.  I re-use the previous "master" build to generate SQL dumps
This felt like a reasonable shortcut, but the automation could just build from master and then do the same thing.