### PR TITLE
Core/Misc: Fix player outdoor status after leaving an instance

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -107,6 +107,7 @@ void WorldSession::HandleMoveWorldportAck()
 
     player->ResetMap();
     player->SetMap(newMap);
+    player->UpdatePositionData();
 
     WorldPackets::Movement::ResumeToken resumeToken;
     resumeToken.SequenceIndex = player->m_movementCounter;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- A regression to player indoor/outdoor status was introduced with https://github.com/TrinityCore/TrinityCore/pull/28731
- After that change, players may have to move after zoning out of an instance before they are able to mount
- This fixes that case, and potentially others; I'm not familiar enough with the teleport semantics to understand it all, but this looks similar to `Player::LoadFromDB` where `UpdatePositionData` follows `SetMap`, so I think it's an appropriate place to add this call.

**Issues addressed:**

None.

**Tests performed:**

Tested in-game.

1. `.tele ragefirechasm`
2. Zone into instance
3. Zone out of instance, but do not move
4. Attempt to mount

**Known issues and TODO list:** (add/remove lines as needed)

None.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
