### PR TITLE
Revision Quest: The Exorcism of Colonel Jules

### DIFF
--- a/sql/updates/world/3.3.5/2025_99_99_99_5_world.sql
+++ b/sql/updates/world/3.3.5/2025_99_99_99_5_world.sql
@@ -1,5 +1,7 @@
 --
+
 -- The Exorcism Bubbling Slimer Bunny (DND) smart ai
+
 SET @ENTRY := 22505;
 UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
 DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
@@ -10,9 +12,10 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (@ENTRY, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 103, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Set rooted'),
 (@ENTRY, 0, 4, 0, 60, 0, 100, 0, 5000, 10000, 15000, 30000, 12, 22506, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Every 15 - 30 seconds (5 - 10s initially) - Self: Summon creature Foul Purge (22506) at Self\'s position, moved by offset (0, 0, 0, 0) as summon type manual despawn');
 
-
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 22505 AND `SourceId` = 0;
 
+-- Correct condition set, because previously you could start the event again even though the quest was finished.
+    
 DELETE FROM `gossip_menu_option` WHERE `MenuID` = 8539;
 INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
 (8539, 1, 0, 'I am ready, Anchorite.  Let us begin the exorcism.', 20396, 1, 3, 0, 0, 0, 0, NULL, 0, 0);
@@ -20,8 +23,12 @@ DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGrou
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `Comment`) VALUES 
 (15, 8539, 1, 0, 0, 9, 0, 10935, 2, 0, 0, 'Player for which gossip text is shown has quest The Exorcism of Colonel Jules (10935) active');
 
+-- Sleeping is not necessary here because a spell takes care of that
+    
 UPDATE `creature_template_addon` SET `StandState` = 0 WHERE `entry` = 22432;
 
+-- Delete non-working Linked spell entry
+    
 DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 39371;
 
  -- Darkness Released smart ai
