### PR TITLE
Scripts/FoS: Ensure Bronjahm always teleports to the middle upon phase switch

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
@@ -109,17 +109,6 @@ struct boss_bronjahm : public BossAI
             Talk(SAY_SLAY);
     }
 
-    void DamageTaken(Unit* /*attacker*/, uint32& /*damage*/, DamageEffectType /*damageType*/, SpellInfo const* /*spellInfo = nullptr*/) override
-    {
-        if (events.IsInPhase(PHASE_1) && !HealthAbovePct(30))
-        {
-            events.SetPhase(PHASE_2);
-            DoCast(me, SPELL_TELEPORT);
-            events.ScheduleEvent(EVENT_FEAR, 12s, 16s, 0, PHASE_2);
-            events.ScheduleEvent(EVENT_SOULSTORM, 100ms, 0, PHASE_2);
-        }
-    }
-
     void JustSummoned(Creature* summon) override
     {
         if (summon->GetEntry() == NPC_CORRUPTED_SOUL_FRAGMENT)
@@ -157,6 +146,14 @@ struct boss_bronjahm : public BossAI
 
         if (me->HasUnitState(UNIT_STATE_CASTING))
             return;
+
+        if (events.IsInPhase(PHASE_1) && !HealthAbovePct(30))
+        {
+            events.SetPhase(PHASE_2);
+            DoCast(me, SPELL_TELEPORT);
+            events.ScheduleEvent(EVENT_FEAR, 12s, 16s, 0, PHASE_2);
+            events.ScheduleEvent(EVENT_SOULSTORM, 100ms, 0, PHASE_2);
+        }
 
         while (uint32 eventId = events.ExecuteEvent())
         {
@@ -199,9 +196,6 @@ struct boss_bronjahm : public BossAI
                 default:
                     break;
             }
-
-            if (me->HasUnitState(UNIT_STATE_CASTING))
-                return;
         }
 
         if (!events.IsInPhase(PHASE_2))


### PR DESCRIPTION
**Changes proposed:**

* Handle the phase switch on UpdateAI instead of DamageTaken, so the teleport is always issued after the current cast has finished, regardless if the threshold was hit while the boss was casting or not.
* Remove unneeded check because the DoMeleeAttackIfReady() below already checks for it

**Issues addressed:**

Closes #30421

**Tests performed:**

Builds & works ingame in both scenarios (health threshold reached while the boss is casting and while the boss isn't casting).

