### PR TITLE
Core/Creature: implement initial SummonInfo API for handling summons in the future

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -49,6 +49,7 @@
 #include "Spell.h"
 #include "SpellAuraEffects.h"
 #include "SpellMgr.h"
+#include "SummonInfo.h"
 #include "TemporarySummon.h"
 #include "Vehicle.h"
 #include "World.h"
@@ -355,6 +356,11 @@ void Creature::AddToWorld()
         if (IsVehicle())
             GetVehicleKit()->Install();
 
+        // If the creature has been summoned, register it for the summoner
+        if (IsSummon())
+            if (Unit* summoner = GetSummonInfo()->GetUnitSummoner())
+                summoner->RegisterSummon(GetSummonInfo());
+
         if (GetZoneScript())
             GetZoneScript()->OnCreatureCreate(this);
     }
@@ -364,6 +370,11 @@ void Creature::RemoveFromWorld()
 {
     if (IsInWorld())
     {
+        // If the creature about to despawn, unregister it for the summoner
+        if (IsSummon())
+            if (Unit* summoner = GetSummonInfo()->GetUnitSummoner())
+                summoner->UnregisterSummon(GetSummonInfo());
+
         if (GetZoneScript())
             GetZoneScript()->OnCreatureRemove(this);
 
@@ -3871,6 +3882,22 @@ void Creature::InitializeInteractSpellId()
         SetInteractSpellId(clickBounds.begin()->second.spellId);
     else
         SetInteractSpellId(0);
+}
+
+void Creature::InitializeSummonInfo(SummonInfoArgs const& args)
+{
+    ASSERT(_summonInfo == nullptr, "SummonInfo has already been initialized and must not be allocated again!");
+    _summonInfo = std::make_unique<SummonInfo>(this, args);
+}
+
+SummonInfo* Creature::GetSummonInfo() const
+{
+    return _summonInfo.get();
+}
+
+bool Creature::IsSummon() const
+{
+    return _summonInfo != nullptr;
 }
 
 void Creature::BuildValuesCreate(ByteBuffer* data, UF::UpdateFieldFlag flags, Player const* target) const

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -32,8 +32,10 @@ class CreatureGroup;
 class Quest;
 class Player;
 class SpellInfo;
+class SummonInfo;
 class WorldSession;
 struct Loot;
+struct SummonInfoArgs;
 
 enum MovementGeneratorType : uint8;
 
@@ -489,6 +491,13 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void InitializeInteractSpellId();
         void SetInteractSpellId(int32 interactSpellId) { SetUpdateFieldValue(m_values.ModifyValue(&Unit::m_unitData).ModifyValue(&UF::UnitData::InteractSpellID), interactSpellId); }
 
+        // Initializes the summon API for this creature which marks it as summon and will be treated accordingly
+        void InitializeSummonInfo(SummonInfoArgs const& args);
+        // Returns a pointer to the SummonInfo API, nullptr if the creature is not a summon
+        SummonInfo* GetSummonInfo() const;
+
+        bool IsSummon() const override;
+
         UF::OptionalUpdateField<UF::VendorData, int32(WowCS::EntityFragment::FVendor_C), 0> m_vendorData;
 
     protected:
@@ -610,6 +619,9 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         uint32 _gossipMenuId;
         Optional<uint32> _trainerId;
         float _sparringHealthPct;
+
+        // The Summon API which controls the behavior of summons
+        std::unique_ptr<SummonInfo> _summonInfo;
 };
 
 class TC_GAME_API AssistDelayEvent : public BasicEvent

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.cpp
@@ -1,0 +1,122 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "SummonInfo.h"
+#include "Creature.h"
+#include "DB2Stores.h"
+#include "Log.h"
+#include "ObjectAccessor.h"
+#include "SummonInfoArgs.h"
+
+SummonInfo::SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args) :
+    _summonedCreature(ASSERT_NOTNULL(summonedCreature)), _summonerGUID(args.SummonerGUID), _remainingDuration(args.Duration), _maxHealth(args.MaxHealth), _summonSpellId(args.SummonSpellId),
+    _despawnOnSummonerLogout(false), _despawnOnSummonerDeath(false), _despawnWhenExpired(false)
+{
+    if (args.SummonPropertiesId.has_value())
+        InitializeSummonProperties(*args.SummonPropertiesId);
+}
+
+void SummonInfo::InitializeSummonProperties(uint32 summonPropertiesId)
+{
+    SummonPropertiesEntry const* summonProperties = sSummonPropertiesStore.LookupEntry(summonPropertiesId);
+    if (!summonProperties)
+    {
+        TC_LOG_ERROR("entities.unit", "Creature {} has been summoned with a non-existing SummonProperties.db2 entry (RecId: {}). Possible dirty DB2 data or missing hotfix entry.", _summonedCreature->GetGUID(), summonPropertiesId);
+        return;
+    }
+
+    if (summonProperties->Faction)
+        _factionId = summonProperties->Faction;
+
+    _despawnOnSummonerLogout = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerLogout);
+    _despawnOnSummonerDeath = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnOnSummonerDeath);
+    _despawnWhenExpired = summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DespawnWhenExpired);
+
+    if (_despawnOnSummonerDeath && summonProperties->GetFlags().HasFlag(SummonPropertiesFlags::DontDespawnOnSummonerDeath))
+        _despawnOnSummonerDeath = false;
+}
+
+Creature* SummonInfo::GetSummonedCreature() const
+{
+    return _summonedCreature;
+}
+
+Unit* SummonInfo::GetUnitSummoner() const
+{
+    if (!_summonerGUID.has_value())
+        return nullptr;
+
+    return ObjectAccessor::GetUnit(*_summonedCreature, *_summonerGUID);
+}
+
+GameObject* SummonInfo::GetGameObjectSummoner() const
+{
+    if (!_summonerGUID.has_value())
+        return nullptr;
+
+    return ObjectAccessor::GetGameObject(*_summonedCreature, *_summonerGUID);
+}
+
+Optional<Milliseconds> SummonInfo::GetRemainingDuration() const
+{
+    return _remainingDuration;
+}
+
+Optional<uint64> SummonInfo::GetMaxHealth() const
+{
+    return _maxHealth;
+}
+
+Optional<uint32> SummonInfo::GetSummonSpellId() const
+{
+    return _summonSpellId;
+}
+
+Optional<uint32> SummonInfo::GetFactionId() const
+{
+    return _factionId;
+}
+
+bool SummonInfo::DespawnsOnSummonerLogout() const
+{
+    return _despawnOnSummonerLogout;
+}
+
+void SummonInfo::SetDespawnOnSummonerLogout(bool set)
+{
+    _despawnOnSummonerLogout = set;
+}
+
+bool SummonInfo::DespawnsOnSummonerDeath() const
+{
+    return _despawnOnSummonerDeath;
+}
+
+void SummonInfo::SetDespawnOnSummonerDeath(bool set)
+{
+    _despawnOnSummonerDeath = set;
+}
+
+bool SummonInfo::DespawnsWhenExpired() const
+{
+    return _despawnWhenExpired;
+}
+
+void SummonInfo::SetDespawnWhenExpired(bool set)
+{
+    _despawnWhenExpired = set;
+}

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfo.h
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SummonInfo_h__
+#define _SummonInfo_h__
+
+#include "Define.h"
+#include "Duration.h"
+#include "ObjectGuid.h"
+#include "Optional.h"
+
+class Creature;
+class GameObject;
+class Unit;
+
+struct SummonInfoArgs;
+
+class TC_GAME_API SummonInfo
+{
+public:
+    SummonInfo(SummonInfo const& right) = delete;
+    SummonInfo(SummonInfo&& right) = delete;
+    SummonInfo& operator=(SummonInfo const& right) = delete;
+    SummonInfo& operator=(SummonInfo&& right) = delete;
+
+    explicit SummonInfo(Creature* summonedCreature, SummonInfoArgs const& args);
+
+    // Initializes additional settings based on the provided SummonProperties ID.
+    void InitializeSummonProperties(uint32 summonPropertiesId);
+    // Returns the creature that is tied to this SummonInfo instance.
+    Creature* GetSummonedCreature() const;
+    // Returns the Unit summoner, or nullptr if no summoner has been provided or if the summoner is not a Unit.
+    Unit* GetUnitSummoner() const;
+    // Returns the GameObject summoner, or nullptr if no summoner has been provided or if the summoner is not a GameObject.
+    GameObject* GetGameObjectSummoner() const;
+
+    // Returns the remaining time until the summon expires. Nullopt when no duration was set which implies that the summon is permanent.
+    Optional<Milliseconds> GetRemainingDuration() const;
+    // Returns the health amount that will override the default max health calculation. Nullopt when no amount is provided.
+    Optional<uint64> GetMaxHealth() const;
+    // Returns the ID of the spell that has been used to summon the creature. Nullopt when the creature has not been summoned by a spell (scripted summons/ other APIs).
+    Optional<uint32> GetSummonSpellId() const;
+    // Returns the FactionTemplate ID of the summon that is overriding the default ID of the creature. Nullopt when the faction has not been overriden.
+    Optional<uint32> GetFactionId() const;
+
+    // Returns true when the summon will despawn when the summoner logs out. This also includes despawning and teleporting between map instances.
+    bool DespawnsOnSummonerLogout() const;
+    // Marks the summon to despawn when the summoner logs out. This also includes despawning and teleporting between map instaces.
+    void SetDespawnOnSummonerLogout(bool set);
+    // Returns true when the summon will despawn when its summoner has died.
+    bool DespawnsOnSummonerDeath() const;
+    // Marks the summon to despawn when the summoner has died.
+    void SetDespawnOnSummonerDeath(bool set);
+    // Returns true when the summon will despawn after its duration has expired. If not set, the summon will just die.
+    bool DespawnsWhenExpired() const;
+    // Marks the summon to despawn after its duration has expired. If disabled, the summon will just die.
+    void SetDespawnWhenExpired(bool set);
+
+private:
+    Creature* _summonedCreature;
+    Optional<ObjectGuid> _summonerGUID;
+    Optional<Milliseconds> _remainingDuration;  // NYI
+    Optional<uint64> _maxHealth;                // NYI
+    Optional<uint32> _summonSpellId;            // NYI
+    Optional<uint32> _factionId;                // NYI
+    bool _despawnOnSummonerLogout;              // NYI
+    bool _despawnOnSummonerDeath;               // NYI
+    bool _despawnWhenExpired;                   // NYI
+};
+
+#endif

