### PR TITLE
Scripts/Spells: Implement Cold Steel, Hot Blood talent

### DIFF
--- a/sql/updates/world/master/2025_09_01_01_world.sql
+++ b/sql/updates/world/master/2025_09_01_01_world.sql
@@ -1,7 +1,7 @@
-DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warr_bloodthirst_cold_steel_hot_blood';
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warr_cold_steel_hot_blood_bloodthirst';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(23881, 'spell_warr_bloodthirst_cold_steel_hot_blood'),
-(335096, 'spell_warr_bloodthirst_cold_steel_hot_blood');
+(23881, 'spell_warr_cold_steel_hot_blood_bloodthirst'),
+(335096, 'spell_warr_cold_steel_hot_blood_bloodthirst');
 
 DELETE FROM `spell_proc` WHERE `SpellId` IN (383959);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES

--- a/sql/updates/world/master/2025_mm_dd_xx_world.sql
+++ b/sql/updates/world/master/2025_mm_dd_xx_world.sql
@@ -1,6 +1,7 @@
-DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warr_cold_steel_hot_blood_proc';
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warr_bloodthirst_cold_steel_hot_blood';
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(383959, 'spell_warr_cold_steel_hot_blood_proc');
+(23881, 'spell_warr_bloodthirst_cold_steel_hot_blood'),
+(335096, 'spell_warr_bloodthirst_cold_steel_hot_blood');
 
 DELETE FROM `spell_proc` WHERE `SpellId` IN (383959);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES

--- a/sql/updates/world/master/2025_mm_dd_xx_world.sql
+++ b/sql/updates/world/master/2025_mm_dd_xx_world.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_warr_cold_steel_hot_blood_proc';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(383959, 'spell_warr_cold_steel_hot_blood_proc');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (383959);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(383959,0x01,4,0x00000000,0x00000400,0x00000000,0x00000000,0x0,0x0,0x1,0x2,0x2,0x0,0x0,0,0,0,0); -- Cold Steel, Hot Blood

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -43,6 +43,7 @@ enum WarriorSpells
     SPELL_WARRIOR_CHARGE_DROP_FIRE_PERIODIC         = 126661,
     SPELL_WARRIOR_CHARGE_EFFECT                     = 198337,
     SPELL_WARRIOR_CHARGE_ROOT_EFFECT                = 105771,
+    SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_AURA         = 383959,
     SPELL_WARRIOR_COLOSSUS_SMASH                    = 167105,
     SPELL_WARRIOR_COLOSSUS_SMASH_AURA               = 208086,
     SPELL_WARRIOR_CRITICAL_THINKING_ENERGIZE        = 392776,
@@ -279,6 +280,36 @@ class spell_warr_bloodthirst : public SpellScript
     }
 };
 
+// 23881 - Bloodthirst
+// 335096 - Bloodbath
+class spell_warr_bloodthirst_cold_steel_hot_blood : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARRIOR_GUSHING_WOUND, SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_AURA });
+    }
+
+    bool Load() override
+    {
+        return GetCaster()->HasAura(SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_AURA);
+    }
+
+    void CastGushingWound(SpellEffIndex /*effIndex*/) const
+    {
+        if (!IsHitCrit())
+            return;
+
+        GetCaster()->CastSpell(GetHitUnit(), SPELL_WARRIOR_GUSHING_WOUND, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR
+        });
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_warr_bloodthirst_cold_steel_hot_blood::CastGushingWound, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+    }
+};
+
 // 384036 - Brutal Vitality
 class spell_warr_brutal_vitality : public AuraScript
 {
@@ -396,27 +427,6 @@ class spell_warr_charge_effect : public SpellScript
     void Register() override
     {
         OnEffectLaunchTarget += SpellEffectFn(spell_warr_charge_effect::HandleCharge, EFFECT_0, SPELL_EFFECT_CHARGE);
-    }
-};
-
-// 383959 - Cold Steel, Hot Blood
-class spell_warr_cold_steel_hot_blood_proc : public AuraScript
-{
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_WARRIOR_GUSHING_WOUND });
-    }
-
-    void HandleProc(ProcEventInfo const& eventInfo) const
-    {
-        GetTarget()->CastSpell(eventInfo.GetActionTarget(), SPELL_WARRIOR_GUSHING_WOUND, CastSpellExtraArgsInit{
-            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR
-        });
-    }
-
-    void Register() override
-    {
-        OnProc += AuraProcFn(spell_warr_cold_steel_hot_blood_proc::HandleProc);
     }
 };
 
