### PR TITLE
Core/Spells: Implemented priority-based target sorting via PriorityRules system

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -18,6 +18,7 @@
 #ifndef __SPELL_H
 #define __SPELL_H
 
+#include "Concepts.h"
 #include "ConditionMgr.h"
 #include "DBCEnums.h"
 #include "Duration.h"
@@ -27,6 +28,7 @@
 #include "Position.h"
 #include "SharedDefines.h"
 #include "SpellDefines.h"
+#include "Types.h"
 #include "UniqueTrackablePtr.h"
 #include <memory>
 
@@ -1055,15 +1057,35 @@ namespace Trinity
 
     TC_GAME_API void SelectRandomInjuredTargets(std::list<WorldObject*>& targets, size_t maxTargets, bool prioritizePlayers, Unit const* prioritizeGroupMembersOf = nullptr);
 
-    struct PriorityRules
+    struct TargetPriorityRule
     {
-        int32 weight;
-        std::function<bool(Unit*)> condition;
+        template <typename Func> requires (!std::same_as<Func, TargetPriorityRule>)
+        TargetPriorityRule(Func&& func) : Rule([func = std::forward<Func>(func)]<typename T = WorldObject /*template to avoid Object.h dependency*/>(T* target)
+        {
+            if constexpr (invocable_r<Func, bool, WorldObject*>)
+                return std::invoke(func, target);
+            else if constexpr (invocable_r<Func, bool, Unit*>)
+                return target->IsUnit() && std::invoke(func, target->ToUnit());
+            else if constexpr (invocable_r<Func, bool, Player*>)
+                return target->IsPlayer() && std::invoke(func, target->ToPlayer());
+            else
+                static_assert(dependant_false_v<T>, "Unsupported object type, use WorldObject* as your rule argument");
+        })
+        {
+        }
+
+        std::function<bool(WorldObject*)> Rule;
     };
 
-    inline std::vector<PriorityRules> CreatePriorityRules(std::initializer_list<PriorityRules> rules) { return { rules }; }
+    TC_GAME_API void SortTargetsWithPriorityRules(std::list<WorldObject*>& targets, size_t maxTargets, std::span<TargetPriorityRule const> rules);
 
-    TC_GAME_API void SortTargetsWithPriorityRules(std::list<WorldObject*>& targets, size_t maxTargets, std::vector<PriorityRules> const& rules);
+    template <std::size_t N>
+    inline void SortTargetsWithPriorityRules(std::list<WorldObject*>& targets, size_t maxTargets, std::array<TargetPriorityRule, N> const& rules)
+    {
+        static_assert(N <= 31);
+
+        SortTargetsWithPriorityRules(targets, maxTargets, std::span(rules));
+    }
 }
 
 extern template void Spell::SearchTargets<Trinity::WorldObjectListSearcher<Trinity::WorldObjectSpellAreaTargetCheck>>(Trinity::WorldObjectListSearcher<Trinity::WorldObjectSpellAreaTargetCheck>& searcher, uint32 containerMask, WorldObject* referer, Position const* pos, float radius);

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -1054,6 +1054,16 @@ namespace Trinity
     };
 
     TC_GAME_API void SelectRandomInjuredTargets(std::list<WorldObject*>& targets, size_t maxTargets, bool prioritizePlayers, Unit const* prioritizeGroupMembersOf = nullptr);
