### PR TITLE
Core/Auth: Do not close Authserver at startup when no valid realms found

### DIFF
--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -192,12 +192,6 @@ int main(int argc, char** argv)
 
     std::shared_ptr<void> sRealmListHandle(nullptr, [](void*) { sRealmList->Close(); });
 
-    if (sRealmList->GetRealms().empty())
-    {
-        TC_LOG_ERROR("server.authserver", "No valid realms specified.");
-        // return 1; (skip to the loop)
-    }
-
     // Start the listening port (acceptor) for auth connections
     int32 port = sConfigMgr->GetIntDefault("RealmServerPort", 3724);
     if (port < 0 || port > 0xFFFF)

--- a/src/server/authserver/Main.cpp
+++ b/src/server/authserver/Main.cpp
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
     if (sRealmList->GetRealms().empty())
     {
         TC_LOG_ERROR("server.authserver", "No valid realms specified.");
-        return 1;
+        // return 1; (skip to the loop)
     }
 
     // Start the listening port (acceptor) for auth connections


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Do not close Authserver at startup when no valid realms found, just skip to the seek loop.

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/30103


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ None, maybe few more tests ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