@@ -1577,11 +1587,11 @@ void AddSC_warrior_spell_scripts()
     RegisterSpellScript(spell_warr_ashen_juggernaut);
     RegisterSpellScript(spell_warr_avatar);
     RegisterSpellScript(spell_warr_bloodthirst);
+    RegisterSpellScript(spell_warr_bloodthirst_cold_steel_hot_blood);
     RegisterSpellScript(spell_warr_brutal_vitality);
     RegisterSpellScript(spell_warr_charge);
     RegisterSpellScript(spell_warr_charge_drop_fire_periodic);
     RegisterSpellScript(spell_warr_charge_effect);
-    RegisterSpellScript(spell_warr_cold_steel_hot_blood_proc);
     RegisterSpellScript(spell_warr_colossus_smash);
     RegisterSpellScript(spell_warr_critical_thinking);
     RegisterSpellScript(spell_warr_deft_experience);

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -43,7 +43,7 @@ enum WarriorSpells
     SPELL_WARRIOR_CHARGE_DROP_FIRE_PERIODIC         = 126661,
     SPELL_WARRIOR_CHARGE_EFFECT                     = 198337,
     SPELL_WARRIOR_CHARGE_ROOT_EFFECT                = 105771,
-    SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_AURA         = 383959,
+    SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_TALENT       = 383959,
     SPELL_WARRIOR_COLOSSUS_SMASH                    = 167105,
     SPELL_WARRIOR_COLOSSUS_SMASH_AURA               = 208086,
     SPELL_WARRIOR_CRITICAL_THINKING_ENERGIZE        = 392776,
@@ -280,36 +280,6 @@ class spell_warr_bloodthirst : public SpellScript
     }
 };
 
-// 23881 - Bloodthirst
-// 335096 - Bloodbath
-class spell_warr_bloodthirst_cold_steel_hot_blood : public SpellScript
-{
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_WARRIOR_GUSHING_WOUND, SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_AURA });
-    }
-
-    bool Load() override
-    {
-        return GetCaster()->HasAura(SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_AURA);
-    }
-
-    void CastGushingWound(SpellEffIndex /*effIndex*/) const
-    {
-        if (!IsHitCrit())
-            return;
-
-        GetCaster()->CastSpell(GetHitUnit(), SPELL_WARRIOR_GUSHING_WOUND, CastSpellExtraArgsInit{
-            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR
-        });
-    }
-
-    void Register() override
-    {
-        OnEffectHitTarget += SpellEffectFn(spell_warr_bloodthirst_cold_steel_hot_blood::CastGushingWound, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
-    }
-};
-
 // 384036 - Brutal Vitality
 class spell_warr_brutal_vitality : public AuraScript
 {
@@ -427,6 +397,36 @@ class spell_warr_charge_effect : public SpellScript
     void Register() override
     {
         OnEffectLaunchTarget += SpellEffectFn(spell_warr_charge_effect::HandleCharge, EFFECT_0, SPELL_EFFECT_CHARGE);
+    }
+};
+
+// 23881 - Bloodthirst
+// 335096 - Bloodbath
+class spell_warr_cold_steel_hot_blood_bloodthirst : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARRIOR_GUSHING_WOUND, SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_TALENT });
+    }
+
+    bool Load() override
+    {
+        return GetCaster()->HasAura(SPELL_WARRIOR_COLD_STEEL_HOT_BLOOD_TALENT);
+    }
+
+    void CastGushingWound(SpellEffIndex /*effIndex*/) const
+    {
+        if (!IsHitCrit())
+            return;
+
+        GetCaster()->CastSpell(GetHitUnit(), SPELL_WARRIOR_GUSHING_WOUND, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR
+            });
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_warr_cold_steel_hot_blood_bloodthirst::CastGushingWound, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
     }
 };
 
