### PR TITLE
Core/Creature: implement initial SummonInfo API class 

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -49,6 +49,7 @@
 #include "Spell.h"
 #include "SpellAuraEffects.h"
 #include "SpellMgr.h"
+#include "SummonInfo.h"
 #include "TemporarySummon.h"
 #include "Vehicle.h"
 #include "World.h"
@@ -3606,6 +3607,21 @@ void Creature::InitializeInteractSpellId()
         SetInteractSpellId(clickBounds.begin()->second.spellId);
     else
         SetInteractSpellId(0);
+}
+
+void Creature::InitializeSummonInfo()
+{
+    _summonInfo = std::make_unique<SummonInfo>(this);
+}
+
+SummonInfo* Creature::GetSummonInfo() const
+{
+    return _summonInfo.get();
+}
+
+bool Creature::IsSummon() const
+{
+    return _summonInfo != nullptr;
 }
 
 void Creature::BuildValuesCreate(ByteBuffer* data, UF::UpdateFieldFlag flags, Player const* target) const

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -355,6 +355,11 @@ void Creature::AddToWorld()
         if (IsVehicle())
             GetVehicleKit()->Install();
 
+        // If the creature has been summoned, register it for the summoner
+        if (IsSummon())
+            if (Unit* summoner = GetSummonInfo()->GetUnitSummoner())
+                summoner->RegisterSummon(GetSummonInfo());
+
         if (GetZoneScript())
             GetZoneScript()->OnCreatureCreate(this);
     }
@@ -364,6 +369,11 @@ void Creature::RemoveFromWorld()
 {
     if (IsInWorld())
     {
+        // If the creature about to despawn, unregister it for the summoner
+        if (IsSummon())
+            if (Unit* summoner = GetSummonInfo()->GetUnitSummoner())
+                summoner->UnregisterSummon(GetSummonInfo());
+
         if (GetZoneScript())
             GetZoneScript()->OnCreatureRemove(this);
 
@@ -3609,10 +3619,10 @@ void Creature::InitializeInteractSpellId()
         SetInteractSpellId(0);
 }
 
-void Creature::InitializeSummonInfo()
+void Creature::InitializeSummonInfo(SummonInfoArgs const& args)
 {
     ASSERT(_summonInfo == nullptr, "SummonInfo has already been initialized and must not be allocated again!");
-    _summonInfo = std::make_unique<SummonInfo>(this);
+    _summonInfo = std::make_unique<SummonInfo>(this, args);
 }
 
 SummonInfo* Creature::GetSummonInfo() const

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3611,6 +3611,7 @@ void Creature::InitializeInteractSpellId()
 
 void Creature::InitializeSummonInfo()
 {
+    ASSERT(_summonInfo == nullptr, "SummonInfo has already been initialized and must not be allocated again!");
     _summonInfo = std::make_unique<SummonInfo>(this);
 }
 

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -32,6 +32,7 @@ class CreatureGroup;
 class Quest;
 class Player;
 class SpellInfo;
+class SummonInfo;
 class WorldSession;
 struct Loot;
 
@@ -463,6 +464,13 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void InitializeInteractSpellId();
         void SetInteractSpellId(int32 interactSpellId) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::InteractSpellID), interactSpellId); }
 
+        // Initializes the summon API for this creature which marks it as summon and will be treated accordingly
+        void InitializeSummonInfo();
+        // Returns a pointer to the SummonInfo API, nullptr if the creature is not a summon
+        SummonInfo* GetSummonInfo() const;
+
+        bool IsSummon() const override;
+
     protected:
         void BuildValuesCreate(ByteBuffer* data, UF::UpdateFieldFlag flags, Player const* target) const override;
         void BuildValuesUpdate(ByteBuffer* data, UF::UpdateFieldFlag flags, Player const* target) const override;
@@ -579,6 +587,9 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 _gossipMenuId;
         Optional<uint32> _trainerId;
         float _sparringHealthPct;
