### PR TITLE
Core/Player: Despawn personal summons on logout and map change

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2141,6 +2141,7 @@ TempSummon* WorldObject::SummonPersonalClone(Position const& pos, TempSummonType
 
             if (Creature* thisCreature = ToCreature())
                 summon->InheritStringIds(thisCreature);
+            privateObjectOwner->AddPersonalSummon(summon->GetGUID());
             return summon;
         }
     }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1684,6 +1684,9 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         void SendQuestUpdate(uint32 questId, bool updateInteractions = true, bool updateGameObjectQuestGiverStatus = false);
         QuestGiverStatus GetQuestDialogStatus(Object const* questGiver) const;
         void SkipQuests(std::vector<uint32> const& questIds); // removes quest from log, flags rewarded, but does not give any rewards to player
+
+        void AddPersonalSummon(ObjectGuid guid);
+        void DespawnAllPersonalSummons();
         void DespawnPersonalSummonsForQuest(uint32 questId);
 
         void SetDailyQuestStatus(uint32 quest_id);
@@ -3323,6 +3326,8 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
 
         bool _usePvpItemLevels;
         ObjectGuid _areaSpiritHealerGUID;
+
+        GuidVector _personalSummonGUIDs;
 
         // Spell cast request handling
     public:


### PR DESCRIPTION
* also track personal summons in a vector

**Tests performed:**
builds, not yet tested
(Does it build, tested in-game, etc.)

EDIT:
Maybe i should merge it with certain SummonProperties flags and just assign personal summons those flags

TODO:
- [ ] Remove summon from list on RemoveFromWorld
