### PR TITLE
Core/MMaps: Experimental Z delta clamping for non-player path normali…

### DIFF
--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -623,7 +623,21 @@ void PathGenerator::BuildPointPath(const float *startPoint, const float *endPoin
 void PathGenerator::NormalizePath()
 {
     constexpr float MAX_Z_DELTA_THRESHOLD = 4.0f;
-    bool isPlayer = _source->GetTypeId() == TYPEID_PLAYER;
+
+    bool shouldRespectThreshold = [this]
+    {
+        Unit const* sourceUnit = _source->ToUnit();
+        if (!sourceUnit)
+            return false;
+
+        if (sourceUnit->IsFlying() || sourceUnit->IsInWater())
+            return false;
+
+        if (!(_type & PATHFIND_NORMAL))
+            return false;
+
+        return true;
+    }();
 
     for (G3D::Vector3& pathPoint : _pathPoints)
     {
@@ -631,7 +645,7 @@ void PathGenerator::NormalizePath()
 
         _source->UpdateAllowedPositionZ(pathPoint.x, pathPoint.y, pathPoint.z);
 
-        if (!isPlayer && (std::abs(pathPoint.z - previousZ) > MAX_Z_DELTA_THRESHOLD))
+        if (shouldRespectThreshold && (std::abs(pathPoint.z - previousZ) > MAX_Z_DELTA_THRESHOLD))
         {
             pathPoint.z = previousZ;
         }

--- a/src/server/game/Movement/PathGenerator.cpp
+++ b/src/server/game/Movement/PathGenerator.cpp
@@ -622,8 +622,20 @@ void PathGenerator::BuildPointPath(const float *startPoint, const float *endPoin
 
 void PathGenerator::NormalizePath()
 {
-    for (uint32 i = 0; i < _pathPoints.size(); ++i)
-        _source->UpdateAllowedPositionZ(_pathPoints[i].x, _pathPoints[i].y, _pathPoints[i].z);
+    constexpr float MAX_Z_DELTA_THRESHOLD = 4.0f;
+    bool isPlayer = _source->GetTypeId() == TYPEID_PLAYER;
+
+    for (G3D::Vector3& pathPoint : _pathPoints)
+    {
+        float previousZ = pathPoint.z;
+
+        _source->UpdateAllowedPositionZ(pathPoint.x, pathPoint.y, pathPoint.z);
+
+        if (!isPlayer && (std::abs(pathPoint.z - previousZ) > MAX_Z_DELTA_THRESHOLD))
+        {
+            pathPoint.z = previousZ;
+        }
+    }
 }
 
 void PathGenerator::BuildShortcut()


### PR DESCRIPTION
…zation

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Clamp z delta to a maximum threshold

**Issues addressed:**

Fixes part of #26751


**Tests performed:**

Tested in game 

https://github.com/user-attachments/assets/b633d1e3-ff3b-4284-8d9d-ccad6f16e56a

Additional Notes:

This also prevents arthas in Drak'Tharon in the quest [Cleansing Drak'Tharon](https://www.wowhead.com/quest=12238/cleansing-draktharon) but is not perfect arthas ends with part of his feet under the ground.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
