### PR TITLE
Core/Players: Allow delayed teleports to be executed even when not alive

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -1323,9 +1323,7 @@ void Player::Update(uint32 p_time)
             m_hostileReferenceCheckTimer -= p_time;
     }
 
-    //we should execute delayed teleports only for alive(!) players
-    //because we don't want player's ghost teleported from graveyard
-    if (IsHasDelayedTeleport() && IsAlive())
+    if (IsHasDelayedTeleport())
         TeleportTo(m_teleport_dest, m_teleport_options);
 }
 


### PR DESCRIPTION
**Changes proposed:**

-  Allow delayed teleports to be executed even when not alive

not alive check was added here: https://github.com/TrinityCore/TrinityCore/commit/4a8a89e1db1f103020ffecbb570e1c570c2e0d21#diff-de71a0bef2855962354cadbe36e913957a5017a1821e44753fae6db29a21f7ebR1393
I'm not sure in which cases this was necessary, so I'm not sure if it's still necessary.
But this check prevents the dead player using unstuck from being able to teleport to the graveyard. (RepopAtGraveyard)
https://github.com/TrinityCore/TrinityCore/blob/f2a83e8238676a030d814741467bc0a43c0d88d5/src/server/game/Spells/SpellEffects.cpp#L3707-L3718

I don't know what you think, can that check be removed or what can we do?


**Issues addressed:**

Closes #17291
Updates #26243 (https://github.com/TrinityCore/TrinityCore/issues/26243#issuecomment-1964089498)


**Tests performed:**

tested in-game

