### PR TITLE
Proxy Protocol v2 support

### DIFF
--- a/src/server/authserver/Server/AuthSocketMgr.h
+++ b/src/server/authserver/Server/AuthSocketMgr.h
@@ -45,7 +45,7 @@ protected:
     NetworkThread<AuthSession>* CreateThreads() const override
     {
         NetworkThread<AuthSession>* threads = new NetworkThread<AuthSession>[1];
-        bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("EnableProxyProtocol", false, true);
+        bool proxyProtocolEnabled = sConfigMgr->GetBoolDefault("EnableProxyProtocol", true);
         if (proxyProtocolEnabled)
             threads[0].EnableProxyProtocol();
         return threads;

--- a/src/server/authserver/Server/AuthSocketMgr.h
+++ b/src/server/authserver/Server/AuthSocketMgr.h
@@ -44,7 +44,11 @@ public:
 protected:
     NetworkThread<AuthSession>* CreateThreads() const override
     {
-        return new NetworkThread<AuthSession>[1];
+        NetworkThread<AuthSession>* threads = new NetworkThread<AuthSession>[1];
+        bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("EnableProxyProtocol", false, true);
+        if (proxyProtocolEnabled)
+            threads[0].EnableProxyProtocol();
+        return threads;
     }
 
     static void OnSocketAccept(tcp::socket&& sock, uint32 threadIndex)

--- a/src/server/authserver/Server/AuthSocketMgr.h
+++ b/src/server/authserver/Server/AuthSocketMgr.h
@@ -18,6 +18,7 @@
 #ifndef AuthSocketMgr_h__
 #define AuthSocketMgr_h__
 
+#include "Config.h"
 #include "SocketMgr.h"
 #include "AuthSession.h"
 

--- a/src/server/authserver/Server/AuthSocketMgr.h
+++ b/src/server/authserver/Server/AuthSocketMgr.h
@@ -46,8 +46,7 @@ protected:
     NetworkThread<AuthSession>* CreateThreads() const override
     {
         NetworkThread<AuthSession>* threads = new NetworkThread<AuthSession>[1];
-        bool proxyProtocolEnabled = sConfigMgr->GetBoolDefault("EnableProxyProtocol", true);
-        if (proxyProtocolEnabled)
+        if (sConfigMgr->GetBoolDefault("EnableProxyProtocol", true))
             threads[0].EnableProxyProtocol();
         return threads;
     }

--- a/src/server/authserver/authserver.conf.dist
+++ b/src/server/authserver/authserver.conf.dist
@@ -66,8 +66,8 @@ BindIP = "0.0.0.0"
 #
 #    EnableProxyProtocol
 #        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
-#					  this server and the proxy/load balancer to track the real IP address of players.
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)
 

--- a/src/server/authserver/authserver.conf.dist
+++ b/src/server/authserver/authserver.conf.dist
@@ -64,6 +64,16 @@ RealmServerPort = 3724
 BindIP = "0.0.0.0"
 
 #
+#    EnableProxyProtocol
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
+#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#					  this server and the proxy/load balancer to track the real IP address of players.
+#        Example:     1 - (Enabled)
+#        Default:     0 - (Disabled)
+
+EnableProxyProtocol = 0
+
+#
 #    PidFile
 #        Description: Auth server PID file.
 #        Example:     "./authserver.pid"  - (Enabled)

--- a/src/server/authserver/authserver.conf.dist
+++ b/src/server/authserver/authserver.conf.dist
@@ -65,8 +65,8 @@ BindIP = "0.0.0.0"
 
 #
 #    EnableProxyProtocol
-#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy,
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both
 #                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)