+
+        // The Summon API which controls the behavior of summons
+        std::unique_ptr<SummonInfo> _summonInfo;
 };
 
 class TC_GAME_API AssistDelayEvent : public BasicEvent

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -35,6 +35,7 @@ class SpellInfo;
 class SummonInfo;
 class WorldSession;
 struct Loot;
+struct SummonInfoArgs;
 
 enum MovementGeneratorType : uint8;
 
@@ -465,7 +466,7 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void SetInteractSpellId(int32 interactSpellId) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::InteractSpellID), interactSpellId); }
 
         // Initializes the summon API for this creature which marks it as summon and will be treated accordingly
-        void InitializeSummonInfo();
+        void InitializeSummonInfo(SummonInfoArgs const& args);
         // Returns a pointer to the SummonInfo API, nullptr if the creature is not a summon
         SummonInfo* GetSummonInfo() const;
 

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "SummonInfo.h"
+
+SummonInfo::SummonInfo(Creature* summonedCreature) : _summonedCreature(summonedCreature)
+{
+}

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -16,12 +16,85 @@
  */
 
 #include "SummonInfo.h"
+#include "DB2Store.h"
+#include "ObjectAccessor.h"
+#include "SummonInfoArgs.h"
 
-SummonInfo::SummonInfo(Creature* summonedCreature) : _summonedCreature(summonedCreature)
+SummonInfo::SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args) : _summonedCreature(summonedCreature)
 {
+    _remainingDuration = args.Duration;
+    _summonerGUID = args.SummonerGUID;
+
+    SummonPropertiesEntry const* summonProperties = nullptr;
+    if (args.SummonPropertiesID.has_value())
+        summonProperties = sSummonPropertiesStore.LookupEntry(*args.SummonPropertiesID);
+
+    if (summonProperties)
+    {
+        _shouldDespawnOnSummonerLogout = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerLogout);
+        _shouldDespawnOnSummonerDeath = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerDeath);
+        _shouldDespawnWhenExpired = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnWhenExpired);
+    }
+    else
+    {
+        _shouldDespawnWhenExpired = false;
+        _shouldDespawnOnSummonerLogout = false;
+        _shouldDespawnOnSummonerDeath = false;
+    }
 }
 
 Creature* SummonInfo::GetSummonedCreature() const
 {
     return _summonedCreature;
+}
+
+Optional<Milliseconds> SummonInfo::GetRemainingDuration() const
+{
+    return _remainingDuration;
+}
+
+Unit* SummonInfo::GetUnitSummoner() const
+{
+    if (!_summonerGUID.has_value())
+        return nullptr;
+
+    return ObjectAccessor::GetUnit(*_summonedCreature, *_summonerGUID);
+}
+
+GameObject* SummonInfo::GetGameObjectSummoner() const
+{
+    if (!_summonerGUID.has_value())
+        return nullptr;
+
+    return ObjectAccessor::GetGameObject(*_summonedCreature, *_summonerGUID);
+}
+
+bool SummonInfo::ShouldDespawnOnSummonerLogout() const
+{
+    return _shouldDespawnOnSummonerLogout;
+}
+
+void SummonInfo::SetShouldDespawnOnSummonerLogout(bool set)
+{
+    _shouldDespawnOnSummonerLogout = set;
+}
+
+bool SummonInfo::ShouldDespawnOnSummonerDeath() const
+{
+    return _shouldDespawnOnSummonerDeath;
+}
+
+void SummonInfo::SetShouldDespawnOnSummonerDeath(bool set)
+{
+    _shouldDespawnOnSummonerDeath = set;
+}
+
+bool SummonInfo::ShouldDespawnWhenExpired() const
+{
+    return _shouldDespawnWhenExpired;
+}
+
+void SummonInfo::SetShouldDespawnWhenExpired(bool set)
+{
+    _shouldDespawnWhenExpired = set;
 }

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -20,3 +20,8 @@
 SummonInfo::SummonInfo(Creature* summonedCreature) : _summonedCreature(summonedCreature)
 {
 }
