### PR TITLE
Scripts/Commands: improve .debug arena

### DIFF
--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -518,12 +518,23 @@ void BattlegroundMgr::ToggleTesting()
     sWorld->SendWorldText(m_Testing ? LANG_DEBUG_BG_ON : LANG_DEBUG_BG_OFF);
 }
 
-void BattlegroundMgr::ToggleArenaTesting(uint32 battlemasterListId)
+bool BattlegroundMgr::ToggleArenaTesting(uint32 battlemasterListId)
 {
+    if (battlemasterListId != 0)
+    {
+        BattlegroundTemplate const* bgTemplate = GetBattlegroundTemplateByTypeId(static_cast<BattlegroundTypeId>(battlemasterListId));
+        if (!bgTemplate)
+            return false;
+
+        if (!bgTemplate->IsArena())
+            return false;
+    }
+
     if (m_ArenaTesting != battlemasterListId)
         sWorld->SendWorldText((battlemasterListId != 0) ? LANG_DEBUG_ARENA_ON : LANG_DEBUG_ARENA_OFF);
 
     m_ArenaTesting = battlemasterListId;
+    return true;
 }
 
 bool BattlegroundMgr::IsValidQueueId(BattlegroundQueueTypeId bgQueueTypeId)

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -303,11 +303,10 @@ BattlegroundScriptTemplate const* BattlegroundMgr::FindBattlegroundScriptTemplat
 
 void BattlegroundMgr::QueuePlayerForArena(Player const* player, uint8 teamSize, uint8 roles)
 {
-    std::unique_ptr<WorldPacket> worldPacket = std::make_unique<WorldPacket>(CMSG_BATTLEMASTER_JOIN_ARENA);
-    *worldPacket << static_cast<uint8>(teamSize);
-    *worldPacket << static_cast<uint8>(roles);
-    WorldPackets::Battleground::BattlemasterJoinArena packet(std::move(*worldPacket));
-    packet.Read();
+    WorldPackets::Battleground::BattlemasterJoinArena packet((WorldPacket(CMSG_BATTLEMASTER_JOIN_ARENA)));
+    packet.TeamSizeIndex = teamSize;
+    packet.Roles = roles;
+
     player->GetSession()->HandleBattlemasterJoinArena(packet);
 }
 

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -65,7 +65,7 @@ uint8 BattlegroundTemplate::GetMaxLevel() const
 
 BattlegroundMgr::BattlegroundMgr() :
     m_NextRatedArenaUpdate(sWorld->getIntConfig(CONFIG_ARENA_RATED_UPDATE_TIMER)),
-    m_UpdateTimer(0), m_ArenaTesting(false), m_Testing(false)
+    m_UpdateTimer(0), m_ArenaTesting(0), m_Testing(false)
 { }
 
 BattlegroundMgr::~BattlegroundMgr()

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -32,6 +32,7 @@
 #include "Player.h"
 #include "SharedDefines.h"
 #include "World.h"
+#include "WorldSession.h"
 
 bool BattlegroundTemplate::IsArena() const
 {

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -300,6 +300,16 @@ BattlegroundScriptTemplate const* BattlegroundMgr::FindBattlegroundScriptTemplat
     return Trinity::Containers::MapGetValuePtr(_battlegroundScriptTemplates, { mapId, BATTLEGROUND_TYPE_NONE });
 }
 
+void BattlegroundMgr::QueuePlayerForArena(Player const* player, uint8 teamSize, uint8 roles)
+{
+    std::unique_ptr<WorldPacket> worldPacket = std::make_unique<WorldPacket>(CMSG_BATTLEMASTER_JOIN_ARENA);
+    *worldPacket << static_cast<uint8>(teamSize);
+    *worldPacket << static_cast<uint8>(roles);
+    WorldPackets::Battleground::BattlemasterJoinArena packet(std::move(*worldPacket));
+    packet.Read();
+    player->GetSession()->HandleBattlemasterJoinArena(packet);
+}
+
 uint32 BattlegroundMgr::CreateClientVisibleInstanceId(BattlegroundTypeId bgTypeId, BattlegroundBracketId bracket_id)
 {
     if (IsArenaType(bgTypeId))

--- a/src/server/game/Battlegrounds/BattlegroundMgr.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.cpp
@@ -507,10 +507,12 @@ void BattlegroundMgr::ToggleTesting()
     sWorld->SendWorldText(m_Testing ? LANG_DEBUG_BG_ON : LANG_DEBUG_BG_OFF);
 }
 