--- a/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
+++ b/src/server/game/Entities/Creature/SummonInfo/SummonInfoArgs.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SummonInfoArgs_h__
+#define _SummonInfoArgs_h__
+
+#include "Define.h"
+#include "Duration.h"
+#include "Optional.h"
+#include "ObjectGuid.h"
+
+// Controls the behavior of a summoned creature and must be set with extreme care. If you want a blank summon that just exists as a permanent spawn, leave all fields untouched.
+struct SummonInfoArgs
+{
+    Optional<ObjectGuid> SummonerGUID;
+    Optional<uint64> MaxHealth;
+    Optional<Milliseconds> Duration;
+    Optional<uint32> SummonPropertiesId;
+    Optional<uint32> SummonSpellId;
+};
+
+#endif // _SummonInfoArgs_h__

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -47,6 +47,7 @@
 #include "SpellMgr.h"
 #include "SpellPackets.h"
 #include "StringConvert.h"
+#include "SummonInfoArgs.h"
 #include "TemporarySummon.h"
 #include "Totem.h"
 #include "Transport.h"
@@ -1978,6 +1979,20 @@ TempSummon* Map::SummonCreature(uint32 entry, Position const& pos, SummonPropert
         delete summon;
         return nullptr;
     }
+
+    // Store special settings which have been extracted from spell effects/scripts
+    SummonInfoArgs args;
+    if (summoner)
+        args.SummonerGUID = summoner->GetGUID();
+    if (properties)
+        args.SummonPropertiesId = properties->ID;
+    if (duration > 0ms)
+        args.Duration = duration;
+    if (spellId)
+        args.SummonSpellId = spellId;
+
+    // Initialize the SummonInfo API which marks the creature as Summon
+    summon->InitializeSummonInfo(args);
 
     TransportBase* transport = summoner ? summoner->GetTransport() : nullptr;
     if (transport)

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -35,6 +35,8 @@
 #include "SpellHistory.h"
 #include "SpellMgr.h"
 #include "SpellPackets.h"
