### PR TITLE
New GM Command .guild list

### DIFF
--- a/sql/updates/world/master/9999_99_99_01_add_guild_list_command.sql
+++ b/sql/updates/world/master/9999_99_99_01_add_guild_list_command.sql
@@ -1,0 +1,2 @@
+-- 9999_99_99_01_add_guild_list_command.sql
+INSERT INTO command (`name`, `help`) VALUES ('guild list',    'Syntax: .guild list.  Lists every guild: ID | Name | GM | Created | Members | Level | Bank gold');

--- a/src/server/game/Guilds/GuildMgr.h
+++ b/src/server/game/Guilds/GuildMgr.h
@@ -43,10 +43,9 @@ public:
     Guild* GetGuildByGuid(ObjectGuid guid) const;
     Guild* GetGuildByName(std::string_view guildName) const;
     std::string GetGuildNameById(ObjectGuid::LowType guildId) const;
-    
+
     // --- new read-only accessor ---
-    using GuildContainer = std::unordered_map<ObjectGuid::LowType, Trinity::unique_trackable_ptr<Guild>>;
-    GuildContainer const& GetGuildStore() const { return GuildStore; }   //<--- ADDED
+    auto const& GetGuildStore() const { return GuildStore; }
     
     void LoadGuildRewards();
 

--- a/src/server/game/Guilds/GuildMgr.h
+++ b/src/server/game/Guilds/GuildMgr.h
@@ -43,7 +43,11 @@ public:
     Guild* GetGuildByGuid(ObjectGuid guid) const;
     Guild* GetGuildByName(std::string_view guildName) const;
     std::string GetGuildNameById(ObjectGuid::LowType guildId) const;
-
+    
+    // --- new read-only accessor ---
+    using GuildContainer = std::unordered_map<ObjectGuid::LowType, Trinity::unique_trackable_ptr<Guild>>;
+    GuildContainer const& GetGuildStore() const { return GuildStore; }   //<--- ADDED
+    
     void LoadGuildRewards();
 
     void LoadGuilds();


### PR DESCRIPTION
**Changes proposed:**

- Add new `.guild list` GM command in `cs_guild.cpp`  that display all guilds info.
  - Register `"list"` subcommand with `HandleGuildListCommand` and `RBAC_PERM_COMMAND_GUILD_INFO`  
  - Include `Define.h` for `PRIu64` formatting macro  
- Introduce a read-only accessor `GetGuildStore()` in `GMFunctionsPanel` to expose `GuildStore`  
- Implement `HandleGuildListCommand` handler to iterate `sGuildMgr->GetGuildStore()` and print ID, Name, GM, Created date, Members count, Level and Bank gold  

**Database changes:**
- Added world DB script `sql/commands/9999_99_99_01_add_guild_list_command.sql`

**Tests performed:**

- Project builds without errors on Windows and Linux  
- Verified `.guild list` in-game prints the full guild list with correct formatting  
- Confirmed that RBAC permission gating prevents non-GM users from invoking the command  
- Checked date formatting and bank gold calculation against known guild data  

**Known issues and TODO list:** (add/remove lines as needed)
