### PR TITLE
Core/Spells: treat spells casts triggered by SPELL_EFFECT_FORCE_CAST_2  as individual casts

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -825,8 +825,13 @@ void Spell::EffectForceCast()
             return;
     }
 
-    CastSpellExtraArgs args(TRIGGERED_FULL_MASK & ~(TRIGGERED_IGNORE_POWER_COST | TRIGGERED_IGNORE_REAGENT_COST));
-    args.SetTriggeringSpell(this);
+    CastSpellExtraArgs args = CastSpellExtraArgs();
+    if (effectInfo->Effect != SPELL_EFFECT_FORCE_CAST_2)
+    {
+        args.SetTriggerFlags(TRIGGERED_FULL_MASK & ~(TRIGGERED_IGNORE_POWER_COST | TRIGGERED_IGNORE_REAGENT_COST));
+        args.SetTriggeringSpell(this);
+    }
+
     if (effectInfo->Effect == SPELL_EFFECT_FORCE_CAST_WITH_VALUE)
         for (std::size_t i = 0; i < spellInfo->GetEffects().size(); ++i)
             args.AddSpellMod(SpellValueMod(SPELLVALUE_BASE_POINT0 + i), damage);


### PR DESCRIPTION
**Changes proposed:**

-  spells which are triggered by SPELL_EFFECT_FORCE_CAST_2  will no longer be treated as an triggered spell cast but instead they act like a followup cast controlled by the server.

**Tests performed:**
- tested ingame on 4.4.2 with the Goblin Town in a Box. Cast data now lines up with sniff behavior
