### PR TITLE
Core/Pet: Replace CastSpell with AddAura

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1481,7 +1481,7 @@ bool Pet::addSpell(uint32 spellId, ActiveStates active /*= ACT_DECIDE*/, PetSpel
     m_spells[spellId] = newspell;
 
     if (spellInfo->IsPassive() && (!spellInfo->CasterAuraState || HasAuraState(AuraStateType(spellInfo->CasterAuraState))))
-        CastSpell(this, spellId, true);
+        AddAura(spellId, this);
     else
         m_charmInfo->AddSpellToActionBar(spellInfo);
 
@@ -1955,7 +1955,7 @@ void Pet::CastPetAura(PetAura const* aura)
     if (auraId == 35696)                                      // Demonic Knowledge
         args.AddSpellMod(SPELLVALUE_BASE_POINT0, CalculatePct(aura->GetDamage(), GetStat(STAT_STAMINA) + GetStat(STAT_INTELLECT)));
 
-    CastSpell(this, auraId, args);
+    AddAura(auraId, this);
 }
 
 bool Pet::IsPetAura(Aura const* aura)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Replace CastSpell with AddAura so passive spells like [Cobra Reflexes](https://www.wowhead.com/wotlk/spell=61682/cobra-reflexes) won't show the animation when learned or while adding pet to the world.
-  Credit goes to [MrSmite](https://github.com/MrSmite)

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/19294


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ Maybe only cast them for stable pets as seen in this video if blizzlike https://youtu.be/JPQon0EG7CA?t=115 ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
