### PR TITLE
Core/SAI: Add actions EXIT_VEHICLE, BOARD_PASSENGER and EXIT_VEHICLE

### DIFF
--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2610,7 +2610,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
             for (WorldObject* target : targets)
             {
-                if (Unit* unitTarget = Object::ToUnit(target))
+                if (Unit* unitTarget = target->ToUnit())
                 {
                     me->EnterVehicle(unitTarget, (uint8)e.action.enterVehicle.seatId);
                     break;
@@ -2625,7 +2625,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
 
             for (WorldObject* target : targets)
             {
-                if (Unit* unitTarget = Object::ToUnit(target))
+                if (Unit* unitTarget = target->ToUnit())
                 {
                     unitTarget->EnterVehicle(me, (uint8)e.action.enterVehicle.seatId);
                     break;
@@ -2637,7 +2637,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             for (WorldObject* target : targets)
             {
-                if (Unit* unitTarget = Object::ToUnit(target))
+                if (Unit* unitTarget = target->ToUnit())
                 {
                     unitTarget->ExitVehicle();
                 }

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2603,6 +2603,47 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             Cell::VisitGridObjects(GetBaseObject(), worker, float(e.action.destroyConversation.range));
             break;
         }
+        case SMART_ACTION_ENTER_VEHICLE:
+        {
+            if (!me)
+                break;
+            
+            for (WorldObject* target : targets)
+            {
+                if (Unit* unitTarget = Object::ToUnit(target))
+                {
+                    me->EnterVehicle(unitTarget, (uint8)e.action.enterVehicle.seatId);
+                    break;
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_BOARD_PASSENGER:
+        {
+            if (!me)
+                break;
+            
+            for (WorldObject* target : targets)
+            {
+                if (Unit* unitTarget = Object::ToUnit(target))
+                {
+                    unitTarget->EnterVehicle(me, (uint8)e.action.enterVehicle.seatId);
+                    break;
+                }
+            }
+            break;
+        }
+        case SMART_ACTION_EXIT_VEHICLE:
+        {
+            for (WorldObject* target : targets)
+            {
+                if (Unit* unitTarget = Object::ToUnit(target))
+                {
+                    unitTarget->ExitVehicle();
+                }
+            }
+            break;
+        }
         default:
             TC_LOG_ERROR("sql.sql", "SmartScript::ProcessAction: Entry {} SourceType {}, Event {}, Unhandled Action type {}", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
             break;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2607,7 +2607,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             if (!me)
                 break;
-            
+
             for (WorldObject* target : targets)
             {
                 if (Unit* unitTarget = Object::ToUnit(target))
@@ -2622,7 +2622,7 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
         {
             if (!me)
                 break;
-            
+
             for (WorldObject* target : targets)
             {
                 if (Unit* unitTarget = Object::ToUnit(target))

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -1030,6 +1030,9 @@ bool SmartAIMgr::CheckUnusedActionParams(SmartScriptHolder const& e)
             case SMART_ACTION_COMPLETE_QUEST: return sizeof(SmartAction::quest);
             case SMART_ACTION_CREDIT_QUEST_OBJECTIVE_TALK_TO: return NO_PARAMS;
             case SMART_ACTION_DESTROY_CONVERSATION: return sizeof(SmartAction::destroyConversation);
+            case SMART_ACTION_ENTER_VEHICLE: return sizeof(SmartAction::enterVehicle);
+            case SMART_ACTION_BOARD_PASSENGER: return sizeof(SmartAction::enterVehicle);
+            case SMART_ACTION_EXIT_VEHICLE: return NO_PARAMS;
             default:
                 TC_LOG_WARN("sql.sql", "SmartAIMgr: Entry {} SourceType {} Event {} Action {} is using an action with no unused params specified in SmartAIMgr::CheckUnusedActionParams(), please report this.",
                     e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType());
@@ -2427,6 +2430,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
         case SMART_ACTION_DESPAWN_SPAWNGROUP:
         case SMART_ACTION_ADD_TO_STORED_TARGET_LIST:
         case SMART_ACTION_DO_ACTION:
+        case SMART_ACTION_EXIT_VEHICLE:
             break;
         case SMART_ACTION_BECOME_PERSONAL_CLONE_FOR_PLAYER:
         {
@@ -2477,6 +2481,16 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             }
 
             TC_SAI_IS_BOOLEAN_VALID(e, e.action.destroyConversation.isPrivate);
+            break;
+        }
+        case SMART_ACTION_ENTER_VEHICLE:
+        case SMART_ACTION_BOARD_PASSENGER:
+        {
+            if (e.action.enterVehicle.seatId >= MAX_VEHICLE_SEATS)
+            {
+                TC_LOG_ERROR("sql.sql", "SmartAIMgr: Entry {} SourceType {} Event {} Action {} uses incorrect seat id (out of range 0 - {}), skipped.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), MAX_VEHICLE_SEATS - 1);
+                return false;
+            }
             break;
         }
         // Unused

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1245,7 +1245,7 @@ struct SmartAction
         {
             uint32 actionId;
         } doAction;
-        
+
         struct
         {
             uint32 seatId;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -608,7 +608,10 @@ enum SMART_ACTION
     SMART_ACTION_COMPLETE_QUEST                     = 152,    // QuestId. Regular quests with objectives can't be completed with this action (only quests with QUEST_FLAGS_COMPLETION_EVENT, QUEST_FLAGS_COMPLETION_AREA_TRIGGER or QUEST_FLAGS_TRACKING_EVENT)
     SMART_ACTION_CREDIT_QUEST_OBJECTIVE_TALK_TO     = 153,
     SMART_ACTION_DESTROY_CONVERSATION               = 154,    // conversation_template.id, isPrivate, range
-    SMART_ACTION_END                                = 155
+    SMART_ACTION_ENTER_VEHICLE                      = 155,    // seat id
+    SMART_ACTION_BOARD_PASSENGER                    = 156,    // seat id
+    SMART_ACTION_EXIT_VEHICLE                       = 157,
+    SMART_ACTION_END                                = 158
 };
 
 enum class SmartActionSummonCreatureFlags
@@ -1242,6 +1245,11 @@ struct SmartAction
         {
             uint32 actionId;
         } doAction;
+        
+        struct
+        {
+            uint32 seatId;
+        } enterVehicle;
 
         struct
         {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add a SAI action `exit vehicle`. While the `exit vehicle` action can be achieved now by using `remove aura` action, it is troublesome, because a) you need to know the spell id b) the intention of remoe aura is not as clear as action dedicated to leaving the vehicle. 
- Add a SAI action `enter vehicle`. This is much more problematic now, because there is no way to override base points of the spell when casting the spell, so using `cast ride vehicle hardcoded` doesn't work in most cases.
- Add a SAI action `board passenger`. I believe it is useful to have both actions where we can either target the vehicle to enter (enter vehicle) or target the passenger to board (board passenger)

**Tests performed:**

- Tested in game with quest "We are here to do one thing, maybe two"

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
