### PR TITLE
Core/Battlegrounds: Properly move team-swapped group in same-faction …

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -730,7 +730,7 @@ bool BattlegroundQueue::CheckSkirmishForSameFaction(uint32 minPlayersPerTeam)
         //set correct team
         (*itr)->Team = otherTeamId;
         //add team to other queue
-        m_QueuedGroups[uint8(BG_QUEUE_NORMAL_ALLIANCE) + uint8(teamIndex)].push_front(*itr);
+        m_QueuedGroups[uint8(BG_QUEUE_NORMAL_ALLIANCE) + uint8(otherTeam)].push_front(*itr);
         //remove team from old queue
         GroupsQueueType::iterator itr2 = itr_team;
         ++itr2;


### PR DESCRIPTION
…skirmishes

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Currently, if two teams of the same faction queue for skirmish, one group will get a second popup of the BG queue after entering the arena due to misbehavior in `BattlegroundQueue::CheckSkirmishForSameFaction`, so `BattlegroundQueue::RemovePlayer` cannot find the player in the queue to remove them.
- This bug was introduced in de9340c

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

1. Get two players of the same faction
2. .debug arena
3. Queue skirmish 2v2
4. There is no duplicate queue popup


**Known issues and TODO list:** (add/remove lines as needed)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->