### PR TITLE
Scripts/Plaguefall: Implement Globgrog encounter

### DIFF
--- a/sql/updates/world/master/2025_99_99_99_boss_globgrog.sql
+++ b/sql/updates/world/master/2025_99_99_99_boss_globgrog.sql
@@ -1,0 +1,121 @@
+SET @CGUID := 777777777;
+SET @ATPROP := 55555;
+
+DELETE FROM `creature` WHERE `guid` BETWEEN @CGUID+0 AND @CGUID+12;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnDifficulties`, `PhaseId`, `PhaseGroup`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `wander_distance`, `currentwaypoint`, `MovementType`, `npcflag`, `unit_flags`, `unit_flags2`, `unit_flags3`, `VerifiedBuild`) VALUES
+(@CGUID+0, 164255, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2036.204833984375, -3596.0087890625, 3263.586669921875, 5.108221054077148437, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Globgrog (Area: Plaguefall - Difficulty: 0) CreateObject1 (Auras: 324366 - Living Slime Flesh, 324304 - Slime Energy Bar, 346098 - Festive Globgrog, 324284 - Slime Infused Bones)
+(@CGUID+1, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2065.329833984375, -3489.607666015625, 3259.728759765625, 4.418760299682617187, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: 0) CreateObject1
+(@CGUID+2, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2001.6632080078125, -3496.3369140625, 3259.882080078125, 5.323053836822509765, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: 0) CreateObject1
+(@CGUID+3, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 1986.467041015625, -3535.326416015625, 3259.689208984375, 0, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+4, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 1986.3507080078125, -3514.569580078125, 3259.451904296875, 0, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+5, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2080.114501953125, -3501.203125, 3259.46337890625, 4.344142436981201171, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+6, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 1986.295166015625, -3556.33154296875, 3259.406494140625, 0.417013734579086303, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+7, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2088.338623046875, -3521.80029296875, 3259.458984375, 3.311464786529541015, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+8, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2054.375, -3583.257080078125, 3259.46630859375, 1.897548079490661621, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+9, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2089.20654296875, -3550.02783203125, 3259.4208984375, 2.60940098762512207, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+10, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2075.007080078125, -3575.5869140625, 3259.41162109375, 2.214966058731079101, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+11, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2028.78125, -3582.810791015625, 3259.513671875, 1.888534903526306152, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305), -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+(@CGUID+12, 166480, 2289, 13228, 13228, '1,2,8,23', '0', 0, 0, 0, 2001.2569580078125, -3580.640625, 3259.760498046875, 1.018098831176757812, 7200, 0, 0, 0, NULL, NULL, NULL, NULL, 63305); -- Living Slime Stalker (Area: Plaguefall - Difficulty: Mythic) CreateObject1
+
+UPDATE `creature_template` SET `unit_flags3`=0x41000001 WHERE `entry`=166480; -- Living Slime Stalker
+UPDATE `creature_template` SET `ScriptName`='boss_globgrog' WHERE `entry`=164255; -- Globgrog
+UPDATE `creature_template` SET `faction`=16, `speed_walk`=2.799999952316284179, `speed_run`=2, `BaseAttackTime`=2000, `unit_flags2`=0x800, `unit_flags3`=0x280000, `ScriptName`='boss_globgrog_slimy_creature' WHERE `entry`=164362; -- Slimy Morsel
+UPDATE `creature_template` SET `faction`=16, `speed_walk`=2.799999952316284179, `speed_run`=2, `BaseAttackTime`=2000, `unit_flags`=0x40, `unit_flags2`=0x800, `unit_flags3`=0x280001, `ScriptName`='boss_globgrog_slimy_creature' WHERE `entry`=171887; -- Slimy Smorgasbord
+
+DELETE FROM `creature_template_addon` WHERE `entry` IN (171887,164362,164255);
+INSERT INTO `creature_template_addon` (`entry`, `PathId`, `mount`, `StandState`, `AnimTier`, `VisFlags`, `SheathState`, `PvpFlags`, `emote`, `aiAnimKit`, `movementAnimKit`, `meleeAnimKit`, `visibilityDistanceType`, `auras`) VALUES
+(171887, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, '123169'), -- 171887 (Slimy Smorgasbord) - Mod Scale 105-110%
+(164362, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, '123169'), -- 164362 (Slimy Morsel) - Mod Scale 105-110%
+(164255, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 3, '324366 324304 346098'); -- 164255 (Globgrog) - Living Slime Flesh, Slime Energy Bar, Festive Globgrog
+
+-- Spells
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_globgrog_victory_start_convo', 'spell_globgrog_beckon_slime_start_convo', 'spell_globgrog_plaguestomp_start_convo', 'spell_globgrog_plaguestomp_damage', 'spell_globgrog_slime_wave_start_convo','spell_globgrog_slime_wave_selector', 'spell_globgrog_beckon_slime_selector', 'spell_globgrog_beckon_slime_mythic_selector');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(332865, 'spell_globgrog_slime_wave_selector'),
+(333420, 'spell_globgrog_slime_wave_start_convo'),
+(324527, 'spell_globgrog_plaguestomp_damage'),
+(333424, 'spell_globgrog_plaguestomp_start_convo'),
+(333417, 'spell_globgrog_beckon_slime_start_convo'),
+(333428, 'spell_globgrog_victory_start_convo'),
+(326273, 'spell_globgrog_beckon_slime_mythic_selector'),
+(324459, 'spell_globgrog_beckon_slime_selector');
+
+-- Conversations
+DELETE FROM `conversation_actors` WHERE (`Idx`=0 AND `ConversationId` IN (15333,15332,15336,15334,15337,15330,15335,15338,15339,15340));
+INSERT INTO `conversation_actors` (`ConversationId`, `ConversationActorId`, `ConversationActorGuid`, `Idx`, `CreatureId`, `CreatureDisplayInfoId`, `NoActorObject`, `ActivePlayerObject`, `VerifiedBuild`)  VALUES
+(15330, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15332, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15333, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15334, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15335, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15336, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15337, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15338, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15339, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305), -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+(15340, 74599, @CGUID+0, 0, 0, 0, 0, 0, 63305); -- Full: 0x202FD51E20A067C0005A3B00005AFAC9 Creature/0 R3061/S23099 Map: 2289 (Plaguefall) Entry: 164255 (Globgrog) Low: 5962441
+
+DELETE FROM `conversation_line_template` WHERE `Id` IN (38462, 38461, 38465, 38463, 38466, 38457, 38464, 38467, 38468, 38469);
+INSERT INTO `conversation_line_template` (`Id`, `UiCameraID`, `ActorIdx`, `Flags`, `ChatType`, `VerifiedBuild`) VALUES
+(38457, 0, 0, 0, 1, 63305),
+(38461, 0, 0, 0, 1, 63305),
+(38462, 0, 0, 0, 1, 63305),
+(38463, 0, 0, 0, 1, 63305),
+(38464, 0, 0, 0, 1, 63305),
+(38465, 0, 0, 0, 1, 63305),
+(38466, 0, 0, 0, 1, 63305),
+(38467, 0, 0, 0, 1, 63305),
+(38468, 0, 0, 0, 1, 63305),
+(38469, 0, 0, 0, 1, 63305);
+
+DELETE FROM `conversation_template` WHERE `Id` IN (15334, 15336, 15335, 15338, 15330, 15337, 15332, 15333, 15339, 15340);
+INSERT INTO `conversation_template` (`Id`, `FirstLineID`, `TextureKitId`, `VerifiedBuild`) VALUES
+(15330, 38457, 0, 63305),
+(15332, 38461, 0, 63305),
+(15333, 38462, 0, 63305),
+(15334, 38463, 0, 63305),
+(15335, 38464, 0, 63305),
+(15336, 38465, 0, 63305),
+(15337, 38466, 0, 63305),
+(15338, 38467, 0, 63305),
+(15339, 38468, 0, 63305),
+(15340, 38469, 0, 63305);
+
+-- Difficulty
+DELETE FROM `creature_template_difficulty` WHERE (`DifficultyID`=23 AND `Entry` IN (171887,164362));
+INSERT INTO `creature_template_difficulty` (`Entry`, `DifficultyID`, `HealthScalingExpansion`, `HealthModifier`, `ManaModifier`, `CreatureDifficultyID`, `TypeFlags`, `TypeFlags2`, `TypeFlags3`) VALUES
+(171887, 23, 8, 2, 1, 193364, 0x200048, 128, 0), -- Slimy Smorgasbord
+(164362, 23, 8, 0.524999976158142089, 1, 184769, 0x200048, 128, 0); -- Slimy Morsel
+
+UPDATE `creature_template_difficulty` SET `StaticFlags1`=0x20000100, `VerifiedBuild`=63305 WHERE (`Entry`=166480 AND `DifficultyID`=0); -- 166480 (Living Slime Stalker) - Sessile, Floating
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `StaticFlags1`=0x10000000, `VerifiedBuild`=63305 WHERE (`Entry`=164255 AND `DifficultyID`=0); -- 164255 (Globgrog) - CanSwim
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `HealthScalingExpansion`=8, `HealthModifier`=2, `CreatureDifficultyID`=193364, `TypeFlags`=0x200048, `TypeFlags2`=128 WHERE (`Entry`=171887 AND `DifficultyID`=23); -- Slimy Smorgasbord
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `HealthScalingExpansion`=8, `HealthModifier`=0.524999976158142089, `CreatureDifficultyID`=184769, `TypeFlags`=0x200048, `TypeFlags2`=128 WHERE (`Entry`=164362 AND `DifficultyID`=23); -- Slimy Morsel
+
+-- Texts
+DELETE FROM `creature_text` WHERE `CreatureID`= 164255;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(164255, 0, 0, 'Intruders! You will be devoured whole!', 14, 0, 100, 0, 0, 152566, 191813, 0, 'Globgrog'),
+(164255, 1, 0, 'The... hunger... ends...', 14, 0, 100, 0, 0, 152556, 191819, 0, 'Globgrog');
+
+-- Instance
+DELETE FROM `instance_template` WHERE `map`=2289;
+INSERT INTO `instance_template` (`map`, `parent`, `script`) VALUES
+(2289, 0, 'instance_plaguefall');
+
+-- Conditions
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=13 AND `SourceEntry`IN (324459, 326273, 326248);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `ConditionStringValue1`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 326248, 0, 0, 51, 0, 5, 164255, 0, '', 0, 0, 0, '', 'Spell \'Beckon Slime\' can only hit \'Globgrog\''),
+(13, 1, 324459, 0, 0, 51, 0, 5, 166480, 0, '', 0, 0, 0, '', 'Spell \'Beckon Slime\' can only hit \'Living Slime Stalker\''),
+(13, 1, 326273, 0, 0, 51, 0, 5, 166480, 0, '', 0, 0, 0, '', 'Spell \'Beckon Slime\' can only hit \'Living Slime Stalker\'');
+
+-- Areatrigger
+SET @ATPROP := 55555;
+
+DELETE FROM `areatrigger_create_properties` WHERE (`IsCustom`=0 AND `Id` IN (19879));
+INSERT INTO `areatrigger_create_properties` (`Id`, `IsCustom`, `AreaTriggerId`, `IsAreatriggerCustom`, `Flags`, `MoveCurveId`, `ScaleCurveId`, `MorphCurveId`, `FacingCurveId`, `AnimId`, `AnimKitId`, `DecalPropertiesId`, `SpellForVisuals`, `TimeToTargetScale`, `Speed`, `Shape`, `ShapeData0`, `ShapeData1`, `ShapeData2`, `ShapeData3`, `ShapeData4`, `ShapeData5`, `ShapeData6`, `ShapeData7`, `ScriptName`, `VerifiedBuild`) VALUES
+(19879, 0, @ATPROP, 1, 4, 0, 0, 0, 0, -1, 0, 0, NULL, 0, 0, 0, 6, 6, 0, 0, 0, 0, 0, 0, 'at_globgrog_living_slime_flesh', 63305);
+
+DELETE FROM `areatrigger_template` WHERE (`IsCustom`=1 AND `Id` IN (@ATPROP));
+INSERT INTO `areatrigger_template` (`Id`, `IsCustom`, `VerifiedBuild`) VALUES
+(@ATPROP, 1, 63305);

--- a/sql/updates/world/master/2025_99_99_99_boss_globgrog.sql
+++ b/sql/updates/world/master/2025_99_99_99_boss_globgrog.sql
@@ -86,10 +86,25 @@ INSERT INTO `creature_template_difficulty` (`Entry`, `DifficultyID`, `HealthScal
 (171887, 23, 8, 2, 1, 193364, 0x200048, 128, 0), -- Slimy Smorgasbord
 (164362, 23, 8, 0.524999976158142089, 1, 184769, 0x200048, 128, 0); -- Slimy Morsel
 
