### PR TITLE
Core/Conversations: Hackfix for NextConversationLineID overflow

### DIFF
--- a/src/server/game/Globals/ConversationDataStore.cpp
+++ b/src/server/game/Globals/ConversationDataStore.cpp
@@ -203,9 +203,9 @@ void ConversationDataStore::LoadConversationTemplates()
     {
         if (conversationLine && conversationLine->NextConversationLineID)
         {
-            uint32 const firstLineId = 60000; // Arbitrary id to cover the affected rows
+            static constexpr uint32 FirstLineId = 60000; // Arbitrary id to cover the affected rows
 
-            if (conversationLine->ID > firstLineId && conversationLine->NextConversationLineID < (sConversationLineStore.GetNumRows() - USHRT_MAX - 1))
+            if (conversationLine->ID > FirstLineId && conversationLine->NextConversationLineID < (sConversationLineStore.GetNumRows() - USHRT_MAX - 1))
                 return (uint32)(USHRT_MAX + conversationLine->NextConversationLineID + 1);
 
             return (uint32)conversationLine->NextConversationLineID;

--- a/src/server/game/Globals/ConversationDataStore.cpp
+++ b/src/server/game/Globals/ConversationDataStore.cpp
@@ -198,11 +198,27 @@ void ConversationDataStore::LoadConversationTemplates()
         TC_LOG_INFO("server.loading", ">> Loaded 0 Conversation actors. DB table `conversation_actors` is empty.");
     }
 
+    // TODO: Remove this hack when NextConversationLineID is changed to uint32
+    auto getNextConversationLineId = [&](ConversationLineEntry const* conversationLine)
+    {
+        if (conversationLine && conversationLine->NextConversationLineID)
+        {
+            uint32 const firstLineId = 60000; // Arbitrary id to cover the affected rows
+
+            if (conversationLine->ID > firstLineId && conversationLine->NextConversationLineID < (sConversationLineStore.GetNumRows() - USHRT_MAX - 1))
+                return (uint32)(USHRT_MAX + conversationLine->NextConversationLineID + 1);
+
+            return (uint32)conversationLine->NextConversationLineID;
+        }
+
+        return 0u;
+    };
+
     // Validate FirstLineId
     std::unordered_map<uint32, uint32> prevConversationLineIds;
     for (ConversationLineEntry const* conversationLine : sConversationLineStore)
-        if (conversationLine->NextConversationLineID)
-            prevConversationLineIds[conversationLine->NextConversationLineID] = conversationLine->ID;
+        if (uint32 nextConversationLineId = getNextConversationLineId(conversationLine))
+            prevConversationLineIds[nextConversationLineId] = conversationLine->ID;
 
     auto getFirstLineIdFromAnyLineId = [&](uint32 lineId)
     {
@@ -248,10 +264,11 @@ void ConversationDataStore::LoadConversationTemplates()
                 else
                     TC_LOG_ERROR("sql.sql", "Table `conversation_line_template` has missing template for line (ID: {}) in Conversation {}, skipped", currentConversationLine->ID, conversationTemplate.Id);
 
-                if (!currentConversationLine->NextConversationLineID)
+                uint32 nextConversationLineId = getNextConversationLineId(currentConversationLine);
+                if (!nextConversationLineId)
                     break;
 
-                currentConversationLine = sConversationLineStore.AssertEntry(currentConversationLine->NextConversationLineID);
+                currentConversationLine = sConversationLineStore.AssertEntry(nextConversationLineId);
             }
 
             _conversationTemplateStore[conversationTemplate.Id] = std::move(conversationTemplate);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Field NextConversationLineID from ConversationLine.db2 is still uint16 so there is an overflow for referenced ids > 65535. Until db2 has the type changed to uint32 we need this hack to make new conversations work
-  Example from db2: ID 66067, NextConversationLineID: 532 (value should be 65536+532=66068)

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
