### PR TITLE
Tools/mapextractor: Fix segfault with CONF_allow_float_to_int=false

### DIFF
--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -891,7 +891,7 @@ bool ConvertADT(ChunkedFile& adt, std::string const& mapName, std::string const&
     }
     else
     {
-        int minX = 255, minY = 255;
+        int minX = ADT_GRID_SIZE, minY = ADT_GRID_SIZE;
         int maxX = 0, maxY = 0;
         maxHeight = -20000;
         minHeight = 20000;
@@ -926,6 +926,9 @@ bool ConvertADT(ChunkedFile& adt, std::string const& mapName, std::string const&
         liquidHeader.width   = maxX - minX + 1 + 1;
         liquidHeader.height  = maxY - minY + 1 + 1;
         liquidHeader.liquidLevel = minHeight;
+
+        if (minY > maxY || minX > maxX)
+            liquidHeader.flags |= map_liquidHeaderFlags::NoHeight;
 
         if (maxHeight == minHeight)
             liquidHeader.flags |= map_liquidHeaderFlags::NoHeight;


### PR DESCRIPTION
Running `mapextractor -f 0` segfaults when the entire grid has `liquid_show[*][*] = false` because it leaves `minX`/`minY` unchanged and then tries to access `liquid_height[y + 255][255]`.

Happened to me in the real world at:
```cpp
ConvertADT (adt=..., mapName="Pandaria", outputPath="/home/user/Games/WorldOfWarcraft/maps/0870_28_25.map", 
	gx=gx@entry=28, gy=gy@entry=25, build=build@entry=63305, ignoreDeepWater=<optimized out>)
```
