### PR TITLE
Remove non-portable hack of including `<__msvc_chrono.hpp>`

### DIFF
--- a/src/common/Utilities/Duration.h
+++ b/src/common/Utilities/Duration.h
@@ -18,12 +18,7 @@
 #ifndef _DURATION_H_
 #define _DURATION_H_
 
-// HACKS TERRITORY
-#if __has_include(<__msvc_chrono.hpp>)
-#include <__msvc_chrono.hpp> // skip all the formatting/istream/locale/mutex bloat
-#else
 #include <chrono>
-#endif
 
 /// Milliseconds shorthand typedef.
 typedef std::chrono::milliseconds Milliseconds;


### PR DESCRIPTION
I work on Microsoft Visual C++, where we regularly build popular open-source projects, including yours, with development builds of our compiler and libraries to detect and prevent shipping regressions that would affect you. This also allows us to provide advance notice of breaking changes, which is the case here.

I just merged https://github.com/microsoft/STL/pull/5105, which revealed a conformance issue in TrinityCore.

The primary compiler error with this STL change is:

```
C:\gitP\TrinityCore\TrinityCore\src\common\Utilities\Duration.h(42,22): error C3083: 'system_clock': the symbol to the left of a '::' must be a type
```

With many cascading errors - deduplicated to one per file, they are:

```
C:\gitP\TrinityCore\TrinityCore\src\common\Metric\Metric.cpp(131,21): error C2582: 'operator =' function is unavailable in 'std::chrono::time_point'
C:\gitP\TrinityCore\TrinityCore\src\common\Metric\Metric.h(53,21): error C2955: 'std::chrono::time_point': use of class template requires template argument list
C:\gitP\TrinityCore\TrinityCore\src\common\Time\Timer.h(133,31): error C3688: invalid literal suffix 's'; literal operator or literal operator template 'operator ""s' not found
C:\gitP\TrinityCore\TrinityCore\src\common\Time\Timezone.cpp(108,8): error C3688: invalid literal suffix 'min'; literal operator or literal operator template 'operator ""min' not found
C:\gitP\TrinityCore\TrinityCore\src\common\Time\Timezone.h(30,61): error C2955: 'std::chrono::time_point': use of class template requires template argument list
C:\gitP\TrinityCore\TrinityCore\src\common\Utilities\EventProcessor.cpp(78,39): error C3688: invalid literal suffix 'ms'; literal operator or literal operator template 'operator ""ms' not found
```

The problem is that https://github.com/TrinityCore/TrinityCore/commit/585900f42d064b9f6adc08015605931163ea79c8 introduced a non-portable hack, reaching into MSVC STL implementation details (undocumented and unsupported). After https://github.com/microsoft/STL/pull/5105, this internal header no longer provides `system_clock` or the `chrono_literals`, so you must include the full `<chrono>`.

(We added `<__msvc_chrono.hpp>` to improve the compiler throughput / build speed of `<thread>` etc., and we're moving `system_clock` etc. out of it in order to further improve compiler throughput. This MSVC STL internal header was never intended for users to include directly, and is not a general mechanism to "include the pre-C++20 parts of `<chrono>`". I recognize that it's ironic that our change to improve compiler throughput elsewhere will decrease your throughput as you have to include the full header.)

As an aside, if you want to significantly improve compiler throughput, I recommend setting up precompiled headers; it takes a bit of work but it significantly improves build throughput. (C++20 header units are an alternative, but may be less easy to adopt.)