+#include "SummonInfo.h"
+#include "SummonInfoArgs.h"
 #include "Unit.h"
 #include "Util.h"
 #include "World.h"
@@ -49,6 +51,8 @@ Pet::Pet(Player* owner, PetType type) :
     m_petSpecialization(0)
 {
     ASSERT(GetOwner());
+
+    InitializeSummonInfo({ .SummonerGUID = GetOwner()->GetGUID() });
 
     m_unitTypeMask |= UNIT_MASK_PET;
     if (type == HUNTER_PET)
@@ -74,6 +78,11 @@ void Pet::AddToWorld()
         ///- Register the pet for guid lookup
         GetMap()->GetObjectsStore().Insert<Pet>(this);
         Unit::AddToWorld();
+
+        // SummonInfo should always be initialized for pets. Make sure that we will not go any further if this is no longer the case.
+        if (Unit* summoner = ASSERT_NOTNULL(GetSummonInfo())->GetUnitSummoner())
+            summoner->RegisterSummon(GetSummonInfo());
+
         AIM_Initialize();
         if (ZoneScript* zoneScript = GetZoneScript() ? GetZoneScript() : GetInstanceScript())
             zoneScript->OnCreatureCreate(this);
@@ -96,6 +105,10 @@ void Pet::RemoveFromWorld()
     ///- Remove the pet from the accessor
     if (IsInWorld())
     {
+        // SummonInfo should always be initialized for pets. Make sure that we will not go any further if this is no longer the case.
+        if (Unit* summoner = ASSERT_NOTNULL(GetSummonInfo())->GetUnitSummoner())
+            summoner->UnregisterSummon(GetSummonInfo());
+
         ///- Don't call the function for Creature, normal mobs + totems go in a different storage
         Unit::RemoveFromWorld();
         GetMap()->GetObjectsStore().Remove<Pet>(this);
@@ -273,6 +286,7 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petEntry, uint32 petnumber, bool c
         }
 
         map->AddToMap(ToCreature());
+
         return true;
     }
 

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -91,6 +91,7 @@ class SpellCastTargets;
 class SpellEffectInfo;
 class SpellHistory;
 class SpellInfo;