+
+Creature* SummonInfo::GetSummonedCreature() const
+{
+    return _summonedCreature;
+}

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -19,8 +19,15 @@
 #define _SummonInfo_h__
 
 #include "Define.h"
+#include "Duration.h"
+#include "ObjectGuid.h"
+#include "Optional.h"
 
 class Creature;
+class GameObject;
+class Unit;
+
+struct SummonInfoArgs;
 
 class TC_GAME_API SummonInfo
 {
@@ -30,13 +37,37 @@ public:
     SummonInfo& operator=(SummonInfo const& right) = delete;
     SummonInfo& operator=(SummonInfo&& right) = delete;
 
-    SummonInfo(Creature* summonedCreature);
+    SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
 
     // Returns the creature that is tied to this SummonInfo instance
     Creature* GetSummonedCreature() const;
+    // Returns the remaining time until the summon expires. Nullopt when no duration was set which implies that the summon is permanent.
+    Optional<Milliseconds> GetRemainingDuration() const;
+    // Returns the Unit summoner, or nullptr if no summoner has been provided or if the summoner is not a Unit
+    Unit* GetUnitSummoner() const;
+    // Returns the GameObject summoner, or nullptr if no summoner has been provided or if the summoner is not a GameObject
+    GameObject* GetGameObjectSummoner() const;
+
+    // Returns true when the summon will despawn when the summoner logs out. This also includes despawning and teleporting between map instances.
+    bool ShouldDespawnOnSummonerLogout() const;
+    // Marks the summon to despawn when the summoner logs out. This also includes despawning and teleporting between map instaces.
+    void SetShouldDespawnOnSummonerLogout(bool set);
+    // Returns true when the summon will despawn when its summoner has died.
+    bool ShouldDespawnOnSummonerDeath() const;
+    // Marks the summon to despawn when the summoner has died.
+    void SetShouldDespawnOnSummonerDeath(bool set);
+    // Returns true when the summon will despawn after its duration has expired. If not set, the summon will just die.
+    bool ShouldDespawnWhenExpired() const;
+    // Marks the summon to despawn after its duration has expired. If disabled, the summon will just die.
+    void SetShouldDespawnWhenExpired(bool set);
 
 private:
     Creature* _summonedCreature;
+    Optional<Milliseconds> _remainingDuration; // NYI
+    Optional<ObjectGuid> _summonerGUID;
+    bool _shouldDespawnOnSummonerLogout; // NYI
+    bool _shouldDespawnOnSummonerDeath;  // NYI
+    bool _shouldDespawnWhenExpired;      // NYI
 };
 
 #endif

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SummonInfo_h__
+#define _SummonInfo_h__
+
+#include "Define.h"
+
+class Creature;
+
+class TC_GAME_API SummonInfo
+{
+public:
+    SummonInfo(SummonInfo const& right) = delete;
+    SummonInfo(SummonInfo&& right) = delete;
+    SummonInfo& operator=(SummonInfo const& right) = delete;
+    SummonInfo& operator=(SummonInfo&& right) = delete;
+
+    SummonInfo(Creature* summonedCreature);
+
+private:
+    Creature* _summonedCreature;
+};
+
+#endif

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -37,7 +37,7 @@ public:
     SummonInfo& operator=(SummonInfo const& right) = delete;
     SummonInfo& operator=(SummonInfo&& right) = delete;
 
-    SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
+    explicit SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
 
     // Returns the creature that is tied to this SummonInfo instance
     Creature* GetSummonedCreature() const;

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -32,6 +32,9 @@ public:
 
     SummonInfo(Creature* summonedCreature);
 
+    // Returns the creature that is tied to this SummonInfo instance
+    Creature* GetSummonedCreature() const;
+
 private:
     Creature* _summonedCreature;
 };

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
@@ -25,7 +25,7 @@
 
 struct SummonPropertiesEntry;
 
