### PR TITLE
Scripts/Shadowfang Keep: Check boss state and door state before opening Arugal door

### DIFF
--- a/sql/updates/world/3.3.5/2025_04_28_00_world.sql
+++ b/sql/updates/world/3.3.5/2025_04_28_00_world.sql
@@ -1,4 +1,4 @@
 -- 
-DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=22 AND `SourceGroup`=1 AND `SourceEntry`=18899;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=22 AND `SourceGroup`=1 AND `SourceEntry`=18899 AND `SourceId`=1;
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (22, 1, 18899, 1, 0, 13, 1, 4, 3, 0, 1, 0, 0, '', 'Execute SAI only if Wolf Master Nandos is not done');

--- a/sql/updates/world/3.3.5/2025_99_99_99_world.sql
+++ b/sql/updates/world/3.3.5/2025_99_99_99_world.sql
@@ -1,0 +1,4 @@
+-- 
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=22 AND `SourceGroup`=1 AND `SourceEntry`=18899;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 1, 18899, 1, 0, 13, 1, 4, 3, 0, 1, 0, 0, '', 'Execute SAI only if Wolf Master Nandos is not done');

--- a/src/server/scripts/EasternKingdoms/ShadowfangKeep/instance_shadowfang_keep.cpp
+++ b/src/server/scripts/EasternKingdoms/ShadowfangKeep/instance_shadowfang_keep.cpp
@@ -174,7 +174,11 @@ public:
                     break;
                 case TYPE_NANDOS:
                     if (data == DONE)
-                        DoUseDoorOrButton(DoorArugalGUID);
+                    {
+                        if (GameObject* go = instance->GetGameObject(DoorArugalGUID))
+                            if (go->GetGoState() == GO_STATE_READY)
+                                DoUseDoorOrButton(DoorArugalGUID);
+                    }
                     m_auiEncounter[3] = data;
                     break;
                 case DATA_SPAWN_VALENTINE_ADDS:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Check boss state and door state before opening Arugal door so you shoud not be able to lock yourself in.
-  
-  

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/27009


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
