### PR TITLE
Tools/vmap_assembler: Fix missing <mutex> header in TileAssembler.cpp

### DIFF
--- a/src/tools/vmap4_assembler/TileAssembler.cpp
+++ b/src/tools/vmap4_assembler/TileAssembler.cpp
@@ -28,6 +28,7 @@
 #include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <set>
+#include <mutex>
 
 template<> struct BoundsTrait<VMAP::ModelSpawn*>
 {

--- a/src/tools/vmap4_assembler/TileAssembler.cpp
+++ b/src/tools/vmap4_assembler/TileAssembler.cpp
@@ -27,8 +27,8 @@
 #include "VMapDefinitions.h"
 #include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <set>
 #include <mutex>
+#include <set>
 
 template<> struct BoundsTrait<VMAP::ModelSpawn*>
 {


### PR DESCRIPTION
**Changes proposed:**

- Added mutex header to TileAssembler.cpp.
- Resolved build errors related to std::call_once at line 85 (now located at line 86) causing compilation issues (C3861, C2039).

**Tests performed:**

- Verified that the project successfully builds after adding the mutex header.
- No in-game testing required as this is a compilation fix.