### PR TITLE
Core/Creature: implement initial SummonInfo API for handling summons in the future

### DIFF
--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -32,8 +32,10 @@ class CreatureGroup;
 class Quest;
 class Player;
 class SpellInfo;
+class SummonInfo;
 class WorldSession;
 struct Loot;
+struct SummonInfoArgs;
 
 enum MovementGeneratorType : uint8;
 
@@ -463,6 +465,13 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void InitializeInteractSpellId();
         void SetInteractSpellId(int32 interactSpellId) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::InteractSpellID), interactSpellId); }
 
+        // Initializes the summon API for this creature which marks it as summon and will be treated accordingly
+        void InitializeSummonInfo(SummonInfoArgs const& args);
+        // Returns a pointer to the SummonInfo API, nullptr if the creature is not a summon
+        SummonInfo* GetSummonInfo() const;
+
+        bool IsSummon() const override;
+
     protected:
         void BuildValuesCreate(ByteBuffer* data, UF::UpdateFieldFlag flags, Player const* target) const override;
         void BuildValuesUpdate(ByteBuffer* data, UF::UpdateFieldFlag flags, Player const* target) const override;
@@ -579,6 +588,9 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 _gossipMenuId;
         Optional<uint32> _trainerId;
         float _sparringHealthPct;
+
+        // The Summon API which controls the behavior of summons
+        std::unique_ptr<SummonInfo> _summonInfo;
 };
 
 class TC_GAME_API AssistDelayEvent : public BasicEvent

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -23,8 +23,8 @@
 #include "SummonInfoArgs.h"
 
 SummonInfo::SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args) :
-    _summonedCreature(ASSERT_NOTNULL(summonedCreature)), _despawnOnSummonerLogout(false), _despawnOnSummonerDeath(false), _despawnWhenExpired(false),
-    _summonerGUID(args.SummonerGUID), _remainingDuration(args.Duration), _maxHealth(args.MaxHealth), _summonSpellId(args.SummonSpellId)
+    _summonedCreature(ASSERT_NOTNULL(summonedCreature)), _summonerGUID(args.SummonerGUID), _remainingDuration(args.Duration), _maxHealth(args.MaxHealth), _summonSpellId(args.SummonSpellId),
+    _despawnOnSummonerLogout(false), _despawnOnSummonerDeath(false), _despawnWhenExpired(false)
 {
     if (args.SummonPropertiesId.has_value())
         InitializeSummonProperties(*args.SummonPropertiesId);

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -30,18 +30,23 @@ SummonInfo::SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args) :
 
 void SummonInfo::InitializeSummonSettings(SummonInfoArgs const& args)
 {
-    _remainingDuration = args.Duration;
     _summonerGUID = args.SummonerGUID;
+    _maxHealth = args.MaxHealth;
+    _remainingDuration = args.Duration;
+    _summonSpellId = args.SummonSpellId;
 
-    if (!args.SummonPropertiesID.has_value())
+    if (!args.SummonPropertiesId.has_value())
         return;
 
-    SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(*args.SummonPropertiesID);
+    SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(*args.SummonPropertiesId);
     if (!summonProperties)
     {
-        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID().ToString(), *args.SummonPropertiesID);
+        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID().ToString(), *args.SummonPropertiesId);
         return;
     }
+
+    if (summonProperties->Faction)
+        _factionId = summonProperties->Faction;
 
     _despawnOnSummonerLogout = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerLogout);
     _despawnOnSummonerDeath = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerDeath);
@@ -54,11 +59,6 @@ void SummonInfo::InitializeSummonSettings(SummonInfoArgs const& args)
 Creature* SummonInfo::GetSummonedCreature() const
 {
     return _summonedCreature;
-}
-
-Optional<Milliseconds> SummonInfo::GetRemainingDuration() const
-{
-    return _remainingDuration;
 }
 
 Unit* SummonInfo::GetUnitSummoner() const
