### PR TITLE
Core/Pools: Refactor PoolGroup::SpawnObject

### DIFF
--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -72,13 +72,13 @@ class TC_GAME_API PoolGroup
         bool isEmpty() const { return ExplicitlyChanced.empty() && EqualChanced.empty(); }
         void AddEntry(PoolObject& poolitem, uint32 maxentries);
         bool CheckPool() const;
-        void DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType guid=0, bool alwaysDeleteRespawnTime = false);
+        void DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType guid, bool alwaysDeleteRespawnTime = false);
+        void DespawnAllObjects(ActivePoolData& spawns, bool alwaysDeleteRespawnTime = false);
         void Despawn1Object(ObjectGuid::LowType guid, bool alwaysDeleteRespawnTime = false, bool saveRespawnTime = true);
         void SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom);
         void RemoveRespawnTimeFromDB(ObjectGuid::LowType guid);
 
         void Spawn1Object(PoolObject* obj);
-        void ReSpawn1Object(PoolObject* obj);
         void RemoveOneRelation(uint32 child_pool_id);
         uint32 GetFirstEqualChancedObjectId()
         {


### PR DESCRIPTION
**Changes proposed:**

-  Prevent double spawn with pools with maxlimit 1 in certain situations
I have been able to reproduce this case with the pools at https://github.com/TrinityCore/TrinityCore/issues/21331#issuecomment-361615047 (quick way, kill said NPCs and before they respawn, restart the server, after that there could be more than one spawn in the same pool)

-  Prevent infinite recursive call with specific case of nested pools
The only pool I've been able to locate this problem with has been with the ones in this commit: https://github.com/TrinityCore/TrinityCore/commit/cd656b7bed44c8c1c96144c0591f275b534df3f1#diff-0232208ba5bf13497f025b12cf66d6644384576212205f820c671886a0b09b70R16-R30
quick way: update in creature db table respawn of those spawn pools to 10 seconds, start server, go to those spawns pools, kill them and repeat until infinite recursive call of Respawn1Object of nested pool is executed

-  ReSpawn1Object is unused now, I preferred not to delete it in case it is useful in the future.

**Issues addressed:**

None


**Tests performed:**

Tested the 2 previous cases described above
Tested: https://github.com/TrinityCore/TrinityCore/issues/28524#issue-1446395539
Tested Vyragosa/Time-Lost Proto-Drake pools
Tested https://github.com/TrinityCore/TrinityCore/pull/26620#issuecomment-867930002
Tested https://github.com/TrinityCore/TrinityCore/issues/21331#issuecomment-361615047
Tested pools with only one spawn:
<details>
  <summary>list</summary>
  
  ```sql
  guid  description
------  -----------------------------------------
 48204  Gilmorian (14447) - Spawn 1
134380  Teremus the Devourer (7846) - Spawn 1
151903  Crippler - Spawnlocation 1
151928  Voidhunter Yar Spawnlocation 1
151938  Fumblub Gearwind - Spawnlocation 1
151942  Crazed Indu le Survivor - Spawnlocation 1
  ```