-void BattlegroundMgr::ToggleArenaTesting()
+void BattlegroundMgr::ToggleArenaTesting(uint32 battlemasterListId)
 {
-    m_ArenaTesting = !m_ArenaTesting;
-    sWorld->SendWorldText(m_ArenaTesting ? LANG_DEBUG_ARENA_ON : LANG_DEBUG_ARENA_OFF);
+    if (m_ArenaTesting != battlemasterListId)
+        sWorld->SendWorldText((battlemasterListId != 0) ? LANG_DEBUG_ARENA_ON : LANG_DEBUG_ARENA_OFF);
+
+    m_ArenaTesting = battlemasterListId;
 }
 
 bool BattlegroundMgr::IsValidQueueId(BattlegroundQueueTypeId bgQueueTypeId)
@@ -686,6 +688,9 @@ BattlegroundTypeId BattlegroundMgr::GetRandomBG(BattlegroundTypeId bgTypeId)
 {
     if (BattlegroundTemplate const* bgTemplate = GetBattlegroundTemplateByTypeId(bgTypeId))
     {
+        if (bgTemplate->IsArena() && isArenaTesting())
+            return static_cast<BattlegroundTypeId>(m_ArenaTesting);
+
         std::vector<BattlegroundTemplate const*> ids;
         ids.reserve(bgTemplate->MapIDs.size());
         for (int32 mapId : bgTemplate->MapIDs)

--- a/src/server/game/Battlegrounds/BattlegroundMgr.h
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.h
@@ -126,7 +126,8 @@ class TC_GAME_API BattlegroundMgr
         void ScheduleQueueUpdate(uint32 arenaMatchmakerRating, BattlegroundQueueTypeId bgQueueTypeId, BattlegroundBracketId bracket_id);
         uint32 GetPrematureFinishTime() const;
 
-        void ToggleArenaTesting(uint32 battlemasterListId);
+        // Return whether toggling was successful. In case of a non-existing battlemasterListId, or this battlemasterListId is not an arena, this would return false.
+        bool ToggleArenaTesting(uint32 battlemasterListId);
         void ToggleTesting();
 
         bool isArenaTesting() const { return m_ArenaTesting != 0; }

--- a/src/server/game/Battlegrounds/BattlegroundMgr.h
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.h
@@ -162,6 +162,8 @@ class TC_GAME_API BattlegroundMgr
         void LoadBattlegroundScriptTemplate();
         BattlegroundScriptTemplate const* FindBattlegroundScriptTemplate(uint32 mapId, BattlegroundTypeId bgTypeId) const;
 
+        static void QueuePlayerForArena(Player const* player, uint8 teamSize, uint8 roles);
+
     private:
         uint32 CreateClientVisibleInstanceId(BattlegroundTypeId bgTypeId, BattlegroundBracketId bracket_id);
         static bool IsArenaType(BattlegroundTypeId bgTypeId);

--- a/src/server/game/Battlegrounds/BattlegroundMgr.h
+++ b/src/server/game/Battlegrounds/BattlegroundMgr.h
@@ -126,10 +126,10 @@ class TC_GAME_API BattlegroundMgr
         void ScheduleQueueUpdate(uint32 arenaMatchmakerRating, BattlegroundQueueTypeId bgQueueTypeId, BattlegroundBracketId bracket_id);
         uint32 GetPrematureFinishTime() const;
 
-        void ToggleArenaTesting();
+        void ToggleArenaTesting(uint32 battlemasterListId);
         void ToggleTesting();
 
-        bool isArenaTesting() const { return m_ArenaTesting; }
+        bool isArenaTesting() const { return m_ArenaTesting != 0; }
         bool isTesting() const { return m_Testing; }
 
         static bool IsRandomBattleground(uint32 battlemasterListId);
@@ -185,7 +185,7 @@ class TC_GAME_API BattlegroundMgr
         std::vector<ScheduledQueueUpdate> m_QueueUpdateScheduler;
         uint32 m_NextRatedArenaUpdate;
         uint32 m_UpdateTimer;
-        bool   m_ArenaTesting;
+        uint32 m_ArenaTesting;
         bool   m_Testing;
         BattleMastersMap mBattleMastersMap;
 

--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -540,9 +540,16 @@ void WorldSession::HandleBattlemasterJoinArena(WorldPackets::Battleground::Battl
         return;
 
     Group* grp = _player->GetGroup();
+    if (!grp)
+    {
+        grp = new Group();
+        grp->Create(_player);
+    }
+
     // no group found, error
     if (!grp)
         return;
+
     if (grp->GetLeaderGUID() != _player->GetGUID())
         return;
 
@@ -559,7 +566,10 @@ void WorldSession::HandleBattlemasterJoinArena(WorldPackets::Battleground::Battl
     GroupQueueInfo* ginfo = nullptr;
 
     ObjectGuid errorGuid;
-    GroupJoinBattlegroundResult err = grp->CanJoinBattlegroundQueue(bgTemplate, bgQueueTypeId, arenatype, arenatype, true, packet.TeamSizeIndex, errorGuid);
+    GroupJoinBattlegroundResult err = ERR_BATTLEGROUND_NONE;
+    if (!sBattlegroundMgr->isArenaTesting())
+        err = grp->CanJoinBattlegroundQueue(bgTemplate, bgQueueTypeId, arenatype, arenatype, true, packet.TeamSizeIndex, errorGuid);
+
     if (!err)
     {
         TC_LOG_DEBUG("bg.battleground", "Battleground: arena team id {}, leader {} queued with matchmaker rating {} for type {}", _player->GetArenaTeamId(packet.TeamSizeIndex), _player->GetName(), matchmakerRating, arenatype);

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -26,7 +26,6 @@ EndScriptData */
 #include "Bag.h"
 #include "BattlefieldMgr.h"
 #include "BattlegroundMgr.h"
-#include "BattlegroundPackets.h"
 #include "CellImpl.h"
 #include "Channel.h"
 #include "ChannelPackets.h"
@@ -864,12 +863,7 @@ public:
         if (!battlemasterListId || !handler || !handler->GetSession())
             return true;
 
-        std::unique_ptr<WorldPacket> worldPacket = std::make_unique<WorldPacket>(CMSG_BATTLEMASTER_JOIN_ARENA);
-        *worldPacket << static_cast<uint8>(0);
-        *worldPacket << static_cast<uint8>(lfg::PLAYER_ROLE_DAMAGE);
-        WorldPackets::Battleground::BattlemasterJoinArena packet(std::move(*worldPacket));
-        packet.Read();
-        handler->GetSession()->HandleBattlemasterJoinArena(packet);
+        BattlegroundMgr::QueuePlayerForArena(handler->GetSession()->GetPlayer(), 0, lfg::PLAYER_ROLE_DAMAGE);
         return true;
     }
 

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -859,7 +859,14 @@ public:
 
     static bool HandleDebugArenaCommand(ChatHandler* handler, uint32 battlemasterListId)
     {
-        sBattlegroundMgr->ToggleArenaTesting(battlemasterListId);
+        bool successful = sBattlegroundMgr->ToggleArenaTesting(battlemasterListId);
+        if (!successful)
+        {
+            handler->PSendSysMessage("BattlemasterListId %u does not exist or is not an arena.", battlemasterListId);
+            handler->SetSentErrorMessage(true);
+            return true;
+        }
+
         if (!battlemasterListId || !handler || !handler->GetSession())
             return true;
 

--- a/src/server/scripts/Commands/cs_debug.cpp
+++ b/src/server/scripts/Commands/cs_debug.cpp
@@ -26,6 +26,7 @@ EndScriptData */
 #include "Bag.h"
 #include "BattlefieldMgr.h"
 #include "BattlegroundMgr.h"
+#include "BattlegroundPackets.h"
 #include "CellImpl.h"
 #include "Channel.h"
 #include "ChannelPackets.h"
@@ -39,6 +40,7 @@ EndScriptData */
 #include "GridNotifiersImpl.h"
 #include "InstanceScript.h"
 #include "Language.h"
+#include "LFG.h"
 #include "Log.h"
 #include "M2Stores.h"
 #include "MapManager.h"
@@ -856,9 +858,18 @@ public:
         return true;
     }
 
-    static bool HandleDebugArenaCommand(ChatHandler* /*handler*/)
+    static bool HandleDebugArenaCommand(ChatHandler* handler, uint32 battlemasterListId)
     {
-        sBattlegroundMgr->ToggleArenaTesting();
+        sBattlegroundMgr->ToggleArenaTesting(battlemasterListId);
+        if (!battlemasterListId || !handler || !handler->GetSession())
+            return true;
+
+        std::unique_ptr<WorldPacket> worldPacket = std::make_unique<WorldPacket>(CMSG_BATTLEMASTER_JOIN_ARENA);
+        *worldPacket << static_cast<uint8>(0);
+        *worldPacket << static_cast<uint8>(lfg::PLAYER_ROLE_DAMAGE);
+        WorldPackets::Battleground::BattlemasterJoinArena packet(std::move(*worldPacket));
+        packet.Read();
+        handler->GetSession()->HandleBattlemasterJoinArena(packet);
         return true;
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Restore 1v1 queue
-  Expand .debug arena command with a battlemasterListId parameter
-  Example usage: `.debug arena 8` will let you solo queue for arenas. Use it on a second client to actually trigger the queue popup and enter arena 8.

**Issues addressed:**

Closes: None, makes developping/testing a bit easier


**Tests performed:**

- Builds locally
- Tested by having 2 clients queue up for arena


**Known issues and TODO list:**

- Maybe we should update the command text
- Not sure if we should allow disabled arenas or not

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