-UPDATE `creature_template_difficulty` SET `StaticFlags1`=0x20000100, `VerifiedBuild`=63305 WHERE (`Entry`=166480 AND `DifficultyID`=0); -- 166480 (Living Slime Stalker) - Sessile, Floating
-UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `StaticFlags1`=0x10000000, `VerifiedBuild`=63305 WHERE (`Entry`=164255 AND `DifficultyID`=0); -- 164255 (Globgrog) - CanSwim
-UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `HealthScalingExpansion`=8, `HealthModifier`=2, `CreatureDifficultyID`=193364, `TypeFlags`=0x200048, `TypeFlags2`=128 WHERE (`Entry`=171887 AND `DifficultyID`=23); -- Slimy Smorgasbord
-UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `HealthScalingExpansion`=8, `HealthModifier`=0.524999976158142089, `CreatureDifficultyID`=184769, `TypeFlags`=0x200048, `TypeFlags2`=128 WHERE (`Entry`=164362 AND `DifficultyID`=23); -- Slimy Morsel
+DELETE FROM `creature_template_difficulty` WHERE (`DifficultyID`=2 AND `Entry` IN (166480, 164362));
+INSERT INTO `creature_template_difficulty` (`Entry`, `DifficultyID`, `HealthScalingExpansion`, `HealthModifier`, `ManaModifier`, `CreatureDifficultyID`, `TypeFlags`, `TypeFlags2`, `TypeFlags3`) VALUES
+(164362, 2, 8, 0.524999976158142089, 1, 184769, 0x200048, 128, 0), -- Slimy Morsel
+(166480, 2, 8, 1, 1, 187184, 0x0, 0, 0); -- Living Slime Stalker
+
+UPDATE `creature_template_difficulty` SET `StaticFlags1`=0x10000000 WHERE `Entry`=164255; -- 164255 (Globgrog) - CanSwim
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=1710, `VerifiedBuild`=66709 WHERE (`Entry`=164255 AND `DifficultyID`=1); -- 164255 (Globgrog) - CanSwim
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=748, `VerifiedBuild`=66709 WHERE (`Entry`=164255 AND `DifficultyID`=2); -- 164255 (Globgrog) - CanSwim
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `VerifiedBuild`=66709 WHERE (`Entry`=164255 AND `DifficultyID`=23); -- 164255 (Globgrog) - CanSwim
+
+UPDATE `creature_template_difficulty` SET `StaticFlags1`=0x20000100, `VerifiedBuild`=66709 WHERE `Entry`=166480; -- 166480 (Living Slime Stalker) - Sessile, Floating
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=1710, `VerifiedBuild`=66709 WHERE (`Entry`=166480 AND `DifficultyID`=1); -- 166480 (Living Slime Stalker) - Sessile, Floating
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=748, `VerifiedBuild`=66709 WHERE (`Entry`=166480 AND `DifficultyID`=2); -- 166480 (Living Slime Stalker) - Sessile, Floating
+
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `VerifiedBuild`=66709 WHERE (`Entry`=171887 AND `DifficultyID`=23); -- Slimy Smorgasbord
+
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=1710, `VerifiedBuild`=66709 WHERE (`Entry`=164362 AND `DifficultyID`=1); -- Slimy Morsel
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=748, `VerifiedBuild`=66709 WHERE (`Entry`=164362 AND `DifficultyID`=2); -- Slimy Morsel
+UPDATE `creature_template_difficulty` SET `ContentTuningID`=749, `VerifiedBuild`=66709 WHERE (`Entry`=164362 AND `DifficultyID`=23); -- Slimy Morsel
 
 -- Texts
 DELETE FROM `creature_text` WHERE `CreatureID`= 164255;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -4949,6 +4949,22 @@ void SpellMgr::LoadSpellInfoCorrections()
     //
 
     //
