### PR TITLE
refactor/Movement: Use `AdjustClientMovementTime` to remove redundant movement time calculations

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -530,16 +530,7 @@ void WorldSession::HandleForceSpeedChangeAck(WorldPacket &recvData)
     }
 
     /* the client data has been verified. let's do the actual change now */
-    int64 movementTime = (int64)movementInfo.time + _timeSyncClockDelta;
-    if (_timeSyncClockDelta == 0 || movementTime < 0 || movementTime > 0xFFFFFFFF)
-    {
-        TC_LOG_WARN("misc", "The computed movement time using clockDelta is erronous. Using fallback instead");
-        movementInfo.time = GameTime::GetGameTimeMS();
-    }
-    else
-    {
-        movementInfo.time = (uint32)movementTime;
-    }
+    movementInfo.time = AdjustClientMovementTime(movementInfo.time);
 
     mover->m_movementInfo = movementInfo;
     mover->UpdatePosition(movementInfo.pos);
@@ -630,17 +621,7 @@ void WorldSession::HandleMoveKnockBackAck(WorldPacket& recvData)
     MovementInfo movementInfo;
     movementInfo.guid = guid;
     ReadMovementInfo(recvData, &movementInfo);
-
-    int64 movementTime = (int64)movementInfo.time + _timeSyncClockDelta;
-    if (_timeSyncClockDelta == 0 || movementTime < 0 || movementTime > 0xFFFFFFFF)
-    {
-        TC_LOG_WARN("misc", "The computed movement time using clockDelta is erronous. Using fallback instead");
-        movementInfo.time = GameTime::GetGameTimeMS();
-    }
-    else
-    {
-        movementInfo.time = (uint32)movementTime;
-    }
+    movementInfo.time = AdjustClientMovementTime(movementInfo.time);
 
     mover->m_movementInfo = movementInfo;
     mover->UpdatePosition(movementInfo.pos);


### PR DESCRIPTION
This PR aims to clean up some redundant movement-time adjustment logic in `MovementHandler.cpp`.

### Background

While reviewing the movement processing code, I noticed that the logic for computing `movementInfo.time` using `_timeSyncClockDelta` appears in multiple places.

Since the project already provides a utility function `uint32 WorldSession::AdjustClientMovementTime(uint32 time)`, for calibrating `movementInfo.time`, reusing this function helps maintain consistent logic and reduces the risk of potential issues caused by updating only one of the duplicated code paths in future changes. Therefore, in my humble opinion, this should be corrected to improve maintainability.

### What this PR does

* Replaces the manual `movementTime` calculation blocks with calls to `AdjustClientMovementTime`.
* Ensures consistent behavior across all movement handlers.
* Reduces code duplication and makes the logic easier to maintain.

### Notes

This is my first attempt at submitting a PR to this project, and I have tried to keep the changes conservative to avoid introducing any unintended side effects.

If any part of this refactor might inadvertently alter gameplay logic or cause regressions, I will gladly pause this PR or prepare a corrective patch immediately.

Thanks to the maintainers for taking the time to review this contribution despite your busy schedules. Sending my sincerest regards.