--- a/src/server/game/Server/WorldSocketMgr.cpp
+++ b/src/server/game/Server/WorldSocketMgr.cpp
@@ -120,5 +120,10 @@ void WorldSocketMgr::OnSocketOpen(tcp::socket&& sock, uint32 threadIndex)
 
 NetworkThread<WorldSocket>* WorldSocketMgr::CreateThreads() const
 {
-    return new WorldSocketThread[GetNetworkThreadCount()];
+    NetworkThread<WorldSocket>* threads = new WorldSocketThread[GetNetworkThreadCount()];
+    bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("Network.EnableProxyProtocol", false, true);
+    if (proxyProtocolEnabled)
+        for (int i = 0; i < GetNetworkThreadCount(); i++)
+            threads[i].EnableProxyProtocol();
+    return threads;
 }

--- a/src/server/game/Server/WorldSocketMgr.cpp
+++ b/src/server/game/Server/WorldSocketMgr.cpp
@@ -121,7 +121,7 @@ void WorldSocketMgr::OnSocketOpen(tcp::socket&& sock, uint32 threadIndex)
 NetworkThread<WorldSocket>* WorldSocketMgr::CreateThreads() const
 {
     NetworkThread<WorldSocket>* threads = new WorldSocketThread[GetNetworkThreadCount()];
-    bool proxyProtocolEnabled = sConfigMgr->GetOption<bool>("Network.EnableProxyProtocol", false, true);
+    bool proxyProtocolEnabled = sConfigMgr->GetBoolDefault("Network.EnableProxyProtocol", true);
     if (proxyProtocolEnabled)
         for (int i = 0; i < GetNetworkThreadCount(); i++)
             threads[i].EnableProxyProtocol();

--- a/src/server/shared/Networking/NetworkThread.h
+++ b/src/server/shared/Networking/NetworkThread.h
@@ -23,6 +23,7 @@
 #include "Errors.h"
 #include "IoContext.h"
 #include "Log.h"
+#include "Socket.h"
 #include "Timer.h"
 #include <boost/asio/ip/tcp.hpp>
 #include <atomic>

--- a/src/server/shared/Networking/NetworkThread.h
+++ b/src/server/shared/Networking/NetworkThread.h
@@ -150,7 +150,8 @@ protected:
             if (proxyHeaderReadingState == PROXY_HEADER_READING_STATE_STARTED)
                 continue;
 
-            switch (proxyHeaderReadingState) {
+            switch (proxyHeaderReadingState)
+            {
                 case PROXY_HEADER_READING_STATE_NOT_STARTED:
                     sock->AsyncReadProxyHeader();
                     break;

--- a/src/server/shared/Networking/NetworkThread.h
+++ b/src/server/shared/Networking/NetworkThread.h
@@ -39,7 +39,7 @@ class NetworkThread
 {
 public:
     NetworkThread() : _connections(0), _stopped(false), _thread(nullptr), _ioContext(1),
-        _acceptSocket(_ioContext), _updateTimer(_ioContext)
+        _acceptSocket(_ioContext), _updateTimer(_ioContext), _proxyHeaderReadingEnabled(false)
     {
     }
 
@@ -93,6 +93,8 @@ public:
 
     tcp::socket* GetSocketForAccept() { return &_acceptSocket; }
 
+    void EnableProxyProtocol() { _proxyHeaderReadingEnabled = true; }
+
 protected:
     virtual void SocketAdded(std::shared_ptr<SocketType> /*sock*/) { }
     virtual void SocketRemoved(std::shared_ptr<SocketType> /*sock*/) { }
@@ -104,18 +106,72 @@ protected:
         if (_newSockets.empty())
             return;
 
-        for (std::shared_ptr<SocketType> sock : _newSockets)
+        if (!_proxyHeaderReadingEnabled)
         {
+            for (std::shared_ptr<SocketType> sock : _newSockets)
+            {
+                if (!sock->IsOpen())
+                {
+                    SocketRemoved(sock);
+                    --_connections;
+                    continue;
+                }
+
+                _sockets.emplace_back(sock);
+
+                sock->Start();
+            }
+
+            _newSockets.clear();
+        }
+        else
+        {
+            HandleNewSocketsProxyReadingOnConnect();
+        }
+    }
+    void HandleNewSocketsProxyReadingOnConnect()
+    {
+        size_t index = 0;
+        std::vector<int> newSocketsToRemoveIndexes;
+        for (auto sock_iter = _newSockets.begin(); sock_iter != _newSockets.end(); ++sock_iter, ++index)
+        {
+            std::shared_ptr<SocketType> sock = *sock_iter;
+
             if (!sock->IsOpen())
             {
+                newSocketsToRemoveIndexes.emplace_back(index);
                 SocketRemoved(sock);
                 --_connections;
+                continue;
             }
-            else
-                _sockets.push_back(sock);
+
+            const auto proxyHeaderReadingState = sock->GetProxyHeaderReadingState();
+            if (proxyHeaderReadingState == PROXY_HEADER_READING_STATE_STARTED)
+                continue;
+
+            switch (proxyHeaderReadingState) {
+                case PROXY_HEADER_READING_STATE_NOT_STARTED:
+                    sock->AsyncReadProxyHeader();
+                    break;
+
+                case PROXY_HEADER_READING_STATE_FINISHED:
+                    newSocketsToRemoveIndexes.emplace_back(index);
+                    _sockets.emplace_back(sock);
+
+                    sock->Start();
+
+                    break;
+
+                default:
+                    newSocketsToRemoveIndexes.emplace_back(index);
+                    SocketRemoved(sock);
+                    --_connections;
+                    break;
+            }
         }
 
-        _newSockets.clear();
+        for (int removeIndex : newSocketsToRemoveIndexes)
+            _newSockets.erase(_newSockets.begin() + removeIndex);
     }
 
     void Run()
@@ -174,6 +230,8 @@ private:
     Trinity::Asio::IoContext _ioContext;
     tcp::socket _acceptSocket;
     Trinity::Asio::DeadlineTimer _updateTimer;
+
+    bool _proxyHeaderReadingEnabled;
 };
 
 #endif // NetworkThread_h__

--- a/src/server/shared/Networking/Socket.h
+++ b/src/server/shared/Networking/Socket.h
@@ -274,7 +274,8 @@ private:
         auto remainingLen = packet.GetActiveSize() - 16;
         readPointer += 16; // Skip strait to address.
 
-        switch (addressFamily) {
+        switch (addressFamily)
+        {
             case PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V4:
             {
                 if (remainingLen < 12)

--- a/src/server/shared/Networking/Socket.h
+++ b/src/server/shared/Networking/Socket.h
@@ -211,7 +211,6 @@ private:
         ReadHandler();
     }
 
-
     // ProxyReadHeaderHandler reads Proxy Protocol v2 header (v1 is not supported).
     // See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt (2.2. Binary header format (version 2)) for more details.
     void ProxyReadHeaderHandler(boost::system::error_code error, size_t transferredBytes)
@@ -323,7 +322,6 @@ private:
         packet.ReadCompleted(len+16);
         _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FINISHED;
     }
-
 
 #ifdef TC_SOCKET_USE_IOCP
 

--- a/src/server/shared/Networking/Socket.h
+++ b/src/server/shared/Networking/Socket.h
@@ -256,7 +256,7 @@ private:
 
         const uint8 addressFamily = readPointer[13];
         const uint16 len = (readPointer[14] << 8) | readPointer[15];
-        if (len+16 > packet.GetActiveSize())
+        if (static_cast<size_t>(len) + 16 > packet.GetActiveSize())
         {
             AsyncReadProxyHeader();
             return;

--- a/src/server/shared/Networking/Socket.h
+++ b/src/server/shared/Networking/Socket.h
@@ -35,14 +35,16 @@ using boost::asio::ip::tcp;
 #define TC_SOCKET_USE_IOCP
 #endif
 
-enum ProxyHeaderReadingState {
+enum ProxyHeaderReadingState
+{
     PROXY_HEADER_READING_STATE_NOT_STARTED,
     PROXY_HEADER_READING_STATE_STARTED,
     PROXY_HEADER_READING_STATE_FINISHED,
     PROXY_HEADER_READING_STATE_FAILED,
 };
 
-enum ProxyHeaderAddressFamilyAndProtocol {
+enum ProxyHeaderAddressFamilyAndProtocol
+{
     PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V4 = 0x11,
     PROXY_HEADER_ADDRESS_FAMILY_AND_PROTOCOL_TCP_V6 = 0x21,
 };

--- a/src/server/shared/Networking/Socket.h
+++ b/src/server/shared/Networking/Socket.h
@@ -240,7 +240,7 @@ private:
         if (memcmp(packet.GetReadPointer(), expectedSignature, signatureSize) != 0)
         {
             _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FAILED;
-            LOG_ERROR("network", "Socket::ProxyReadHeaderHandler: received bad PROXY Protocol v2 signature for {}", GetRemoteIpAddress().to_string());
+            TC_LOG_DEBUG("network", "Socket::ProxyReadHeaderHandler: received bad PROXY Protocol v2 signature for {}", GetRemoteIpAddress().to_string());
             return;
         }
 
@@ -250,7 +250,7 @@ private:
         if (version != 2)
         {
             _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FAILED;
-            LOG_ERROR("network", "Socket::ProxyReadHeaderHandler: received bad PROXY Protocol v2 signature for {}", GetRemoteIpAddress().to_string());
+            TC_LOG_DEBUG("network", "Socket::ProxyReadHeaderHandler: received bad PROXY Protocol v2 signature for {}", GetRemoteIpAddress().to_string());
             return;
         }
 
@@ -316,7 +316,7 @@ private:
 
             default:
                 _proxyHeaderReadingState = PROXY_HEADER_READING_STATE_FAILED;
-                LOG_ERROR("network", "Socket::ProxyReadHeaderHandler: unsupported address family type {}", GetRemoteIpAddress().to_string());
+                TC_LOG_DEBUG("network", "Socket::ProxyReadHeaderHandler: unsupported address family type {}", GetRemoteIpAddress().to_string());
                 return;
         }
 

--- a/src/server/shared/Networking/SocketMgr.h
+++ b/src/server/shared/Networking/SocketMgr.h
@@ -100,8 +100,6 @@ public:
         try
         {
             std::shared_ptr<SocketType> newSocket = std::make_shared<SocketType>(std::move(sock));
-            newSocket->Start();
-
             _threads[threadIndex].AddSocket(newSocket);
         }
         catch (boost::system::system_error const& err)

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3012,8 +3012,8 @@ Network.TcpNodelay = 1
 
 #
 #    Network.EnableProxyProtocol
-#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy,
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both
 #                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3011,6 +3011,16 @@ Network.OutUBuff = 65536
 Network.TcpNodelay = 1
 
 #
+#    Network.EnableProxyProtocol
+#        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
+#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#					  this server and the proxy/load balancer to track the real IP address of players.
+#        Example:     1 - (Enabled)
+#        Default:     0 - (Disabled)
+
+Network.EnableProxyProtocol = 0
+
+#
 ###################################################################################################
 
 ###################################################################################################

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3013,8 +3013,8 @@ Network.TcpNodelay = 1
 #
 #    Network.EnableProxyProtocol
 #        Description: Enables Proxy Protocol v2. When your server is behind a proxy, 
-#					  load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
-#					  this server and the proxy/load balancer to track the real IP address of players.
+#                     load balancer, or similar component, you need to enable Proxy Protocol v2 on both 
+#                     this server and the proxy/load balancer to track the real IP address of players.
 #        Example:     1 - (Enabled)
 #        Default:     0 - (Disabled)
 


### PR DESCRIPTION
**Changes proposed:**

-  Authserver
-  Worldserver
-  Shared Network

**Issues addressed:**

[Closes #27597](https://github.com/TrinityCore/TrinityCore/issues/27597)


**Tests performed:**

Auth- and world-server tested and show/stores real client ips in account table, with haproxy frontend.


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Failed to retrieve client's remote address remote_endpoint: Transport endpoint is not connected
