### PR TITLE
Core/Creatures: Fix point_X behaviour for creature_formations

### DIFF
--- a/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
@@ -102,7 +102,15 @@ bool FormationMovementGenerator::DoUpdate(Creature* owner, uint32 diff)
                 if (Creature* leader = formation->GetLeader())
                 {
                     uint8 currentWaypoint = leader->GetCurrentWaypointInfo().first;
-                    if (currentWaypoint == _point1 || currentWaypoint == _point2)
+                    bool needsAngleUpdate = [=]()
+                    {
+                        if (_point1 <= _point2)
+                            return _point1 <= currentWaypoint && currentWaypoint < _point2;
+                        else
+                            return _point1 <= currentWaypoint || currentWaypoint < _point2;
+                    }();
+
+                    if (needsAngleUpdate)
                         _angle = float(M_PI) * 2 - _angle;
                 }
             }

--- a/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
@@ -102,7 +102,7 @@ bool FormationMovementGenerator::DoUpdate(Creature* owner, uint32 diff)
                 if (Creature* leader = formation->GetLeader())
                 {
                     uint8 currentWaypoint = leader->GetCurrentWaypointInfo().first;
-                    bool needsAngleUpdate = [=]()
+                    bool needsAngleUpdate = [&]()
                     {
                         if (_point1 <= _point2)
                             return _point1 <= currentWaypoint && currentWaypoint < _point2;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix point_X behaviour for creature_formations (check https://github.com/TrinityCore/TrinityCore/issues/29950)

**Issues addressed:**

Closes #29950


**Tests performed:**
Builds, tested in-game (.go creature 395362)


**Known issues and TODO list:** (add/remove lines as needed)
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
