### PR TITLE
Core/Items: Properly display item spell charges

### DIFF
--- a/src/server/game/Server/Packets/QueryPackets.cpp
+++ b/src/server/game/Server/Packets/QueryPackets.cpp
@@ -173,7 +173,7 @@ WorldPacket const* WorldPackets::Query::QueryItemSingleResponse::Write()
             {
                 _worldPacket << Stats.Spells[s].SpellId;
                 _worldPacket << Stats.Spells[s].SpellTrigger;
-                _worldPacket << uint32(-abs(Stats.Spells[s].SpellCharges));
+                _worldPacket << int32(Stats.Spells[s].SpellCharges);
                 _worldPacket << uint32(Stats.Spells[s].SpellCooldown);
                 _worldPacket << uint32(Stats.Spells[s].SpellCategory);
                 _worldPacket << uint32(Stats.Spells[s].SpellCategoryCooldown);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes items like [Black Husk Shield](https://www.wowhead.com/wotlk/item=4444/black-husk-shield) not beign allowed to sell on the auction house with the error **"You cannot auction an item with used charges"** even tho the item is brand new

**NOTE**: Delete client cache before testing these changes

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
