### PR TITLE
Scripts/Gundrak: Properly handle wipes on Drakkari Colossus encounter

### DIFF
--- a/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
+++ b/src/server/scripts/Northrend/Gundrak/boss_drakkari_colossus.cpp
@@ -340,6 +340,13 @@ struct boss_drakkari_elemental : public ScriptedAI
         }
     }
 
+    void EnterEvadeMode(EvadeReason /*why*/) override
+    {
+        if (Creature* colossus = instance->GetCreature(DATA_DRAKKARI_COLOSSUS))
+            colossus->AI()->DoAction(ACTION_UNFREEZE_COLOSSUS);
+        me->DespawnOrUnsummon();
+    }
+
     void SpellHitTarget(WorldObject* target, SpellInfo const* spellInfo) override
     {
         if (spellInfo->Id == SPELL_MERGE)


### PR DESCRIPTION
**Changes proposed:**

Rework encounter evade logic so that

-  If a wipe happens during a colossus stage, the colossus resets properly
-  If a wipe happens during an elemental stage, the elemental despawns and the colossus resets properly.

**Issues addressed:**

Closes #27811

**Tests performed:**

builds; tested and working in-game
