### PR TITLE
Fix Quest "Loss Reduction"

### DIFF
--- a/sql/updates/world/master/2025_99_99_99_loss_reduction.sql
+++ b/sql/updates/world/master/2025_99_99_99_loss_reduction.sql
@@ -1,0 +1,74 @@
+-- https://www.wowhead.com/quest=25179/loss-reduction
+DELETE FROM `npc_spellclick_spells` WHERE `npc_entry`=39270 AND `spell_id`=73705;
+INSERT INTO `npc_spellclick_spells` (`npc_entry`, `spell_id`, `cast_flags`, `user_type`) VALUES (39270, 73705, 1, 0);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=18 AND `SourceGroup`=39270 AND `SourceEntry`=73705;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `ConditionStringValue1`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES 
+(18, 39270, 73705, 0, 0, 8, 0, 25173, 0, 0, '', 0, 0, 0, '', NULL),
+(18, 39270, 73705, 0, 0, 8, 0, 25176, 0, 0, '', 0, 0, 0, '', NULL),
+(18, 39270, 73705, 0, 0, 8, 0, 25179, 0, 0, '', 1, 0, 0, '', NULL);
+
+UPDATE `creature_template_addon` SET `StandState`=7, `auras`='76143 73713' WHERE `entry`=39270;
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 39270 AND `GroupID` IN (1, 2);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(39270, 1, 0, 'You\'ve saved my life, $c.  Protect me for a few more moments while I recover.', 12, 1, 100, 0, 0, 0, 39301, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 1, 1, 'For the Warchief!  You lead, I will follow.', 12, 1, 100, 0, 0, 0, 39302, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 1, 2, 'I was supposed to die in battle... ah well, another day.  I will follow you until I recover.', 12, 1, 100, 0, 0, 0, 39300, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 2, 0, 'It was an honor to watch you fight, $n.', 12, 1, 100, 0, 0, 0, 39305, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 2, 1, 'Thank you again.  I will return to Razor Hill now.', 12, 1, 100, 0, 0, 0, 39304, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 1, 3, 'Thank you, $r... I was close to death.  May I stay by your side for a moment?', 12, 1, 100, 0, 0, 0, 39299, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 2, 2, 'You fight well.  I will leave you now.  Lok\'tar ogar!', 12, 1, 100, 0, 0, 0, 39306, 0, 'Injured Razor Hill Grunt to Player'),
+(39270, 2, 3, 'I feel much better now.  For the Horde!', 12, 1, 100, 0, 0, 0, 39303, 0, 'Injured Razor Hill Grunt to Player');
+
+ -- Timed list 3927000 smart ai
+SET @ENTRY := 3927000;
+DELETE FROM `smart_scripts` WHERE `source_type` = 9 AND `entryOrGuid` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `action_param7`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`, `Difficulties`) VALUES
+(@ENTRY, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Look at storedTarget[0]', ''),
+(@ENTRY, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 17, 93, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Set emote state to STATE_STUN_NOSHEATHE (93)', ''),
+(@ENTRY, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Set npc flags NONE', ''),
+(@ENTRY, 9, 3, 0, 0, 0, 100, 0, 1200, 1200, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 'After 1.2 seconds - Self: Talk 1 to storedTarget[0]', ''),
+(@ENTRY, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 29, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Follow storedTarget[0] by distance 0, angle 0', ''),
+(@ENTRY, 9, 5, 0, 0, 0, 100, 0, 40000, 40000, 0, 0, 0, 17, 333, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'After 40 seconds - Self: Set emote state to STATE_READY1H (333)', ''),
+(@ENTRY, 9, 6, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Talk 2 to storedTarget[0]', ''),
+(@ENTRY, 9, 7, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Follow None by distance 0, angle 0', ''),
+(@ENTRY, 9, 8, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 22, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Set event phase to phase 3', ''),
+(@ENTRY, 9, 9, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1.48353, 'After 0 seconds - Self: Set orientation to 1.48353', ''),
+(@ENTRY, 9, 10, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 41, 6000, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'After 0 seconds - Self: Despawn in 6 s', '');
+
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 3927000 AND `SourceId` = 9;
+ -- Injured Razor Hill Grunt smart ai
+SET @ENTRY := 39270;
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `action_param7`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`, `Difficulties`) VALUES
+(@ENTRY, 0, 0, 0, 1, 1, 100, 0, 2000, 5000, 6000, 25000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Every 6 - 25 seconds (2 - 5s initially) (OOC) - Self: Talk 0 to invoker', ''),
+(@ENTRY, 0, 1, 2, 63, 0, 100, 0, 0, 0, 0, 0, 0, 22, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'On just created - Set event phase to phase 1', ''),
+(@ENTRY, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 136, 1, 5, 35, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just created - Self: Set movement MOVE_RUN speed to 5.35', ''),
+(@ENTRY, 0, 3, 4, 73, 1, 100, 0, 0, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Set event phase to phase 2', ''),
+(@ENTRY, 0, 4, 5, 61, 0, 100, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Self: storedTarget[0] = Clicker', ''),
+(@ENTRY, 0, 5, 6, 61, 0, 100, 0, 0, 0, 0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Self: Set stand state to STAND', ''),
+(@ENTRY, 0, 6, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 67, 1, 1200, 1200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Trigger timed event timedEvent[1] in 1200 - 1200 ms // -meta_wait', ''),
+(@ENTRY, 0, 7, 8, 59, 0, 100, 0, 1, 0, 0, 0, 0, 7, 25179, 0, 1, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 'On timed event timedEvent[1] triggered - storedTarget[0]: Offer quest Loss Reduction (25179)', ''),
+(@ENTRY, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 80, 3927000, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On timed event timedEvent[1] triggered - Self: Start timed action list id #Injured Razor Hill Grunt #0 (3927000) (update out of combat)', ''),
+(@ENTRY, 0, 9, 10, 73, 1, 100, 0, 0, 0, 0, 0, 0, 22, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Set event phase to phase 2', ''),
+(@ENTRY, 0, 10, 11, 61, 0, 100, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Self: storedTarget[0] = Clicker', ''),
+(@ENTRY, 0, 11, 12, 61, 0, 100, 0, 0, 0, 0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Self: Set stand state to STAND', ''),
+(@ENTRY, 0, 12, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 67, 2, 1200, 1200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'On spellclick - Trigger timed event timedEvent[2] in 1200 - 1200 ms // -meta_wait', ''),
+(@ENTRY, 0, 13, 14, 59, 0, 100, 0, 2, 0, 0, 0, 0, 33, 39270, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 'On timed event timedEvent[2] triggered - storedTarget[0]: Give kill credit Injured Razor Hill Grunt (39270)', ''),
+(@ENTRY, 0, 14, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 80, 3927000, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On timed event timedEvent[2] triggered - Self: Start timed action list id #Injured Razor Hill Grunt #0 (3927000) (update out of combat)', ''),
+(@ENTRY, 0, 15, 0, 34, 4, 100, 0, 16, 1006, 0, 0, 0, 114, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 30, 0, 0, 'On movement of type EFFECT_MOTION_TYPE inform, point 1006 - Self: Move forward by 30, left by 0, up by 0 yards', ''),
+(@ENTRY, 0, 16, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On movement of type POINT_MOTION_TYPE inform, point 1 - Self: Despawn instantly', '');
+
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 39270 AND `SourceId` = 0;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `ConditionStringValue1`, `NegativeCondition`, `Comment`) VALUES 
+(22, 4, 39270, 0, 0, 47, 0, 25179, 1, 0, '', 0, 'Action invoker has Loss Reduction (25179) in state none'),
+(22, 10, 39270, 0, 0, 47, 0, 25179, 10, 0, '', 0, 'Action invoker has Loss Reduction (25179) in state complete, incomplete');
+
+
+UPDATE `spell_script_names` SET `ScriptName`='spell_gen_low_health' WHERE `spell_id`=76143;
+-- otherwise the aura change is overriden when setting spawn health
+UPDATE `creature` SET `curHealthPct` = 10 WHERE `id` IN (39270);

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -501,7 +501,14 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
                                 if (WorldSession* session = player->GetSession())
                                 {
                                     PlayerMenu menu(session);
-                                    menu.SendQuestGiverQuestDetails(q, me->GetGUID(), true, false);
+
+                                    if (e.action.questOffer.playerMenu)
+                                    {
+                                        player->SetQuestSharingInfo(player->GetGUID(), e.action.questOffer.questID);
+                                        player->SetSelfOfferQuest(e.action.questOffer.questID);
+                                    }
+
+                                    menu.SendQuestGiverQuestDetails(q, e.action.questOffer.playerMenu ? player->GetGUID() : me->GetGUID(), true, false);
                                     TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_OFFER_QUEST: Player {} - offering quest {}", player->GetGUID().ToString(), e.action.questOffer.questID);
                                 }
                             }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -504,7 +504,6 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                                     if (e.action.questOffer.playerMenu)
                                     {
-                                        player->SetQuestSharingInfo(player->GetGUID(), int32(e.action.questOffer.questID));
                                         player->SetSelfOfferQuest(int32(e.action.questOffer.questID));
                                     }
 

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -504,8 +504,8 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
                                     if (e.action.questOffer.playerMenu)
                                     {
-                                        player->SetQuestSharingInfo(player->GetGUID(), e.action.questOffer.questID);
-                                        player->SetSelfOfferQuest(e.action.questOffer.questID);
+                                        player->SetQuestSharingInfo(player->GetGUID(), int32(e.action.questOffer.questID));
+                                        player->SetSelfOfferQuest(int32(e.action.questOffer.questID));
                                     }
 
                                     menu.SendQuestGiverQuestDetails(q, e.action.questOffer.playerMenu ? player->GetGUID() : me->GetGUID(), true, false);

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -673,6 +673,7 @@ struct SmartAction
         {
             uint32 questID;
             SAIBool directAdd;
+            SAIBool playerMenu;
         } questOffer;
 
         struct

--- a/src/server/game/Entities/Object/Updates/UpdateFields.h
+++ b/src/server/game/Entities/Object/Updates/UpdateFields.h
@@ -556,7 +556,7 @@ struct PlayerData : public IsUpdateFieldStructureTag, public HasChangesMask<322>
     UpdateField<int64, 32, 33> LogoutTime;
     UpdateField<std::string, 32, 34> Name;
     UpdateField<int32, 32, 35> Field_1AC;
-    UpdateField<int32, 32, 36> Field_1B0;
+    UpdateField<int32, 32, 36> Field_1B0; // related to accepting quests from self, needs to be set to quest currently send in offer message, otherwise client does not send accept packet
     UpdateField<int32, 32, 37> CurrentBattlePetSpeciesID;
     UpdateField<UF::CTROptions, 32, 38> CtrOptions;
     UpdateField<int32, 32, 39> CovenantID;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -31068,3 +31068,13 @@ bool Player::CanExecutePendingSpellCastRequest()
 
     return true;
 }
+
+void Player::SetSelfOfferQuest(uint32 questId)
+{
+    SetUpdateFieldValue(m_values.ModifyValue(&Player::m_playerData).ModifyValue(&UF::PlayerData::Field_1B0), questId);
+}
+
+uint32 Player::GetSelfOfferQuest() const
+{
+    return m_playerData->Field_1B0;
+}

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -31069,12 +31069,12 @@ bool Player::CanExecutePendingSpellCastRequest()
     return true;
 }
 
-void Player::SetSelfOfferQuest(uint32 questId)
+void Player::SetSelfOfferQuest(int32 questId)
 {
     SetUpdateFieldValue(m_values.ModifyValue(&Player::m_playerData).ModifyValue(&UF::PlayerData::Field_1B0), questId);
 }
 
-uint32 Player::GetSelfOfferQuest() const
+int32 Player::GetSelfOfferQuest() const
 {
     return m_playerData->Field_1B0;
 }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2973,6 +2973,9 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         void SendAreaSpiritHealerTime(Unit* spiritHealer) const;
         void SendAreaSpiritHealerTime(ObjectGuid const& spiritHealerGUID, int32 timeLeft) const;
 
+        void SetSelfOfferQuest(uint32 questId);
+        uint32 GetSelfOfferQuest() const;
+
     protected:
         // Gamemaster whisper whitelist
         GuidList WhisperList;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2973,8 +2973,8 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         void SendAreaSpiritHealerTime(Unit* spiritHealer) const;
         void SendAreaSpiritHealerTime(ObjectGuid const& spiritHealerGUID, int32 timeLeft) const;
 
-        void SetSelfOfferQuest(uint32 questId);
-        uint32 GetSelfOfferQuest() const;
+        void SetSelfOfferQuest(int32 questId);
+        int32 GetSelfOfferQuest() const;
 
     protected:
         // Gamemaster whisper whitelist

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -1163,6 +1163,9 @@ void WorldSession::HandleCloseInteraction(WorldPackets::Misc::CloseInteraction& 
 
     if (_player->GetStableMaster() == closeInteraction.SourceGuid)
         _player->SetStableMaster(ObjectGuid::Empty);
+
+    if (_player->GetSelfOfferQuest())
+        _player->SetSelfOfferQuest(0);
 }
 
 void WorldSession::HandleConversationLineStarted(WorldPackets::Misc::ConversationLineStarted& conversationLineStarted)

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -107,15 +107,26 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPackets::Quest::QuestG
 
     if (Player* playerQuestObject = object->ToPlayer())
     {
-        if ((_player->GetPlayerSharingQuest().IsEmpty() && _player->GetPlayerSharingQuest() != packet.QuestGiverGUID) || !playerQuestObject->CanShareQuest(packet.QuestID))
+        if (_player != playerQuestObject)
         {
-            CLOSE_GOSSIP_CLEAR_SHARING_INFO();
-            return;
+            if ((_player->GetPlayerSharingQuest().IsEmpty() && _player->GetPlayerSharingQuest() != packet.QuestGiverGUID) || !playerQuestObject->CanShareQuest(packet.QuestID))
+            {
+                CLOSE_GOSSIP_CLEAR_SHARING_INFO();
+                return;
+            }
+            if (!_player->IsInSameRaidWith(playerQuestObject))
+            {
+                CLOSE_GOSSIP_CLEAR_SHARING_INFO();
+                return;
+            }
         }
-        if (!_player->IsInSameRaidWith(playerQuestObject))
+        else
         {
-            CLOSE_GOSSIP_CLEAR_SHARING_INFO();
-            return;
+            if (_player->GetSelfOfferQuest() != packet.QuestID)
+            {
+                CLOSE_GOSSIP_CLEAR_SHARING_INFO();
+                return;
+            }
         }
     }
     else

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -5093,6 +5093,18 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx &= ~SPELL_ATTR1_IS_CHANNELLED;
     });
 
+    //
+    // DUROTAR SPELLS
+    //
+
+    // Injured Razor Hill Grunt - Cancel Feign Death cast time 0
+    ApplySpellFix({ 73705 }, [](SpellInfo* spellInfo)
+    {
+            spellInfo->CastTimeEntry = sSpellCastTimesStore.LookupEntry(0);
+    });
+
+    // ENDOF THE DUROTAR SPELLS
+
     for (SpellInfo const& s : mSpellInfoMap)
     {
         SpellInfo* spellInfo = &const_cast<SpellInfo&>(s);

--- a/src/server/scripts/EasternKingdoms/zone_dun_morogh_area_coldridge_valley.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_dun_morogh_area_coldridge_valley.cpp
@@ -430,39 +430,6 @@ public:
     }
 };
 
-/*######
-# spell_low_health
-# 76143 - Low Health
-######*/
-
-class spell_low_health: public SpellScriptLoader
-{
-public:
-    spell_low_health() : SpellScriptLoader("spell_low_health") { }
-
-    class spell_low_health_SpellScript : public SpellScript
-    {
-        void HandleDummyEffect(SpellEffIndex /*eff*/)
-        {
-            if (Creature* target = GetHitCreature())
-            {
-                target->SetRegenerateHealth(false);
-                target->SetHealth(target->CountPctFromMaxHealth(10));
-            }
-        }
-
-        void Register() override
-        {
-            OnEffectHitTarget += SpellEffectFn(spell_low_health_SpellScript::HandleDummyEffect, EFFECT_0, SPELL_EFFECT_APPLY_AURA);
-        }
-    };
-
-    SpellScript* GetSpellScript() const override
-    {
-        return new spell_low_health_SpellScript();
-    }
-};
-
 Position const RockjawInvaderSpawnPoints[7] =
 {
     { -6237.6807f, 375.5191f, 385.44696f, 5.168368339538574218f },
@@ -555,6 +522,5 @@ void AddSC_dun_morogh_area_coldridge_valley()
     new npc_milos_gyro();
     new spell_a_trip_to_ironforge_quest_complete();
     new spell_follow_that_gyrocopter_quest_start();
-    new spell_low_health();
     RegisterCreatureAI(npc_joren_ironstock);
 }

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -5555,6 +5555,35 @@ struct at_gen_spatial_rift : AreaTriggerAI
     }
 };
 
+// 76143 - Low Health
+class spell_gen_low_health : public AuraScript
+{
+    void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        if (Creature* creature = target->ToCreature())
+        {
+            creature->SetRegenerateHealth(false);
+            creature->SetHealth(target->CountPctFromMaxHealth(10));
+        }
+    }
+
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        Unit* target = GetTarget();
+        if (Creature* creature = target->ToCreature())
+        {
+            creature->SetRegenerateHealth(true);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_gen_low_health::OnApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        OnEffectRemove += AuraEffectRemoveFn(spell_gen_low_health::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 void AddSC_generic_spell_scripts()
 {
     RegisterSpellScript(spell_gen_absorb0_hitlimit1);
@@ -5740,4 +5769,5 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_saddlechute);
     RegisterSpellScript(spell_gen_spatial_rift);
     RegisterAreaTriggerAI(at_gen_spatial_rift);
+    RegisterSpellScript(spell_gen_low_health);
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Implements offering quests with the player as a questgiver.
Allows to set the player as quest offerer in SMART_ACTION_OFFER_QUEST.
Script https://www.wowhead.com/quest=25179/loss-reduction.

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Tested in-game.


**Known issues and TODO list:** (add/remove lines as needed)

The grunts talking while waiting for help seem to be handled by a serverside spell on retail.
I had to set the grunts' speed in the SAI script, but Blizz doesn't seem to communicate a speed change. Their move packets do have a lower computed speed of 5.35.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
