### PR TITLE
Core/Conditions: Improve the CONDITION-AURA triggering condition

### DIFF
--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -292,7 +292,25 @@ bool Condition::Meets(ConditionSourceInfo& sourceInfo) const
         case CONDITION_AURA:
         {
             if (Unit const* unit = object->ToUnit())
-                condMeets = unit->HasAuraEffect(ConditionValue1, ConditionValue2);
+            {
+                AuraEffect const* auraEffect = unit->GetAuraEffect(ConditionValue1, ConditionValue2);
+                if (auraEffect)
+                {
+                    if (ConditionValue3 != 0)
+                    {
+                        uint8 stackAmount = auraEffect->GetBase()->GetStackAmount();
+                        condMeets = (stackAmount >= uint32(ConditionValue3));
+                    }
+                    else
+                    {
+                        condMeets = true;
+                    }
+                }
+                else
+                {
+                    condMeets = false;
+                }
+            }
             break;
         }
         case CONDITION_ITEM:


### PR DESCRIPTION


<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Improve the CONDITION-AURA trigger condition to use ConditionValue3 as the criterion for determining the number of halo layers a player possesses. When the number of halo layers a player possesses is greater than or equal to ConditionValue3, the condition will be triggered.

**Issues addressed:**

Closes #30906

**Tests performed:**

 tested in-game


**Known issues and TODO list:** (add/remove lines as needed)

- none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