@@ -32,5 +39,9 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (@ENTRY, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 89, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Move randomly in radius 15 yards'),
 (@ENTRY, 0, 1, 0, 8, 0, 100, 0, 39371, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On spell  Gebetsperlen (39371) hit - Self: Die');
 
-
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 22507 AND `SourceId` = 0;
+
+-- Spellscript Entry
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 39371;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (39371, 'spell_39322_prayer_beads');

--- a/sql/updates/world/3.3.5/2025_99_99_99_5_world.sql
+++ b/sql/updates/world/3.3.5/2025_99_99_99_5_world.sql
@@ -1,0 +1,36 @@
+--
+-- The Exorcism Bubbling Slimer Bunny (DND) smart ai
+SET @ENTRY := 22505;
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(@ENTRY, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 11, 39300, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Cast spell  Quest - The Exorcism Bubbling Slimer (39300) on Self'),
+(@ENTRY, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 146, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Set uninteractable'),
+(@ENTRY, 0, 2, 3, 61, 0, 100, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Set react state to Passive'),
+(@ENTRY, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 103, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Set rooted'),
+(@ENTRY, 0, 4, 0, 60, 0, 100, 0, 5000, 10000, 15000, 30000, 12, 22506, 8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Every 15 - 30 seconds (5 - 10s initially) - Self: Summon creature Foul Purge (22506) at Self\'s position, moved by offset (0, 0, 0, 0) as summon type manual despawn');
+
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 22505 AND `SourceId` = 0;
+
+DELETE FROM `gossip_menu_option` WHERE `MenuID` = 8539;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
+(8539, 1, 0, 'I am ready, Anchorite.  Let us begin the exorcism.', 20396, 1, 3, 0, 0, 0, 0, NULL, 0, 0);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` IN (8539));
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `Comment`) VALUES 
+(15, 8539, 1, 0, 0, 9, 0, 10935, 2, 0, 0, 'Player for which gossip text is shown has quest The Exorcism of Colonel Jules (10935) active');
+
+UPDATE `creature_template_addon` SET `StandState` = 0 WHERE `entry` = 22432;
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 39371;
+
+ -- Darkness Released smart ai
+SET @ENTRY := 22507;
+UPDATE `creature_template` SET `AIName` = 'SmartAI', `ScriptName` = '' WHERE `entry` = @ENTRY;
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryOrGuid` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(@ENTRY, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 89, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On just summoned - Self: Move randomly in radius 15 yards'),
+(@ENTRY, 0, 1, 0, 8, 0, 100, 0, 39371, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'On spell  Gebetsperlen (39371) hit - Self: Die');
+
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 22507 AND `SourceId` = 0;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2966,7 +2966,15 @@ void SpellMgr::LoadSpellInfoCorrections()
         {
             spellInfo->_GetEffect(EFFECT_0).Amplitude = 1 * IN_MILLISECONDS;
         });
-
+        
+        ApplySpellFix({
+            39284
+            }, [](SpellInfo* spellInfo)
+            {
+                 /* Handle Periodic Trigger 2 Seconds to much for summon*/
+                spellInfo->_GetEffect(EFFECT_0).Amplitude = 5 * IN_MILLISECONDS;
+            });
+        
         ApplySpellFix({
             24707, // Food
             26263, // Dim Sum

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2969,11 +2969,11 @@ void SpellMgr::LoadSpellInfoCorrections()
         
         ApplySpellFix({
             39284
-            }, [](SpellInfo* spellInfo)
-            {
-                 /* Handle Periodic Trigger 2 Seconds to much for summon*/
-                spellInfo->_GetEffect(EFFECT_0).Amplitude = 5 * IN_MILLISECONDS;
-            });
+    },  [](SpellInfo* spellInfo)
+    {
+        /* Handle Periodic Trigger 2 Seconds to much for summon*/
+        spellInfo->_GetEffect(EFFECT_0).Amplitude = 5 * IN_MILLISECONDS;
+    });
         
         ApplySpellFix({
             24707, // Food

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2966,7 +2966,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         {
             spellInfo->_GetEffect(EFFECT_0).Amplitude = 1 * IN_MILLISECONDS;
         });
-        
         ApplySpellFix({
             39284
     },  [](SpellInfo* spellInfo)
@@ -2974,7 +2973,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         /* Handle Periodic Trigger 2 Seconds to much for summon*/
         spellInfo->_GetEffect(EFFECT_0).Amplitude = 5 * IN_MILLISECONDS;
     });
-        
         ApplySpellFix({
             24707, // Food
             26263, // Dim Sum

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -448,9 +448,7 @@ private:
 enum spell_ritual_prayer_beads
 {
     SPELL_HEAL_BARADA           = 39322,
-    NPC_ANCHORITE_BARADA        = 22431,
-    NPC_DARKNESS_RELEASED       = 22507,
-    NPC_FOUL_PURGE              = 22506
+    NPC_ANCHORITE_BARADA        = 22431
 };
 
 /*Handle Prayer Beads item -> Linked spell in Database not working*/

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -235,7 +235,6 @@ struct npc_barada : public ScriptedAI
             julesGUID = jules->GetGUID();
             jules->AI()->Talk(SAY_JULES_1);
         }
-        
         me->SetWalk(true);
         me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
         Talk(SAY_BARADA_2);

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -31,13 +31,13 @@
 
 enum ExorcismSpells
 {
-    SPELL_JULES_GOES_PRONE     = 39283,
+    SPELL_JULES_GOES_PRONE = 39283,
     SPELL_JULES_THREATENS_AURA = 39284,
-    SPELL_JULES_GOES_UPRIGHT   = 39294,
-    SPELL_JULES_VOMITS_AURA    = 39295,
+    SPELL_JULES_GOES_UPRIGHT = 39294,
+    SPELL_JULES_VOMITS_AURA = 39295,
 
-    SPELL_BARADAS_COMMAND      = 39277,
-    SPELL_BARADA_FALTERS       = 39278,
+    SPELL_BARADAS_COMMAND = 39277,
+    SPELL_BARADA_FALTERS = 39278,
 };
 
 enum ExorcismTexts
@@ -51,469 +51,432 @@ enum ExorcismTexts
     SAY_BARADA_7 = 6,
     SAY_BARADA_8 = 7,
 
-    SAY_JULES_1  = 0,
-    SAY_JULES_2  = 1,
-    SAY_JULES_3  = 2,
-    SAY_JULES_4  = 3,
-    SAY_JULES_5  = 4,
+    SAY_JULES_1 = 0,
+    SAY_JULES_2 = 1,
+    SAY_JULES_3 = 2,
+    SAY_JULES_4 = 3,
+    SAY_JULES_5 = 4,
 };
 
-Position const exorcismPos[11] =
+Position const exorcismPos[12] =
 {
-    { -707.123f, 2751.686f, 101.592f, 4.577416f }, //Barada Waypoint-1      0
-    { -710.731f, 2749.075f, 101.592f, 1.513286f }, //Barada Cast position   1
-    { -710.332f, 2754.394f, 102.948f, 3.207566f }, //Jules                  2
-    { -714.261f, 2747.754f, 103.391f, 0.0f },      //Jules Waypoint-1       3
-    { -713.113f, 2750.194f, 103.391f, 0.0f },      //Jules Waypoint-2       4
-    { -710.385f, 2750.896f, 103.391f, 0.0f },      //Jules Waypoint-3       5
-    { -708.309f, 2750.062f, 103.391f, 0.0f },      //Jules Waypoint-4       6
-    { -707.401f, 2747.696f, 103.391f, 0.0f },      //Jules Waypoint-5       7
-    { -708.591f, 2745.266f, 103.391f, 0.0f },      //Jules Waypoint-6       8
-    { -710.597f, 2744.035f, 103.391f, 0.0f },      //Jules Waypoint-7       9
-    { -713.089f, 2745.302f, 103.391f, 0.0f },      //Jules Waypoint-8      10
+    { -707.42f, 2747.98f, 101.59f, 4.577416f },
+    { -711.20f, 2747.75f, 101.59f, 1.51f },
+    { -710.84f, 2749.55f, 101.59f, 1.63f },
+    { -710.332f, 2754.394f, 102.948f, 3.207566f },
+    { -714.261f, 2747.754f, 103.391f, 0.0f },
+    { -713.113f, 2750.194f, 103.391f, 0.0f },
+    { -710.385f, 2750.896f, 103.391f, 0.0f },
+    { -708.309f, 2750.062f, 103.391f, 0.0f },
+    { -707.401f, 2747.696f, 103.391f, 0.0f },
+    { -708.591f, 2745.266f, 103.391f, 0.0f },
+    { -710.597f, 2744.035f, 103.391f, 0.0f },
+    { -713.089f, 2745.302f, 103.391f, 0.0f },
 };
 
 enum ExorcismMisc
 {
-    NPC_DARKNESS_RELEASED               = 22507,
-    NPC_FOUL_PURGE                      = 22506,
-    NPC_COLONEL_JULES                   = 22432,
+    NPC_COLONEL_JULES                           = 22432,
+    NPC_DARKNESS_RELEASED                       = 22507,
+    NPC_FOUL_PURGE                              = 22506,
+    NPC_THE_EXORCISM_BUBBLING_SLIMER_BUNNY      = 22505,
 
-    BARADAS_GOSSIP_MESSAGE              = 10683,
-
-    QUEST_THE_EXORCISM_OF_COLONEL_JULES = 10935,
-
-    ACTION_START_EVENT                  = 1,
-    ACTION_JULES_HOVER                  = 2,
-    ACTION_JULES_FLIGHT                 = 3,
-    ACTION_JULES_MOVE_HOME              = 4,
+    ACTION_START_EVENT                          = 1,
+    ACTION_JULES_HOVER                          = 2,
+    ACTION_JULES_FLIGHT                         = 3,
+    ACTION_JULES_MOVE_HOME                      = 4,
 };
 
 enum ExorcismEvents
 {
     EVENT_BARADAS_TALK = 1,
-    EVENT_RESET        = 2,
-
-    //Colonel Jules
-    EVENT_SUMMON_SKULL = 1,
+    EVENT_RESET = 2
 };
 
 /*######
 ## npc_colonel_jules
 ######*/
 
-class npc_colonel_jules : public CreatureScript
+struct npc_colonel_jules : public ScriptedAI
 {
-public:
-    npc_colonel_jules() : CreatureScript("npc_colonel_jules") { }
+    npc_colonel_jules(Creature* creature) : ScriptedAI(creature) {}
 
-    struct npc_colonel_julesAI : public ScriptedAI
+    void Reset() override
     {
-        npc_colonel_julesAI(Creature* creature) : ScriptedAI(creature), summons(me)
-        {
-            Initialize();
-        }
-
-        void Initialize()
-        {
-            point = 3;
-            wpreached = false;
-            success = false;
-        }
-
-        void Reset() override
-        {
-            events.Reset();
-
-            summons.DespawnAll();
-            Initialize();
-        }
-
-        bool success;
-
-        void DoAction(int32 action) override
-        {
-            switch (action)
-            {
-            case ACTION_JULES_HOVER:
-                me->AddAura(SPELL_JULES_GOES_PRONE, me);
-                me->AddAura(SPELL_JULES_THREATENS_AURA, me);
-
-                me->SetCanFly(true);
-                me->SetSpeedRate(MOVE_RUN, 0.2f);
-
-                me->SetFacingTo(3.207566f);
-                me->GetMotionMaster()->MoveJump(exorcismPos[2], 2.0f, 2.0f);
-
-                success = false;
-
-                events.ScheduleEvent(EVENT_SUMMON_SKULL, 10s);
-                break;
-            case ACTION_JULES_FLIGHT:
-                me->RemoveAura(SPELL_JULES_GOES_PRONE);
-
-                me->AddAura(SPELL_JULES_GOES_UPRIGHT, me);
-                me->AddAura(SPELL_JULES_VOMITS_AURA, me);
-
-                wpreached = true;
-                me->GetMotionMaster()->MovePoint(point, exorcismPos[point]);
-                break;
-            case ACTION_JULES_MOVE_HOME:
-                wpreached = false;
-                me->SetSpeedRate(MOVE_RUN, 1.0f);
-                me->GetMotionMaster()->MovePoint(11, exorcismPos[2]);
-
-                events.CancelEvent(EVENT_SUMMON_SKULL);
-                break;
-            }
-        }
-
-        void JustSummoned(Creature* summon) override
-        {
-            summons.Summon(summon);
-            summon->GetMotionMaster()->MoveRandom(10.0f);
-        }
-
-        void MovementInform(uint32 type, uint32 id) override
-        {
-            if (type != POINT_MOTION_TYPE)
-                return;
-
-            if (id < 10)
-                wpreached = true;
-
-            if (id == 8)
-            {
-                for (uint8 i = 0; i < 2; i++)
-                    DoSummon(NPC_FOUL_PURGE, exorcismPos[8]);
-            }
-
-            if (id == 10)
-            {
-                wpreached = true;
-                point = 3;
-            }
-        }
-
-        void UpdateAI(uint32 diff) override
-        {
-            if (wpreached)
-            {
-                me->GetMotionMaster()->MovePoint(point, exorcismPos[point]);
-                point++;
-                wpreached = false;
-            }
-
-            events.Update(diff);
-
-            while (uint32 eventId = events.ExecuteEvent())
-            {
-                switch (eventId)
-                {
-                case EVENT_SUMMON_SKULL:
-                    uint8 summonCount = urand(1, 3);
-
-                    for (uint8 i = 0; i < summonCount; i++)
-                        me->SummonCreature(NPC_DARKNESS_RELEASED, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 1.5f, 0, TEMPSUMMON_MANUAL_DESPAWN);
-
-                    events.ScheduleEvent(EVENT_SUMMON_SKULL, 10s, 15s);
-                    break;
-                }
-            }
-        }
-
-        bool OnGossipHello(Player* player) override
-        {
-            if (success)
-                player->KilledMonsterCredit(NPC_COLONEL_JULES, ObjectGuid::Empty);
-
-            SendGossipMenuFor(player, player->GetGossipTextId(me), me->GetGUID());
-            return true;
-        }
-
-    private:
-        EventMap events;
-        SummonList summons;
-
-        uint8 point;
-
-        bool wpreached;
-    };
-
-    CreatureAI* GetAI(Creature* creature) const override
-    {
-        return new npc_colonel_julesAI(creature);
+        events.Reset();
+        point = 4;
+        wpreached = false;
+        success = false;
+        me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+        me->AddAura(SPELL_JULES_GOES_PRONE, me);
     }
+
+    void DoAction(int32 action) override
+    {
+        switch (action)
+        {
+        case ACTION_JULES_HOVER:
+            me->AddAura(SPELL_JULES_THREATENS_AURA, me);
+            me->SetCanFly(true);
+            me->SetWalk(true);
+            me->SetFacingTo(3.207566f);
+            me->GetMotionMaster()->MoveJump(exorcismPos[3], 2.0f, 2.0f);
+            success = false;
+            break;
+        case ACTION_JULES_FLIGHT:
+            me->RemoveAura(SPELL_JULES_GOES_PRONE);
+            me->AddAura(SPELL_JULES_GOES_UPRIGHT, me);
+            me->AddAura(SPELL_JULES_VOMITS_AURA, me);
+            me->SetWalk(true);
+            wpreached = true;
+            me->GetMotionMaster()->MovePoint(point, exorcismPos[4]);
+            break;
+        case ACTION_JULES_MOVE_HOME:
+            wpreached = false;
+            me->SetWalk(true);
+            me->GetMotionMaster()->MoveTargetedHome();
+            me->SetCanFly(false);
+            me->AddAura(SPELL_JULES_GOES_PRONE, me);
+            me->RemoveAura(SPELL_JULES_GOES_UPRIGHT);
+            me->RemoveAura(SPELL_JULES_VOMITS_AURA);
+            me->RemoveAura(SPELL_JULES_THREATENS_AURA);
+            std::list<uint32> despawnEntries = { NPC_DARKNESS_RELEASED, NPC_FOUL_PURGE, NPC_THE_EXORCISM_BUBBLING_SLIMER_BUNNY };
+            for (uint32 entry : despawnEntries)
+            {
+                std::list<Creature*> npcs;
+                me->GetCreatureListWithEntryInGrid(npcs, entry, 40.0f);
+                for (Creature* npc : npcs)
+                    npc->DespawnOrUnsummon();
+            }
+            break;
+        }
+    }
+
+    void MovementInform(uint32 type, uint32 id) override
+    {
+        if (type != POINT_MOTION_TYPE)
+            return;
+
+        if (id < 9)
+            wpreached = true;
+
+        if (id == 9)
+        {
+            wpreached = true;
+            point = 4;
+        }
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (wpreached)
+        {
+            me->GetMotionMaster()->MovePoint(point, exorcismPos[point]);
+            point++;
+            wpreached = false;
+        }
+        events.Update(diff);
+    }
+
+    bool OnGossipHello(Player* player) override
+    {
+        if (success)
+            player->KilledMonsterCredit(NPC_COLONEL_JULES, ObjectGuid::Empty);
+        SendGossipMenuFor(player, player->GetGossipTextId(me), me->GetGUID());
+        return true;
+    }
+
+private:
+    EventMap events;
+    uint8 point;
+    bool wpreached;
+public:
+    bool success;
 };
 
 /*######
 ## npc_barada
 ######*/
 
-class npc_barada : public CreatureScript
+struct npc_barada : public ScriptedAI
 {
-public:
-    npc_barada() : CreatureScript("npc_barada") { }
+    npc_barada(Creature* creature) : ScriptedAI(creature) {}
 
-    struct npc_baradaAI : public ScriptedAI
+    void Reset() override
     {
-        npc_baradaAI(Creature* creature) : ScriptedAI(creature)
-        {
-            Initialize();
-        }
+        events.Reset();
+        step = 0;
+        playerGUID.Clear();
+        me->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
+        me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+    }
 
-        void Initialize()
-        {
-            step = 0;
-        }
-
-        void Reset() override
-        {
-            events.Reset();
-            Initialize();
-
-            playerGUID.Clear();
-            me->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
-            me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-        }
-
-        bool OnGossipSelect(Player* player, uint32 /*menuId*/, uint32 gossipListId) override
-        {
-            ClearGossipMenuFor(player);
-            switch (gossipListId)
-            {
-                case 1:
-                    player->PlayerTalkClass->SendCloseGossip();
-                    me->AI()->Talk(SAY_BARADA_1);
-                    me->AI()->DoAction(ACTION_START_EVENT);
-                    me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
-                    break;
-                default:
-                    break;
-            }
-            return false;
-        }
-
-        void DoAction(int32 action) override
-        {
-            if (action == ACTION_START_EVENT)
-            {
-                if (Creature* jules = me->FindNearestCreature(NPC_COLONEL_JULES, 20.0f, true))
-                {
-                    julesGUID = jules->GetGUID();
-                    jules->AI()->Talk(SAY_JULES_1);
-                }
-
-                me->GetMotionMaster()->MovePoint(0, exorcismPos[1]);
-                Talk(SAY_BARADA_2);
-
-                me->SetUnitFlag(UNIT_FLAG_PACIFIED);
-            }
-        }
-
-        void MovementInform(uint32 type, uint32 id) override
-        {
-            if (type != POINT_MOTION_TYPE)
-                return;
-
-            if (id == 0)
-                me->GetMotionMaster()->MovePoint(1, exorcismPos[1]);
-
-            if (id == 1)
-                events.ScheduleEvent(EVENT_BARADAS_TALK, 2s);
-        }
-
-        void JustDied(Unit* /*killer*/) override
+    bool OnGossipSelect(Player* player, uint32 /*menuId*/, uint32 gossipListId) override
+    {
+        ClearGossipMenuFor(player);
+        if (gossipListId == 1)
         {
             if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-            {
-                jules->AI()->DoAction(ACTION_JULES_MOVE_HOME);
-                jules->RemoveAllAuras();
-            }
+                jules->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+            player->PlayerTalkClass->SendCloseGossip();
+            me->AI()->Talk(SAY_BARADA_1);
+            me->AI()->DoAction(ACTION_START_EVENT);
         }
+        return false;
+    }
 
-        void UpdateAI(uint32 diff) override
-        {
-            events.Update(diff);
-
-            while (uint32 eventId = events.ExecuteEvent())
-            {
-                switch (eventId)
-                {
-                    case EVENT_BARADAS_TALK:
-                        switch (step)
-                        {
-                            case 0:
-                                me->SetFacingTo(1.513286f);
-
-                                me->HandleEmoteCommand(EMOTE_ONESHOT_KNEEL);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 3s);
-                                step++;
-                                break;
-                            case 1:
-                                DoCast(SPELL_BARADAS_COMMAND);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 5s);
-                                step++;
-                                break;
-                            case 2:
-                                Talk(SAY_BARADA_3);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 7s);
-                                step++;
-                                break;
-                            case 3:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_2);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 18s);
-                                step++;
-                                break;
-                            case 4:
-                                DoCast(SPELL_BARADA_FALTERS);
-                                me->HandleEmoteCommand(EMOTE_STAND_STATE_NONE);
-
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->DoAction(ACTION_JULES_HOVER);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 11s);
-                                step++;
-                                break;
-                            case 5:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_3);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 13s);
-                                step++;
-                                break;
-                            case 6:
-                                Talk(SAY_BARADA_4);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 5s);
-                                step++;
-                                break;
-                            case 7:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_3);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 13s);
-                                step++;
-                                break;
-                            case 8:
-                                Talk(SAY_BARADA_4);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 12s);
-                                step++;
-                                break;
-                            case 9:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_4);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 12s);
-                                step++;
-                                break;
-                            case 10:
-                                Talk(SAY_BARADA_4);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 5s);
-                                step++;
-                                break;
-                            case 11:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->DoAction(ACTION_JULES_FLIGHT);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 12:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_4);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 8s);
-                                step++;
-                                break;
-                            case 13:
-                                Talk(SAY_BARADA_5);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 14:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_4);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 15:
-                                Talk(SAY_BARADA_6);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 16:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_5);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 17:
-                                Talk(SAY_BARADA_7);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 18:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                    jules->AI()->Talk(SAY_JULES_3);
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 19:
-                                Talk(SAY_BARADA_7);
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 20:
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                {
-                                    jules->AI()->DoAction(ACTION_JULES_MOVE_HOME);
-                                    jules->RemoveAura(SPELL_JULES_VOMITS_AURA);
-                                }
-
-                                events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
-                                step++;
-                                break;
-                            case 21:
-                                //End
-                                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                                {
-                                    ENSURE_AI(npc_colonel_jules::npc_colonel_julesAI, jules->AI())->success = true;
-                                    jules->RemoveAllAuras();
-                                }
-
-                                me->RemoveAura(SPELL_BARADAS_COMMAND);
-                                me->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
-
-                                Talk(SAY_BARADA_8);
-                                me->GetMotionMaster()->MoveTargetedHome();
-                                EnterEvadeMode();
-                                events.ScheduleEvent(EVENT_RESET, 2min);
-                                break;
-                        }
-                        break;
-                    case EVENT_RESET:
-                        if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
-                            ENSURE_AI(npc_colonel_jules::npc_colonel_julesAI, jules->AI())->success = false;
-                        break;
-                }
-            }
-        }
-
-        private:
-            EventMap events;
-            uint8 step;
-            ObjectGuid julesGUID;
-            ObjectGuid playerGUID;
-    };
-
-    CreatureAI* GetAI(Creature* creature) const override
+    void DoAction(int32 action) override
     {
-        return new npc_baradaAI(creature);
+        if (action != ACTION_START_EVENT)
+            return;
+
+        if (Creature* jules = me->FindNearestCreature(NPC_COLONEL_JULES, 20.0f, true))
+        {
+            julesGUID = jules->GetGUID();
+            jules->AI()->Talk(SAY_JULES_1);
+        }
+        
+        me->SetWalk(true);
+        me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+        Talk(SAY_BARADA_2);
+        me->SetUnitFlag(UNIT_FLAG_PACIFIED);
+        me->GetMotionMaster()->MovePoint(0, exorcismPos[0]);
+    }
+
+    void MovementInform(uint32 type, uint32 id) override
+    {
+        if (type != POINT_MOTION_TYPE)
+            return;
+
+        if (id == 0)
+            me->GetMotionMaster()->MovePoint(1, exorcismPos[1]);
+        else if (id == 1)
+            me->GetMotionMaster()->MovePoint(2, exorcismPos[2]);
+        else if (id == 2)
+            events.ScheduleEvent(EVENT_BARADAS_TALK, 2s);
+    }
+
+    void JustDied(Unit* /*killer*/) override
+    {
+        if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+        {
+            jules->AI()->DoAction(ACTION_JULES_MOVE_HOME);
+            jules->RemoveAllAuras();
+            jules->AddAura(SPELL_JULES_GOES_PRONE, jules);
+        }
+        me->DespawnOrUnsummon(1s,10s);
+        std::list<uint32> despawnEntries = { NPC_DARKNESS_RELEASED, NPC_FOUL_PURGE, NPC_THE_EXORCISM_BUBBLING_SLIMER_BUNNY };
+        for (uint32 entry : despawnEntries)
+        {
+            std::list<Creature*> npcs;
+            me->GetCreatureListWithEntryInGrid(npcs, entry, 40.0f);
+            for (Creature* npc : npcs)
+                npc->DespawnOrUnsummon();
+        }
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        events.Update(diff);
+
+        while (uint32 eventId = events.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+            case EVENT_BARADAS_TALK:
+                switch (step)
+                {
+                case 0:
+                    me->SetFacingTo(1.513286f);
+                    me->HandleEmoteCommand(EMOTE_ONESHOT_KNEEL);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 3s);
+                    step++;
+                    break;
+                case 1:
+                    DoCast(SPELL_BARADAS_COMMAND);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 5s);
+                    step++;
+                    break;
+                case 2:
+                    Talk(SAY_BARADA_3);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 7s);
+                    step++;
+                    break;
+                case 3:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_2);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 18s);
+                    step++;
+                    break;
+                case 4:
+                    DoCast(SPELL_BARADA_FALTERS);
+                    me->HandleEmoteCommand(EMOTE_STAND_STATE_NONE);
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->DoAction(ACTION_JULES_HOVER);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 11s);
+                    step++;
+                    break;
+                case 5:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_3);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 13s);
+                    step++;
+                    break;
+                case 6:
+                    Talk(SAY_BARADA_4);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 5s);
+                    step++;
+                    break;
+                case 7:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_3);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 13s);
+                    step++;
+                    break;
+                case 8:
+                    Talk(SAY_BARADA_4);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 12s);
+                    step++;
+                    break;
+                case 9:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_4);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 12s);
+                    step++;
+                    break;
+                case 10:
+                    Talk(SAY_BARADA_4);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 5s);
+                    step++;
+                    break;
+                case 11:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->DoAction(ACTION_JULES_FLIGHT);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 12:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_4);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 8s);
+                    step++;
+                    break;
+                case 13:
+                    Talk(SAY_BARADA_5);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 14:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_4);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 15:
+                    Talk(SAY_BARADA_6);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 16:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_5);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 17:
+                    Talk(SAY_BARADA_7);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 18:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->Talk(SAY_JULES_3);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 19:
+                    Talk(SAY_BARADA_7);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 10s);
+                    step++;
+                    break;
+                case 20:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                        jules->AI()->DoAction(ACTION_JULES_MOVE_HOME);
+                    events.ScheduleEvent(EVENT_BARADAS_TALK, 1s);
+                    step++;
+                    break;
+                case 21:
+                    if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                    {
+                        ENSURE_AI(npc_colonel_jules, jules->AI())->success = true;
+                        jules->RemoveAllAuras();
+                        jules->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+                        jules->SetUnitFlag(UNIT_FLAG_STUNNED);
+                        jules->AddAura(SPELL_JULES_GOES_PRONE, jules);
+                    }
+                    me->RemoveAura(SPELL_BARADAS_COMMAND);
+                    me->RemoveUnitFlag(UNIT_FLAG_PACIFIED);
+                    Talk(SAY_BARADA_8);
+                    me->GetMotionMaster()->MoveTargetedHome();
+                    EnterEvadeMode();
+                    me->SetWalk(true);
+                    events.ScheduleEvent(EVENT_RESET, 45s);
+                    break;
+                }
+                break;
+            case EVENT_RESET:
+                if (Creature* jules = ObjectAccessor::GetCreature(*me, julesGUID))
+                {
+                    ENSURE_AI(npc_colonel_jules, jules->AI())->success = false;
+                    jules->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+                    jules->RemoveUnitFlag(UNIT_FLAG_STUNNED);
+                }
+                break;
+            }
+        }
+    }
+
+private:
+    EventMap events;
+    uint8 step;
+    ObjectGuid julesGUID;
+    ObjectGuid playerGUID;
+};
+
+enum spell_ritual_prayer_beads
+{
+    SPELL_HEAL_BARADA           = 39322,
+    NPC_ANCHORITE_BARADA        = 22431,
+    NPC_DARKNESS_RELEASED       = 22507,
+    NPC_FOUL_PURGE              = 22506
+};
+
+/*Handle Prayer Beads item -> Linked spell in Database not working*/
+
+class spell_39322_prayer_beads : public SpellScript
+{
+    PrepareSpellScript(spell_39322_prayer_beads);
+
+    void HandleAfterHit()
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetHitUnit();
+        if (!caster || !target || !target->IsCreature())
+            return;
+
+        uint32 entry = target->GetEntry();
+        if (entry == NPC_ANCHORITE_BARADA || entry == NPC_DARKNESS_RELEASED || entry == NPC_FOUL_PURGE)
+        {
+            if (Creature* npc22431 = target->FindNearestCreature(NPC_ANCHORITE_BARADA, 40.0f, true))
+            {
+                caster->CastSpell(npc22431, SPELL_HEAL_BARADA, true);
+            }
+        }
+    }
+
+    void Register() override
+    {
+        AfterHit += SpellHitFn(spell_39322_prayer_beads::HandleAfterHit);
     }
 };
 
