### PR TITLE
Core/Players: Fix deleting favorite spells

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -21415,8 +21415,8 @@ void Player::_SaveSpells(CharacterDatabaseTransaction trans)
             }
 
             stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_SPELL_FAVORITE);
-            stmt->setUInt32(0, itr->first);
-            stmt->setUInt64(1, GetGUID().GetCounter());
+            stmt->setUInt64(0, GetGUID().GetCounter());
+            stmt->setUInt32(1, itr->first);
             trans->Append(stmt);
 
             if (itr->second.favorite)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix parameter order for `CHAR_DEL_CHAR_SPELL_FAVORITE`

**Issues addressed:**

The incorrect order causes errors like

> SQL(p): INSERT INTO character_spell_favorite (guid, spell) VALUES (3, 3919)
>  [ERROR]: [1062] Duplicate entry '3-3919' for key 'PRIMARY'

(because the intended delete never happened) which fails the entire character update transaction on logout.

**Tests performed:**

Tested in-game:

1. Mark a spell as favorite
2. Log out
3. Log back in
4. Teleport to a different location
5. Log out
6. Notice the original location is still displayed in the character list

**Known issues and TODO list:** (add/remove lines as needed)

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
