### PR TITLE
Scripts/Westfall: scripted Overloarded Harvest Golem visuals * removed somple duplicate spawns and event related spawns that are already spawnt

### DIFF
--- a/sql/updates/world/master/2025_09_27_00_world_2020_01_30_01_world.sql
+++ b/sql/updates/world/master/2025_09_27_00_world_2020_01_30_01_world.sql
@@ -1,0 +1,17 @@
+DELETE FROM `creature` WHERE `guid` IN (290983, 276237, 275702, 275704, 275497, 275496, 275274, 275275, 275809, 308009, 280400);
+DELETE FROM `creature_addon` WHERE `guid` IN (290983, 276237, 275702, 275704, 275497, 275496, 275274, 275275, 275809, 308009, 280400);
+
+-- Creature Overloaded Harvest Golem 42381 SAI
+SET @ENTRY := 42381;
+UPDATE `creature_template` SET `AIName`="SmartAI" WHERE `entry`= @ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(@ENTRY, 0, 0, 0, 1, 0, 100, 0, 3000, 6000, 3500, 6000, 11, 79084, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "When out of combat and timer at the begining between 3000 and 6000 ms (and later repeats every 3500 and 6000 ms) - Self: Cast spell Unbound Energy (79084) on Self // ");
+
+DELETE FROM `conditions` WHERE `SourceEntry`= 79084 AND `SourceTypeOrReferenceId`= 13;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ScriptName`, `Comment`) VALUES
+(13, 1, 79084, 0, 0, 31, 0, 3, 42381, 0, 0, 0, '', 'Unbound Energy - Target Overloaded Harvest Golem');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_westfall_unbound_energy';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(79084, 'spell_westfall_unbound_energy');

--- a/src/server/scripts/EasternKingdoms/eastern_kingdoms_script_loader.cpp
+++ b/src/server/scripts/EasternKingdoms/eastern_kingdoms_script_loader.cpp
@@ -203,6 +203,7 @@ void AddSC_tirisfal_glades();
 void AddSC_tol_barad();
 void AddSC_undercity();
 //void AddSC_western_plaguelands();
+void AddSC_westfall();
 
 // Return to Karazhan
 void AddSC_instance_return_to_karazhan();
@@ -402,6 +403,7 @@ void AddEasternKingdomsScripts()
     AddSC_tol_barad();
     AddSC_undercity();
     //AddSC_western_plaguelands();
+    AddSC_westfall();
 
     // Return to Karazhan
     AddSC_instance_return_to_karazhan();

--- a/src/server/scripts/EasternKingdoms/zone_westfall.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_westfall.cpp
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Containers.h"
+#include "ScriptedCreature.h"
+#include "ScriptMgr.h"
+#include "SpellScript.h"
+
+// 79084 - Unbound Energy
+class spell_westfall_unbound_energy : public SpellScript
+{
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        if (targets.empty())
+            return;
+
+        Unit* caster = GetCaster();
+        targets.remove_if([caster](WorldObject const* target) -> bool
+        {
+            return caster->ToWorldObject() == target;
+        });
+
+        if (targets.size() > 1)
+            Trinity::Containers::RandomResize(targets, 1);
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_westfall_unbound_energy::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENTRY);
+    }
+};
+
+void AddSC_westfall()
+{
+    RegisterSpellScript(spell_westfall_unbound_energy);
+}


### PR DESCRIPTION
(cherry picked from commit 7f6e63f850aaf71668dedd8394f023eff2ef8452)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Cherry-picked from https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/7f6e63f850aaf71668dedd8394f023eff2ef8452

**Issues addressed:**

None


**Tests performed:**

build, tested ingame


**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