@@ -75,6 +75,26 @@ GameObject* SummonInfo::GetGameObjectSummoner() const
         return nullptr;
 
     return ObjectAccessor::GetGameObject(*_summonedCreature, *_summonerGUID);
+}
+
+Optional<Milliseconds> SummonInfo::GetRemainingDuration() const
+{
+    return _remainingDuration;
+}
+
+Optional<uint64> SummonInfo::GetMaxHealth() const
+{
+    return _maxHealth;
+}
+
+Optional<uint32> SummonInfo::GetSummonSpellId() const
+{
+    return _summonSpellId;
+}
+
+Optional<uint32> SummonInfo::GetFactionId() const
+{
+    return _factionId;
 }
 
 bool SummonInfo::DespawnsOnSummonerLogout() const

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "SummonInfo.h"
+#include "Creature.h"
+#include "DB2Stores.h"
+#include "Log.h"
+#include "ObjectAccessor.h"
+#include "SummonInfoArgs.h"
+
+SummonInfo::SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args) :
+    _summonedCreature(ASSERT_NOTNULL(summonedCreature)), _despawnOnSummonerLogout(false), _despawnOnSummonerDeath(false), _despawnWhenExpired(false)
+{
+    InitializeSummonSettings(args);
+}
+
+void SummonInfo::InitializeSummonSettings(SummonInfoArgs const& args)
+{
+    _remainingDuration = args.Duration;
+    _summonerGUID = args.SummonerGUID;
+
+    if (!args.SummonPropertiesID.has_value())
+        return;
+
+    SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(*args.SummonPropertiesID);
+    if (!summonProperties)
+    {
+        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID().ToString(), *args.SummonPropertiesID);
+        return;
+    }
+
+    _despawnOnSummonerLogout = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerLogout);
+    _despawnOnSummonerDeath = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerDeath);
+    _despawnWhenExpired = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnWhenExpired);
+
+    if (_despawnOnSummonerDeath && summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DontDespawnOnSummonerDeath))
+        _despawnOnSummonerDeath = false;
+}
+
+Creature* SummonInfo::GetSummonedCreature() const
+{
+    return _summonedCreature;
+}
+
+Optional<Milliseconds> SummonInfo::GetRemainingDuration() const
+{
+    return _remainingDuration;
+}
+
+Unit* SummonInfo::GetUnitSummoner() const
+{
+    if (!_summonerGUID.has_value())
+        return nullptr;
+
+    return ObjectAccessor::GetUnit(*_summonedCreature, *_summonerGUID);
+}
+
+GameObject* SummonInfo::GetGameObjectSummoner() const
+{
+    if (!_summonerGUID.has_value())
+        return nullptr;
+
+    return ObjectAccessor::GetGameObject(*_summonedCreature, *_summonerGUID);
+}
+
+bool SummonInfo::DespawnsOnSummonerLogout() const
+{
+    return _despawnOnSummonerLogout;
+}
+
+void SummonInfo::SetDespawnOnSummonerLogout(bool set)
+{
+    _despawnOnSummonerLogout = set;
+}
+
+bool SummonInfo::DespawnsOnSummonerDeath() const
+{
+    return _despawnOnSummonerDeath;
+}
+
+void SummonInfo::SetDespawnOnSummonerDeath(bool set)
+{
+    _despawnOnSummonerDeath = set;
+}
+
+bool SummonInfo::DespawnsWhenExpired() const
+{
+    return _despawnWhenExpired;
+}
+
+void SummonInfo::SetDespawnWhenExpired(bool set)
+{
+    _despawnWhenExpired = set;
+}

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -23,25 +23,19 @@
 #include "SummonInfoArgs.h"
 
 SummonInfo::SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args) :
