### PR TITLE
Core/Graveyards: Rework the graveyard selection logic to allow linking graveyards to areas, not just zones.

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,8 @@
+
+DELETE FROM `graveyard_zone` WHERE `ID`=709;
+INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Comment`) VALUES
+(709, 363, 'Kalimdor, Valley of Trials GY - Valleyof Trials Start'),
+(709, 364, 'Kalimdor, Valley of Trials GY - The Den'),
+(709, 365, 'Kalimdor, Valley of Trials GY - Burning Blade Coven'),
+(709, 638, 'Kalimdor, Valley of Trials GY - Hidden Path'),
+(709, 639, 'Kalimdor, Valley of Trials GY - Spirit Rock');

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,7 +1,7 @@
 
 DELETE FROM `graveyard_zone` WHERE `ID`=709;
 INSERT INTO `graveyard_zone` (`ID`, `GhostZone`, `Comment`) VALUES
-(709, 363, 'Kalimdor, Valley of Trials GY - Valleyof Trials Start'),
+(709, 363, 'Kalimdor, Valley of Trials GY - Valley of Trials Start'),
 (709, 364, 'Kalimdor, Valley of Trials GY - The Den'),
 (709, 365, 'Kalimdor, Valley of Trials GY - Burning Blade Coven'),
 (709, 638, 'Kalimdor, Valley of Trials GY - Hidden Path'),

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -6848,19 +6848,19 @@ WorldSafeLocsEntry const* ObjectMgr::GetClosestGraveyard(WorldLocation const& lo
     uint32 MapId = location.GetMapId();
 
     // search for zone associated closest graveyard
-    uint32 zoneId = sTerrainMgr.GetZoneId(conditionObject ? conditionObject->GetPhaseShift() : PhasingHandler::GetEmptyPhaseShift(), MapId, x, y, z);
+    uint32 areaId = sTerrainMgr.GetAreaId(conditionObject ? conditionObject->GetPhaseShift() : PhasingHandler::GetEmptyPhaseShift(), MapId, x, y, z);
 
-    if (!zoneId)
+    if (!areaId)
     {
         if (z > -500)
         {
-            TC_LOG_ERROR("misc", "ZoneId not found for map {} coords ({}, {}, {})", MapId, x, y, z);
+            TC_LOG_ERROR("misc", "AreaId not found for map {} coords ({}, {}, {})", MapId, x, y, z);
             return GetDefaultGraveyard(team);
         }
     }
 
-    WorldSafeLocsEntry const* graveyard = GetClosestGraveyardInZone(location, team, conditionObject, zoneId);
-    AreaTableEntry const* zoneEntry = sAreaTableStore.AssertEntry(zoneId);
+    WorldSafeLocsEntry const* graveyard = GetClosestGraveyardInZone(location, team, conditionObject, areaId);
+    AreaTableEntry const* zoneEntry = sAreaTableStore.AssertEntry(areaId);
     AreaTableEntry const* parentEntry = sAreaTableStore.LookupEntry(zoneEntry->ParentAreaID);
 
     while (!graveyard && parentEntry)


### PR DESCRIPTION
When he dies in Area: 

363 - Valley of Trials
364 - The Den
365 - Burning Blade Coven
638 - Hidden Path
639 - Spirit Rock

the player is moved to an incorrect graveyard in the Razor Hill area.  When the player enters that area, the server sends the following player location information:

```sql
ServerToClient: SMSG_INIT_WORLD_STATES (0x3701DB) Length: 56192 ConnIdx: 1 Time: 01/01/2025 22:09:17.641 Number: 1080
MapID: 1 (Kalimdor)
AreaId: 6451 (ValleyofTrials)
SubareaID: 363 (Valley of Trials)

ServerToClient: SMSG_INIT_WORLD_STATES (0x3701DB) Length: 16 ConnIdx: 1 Time: 01/01/2025 22:10:35.156 Number: 3172
MapID: 1 (Kalimdor)
AreaId: 6451 (ValleyofTrials)
SubareaID: 364 (The Den)

ServerToClient: SMSG_INIT_WORLD_STATES (0x3701DB) Length: 64 ConnIdx: 1 Time: 01/01/2025 22:14:57.876 Number: 10076
MapID: 1 (Kalimdor)
AreaId: 14 (RazorHill)
SubareaID: 638 (Hidden Path)

ServerToClient: SMSG_INIT_WORLD_STATES (0x3701DB) Length: 64 ConnIdx: 1 Time: 01/01/2025 22:15:02.395 Number: 10166
MapID: 1 (Kalimdor)
AreaId: 14 (RazorHill)
SubareaID: 639 (Spirit Rock)

ServerToClient: SMSG_INIT_WORLD_STATES (0x3701DB) Length: 64 ConnIdx: 1 Time: 01/01/2025 22:17:25.545 Number: 13726
MapID: 1 (Kalimdor)
AreaId: 14 (RazorHill)
SubareaID: 365 (Burning Blade Coven)

ServerToClient: SMSG_DEATH_RELEASE_LOC (0x37016B) Length: 16 ConnIdx: 1 Time: 01/01/2025 22:15:53.478 Number: 11436
Map Id: 1 (Kalimdor)
Position: X: -636.502 Y: -4292.55 Z: 40.3022

ServerToClient: SMSG_REQUEST_CEMETERY_LIST_RESPONSE (0x370025) Length: 25 ConnIdx: 1 Time: 01/01/2025 22:09:22.717 Number: 1534
IsTriggered: False
Count: 5
[0] CemeteryID: 709
[1] CemeteryID: 32
[2] CemeteryID: 649
[3] CemeteryID: 850
[4] CemeteryID: 1700
```

Evidently the server is looking for a cemetery in Zone: 14 - Razor Hill, instead of looking for a cemetery in Zone: 6451 - Valley of Trials. When you should search for an available cemetery by Area.

**Changes proposed:**

-  Modify graveyard search by AreaId. (AreaTable.ID)
-  Add in table `graveyard_zone`. `GhostZone` -> AreaTable.ID

**Issues addressed:**

Closes # [30565](https://github.com/TrinityCore/TrinityCore/issues/30565)


**Tests performed:**

- Does it build, tested in-game, etc.