### PR TITLE
Core/Units: Don't change hover anim for vehicle passengers

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13222,15 +13222,19 @@ bool Unit::SetDisableGravity(bool disable, bool updateAnimTier /*= true*/)
         SendMessageToSet(packet.Write(), true);
     }
 
-    if (IsAlive())
+    if (!GetVehicle())
     {
-        if (IsGravityDisabled() || IsHovering())
-            SetPlayHoverAnim(true);
-        else
-            SetPlayHoverAnim(false);
+        if (IsAlive())
+        {
+            if (IsGravityDisabled() || IsHovering())
+                SetPlayHoverAnim(true);
+            else
+                SetPlayHoverAnim(false);
+        }
+        else if (IsPlayer()) // To update player who dies while flying/hovering
+            SetPlayHoverAnim(false, false);
     }
-    else if (IsPlayer()) // To update player who dies while flying/hovering
-        SetPlayHoverAnim(false, false);
+
 
     if (IsCreature() && updateAnimTier && IsAlive() && !HasUnitState(UNIT_STATE_ROOT))
     {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -13235,7 +13235,6 @@ bool Unit::SetDisableGravity(bool disable, bool updateAnimTier /*= true*/)
             SetPlayHoverAnim(false, false);
     }
 
-
     if (IsCreature() && updateAnimTier && IsAlive() && !HasUnitState(UNIT_STATE_ROOT))
     {
         if (IsGravityDisabled())


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Hover animation will not be automatically played for vehicle passengers if disable gravity flag is set:
- https://github.com/TrinityCore/TrinityCore/pull/29434 has added automatic playing hover animation when the gravity is disabled, but it doesn't seem to be correct for vehicles, i.e. seats of vehicle 835 (7913, 7914, 7915, 7916, 7917) have seat flag VEHICLE_SEAT_FLAG_DISABLE_GRAVITY, the gravity is disabled in the sniff:
```
[3] MovementFlags: 1536 (DisableGravity, Root)
```
However, there are no signs of hover in the sniff. Therefore, my proposal is to exclude vehicle passengers from this play hover anim behaviour.

Before:
![before](https://github.com/user-attachments/assets/d2702e7a-91f3-4fac-a599-65bcc034407d)

After:
![after](https://github.com/user-attachments/assets/3fe694e6-d8ff-4afa-947b-34e5969f049b)


**Tests performed:**

- Tested in game for vehicle 835 in quest We're here to do one thing, maybe two.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