-    _summonedCreature(ASSERT_NOTNULL(summonedCreature)), _despawnOnSummonerLogout(false), _despawnOnSummonerDeath(false), _despawnWhenExpired(false)
+    _summonedCreature(ASSERT_NOTNULL(summonedCreature)), _despawnOnSummonerLogout(false), _despawnOnSummonerDeath(false), _despawnWhenExpired(false),
+    _summonerGUID(args.SummonerGUID), _remainingDuration(args.Duration), _maxHealth(args.MaxHealth), _summonSpellId(args.SummonSpellId)
 {
-    InitializeSummonSettings(args);
+    if (args.SummonPropertiesId.has_value())
+        InitializeSummonProperties(*args.SummonPropertiesId);
 }
 
-void SummonInfo::InitializeSummonSettings(SummonInfoArgs const& args)
+void SummonInfo::InitializeSummonProperties(uint32 summonPropertiesId)
 {
-    _summonerGUID = args.SummonerGUID;
-    _maxHealth = args.MaxHealth;
-    _remainingDuration = args.Duration;
-    _summonSpellId = args.SummonSpellId;
-
-    if (!args.SummonPropertiesId.has_value())
-        return;
-
-    SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(*args.SummonPropertiesId);
+    SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(summonPropertiesId);
     if (!summonProperties)
     {
-        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID().ToString(), *args.SummonPropertiesId);
+        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID().ToString(), summonPropertiesId);
         return;
     }
 

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -35,7 +35,7 @@ void SummonInfo::InitializeSummonProperties(uint32 summonPropertiesId)
     SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(summonPropertiesId);
     if (!summonProperties)
     {
-        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID().ToString(), summonPropertiesId);
+        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID(), summonPropertiesId);
         return;
     }
 

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -39,16 +39,23 @@ public:
 
     explicit SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
 
-    // Initializes the default settings with the provided SummonInfoArgs
+    // Initializes the default settings with the provided SummonInfoArgs.
     void InitializeSummonSettings(SummonInfoArgs const& args);
-    // Returns the creature that is tied to this SummonInfo instance
+    // Returns the creature that is tied to this SummonInfo instance.
     Creature* GetSummonedCreature() const;
+    // Returns the Unit summoner, or nullptr if no summoner has been provided or if the summoner is not a Unit.
+    Unit* GetUnitSummoner() const;
+    // Returns the GameObject summoner, or nullptr if no summoner has been provided or if the summoner is not a GameObject.
+    GameObject* GetGameObjectSummoner() const;
+
     // Returns the remaining time until the summon expires. Nullopt when no duration was set which implies that the summon is permanent.
     Optional<Milliseconds> GetRemainingDuration() const;
-    // Returns the Unit summoner, or nullptr if no summoner has been provided or if the summoner is not a Unit
-    Unit* GetUnitSummoner() const;
-    // Returns the GameObject summoner, or nullptr if no summoner has been provided or if the summoner is not a GameObject
-    GameObject* GetGameObjectSummoner() const;
+    // Returns the health amount that will override the default max health calculation. Nullopt when no amount is provided.
+    Optional<uint64> GetMaxHealth() const;
+    // Returns the ID of the spell that has been used to summon the creature. Nullopt when the creature has not been summoned by a spell (scripted summons/ other APIs).
+    Optional<uint32> GetSummonSpellId() const;
+    // Returns the FactionTemplate ID of the summon that is overriding the default ID of the creature. Nullopt when the faction has not been overriden.
+    Optional<uint32> GetFactionId() const;
 
     // Returns true when the summon will despawn when the summoner logs out. This also includes despawning and teleporting between map instances.
     bool DespawnsOnSummonerLogout() const;
@@ -67,6 +74,9 @@ private:
     Creature* _summonedCreature;
     Optional<ObjectGuid> _summonerGUID;
     Optional<Milliseconds> _remainingDuration;  // NYI