-struct TC_GAME_API SummonInfoArgs
+struct SummonInfoArgs
 {
     Optional<ObjectGuid> SummonerGUID;
     Optional<uint32> SummonPropertiesID;

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SummonInfoArgs_h__
+#define _SummonInfoArgs_h__
+
+#include "define.h"
+#include "Duration.h"
+#include "Optional.h"
+#include "ObjectGuid.h"
+
+struct SummonPropertiesEntry;
+
+struct TC_GAME_API SummonInfoArgs
+{
+    Optional<ObjectGuid> SummonerGUID;
+    Optional<uint32> SummonPropertiesID;
+    Optional<uint64> MaxHealth;
+    Optional<Milliseconds> Duration;
+};
+
+#endif // _SummonInfoArgs_h__

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -47,6 +47,7 @@
 #include "SpellMgr.h"
 #include "SpellPackets.h"
 #include "StringConvert.h"
+#include "SummonInfoArgs.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -1958,8 +1959,17 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
         return nullptr;
     }
 
+    // Store special settings which have been extracted from spell effects/scripts
+    SummonInfoArgs args;
+    if (summoner)
+        args.SummonerGUID = summoner->GetGUID();
+    if (properties)
+        args.SummonPropertiesID = properties->ID;
+    if (duration > 0ms)
+        args.Duration = duration;
+
     // Initialize the SummonInfo API which marks the creature as Summon
-    summon->InitializeSummonInfo();
+    summon->InitializeSummonInfo(args);
 
     TransportBase* transport = summoner ? summoner->GetTransport() : nullptr;
     if (transport)

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1958,6 +1958,9 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
         return nullptr;
     }
 
+    // Initialize the SummonInfo API which marks the creature as Summon
+    summon->InitializeSummonInfo();
+
     TransportBase* transport = summoner ? summoner->GetTransport() : nullptr;
     if (transport)
     {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -116,6 +116,7 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellPackets.h"
+#include "SummonInfoArgs.h"
 #include "StringConvert.h"
 #include "TalentGroupInfo.h"
 #include "TalentPackets.h"
@@ -27392,6 +27393,8 @@ Pet* Player::SummonPet(uint32 entry, Optional<PetSaveMode> slot, float x, float 
     pet->SetPetNameTimestamp(uint32(GameTime::GetGameTime()));
 
     map->AddToMap(pet->ToCreature());
+
+    pet->InitializeSummonInfo({ .SummonerGUID = GetGUID() });
 
     ASSERT(!petStable.CurrentPetIndex);
     petStable.SetCurrentUnslottedPetIndex(petStable.UnslottedPets.size());

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -79,6 +79,7 @@
 #include "SpellMgr.h"
 #include "SpellPackets.h"
 #include "StringConvert.h"
+#include "SummonInfo.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -9143,6 +9144,17 @@ uint32 Unit::GetCreatureTypeMask() const
     return (creatureType >= 1) ? (1 << (creatureType - 1)) : 0;
 }
 
+void Unit::RegisterSummon(SummonInfo* summon)
+{
+    if (std::find(_activeSummons.begin(), _activeSummons.end(), summon) != _activeSummons.end())
+        _activeSummons.push_back(summon);
+}
+
+void Unit::UnregisterSummon(SummonInfo* summon)
+{
+    std::erase_if(_activeSummons, [summon](SummonInfo const* activeSummon) { return activeSummon == summon; });
+}
+
 void Unit::SetShapeshiftForm(ShapeshiftForm form)
 {
     SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::ShapeshiftForm), form);
@@ -9922,6 +9934,9 @@ void Unit::RemoveFromWorld()
                 ABORT();
             }
         }
+
+        // Clear all active summon references. If we are about to switch map instances, we want to make sure that we leave all summons behind so we won't do threadunsafe operations
+        _activeSummons.clear();
 
         WorldObject::RemoveFromWorld();
         m_duringRemoveFromWorld = false;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -80,6 +80,7 @@
 #include "SpellPackets.h"
 #include "StringConvert.h"
 #include "SummonInfo.h"
