### PR TITLE
Scripts/MoltenCore: Cast Suicide spell as triggered in Golemagg's encounter to ensure it will be used under CC

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_golemagg.cpp
@@ -155,7 +155,7 @@ struct npc_core_rager : public ScriptedAI
     void DoAction(int32 action) override
     {
         if (action == ACTION_QUIET_SUICIDE)
-            DoCastSelf(SPELL_QUIET_SUICIDE);
+            DoCastSelf(SPELL_QUIET_SUICIDE, true);
     }
 
     void OnSpellCast(SpellInfo const* spell) override


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Title

**Issues addressed:**

Updates #31314

**Tests performed:**

builds, tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
