### PR TITLE
[WIP] Spells/Priest: Implement Idol of N'Zoth

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world_idol_of_nzoth.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_idol_of_nzoth.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_pri_idol_of_nzoth');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(373280, 'spell_pri_idol_of_nzoth');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (373280);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(373280,0x00,6,0x00000000,0x00000000,0x00000000,0x00000000,0x0,0x0,0x0,0x2,0x0,0x0,0x0,0,0,0,0); -- Idol of N'Zoth


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implement [Idol of N'Zoth](https://www.wowhead.com/spell=373280/idol-of-nzoth) talent

**Issues addressed:**
From what i ve seen as behavior on retail:
- Stacks also take into consideration how much insanity a spell generates - **stack * insanity gen**
- Periodic ticks shouldn't proc stacks
- For channeled it gives stack per damage tick

I would want some confirmation on the behavior

Closes #  35076c7958c95abd4bec06f7ef4a6423eb4f11bc

**Tests performed:**
Builds and tested in-game


**Known issues and TODO list:**
None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
