### PR TITLE
Core/Player: Do not allow to wear two fishing poles when spec into Titans Grip

### DIFF
--- a/src/server/game/Entities/Item/ItemTemplate.cpp
+++ b/src/server/game/Entities/Item/ItemTemplate.cpp
@@ -139,6 +139,32 @@ uint32 ItemTemplate::GetSkill() const
     }
 }
 
+bool ItemTemplate::IsWeaponOfSubClass(ItemSubclassWeapon subClass) const
+{
+    if (Class != ITEM_CLASS_WEAPON)
+        return false;
+
+    return SubClass == subClass;
+}
+
+bool ItemTemplate::IsWeaponOfSubClass(std::initializer_list<ItemSubclassWeapon> subClasses) const
+{
+    if (Class != ITEM_CLASS_WEAPON)
+        return false;
+
+    for (auto const& subClass : subClasses)
+        if (IsWeaponOfSubClass(subClass))
+            return true;
+
+    return false;
+}
+
+bool ItemTemplate::CanBeDualWieldedWithTitansGrip() const
+{
+    SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(46917); // Titan's Grip
+    return ((1 << SubClass) & spellInfo->EquippedItemSubClassMask) != 0;
+}
+
 void ItemTemplate::_LoadTotalAP()
 {
     int32 totalAP = 0;

--- a/src/server/game/Entities/Item/ItemTemplate.cpp
+++ b/src/server/game/Entities/Item/ItemTemplate.cpp
@@ -144,7 +144,7 @@ bool ItemTemplate::IsWeaponOfSubClass(ItemSubclassWeapon subClass) const
     if (Class != ITEM_CLASS_WEAPON)
         return false;
 
-    return SubClass == subClass;
+    return SubClass == subClass; // here we got a sign unsigned error iirc
 }
 
 bool ItemTemplate::IsWeaponOfSubClass(std::initializer_list<ItemSubclassWeapon> subClasses) const
@@ -161,7 +161,7 @@ bool ItemTemplate::IsWeaponOfSubClass(std::initializer_list<ItemSubclassWeapon> 
 
 bool ItemTemplate::CanBeDualWieldedWithTitansGrip() const
 {
-    SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(46917); // Titan's Grip
+    SpellInfo const* spellInfo = sSpellMgr->AssertSpellInfo(46917); // Titan's Grip // maybe there's better option instead this hardcoded
     return ((1 << SubClass) & spellInfo->EquippedItemSubClassMask) != 0;
 }
 

--- a/src/server/game/Entities/Item/ItemTemplate.h
+++ b/src/server/game/Entities/Item/ItemTemplate.h
@@ -704,6 +704,10 @@ struct TC_GAME_API ItemTemplate
     bool IsConjuredConsumable() const { return Class == ITEM_CLASS_CONSUMABLE && HasFlag(ITEM_FLAG_CONJURED); }
     bool HasSignature() const;
 
+    bool IsWeaponOfSubClass(ItemSubclassWeapon subClass) const;
+    bool IsWeaponOfSubClass(std::initializer_list<ItemSubclassWeapon> subClasses) const;
+    bool CanBeDualWieldedWithTitansGrip() const;
+
     inline bool HasFlag(ItemFlags flag) const { return (Flags & flag) != 0; }
     inline bool HasFlag(ItemFlags2 flag) const { return (Flags2 & flag) != 0; }
     inline bool HasFlag(ItemFlagsCustom customFlag) const { return (FlagsCu & customFlag) != 0; }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Well this will fix the targeted issue but I need some help with the mentioned issues in the second commit.
-  All the credit goes to [Sava Vranešević](https://github.com/svranesevic), I only updated a bit his abandoned pr to fit new tc.

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/20972


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ I commented out (in the second commit) the parts of the code that need improvements. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