@@ -956,8 +919,8 @@ class spell_hellfire_peninsula_absorb_eye_of_grillok : public AuraScript
 
 void AddSC_hellfire_peninsula()
 {
-    new npc_colonel_jules();
-    new npc_barada();
+    RegisterCreatureAI(npc_colonel_jules);
+    RegisterCreatureAI(npc_barada);
     new npc_magister_aledis();
     RegisterCreatureAI(npc_watch_commander_leonus);
     RegisterCreatureAI(npc_infernal_rain_hellfire);

--- a/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
+++ b/src/server/scripts/Outland/zone_hellfire_peninsula.cpp
@@ -140,6 +140,7 @@ struct npc_colonel_jules : public ScriptedAI
             me->RemoveAura(SPELL_JULES_GOES_UPRIGHT);
             me->RemoveAura(SPELL_JULES_VOMITS_AURA);
             me->RemoveAura(SPELL_JULES_THREATENS_AURA);
+
             std::list<uint32> despawnEntries = { NPC_DARKNESS_RELEASED, NPC_FOUL_PURGE, NPC_THE_EXORCISM_BUBBLING_SLIMER_BUNNY };
             for (uint32 entry : despawnEntries)
             {
@@ -175,6 +176,7 @@ struct npc_colonel_jules : public ScriptedAI
             point++;
             wpreached = false;
         }
+
         events.Update(diff);
     }
 
