### PR TITLE
Core/Loot: Fix loot completion for containers and possible to equip this container

### DIFF
--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -208,6 +208,8 @@ class TC_GAME_API Item : public Object
         uint32 GetScriptId() const { return GetTemplate()->ScriptId; }
 
         std::string GetDebugInfo() const override;
+
+        bool IsLootCompletelyUsed() const { return m_lootGenerated && loot.isLooted(); }
     private:
         std::string m_text;
         uint8 m_slot;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10076,7 +10076,12 @@ InventoryResult Player::CanTakeMoreSimilarItems(uint32 entry, uint32 count, Item
     }
 
     if (pItem && pItem->m_lootGenerated)
+    {
+        if (pProto->InventoryType == INVTYPE_NON_EQUIP)
+            return EQUIP_ERR_NOT_EQUIPPABLE;
+
         return EQUIP_ERR_LOOT_GONE;
+    }
 
     // no maximum
     if ((pProto->MaxCount <= 0 && pProto->ItemLimitCategory == 0) || pProto->MaxCount == 2147483647)
@@ -10377,7 +10382,7 @@ InventoryResult Player::CanStoreItem(uint8 bag, uint8 slot, ItemPosCountVec &des
     if (pItem)
     {
         // item used
-        if (pItem->m_lootGenerated)
+        if (pItem->IsLootCompletelyUsed())
         {
             if (no_space_count)
                 *no_space_count = count;
@@ -11130,10 +11135,6 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16 &dest, Item* pItem, bool
         ItemTemplate const* pProto = pItem->GetTemplate();
         if (pProto)
         {
-            // item used
-            if (pItem->m_lootGenerated)
-                return EQUIP_ERR_LOOT_GONE;
-
             if (pItem->IsBindedNotWith(this))
                 return EQUIP_ERR_NOT_OWNER;
 
@@ -11181,6 +11182,10 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16 &dest, Item* pItem, bool
             uint8 eslot = FindEquipSlot(pItem, slot, swap);
             if (eslot == NULL_SLOT)
                 return EQUIP_ERR_NOT_EQUIPPABLE;
+
+            // item used
+            if (pItem->m_lootGenerated)
+                return EQUIP_ERR_LOOT_GONE;
 
             res = CanUseItem(pItem, not_loading);
             if (res != EQUIP_ERR_OK)


### PR DESCRIPTION
fix message "already looted" when move container in inventory and try equip this container

sorry, my english poor and bad

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add a check to ensure that the loot is completely removed from the container and add new func IsLootCompletelyUsed() for it
-  Add a check that the item (container) cannot be equipped to receive the correct message
-  Move the check a little further in the "CanEquipItem" method for the correct sequence of checks and messages

**Issues addressed:**

Closes #30686  (insert issue tracker number)


**Tests performed:**

Successfully builded and tested.

Test cases:
1.  Open container, don't loot items, close loot window. Try to move container in inventory bag.
2. Open container, loot all items.
3. Open container, loot 1 items and 2 left in bag. Close loot window. Try move.
4. Open container. Loot only gold, close loot windows. Try move.
5. Try equip container.
6. Try equip container, when loot 1 items or don't loot and close loot windows.

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
