### PR TITLE
Core/Maps: Do not allow entering an instance if the player is not alive and does not have the corpse inside or in inner instance

### DIFF
--- a/src/server/game/Maps/MapManager.cpp
+++ b/src/server/game/Maps/MapManager.cpp
@@ -180,7 +180,10 @@ Map::EnterState MapManager::PlayerCannotEnter(uint32 mapid, Player* player, bool
             TC_LOG_DEBUG("maps", "MAP: Player '{}' has corpse in instance '{}' and can enter.", player->GetName(), mapName);
         }
         else
+        {
             TC_LOG_DEBUG("maps", "Map::CanPlayerEnter - player '{}' is dead but does not have a corpse!", player->GetName());
+            return Map::CANNOT_ENTER_CORPSE_IN_DIFFERENT_INSTANCE;
+        }
     }
 
     //Get instance where player's group is bound & its map


### PR DESCRIPTION
**Changes proposed:**

-  Do not allow entering an instance if the player is not alive and does not have the corpse inside or in inner instance

I don't see any reason to allow player access to the instance if is dead and has no corpse.
I found this case in wowhead about: https://www.wowhead.com/blue-tracker/topic/servers-just-went-down-and-i-cant-get-corpse-1567936776

**Issues addressed:**

Update #26243


**Tests performed:**

tested in-game
test: https://github.com/TrinityCore/TrinityCore/issues/26243#issuecomment-1945985713
test: https://github.com/TrinityCore/TrinityCore/issues/26243#issuecomment-2226858498
also test enter in Blackwing lair, die and go in ghost to Blackrock Spire and go inside Blackrock Spire in ghost, enter in Blackwing lair and revive.
(instance_template parent_map)

