### PR TITLE
Core/Groups: align the player's dungeon/raid difficulty with the group's difficulty upon joining, regardless of the player's level.

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -467,18 +467,15 @@ bool Group::AddMember(Player* player)
         player->ResetInstances(INSTANCE_RESET_GROUP_JOIN, false);
         player->ResetInstances(INSTANCE_RESET_GROUP_JOIN, true);
 
-        if (player->GetLevel() >= LEVELREQUIREMENT_HEROIC)
+        if (player->GetDungeonDifficulty() != GetDungeonDifficulty())
         {
-            if (player->GetDungeonDifficulty() != GetDungeonDifficulty())
-            {
-                player->SetDungeonDifficulty(GetDungeonDifficulty());
-                player->SendDungeonDifficulty(true);
-            }
-            if (player->GetRaidDifficulty() != GetRaidDifficulty())
-            {
-                player->SetRaidDifficulty(GetRaidDifficulty());
-                player->SendRaidDifficulty(true);
-            }
+            player->SetDungeonDifficulty(GetDungeonDifficulty());
+            player->SendDungeonDifficulty(true);
+        }
+        if (player->GetRaidDifficulty() != GetRaidDifficulty())
+        {
+            player->SetRaidDifficulty(GetRaidDifficulty());
+            player->SendRaidDifficulty(true);
         }
     }
     player->SetGroupUpdateFlag(GROUP_UPDATE_FULL);

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -216,11 +216,6 @@ public:
 
 #pragma pack(push, 1)
 
-enum LevelRequirementVsMode
-{
-    LEVELREQUIREMENT_HEROIC = 70
-};
-
 struct ZoneDynamicInfo
 {
     ZoneDynamicInfo();


### PR DESCRIPTION
**Changes proposed:**

-  Remove level requirement check that prevent set Dungeon/Raid difficulty when member joins to the group
-  here was removed when group leader set difficulty: 85caf3a2c1abef00ae3c650c17473d076e1cf965
-  also here: ad039c099911d1dde4c6c6f18a5268c1f1616469
So seems wrong check

**Issues addressed:**

none


**Tests performed:**

tested in-game
- Get a level 70+ player and go to a dungeon like blood furnace (.go instance blood furnace)
- Get another player with level 60 by example.
- Set with level 70+ player dungeon dificulty heroic and invite level 60 player
- Enter in dungeon, level 60 player is in heroic version without meet access_requirement table.

