### PR TITLE
Core/Transport: Fixed events not triggering when timestamp matches path progress

### DIFF
--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -207,7 +207,7 @@ void Transport::Update(uint32 diff)
     size_t eventToTriggerIndex = _eventsToTrigger->find_first();
     if (eventToTriggerIndex != boost::dynamic_bitset<uint8>::npos)
     {
-        while (eventToTriggerIndex < _transportInfo->Events.size() && _transportInfo->Events[eventToTriggerIndex].Timestamp < timer)
+        while (eventToTriggerIndex < _transportInfo->Events.size() && _transportInfo->Events[eventToTriggerIndex].Timestamp <= timer)
         {
             if (TransportPathLeg const* leg = _transportInfo->GetLegForTime(_transportInfo->Events[eventToTriggerIndex].Timestamp))
                 if (leg->MapId == GetMapId())


### PR DESCRIPTION
**Changes proposed:**

- Fixed an issue where transport events (ArrivalEventID / DepartureEventID) were not triggered if their timestamp exactly matched the current path progress.
- Updated event loop in Transport::Update() to use <= comparison instead of <, allowing events aligned with the current timer to fire correctly.

**Issues addressed:**

None.

**Tests performed:**

- Built successfully.
- Tested in-game using transport path ID 9467 (node 8 ArrivalEventID = 87513).
- Confirmed events now trigger even when timestamp == path progress.
- Verified other transports still function as expected.

**Known issues and TODO list:** (add/remove lines as needed)

- It could be optional, but maybe implementing a tolerance window (>= prev && <= now) to handle skipped frames due to any lag happening.