+
+    struct PriorityRules
+    {
+        int32 weight;
+        std::function<bool(Unit*)> condition;
+    };
+
+    inline std::vector<PriorityRules> CreatePriorityRules(std::initializer_list<PriorityRules> rules) { return { rules }; }
+
+    TC_GAME_API void SortTargetsWithPriorityRules(std::list<WorldObject*>& targets, size_t maxTargets, std::vector<PriorityRules> const& rules);
 }
 
 extern template void Spell::SearchTargets<Trinity::WorldObjectListSearcher<Trinity::WorldObjectSpellAreaTargetCheck>>(Trinity::WorldObjectListSearcher<Trinity::WorldObjectSpellAreaTargetCheck>& searcher, uint32 containerMask, WorldObject* referer, Position const* pos, float radius);

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -753,7 +753,6 @@ class spell_dru_efflorescence_heal : public SpellScript
 {
     void FilterTargets(std::list<WorldObject*>& targets) const
     {
-        // Efflorescence became a smart heal which prioritizes players and their pets in their group before any unit outside their group.
         Trinity::SelectRandomInjuredTargets(targets, 3, true, GetCaster());
     }
 
@@ -2542,7 +2541,7 @@ class spell_dru_yseras_gift : public AuraScript
 // 145110 - Ysera's Gift (heal)
 class spell_dru_yseras_gift_group_heal : public SpellScript
 {
-    void SelectTargets(std::list<WorldObject*>& targets)
+    static void SelectTargets(SpellScript const&, std::list<WorldObject*>& targets)
     {
         Trinity::SelectRandomInjuredTargets(targets, 1, true);
     }

--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2115,28 +2115,15 @@ class spell_pri_power_word_radiance : public SpellScript
 
     void FilterTargets(std::list<WorldObject*>& targets)
     {
+        Unit* caster = GetCaster();
         Unit* explTarget = GetExplTargetUnit();
 
         // we must add one since explicit target is always chosen.
         uint32 maxTargets = GetEffectInfo(EFFECT_2).CalcValue(GetCaster()) + 1;
 
-        if (targets.size() > maxTargets)
-        {
-            // priority is: a) no Atonement b) injured c) anything else (excluding explicit target which is always added).
-            targets.sort([this, explTarget](WorldObject* lhs, WorldObject* rhs)
-            {
-                if (lhs == explTarget) // explTarget > anything: always true
-                    return true;
-                if (rhs == explTarget) // anything > explTarget: always false
-                    return false;
+        SortTargetsWithPriorityRules(targets, maxTargets, GetRadianceRules(caster, explTarget));
 
-                return MakeSortTuple(lhs) > MakeSortTuple(rhs);
-            });
-
-            targets.resize(maxTargets);
-        }
-
-        for (WorldObject* target : targets)
+        for (WorldObject const* target : targets)
         {
             if (target == explTarget)
                 continue;
@@ -2152,30 +2139,22 @@ class spell_pri_power_word_radiance : public SpellScript
                 GetHitUnit()->SendPlaySpellVisual(target, SPELL_VISUAL_PRIEST_POWER_WORD_RADIANCE, 0, 0, 70.0f);
     }
 
+    static std::vector<Trinity::PriorityRules> GetRadianceRules(Unit const* caster, Unit const* explTarget)
+    {
+        return Trinity::CreatePriorityRules
+        ({
+            { .weight = 1,  .condition = [caster](Unit const* target) { return target->IsInRaidWith(caster); }},
+            { .weight = 2,  .condition = [](Unit const* target) { return target->IsPlayer() || (target->IsCreature() && target->ToCreature()->IsTreatedAsRaidUnit()); }},
+            { .weight = 4,  .condition = [](Unit const* target) { return !target->IsFullHealth(); }},
+            { .weight = 8,  .condition = [caster](Unit const* target) { return !target->HasAura(SPELL_PRIEST_ATONEMENT_EFFECT, caster->GetGUID()); }},
+            { .weight = 16, .condition = [explTarget](Unit const* target) { return target == explTarget; }}
+        });
+    }
+
     void Register() override
     {
         OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_pri_power_word_radiance::FilterTargets, EFFECT_1, TARGET_UNIT_DEST_AREA_ALLY);
         OnEffectHitTarget += SpellEffectFn(spell_pri_power_word_radiance::HandleEffectHitTarget, EFFECT_0, SPELL_EFFECT_DUMMY);
-    }
-
-private:
-    std::tuple<bool, bool> MakeSortTuple(WorldObject* obj) const
-    {
-        return std::make_tuple(IsUnitWithNoAtonement(obj), IsUnitInjured(obj));
-    }
-
-    // Returns true if obj is a unit but has no atonement
-    bool IsUnitWithNoAtonement(WorldObject* obj) const
-    {
-        Unit* unit = obj->ToUnit();
-        return unit && !unit->HasAura(SPELL_PRIEST_ATONEMENT_EFFECT, GetCaster()->GetGUID());
-    }
-
-    // Returns true if obj is a unit and is injured
-    static bool IsUnitInjured(WorldObject* obj)
-    {
-        Unit* unit = obj->ToUnit();
-        return unit && !unit->IsFullHealth();
     }
 
     std::vector<ObjectGuid> _visualTargets;

--- a/src/server/scripts/Spells/spell_shaman.cpp
+++ b/src/server/scripts/Spells/spell_shaman.cpp
@@ -297,11 +297,6 @@ class spell_sha_ancestral_guidance : public AuraScript
 // 114911 - Ancestral Guidance Heal
 class spell_sha_ancestral_guidance_heal : public SpellScript
 {
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_SHAMAN_ANCESTRAL_GUIDANCE });
-    }
-
     static void ResizeTargets(SpellScript const&, std::list<WorldObject*>& targets)
     {
         Trinity::SelectRandomInjuredTargets(targets, 3, true);


### PR DESCRIPTION
Introduces a lightweight, flexible system to sort spell targets based on script-defined priority rules. This replaces hardcoded or purely random selection logic with a more precise, predictable approach using weighted scoring.

**Changes proposed:**

- Added PriorityRules structure to define scoring conditions with weights.
- Implemented SortTargetsWithPriorityRules():
1. Scores all eligible targets based on provided rules.
2. Sorts by descending score.
3. Shuffles tied entries around the cutoff to avoid deterministic bias.
- SortTargetsWithPriorityRules now requires an explicit rule set, improving clarity and avoiding hidden logic.

**Tests performed:**

- Verified Power Word: Radiance correctly prioritizes groupmates with no Atonement before other targets.
- Confirmed deterministic behavior no longer occurs on repeated casts with tied scores.

**Known issues and TODO list:**

None.