### PR TITLE
Scripts/Forge of Souls: Ensure that Bronjahm teleport is executed when entering the second phase

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/ForgeOfSouls/boss_bronjahm.cpp
@@ -50,11 +50,12 @@ enum Spells
 
 enum Events
 {
-    EVENT_MAGIC_BANE    = 1,
-    EVENT_SHADOW_BOLT   = 2,
-    EVENT_CORRUPT_SOUL  = 3,
-    EVENT_SOULSTORM     = 4,
-    EVENT_FEAR          = 5
+    EVENT_MAGIC_BANE = 1,
+    EVENT_SHADOW_BOLT,
+    EVENT_CORRUPT_SOUL,
+    EVENT_SOULSTORM,
+    EVENT_FEAR,
+    EVENT_TELEPORT
 };
 
 enum CombatPhases
@@ -114,9 +115,7 @@ struct boss_bronjahm : public BossAI
         if (events.IsInPhase(PHASE_1) && !HealthAbovePct(30))
         {
             events.SetPhase(PHASE_2);
-            DoCast(me, SPELL_TELEPORT);
-            events.ScheduleEvent(EVENT_FEAR, 12s, 16s, 0, PHASE_2);
-            events.ScheduleEvent(EVENT_SOULSTORM, 100ms, 0, PHASE_2);
+            events.ScheduleEvent(EVENT_TELEPORT, 1ms, 0, PHASE_2);
         }
     }
 
@@ -195,6 +194,11 @@ struct boss_bronjahm : public BossAI
                 case EVENT_FEAR:
                     me->CastSpell(nullptr, SPELL_FEAR, { SPELLVALUE_MAX_TARGETS, 1 });
                     events.ScheduleEvent(EVENT_FEAR, 8s, 12s, 0, PHASE_2);
+                    break;
+                case EVENT_TELEPORT:
+                    DoCastSelf(SPELL_TELEPORT);
+                    events.ScheduleEvent(EVENT_FEAR, 12s, 16s, 0, PHASE_2);
+                    events.ScheduleEvent(EVENT_SOULSTORM, 100ms, 0, PHASE_2);
                     break;
                 default:
                     break;


### PR DESCRIPTION

**Changes proposed:**

-  Schedule an event instead of cast the teleport when phase switch 
-  Supersedes #30427

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/30421

**Tests performed:**

tested in-game