@@ -1587,11 +1587,11 @@ void AddSC_warrior_spell_scripts()
     RegisterSpellScript(spell_warr_ashen_juggernaut);
     RegisterSpellScript(spell_warr_avatar);
     RegisterSpellScript(spell_warr_bloodthirst);
-    RegisterSpellScript(spell_warr_bloodthirst_cold_steel_hot_blood);
     RegisterSpellScript(spell_warr_brutal_vitality);
     RegisterSpellScript(spell_warr_charge);
     RegisterSpellScript(spell_warr_charge_drop_fire_periodic);
     RegisterSpellScript(spell_warr_charge_effect);
+    RegisterSpellScript(spell_warr_cold_steel_hot_blood_bloodthirst);
     RegisterSpellScript(spell_warr_colossus_smash);
     RegisterSpellScript(spell_warr_critical_thinking);
     RegisterSpellScript(spell_warr_deft_experience);

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -58,6 +58,7 @@ enum WarriorSpells
     SPELL_WARRIOR_GLYPH_OF_THE_BLAZING_TRAIL        = 123779,
     SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP              = 159708,
     SPELL_WARRIOR_GLYPH_OF_HEROIC_LEAP_BUFF         = 133278,
+    SPELL_WARRIOR_GUSHING_WOUND                     = 385042,
     SPELL_WARRIOR_HEROIC_LEAP_JUMP                  = 178368,
     SPELL_WARRIOR_IGNORE_PAIN                       = 190456,
     SPELL_WARRIOR_IMPROVED_RAGING_BLOW              = 383854,
@@ -395,6 +396,27 @@ class spell_warr_charge_effect : public SpellScript
     void Register() override
     {
         OnEffectLaunchTarget += SpellEffectFn(spell_warr_charge_effect::HandleCharge, EFFECT_0, SPELL_EFFECT_CHARGE);
+    }
+};
+
+// 383959 - Cold Steel, Hot Blood
+class spell_warr_cold_steel_hot_blood_proc : public AuraScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARRIOR_GUSHING_WOUND });
+    }
+
+    void HandleProc(ProcEventInfo const& eventInfo) const
+    {
+        GetTarget()->CastSpell(eventInfo.GetActionTarget(), SPELL_WARRIOR_GUSHING_WOUND, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR
+        });
+    }
+
+    void Register() override
+    {
+        OnProc += AuraProcFn(spell_warr_cold_steel_hot_blood_proc::HandleProc);
     }
 };
 
@@ -1559,6 +1581,7 @@ void AddSC_warrior_spell_scripts()
     RegisterSpellScript(spell_warr_charge);
     RegisterSpellScript(spell_warr_charge_drop_fire_periodic);
     RegisterSpellScript(spell_warr_charge_effect);
+    RegisterSpellScript(spell_warr_cold_steel_hot_blood_proc);
     RegisterSpellScript(spell_warr_colossus_smash);
     RegisterSpellScript(spell_warr_critical_thinking);
     RegisterSpellScript(spell_warr_deft_experience);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implement Coldl Steel, Hot Blood talent

**Issues addressed:**

Closes: none?


**Tests performed:**

- Builds locally
- Crits on Bloodthirst/Bloodbath give debuff


**Known issues and TODO list:**

- [ ] It seems like only one target can get the debuff, while all targets on whom the crit occured should have the debuff.  
Retail behaviour: While more targets can get crit at the same time, the extra rage generated is only cast with one spell_go (no spell_start). But the rage gained is still summed up (so 2 targets critted, means double rage gained).


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
