### PR TITLE
Core/Worgen race creation fix

### DIFF
--- a/src/server/game/Miscellaneous/RaceMask.h
+++ b/src/server/game/Miscellaneous/RaceMask.h
@@ -81,7 +81,7 @@ enum Races
 };
 
 // max+1 for player race
-#define MAX_RACES                       22
+#define MAX_RACES                       23
 
 namespace Trinity
 {


### PR DESCRIPTION
**Changes proposed:**
Changed the MAX_RACE 22 to 23. If the worgen race 22 and last, then not 22 the MAX_RACE, need +1, so 23.
-  
 

**Issues addressed:**
Cant create Worgen Race in the Character creation screen.


**Tests performed:**
Tested in game, and now work.