+    Optional<uint64> _maxHealth;                // NYI
+    Optional<uint32> _summonSpellId;            // NYI
+    Optional<uint32> _factionId;                // NYI
     bool _despawnOnSummonerLogout;              // NYI
     bool _despawnOnSummonerDeath;               // NYI
     bool _despawnWhenExpired;                   // NYI

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SummonInfo_h__
+#define _SummonInfo_h__
+
+#include "Define.h"
+#include "Duration.h"
+#include "ObjectGuid.h"
+#include "Optional.h"
+
+class Creature;
+class GameObject;
+class Unit;
+
+struct SummonInfoArgs;
+
+class TC_GAME_API SummonInfo
+{
+public:
+    SummonInfo(SummonInfo const& right) = delete;
+    SummonInfo(SummonInfo&& right) = delete;
+    SummonInfo& operator=(SummonInfo const& right) = delete;
+    SummonInfo& operator=(SummonInfo&& right) = delete;
+
+    explicit SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
+
+    // Initializes the default settings with the provided SummonInfoArgs
+    void InitializeSummonSettings(SummonInfoArgs const& args);
+    // Returns the creature that is tied to this SummonInfo instance
+    Creature* GetSummonedCreature() const;
+    // Returns the remaining time until the summon expires. Nullopt when no duration was set which implies that the summon is permanent.
+    Optional<Milliseconds> GetRemainingDuration() const;
+    // Returns the Unit summoner, or nullptr if no summoner has been provided or if the summoner is not a Unit
+    Unit* GetUnitSummoner() const;
+    // Returns the GameObject summoner, or nullptr if no summoner has been provided or if the summoner is not a GameObject
+    GameObject* GetGameObjectSummoner() const;
+
+    // Returns true when the summon will despawn when the summoner logs out. This also includes despawning and teleporting between map instances.
+    bool DespawnsOnSummonerLogout() const;
+    // Marks the summon to despawn when the summoner logs out. This also includes despawning and teleporting between map instaces.
+    void SetDespawnOnSummonerLogout(bool set);
+    // Returns true when the summon will despawn when its summoner has died.
+    bool DespawnsOnSummonerDeath() const;
+    // Marks the summon to despawn when the summoner has died.
+    void SetDespawnOnSummonerDeath(bool set);
+    // Returns true when the summon will despawn after its duration has expired. If not set, the summon will just die.
+    bool DespawnsWhenExpired() const;
+    // Marks the summon to despawn after its duration has expired. If disabled, the summon will just die.
+    void SetDespawnWhenExpired(bool set);
+
+private:
+    Creature* _summonedCreature;
+    Optional<ObjectGuid> _summonerGUID;
+    Optional<Milliseconds> _remainingDuration;  // NYI
+    bool _despawnOnSummonerLogout;              // NYI
+    bool _despawnOnSummonerDeath;               // NYI
+    bool _despawnWhenExpired;                   // NYI
+};
+
+#endif

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -39,8 +39,8 @@ public:
 
     explicit SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
 
-    // Initializes the default settings with the provided SummonInfoArgs.
-    void InitializeSummonSettings(SummonInfoArgs const& args);
+    // Initializes additional settings based on the provided SummonProperties ID.
+    void InitializeSummonProperties(uint32 summonPropertiesId);
     // Returns the creature that is tied to this SummonInfo instance.
     Creature* GetSummonedCreature() const;
     // Returns the Unit summoner, or nullptr if no summoner has been provided or if the summoner is not a Unit.

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
@@ -23,8 +23,6 @@
 #include "Optional.h"
 #include "ObjectGuid.h"
 
