### PR TITLE
Core/Scripts: Implement OnInterrupt Aura Hook

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4018,10 +4018,15 @@ void Unit::RemoveAurasWithInterruptFlags(uint32 flag, uint32 except)
     // interrupt auras
     for (AuraApplicationList::iterator iter = m_interruptableAuras.begin(); iter != m_interruptableAuras.end();)
     {
-        Aura* aura = (*iter)->GetBase();
+        AuraApplication* aurApp = *iter;
+        Aura* aura = aurApp->GetBase();
         ++iter;
         if ((aura->GetSpellInfo()->AuraInterruptFlags & flag) && (!except || aura->GetId() != except))
         {
+            // allow to prevent interruption in scripts
+            if (aura->CallScriptAuraInterruptHandlers(aurApp, flag))
+                continue;
+
             uint32 removedAuras = m_removedAurasCount;
             RemoveAura(aura);
             if (m_removedAurasCount > removedAuras + 1)

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2231,6 +2231,22 @@ void Aura::CallScriptAfterDispel(DispelInfo* dispelInfo)
     }
 }
 
+bool Aura::CallScriptAuraInterruptHandlers(AuraApplication const* aurApp, uint32 interruptMask)
+{
+    bool preventDefault = false;
+    for (auto scritr = m_loadedScripts.begin(); scritr != m_loadedScripts.end(); ++scritr)
+    {
+        (*scritr)->_PrepareScriptCall(AURA_SCRIPT_HOOK_ON_INTERRUPT, aurApp);
+        auto hookItrEnd = (*scritr)->OnInterrupt.end(), hookItr = (*scritr)->OnInterrupt.begin();
+        for (; hookItr != hookItrEnd; ++hookItr)
+            if (hookItr->Call(*scritr, aurApp, interruptMask))
+                preventDefault = true;
+
+        (*scritr)->_FinishScriptCall();
+    }
+    return preventDefault;
+}
+
 bool Aura::CallScriptEffectApplyHandlers(AuraEffect const* aurEff, AuraApplication const* aurApp, AuraEffectHandleModes mode)
 {
     bool preventDefault = false;

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -231,6 +231,7 @@ class TC_GAME_API Aura
         bool CallScriptCheckAreaTargetHandlers(Unit* target);
         void CallScriptDispel(DispelInfo* dispelInfo);
         void CallScriptAfterDispel(DispelInfo* dispelInfo);
+        bool CallScriptAuraInterruptHandlers(AuraApplication const* aurApp, uint32 interruptMask);
         bool CallScriptEffectApplyHandlers(AuraEffect const* aurEff, AuraApplication const* aurApp, AuraEffectHandleModes mode);
         bool CallScriptEffectRemoveHandlers(AuraEffect const* aurEff, AuraApplication const* aurApp, AuraEffectHandleModes mode);
         void CallScriptAfterEffectApplyHandlers(AuraEffect const* aurEff, AuraApplication const* aurApp, AuraEffectHandleModes mode);

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -859,6 +859,16 @@ void AuraScript::AuraDispelHandler::Call(AuraScript* auraScript, DispelInfo* _di
     (auraScript->*pHandlerScript)(_dispelInfo);
 }
 
+AuraScript::AuraInterruptHandler::AuraInterruptHandler(AuraInterruptFnType _pHandlerScript)
+{
+    pHandlerScript = _pHandlerScript;
+}
+
+bool AuraScript::AuraInterruptHandler::Call(AuraScript* auraScript, AuraApplication const* aurApp, uint32 interruptMask)
+{
+    return (auraScript->*pHandlerScript)(aurApp, interruptMask);
+}
+
 AuraScript::EffectBase::EffectBase(uint8 _effIndex, uint16 _effName)
     : _SpellScript::EffectAuraNameCheck(_effName), _SpellScript::EffectHook(_effIndex) { }
 

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -551,6 +551,7 @@ enum AuraScriptHookType
     AURA_SCRIPT_HOOK_CHECK_AREA_TARGET,
     AURA_SCRIPT_HOOK_DISPEL,
     AURA_SCRIPT_HOOK_AFTER_DISPEL,
+    AURA_SCRIPT_HOOK_ON_INTERRUPT,
     // Spell Proc Hooks
     AURA_SCRIPT_HOOK_CHECK_PROC,
     AURA_SCRIPT_HOOK_CHECK_EFFECT_PROC,
@@ -576,6 +577,7 @@ class TC_GAME_API AuraScript : public _SpellScript
     #define AURASCRIPT_FUNCTION_TYPE_DEFINES(CLASSNAME) \
         typedef bool(CLASSNAME::*AuraCheckAreaTargetFnType)(Unit* target); \
         typedef void(CLASSNAME::*AuraDispelFnType)(DispelInfo* dispelInfo); \
+        typedef bool(CLASSNAME::*AuraInterruptFnType)(AuraApplication const* aurApp, uint32 interruptMask); \
         typedef void(CLASSNAME::*AuraEffectApplicationModeFnType)(AuraEffect const*, AuraEffectHandleModes); \
         typedef void(CLASSNAME::*AuraEffectPeriodicFnType)(AuraEffect const*); \
         typedef void(CLASSNAME::*AuraEffectUpdatePeriodicFnType)(AuraEffect*); \
@@ -606,6 +608,14 @@ class TC_GAME_API AuraScript : public _SpellScript
                 void Call(AuraScript* auraScript, DispelInfo* dispelInfo);
             private:
                 AuraDispelFnType pHandlerScript;
+        };
+        class TC_GAME_API AuraInterruptHandler
+        {
+            public:
+                AuraInterruptHandler(AuraInterruptFnType pHandlerScript);
+                bool Call(AuraScript* auraScript, AuraApplication const* aurApp, uint32 interruptMask);
+            private:
+                AuraInterruptFnType pHandlerScript;
         };
         class TC_GAME_API EffectBase : public  _SpellScript::EffectAuraNameCheck, public _SpellScript::EffectHook
         {
@@ -723,6 +733,7 @@ class TC_GAME_API AuraScript : public _SpellScript
         #define AURASCRIPT_FUNCTION_CAST_DEFINES(CLASSNAME) \
         class CheckAreaTargetFunction : public AuraScript::CheckAreaTargetHandler { public: explicit CheckAreaTargetFunction(AuraCheckAreaTargetFnType _pHandlerScript) : AuraScript::CheckAreaTargetHandler((AuraScript::AuraCheckAreaTargetFnType)_pHandlerScript) { } }; \
         class AuraDispelFunction : public AuraScript::AuraDispelHandler { public: explicit AuraDispelFunction(AuraDispelFnType _pHandlerScript) : AuraScript::AuraDispelHandler((AuraScript::AuraDispelFnType)_pHandlerScript) { } }; \
+        class AuraInterruptHandlerFunction : public AuraScript::AuraInterruptHandler { public: explicit AuraInterruptHandlerFunction(AuraInterruptFnType _pHandlerScript) : AuraScript::AuraInterruptHandler((AuraScript::AuraInterruptFnType)_pHandlerScript) { } }; \
         class EffectPeriodicHandlerFunction : public AuraScript::EffectPeriodicHandler { public: explicit EffectPeriodicHandlerFunction(AuraEffectPeriodicFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName) : AuraScript::EffectPeriodicHandler((AuraScript::AuraEffectPeriodicFnType)_pEffectHandlerScript, _effIndex, _effName) { } }; \
         class EffectUpdatePeriodicHandlerFunction : public AuraScript::EffectUpdatePeriodicHandler { public: explicit EffectUpdatePeriodicHandlerFunction(AuraEffectUpdatePeriodicFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName) : AuraScript::EffectUpdatePeriodicHandler((AuraScript::AuraEffectUpdatePeriodicFnType)_pEffectHandlerScript, _effIndex, _effName) { } }; \
         class EffectCalcAmountHandlerFunction : public AuraScript::EffectCalcAmountHandler { public: explicit EffectCalcAmountHandlerFunction(AuraEffectCalcAmountFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName) : AuraScript::EffectCalcAmountHandler((AuraScript::AuraEffectCalcAmountFnType)_pEffectHandlerScript, _effIndex, _effName) { } }; \
@@ -785,6 +796,12 @@ class TC_GAME_API AuraScript : public _SpellScript
         // where function is: void function (DispelInfo* dispelInfo);
         HookList<AuraDispelHandler> AfterDispel;
         #define AuraDispelFn(F) AuraDispelFunction(&F)
+
+        // executed when aura checks if it can be interrupted
+        // example: OnInterrupt += AuraInterruptFn(class::function);
+        // where function is: bool function (AuraApplication const* aurApp, uint32 interruptMask);
+        HookList<AuraInterruptHandler> OnInterrupt;
+        #define AuraInterruptFn(F) AuraInterruptHandlerFunction(&F)
 
         // executed when aura effect is applied with specified mode to target
         // should be used when when effect handler preventing/replacing is needed, do not use this hook for triggering spellcasts/removing auras etc - may be unsafe


### PR DESCRIPTION
**Changes proposed:**
-  Allow to change the outcome of an aura interruption in scripts.

**Issues addressed:**
None.

Not sure if this could be used in any 3.3.5a scripts. It's a long shot.