### PR TITLE
Cmake/genrev: Now shows more accurate host system build in windows

### DIFF
--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -126,13 +126,13 @@ cmake_host_system_information(RESULT TRINITY_BUILD_HOST_SYSTEM QUERY OS_NAME)
 cmake_host_system_information(RESULT TRINITY_BUILD_HOST_DISTRO QUERY DISTRIB_INFO)
 cmake_host_system_information(RESULT TRINITY_BUILD_HOST_SYSTEM_RELEASE QUERY OS_RELEASE)
 # on windows OS_RELEASE contains sub-type string tag like "Professional" instead of a version number and OS_VERSION has only build number
-# so we grab that from cmd "ver" command
+# so we grab that with Get-CimInstance powershell cmdlet
 if(WIN32)
   execute_process(
     COMMAND powershell -NoProfile -Command "$v=(Get-CimInstance -ClassName Win32_OperatingSystem); '{0} ({1})' -f $v.Caption, $v.Version"
     OUTPUT_VARIABLE TRINITY_BUILD_HOST_SYSTEM_RELEASE
+	OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-  string(STRIP ${TRINITY_BUILD_HOST_SYSTEM_RELEASE} TRINITY_BUILD_HOST_SYSTEM_RELEASE)
   # Remove "Microsoft Windows" from the result
   string(REPLACE "Microsoft Windows " "" TRINITY_BUILD_HOST_SYSTEM_RELEASE ${TRINITY_BUILD_HOST_SYSTEM_RELEASE})
 endif()

--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -135,14 +135,15 @@ if(WIN32)
   string(STRIP ${TRINITY_BUILD_HOST_SYSTEM_RELEASE} TRINITY_BUILD_HOST_SYSTEM_RELEASE)
   string(REGEX MATCH "[0-9]+[.][0-9]+[.][0-9]+" TRINITY_BUILD_HOST_SYSTEM_RELEASE ${TRINITY_BUILD_HOST_SYSTEM_RELEASE})
 
-  # Use systeminfo to detect the OS version
+  # Use PowerShell to detect the Windows version
   execute_process(
-    COMMAND systeminfo
-    OUTPUT_VARIABLE SYSTEMINFO_OUTPUT
+    COMMAND powershell -NoProfile -Command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"
+    OUTPUT_VARIABLE RAW_WINDOWS_NAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
   # Extract only the Windows version (e.g., "Windows 10 Enterprise", "Windows 11 Enterprise") from the output
-  string(REGEX MATCH "Windows [0-9\\.]+[ ]*[A-Za-z]*" TRINITY_BUILD_HOST_SYSTEM ${SYSTEMINFO_OUTPUT})
+  string(REGEX REPLACE "Microsoft " "" SKYFIRE_BUILD_HOST_SYSTEM ${RAW_WINDOWS_NAME})
 
   # If no match was found, set a default value
   if(NOT TRINITY_BUILD_HOST_SYSTEM)

--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -138,17 +138,15 @@ if(WIN32)
   # Use PowerShell to detect the Windows version
   execute_process(
     COMMAND powershell -NoProfile -Command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"
-    OUTPUT_VARIABLE RAW_WINDOWS_NAME
+    OUTPUT_VARIABLE TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  # Extract only the Windows version (e.g., "Windows 10 Enterprise", "Windows 11 Enterprise") from the output
-  string(REGEX REPLACE "Microsoft " "" TRINITY_BUILD_HOST_SYSTEM ${RAW_WINDOWS_NAME})
+  # Remove "Microsoft Windows" from the result
+  string(REPLACE "Microsoft Windows " "" TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME ${TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME})
 
-  # If no match was found, set a default value
-  if(NOT TRINITY_BUILD_HOST_SYSTEM)
-    set(TRINITY_BUILD_HOST_SYSTEM "Windows")
-  endif()
+  # Combine both version name and version number
+  set(TRINITY_BUILD_HOST_SYSTEM_RELEASE "${TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME} (${TRINITY_BUILD_HOST_SYSTEM_RELEASE})")
 endif()
 
 if(CMAKE_SCRIPT_MODE_FILE)

--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -143,7 +143,7 @@ if(WIN32)
   )
 
   # Extract only the Windows version (e.g., "Windows 10 Enterprise", "Windows 11 Enterprise") from the output
-  string(REGEX REPLACE "Microsoft " "" SKYFIRE_BUILD_HOST_SYSTEM ${RAW_WINDOWS_NAME})
+  string(REGEX REPLACE "Microsoft " "" TRINITY_BUILD_HOST_SYSTEM ${RAW_WINDOWS_NAME})
 
   # If no match was found, set a default value
   if(NOT TRINITY_BUILD_HOST_SYSTEM)

--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -134,6 +134,20 @@ if(WIN32)
   )
   string(STRIP ${TRINITY_BUILD_HOST_SYSTEM_RELEASE} TRINITY_BUILD_HOST_SYSTEM_RELEASE)
   string(REGEX MATCH "[0-9]+[.][0-9]+[.][0-9]+" TRINITY_BUILD_HOST_SYSTEM_RELEASE ${TRINITY_BUILD_HOST_SYSTEM_RELEASE})
+
+  # Use systeminfo to detect the OS version
+  execute_process(
+    COMMAND systeminfo
+    OUTPUT_VARIABLE SYSTEMINFO_OUTPUT
+  )
+
+  # Extract only the Windows version (e.g., "Windows 10 Enterprise", "Windows 11 Enterprise") from the output
+  string(REGEX MATCH "Windows [0-9\\.]+[ ]*[A-Za-z]*" TRINITY_BUILD_HOST_SYSTEM ${SYSTEMINFO_OUTPUT})
+
+  # If no match was found, set a default value
+  if(NOT TRINITY_BUILD_HOST_SYSTEM)
+    set(TRINITY_BUILD_HOST_SYSTEM "Windows")
+  endif()
 endif()
 
 if(CMAKE_SCRIPT_MODE_FILE)

--- a/cmake/genrev.cmake
+++ b/cmake/genrev.cmake
@@ -129,24 +129,12 @@ cmake_host_system_information(RESULT TRINITY_BUILD_HOST_SYSTEM_RELEASE QUERY OS_
 # so we grab that from cmd "ver" command
 if(WIN32)
   execute_process(
-    COMMAND cmd /c ver
+    COMMAND powershell -NoProfile -Command "$v=(Get-CimInstance -ClassName Win32_OperatingSystem); '{0} ({1})' -f $v.Caption, $v.Version"
     OUTPUT_VARIABLE TRINITY_BUILD_HOST_SYSTEM_RELEASE
   )
   string(STRIP ${TRINITY_BUILD_HOST_SYSTEM_RELEASE} TRINITY_BUILD_HOST_SYSTEM_RELEASE)
-  string(REGEX MATCH "[0-9]+[.][0-9]+[.][0-9]+" TRINITY_BUILD_HOST_SYSTEM_RELEASE ${TRINITY_BUILD_HOST_SYSTEM_RELEASE})
-
-  # Use PowerShell to detect the Windows version
-  execute_process(
-    COMMAND powershell -NoProfile -Command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"
-    OUTPUT_VARIABLE TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
   # Remove "Microsoft Windows" from the result
-  string(REPLACE "Microsoft Windows " "" TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME ${TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME})
-
-  # Combine both version name and version number
-  set(TRINITY_BUILD_HOST_SYSTEM_RELEASE "${TRINITY_BUILD_HOST_SYSTEM_VERSION_NAME} (${TRINITY_BUILD_HOST_SYSTEM_RELEASE})")
+  string(REPLACE "Microsoft Windows " "" TRINITY_BUILD_HOST_SYSTEM_RELEASE ${TRINITY_BUILD_HOST_SYSTEM_RELEASE})
 endif()
 
 if(CMAKE_SCRIPT_MODE_FILE)


### PR DESCRIPTION
Also Support Windows 11

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

**revision_data.h:**

before:

```
#define TRINITY_BUILD_HOST_SYSTEM                   R"(Windows)"
#define TRINITY_BUILD_HOST_SYSTEM_VERSION           R"(10.0.22635)"
```

after: 
```
#define TRINITY_BUILD_HOST_SYSTEM                   R"(Windows 11 Enterprise)"
#define TRINITY_BUILD_HOST_SYSTEM_VERSION           R"(10.0.22635)"
```