### PR TITLE
Spells/Priest: Shadow Covenant trigger flag missing

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -2959,7 +2959,7 @@ class spell_pri_shadow_covenant : public SpellScript
     void HandleAfterCast() const
     {
         GetCaster()->CastSpell(GetCaster(), SPELL_PRIEST_SHADOW_COVENANT_EFFECT, CastSpellExtraArgsInit{
-            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR,
+            .TriggerFlags = TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR | TRIGGERED_IGNORE_SHAPESHIFT,
             .TriggeringSpell = GetSpell()
         });
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Issues addressed:**
[Shadow Covenant](https://www.wowhead.com/spell=314867/shadow-covenant) Aura is not getting triggered because it gives a "shadow form required" error, which shouldn't be the case.

Closes #  7e0d3678db4c3a4ea379ccb4416f0c486ed4f3d0

**Tests performed:**
in-game
.cast 322105 - gives error


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