@@ -182,6 +184,7 @@ struct npc_colonel_jules : public ScriptedAI
     {
         if (success)
             player->KilledMonsterCredit(NPC_COLONEL_JULES, ObjectGuid::Empty);
+
         SendGossipMenuFor(player, player->GetGossipTextId(me), me->GetGUID());
         return true;
     }


### PR DESCRIPTION
**Changes proposed:**

I also changed the following:

- Improved the waypoint for Barada
- Summoning NPCs via original spells
- Removed Jules' flag
- Set the stunned flag when the event ends and you talk to Jules so he doesn't move.
- Added the missing bunny NPC
- Spell script for the item because the linked spell in the database doesn't work
- Reset the event when Barada dies
- SmartAI script for the bunny NPC
- Removed Jules's sleeping spell from the database because it's triggered by a spell
- Set the Gossip Quest Required correctly
- Spell fix because 2 seconds is too fast.
- Set Walk for Barada and Jules
- Another problem was that too many skulls appeared because they were summoned twice. I removed that, as well as the slimes that spawned in the air, etc. All handled by the spells.

And much more...

** Open Issue**

I took this open issue: https://github.com/TrinityCore/TrinityCore/issues/15370 and added the missing points.

**Tests performed:**

(Does it build, tested in-game, etc.)

Working more Blizzlike with my Changes
Video with my Changes: https://youtu.be/3FzXBitt6eU


**Known issues and TODO list:** (add/remove lines as needed)

- [I didn't manage to get the Drowned effect working, so the NPC is floating in the air. Only after resetting, when he stopped moving, did he get it in my tests. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
