### PR TITLE
Scripts/Spells: Implement first aid related anti-venom item spells

### DIFF
--- a/sql/updates/world/3.3.5/XXXX_XX_XX_YY_world.sql
+++ b/sql/updates/world/3.3.5/XXXX_XX_XX_YY_world.sql
@@ -1,0 +1,6 @@
+-- Assign first aid anti-venom items spellscript
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_item_antivenom';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(7932, 'spell_item_antivenom'),
+(7933, 'spell_item_antivenom'),
+(23786, 'spell_item_antivenom');

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -4356,13 +4356,15 @@ class spell_item_antivenom : public SpellScript
         if (Unit* target = GetHitUnit())
         {
             // Remove poison effects from the target up to X level
-            if (GetSpellInfo()->MaxLevel >= target->GetLevel())
+            uint32 maxLevel = GetSpellInfo()->MaxLevel;
+
+            target->RemoveAppliedAuras([&maxLevel](AuraApplication const* aurApp) -> bool
             {
-                target->RemoveAppliedAuras([](AuraApplication const* aurApp) -> bool
-                {
-                    return aurApp->GetBase()->GetSpellInfo()->Dispel == DISPEL_POISON;
-                });
-            }
+                Aura const* aura = aurApp->GetBase();
+                bool isPoison = aura->GetSpellInfo()->Dispel == DISPEL_POISON;
+                bool passesLevelCheck = aura->GetCasterLevel() <= maxLevel;
+                return isPoison && passesLevelCheck;
+            });
         }
     }
 

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -4344,6 +4344,34 @@ class spell_item_titanium_seal_of_dalaran_catch : public SpellScript
     }
 };
 
+// 7932 - Anti-Venom
+// 7933 - Strong Anti-Venom
+// 23786 - Powerful Anti-Venom
+class spell_item_antivenom : public SpellScript
+{
+    PrepareSpellScript(spell_item_antivenom);
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* target = GetHitUnit())
+        {
+            // Remove poison effects from the target up to X level
+            if (GetSpellInfo()->MaxLevel >= target->GetLevel())
+            {
+                target->RemoveAppliedAuras([](AuraApplication const* aurApp) -> bool
+                {
+                    return aurApp->GetBase()->GetSpellInfo()->Dispel == DISPEL_POISON;
+                });
+            }
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_item_antivenom::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
 void AddSC_item_spell_scripts()
 {
     // 23074 Arcanite Dragonling
@@ -4481,4 +4509,5 @@ void AddSC_item_spell_scripts()
     RegisterSpellScript(spell_item_eggnog);
     RegisterSpellScript(spell_item_titanium_seal_of_dalaran_toss);
     RegisterSpellScript(spell_item_titanium_seal_of_dalaran_catch);
+    RegisterSpellScript(spell_item_antivenom);
 }


### PR DESCRIPTION
**Changes proposed:**

Makes the following first aid related items work:

* [Anti-Venom](https://www.wowhead.com/wotlk/item=6452/anti-venoml)
* [Strong Anti-Venom](https://www.wowhead.com/wotlk/item=6453/strong-anti-venom)
* [Powerful Anti-Venom](https://www.wowhead.com/wotlk/item=19440/powerful-anti-venom)

Note that WotlK era introduced a hard nerf to the anti-venom items, making them take in account the target's max level instead of the poison spell level, so players couldn't abuse the items to bypass higher level poison mechanics anymore. A conversation regarding this nerf and how the items behaved on higher level targets can be seen [here](https://www.wowhead.com/item=19440/powerful-anti-venom#comments:id=713457). This is reflected in the spell script.

While the PR targets 3.3.5, if someone seeing this takes this code to the master branch, the scriptname should also be assigned to the spell ids 172368 and 307165, from future expansions.

**Issues addressed:**

Closes #21518


**Tests performed:**

Builds & works ingame. Tested against the example in #21518 with one and multiple poison effects present.
