### PR TITLE
Core/Pools: Fix handle respawning for nested pools

### DIFF
--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -393,9 +393,13 @@ void PoolGroup<GameObject>::ReSpawn1Object(PoolObject* obj)
     Spawn1Object(obj);
 }
 
-// Nothing to do for a child Pool
+// Method that does the respawn job on the specified pool
 template <>
-void PoolGroup<Pool>::ReSpawn1Object(PoolObject* /*obj*/) { }
+void PoolGroup<Pool>::ReSpawn1Object(PoolObject* obj)
+{
+    Despawn1Object(obj->guid, false, false);
+    Spawn1Object(obj);
+}
 
 template <>
 void PoolGroup<Creature>::RemoveRespawnTimeFromDB(ObjectGuid::LowType guid)

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -377,25 +377,9 @@ void PoolGroup<Pool>::Spawn1Object(PoolObject* obj)
     sPoolMgr->SpawnPool(obj->guid);
 }
 
-// Method that does the respawn job on the specified creature
-template <>
-void PoolGroup<Creature>::ReSpawn1Object(PoolObject* obj)
-{
-    Despawn1Object(obj->guid, false, false);
-    Spawn1Object(obj);
-}
-
-// Method that does the respawn job on the specified gameobject
-template <>
-void PoolGroup<GameObject>::ReSpawn1Object(PoolObject* obj)
-{
-    Despawn1Object(obj->guid, false, false);
-    Spawn1Object(obj);
-}
-
-// Method that does the respawn job on the specified pool
-template <>
-void PoolGroup<Pool>::ReSpawn1Object(PoolObject* obj)
+// Method that does the respawn job on the specified object
+template <typename T>
+void PoolGroup<T>::ReSpawn1Object(PoolObject* obj)
 {
     Despawn1Object(obj->guid, false, false);
     Spawn1Object(obj);


### PR DESCRIPTION
**Changes proposed:**

-  implements `PoolGroup<Pool>::ReSpawn1Object` like PoolGroup of Creature and Gameobject

**Issues addressed:**

Closes #28524


**Tests performed:**

Tested: https://github.com/TrinityCore/TrinityCore/issues/28524#issue-1446395539
Tested Vyragosa/Time-Lost Proto-Drake pools (same problem as nodes)
Tested https://github.com/TrinityCore/TrinityCore/pull/26620#issuecomment-867930002
Tested https://github.com/TrinityCore/TrinityCore/issues/21331#issuecomment-361615047
Tested pools with only one spawn:
<details>
  <summary>list</summary>
  
  ```sql
  guid  description
------  -----------------------------------------
 48204  Gilmorian (14447) - Spawn 1
134380  Teremus the Devourer (7846) - Spawn 1
151903  Crippler - Spawnlocation 1
151928  Voidhunter Yar Spawnlocation 1
151938  Fumblub Gearwind - Spawnlocation 1
151942  Crazed Indu le Survivor - Spawnlocation 1
  ```
  
</details>

