### PR TITLE
Core/Network: Update LoginRESTService to check all addresses together

### DIFF
--- a/src/server/bnetserver/REST/LoginRESTService.h
+++ b/src/server/bnetserver/REST/LoginRESTService.h
@@ -81,7 +81,10 @@ private:
     JSON::Login::FormInputs _formInputs;
     std::string _bindIP;
     uint16 _port;
-    std::array<std::pair<std::string, std::vector<boost::asio::ip::address>>, 2> _hostnames;
+    std::string _externalHostname;
+    std::string _localHostname;
+    std::vector<boost::asio::ip::address> _addresses;
+    std::size_t _firstLocalAddressIndex; // index inside _addresses where the first local address can be found
     uint32 _loginTicketDuration;
 };
 }

--- a/src/server/bnetserver/REST/LoginRESTService.h
+++ b/src/server/bnetserver/REST/LoginRESTService.h
@@ -51,7 +51,7 @@ public:
     using HttpRequestContext = Trinity::Net::Http::RequestContext;
     using HttpSessionState = Trinity::Net::Http::SessionState;
 
-    LoginRESTService() : HttpService("login"), _port(0), _loginTicketDuration(0) { }
+    LoginRESTService() : HttpService("login"), _port(0), _firstLocalAddressIndex(0), _loginTicketDuration(0) { }
 
     static LoginRESTService& Instance();
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

Rework how `LoginRESTService` handles hostnames and addresses so that it can properly call `SelectAddressForClient` using all potential addresses. This fixes a bug where clients are unable to connect locally when an external address is defined in `bnetserver.conf`.

To repro bug:

1. In `bnetserver.conf`, set `LoginREST.ExternalAddress` to any public IP address
2. In `bnetserver.conf`, set `LoginREST.LocalAddress` to the private (LAN) IP address where TC is running
3. Connect client to bnetserver using address from `LoginREST.LocalAddress`
4. Client is unable to connect because bnetserver always returns URL containing public IP address

**Issues addressed:**

Allows clients to connect locally when an external address is defined.

**Tests performed:**

Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
