### PR TITLE
Core/SharedDefines: Define SPELL_ATTR10_UNK10

### DIFF
--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -809,7 +809,7 @@ enum SpellAttr10 : uint32
     SPELL_ATTR10_TELEPORT_PLAYER                 = 0x00000080, // TITLE Ignore instance lock and farm limit on teleport
     SPELL_ATTR10_UNK8                            = 0x00000100, // TITLE Unknown attribute 8@Attr10
     SPELL_ATTR10_UNK9                            = 0x00000200, // TITLE Unknown attribute 9@Attr10
-    SPELL_ATTR10_UNK10                           = 0x00000400, // TITLE Unknown attribute 10@Attr10
+    SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET        = 0x00000400, /*NYI*/ // TITLE Proc cooldown on a per-target basis
     SPELL_ATTR10_HERB_GATHERING_MINING           = 0x00000800, // TITLE Lock chest at precast
     SPELL_ATTR10_USE_SPELL_BASE_LEVEL_FOR_SCALING= 0x00001000, // TITLE Use Spell Base Level For Scaling
     SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END = 0x00002000, // TITLE Reset cooldown upon ending an encounter

--- a/src/server/game/Miscellaneous/enuminfo_SharedDefines.cpp
+++ b/src/server/game/Miscellaneous/enuminfo_SharedDefines.cpp
@@ -1574,7 +1574,7 @@ TC_API_EXPORT EnumText EnumUtils<SpellAttr10>::ToString(SpellAttr10 value)
         case SPELL_ATTR10_TELEPORT_PLAYER: return { "SPELL_ATTR10_TELEPORT_PLAYER", "Ignore instance lock and farm limit on teleport", "" };
         case SPELL_ATTR10_UNK8: return { "SPELL_ATTR10_UNK8", "Unknown attribute 8@Attr10", "" };
         case SPELL_ATTR10_UNK9: return { "SPELL_ATTR10_UNK9", "Unknown attribute 9@Attr10", "" };
-        case SPELL_ATTR10_UNK10: return { "SPELL_ATTR10_UNK10", "Unknown attribute 10@Attr10", "" };
+        case SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET: return { "SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET", "Proc cooldown on a per-target basis", "" };
         case SPELL_ATTR10_HERB_GATHERING_MINING: return { "SPELL_ATTR10_HERB_GATHERING_MINING", "Lock chest at precast", "" };
         case SPELL_ATTR10_USE_SPELL_BASE_LEVEL_FOR_SCALING: return { "SPELL_ATTR10_USE_SPELL_BASE_LEVEL_FOR_SCALING", "Use Spell Base Level For Scaling", "" };
         case SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END: return { "SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END", "Reset cooldown upon ending an encounter", "" };
@@ -1618,7 +1618,7 @@ TC_API_EXPORT SpellAttr10 EnumUtils<SpellAttr10>::FromIndex(size_t index)
         case 7: return SPELL_ATTR10_TELEPORT_PLAYER;
         case 8: return SPELL_ATTR10_UNK8;
         case 9: return SPELL_ATTR10_UNK9;
-        case 10: return SPELL_ATTR10_UNK10;
+        case 10: return SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET;
         case 11: return SPELL_ATTR10_HERB_GATHERING_MINING;
         case 12: return SPELL_ATTR10_USE_SPELL_BASE_LEVEL_FOR_SCALING;
         case 13: return SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END;
@@ -1659,7 +1659,7 @@ TC_API_EXPORT size_t EnumUtils<SpellAttr10>::ToIndex(SpellAttr10 value)
         case SPELL_ATTR10_TELEPORT_PLAYER: return 7;
         case SPELL_ATTR10_UNK8: return 8;
         case SPELL_ATTR10_UNK9: return 9;
-        case SPELL_ATTR10_UNK10: return 10;
+        case SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET: return 10;
         case SPELL_ATTR10_HERB_GATHERING_MINING: return 11;
         case SPELL_ATTR10_USE_SPELL_BASE_LEVEL_FOR_SCALING: return 12;
         case SPELL_ATTR10_RESET_COOLDOWN_ON_ENCOUNTER_END: return 13;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Define SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET

Noticed that Wowhead had an attribute defined that TrinityCore did not.
This attribute denotes that the proc cooldown should apply per target.

Example spell: [Wowhead - Spellweaving (106040)](https://www.wowhead.com/spell=106040/spellweaving), Spellweaving from madness of deathwing boss can proc simultaneously on multiple targets as the internal cd only applies per target.

Checked SpellWork for other spells implementing said attribute and it seems to be correct.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