+    // PLAGUEFALL SPELLS
+    //
+
+    // Slime Wave
+    ApplySpellFix({ 332865 }, [](SpellInfo* spellInfo)
+    {
+        ApplySpellEffectFix(spellInfo, EFFECT_1, [](SpellEffectInfo* spellEffectInfo)
+        {
+            spellEffectInfo->Effect = SPELL_EFFECT_NONE;
+        });
+    });
+
+    // ENDOF PLAGUEFALL SPELLS
+    //
+
+    //
     // SHRINE OF THE STORM SPELLS
     //
 

--- a/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
@@ -1,0 +1,506 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AreaTrigger.h"
+#include "AreaTriggerAI.h"
+#include "Creature.h"
+#include "InstanceScript.h"
+#include "Map.h"
+#include "MotionMaster.h"
+#include "ScriptMgr.h"
+#include "ScriptedCreature.h"
+#include "SpellAuraEffects.h"
+#include "SpellScript.h"
+#include "TaskScheduler.h"
+#include "TemporarySummon.h"
+#include "plaguefall.h"
+
+enum GlobgrogSpells
+{
+    SPELL_SLIME_WAVE_SELECTOR          = 332865,
+    SPELL_SLIME_WAVE                   = 324667,
+    SPELL_PLAGUESTOMP                  = 324527,
+    SPELL_DEBILITATING_PLAGUE          = 331238,
+    SPELL_BECKON_SLIME_SELECTOR        = 324459,
+    SPELL_BECKON_SLIME_MISSILE         = 319776,
+    SPELL_BECKON_SLIME_MYTHIC_SELECTOR = 326273,
+    SPELL_BECKON_SLIME_MYTHIC_MISSILE  = 335517,
+    SPELL_BECKON_SLIME_VISUAL_DUMMY    = 326247,
+    SPELL_SLIME_INFUSED_BONES          = 324284,
+    SPELL_LIVING_SLIME_FLESH           = 324377,
+    SPELL_CONSUME_SLIME                = 319780,
+
+    // Conversations (texts)
+    SPELL_KILLS_PLAYER_TEXT_1          = 333415,
+    SPELL_KILLS_PLAYER_TEXT_2          = 333416,
+    SPELL_BECKON_SLIME_START_CONVO     = 333417,
+    SPELL_BECKON_SLIME_TEXT_1          = 333418,
+    SPELL_BECKON_SLIME_TEXT_2          = 333419,
+    SPELL_SLIME_WAVE_START_CONVO       = 333420,
+    SPELL_SLIME_WAVE_TEXT_1            = 333421,
+    SPELL_SLIME_WAVE_TEXT_2            = 333422,
+    SPELL_PLAGUESTOMP_START_CONVO      = 333424,
+    SPELL_PLAGUESTOMP_TEXT_1           = 333425,
+    SPELL_PLAGUESTOMP_TEXT_2           = 333426,
+    SPELL_VICTORY_START_CONVO          = 333428,
+    SPELL_VICTORY_TEXT_1               = 333429,
+    SPELL_VICTORY_TEXT_2               = 333430
+};
+
+enum GlobgrogEvents
+{
+    EVENT_ENERGIZE = 1,
+    EVENT_CHECK_ENERGY,
+    EVENT_PLAGUESTOMP,
+    EVENT_SLIME_WAVE
+};
+
+enum GlobgrogTexts
+{
+    SAY_AGGRO = 0,
+    SAY_DEATH = 1
+};
+
+enum GlobgrogMisc
+{
+    NPC_SLIMY_MORSEL      = 164362,
+    NPC_SLIMY_SMORGASBORD = 171887
+};
+
+// 164255 - Globgrog
+struct boss_globgrog : public BossAI
+{
+    boss_globgrog(Creature* creature) : BossAI(creature, DATA_GLOBGROG), _plaguestompCount(1), _slimeWaveCount(1) { }
+
+    void JustAppeared() override
+    {
+        me->SetPowerType(POWER_ENERGY);
+        me->SetPower(POWER_ENERGY, 50);
+        DoCastSelf(SPELL_SLIME_INFUSED_BONES);
+    }
+
+    void Reset() override
+    {
+        BossAI::Reset();
+
+        _plaguestompCount = 1;
+        _slimeWaveCount = 1;
+    }
+
+    void DespawnSlimes()
+    {
+        std::list<Creature*> slimyMorsels;
+        me->GetCreatureListWithOptionsInGrid(slimyMorsels, 200.0f, { .CreatureId = NPC_SLIMY_MORSEL });
+        for (Creature* slimyMorsel : slimyMorsels)
+            slimyMorsel->DespawnOrUnsummon();
+
+        std::list<Creature*> slimySmorgasbords;
+        me->GetCreatureListWithOptionsInGrid(slimySmorgasbords, 200.0f, { .CreatureId = NPC_SLIMY_SMORGASBORD });
+        for (Creature* slimySmorgasbord : slimySmorgasbords)
+            slimySmorgasbord->DespawnOrUnsummon();
+    }
+
+    void EnterEvadeMode(EvadeReason /*why*/) override
+    {
+        instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
+        instance->SetBossState(DATA_GLOBGROG, FAIL);
+
+        _EnterEvadeMode();
+        _DespawnAtEvade();
+
+        DespawnSlimes();
+    }
+
+    void JustEngagedWith(Unit* who) override
+    {
+        BossAI::JustEngagedWith(who);
+
+        Talk(SAY_AGGRO);
+        instance->SendEncounterUnit(ENCOUNTER_FRAME_ENGAGE, me, 1);
+        instance->SetBossState(DATA_GLOBGROG, IN_PROGRESS);
+
+        events.ScheduleEvent(EVENT_ENERGIZE, 1s);
+        events.ScheduleEvent(EVENT_SLIME_WAVE, 17100ms);
+        events.ScheduleEvent(EVENT_PLAGUESTOMP, 8900ms);
+        events.ScheduleEvent(EVENT_CHECK_ENERGY, 500ms);
+    }
+
+    void JustDied(Unit* /*killer*/) override
+    {
+        _JustDied();
+        Talk(SAY_DEATH);
+        instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
+        instance->SetBossState(DATA_GLOBGROG, DONE);
+
+        DespawnSlimes();
+    }
+
+    void KilledUnit(Unit* /*victim*/) override
+    {
+        DoCastSelf(SPELL_VICTORY_START_CONVO);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!UpdateVictim())
+            return;
+
+        events.Update(diff);
+
+        if (me->HasUnitState(UNIT_STATE_CASTING))
+            return;
+
+        while (uint32 eventId = events.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+                case EVENT_ENERGIZE:
+                {
+                    me->SetPower(POWER_ENERGY, me->GetPower(POWER_ENERGY) + 2);
+                    events.Repeat(1s);
+                    break;
+                }
+                case EVENT_CHECK_ENERGY:
+                {
+                    if (me->GetPower(POWER_ENERGY) >= 100)
+                        DoCastSelf(SPELL_BECKON_SLIME_SELECTOR);
+                    events.Repeat(500ms);
+                    break;
+                }
+                case EVENT_PLAGUESTOMP:
+                {
+                    DoCastSelf(SPELL_PLAGUESTOMP_START_CONVO);
+                    DoCast(SPELL_PLAGUESTOMP);
+                    _plaguestompCount++;
+                    if (_plaguestompCount % 2 == 0)
+                        events.Repeat(35s);
+                    else
+                        events.Repeat(20s);
+                    break;
+                }
+                case EVENT_SLIME_WAVE:
+                {
+                    me->AttackStop();
+                    DoCastSelf(SPELL_SLIME_WAVE_SELECTOR);
+                    _slimeWaveCount++;
+                    if (_slimeWaveCount % 2 == 0)
+                        events.Repeat(37700ms);
+                    else
+                        events.Repeat(10s);
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            if (me->HasUnitState(UNIT_STATE_CASTING))
+                return;
+        }
+    }
+
+private:
+    TaskScheduler _scheduler;
+    uint32 _plaguestompCount;
+    uint32 _slimeWaveCount;
+};
+
+// 164362 - Slimy Morsel
+// 171887 - Slimy Smorgasbord
+struct boss_globgrog_slimy_creature : public ScriptedAI
+{
+    boss_globgrog_slimy_creature(Creature* creature) : ScriptedAI(creature) { }
+
+    void JustAppeared() override
+    {
+        DoCastSelf(SPELL_LIVING_SLIME_FLESH);
+        me->SetReactState(REACT_PASSIVE);
+    }
+
+    void SpellHit(WorldObject* /*caster*/, SpellInfo const* spellInfo) override
+    {
+        if (spellInfo->Id == SPELL_LIVING_SLIME_FLESH)
+        {
+            Creature* globgrog = me->GetInstanceScript()->GetCreature(DATA_GLOBGROG);
+            if (!globgrog)
+                return;
+
+            me->GetMotionMaster()->MoveFollow(globgrog, 0.0f);
+        }
+    }
+};
+
+// 324459 - Beckon Slime
+class spell_globgrog_beckon_slime_selector : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_BECKON_SLIME_MISSILE, SPELL_BECKON_SLIME_VISUAL_DUMMY, SPELL_BECKON_SLIME_MYTHIC_SELECTOR, SPELL_BECKON_SLIME_START_CONVO });
+    }
+
+    void HandleHitTarget(SpellEffIndex /*effIndex*/) const
+    {
+        Unit* target = GetHitUnit();
+        target->CastSpell(target, SPELL_BECKON_SLIME_MISSILE, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+
+        target->CastSpell(target, SPELL_BECKON_SLIME_VISUAL_DUMMY, TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);
+    }
+
+    void HandleHit() const
+    {
+        Unit* caster = GetCaster();
+        caster->CastSpell(caster, SPELL_BECKON_SLIME_START_CONVO, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void HandleAfterCast() const
+    {
+        Unit* caster = GetCaster();
+        if (caster->GetMap()->IsMythic() || caster->GetMap()->IsMythicPlus())
+            caster->CastSpell(caster, SPELL_BECKON_SLIME_MYTHIC_SELECTOR, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_globgrog_beckon_slime_selector::HandleHitTarget, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnHit += SpellHitFn(spell_globgrog_beckon_slime_selector::HandleHit);
+        AfterCast += SpellCastFn(spell_globgrog_beckon_slime_selector::HandleAfterCast);
+    }
+};
+
+// 326273 - Beckon Slime
+class spell_globgrog_beckon_slime_mythic_selector : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_BECKON_SLIME_MYTHIC_MISSILE });
+    }
+
+    void HandleHit() const
+    {
+        Unit* target = GetHitUnit();
+        target->CastSpell(target, SPELL_BECKON_SLIME_MYTHIC_MISSILE, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnHit += SpellHitFn(spell_globgrog_beckon_slime_mythic_selector::HandleHit);
+    }
+};
+
+// 332865 - Slime Wave
+class spell_globgrog_slime_wave_selector : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SLIME_WAVE, SPELL_SLIME_WAVE_START_CONVO });
+    }
+
+    void HandleHitTarget(SpellEffIndex /*effIndex*/) const
+    {
+        GetCaster()->CastSpell(*GetHitDest(), SPELL_SLIME_WAVE, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void HandleHit() const
+    {
+        Unit* caster = GetCaster();
+
+        caster->CastSpell(caster, SPELL_SLIME_WAVE_START_CONVO, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_globgrog_slime_wave_selector::HandleHitTarget, EFFECT_0, SPELL_EFFECT_DUMMY);
+        OnHit += SpellHitFn(spell_globgrog_slime_wave_selector::HandleHit);
+    }
+};
+
+// 333420 - Slime Wave
+class spell_globgrog_slime_wave_start_convo : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SLIME_WAVE_TEXT_1, SPELL_SLIME_WAVE_TEXT_2 });
+    }
+
+    void HandleHit() const
+    {
+        Unit* caster = GetCaster();
+
+        uint32 spellId = RAND(SPELL_SLIME_WAVE_TEXT_1, SPELL_SLIME_WAVE_TEXT_2);
+        caster->CastSpell(caster, spellId, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnHit += SpellHitFn(spell_globgrog_slime_wave_start_convo::HandleHit);
+    }
+};
+
+// 324527 - Plaguestomp
+class spell_globgrog_plaguestomp_damage : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_DEBILITATING_PLAGUE });
+    }
+
+    void HandleHitTarget(SpellEffIndex /*effIndex*/) const
+    {
+        GetCaster()->CastSpell(GetHitUnit(), SPELL_DEBILITATING_PLAGUE, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_globgrog_plaguestomp_damage::HandleHitTarget, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+    }
+};
+
+// 333424 - Plaguestomp
+class spell_globgrog_plaguestomp_start_convo : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_PLAGUESTOMP_TEXT_1, SPELL_PLAGUESTOMP_TEXT_2 });
+    }
+
+    void HandleHit() const
+    {
+        Unit* caster = GetCaster();
+
+        uint32 spellId = RAND(SPELL_PLAGUESTOMP_TEXT_1, SPELL_PLAGUESTOMP_TEXT_2);
+        caster->CastSpell(caster, spellId, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnHit += SpellHitFn(spell_globgrog_plaguestomp_start_convo::HandleHit);
+    }
+};
+
+// 333417 - Beckon Slime
+class spell_globgrog_beckon_slime_start_convo : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_BECKON_SLIME_TEXT_1, SPELL_BECKON_SLIME_TEXT_2 });
+    }
+
+    void HandleHit() const
+    {
+        Unit* caster = GetCaster();
+
+        uint32 spellId = RAND(SPELL_BECKON_SLIME_TEXT_1, SPELL_BECKON_SLIME_TEXT_1);
+        caster->CastSpell(caster, spellId, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnHit += SpellHitFn(spell_globgrog_beckon_slime_start_convo::HandleHit);
+    }
+};
+
+// 333428 - Victory
+class spell_globgrog_victory_start_convo : public SpellScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_VICTORY_TEXT_1, SPELL_VICTORY_TEXT_2 });
+    }
+
+    void HandleHit() const
+    {
+        Creature* creatureCaster = GetCaster()->ToCreature();
+        if (!creatureCaster)
+            return;
+
+        uint32 spellId = RAND(SPELL_VICTORY_TEXT_1, SPELL_VICTORY_TEXT_2);
+        creatureCaster->CastSpell(creatureCaster, spellId, CastSpellExtraArgsInit{
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggeringSpell = GetSpell()
+        });
+    }
+
+    void Register() override
+    {
+        OnHit += SpellHitFn(spell_globgrog_victory_start_convo::HandleHit);
+    }
+};
+
+// 324366 - Living Slime Flesh
+// Id - 19879
+struct at_globgrog_living_slime_flesh : AreaTriggerAI
+{
+    using AreaTriggerAI::AreaTriggerAI;
+
+    void OnUnitEnter(Unit* unit) override
+    {
+        if (unit->GetEntry() != NPC_SLIMY_MORSEL && unit->GetEntry() != NPC_SLIMY_SMORGASBORD)
+            return;
+
+        Unit* caster = at->GetCaster();
+        if (!caster)
+            return;
+
+        caster->CastSpell(unit, SPELL_CONSUME_SLIME, TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);
+    }
+};
+
+void AddSC_boss_globgrog()
+{
+    RegisterPlaguefallCreatureAI(boss_globgrog);
+    RegisterPlaguefallCreatureAI(boss_globgrog_slimy_creature);
+
+    RegisterSpellScript(spell_globgrog_beckon_slime_selector);
+    RegisterSpellScript(spell_globgrog_beckon_slime_mythic_selector);
+    RegisterSpellScript(spell_globgrog_slime_wave_selector);
+    RegisterSpellScript(spell_globgrog_slime_wave_start_convo);
+    RegisterSpellScript(spell_globgrog_plaguestomp_damage);
+    RegisterSpellScript(spell_globgrog_plaguestomp_start_convo);
+    RegisterSpellScript(spell_globgrog_beckon_slime_start_convo);
+    RegisterSpellScript(spell_globgrog_victory_start_convo);
+
+    RegisterAreaTriggerAI(at_globgrog_living_slime_flesh);
+}

