### PR TITLE
Shared/LinkedList: Fix delink logic to handle first and last elements in linked list

### DIFF
--- a/src/server/shared/Dynamic/LinkedList.h
+++ b/src/server/shared/Dynamic/LinkedList.h
@@ -37,7 +37,7 @@ class LinkedListElement
 
         bool hasNext() const  { return (iNext && iNext->iNext != nullptr); }
         bool hasPrev() const  { return (iPrev && iPrev->iPrev != nullptr); }
-        bool isInList() const { return (iNext != nullptr && iPrev != nullptr); }
+        bool isInList() const { return (iNext != nullptr || iPrev != nullptr); }
 
         LinkedListElement      * next()       { return hasNext() ? iNext : nullptr; }
         LinkedListElement const* next() const { return hasNext() ? iNext : nullptr; }
@@ -54,8 +54,11 @@ class LinkedListElement
             if (!isInList())
                 return;
 
-            iNext->iPrev = iPrev;
-            iPrev->iNext = iNext;
+            if (iNext)
+                iNext->iPrev = iPrev;
+            if (iPrev)
+                iPrev->iNext = iNext;
+            
             iNext = nullptr;
             iPrev = nullptr;
         }


### PR DESCRIPTION
In some other fork, I saw a dangling pointer usage of the player object in the map update. I started digging into this and found this issue. 
But since this is ancient code and there have been no complaints so far, I have a feeling that I might have misunderstood something...