### PR TITLE
Core/Database: Add MySQL 9.4 support to auto updater

### DIFF
--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -375,17 +375,18 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
     if (ssl == "ssl")
         args.emplace_back("--ssl-mode=REQUIRED");
 
+#if MYSQL_VERSION_ID >= 90400
+
+    // Since MySQL 9.4 command line client commands are disabled by default
+    // We need to enable them to use `SOURCE` command
+    args.emplace_back("--commands=ON");
+
+#endif
+
 #else
 
     if (ssl == "ssl")
         args.emplace_back("--ssl");
-
-#endif
-
-#if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 90400
-
-    // Needed to execute the SQL file through CLI, as using `SOURCE` is disabled by default.
-    args.emplace_back("--commands=ON");
 
 #endif
 

--- a/src/server/database/Updater/DBUpdater.cpp
+++ b/src/server/database/Updater/DBUpdater.cpp
@@ -382,6 +382,13 @@ void DBUpdater<T>::ApplyFile(DatabaseWorkerPool<T>& pool, std::string const& hos
 
 #endif
 
+#if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 90400
+
+    // Needed to execute the SQL file through CLI, as using `SOURCE` is disabled by default.
+    args.emplace_back("--commands=ON");
+
+#endif
+
     // Execute sql file
     args.emplace_back("-e");
     args.emplace_back(Trinity::StringFormat("BEGIN; SOURCE {}; COMMIT;", path.generic_string()));


### PR DESCRIPTION
MySQL 9.4 added `--commands` option which is disabled by default: https://dev.mysql.com/doc/refman/9.4/en/mysql-command-options.html#option_mysql_commands

**Changes proposed:**

-  Add MySQL 9.4 support to auto updater

**Tests performed:**

- Builds and performs automatic updates