-struct SummonPropertiesEntry;
-
 // Controls the behavior of a summoned creature and must be set with extreme care. If you want a blank summon that just exists as a permanent spawn, leave all fields untouched.
 struct SummonInfoArgs
 {

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
@@ -25,13 +25,14 @@
 
 struct SummonPropertiesEntry;
 
-// Controls the behavior of a summoned creature and must be set with extreme care. If you want a blank summon that just exists as a permanent spawn, leave all fields untouched
+// Controls the behavior of a summoned creature and must be set with extreme care. If you want a blank summon that just exists as a permanent spawn, leave all fields untouched.
 struct SummonInfoArgs
 {
     Optional<ObjectGuid> SummonerGUID;
     Optional<uint64> MaxHealth;
     Optional<Milliseconds> Duration;
-    Optional<uint32> SummonPropertiesID;
+    Optional<uint32> SummonPropertiesId;
+    Optional<uint32> SummonSpellId;
 };
 
 #endif // _SummonInfoArgs_h__

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SummonInfoArgs_h__
+#define _SummonInfoArgs_h__
+
+#include "Define.h"
+#include "Duration.h"
+#include "Optional.h"
+#include "ObjectGuid.h"
+
+struct SummonPropertiesEntry;
+
+// Controls the behavior of a summoned creature and must be set with extreme care. If you want a blank summon that just exists as a permanent spawn, leave all fields untouched
+struct SummonInfoArgs
+{
+    Optional<ObjectGuid> SummonerGUID;
+    Optional<uint64> MaxHealth;
+    Optional<Milliseconds> Duration;
+    Optional<uint32> SummonPropertiesID;
+};
+
+#endif // _SummonInfoArgs_h__

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -47,6 +47,7 @@
 #include "SpellMgr.h"
 #include "SpellPackets.h"
 #include "StringConvert.h"
+#include "SummonInfoArgs.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -1957,6 +1958,18 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
         delete summon;
         return nullptr;
     }
+
+    // Store special settings which have been extracted from spell effects/scripts
+    SummonInfoArgs args;
+    if (summoner)
+        args.SummonerGUID = summoner->GetGUID();
+    if (properties)
+        args.SummonPropertiesID = properties->ID;
+    if (duration > 0ms)
+        args.Duration = duration;
+
+    // Initialize the SummonInfo API which marks the creature as Summon
+    summon->InitializeSummonInfo(args);
 
     TransportBase* transport = summoner ? summoner->GetTransport() : nullptr;
     if (transport)

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -1964,9 +1964,11 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
     if (summoner)
         args.SummonerGUID = summoner->GetGUID();
     if (properties)
-        args.SummonPropertiesID = properties->ID;
+        args.SummonPropertiesId = properties->ID;
     if (duration > 0ms)
         args.Duration = duration;
+    if (spellId)
+        args.SummonSpellId = spellId;
 
     // Initialize the SummonInfo API which marks the creature as Summon
     summon->InitializeSummonInfo(args);

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -52,7 +52,7 @@ Pet::Pet(Player* owner, PetType type) :
 {
     ASSERT(GetOwner());
 
-    InitializeSummonInfo({ .SummonerGUID = GetOwner()->GetGUID()});
+    InitializeSummonInfo({ .SummonerGUID = GetOwner()->GetGUID() });
 
     m_unitTypeMask |= UNIT_MASK_PET;
     if (type == HUNTER_PET)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -116,7 +116,6 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellPackets.h"
-#include "SummonInfoArgs.h"
 #include "StringConvert.h"
 #include "TalentGroupInfo.h"
 #include "TalentPackets.h"

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -116,6 +116,7 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellPackets.h"
+#include "SummonInfoArgs.h"
 #include "StringConvert.h"
 #include "TalentGroupInfo.h"
 #include "TalentPackets.h"

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -80,7 +80,6 @@
 #include "SpellPackets.h"
 #include "StringConvert.h"
 #include "SummonInfo.h"
-#include "SummonInfoArgs.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -79,6 +79,8 @@
 #include "SpellMgr.h"
 #include "SpellPackets.h"
 #include "StringConvert.h"
+#include "SummonInfo.h"
+#include "SummonInfoArgs.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -9143,6 +9145,23 @@ uint32 Unit::GetCreatureTypeMask() const
     return (creatureType >= 1) ? (1 << (creatureType - 1)) : 0;
 }
 
+void Unit::RegisterSummon(SummonInfo* summon)
+{
+    if (!summon)
+        return;
+
+    if (!advstd::ranges::contains(_activeSummons, summon))
+        _activeSummons.push_back(summon);
+}
+
+void Unit::UnregisterSummon(SummonInfo* summon)
+{
+    if (!summon)
+        return;
+
+    std::erase(_activeSummons, summon);
+}
+
 void Unit::SetShapeshiftForm(ShapeshiftForm form)
 {
     SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::ShapeshiftForm), form);
