### PR TITLE
Fix Talk Interrupting Dancing

### DIFF
--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -651,6 +651,7 @@ void WorldSession::HandleTextEmoteOpcode(WorldPacket& recvData)
             break;
         case EMOTE_STATE_DANCE:
             GetPlayer()->SetEmoteState(emote);
+            break;
         default:
             // Only allow text-emotes for "dead" entities (feign death included)
             if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))

--- a/src/server/game/Handlers/ChatHandler.cpp
+++ b/src/server/game/Handlers/ChatHandler.cpp
@@ -649,6 +649,8 @@ void WorldSession::HandleTextEmoteOpcode(WorldPacket& recvData)
         case EMOTE_STATE_KNEEL:
         case EMOTE_ONESHOT_NONE:
             break;
+        case EMOTE_STATE_DANCE:
+            GetPlayer()->SetEmoteState(emote);
         default:
             // Only allow text-emotes for "dead" entities (feign death included)
             if (GetPlayer()->HasUnitState(UNIT_STATE_DIED))

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -282,6 +282,10 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvPacket)
     Unit* mover = client->GetActivelyMovedUnit();
     Player* plrMover = mover->ToPlayer();
 
+    if (plrMover && plrMover->GetEmoteState() != EMOTE_ONESHOT_NONE) {
+        plrMover->SetEmoteState(EMOTE_ONESHOT_NONE);
+    }
+
     // ignore, waiting processing in WorldSession::HandleMoveWorldportAckOpcode and WorldSession::HandleMoveTeleportAck
     if (plrMover && plrMover->IsBeingTeleported())
     {

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -282,9 +282,8 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvPacket)
     Unit* mover = client->GetActivelyMovedUnit();
     Player* plrMover = mover->ToPlayer();
 
-    if (plrMover && plrMover->GetEmoteState() != EMOTE_ONESHOT_NONE) {
+    if (plrMover && plrMover->GetEmoteState() != EMOTE_ONESHOT_NONE)
         plrMover->SetEmoteState(EMOTE_ONESHOT_NONE);
-    }
 
     // ignore, waiting processing in WorldSession::HandleMoveWorldportAckOpcode and WorldSession::HandleMoveTeleportAck
     if (plrMover && plrMover->IsBeingTeleported())


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Talking will not completely interrupt dancing and players will continue dancing once the talk emote completes.

[Video evidence from 2009 at the 40 second mark the draenei is dancing, speaks, then resumes dancing.](https://www.youtube.com/watch?v=9WfJALE2aCA&t=40s)

**Tests performed:**

Active usage on our server for more than a year.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