+#include "SummonInfoArgs.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -9146,13 +9147,19 @@ uint32 Unit::GetCreatureTypeMask() const
 
 void Unit::RegisterSummon(SummonInfo* summon)
 {
-    if (std::find(_activeSummons.begin(), _activeSummons.end(), summon) != _activeSummons.end())
+    if (!summon)
+        return;
+
+    if (!advstd::ranges::contains(_activeSummons, summon))
         _activeSummons.push_back(summon);
 }
 
 void Unit::UnregisterSummon(SummonInfo* summon)
 {
-    std::erase_if(_activeSummons, [summon](SummonInfo const* activeSummon) { return activeSummon == summon; });
+    if (!summon)
+        return;
+
+    std::erase(_activeSummons, summon);
 }
 
 void Unit::SetShapeshiftForm(ShapeshiftForm form)
@@ -10755,6 +10762,8 @@ Pet* Unit::CreateTamedPetFrom(Creature* creatureTarget, uint32 spell_id)
         return nullptr;
     }
 
+    pet->InitializeSummonInfo({ .SummonerGUID = GetGUID() });
+
     uint8 level = creatureTarget->GetLevelForTarget(this) + 5 < GetLevel() ? (GetLevel() - 5) : creatureTarget->GetLevelForTarget(this);
 
     if (!InitTamedPet(pet, level, spell_id))
@@ -10782,6 +10791,8 @@ Pet* Unit::CreateTamedPetFrom(uint32 creatureEntry, uint32 spell_id)
         delete pet;
         return nullptr;
     }
+
+    pet->InitializeSummonInfo({ .SummonerGUID = GetGUID() });
 
     return pet;
 }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -742,7 +742,7 @@ class TC_GAME_API Unit : public WorldObject
 
         uint32 HasUnitTypeMask(uint32 mask) const { return mask & m_unitTypeMask; }
         void AddUnitTypeMask(uint32 mask) { m_unitTypeMask |= mask; }
-        bool IsSummon() const   { return (m_unitTypeMask & UNIT_MASK_SUMMON) != 0; }
+        virtual bool IsSummon() const { return false; }
         bool IsGuardian() const { return (m_unitTypeMask & UNIT_MASK_GUARDIAN) != 0; }
         bool IsPet() const      { return (m_unitTypeMask & UNIT_MASK_PET) != 0; }
         bool IsHunterPet() const{ return (m_unitTypeMask & UNIT_MASK_HUNTER_PET) != 0; }

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -87,6 +87,7 @@ class SpellCastTargets;
 class SpellEffectInfo;
 class SpellHistory;
 class SpellInfo;
+class SummonInfo;
 class Totem;
 class Transport;
 class TransportBase;
@@ -1467,6 +1468,12 @@ class TC_GAME_API Unit : public WorldObject
 
         std::array<ObjectGuid, MAX_SUMMON_SLOT> m_SummonSlot;
         std::array<ObjectGuid, MAX_GAMEOBJECT_SLOT> m_ObjectSlot;
+
+        std::vector<SummonInfo*> _activeSummons;
+        // Registers the SummonInfo API of a summoned creature to allow accessing it to allow safe accessing
+        void RegisterSummon(SummonInfo* summon);
+        // Unregisters the SummonInfo API of a summoned creature so it can no longer be accessed
+        void UnregisterSummon(SummonInfo* summon);
 
         ShapeshiftForm GetShapeshiftForm() const { return ShapeshiftForm(*m_unitData->ShapeshiftForm); }
         void SetShapeshiftForm(ShapeshiftForm form);


### PR DESCRIPTION
 This new class will be the new centralized API for summon behavior. The plan is to eventually migrate/correct/fix the entire summons implementation over into that API to have it nicely organized and refactored in a way that it fixes fundamental design issues, such as taming hunter pets being unable to get converted from open world spawns.

The approach will be to migrate functions over one by one to avoid large regressions or creating new issues.

**Changes proposed:**

-  Added SummonInfo class and handle its initialization
-  Changed the Unit::IsSummon helper to check for an existing SummonInfo ptr instead of relying on unit_masks (which will get removed eventually as well)

**Tests performed:**
- tested ingame, no behavior changes observed
