### PR TITLE
DB/SpellsGroups: Add warrior stances

### DIFF
--- a/sql/updates/world/master/2025_07_12_00_world.sql
+++ b/sql/updates/world/master/2025_07_12_00_world.sql
@@ -1,4 +1,4 @@
-SET @GROUP_ID := 10000; -- TODO change me
+SET @GROUP_ID := 1502; 
 
 DELETE FROM  `spell_group_stack_rules` WHERE `group_id`= @GROUP_ID;
 INSERT INTO `spell_group_stack_rules` (`group_id`, `stack_rule`) VALUES

--- a/sql/updates/world/master/2025_mm_dd_xx_world.sql
+++ b/sql/updates/world/master/2025_mm_dd_xx_world.sql
@@ -1,0 +1,11 @@
+SET @GROUP_ID := 10000; -- TODO change me
+
+DELETE FROM  `spell_group_stack_rules` WHERE `group_id`= @GROUP_ID;
+INSERT INTO `spell_group_stack_rules` (`group_id`, `stack_rule`) VALUES
+(@GROUP_ID, 1);
+
+DELETE FROM `spell_group` WHERE `id` = @GROUP_ID;
+INSERT INTO `spell_group` (`id`, `spell_id`) VALUES
+(@GROUP_ID, 386208), -- Defensive Stance
+(@GROUP_ID, 386196), -- Berserker Stance 
+(@GROUP_ID, 386164); -- Battle Stance


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add spell group data for warrior stances

**Issues addressed:**

Closes: none?


**Tests performed:**

- server starts
- stances are excluded from each other (activating one stance, de-activates the other)


**Known issues and TODO list:**

- none? Wasn't sure about group_id


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
