### PR TITLE
Core/Spells: move force casts into a queue that's being processed at the end of a spell

### DIFF
--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -704,6 +704,9 @@ class TC_GAME_API Spell
 
         std::pair<float, float> GetMinMaxRange(bool strict) const;
 
+        // Adds a spell cast to a queue which will be executed after this spell has finished
+        void AddForceCast(uint32 spellId, ObjectGuid spellCasterGuid, CastSpellExtraArgs& spellCastArgs);
+
     protected:
         bool HasGlobalCooldown() const;
         void TriggerGlobalCooldown();
@@ -779,6 +782,8 @@ class TC_GAME_API Spell
 
         // -------------------------------------------
         GameObject* focusObject;
+
+        std::vector<ForceCastInfo> _triggeredForceCasts;
 
         // Damage and healing in effects need just calculate
         int32 m_damage;           // Damage  in effects count here
@@ -894,6 +899,8 @@ class TC_GAME_API Spell
 
         void PrepareTargetProcessing();
         void FinishTargetProcessing();
+
+        void ProcessForceCasts();
 
         // Scripting system
         void LoadScripts();

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -524,6 +524,18 @@ struct TC_GAME_API CastSpellExtraArgs : public CastSpellExtraArgsInit
     CastSpellExtraArgs& SetScriptWaitsForSpellHit(bool scriptWaitsForSpellHit) { ScriptWaitsForSpellHit = scriptWaitsForSpellHit; return *this; }
 };
 
+struct TC_GAME_API ForceCastInfo
+{
+    ForceCastInfo(uint32 spellId, ObjectGuid spellCasterGuid, CastSpellExtraArgs& spellCastArgs) :
+        SpellId(spellId), SpellCasterGuid(spellCasterGuid), SpellCastArgs(std::move(spellCastArgs))
+    {
+    }
+
+    uint32 SpellId;
+    ObjectGuid SpellCasterGuid;
+    CastSpellExtraArgs SpellCastArgs;
+};
+
 struct SpellCastVisual
 {
     uint32 SpellXSpellVisualID = 0;


### PR DESCRIPTION

**Changes proposed:**

-  instead of launching force cast spells right away, possibly interrupting their parent spell when not marked as triggered, we can now collect and execute them at the end of the parent spell cast.

**Tests performed:**
- tested ingame

