### PR TITLE
Core/Spells: Allow persistent area auras to apply all of their effects upon creation.

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1601,7 +1601,7 @@ void Spell::EffectPersistentAA()
 
     ASSERT(_dynObjAura->GetDynobjOwner());
     for (size_t i = 0; i < m_spellInfo->GetEffects().size(); ++i)
-        if (!m_spellInfo->GetEffect(SpellEffIndex(i)).IsEffect(SPELL_EFFECT_NONE))
+        if (m_spellInfo->GetEffect(SpellEffIndex(i)).IsEffect(SPELL_EFFECT_PERSISTENT_AREA_AURA))
             _dynObjAura->_ApplyEffectForTargets(i);
 }
 

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1600,7 +1600,9 @@ void Spell::EffectPersistentAA()
         return;
 
     ASSERT(_dynObjAura->GetDynobjOwner());
-    _dynObjAura->_ApplyEffectForTargets(effectInfo->EffectIndex);
+    for (size_t i = 0; i < m_spellInfo->GetEffects().size(); ++i)
+        if (!m_spellInfo->GetEffect(SpellEffIndex(i)).IsEffect(SPELL_EFFECT_NONE))
+            _dynObjAura->_ApplyEffectForTargets(i);
 }
 
 void Spell::EffectEnergize()


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Cherrypick https://github.com/Project-Epoch/TrinityCore/commit/144769fceaf7985f2c4f96fae1b7785e65d857b6#diff-0d2a44370e18523042eca998013bf68fa21f38524f406c0ccdfd557f62342a30L1751
-  This fixes the issue where the area auras do not instantly apply their effects. Actually, they were only applying the last SPELL_EFFECT_PERSISTENT_AREA_AURA; Flare and Frost Trap have 2 and 3 SPELL_EFFECT_PERSISTENT_AREA_AURA effects respectively, so only the last one would be applied.
-  Credit goes to original authors.

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/29903

Closes https://github.com/TrinityCore/TrinityCore/issues/29605

**Tests performed:**

Does it build, tested in-game, as can be seen below:

https://youtu.be/8CgMXaAJAbg

**Known issues and TODO list:** (add/remove lines as needed)

- [ None ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
