### PR TITLE
Scripts/CoS: Do not permabind players upon completing Mal'Ganis encounter on normal difficulty

### DIFF
--- a/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_mal_ganis.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/CullingOfStratholme/boss_mal_ganis.cpp
@@ -87,8 +87,9 @@ class boss_mal_ganis : public CreatureScript
                     _defeated = true;
 
                     // @todo hack most likely
-                    if (InstanceMap* map = instance->instance->ToInstanceMap())
-                        map->PermBindAllPlayers();
+                    if (instance->instance->IsHeroic())
+                        if (InstanceMap* map = instance->instance->ToInstanceMap())
+                            map->PermBindAllPlayers();
                 }
             }
 


### PR DESCRIPTION

**Changes proposed:**

-  Do not permabind players upon completing Mal'Ganis encounter on normal difficulty


**Issues addressed:**

Closes None


**Tests performed:**

tested in-game