--- a/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
@@ -25,7 +25,6 @@
 #include "ScriptedCreature.h"
 #include "SpellAuraEffects.h"
 #include "SpellScript.h"
-#include "TaskScheduler.h"
 #include "TemporarySummon.h"
 #include "plaguefall.h"
 
@@ -213,7 +212,6 @@ struct boss_globgrog : public BossAI
     }
 
 private:
-    TaskScheduler _scheduler;
     uint32 _plaguestompCount;
     uint32 _slimeWaveCount;
 };

--- a/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
@@ -451,7 +451,6 @@ class spell_globgrog_victory_start_convo : public SpellScript
     void HandleHit() const
     {
         Unit* caster = GetCaster();
-    
         uint32 spellId = RAND(SPELL_VICTORY_TEXT_1, SPELL_VICTORY_TEXT_2);
         caster->CastSpell(caster, spellId, CastSpellExtraArgsInit{
             .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,

--- a/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/boss_globgrog.cpp
@@ -450,12 +450,10 @@ class spell_globgrog_victory_start_convo : public SpellScript
 
     void HandleHit() const
     {
-        Creature* creatureCaster = GetCaster()->ToCreature();
-        if (!creatureCaster)
-            return;
-
+        Unit* caster = GetCaster();
+    
         uint32 spellId = RAND(SPELL_VICTORY_TEXT_1, SPELL_VICTORY_TEXT_2);
-        creatureCaster->CastSpell(creatureCaster, spellId, CastSpellExtraArgsInit{
+        caster->CastSpell(caster, spellId, CastSpellExtraArgsInit{
             .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
             .TriggeringSpell = GetSpell()
         });

--- a/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AreaBoundary.h"
+#include "InstanceScript.h"
+#include "ScriptMgr.h"
+#include "plaguefall.h"
+
+BossBoundaryData const boundaries =
+{
+    { DATA_GLOBGROG, new CircleBoundary(Position(2021.948120f, -3556.348848), 83.0f) }
+};
+
+ObjectData const creatureData[] =
+{
+    { BOSS_GLOBGROG,          DATA_GLOBGROG          },
+    { BOSS_DOCTOR_ICKUS,      DATA_DOCTOR_ICKUS      },
+    { BOSS_DOMINA_VENOMBLADE, DATA_DOMINA_VENOMBLADE },
+    { BOSS_MARGRAVE_STRADAMA, DATA_MARGRAVE_STRADAMA },
+    { 0,                      0                      }  // END
+};
+
+DungeonEncounterData const encounters[] =
+{
+    { DATA_GLOBGROG,          {{ 2382 }} },
+    { DATA_DOCTOR_ICKUS,      {{ 2384 }} },
+    { DATA_DOMINA_VENOMBLADE, {{ 2385 }} },
+    { DATA_MARGRAVE_STRADAMA, {{ 2386 }} }
+};
+
+class instance_plaguefall : public InstanceMapScript
+{
+    public:
+        instance_plaguefall() : InstanceMapScript(PFScriptName, 2289) { }
+
+        struct instance_plaguefall_InstanceMapScript: public InstanceScript
+        {
+            instance_plaguefall_InstanceMapScript(InstanceMap* map) : InstanceScript(map)
+            {
+                SetHeaders(DataHeader);
+                SetBossNumber(EncounterCount);
+                LoadObjectData(creatureData, nullptr);
+                LoadDungeonEncounterData(encounters);
+            }
+        };
+
+        InstanceScript* GetInstanceScript(InstanceMap* map) const override
+        {
+            return new instance_plaguefall_InstanceMapScript(map);
+        }
+};
+
+void AddSC_instance_plaguefall()
+{
+    new instance_plaguefall();
+}

--- a/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
@@ -22,7 +22,7 @@
 
 BossBoundaryData const boundaries =
 {
-    { DATA_GLOBGROG, new CircleBoundary(Position(2021.948120f, -3556.348848), 83.0f) }
+    { DATA_GLOBGROG, new CircleBoundary(Position(2021.948120f, -3556.348848f), 83.0f) }
 };
 
 ObjectData const creatureData[] =

--- a/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
@@ -25,16 +25,15 @@ BossBoundaryData const boundaries =
     { DATA_GLOBGROG, new CircleBoundary(Position(2021.948120f, -3556.348848f), 83.0f) }
 };
 
-ObjectData const creatureData[] =
+static constexpr ObjectData creatureData[] =
 {
     { BOSS_GLOBGROG,          DATA_GLOBGROG          },
     { BOSS_DOCTOR_ICKUS,      DATA_DOCTOR_ICKUS      },
     { BOSS_DOMINA_VENOMBLADE, DATA_DOMINA_VENOMBLADE },
-    { BOSS_MARGRAVE_STRADAMA, DATA_MARGRAVE_STRADAMA },
-    { 0,                      0                      }  // END
+    { BOSS_MARGRAVE_STRADAMA, DATA_MARGRAVE_STRADAMA }
 };
 
-DungeonEncounterData const encounters[] =
+static constexpr DungeonEncounterData const encounters[] =
 {
     { DATA_GLOBGROG,          {{ 2382 }} },
     { DATA_DOCTOR_ICKUS,      {{ 2384 }} },

--- a/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
@@ -53,6 +53,7 @@ class instance_plaguefall : public InstanceMapScript
                 SetHeaders(DataHeader);
                 SetBossNumber(EncounterCount);
                 LoadObjectData(creatureData, {});
+                LoadBossBoundaries(boundaries);
                 LoadDungeonEncounterData(encounters);
             }
         };

--- a/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
+++ b/src/server/scripts/Shadowlands/Plaguefall/instance_plaguefall.cpp
@@ -52,7 +52,7 @@ class instance_plaguefall : public InstanceMapScript
             {
                 SetHeaders(DataHeader);
                 SetBossNumber(EncounterCount);
-                LoadObjectData(creatureData, nullptr);
+                LoadObjectData(creatureData, {});
                 LoadDungeonEncounterData(encounters);
             }
         };

--- a/src/server/scripts/Shadowlands/Plaguefall/plaguefall.h
+++ b/src/server/scripts/Shadowlands/Plaguefall/plaguefall.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _Plaguefall_h__
+#define _Plaguefall_h__
+
+#include "CreatureAIImpl.h"
+
+#define DataHeader "PF"
+#define PFScriptName "instance_plaguefall"
+
+uint32 const EncounterCount = 4;
+
+enum PFDataTypes
+{
+    // Encounters
+    DATA_GLOBGROG = 0,
+    DATA_DOCTOR_ICKUS,
+    DATA_DOMINA_VENOMBLADE,
+    DATA_MARGRAVE_STRADAMA
+};
+
+enum PFCreatureIds
+{
+    // Bosses
+    BOSS_GLOBGROG          = 164255,
+    BOSS_DOCTOR_ICKUS      = 164967,
+    BOSS_DOMINA_VENOMBLADE = 164266,
+    BOSS_MARGRAVE_STRADAMA = 164267
+};
+
+template <class AI, class T>
+inline AI* GetPlaguefallAI(T* obj)
+{
+    return GetInstanceAI<AI>(obj, PFScriptName);
+}
+
+#define RegisterPlaguefallCreatureAI(ai_name) RegisterCreatureAIWithFactory(ai_name, GetPlaguefallAI)
+
+#endif // _Plaguefall_h__

--- a/src/server/scripts/Shadowlands/shadowlands_script_loader.cpp
+++ b/src/server/scripts/Shadowlands/shadowlands_script_loader.cpp
@@ -25,6 +25,10 @@ void AddSC_instance_sanctum_of_domination();
 void AddSC_boss_anduin_wrynn();
 void AddSC_instance_sepulcher_of_the_first_ones();
 
+// Plaguefall
+void AddSC_boss_globgrog();
+void AddSC_instance_plaguefall();
+
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
 void AddShadowlandsScripts()
@@ -39,4 +43,8 @@ void AddShadowlandsScripts()
     // Sepulcher of The First Ones
     AddSC_boss_anduin_wrynn();
     AddSC_instance_sepulcher_of_the_first_ones();
+
+    // Plaguefall
+    AddSC_boss_globgrog();
+    AddSC_instance_plaguefall();
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implement Globgrog encounter

**Tests performed:**

Tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Spell 324667 (Slime Wave) is not working due to missing implementation of SPELL_ATTR11_UNK0 (Lock Caster Movement and Facing While Casting) and SPELL_ATTR12_UNK11 (Face Destination)

- [x] Add creature_template_difficulty_for normal and heroic mode

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
