### PR TITLE
DB/Dungeons: Remove deprecated The Black Morass attunement

### DIFF
--- a/sql/updates/world/master/2025_05_27_04_world.sql
+++ b/sql/updates/world/master/2025_05_27_04_world.sql
@@ -1,0 +1,1 @@
+UPDATE `access_requirement` SET `quest_done_A`=0, `quest_done_H`=0, `quest_failed_text`=NULL WHERE `mapId`=269 AND `difficulty` IN (1,2);

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,0 +1,1 @@
+UPDATE `access_requirement` SET `quest_done_A` = 0, `quest_done_H` = 0, `quest_failed_text` = NULL WHERE `mapId` = 269 AND `difficulty` IN (1, 2);

--- a/sql/updates/world/master/9999_99_99_99_world.sql
+++ b/sql/updates/world/master/9999_99_99_99_world.sql
@@ -1,1 +1,0 @@
-UPDATE `access_requirement` SET `quest_done_A` = 0, `quest_done_H` = 0, `quest_failed_text` = NULL WHERE `mapId` = 269 AND `difficulty` IN (1, 2);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  The quest 10285 - Return to Andormu was deprecated in Cataclysm (and marked disabled in TDB), but the attunement was never removed from The Black Morass. This removes that deprecated access requirement.

**Issues addressed:**

None.

**Tests performed:**

Tested in-game; characters can now zone into The Black Morass.

**Known issues and TODO list:** (add/remove lines as needed)

None.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