+class SummonInfo;
 class Totem;
 class Transport;
 class TransportBase;
@@ -743,7 +744,7 @@ class TC_GAME_API Unit : public WorldObject
 
         uint32 HasUnitTypeMask(uint32 mask) const { return mask & m_unitTypeMask; }
         void AddUnitTypeMask(uint32 mask) { m_unitTypeMask |= mask; }
-        bool IsSummon() const   { return (m_unitTypeMask & UNIT_MASK_SUMMON) != 0; }
+        virtual bool IsSummon() const { return false; }
         bool IsGuardian() const { return (m_unitTypeMask & UNIT_MASK_GUARDIAN) != 0; }
         bool IsPet() const      { return (m_unitTypeMask & UNIT_MASK_PET) != 0; }
         bool IsHunterPet() const{ return (m_unitTypeMask & UNIT_MASK_HUNTER_PET) != 0; }
@@ -1487,6 +1488,11 @@ class TC_GAME_API Unit : public WorldObject
         std::array<ObjectGuid, MAX_SUMMON_SLOT> m_SummonSlot;
         std::array<ObjectGuid, MAX_GAMEOBJECT_SLOT> m_ObjectSlot;
 
+        // Registers the SummonInfo API of a summoned creature to allow accessing it to allow safe accessing
+        void RegisterSummon(SummonInfo* summon);
+        // Unregisters the SummonInfo API of a summoned creature so it can no longer be accessed
+        void UnregisterSummon(SummonInfo* summon);
+
         ShapeshiftForm GetShapeshiftForm() const { return ShapeshiftForm(*m_unitData->ShapeshiftForm); }
         void SetShapeshiftForm(ShapeshiftForm form);
         void CancelShapeshiftForm(bool onlyTravelShapeshiftForm = false, AuraRemoveMode removeMode = AURA_REMOVE_BY_DEFAULT, bool force = false);
@@ -2023,6 +2029,9 @@ class TC_GAME_API Unit : public WorldObject
         PositionUpdateInfo _positionUpdateInfo;
 
         bool _isCombatDisallowed;
+
+        // SummonInfo API
+        std::vector<SummonInfo*> _activeSummons;
 };
 
 #endif


### PR DESCRIPTION
A rebase of https://github.com/TrinityCore/TrinityCore/pull/30605 for the master branch. See that closed PR for previous discussions.

**Changes proposed:**

-  Implement a initial framework for handling summons in the future. The end goal will be getting rid of all the current summon classes and control their behavior within creature and their AI with the help of this new class. This will make managing creatures and summons much less of a pain in the ass
-  Right now it only implements the basics accessors. In the following months (or years) it will be expanded to eventually support all summon features and more.



**Tests performed:**
- tested on 4.3.4 and cata_classic