@@ -9922,6 +9941,9 @@ void Unit::RemoveFromWorld()
                 ABORT();
             }
         }
+
+        // Clear all active summon references. If we are about to switch map instances, we want to make sure that we leave all summons behind so we won't do threadunsafe operations
+        _activeSummons.clear();
 
         WorldObject::RemoveFromWorld();
         m_duringRemoveFromWorld = false;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -87,6 +87,7 @@ class SpellCastTargets;
 class SpellEffectInfo;
 class SpellHistory;
 class SpellInfo;
+class SummonInfo;
 class Totem;
 class Transport;
 class TransportBase;
@@ -742,7 +743,7 @@ class TC_GAME_API Unit : public WorldObject
 
         uint32 HasUnitTypeMask(uint32 mask) const { return mask & m_unitTypeMask; }
         void AddUnitTypeMask(uint32 mask) { m_unitTypeMask |= mask; }
-        bool IsSummon() const   { return (m_unitTypeMask & UNIT_MASK_SUMMON) != 0; }
+        virtual bool IsSummon() const { return false; }
         bool IsGuardian() const { return (m_unitTypeMask & UNIT_MASK_GUARDIAN) != 0; }
         bool IsPet() const      { return (m_unitTypeMask & UNIT_MASK_PET) != 0; }
         bool IsHunterPet() const{ return (m_unitTypeMask & UNIT_MASK_HUNTER_PET) != 0; }
@@ -1467,6 +1468,12 @@ class TC_GAME_API Unit : public WorldObject
 
         std::array<ObjectGuid, MAX_SUMMON_SLOT> m_SummonSlot;
         std::array<ObjectGuid, MAX_GAMEOBJECT_SLOT> m_ObjectSlot;
+
+        std::vector<SummonInfo*> _activeSummons;
+        // Registers the SummonInfo API of a summoned creature to allow accessing it to allow safe accessing
+        void RegisterSummon(SummonInfo* summon);
+        // Unregisters the SummonInfo API of a summoned creature so it can no longer be accessed
+        void UnregisterSummon(SummonInfo* summon);
 
         ShapeshiftForm GetShapeshiftForm() const { return ShapeshiftForm(*m_unitData->ShapeshiftForm); }
         void SetShapeshiftForm(ShapeshiftForm form);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1469,7 +1469,6 @@ class TC_GAME_API Unit : public WorldObject
         std::array<ObjectGuid, MAX_SUMMON_SLOT> m_SummonSlot;
         std::array<ObjectGuid, MAX_GAMEOBJECT_SLOT> m_ObjectSlot;
 
-        std::vector<SummonInfo*> _activeSummons;
         // Registers the SummonInfo API of a summoned creature to allow accessing it to allow safe accessing
         void RegisterSummon(SummonInfo* summon);
         // Unregisters the SummonInfo API of a summoned creature so it can no longer be accessed
@@ -2007,6 +2006,9 @@ class TC_GAME_API Unit : public WorldObject
         uint32 _healthRegenerationTimer;
         std::array<float, MAX_POWERS_PER_CLASS> _powerFraction;
         std::array<Powers, MAX_POWERS_PER_CLASS> _usedPowerTypes;
+
+        // SummonInfo API
+        std::vector<SummonInfo*> _activeSummons;
     public:
         // Returns an array that contains information about which power type is used at which power index. MAX_POWERS implies that a power at given index is not used.
         std::array<Powers, MAX_POWERS_PER_CLASS> const& GetUsedPowerTypes() const { return _usedPowerTypes; }


### PR DESCRIPTION
New attempt:

**Changes proposed:**

-  added a new SummonInfo API which will serve as future place to handle summons in all kinds of way
-  for now it only supports accessing summoners. The API will get expanded as the implementation goes on. We will add more step by step to make sure we won't break anything/too much at once.
-  

**Tests performed:**
- tested ingame