### PR TITLE
Core/Gossips: Fix interaction with gossip launched by accepting quest

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -231,11 +231,13 @@ class InteractionData
             SourceGuid.Clear();
             TrainerId = 0;
             PlayerChoiceId = 0;
+            IsLaunchedByQuest = false;
         }
 
         ObjectGuid SourceGuid;
         uint32 TrainerId = 0;
         uint32 PlayerChoiceId = 0;
+        bool IsLaunchedByQuest = false;
 };
 
 class TC_GAME_API PlayerMenu

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1155,7 +1155,9 @@ void WorldSession::HandleMountSetFavorite(WorldPackets::Misc::MountSetFavorite& 
 
 void WorldSession::HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& closeInteraction)
 {
-    if (_player->PlayerTalkClass->GetInteractionData().SourceGuid == closeInteraction.SourceGuid)
+    if (_player->PlayerTalkClass->GetInteractionData().IsLaunchedByQuest)
+        _player->PlayerTalkClass->GetInteractionData().IsLaunchedByQuest = false;
+    else if (_player->PlayerTalkClass->GetInteractionData().SourceGuid == closeInteraction.SourceGuid)
         _player->PlayerTalkClass->GetInteractionData().Reset();
 
     if (_player->GetStableMaster() == closeInteraction.SourceGuid)

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -181,15 +181,14 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPackets::Quest::QuestG
                 }
             }
 
-            _player->PlayerTalkClass->SendCloseGossip();
-
-            if (quest->HasFlag(QUEST_FLAGS_LAUNCH_GOSSIP_ACCEPT))
+            if (quest->HasFlag(QUEST_FLAGS_LAUNCH_GOSSIP_ACCEPT) && !quest->HasFlagEx(QUEST_FLAGS_EX_SUPPRESS_GOSSIP_ACCEPT))
             {
                 auto launchGossip = [&](WorldObject* worldObject)
                 {
                     _player->PlayerTalkClass->ClearMenus();
                     _player->PrepareGossipMenu(worldObject, _player->GetGossipMenuForSource(worldObject), true);
                     _player->SendPreparedGossip(worldObject);
+                    _player->PlayerTalkClass->GetInteractionData().IsLaunchedByQuest = true;
                 };
 
                 if (Creature* creature = object->ToCreature())
@@ -197,6 +196,8 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPackets::Quest::QuestG
                 else if (GameObject* go = object->ToGameObject())
                     launchGossip(go);
             }
+            else
+                _player->PlayerTalkClass->SendCloseGossip();
 
             return;
         }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix interaction with gossip launched by accepting quest (using QUEST_FLAGS_LAUNCH_GOSSIP_ACCEPT)
    1. CMSG_QUEST_GIVER_ACCEPT_QUEST 
        -  https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Handlers/QuestHandler.cpp#L188 (prepare and send gossip menu)
        -  https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Entities/Creature/GossipDef.cpp#L243 (populate interaction data)
    2. CMSG_CLOSE_INTERACTION (client sends this opcode always)
       - https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Handlers/MiscHandler.cpp#L1159 (interaction data is reset)
    3. The client shows the gossip but interaction data is empty so any gossip menu option will fail this check: https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Handlers/NPCHandler.cpp#L201

**Issues addressed:**
None


**Tests performed:**
Builds, tested in-game


**Known issues and TODO list:** (add/remove lines as needed)
None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
