### PR TITLE
Core/Reputation: Fix ReputationMgr crash at first character login due…

### DIFF
--- a/src/server/game/Reputation/ReputationMgr.cpp
+++ b/src/server/game/Reputation/ReputationMgr.cpp
@@ -352,7 +352,7 @@ void ReputationMgr::SendState(FactionState const* faction)
         {
             state.needSend = false;
             if (!faction || state.ReputationListID != faction->ReputationListID)
-                setFactionStanding.Faction.emplace_back(int32(state.ReputationListID), getStandingForPacket(&state), faction->ID);
+                setFactionStanding.Faction.emplace_back(int32(state.ReputationListID), getStandingForPacket(&state), state.ID);
         }
     }
 


### PR DESCRIPTION
… to AllReputation config

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-In ReputationMgr::SendState there existed a way for nullptr of faction to be dereferenced. This looks like a mistake in copy pasting code from an earlier commit. Since we're looping through states, we should be using the state.ID not the parameter faction ID

**Issues addressed:**

Closes #  [31245](https://github.com/TrinityCore/TrinityCore/issues/31245)


**Tests performed:**
Built, Run, Tested Issue, No Crash.

