### PR TITLE
Core/Database: dropped support for MariaDB and MySQL 5.7 and set 8.0.34 as the new required minimum version

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -41,12 +41,12 @@
 #include <boost/stacktrace.hpp>
 #endif
 
-constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80834;
+constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80034;
 #define MIN_MYSQL_SERVER_VERSION_STRING "8.0.34"
-constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80834;
+constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80034;
 #define MIN_MYSQL_CLIENT_VERSION_STRING "8.0.34"
 
-static_assert(MIN_MYSQL_SERVER_VERSION >= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you meet the minimum required version as defined in MIN_MYSQL_SERVER_VERSION");
+static_assert(MIN_MYSQL_SERVER_VERSION <= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you meet the minimum required version as defined in MIN_MYSQL_SERVER_VERSION");
 
 namespace
 {

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -41,9 +41,9 @@
 #include <boost/stacktrace.hpp>
 #endif
 
-constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80034;
+constexpr uint32 MIN_MYSQL_SERVER_VERSION = 80034u;
 #define MIN_MYSQL_SERVER_VERSION_STRING "8.0.34"
-constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80034;
+constexpr uint32 MIN_MYSQL_CLIENT_VERSION = 80034u;
 #define MIN_MYSQL_CLIENT_VERSION_STRING "8.0.34"
 
 static_assert(MIN_MYSQL_SERVER_VERSION <= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you are using the minimum required version as defined in MIN_MYSQL_SERVER_VERSION.");

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -111,7 +111,7 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
     : _async_threads(0), _synch_threads(0)
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
-    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below "MIN_MYSQL_SERVER_VERSION_STRING" (found %s id %lu, need id >= %u), please update your MySQL client library", mysql_get_client_info(), mysql_get_client_version(), MIN_MYSQL_CLIENT_VERSION);
+    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below " MIN_MYSQL_SERVER_VERSION_STRING " (found %s id %lu, need id >= %u), please update your MySQL client library", mysql_get_client_info(), mysql_get_client_version(), MIN_MYSQL_CLIENT_VERSION);
     WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s id %lu) does not match the version id used to compile TrinityCore (id %u). Search on forum for TCE00011.", mysql_get_client_info(), mysql_get_client_version(), MYSQL_VERSION_ID);
 }
 

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -41,15 +41,12 @@
 #include <boost/stacktrace.hpp>
 #endif
 
-#define MIN_MYSQL_SERVER_VERSION 50700u
-#define MIN_MYSQL_SERVER_VERSION_STRING "5.7"
-#define MIN_MYSQL_CLIENT_VERSION 50700u
-#define MIN_MYSQL_CLIENT_VERSION_STRING "5.7"
+constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80834;
+constexpr std::string MIN_MYSQL_SERVER_VERSION_STRING = "8.0.34";
+constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80834;
+constexpr std::string MIN_MYSQL_CLIENT_VERSION_STRING = "8.0.34";
 
-#define MIN_MARIADB_SERVER_VERSION 100209u
-#define MIN_MARIADB_SERVER_VERSION_STRING "10.2.9"
-#define MIN_MARIADB_CLIENT_VERSION 30003u
-#define MIN_MARIADB_CLIENT_VERSION_STRING "3.0.3"
+static_assert(MIN_MYSQL_SERVER_VERSION >= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you meet the minimum required version as defined in MIN_MYSQL_SERVER_VERSION");
 
 namespace
 {
@@ -114,14 +111,8 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
     : _async_threads(0), _synch_threads(0)
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
-
-#if defined(LIBMARIADB) && MARIADB_PACKAGE_VERSION_ID >= 30200
-    WPFatal(mysql_get_client_version() >= MIN_MARIADB_CLIENT_VERSION, "TrinityCore does not support MariaDB versions below " MIN_MARIADB_CLIENT_VERSION_STRING " (found %s id %lu, need id >= %u), please update your MariaDB client library", mysql_get_client_info(), mysql_get_client_version(), MIN_MARIADB_CLIENT_VERSION);
-    WPFatal(mysql_get_client_version() == MARIADB_PACKAGE_VERSION_ID, "Used MariaDB library version (%s id %lu) does not match the version id used to compile TrinityCore (id %u). Search on forum for TCE00011.", mysql_get_client_info(), mysql_get_client_version(), MARIADB_PACKAGE_VERSION_ID);
-#else
-    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below " MIN_MYSQL_CLIENT_VERSION_STRING " (found %s id %lu, need id >= %u), please update your MySQL client library", mysql_get_client_info(), mysql_get_client_version(), MIN_MYSQL_CLIENT_VERSION);
+    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below %s (found %s id %lu, need id >= %u), please update your MySQL client library", MIN_MYSQL_CLIENT_VERSION_STRING.c_str(), mysql_get_client_info(), mysql_get_client_version(), MIN_MYSQL_CLIENT_VERSION);
     WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s id %lu) does not match the version id used to compile TrinityCore (id %u). Search on forum for TCE00011.", mysql_get_client_info(), mysql_get_client_version(), MYSQL_VERSION_ID);
-#endif
 }
 
 template <class T>
@@ -458,18 +449,9 @@ uint32 DatabaseWorkerPool<T>::OpenConnections(InternalIndex type, uint8 numConne
             _connections[type].clear();
             return error;
         }
-#ifndef LIBMARIADB
         else if (connection->GetServerVersion() < MIN_MYSQL_SERVER_VERSION)
-#else
-        else if (connection->GetServerVersion() < MIN_MARIADB_SERVER_VERSION)
-#endif
         {
-#ifndef LIBMARIADB
-            TC_LOG_ERROR("sql.driver", "TrinityCore does not support MySQL versions below " MIN_MYSQL_SERVER_VERSION_STRING " (found id {}, need id >= {}), please update your MySQL server", connection->GetServerVersion(), MIN_MYSQL_SERVER_VERSION);
-#else
-            TC_LOG_ERROR("sql.driver", "TrinityCore does not support MariaDB versions below " MIN_MARIADB_SERVER_VERSION_STRING " (found id {}, need id >= {}), please update your MySQL server", connection->GetServerVersion(), MIN_MARIADB_SERVER_VERSION);
-#endif
-
+            TC_LOG_ERROR("sql.driver", "TrinityCore does not support MySQL versions below {} (found id {}, need id >= {}), please update your MySQL server", MIN_MYSQL_SERVER_VERSION, connection->GetServerVersion(), MIN_MYSQL_SERVER_VERSION);
             return 1;
         }
         else

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -46,7 +46,7 @@ constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80034;
 constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80034;
 #define MIN_MYSQL_CLIENT_VERSION_STRING "8.0.34"
 
-static_assert(MIN_MYSQL_SERVER_VERSION <= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you meet the minimum required version as defined in MIN_MYSQL_SERVER_VERSION");
+static_assert(MIN_MYSQL_SERVER_VERSION <= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you are using the minimum required version as defined in MIN_MYSQL_SERVER_VERSION.");
 
 namespace
 {

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -451,7 +451,7 @@ uint32 DatabaseWorkerPool<T>::OpenConnections(InternalIndex type, uint8 numConne
         }
         else if (connection->GetServerVersion() < MIN_MYSQL_SERVER_VERSION)
         {
-            TC_LOG_ERROR("sql.driver", "TrinityCore does not support MySQL versions below {} (found id {}, need id >= {}), please update your MySQL server", MIN_MYSQL_SERVER_VERSION, connection->GetServerVersion(), MIN_MYSQL_SERVER_VERSION);
+            TC_LOG_ERROR("sql.driver", "TrinityCore does not support MySQL versions below " MIN_MYSQL_SERVER_VERSION_STRING " (found id {}, need id >= {}), please update your MySQL server", connection->GetServerVersion(), MIN_MYSQL_SERVER_VERSION);
             return 1;
         }
         else

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -42,9 +42,9 @@
 #endif
 
 constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80834;
-constexpr std::string_view MIN_MYSQL_SERVER_VERSION_STRING = "8.0.34";
+#define MIN_MYSQL_SERVER_VERSION_STRING "8.0.34"
 constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80834;
-constexpr std::string_view MIN_MYSQL_CLIENT_VERSION_STRING = "8.0.34";
+#define MIN_MYSQL_CLIENT_VERSION_STRING "8.0.34"
 
 static_assert(MIN_MYSQL_SERVER_VERSION >= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you meet the minimum required version as defined in MIN_MYSQL_SERVER_VERSION");
 
@@ -111,7 +111,7 @@ DatabaseWorkerPool<T>::DatabaseWorkerPool()
     : _async_threads(0), _synch_threads(0)
 {
     WPFatal(mysql_thread_safe(), "Used MySQL library isn't thread-safe.");
-    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below %s (found %s id %lu, need id >= %u), please update your MySQL client library", MIN_MYSQL_CLIENT_VERSION_STRING.c_str(), mysql_get_client_info(), mysql_get_client_version(), MIN_MYSQL_CLIENT_VERSION);
+    WPFatal(mysql_get_client_version() >= MIN_MYSQL_CLIENT_VERSION, "TrinityCore does not support MySQL versions below "MIN_MYSQL_SERVER_VERSION_STRING" (found %s id %lu, need id >= %u), please update your MySQL client library", mysql_get_client_info(), mysql_get_client_version(), MIN_MYSQL_CLIENT_VERSION);
     WPFatal(mysql_get_client_version() == MYSQL_VERSION_ID, "Used MySQL library version (%s id %lu) does not match the version id used to compile TrinityCore (id %u). Search on forum for TCE00011.", mysql_get_client_info(), mysql_get_client_version(), MYSQL_VERSION_ID);
 }
 

--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -42,9 +42,9 @@
 #endif
 
 constexpr uint64 MIN_MYSQL_SERVER_VERSION = 80834;
-constexpr std::string MIN_MYSQL_SERVER_VERSION_STRING = "8.0.34";
+constexpr std::string_view MIN_MYSQL_SERVER_VERSION_STRING = "8.0.34";
 constexpr uint64 MIN_MYSQL_CLIENT_VERSION = 80834;
-constexpr std::string MIN_MYSQL_CLIENT_VERSION_STRING = "8.0.34";
+constexpr std::string_view MIN_MYSQL_CLIENT_VERSION_STRING = "8.0.34";
 
 static_assert(MIN_MYSQL_SERVER_VERSION >= MYSQL_VERSION_ID, "The MySQL version used to compile the solution is too low. Please make sure that you meet the minimum required version as defined in MIN_MYSQL_SERVER_VERSION");
 


### PR DESCRIPTION
Due to MySQL 5.7 being no longer supported and MariaDB being based on 5.7, both versions will no longer be supported to compile or run the source. MySQL 8.0.34 is set as a new standard as it is the first 8.0 version that started using OpenSSL 3 which we already require as well.

This superceedes the previous PR of depcecating these versions.

- MySQL 5.7 and MariaDB are no longer accepted to compile or run the applications
- Added a static_assert that throws a compile error when the mysql version is too low to reduce user errors

There is no point in arguing around anymore. It will happen. You had plenty of time to update your setup, the grace period is over.