### PR TITLE
Core/Player: Fixed an issue where overridden specialization spells we…

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2370,11 +2370,8 @@ bool Player::IsMaxLevel() const
 void Player::InitTalentForLevel()
 {
     uint8 level = GetLevel();
-    // talents base at level diff (talents = level - 9 but some can be used already)
-    if (level < MIN_SPECIALIZATION_LEVEL)
-        ResetTalentSpecialization();
-
     int32 talentTiers = DB2Manager::GetNumTalentsAtLevel(level, Classes(GetClass()));
+
     if (level < 15)
     {
         // Remove all talent points

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -30320,26 +30320,24 @@ void Player::LearnSpecializationSpells()
 
 void Player::RemoveSpecializationSpells()
 {
-    for (uint32 i = 0; i < MAX_SPECIALIZATIONS; ++i)
-    {
-        if (ChrSpecializationEntry const* specialization = sDB2Manager.GetChrSpecializationByIndex(GetClass(), i))
-        {
-            if (std::vector<SpecializationSpellsEntry const*> const* specSpells = sDB2Manager.GetSpecializationSpells(specialization->ID))
-            {
-                for (size_t j = 0; j < specSpells->size(); ++j)
-                {
-                    SpecializationSpellsEntry const* specSpell = (*specSpells)[j];
-                    RemoveSpell(specSpell->SpellID);
-                    if (specSpell->OverridesSpellID)
-                        RemoveOverrideSpell(specSpell->OverridesSpellID, specSpell->SpellID);
-                }
-            }
+    ChrSpecializationEntry const* specialization = sDB2Manager.GetChrSpecializationByIndex(GetClass(), AsUnderlyingType(GetPrimarySpecialization()));
+    if (!specialization)
+        return;
 
-            for (uint32 j = 0; j < MAX_MASTERY_SPELLS; ++j)
-                if (uint32 mastery = specialization->MasterySpellID[j])
-                    RemoveAurasDueToSpell(mastery);
+    if (std::vector<SpecializationSpellsEntry const*> const* specSpells = sDB2Manager.GetSpecializationSpells(specialization->ID))
+    {
+        for (size_t j = 0; j < specSpells->size(); ++j)
+        {
+            SpecializationSpellsEntry const* specSpell = (*specSpells)[j];
+            RemoveSpell(specSpell->SpellID);
+            if (specSpell->OverridesSpellID)
+                RemoveOverrideSpell(specSpell->OverridesSpellID, specSpell->SpellID);
         }
     }
+
+    for (uint32 j = 0; j < MAX_MASTERY_SPELLS; ++j)
+        if (uint32 mastery = specialization->MasterySpellID[j])
+            RemoveAurasDueToSpell(mastery);
 }
 
 void Player::AddSpellCategoryCooldownMod(int32 spellCategoryId, int32 mod)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1904,7 +1904,8 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         void AddOverrideSpell(uint32 overridenSpellId, uint32 newSpellId);
         void RemoveOverrideSpell(uint32 overridenSpellId, uint32 newSpellId);
         void LearnSpecializationSpells();
-        void RemoveSpecializationSpells();
+        void RemovePrimarySpecializationSpells();
+        void RemoveAllSpecializationsSpells();
         void AddSpellCategoryCooldownMod(int32 spellCategoryId, int32 mod);
         void RemoveSpellCategoryCooldownMod(int32 spellCategoryId, int32 mod);
         void SetSpellFavorite(uint32 spellId, bool favorite);


### PR DESCRIPTION
…re incorrectly removed for all specializations. Now, they are only removed for the primary specialization when changing specs

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Spells are now removed only for the primary specialization when the player's spec is changed.
- The loop for iterating through all specializations has been moved to call in `Player::ResetTalentSpecialization`, ensuring a more precise behavior for the primary specialization.
- Mastery spells are now properly handled for the primary specialization.

**Issues addressed:**

Closes #30648


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
