### PR TITLE
Core/AI: Drop script_waypoints and move data to waypoint_data

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_23_00_world_2023_04_10_00_world_script_waypoints.sql
+++ b/sql/updates/world/3.3.5/2025_12_23_00_world_2023_04_10_00_world_script_waypoints.sql
@@ -1,0 +1,150 @@
+-- 
+DROP PROCEDURE IF EXISTS apply_if_exists_2023_04_10_00_world;
+
+DELIMITER ;;
+CREATE PROCEDURE apply_if_exists_2023_04_10_00_world() BEGIN
+  IF EXISTS (SELECT * FROM `information_schema`.`columns` WHERE `table_schema`=SCHEMA() AND `table_name`='script_waypoint') THEN
+    DELETE FROM `waypoint_data` WHERE `id` & 2;
+    INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `delay`) SELECT ((s.`entry` << 3) | 2), s.`pointid`, s.`location_x`, s.`location_y`, s.`location_z`, s.`waittime` FROM `script_waypoint` s;
+    
+    DROP TABLE IF EXISTS `script_waypoint`;
+  END IF;
+END;;
+
+DELIMITER ;
+CALL apply_if_exists_2023_04_10_00_world();
+
+DROP PROCEDURE IF EXISTS apply_if_exists_2023_04_10_00_world;
+
+-- Rage Winterchill
+SET @PATH_ID := 142138;
+DELETE FROM `waypoint_data` WHERE `id`=@PATH_ID;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES
+(@PATH_ID, 0, 4896.08, -1576.35, 1333.65),
+(@PATH_ID, 1, 4898.68, -1615.02, 1329.48),
+(@PATH_ID, 2, 4907.12, -1667.08, 1321.00),
+(@PATH_ID, 3, 4963.18, -1699.35, 1340.51),
+(@PATH_ID, 4, 4989.16, -1716.67, 1335.74),
+(@PATH_ID, 5, 5026.27, -1736.89, 1323.02),
+(@PATH_ID, 6, 5037.77, -1770.56, 1324.36),
+(@PATH_ID, 7, 5067.23, -1789.95, 1321.17);
+
+-- Kazrogal
+SET @PATH_ID := 143106;
+DELETE FROM `waypoint_data` WHERE `id`=@PATH_ID;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES
+(@PATH_ID, 0, 5492.91, -2404.61, 1462.63),
+(@PATH_ID, 1, 5531.76, -2460.87, 1469.55),
+(@PATH_ID, 2, 5554.58, -2514.66, 1476.12),
+(@PATH_ID, 3, 5554.16, -2567.23, 1479.90),
+(@PATH_ID, 4, 5540.67, -2625.99, 1480.89),
+(@PATH_ID, 5, 5508.16, -2659.20, 1480.15),
+(@PATH_ID, 6, 5489.62, -2704.05, 1482.18),
+(@PATH_ID, 7, 5457.04, -2726.26, 1485.10);
+
+-- Azgalor
+SET @PATH_ID := 142738;
+DELETE FROM `waypoint_data` WHERE `id`=@PATH_ID;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES
+(@PATH_ID, 0, 5492.91, -2404.61, 1462.63),
+(@PATH_ID, 1, 5531.76, -2460.87, 1469.55),
+(@PATH_ID, 2, 5554.58, -2514.66, 1476.12),
+(@PATH_ID, 3, 5554.16, -2567.23, 1479.90),
+(@PATH_ID, 4, 5540.67, -2625.99, 1480.89),
+(@PATH_ID, 5, 5508.16, -2659.20, 1480.15),
+(@PATH_ID, 6, 5489.62, -2704.05, 1482.18),
+(@PATH_ID, 7, 5457.04, -2726.26, 1485.10);
+
+-- Anetheron
+SET @PATH_ID := 142466;
+DELETE FROM `waypoint_data` WHERE `id`=@PATH_ID;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`) VALUES
+(@PATH_ID, 0, 4896.08, -1576.35, 1333.65),
+(@PATH_ID, 1, 4898.68, -1615.02, 1329.48),
+(@PATH_ID, 2, 4907.12, -1667.08, 1321.00),
+(@PATH_ID, 3, 4963.18, -1699.35, 1340.51),
+(@PATH_ID, 4, 4989.16, -1716.67, 1335.74),
+(@PATH_ID, 5, 5026.27, -1736.89, 1323.02),
+(@PATH_ID, 6, 5037.77, -1770.56, 1324.36),
+(@PATH_ID, 7, 5067.23, -1789.95, 1321.17);
+
+-- ------------------------------------------------------------------------------------------------
+
+SET @MOVE_TYPE_RUN := 1;
+SET @MOVE_TYPE_WALK := 0;
+
+-- Thrall, old_hillsbrad.cpp
+SET @PATHID := 143010;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` < 8;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` BETWEEN 8 AND 10;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` BETWEEN 11 AND 29;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` = 30;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` BETWEEN 31 AND 58;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point`=59;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` BETWEEN 60 AND 63;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` BETWEEN 64 AND 70;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` BETWEEN 71 AND 80;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` BETWEEN 81 AND 83;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` BETWEEN 84 AND 90;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` BETWEEN 91 AND 96;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 97;
+
+-- Magwin, zone_azuremyst_isle.cpp
+SET @PATHID := 138498;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 28;
+
+-- Wizzlecrank Shredder, zone_the_barrens.cpp
+SET @PATHID := 27514;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` BETWEEN 9 AND 17;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 18;
+
+-- Brann Bronzebeard, halls_of_stone.cpp
+SET @PATHID := 224562;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 1;
+
+-- Maghar Captive, zone_nagrand.cpp
+SET @PATHID := 145682;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 16;
+
+-- ------------------------------------------------------------------------------------------------
+
+-- Mograine, chapter5.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=233386;
+
+-- Scarlet Trainee, boss_herod.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=52602;
+
+-- Anetheron, boss_anetheron.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=142466;
+
+-- Azgalor, boss_azgalor.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=142738;
+
+-- Kazrogal, boss_kazrogal.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=143106;
+
+-- Rage Winterchill, boss_rage_winterchill.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=142138;
+
+-- Legoso, zone_bloodmyst_isle.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=143858;
+
+-- Skeletal Gryphon, boss_black_knight.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=283930;
+
+-- Crok Scourgebane, boss_sister_svalna.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=297034;
+
+-- Mimirons Inferno, boss_flame_leviathan.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=266962;
+
+-- Icefang, zone_storm_peaks.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=236818;
+
+-- Garments of quests, npcs_special.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id` IN(99386,99418,99426,99434,99442);
+
+-- Taretha, old_hillsbrad.cpp
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=151098;

--- a/sql/updates/world/3.3.5/2025_12_23_00_world_2023_04_10_00_world_script_waypoints.sql
+++ b/sql/updates/world/3.3.5/2025_12_23_00_world_2023_04_10_00_world_script_waypoints.sql
@@ -94,12 +94,6 @@ SET @PATHID := 138498;
 UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID;
 UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 28;
 
--- Wizzlecrank Shredder, zone_the_barrens.cpp
-SET @PATHID := 27514;
-UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID;
-UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_WALK WHERE `id`=@PATHID AND `point` BETWEEN 9 AND 17;
-UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 18;
-
 -- Brann Bronzebeard, halls_of_stone.cpp
 SET @PATHID := 224562;
 UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 1;
@@ -107,6 +101,10 @@ UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `po
 -- Maghar Captive, zone_nagrand.cpp
 SET @PATHID := 145682;
 UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 16;
+
+-- Rin'ji, zone_hinterlands.cpp
+SET @PATHID := 62242;
+UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=@PATHID AND `point` >= 17;
 
 -- ------------------------------------------------------------------------------------------------
 
@@ -142,9 +140,6 @@ UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=266962;
 
 -- Icefang, zone_storm_peaks.cpp
 UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=236818;
-
--- Garments of quests, npcs_special.cpp
-UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id` IN(99386,99418,99426,99434,99442);
 
 -- Taretha, old_hillsbrad.cpp
 UPDATE `waypoint_data` SET `move_type`=@MOVE_TYPE_RUN WHERE `id`=151098;

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.cpp
@@ -25,6 +25,7 @@
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "ScriptSystem.h"
+#include "WaypointManager.h"
 #include "World.h"
 
 enum Points
@@ -34,7 +35,7 @@ enum Points
 };
 
 EscortAI::EscortAI(Creature* creature) : ScriptedAI(creature), _pauseTimer(2500ms), _playerCheckTimer(1000), _escortState(STATE_ESCORT_NONE), _maxPlayerDistance(DEFAULT_MAX_PLAYER_DISTANCE),
-    _escortQuest(nullptr), _activeAttacker(true), _running(false), _instantRespawn(false), _returnToStart(false), _despawnAtEnd(true), _despawnAtFar(true), _manualPath(false),
+    _escortQuest(nullptr), _activeAttacker(true), _instantRespawn(false), _returnToStart(false), _despawnAtEnd(true), _despawnAtFar(true),
     _hasImmuneToNPCFlags(false), _started(false), _ended(false), _resume(false)
 {
 }
@@ -130,7 +131,7 @@ void EscortAI::MovementInform(uint32 type, uint32 id)
         if (id == POINT_LAST_POINT)
         {
             TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::MovementInform: returned to before combat position ({})", me->GetGUID().ToString());
-            me->SetWalk(!_running);
+            me->SetWalk(false);
             RemoveEscortState(STATE_ESCORT_RETURNING);
         }
         else if (id == POINT_HOME)
@@ -254,7 +255,12 @@ void EscortAI::UpdateEscortAI(uint32 /*diff*/)
     DoMeleeAttackIfReady();
 }
 
-void EscortAI::AddWaypoint(uint32 id, float x, float y, float z, float orientation/* = 0*/, Milliseconds waitTime/* = 0s*/)
+void EscortAI::AddWaypoint(uint32 id, float x, float y, float z, bool run)
+{
+    AddWaypoint(id, x, y, z, 0.0f, 0s, run);
+}
+
+void EscortAI::AddWaypoint(uint32 id, float x, float y, float z, float orientation/* = 0*/, Milliseconds waitTime/* = 0s*/, bool run /*= false*/)
 {
     Trinity::NormalizeMapCoord(x);
     Trinity::NormalizeMapCoord(y);
@@ -265,18 +271,38 @@ void EscortAI::AddWaypoint(uint32 id, float x, float y, float z, float orientati
     waypoint.y = y;
     waypoint.z = z;
     waypoint.orientation = orientation;
-    waypoint.moveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
+    waypoint.moveType = run ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
     waypoint.delay = waitTime.count();
     waypoint.eventId = 0;
     waypoint.eventChance = 100;
     _path.nodes.push_back(std::move(waypoint));
+}
 
-    _manualPath = true;
+void EscortAI::ResetPath()
+{
+    _path.nodes.clear();
+}
+
+void EscortAI::LoadPath(uint32 pathId)
+{
+    WaypointPath const* path = sWaypointMgr->GetPath(pathId);
+    if (!path)
+    {
+        TC_LOG_ERROR("scripts.ai.escortai", "EscortAI::LoadPath: (script: {}) path {} is invalid ({})", me->GetScriptName(), pathId, me->GetGUID().ToString());
+        return;
+    }
+    _path = *path;
 }
 
 /// @todo get rid of this many variables passed in function.
-void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, ObjectGuid playerGUID /* = 0 */, Quest const* quest /* = nullptr */, bool instantRespawn /* = false */, bool canLoopPath /* = false */, bool resetWaypoints /* = true */)
+void EscortAI::Start(bool isActiveAttacker /* = true*/, ObjectGuid playerGUID /* = 0 */, Quest const* quest /* = nullptr */, bool instantRespawn /* = false */, bool canLoopPath /* = false */)
 {
+    if (_path.nodes.empty())
+    {
+        TC_LOG_ERROR("scripts.ai.escortai", "EscortAI::Start: (script: {}) path is empty ({})", me->GetScriptName(), me->GetGUID().ToString());
+        return;
+    }
+
     // Queue respawn from the point it starts
     if (CreatureData const* cdata = me->GetCreatureData())
     {
@@ -295,11 +321,6 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
         TC_LOG_ERROR("scripts.ai.escortai", "EscortAI::Start: (script: {}) attempts to Start while already escorting ({})", me->GetScriptName(), me->GetGUID().ToString());
         return;
     }
-
-    _running = run;
-
-    if (!_manualPath && resetWaypoints)
-        FillPointMovementListForCreature();
 
     if (_path.nodes.empty())
     {
@@ -328,26 +349,11 @@ void EscortAI::Start(bool isActiveAttacker /* = true*/, bool run /* = false */, 
         me->SetImmuneToNPC(false);
     }
 
-    TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::Start: (script: {}) started with {} waypoints. ActiveAttacker = {}, Run = {}, Player = {} ({})",
-        me->GetScriptName(), uint32(_path.nodes.size()), _activeAttacker, _running, _playerGUID.ToString(), me->GetGUID().ToString());
-
-    // set initial speed
-    me->SetWalk(!_running);
+    TC_LOG_DEBUG("scripts.ai.escortai", "EscortAI::Start: (script: {}) started with {} waypoints. ActiveAttacker = {}, Player = {} ({})",
+        me->GetScriptName(), uint32(_path.nodes.size()), _activeAttacker, _playerGUID.ToString(), me->GetGUID().ToString());
 
     _started = false;
     AddEscortState(STATE_ESCORT_ESCORTING);
-}
-
-void EscortAI::SetRun(bool on)
-{
-    if (on == _running)
-        return;
-
-    for (auto& node : _path.nodes)
-        node.moveType = on ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
-
-    me->SetWalk(!on);
-    _running = on;
 }
 
 void EscortAI::SetEscortPaused(bool on)
@@ -435,21 +441,4 @@ bool EscortAI::IsPlayerOrGroupInRange()
     }
 
     return false;
-}
-
-void EscortAI::FillPointMovementListForCreature()
-{
-    WaypointPath const* path = sScriptSystemMgr->GetPath(me->GetEntry());
-    if (!path)
-        return;
-
-    for (WaypointNode const& value : path->nodes)
-    {
-        WaypointNode node = value;
-        Trinity::NormalizeMapCoord(node.x);
-        Trinity::NormalizeMapCoord(node.y);
-        node.moveType = _running ? WAYPOINT_MOVE_TYPE_RUN : WAYPOINT_MOVE_TYPE_WALK;
-
-        _path.nodes.push_back(std::move(node));
-    }
 }

--- a/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedEscortAI.h
@@ -48,10 +48,12 @@ struct TC_GAME_API EscortAI : public ScriptedAI
         void UpdateAI(uint32 diff) override; // the "internal" update, calls UpdateEscortAI()
 
         virtual void UpdateEscortAI(uint32 diff); // used when it's needed to add code in update (abilities, scripted events, etc)
-        void AddWaypoint(uint32 id, float x, float y, float z, float orientation = 0.f, Milliseconds waitTime = 0s);
-        void Start(bool isActiveAttacker = true, bool run = false, ObjectGuid playerGUID = ObjectGuid::Empty, Quest const* quest = nullptr, bool instantRespawn = false, bool canLoopPath = false, bool resetWaypoints = true);
+        void AddWaypoint(uint32 id, float x, float y, float z, bool run);
+        void AddWaypoint(uint32 id, float x, float y, float z, float orientation = 0.f, Milliseconds waitTime = 0s, bool run = false);
+        void ResetPath();
+        void LoadPath(uint32 pathId);
+        void Start(bool isActiveAttacker = true, ObjectGuid playerGUID = ObjectGuid::Empty, Quest const* quest = nullptr, bool instantRespawn = false, bool canLoopPath = false);
 
-        void SetRun(bool on = true);
         void SetEscortPaused(bool on);
         void SetPauseTimer(Milliseconds timer) { _pauseTimer = timer; }
         bool HasEscortState(uint32 escortState) { return (_escortState & escortState) != 0; }
@@ -70,7 +72,6 @@ struct TC_GAME_API EscortAI : public ScriptedAI
     private:
         bool AssistPlayerInCombatAgainst(Unit* who);
         bool IsPlayerOrGroupInRange();
-        void FillPointMovementListForCreature();
 
         void AddEscortState(uint32 escortState) { _escortState |= escortState; }
         void RemoveEscortState(uint32 escortState) { _escortState &= ~escortState; }
@@ -86,12 +87,10 @@ struct TC_GAME_API EscortAI : public ScriptedAI
         WaypointPath _path;
 
         bool _activeAttacker;      // obsolete, determined by faction.
-        bool _running;             // all creatures are walking by default (has flag MOVEMENTFLAG_WALK)
         bool _instantRespawn;      // if creature should respawn instantly after escort over (if not, database respawntime are used)
         bool _returnToStart;       // if creature can walk same path (loop) without despawn. Not for regular escort quests.
         bool _despawnAtEnd;
         bool _despawnAtFar;
-        bool _manualPath;
         bool _hasImmuneToNPCFlags;
         bool _started;
         bool _ended;

--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1130,7 +1130,6 @@ void ScriptMgr::Unload()
 
 void ScriptMgr::LoadDatabase()
 {
-    sScriptSystemMgr->LoadScriptWaypoints();
     sScriptSystemMgr->LoadScriptSplineChains();
 }
 

--- a/src/server/game/Scripting/ScriptSystem.cpp
+++ b/src/server/game/Scripting/ScriptSystem.cpp
@@ -32,62 +32,6 @@ SystemMgr* SystemMgr::instance()
     return &instance;
 }
 
-void SystemMgr::LoadScriptWaypoints()
-{
-    uint32 oldMSTime = getMSTime();
-
-    // drop Existing Waypoint list
-    _waypointStore.clear();
-
-    uint64 entryCount = 0;
-
-    // load Waypoints
-    QueryResult result = WorldDatabase.Query("SELECT COUNT(entry) FROM script_waypoint GROUP BY entry");
-    if (result)
-        entryCount = result->GetRowCount();
-
-    TC_LOG_INFO("server.loading", "Loading Script Waypoints for {} creature(s)...", entryCount);
-
-    //                                     0       1         2           3           4           5
-    result = WorldDatabase.Query("SELECT entry, pointid, location_x, location_y, location_z, waittime FROM script_waypoint ORDER BY pointid");
-
-    if (!result)
-    {
-        TC_LOG_INFO("server.loading", ">> Loaded 0 Script Waypoints. DB table `script_waypoint` is empty.");
-        return;
-    }
-    uint32 count = 0;
-
-    do
-    {
-        Field* fields = result->Fetch();
-        uint32 entry = fields[0].GetUInt32();
-        uint32 id = fields[1].GetUInt32();
-        float x = fields[2].GetFloat();
-        float y = fields[3].GetFloat();
-        float z = fields[4].GetFloat();
-        uint32 waitTime = fields[5].GetUInt32();
-
-        CreatureTemplate const* info = sObjectMgr->GetCreatureTemplate(entry);
-        if (!info)
-        {
-            TC_LOG_ERROR("sql.sql", "SystemMgr: DB table script_waypoint has waypoint for non-existant creature entry {}", entry);
-            continue;
-        }
-
-        if (!info->ScriptID)
-            TC_LOG_ERROR("sql.sql", "SystemMgr: DB table script_waypoint has waypoint for creature entry {}, but creature does not have ScriptName defined and then useless.", entry);
-
-        WaypointPath& path = _waypointStore[entry];
-        path.id = entry;
-        path.nodes.emplace_back(id, x, y, z, std::nullopt, waitTime);
-
-        ++count;
-    } while (result->NextRow());
-
-    TC_LOG_INFO("server.loading", ">> Loaded {} Script Waypoint nodes in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
-}
-
 void SystemMgr::LoadScriptSplineChains()
 {
     uint32 oldMSTime = getMSTime();
@@ -160,15 +104,6 @@ void SystemMgr::LoadScriptSplineChains()
 
         TC_LOG_INFO("server.loading", ">> Loaded spline chain data for {} chains, consisting of {} splines with {} waypoints in {} ms", chainCount, splineCount, wpCount, GetMSTimeDiffToNow(oldMSTime));
     }
-}
-
-WaypointPath const* SystemMgr::GetPath(uint32 creatureEntry) const
-{
-    auto itr = _waypointStore.find(creatureEntry);
-    if (itr == _waypointStore.end())
-        return nullptr;
-
-    return &itr->second;
 }
 
 std::vector<SplineChainLink> const* SystemMgr::GetSplineChain(uint32 entry, uint16 chainId) const

--- a/src/server/game/Scripting/ScriptSystem.h
+++ b/src/server/game/Scripting/ScriptSystem.h
@@ -33,10 +33,7 @@ class TC_GAME_API SystemMgr
         static SystemMgr* instance();
 
         // database
-        void LoadScriptWaypoints();
         void LoadScriptSplineChains();
-
-        WaypointPath const* GetPath(uint32 creatureEntry) const;
 
         std::vector<SplineChainLink> const* GetSplineChain(uint32 entry, uint16 chainId) const;
         std::vector<SplineChainLink> const* GetSplineChain(Creature const* who, uint16 id) const;
@@ -50,7 +47,6 @@ class TC_GAME_API SystemMgr
         SystemMgr(SystemMgr const&) = delete;
         SystemMgr& operator=(SystemMgr const&) = delete;
 
-        std::unordered_map<uint32, WaypointPath> _waypointStore;
         std::unordered_map<ChainKeyType, std::vector<SplineChainLink>> m_mSplineChainsMap; // spline chains
 };
 

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackrockDepths/blackrock_depths.cpp
@@ -125,6 +125,8 @@ enum GrimstoneTexts
     SAY_TEXT6          = 5
 };
 
+static constexpr uint32 PATH_ESCORT_GRIMSTONE = 80770;
+
 /// @todo implement quest part of event (different end boss)
 class npc_grimstone : public CreatureScript
 {
@@ -288,7 +290,8 @@ public:
                     case 0:
                         Talk(SAY_TEXT5);
                         HandleGameObject(DATA_ARENA4, false);
-                        Start(false, false);
+                        LoadPath(PATH_ESCORT_GRIMSTONE);
+                        Start(false);
                         CanWalk = true;
                         Event_Timer = 0;
                         break;
@@ -503,7 +506,8 @@ enum Rocknot
 {
     SAY_GOT_BEER       = 0,
     QUEST_ALE          = 4295,
-    SPELL_DRUNKEN_RAGE = 14872
+    SPELL_DRUNKEN_RAGE = 14872,
+    PATH_ESCORT_ROCKNOT = 76026
 };
 
 class npc_rocknot : public CreatureScript
@@ -619,7 +623,8 @@ public:
                     Talk(SAY_GOT_BEER);
                     DoCastSelf(SPELL_DRUNKEN_RAGE, false);
 
-                    Start(false, false);
+                    LoadPath(PATH_ESCORT_ROCKNOT);
+                    Start(false);
                 }
             }
         }

--- a/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.cpp
+++ b/src/server/scripts/EasternKingdoms/Gnomeregan/gnomeregan.cpp
@@ -57,7 +57,9 @@ enum BlastmasterEmi
     SAY_BLASTMASTER_18  = 18,
     SAY_BLASTMASTER_19  = 19,
 
-    SAY_GRUBBIS         = 0
+    SAY_GRUBBIS         = 0,
+
+    PATH_ESCORT_BLASTMASTER_EMI = 63986,
 };
 
 const Position SpawnPosition[] =
@@ -134,7 +136,8 @@ public:
         {
             if (gossipListId == 0)
             {
-                Start(true, false, player->GetGUID());
+                LoadPath(PATH_ESCORT_BLASTMASTER_EMI);
+                Start(true, player->GetGUID());
 
                 me->SetFaction(player->GetFaction());
                 SetData(1, 0);

--- a/src/server/scripts/EasternKingdoms/Karazhan/karazhan.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/karazhan.cpp
@@ -123,6 +123,8 @@ float Spawns[6][2]=
 #define SPAWN_Y             -1758
 #define SPAWN_O             4.738f
 
+static constexpr uint32 PATH_ESCORT_BARNES = 134498;
+
 class npc_barnes : public CreatureScript
 {
 public:
@@ -176,7 +178,8 @@ public:
             if (m_uiEventId == EVENT_OZ)
                 instance->SetData(DATA_OPERA_OZ_DEATHCOUNT, IN_PROGRESS);
 
-            Start(false, false);
+            LoadPath(PATH_ESCORT_BARNES);
+            Start(false);
         }
 
         void JustEngagedWith(Unit* /*who*/) override { }

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter5.cpp
@@ -271,6 +271,8 @@ Position const LightofDawnLoc[] =
     {2273.972f, -5257.676f, 78.862f, 0},     // 29 Lich king moves forward
 };
 
+static constexpr uint32 PATH_ESCORT_MOGRAINE = 233386;
+
 class npc_highlord_darion_mograine : public CreatureScript
 {
 public:
@@ -1621,7 +1623,8 @@ public:
                 case GOSSIP_ACTION_INFO_DEF + 1:
                     CloseGossipMenuFor(player);
                     uiStep = 1;
-                    Start(true, true, player->GetGUID());
+                    LoadPath(PATH_ESCORT_MOGRAINE);
+                    Start(true, player->GetGUID());
                     break;
             }
             return true;

--- a/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_herod.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletMonastery/boss_herod.cpp
@@ -125,6 +125,8 @@ private:
     bool _enrage;
 };
 
+static constexpr uint32 PATH_ESCORT_SCARLET_TRAINEE = 52602;
+
 struct npc_scarlet_trainee : public EscortAI
 {
     npc_scarlet_trainee(Creature* creature) : EscortAI(creature)
@@ -138,7 +140,8 @@ struct npc_scarlet_trainee : public EscortAI
         {
             if (_startTimer <= diff)
             {
-                Start(true, true);
+                LoadPath(PATH_ESCORT_SCARLET_TRAINEE);
+                Start(true);
                 _startTimer = 0;
             }
             else

--- a/src/server/scripts/EasternKingdoms/ShadowfangKeep/shadowfang_keep.cpp
+++ b/src/server/scripts/EasternKingdoms/ShadowfangKeep/shadowfang_keep.cpp
@@ -118,7 +118,8 @@ public:
             if (action == GOSSIP_ACTION_INFO_DEF + 1)
             {
                 CloseGossipMenuFor(player);
-                Start(false, false, player->GetGUID());
+                LoadPath((me->GetEntry() << 3) | 2);
+                Start(false, player->GetGUID());
             }
             return true;
         }

--- a/src/server/scripts/EasternKingdoms/zone_hinterlands.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_hinterlands.cpp
@@ -62,6 +62,8 @@ Position const AmbushMoveTo[] =
     { 70.886589f,  -2874.335449f, 116.675f, 0.0f }
 };
 
+static constexpr uint32 PATH_ESCORT_RINJI = 62242;
+
 class npc_rinji : public CreatureScript
 {
 public:
@@ -140,7 +142,8 @@ public:
                 if (GameObject* go = me->FindNearestGameObject(GO_RINJI_CAGE, INTERACTION_DISTANCE))
                     go->UseDoorOrButton();
 
-                EscortAI::Start(false, false, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_RINJI);
+                Start(false, player->GetGUID(), quest);
             }
         }
 
@@ -164,7 +167,6 @@ public:
                 case 17:
                     Talk(SAY_RIN_COMPLETE, player);
                     player->GroupEventHappens(QUEST_RINJI_TRAPPED, me);
-                    SetRun();
                     postEventCount = 1;
                     break;
             }

--- a/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_stormwind_city.cpp
@@ -319,6 +319,8 @@ enum TyrionSpybot
     NPC_LORD_GREGOR_LESCOVAR = 1754,
 };
 
+static constexpr uint32 PATH_ESCORT_LESCOVAR = 70850;
+
 class npc_tyrion_spybot : public CreatureScript
 {
 public:
@@ -438,8 +440,12 @@ public:
                             {
                                 if (Player* player = GetPlayerForEscort())
                                 {
-                                    ENSURE_AI(npc_lord_gregor_lescovar::npc_lord_gregor_lescovarAI, pLescovar->AI())->Start(false, false, player->GetGUID());
-                                    ENSURE_AI(npc_lord_gregor_lescovar::npc_lord_gregor_lescovarAI, pLescovar->AI())->SetMaxPlayerDistance(200.0f);
+                                    if (EscortAI* ai = CAST_AI(EscortAI, pLescovar->AI()))
+                                    {
+                                        ai->LoadPath(PATH_ESCORT_LESCOVAR);
+                                        ai->Start(false, player->GetGUID());
+                                        ai->SetMaxPlayerDistance(200.0f);
+                                    }
                                 }
                             }
                             me->DisappearAndDie();
@@ -468,6 +474,8 @@ enum Tyrion
     NPC_TYRION_SPYBOT = 8856
 };
 
+static constexpr uint32 PATH_ESCORT_TYRION_SPYBOT = 14034;
+
 class npc_tyrion : public CreatureScript
 {
 public:
@@ -483,8 +491,12 @@ public:
             {
                 if (Creature* spybot = me->FindNearestCreature(NPC_TYRION_SPYBOT, 5.0f, true))
                 {
-                    ENSURE_AI(npc_tyrion_spybot::npc_tyrion_spybotAI, spybot->AI())->Start(false, false, player->GetGUID());
-                    ENSURE_AI(npc_tyrion_spybot::npc_tyrion_spybotAI, spybot->AI())->SetMaxPlayerDistance(200.0f);
+                    if (EscortAI* ai = CAST_AI(EscortAI, spybot->AI()))
+                    {
+                        ai->LoadPath(PATH_ESCORT_TYRION_SPYBOT);
+                        ai->Start(false, player->GetGUID());
+                        ai->SetMaxPlayerDistance(200.0f);
+                    }
                 }
             }
         }

--- a/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
+++ b/src/server/scripts/Kalimdor/BlackfathomDeeps/blackfathom_deeps.cpp
@@ -165,7 +165,9 @@ private:
 enum Morridune
 {
     SAY_MORRIDUNE_1 = 0,
-    SAY_MORRIDUNE_2 = 1
+    SAY_MORRIDUNE_2 = 1,
+
+    PATH_ESCORT_MORRIDUNE = 53834,
 };
 
 struct npc_morridune : public EscortAI
@@ -176,6 +178,7 @@ struct npc_morridune : public EscortAI
     {
         Talk(SAY_MORRIDUNE_1);
         me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
+        LoadPath(PATH_ESCORT_MORRIDUNE);
         Start(false);
     }
 

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_anetheron.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_anetheron.cpp
@@ -43,6 +43,8 @@ enum Texts
     SAY_ONAGGRO         = 5,
 };
 
+static constexpr uint32 PATH_ESCORT_ANETHERON = 142466;
+
 class boss_anetheron : public CreatureScript
 {
 public:
@@ -126,15 +128,8 @@ public:
                 if (!go)
                 {
                     go = true;
-                    AddWaypoint(0, 4896.08f,    -1576.35f,    1333.65f);
-                    AddWaypoint(1, 4898.68f,    -1615.02f,    1329.48f);
-                    AddWaypoint(2, 4907.12f,    -1667.08f,    1321.00f);
-                    AddWaypoint(3, 4963.18f,    -1699.35f,    1340.51f);
-                    AddWaypoint(4, 4989.16f,    -1716.67f,    1335.74f);
-                    AddWaypoint(5, 5026.27f,    -1736.89f,    1323.02f);
-                    AddWaypoint(6, 5037.77f,    -1770.56f,    1324.36f);
-                    AddWaypoint(7, 5067.23f,    -1789.95f,    1321.17f);
-                    Start(false, true);
+                    LoadPath(PATH_ESCORT_ANETHERON);
+                    Start(false);
                     SetDespawnAtEnd(false);
                 }
             }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_azgalor.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_azgalor.cpp
@@ -42,6 +42,8 @@ enum Texts
     SAY_ONAGGRO             = 3,
 };
 
+static constexpr uint32 PATH_ESCORT_AZGALOR = 142738;
+
 class boss_azgalor : public CreatureScript
 {
 public:
@@ -129,15 +131,8 @@ public:
                 if (!go)
                 {
                     go = true;
-                    AddWaypoint(0, 5492.91f,    -2404.61f,    1462.63f);
-                    AddWaypoint(1, 5531.76f,    -2460.87f,    1469.55f);
-                    AddWaypoint(2, 5554.58f,    -2514.66f,    1476.12f);
-                    AddWaypoint(3, 5554.16f,    -2567.23f,    1479.90f);
-                    AddWaypoint(4, 5540.67f,    -2625.99f,    1480.89f);
-                    AddWaypoint(5, 5508.16f,    -2659.2f,    1480.15f);
-                    AddWaypoint(6, 5489.62f,    -2704.05f,    1482.18f);
-                    AddWaypoint(7, 5457.04f,    -2726.26f,    1485.10f);
-                    Start(false, true);
+                    LoadPath(PATH_ESCORT_AZGALOR);
+                    Start(false);
                     SetDespawnAtEnd(false);
                 }
             }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_kazrogal.cpp
@@ -43,6 +43,8 @@ enum Sounds
     SOUND_ONDEATH       = 11018,
 };
 
+static constexpr uint32 PATH_ESCORT_KAZROGAL = 143106;
+
 class boss_kazrogal : public CreatureScript
 {
 public:
@@ -124,15 +126,8 @@ public:
                 if (!go)
                 {
                     go = true;
-                    AddWaypoint(0, 5492.91f,    -2404.61f,    1462.63f);
-                    AddWaypoint(1, 5531.76f,    -2460.87f,    1469.55f);
-                    AddWaypoint(2, 5554.58f,    -2514.66f,    1476.12f);
-                    AddWaypoint(3, 5554.16f,    -2567.23f,    1479.90f);
-                    AddWaypoint(4, 5540.67f,    -2625.99f,    1480.89f);
-                    AddWaypoint(5, 5508.16f,    -2659.2f,    1480.15f);
-                    AddWaypoint(6, 5489.62f,    -2704.05f,    1482.18f);
-                    AddWaypoint(7, 5457.04f,    -2726.26f,    1485.10f);
-                    Start(false, true);
+                    LoadPath(PATH_ESCORT_KAZROGAL);
+                    Start(false);
                     SetDespawnAtEnd(false);
                 }
             }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_rage_winterchill.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/boss_rage_winterchill.cpp
@@ -38,6 +38,8 @@ enum Texts
     SAY_ONAGGRO                 = 4
 };
 
+static constexpr uint32 PATH_ESCORT_RAGE_WINTERCHILL = 142138;
+
 class boss_rage_winterchill : public CreatureScript
 {
 public:
@@ -119,15 +121,8 @@ public:
                 if (!go)
                 {
                     go = true;
-                    AddWaypoint(0, 4896.08f,    -1576.35f,    1333.65f);
-                    AddWaypoint(1, 4898.68f,    -1615.02f,    1329.48f);
-                    AddWaypoint(2, 4907.12f,    -1667.08f,    1321.00f);
-                    AddWaypoint(3, 4963.18f,    -1699.35f,    1340.51f);
-                    AddWaypoint(4, 4989.16f,    -1716.67f,    1335.74f);
-                    AddWaypoint(5, 5026.27f,    -1736.89f,    1323.02f);
-                    AddWaypoint(6, 5037.77f,    -1770.56f,    1324.36f);
-                    AddWaypoint(7, 5067.23f,    -1789.95f,    1321.17f);
-                    Start(false, true);
+                    LoadPath(PATH_ESCORT_RAGE_WINTERCHILL);
+                    Start(false);
                     SetDespawnAtEnd(false);
                 }
             }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjalAI.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjalAI.cpp
@@ -508,7 +508,6 @@ void hyjalAI::SummonCreature(uint32 entry, float Base[4][3])
         ++EnemyCount;
 
         creature->SetWalk(false);
-        ENSURE_AI(hyjal_trashAI, creature->AI())->SetRun();
         creature->setActive(true);
         creature->SetFarVisible(true);
         switch (entry)
@@ -628,7 +627,7 @@ void hyjalAI::Retreat()
         instance->SetData(DATA_ALLIANCE_RETREAT, 1);
         AddWaypoint(0, JainaWPs[0][0], JainaWPs[0][1], JainaWPs[0][2]);
         AddWaypoint(1, JainaWPs[1][0], JainaWPs[1][1], JainaWPs[1][2]);
-        Start(false, false);
+        Start(false);
         SetDespawnAtEnd(false);//move to center of alliance base
     }
     if (Faction == 1)
@@ -642,7 +641,7 @@ void hyjalAI::Retreat()
             DummyGuid = JainaDummy->GetGUID();
         }
         AddWaypoint(0, JainaDummySpawn[1][0], JainaDummySpawn[1][1], JainaDummySpawn[1][2]);
-        Start(false, false);
+        Start(false);
         SetDespawnAtEnd(false);//move to center of alliance base
     }
     SpawnVeins();

--- a/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/BattleForMountHyjal/hyjal_trash.cpp
@@ -227,56 +227,56 @@ void hyjal_trashAI::UpdateAI(uint32 /*diff*/)
                 switch (OverrunType)
                 {
                     case 0:
-                        AddWaypoint(4, AllianceOverrunWP[22][0]+irand(-3, 3), AllianceOverrunWP[22][1]+irand(-3, 3), AllianceOverrunWP[22][2]);
-                        AddWaypoint(5, AllianceOverrunWP[23][0]+irand(-3, 3), AllianceOverrunWP[23][1]+irand(-3, 3), AllianceOverrunWP[23][2]);
-                        AddWaypoint(6, AllianceOverrunWP[24][0]+irand(-3, 3), AllianceOverrunWP[24][1]+irand(-3, 3), AllianceOverrunWP[24][2]);
-                        AddWaypoint(7, AllianceOverrunWP[25][0]+irand(-3, 3), AllianceOverrunWP[25][1]+irand(-3, 3), AllianceOverrunWP[25][2]);
-                        AddWaypoint(8, AllianceOverrunWP[26][0]+irand(-3, 3), AllianceOverrunWP[26][1]+irand(-3, 3), AllianceOverrunWP[26][2]);
-                        AddWaypoint(9, AllianceOverrunWP[27][0]+irand(-3, 3), AllianceOverrunWP[27][1]+irand(-3, 3), AllianceOverrunWP[27][2]);
-                        AddWaypoint(10, AllianceOverrunWP[28][0]+irand(-3, 3), AllianceOverrunWP[28][1]+irand(-3, 3), AllianceOverrunWP[28][2]);
+                        AddWaypoint(4, AllianceOverrunWP[22][0]+irand(-3, 3), AllianceOverrunWP[22][1]+irand(-3, 3), AllianceOverrunWP[22][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[23][0]+irand(-3, 3), AllianceOverrunWP[23][1]+irand(-3, 3), AllianceOverrunWP[23][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[24][0]+irand(-3, 3), AllianceOverrunWP[24][1]+irand(-3, 3), AllianceOverrunWP[24][2], true);
+                        AddWaypoint(7, AllianceOverrunWP[25][0]+irand(-3, 3), AllianceOverrunWP[25][1]+irand(-3, 3), AllianceOverrunWP[25][2], true);
+                        AddWaypoint(8, AllianceOverrunWP[26][0]+irand(-3, 3), AllianceOverrunWP[26][1]+irand(-3, 3), AllianceOverrunWP[26][2], true);
+                        AddWaypoint(9, AllianceOverrunWP[27][0]+irand(-3, 3), AllianceOverrunWP[27][1]+irand(-3, 3), AllianceOverrunWP[27][2], true);
+                        AddWaypoint(10, AllianceOverrunWP[28][0]+irand(-3, 3), AllianceOverrunWP[28][1]+irand(-3, 3), AllianceOverrunWP[28][2], true);
 
-                        AddWaypoint(11, AllianceOverrunWP[36][0]+irand(-3, 3), AllianceOverrunWP[36][1]+irand(-3, 3), AllianceOverrunWP[36][2]);
-                        AddWaypoint(12, AllianceOverrunWP[37][0]+irand(-3, 3), AllianceOverrunWP[37][1]+irand(-3, 3), AllianceOverrunWP[37][2]);
-                        AddWaypoint(13, AllianceOverrunWP[38][0]+irand(-3, 3), AllianceOverrunWP[38][1]+irand(-3, 3), AllianceOverrunWP[38][2]);
-                        AddWaypoint(14, AllianceOverrunWP[39][0]+irand(-3, 3), AllianceOverrunWP[39][1]+irand(-3, 3), AllianceOverrunWP[39][2]);
-                        AddWaypoint(15, AllianceOverrunWP[40][0]+irand(-3, 3), AllianceOverrunWP[40][1]+irand(-3, 3), AllianceOverrunWP[40][2]);
-                        AddWaypoint(16, AllianceOverrunWP[41][0]+irand(-3, 3), AllianceOverrunWP[41][1]+irand(-3, 3), AllianceOverrunWP[41][2]);
-                        AddWaypoint(17, AllianceOverrunWP[42][0]+irand(-3, 3), AllianceOverrunWP[42][1]+irand(-3, 3), AllianceOverrunWP[42][2]);
-                        AddWaypoint(18, AllianceOverrunWP[43][0]+irand(-3, 3), AllianceOverrunWP[43][1]+irand(-3, 3), AllianceOverrunWP[43][2]);
+                        AddWaypoint(11, AllianceOverrunWP[36][0]+irand(-3, 3), AllianceOverrunWP[36][1]+irand(-3, 3), AllianceOverrunWP[36][2], true);
+                        AddWaypoint(12, AllianceOverrunWP[37][0]+irand(-3, 3), AllianceOverrunWP[37][1]+irand(-3, 3), AllianceOverrunWP[37][2], true);
+                        AddWaypoint(13, AllianceOverrunWP[38][0]+irand(-3, 3), AllianceOverrunWP[38][1]+irand(-3, 3), AllianceOverrunWP[38][2], true);
+                        AddWaypoint(14, AllianceOverrunWP[39][0]+irand(-3, 3), AllianceOverrunWP[39][1]+irand(-3, 3), AllianceOverrunWP[39][2], true);
+                        AddWaypoint(15, AllianceOverrunWP[40][0]+irand(-3, 3), AllianceOverrunWP[40][1]+irand(-3, 3), AllianceOverrunWP[40][2], true);
+                        AddWaypoint(16, AllianceOverrunWP[41][0]+irand(-3, 3), AllianceOverrunWP[41][1]+irand(-3, 3), AllianceOverrunWP[41][2], true);
+                        AddWaypoint(17, AllianceOverrunWP[42][0]+irand(-3, 3), AllianceOverrunWP[42][1]+irand(-3, 3), AllianceOverrunWP[42][2], true);
+                        AddWaypoint(18, AllianceOverrunWP[43][0]+irand(-3, 3), AllianceOverrunWP[43][1]+irand(-3, 3), AllianceOverrunWP[43][2], true);
                         me->SetHomePosition(AllianceOverrunWP[43][0]+irand(-3, 3), AllianceOverrunWP[43][1]+irand(-3, 3), AllianceOverrunWP[43][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 18;
-                        Start(true, true);
+                        Start(true);
                         break;
                      case 1:
-                        AddWaypoint(4, AllianceOverrunWP[22][0]+irand(-3, 3), AllianceOverrunWP[22][1]+irand(-3, 3), AllianceOverrunWP[22][2]);
-                        AddWaypoint(5, AllianceOverrunWP[23][0]+irand(-3, 3), AllianceOverrunWP[23][1]+irand(-3, 3), AllianceOverrunWP[23][2]);
-                        AddWaypoint(6, AllianceOverrunWP[24][0]+irand(-3, 3), AllianceOverrunWP[24][1]+irand(-3, 3), AllianceOverrunWP[24][2]);
-                        AddWaypoint(7, AllianceOverrunWP[25][0]+irand(-3, 3), AllianceOverrunWP[25][1]+irand(-3, 3), AllianceOverrunWP[25][2]);
-                        AddWaypoint(8, AllianceOverrunWP[26][0]+irand(-3, 3), AllianceOverrunWP[26][1]+irand(-3, 3), AllianceOverrunWP[26][2]);
-                        AddWaypoint(9, AllianceOverrunWP[27][0]+irand(-3, 3), AllianceOverrunWP[27][1]+irand(-3, 3), AllianceOverrunWP[27][2]);
-                        AddWaypoint(10, AllianceOverrunWP[28][0]+irand(-3, 3), AllianceOverrunWP[28][1]+irand(-3, 3), AllianceOverrunWP[28][2]);
+                        AddWaypoint(4, AllianceOverrunWP[22][0]+irand(-3, 3), AllianceOverrunWP[22][1]+irand(-3, 3), AllianceOverrunWP[22][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[23][0]+irand(-3, 3), AllianceOverrunWP[23][1]+irand(-3, 3), AllianceOverrunWP[23][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[24][0]+irand(-3, 3), AllianceOverrunWP[24][1]+irand(-3, 3), AllianceOverrunWP[24][2], true);
+                        AddWaypoint(7, AllianceOverrunWP[25][0]+irand(-3, 3), AllianceOverrunWP[25][1]+irand(-3, 3), AllianceOverrunWP[25][2], true);
+                        AddWaypoint(8, AllianceOverrunWP[26][0]+irand(-3, 3), AllianceOverrunWP[26][1]+irand(-3, 3), AllianceOverrunWP[26][2], true);
+                        AddWaypoint(9, AllianceOverrunWP[27][0]+irand(-3, 3), AllianceOverrunWP[27][1]+irand(-3, 3), AllianceOverrunWP[27][2], true);
+                        AddWaypoint(10, AllianceOverrunWP[28][0]+irand(-3, 3), AllianceOverrunWP[28][1]+irand(-3, 3), AllianceOverrunWP[28][2], true);
 
-                        AddWaypoint(11, AllianceOverrunWP[36][0]+irand(-3, 3), AllianceOverrunWP[36][1]+irand(-3, 3), AllianceOverrunWP[36][2]);
-                        AddWaypoint(12, AllianceOverrunWP[37][0]+irand(-3, 3), AllianceOverrunWP[37][1]+irand(-3, 3), AllianceOverrunWP[37][2]);
-                        AddWaypoint(13, AllianceOverrunWP[38][0]+irand(-3, 3), AllianceOverrunWP[38][1]+irand(-3, 3), AllianceOverrunWP[38][2]);
-                        AddWaypoint(14, AllianceOverrunWP[39][0]+irand(-3, 3), AllianceOverrunWP[39][1]+irand(-3, 3), AllianceOverrunWP[39][2]);
-                        AddWaypoint(15, AllianceOverrunWP[40][0]+irand(-3, 3), AllianceOverrunWP[40][1]+irand(-3, 3), AllianceOverrunWP[40][2]);
-                        AddWaypoint(16, AllianceOverrunWP[41][0]+irand(-3, 3), AllianceOverrunWP[41][1]+irand(-3, 3), AllianceOverrunWP[41][2]);
-                        AddWaypoint(17, AllianceOverrunWP[42][0]+irand(-3, 3), AllianceOverrunWP[42][1]+irand(-3, 3), AllianceOverrunWP[42][2]);
-                        AddWaypoint(18, AllianceOverrunWP[44][0]+irand(-3, 3), AllianceOverrunWP[44][1]+irand(-3, 3), AllianceOverrunWP[44][2]);
+                        AddWaypoint(11, AllianceOverrunWP[36][0]+irand(-3, 3), AllianceOverrunWP[36][1]+irand(-3, 3), AllianceOverrunWP[36][2], true);
+                        AddWaypoint(12, AllianceOverrunWP[37][0]+irand(-3, 3), AllianceOverrunWP[37][1]+irand(-3, 3), AllianceOverrunWP[37][2], true);
+                        AddWaypoint(13, AllianceOverrunWP[38][0]+irand(-3, 3), AllianceOverrunWP[38][1]+irand(-3, 3), AllianceOverrunWP[38][2], true);
+                        AddWaypoint(14, AllianceOverrunWP[39][0]+irand(-3, 3), AllianceOverrunWP[39][1]+irand(-3, 3), AllianceOverrunWP[39][2], true);
+                        AddWaypoint(15, AllianceOverrunWP[40][0]+irand(-3, 3), AllianceOverrunWP[40][1]+irand(-3, 3), AllianceOverrunWP[40][2], true);
+                        AddWaypoint(16, AllianceOverrunWP[41][0]+irand(-3, 3), AllianceOverrunWP[41][1]+irand(-3, 3), AllianceOverrunWP[41][2], true);
+                        AddWaypoint(17, AllianceOverrunWP[42][0]+irand(-3, 3), AllianceOverrunWP[42][1]+irand(-3, 3), AllianceOverrunWP[42][2], true);
+                        AddWaypoint(18, AllianceOverrunWP[44][0]+irand(-3, 3), AllianceOverrunWP[44][1]+irand(-3, 3), AllianceOverrunWP[44][2], true);
                         me->SetHomePosition(AllianceOverrunWP[44][0]+irand(-3, 3), AllianceOverrunWP[44][1]+irand(-3, 3), AllianceOverrunWP[44][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 18;
-                        Start(true, true);
+                        Start(true);
                         break;
                     default:
                         for (uint8 i = 22; i < 36; ++i)
-                            AddWaypoint(i-18, AllianceOverrunWP[i][0]+irand(-3, 3), AllianceOverrunWP[i][1]+irand(-3, 3), AllianceOverrunWP[i][2]);
+                            AddWaypoint(i-18, AllianceOverrunWP[i][0]+irand(-3, 3), AllianceOverrunWP[i][1]+irand(-3, 3), AllianceOverrunWP[i][2], true);
 
                         SetDespawnAtEnd(true);
                         LastOverronPos = 17;
-                        Start(true, true);
+                        Start(true);
                         break;
                 }
             }
@@ -287,68 +287,68 @@ void hyjal_trashAI::UpdateAI(uint32 /*diff*/)
                 switch (OverrunType)
                 {
                     case 0:
-                        AddWaypoint(4, AllianceOverrunWP[1][0]+irand(-3, 3), AllianceOverrunWP[1][1]+irand(-3, 3), AllianceOverrunWP[1][2]);
-                        AddWaypoint(5, AllianceOverrunWP[2][0]+irand(-3, 3), AllianceOverrunWP[2][1]+irand(-3, 3), AllianceOverrunWP[2][2]);
+                        AddWaypoint(4, AllianceOverrunWP[1][0]+irand(-3, 3), AllianceOverrunWP[1][1]+irand(-3, 3), AllianceOverrunWP[1][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[2][0]+irand(-3, 3), AllianceOverrunWP[2][1]+irand(-3, 3), AllianceOverrunWP[2][2], true);
                         me->SetHomePosition(AllianceOverrunWP[2][0]+irand(-3, 3), AllianceOverrunWP[2][1]+irand(-3, 3), AllianceOverrunWP[2][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 5;
-                        Start(true, true);
+                        Start(true);
                         break;
                     case 1:
-                        AddWaypoint(4, AllianceOverrunWP[3][0]+irand(-3, 3), AllianceOverrunWP[3][1]+irand(-3, 3), AllianceOverrunWP[3][2]);
-                        AddWaypoint(5, AllianceOverrunWP[4][0]+irand(-3, 3), AllianceOverrunWP[4][1]+irand(-3, 3), AllianceOverrunWP[4][2]);
-                        AddWaypoint(6, AllianceOverrunWP[5][0]+irand(-3, 3), AllianceOverrunWP[5][1]+irand(-3, 3), AllianceOverrunWP[5][2]);
+                        AddWaypoint(4, AllianceOverrunWP[3][0]+irand(-3, 3), AllianceOverrunWP[3][1]+irand(-3, 3), AllianceOverrunWP[3][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[4][0]+irand(-3, 3), AllianceOverrunWP[4][1]+irand(-3, 3), AllianceOverrunWP[4][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[5][0]+irand(-3, 3), AllianceOverrunWP[5][1]+irand(-3, 3), AllianceOverrunWP[5][2], true);
                         me->SetHomePosition(AllianceOverrunWP[5][0]+irand(-3, 3), AllianceOverrunWP[5][1]+irand(-3, 3), AllianceOverrunWP[5][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 6;
-                        Start(true, true);
+                        Start(true);
                         break;
                     case 2:
-                        AddWaypoint(4, AllianceOverrunWP[6][0]+irand(-3, 3), AllianceOverrunWP[6][1]+irand(-3, 3), AllianceOverrunWP[6][2]);
-                        AddWaypoint(5, AllianceOverrunWP[7][0]+irand(-3, 3), AllianceOverrunWP[7][1]+irand(-3, 3), AllianceOverrunWP[7][2]);
-                        AddWaypoint(6, AllianceOverrunWP[8][0]+irand(-3, 3), AllianceOverrunWP[8][1]+irand(-3, 3), AllianceOverrunWP[8][2]);
-                        AddWaypoint(7, AllianceOverrunWP[9][0]+irand(-3, 3), AllianceOverrunWP[9][1]+irand(-3, 3), AllianceOverrunWP[9][2]);
+                        AddWaypoint(4, AllianceOverrunWP[6][0]+irand(-3, 3), AllianceOverrunWP[6][1]+irand(-3, 3), AllianceOverrunWP[6][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[7][0]+irand(-3, 3), AllianceOverrunWP[7][1]+irand(-3, 3), AllianceOverrunWP[7][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[8][0]+irand(-3, 3), AllianceOverrunWP[8][1]+irand(-3, 3), AllianceOverrunWP[8][2], true);
+                        AddWaypoint(7, AllianceOverrunWP[9][0]+irand(-3, 3), AllianceOverrunWP[9][1]+irand(-3, 3), AllianceOverrunWP[9][2], true);
                         me->SetHomePosition(AllianceOverrunWP[9][0]+irand(-3, 3), AllianceOverrunWP[9][1]+irand(-3, 3), AllianceOverrunWP[9][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 7;
-                        Start(true, true);
+                        Start(true);
                         break;
                     case 3:
-                        AddWaypoint(4, AllianceOverrunWP[10][0]+irand(-3, 3), AllianceOverrunWP[10][1]+irand(-3, 3), AllianceOverrunWP[10][2]);
-                        AddWaypoint(5, AllianceOverrunWP[11][0]+irand(-3, 3), AllianceOverrunWP[11][1]+irand(-3, 3), AllianceOverrunWP[11][2]);
-                        AddWaypoint(6, AllianceOverrunWP[12][0]+irand(-3, 3), AllianceOverrunWP[12][1]+irand(-3, 3), AllianceOverrunWP[12][2]);
+                        AddWaypoint(4, AllianceOverrunWP[10][0]+irand(-3, 3), AllianceOverrunWP[10][1]+irand(-3, 3), AllianceOverrunWP[10][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[11][0]+irand(-3, 3), AllianceOverrunWP[11][1]+irand(-3, 3), AllianceOverrunWP[11][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[12][0]+irand(-3, 3), AllianceOverrunWP[12][1]+irand(-3, 3), AllianceOverrunWP[12][2], true);
                         me->SetHomePosition(AllianceOverrunWP[12][0]+irand(-3, 3), AllianceOverrunWP[12][1]+irand(-3, 3), AllianceOverrunWP[12][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 6;
-                        Start(true, true);
+                        Start(true);
                         break;
                     case 4:
-                        AddWaypoint(4, AllianceOverrunWP[13][0]+irand(-3, 3), AllianceOverrunWP[13][1]+irand(-3, 3), AllianceOverrunWP[13][2]);
-                        AddWaypoint(5, AllianceOverrunWP[14][0]+irand(-3, 3), AllianceOverrunWP[14][1]+irand(-3, 3), AllianceOverrunWP[14][2]);
-                        AddWaypoint(6, AllianceOverrunWP[15][0]+irand(-3, 3), AllianceOverrunWP[15][1]+irand(-3, 3), AllianceOverrunWP[15][2]);
+                        AddWaypoint(4, AllianceOverrunWP[13][0]+irand(-3, 3), AllianceOverrunWP[13][1]+irand(-3, 3), AllianceOverrunWP[13][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[14][0]+irand(-3, 3), AllianceOverrunWP[14][1]+irand(-3, 3), AllianceOverrunWP[14][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[15][0]+irand(-3, 3), AllianceOverrunWP[15][1]+irand(-3, 3), AllianceOverrunWP[15][2], true);
                         me->SetHomePosition(AllianceOverrunWP[15][0]+irand(-3, 3), AllianceOverrunWP[15][1]+irand(-3, 3), AllianceOverrunWP[15][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 6;
-                        Start(true, true);
+                        Start(true);
                         break;
                     case 5:
-                        AddWaypoint(4, AllianceOverrunWP[16][0]+irand(-3, 3), AllianceOverrunWP[16][1]+irand(-3, 3), AllianceOverrunWP[16][2]);
-                        AddWaypoint(5, AllianceOverrunWP[17][0]+irand(-3, 3), AllianceOverrunWP[17][1]+irand(-3, 3), AllianceOverrunWP[17][2]);
-                        AddWaypoint(6, AllianceOverrunWP[18][0]+irand(-3, 3), AllianceOverrunWP[18][1]+irand(-3, 3), AllianceOverrunWP[18][2]);
-                        AddWaypoint(7, AllianceOverrunWP[19][0]+irand(-3, 3), AllianceOverrunWP[19][1]+irand(-3, 3), AllianceOverrunWP[19][2]);
-                        AddWaypoint(8, AllianceOverrunWP[20][0]+irand(-3, 3), AllianceOverrunWP[20][1]+irand(-3, 3), AllianceOverrunWP[20][2]);
-                        AddWaypoint(9, AllianceOverrunWP[21][0]+irand(-3, 3), AllianceOverrunWP[21][1]+irand(-3, 3), AllianceOverrunWP[21][2]);
+                        AddWaypoint(4, AllianceOverrunWP[16][0]+irand(-3, 3), AllianceOverrunWP[16][1]+irand(-3, 3), AllianceOverrunWP[16][2], true);
+                        AddWaypoint(5, AllianceOverrunWP[17][0]+irand(-3, 3), AllianceOverrunWP[17][1]+irand(-3, 3), AllianceOverrunWP[17][2], true);
+                        AddWaypoint(6, AllianceOverrunWP[18][0]+irand(-3, 3), AllianceOverrunWP[18][1]+irand(-3, 3), AllianceOverrunWP[18][2], true);
+                        AddWaypoint(7, AllianceOverrunWP[19][0]+irand(-3, 3), AllianceOverrunWP[19][1]+irand(-3, 3), AllianceOverrunWP[19][2], true);
+                        AddWaypoint(8, AllianceOverrunWP[20][0]+irand(-3, 3), AllianceOverrunWP[20][1]+irand(-3, 3), AllianceOverrunWP[20][2], true);
+                        AddWaypoint(9, AllianceOverrunWP[21][0]+irand(-3, 3), AllianceOverrunWP[21][1]+irand(-3, 3), AllianceOverrunWP[21][2], true);
                         me->SetHomePosition(AllianceOverrunWP[21][0]+irand(-3, 3), AllianceOverrunWP[21][1]+irand(-3, 3), AllianceOverrunWP[21][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 9;
-                        Start(true, true);
+                        Start(true);
                         break;
                     default:
                         for (uint8 i = 22; i < 36; ++i)
-                            AddWaypoint(i-18, AllianceOverrunWP[i][0]+irand(-3, 3), AllianceOverrunWP[i][1]+irand(-3, 3), AllianceOverrunWP[i][2]);
+                            AddWaypoint(i-18, AllianceOverrunWP[i][0]+irand(-3, 3), AllianceOverrunWP[i][1]+irand(-3, 3), AllianceOverrunWP[i][2], true);
                         SetDespawnAtEnd(true);
                         LastOverronPos = 17;
-                        Start(true, true);
+                        Start(true);
                         break;
                 }
             }
@@ -362,43 +362,43 @@ void hyjal_trashAI::UpdateAI(uint32 /*diff*/)
                 switch (OverrunType)
                 {
                     case 0:
-                        AddWaypoint(5, HordeOverrunWP[16][0]+irand(-10, 10), HordeOverrunWP[16][1]+irand(-10, 10), HordeOverrunWP[16][2]);
-                        AddWaypoint(6, HordeOverrunWP[17][0]+irand(-10, 10), HordeOverrunWP[17][1]+irand(-10, 10), HordeOverrunWP[17][2]);
-                        AddWaypoint(7, HordeOverrunWP[18][0], HordeOverrunWP[18][1], HordeOverrunWP[18][2]);
-                        AddWaypoint(8, HordeOverrunWP[19][0], HordeOverrunWP[19][1], HordeOverrunWP[19][2]);
+                        AddWaypoint(5, HordeOverrunWP[16][0]+irand(-10, 10), HordeOverrunWP[16][1]+irand(-10, 10), HordeOverrunWP[16][2], true);
+                        AddWaypoint(6, HordeOverrunWP[17][0]+irand(-10, 10), HordeOverrunWP[17][1]+irand(-10, 10), HordeOverrunWP[17][2], true);
+                        AddWaypoint(7, HordeOverrunWP[18][0], HordeOverrunWP[18][1], HordeOverrunWP[18][2], true);
+                        AddWaypoint(8, HordeOverrunWP[19][0], HordeOverrunWP[19][1], HordeOverrunWP[19][2], true);
                         me->SetHomePosition(HordeOverrunWP[19][0], HordeOverrunWP[19][1], HordeOverrunWP[19][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 8;
-                        Start(true, true);
+                        Start(true);
                         break;
                     case 1:
-                        AddWaypoint(5, HordeOverrunWP[16][0]+irand(-10, 10), HordeOverrunWP[16][1]+irand(-10, 10), HordeOverrunWP[16][2]);
-                        AddWaypoint(6, HordeOverrunWP[17][0]+irand(-10, 10), HordeOverrunWP[17][1]+irand(-10, 10), HordeOverrunWP[17][2]);
-                        AddWaypoint(7, HordeOverrunWP[18][0], HordeOverrunWP[18][1], HordeOverrunWP[18][2]);
-                        AddWaypoint(8, HordeOverrunWP[20][0], HordeOverrunWP[20][1], HordeOverrunWP[20][2]);
+                        AddWaypoint(5, HordeOverrunWP[16][0]+irand(-10, 10), HordeOverrunWP[16][1]+irand(-10, 10), HordeOverrunWP[16][2], true);
+                        AddWaypoint(6, HordeOverrunWP[17][0]+irand(-10, 10), HordeOverrunWP[17][1]+irand(-10, 10), HordeOverrunWP[17][2], true);
+                        AddWaypoint(7, HordeOverrunWP[18][0], HordeOverrunWP[18][1], HordeOverrunWP[18][2], true);
+                        AddWaypoint(8, HordeOverrunWP[20][0], HordeOverrunWP[20][1], HordeOverrunWP[20][2], true);
                         me->SetHomePosition(HordeOverrunWP[20][0], HordeOverrunWP[20][1], HordeOverrunWP[20][2], 0);
                         SetDespawnAtEnd(false);
                         LastOverronPos = 8;
-                        Start(true, true);
+                        Start(true);
                         break;
                     default:
                         for (uint8 i = 0; i < 16; ++i)
-                            AddWaypoint(i+6, HordeOverrunWP[i][0]+irand(-10, 10), HordeOverrunWP[i][1]+irand(-10, 10), HordeOverrunWP[i][2]);
+                            AddWaypoint(i+6, HordeOverrunWP[i][0]+irand(-10, 10), HordeOverrunWP[i][1]+irand(-10, 10), HordeOverrunWP[i][2], true);
                         SetDespawnAtEnd(true);
                         LastOverronPos = 21;
-                        Start(true, true);
+                        Start(true);
                         break;
                 }
             }
             if (me->GetEntry() == ABOMINATION)
             {
                 for (uint8 i = 0; i < 6; ++i)
-                    AddWaypoint(i, HordeWPs[i][0]+irand(-10, 10), HordeWPs[i][1]+irand(-10, 10), HordeWPs[i][2]);
+                    AddWaypoint(i, HordeWPs[i][0]+irand(-10, 10), HordeWPs[i][1]+irand(-10, 10), HordeWPs[i][2], true);
                 for (uint8 i = 0; i < 16; ++i)
-                    AddWaypoint(i+6, HordeOverrunWP[i][0]+irand(-10, 10), HordeOverrunWP[i][1]+irand(-10, 10), HordeOverrunWP[i][2]);
+                    AddWaypoint(i+6, HordeOverrunWP[i][0]+irand(-10, 10), HordeOverrunWP[i][1]+irand(-10, 10), HordeOverrunWP[i][2], true);
                 SetDespawnAtEnd(true);
                 LastOverronPos = 21;
-                Start(true, true);
+                Start(true);
             }
         }
     }
@@ -513,8 +513,8 @@ public:
                 if (!go)
                 {
                     go = true;
-                    AddWaypoint(0, HordeWPs[7][0]+irand(-3, 3),    HordeWPs[7][1]+irand(-3, 3),    HordeWPs[7][2]);//HordeWPs[7] infront of thrall
-                    Start(true, true);
+                    AddWaypoint(0, HordeWPs[7][0]+irand(-3, 3), HordeWPs[7][1]+irand(-3, 3), HordeWPs[7][2], true);//HordeWPs[7] infront of thrall
+                    Start(true);
                     SetDespawnAtEnd(false);
                 }
             }
@@ -613,14 +613,14 @@ public:
                     if (instance->GetData(DATA_ALLIANCE_RETREAT))//2.alliance boss down, use horde WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3),    HordeWPs[i][1]+irand(-3, 3),    HordeWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3), HordeWPs[i][1]+irand(-3, 3), HordeWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }else//use alliance WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3),    AllianceWPs[i][1]+irand(-3, 3),    AllianceWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3), AllianceWPs[i][1]+irand(-3, 3), AllianceWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }
                 }
@@ -717,14 +717,14 @@ public:
                     if (instance->GetData(DATA_ALLIANCE_RETREAT))//2.alliance boss down, use horde WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3),    HordeWPs[i][1]+irand(-3, 3),    HordeWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3), HordeWPs[i][1]+irand(-3, 3), HordeWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }else//use alliance WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3),    AllianceWPs[i][1]+irand(-3, 3),    AllianceWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3), AllianceWPs[i][1]+irand(-3, 3), AllianceWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }
                 }
@@ -851,14 +851,14 @@ public:
                     if (instance->GetData(DATA_ALLIANCE_RETREAT))//2.alliance boss down, use horde WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3),    HordeWPs[i][1]+irand(-3, 3),    HordeWPs[i][2]);
-                        Start(true, true);
+                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3), HordeWPs[i][1]+irand(-3, 3), HordeWPs[i][2], true);
+                        Start(true);
                         SetDespawnAtEnd(false);
                     }else//use alliance WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3),    AllianceWPs[i][1]+irand(-3, 3),    AllianceWPs[i][2]);
-                        Start(true, true);
+                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3), AllianceWPs[i][1]+irand(-3, 3), AllianceWPs[i][2], true);
+                        Start(true);
                         SetDespawnAtEnd(false);
                     }
                 }
@@ -960,14 +960,14 @@ public:
                     if (instance->GetData(DATA_ALLIANCE_RETREAT))//2.alliance boss down, use horde WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3),    HordeWPs[i][1]+irand(-3, 3),    HordeWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3), HordeWPs[i][1]+irand(-3, 3), HordeWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }else//use alliance WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3),    AllianceWPs[i][1]+irand(-3, 3),    AllianceWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3), AllianceWPs[i][1]+irand(-3, 3), AllianceWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }
                 }
@@ -1061,14 +1061,14 @@ public:
                     if (instance->GetData(DATA_ALLIANCE_RETREAT))//2.alliance boss down, use horde WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3),    HordeWPs[i][1]+irand(-3, 3),    HordeWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3), HordeWPs[i][1]+irand(-3, 3), HordeWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }else//use alliance WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3),    AllianceWPs[i][1]+irand(-3, 3),    AllianceWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3), AllianceWPs[i][1]+irand(-3, 3), AllianceWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }
                 }
@@ -1152,14 +1152,14 @@ public:
                     if (instance->GetData(DATA_ALLIANCE_RETREAT))//2.alliance boss down, use horde WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3),    HordeWPs[i][1]+irand(-3, 3),    HordeWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, HordeWPs[i][0]+irand(-3, 3), HordeWPs[i][1]+irand(-3, 3), HordeWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }else//use alliance WPs
                     {
                         for (uint8 i = 0; i < 8; ++i)
-                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3),    AllianceWPs[i][1]+irand(-3, 3),    AllianceWPs[i][2]);
-                        Start(false, true);
+                            AddWaypoint(i, AllianceWPs[i][0]+irand(-3, 3), AllianceWPs[i][1]+irand(-3, 3), AllianceWPs[i][2], true);
+                        Start(false);
                         SetDespawnAtEnd(false);
                     }
                 }
@@ -1256,15 +1256,15 @@ public:
                     if (!useFlyPath)
                     {
                         for (uint8 i = 0; i < 3; ++i)
-                            AddWaypoint(i, FrostWyrmWPs[i][0],    FrostWyrmWPs[i][1],    FrostWyrmWPs[i][2]);
+                            AddWaypoint(i, FrostWyrmWPs[i][0], FrostWyrmWPs[i][1], FrostWyrmWPs[i][2], true);
                     }
                     else
                     {//fly path FlyPathWPs
                         for (uint8 i = 0; i < 3; ++i)
-                            AddWaypoint(i, FlyPathWPs[i][0]+irand(-10, 10),    FlyPathWPs[i][1]+irand(-10, 10),    FlyPathWPs[i][2]);
+                            AddWaypoint(i, FlyPathWPs[i][0]+irand(-10, 10), FlyPathWPs[i][1]+irand(-10, 10), FlyPathWPs[i][2], true);
                     }
                     go = true;
-                    Start(false, true);
+                    Start(false);
                     SetDespawnAtEnd(false);
                 }
             }
@@ -1379,13 +1379,13 @@ public:
                     if (!useFlyPath)
                     {
                         for (uint8 i = 0; i < 3; ++i)
-                            AddWaypoint(i, GargoyleWPs[i][0]+irand(-10, 10), GargoyleWPs[i][1]+irand(-10, 10), GargoyleWPs[i][2]);
+                            AddWaypoint(i, GargoyleWPs[i][0]+irand(-10, 10), GargoyleWPs[i][1]+irand(-10, 10), GargoyleWPs[i][2], true);
                     }else{//fly path FlyPathWPs
                         for (uint8 i = 0; i < 3; ++i)
-                            AddWaypoint(i, FlyPathWPs[i][0]+irand(-10, 10),    FlyPathWPs[i][1]+irand(-10, 10),    FlyPathWPs[i][2]);
+                            AddWaypoint(i, FlyPathWPs[i][0]+irand(-10, 10), FlyPathWPs[i][1]+irand(-10, 10), FlyPathWPs[i][2], true);
                     }
                     go = true;
-                    Start(false, true);
+                    Start(false);
                     SetDespawnAtEnd(false);
                 }
             }

--- a/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/EscapeFromDurnholdeKeep/old_hillsbrad.cpp
@@ -185,6 +185,9 @@ enum ThrallOldHillsbrad
 #define SPEED_RUN               (1.0f)
 #define SPEED_MOUNT             (1.6f)
 
+static constexpr uint32 PATH_ESCORT_THRALL_OLD_HILLSBRAD = 143010;
+static constexpr uint32 PATH_ESCORT_TARETHA = 151098;
+
 struct npc_thrall_old_hillsbrad : public EscortAI
 {
     npc_thrall_old_hillsbrad(Creature* creature) : EscortAI(creature)
@@ -204,7 +207,7 @@ struct npc_thrall_old_hillsbrad : public EscortAI
     void InitializeAI() override
     {
         /* correct respawn positions after wipe cannot be used because of how waypoints are set up for this creature
-         * it would require splitting the path into 4 segments, moving it out of script_waypoint table and changing
+         * it would require splitting the path into 4 segments, moving it out of waypoint_data table and changing
          * all waypoint ids in WaypointReached function
         switch (instance->GetData(TYPE_THRALL_EVENT))
         {
@@ -243,7 +246,6 @@ struct npc_thrall_old_hillsbrad : public EscortAI
         switch (waypointId)
         {
             case 8:
-                SetRun(false);
                 me->SummonCreature(18764, 2181.87f, 112.46f, 89.45f, 0.26f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5s);
                 break;
             case 9:
@@ -255,7 +257,6 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                 me->SetDisplayId(THRALL_MODEL_EQUIPPED);
                 break;
             case 11:
-                SetRun();
                 break;
             case 15:
                 me->SummonCreature(NPC_RIFLE, 2200.28f, 137.37f, 87.93f, 5.07f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5s);
@@ -288,13 +289,11 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                 //temporary, skarloc should rather be triggered to walk up to thrall
                 break;
             case 30:
-                SetRun(false);
                 break;
             case 31:
                 Talk(SAY_TH_MOUNTS_UP);
                 HadMount = true;
                 DoMount();
-                SetRun();
                 break;
             case 37:
                 //possibly regular patrollers? If so, remove this and let database handle them
@@ -306,17 +305,14 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                 me->SummonCreature(SKARLOC_MOUNT, 2488.64f, 625.77f, 58.26f, 4.71f, TEMPSUMMON_TIMED_DESPAWN, 10s);
                 DoUnmount();
                 HadMount = false;
-                SetRun(false);
                 break;
             case 60:
                 me->HandleEmoteCommand(EMOTE_ONESHOT_EXCLAMATION);
                 //make horsie run off
                 SetEscortPaused(true);
                 instance->SetData(TYPE_THRALL_EVENT, OH_ESCORT_BARN_TO_TARETHA);
-                SetRun();
                 break;
             case 64:
-                SetRun(false);
                 break;
             case 68:
                 me->SummonCreature(NPC_BARN_PROTECTOR, 2500.22f, 692.60f, 55.50f, 2.84f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5s);
@@ -325,10 +321,8 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                 me->SummonCreature(NPC_BARN_GUARDSMAN, 2500.94f, 695.81f, 55.50f, 3.14f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5s);
                 break;
             case 71:
-                SetRun();
                 break;
             case 81:
-                SetRun(false);
                 break;
             case 83:
                 me->SummonCreature(NPC_CHURCH_PROTECTOR, 2627.33f, 646.82f, 56.03f, 4.28f, TEMPSUMMON_TIMED_OR_DEAD_DESPAWN, 5s);
@@ -338,11 +332,6 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                 break;
             case 84:
                 Talk(SAY_TH_CHURCH_END);
-                SetRun();
-                break;
-            case 91:
-                me->SetWalk(true);
-                SetRun(false);
                 break;
             case 93:
                 me->SummonCreature(NPC_INN_PROTECTOR, 2652.71f, 660.31f, 61.93f, 1.67f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 5s);
@@ -364,7 +353,6 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                 break;
             case 97:
                 Talk(SAY_TH_EPOCH_KILL_TARETHA);
-                SetRun();
                 break;
             case 98:
                 //trigger epoch Yell("Thrall! Come outside and face your fate! ....")
@@ -376,7 +364,13 @@ struct npc_thrall_old_hillsbrad : public EscortAI
                     if (Creature* Taretha = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_TARETHA)))
                     {
                         if (Player* player = GetPlayerForEscort())
-                            ENSURE_AI(EscortAI, (Taretha->AI()))->Start(false, true, player->GetGUID());
+                        {
+                            if (EscortAI* ai = CAST_AI(EscortAI, Taretha->AI()))
+                            {
+                                ai->LoadPath(PATH_ESCORT_TARETHA);
+                                ai->Start(false, player->GetGUID());
+                            }
+                        }
                     }
 
                     //kill credit Creature for quest
@@ -504,7 +498,8 @@ struct npc_thrall_old_hillsbrad : public EscortAI
 
                 Talk(SAY_TH_START_EVENT_PART1);
 
-                Start(true, true, player->GetGUID());
+                LoadPath(PATH_ESCORT_THRALL_OLD_HILLSBRAD);
+                Start(true, player->GetGUID());
 
                 SetMaxPlayerDistance(100.0f);//not really needed, because it will not despawn if player is too far
                 SetDespawnAtEnd(false);

--- a/src/server/scripts/Kalimdor/WailingCaverns/wailing_caverns.cpp
+++ b/src/server/scripts/Kalimdor/WailingCaverns/wailing_caverns.cpp
@@ -74,6 +74,8 @@ enum Enums
     NPC_DEVIATE_MOCCASIN          = 5762,
     NPC_NIGHTMARE_ECTOPLASM       = 5763,
     NPC_MUTANUS_THE_DEVOURER      = 3654,
+
+    PATH_ESCORT_NARALEX_DISCIPLE  = 29426,
 };
 
 class npc_disciple_of_naralex : public CreatureScript
@@ -281,7 +283,6 @@ public:
                                     naralex->AI()->Talk(SAY_FAREWELL);
                                     naralex->AddAura(SPELL_FLIGHT_FORM, naralex);
                                 }
-                                SetRun();
                                 me->SetStandState(UNIT_STAND_STATE_STAND);
                                 me->AddAura(SPELL_FLIGHT_FORM, me);
                             }
@@ -335,7 +336,8 @@ public:
                 me->SetFaction(FACTION_ESCORTEE_N_NEUTRAL_ACTIVE);
                 me->SetImmuneToPC(false);
 
-                Start(false, false, player->GetGUID());
+                LoadPath(PATH_ESCORT_NARALEX_DISCIPLE);
+                Start(false, player->GetGUID());
                 SetDespawnAtFar(false);
                 SetDespawnAtEnd(false);
             }

--- a/src/server/scripts/Kalimdor/zone_ashenvale.cpp
+++ b/src/server/scripts/Kalimdor/zone_ashenvale.cpp
@@ -47,7 +47,8 @@ enum RuulSnowhoof
     QUEST_FREEDOM_TO_RUUL       = 6482,
     GO_CAGE                     = 178147,
     RUUL_SHAPECHANGE            = 20514,
-    SAY_FINISH                  = 0
+    SAY_FINISH                  = 0,
+    PATH_ESCORT_RUUL_SNOWHOOF   = 102546,
 };
 
 Position const RuulSnowhoofSummonsCoord[6] =
@@ -87,7 +88,8 @@ public:
             if (quest->GetQuestId() == QUEST_FREEDOM_TO_RUUL)
             {
                 me->SetFaction(FACTION_ESCORTEE_N_NEUTRAL_PASSIVE);
-                EscortAI::Start(true, false, player->GetGUID());
+                LoadPath(PATH_ESCORT_RUUL_SNOWHOOF);
+                EscortAI::Start(true, player->GetGUID());
             }
         }
 
@@ -168,7 +170,9 @@ enum Muglash
     NPC_WRATH_SEAWITCH      = 3715,
 
     NPC_VORSHA              = 12940,
-    NPC_MUGLASH             = 12717
+    NPC_MUGLASH             = 12717,
+
+    PATH_ESCORT_MUGLASH     = 101738,
 };
 
 Position const FirstNagaCoord[3] =
@@ -240,7 +244,8 @@ public:
             {
                 Talk(SAY_MUG_START1);
                 me->SetFaction(FACTION_ESCORTEE_N_NEUTRAL_PASSIVE);
-                EscortAI::Start(true, false, player->GetGUID());
+                LoadPath(PATH_ESCORT_MUGLASH);
+                EscortAI::Start(true, player->GetGUID());
             }
         }
 

--- a/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_azuremyst_isle.cpp
@@ -338,7 +338,8 @@ enum Magwin
     EVENT_STAND                 = 3,
     EVENT_TALK_END              = 4,
     EVENT_COWLEN_TALK           = 5,
-    QUEST_A_CRY_FOR_HELP        = 9528
+    QUEST_A_CRY_FOR_HELP        = 9528,
+    PATH_ESCORT_MAGWIN          = 138498,
 };
 
 class npc_magwin : public CreatureScript
@@ -381,7 +382,6 @@ public:
                     case 28:
                         player->GroupEventHappens(QUEST_A_CRY_FOR_HELP, me);
                         _events.ScheduleEvent(EVENT_TALK_END, 2s);
-                        SetRun(true);
                         break;
                     case 29:
                         if (Creature* cowlen = me->FindNearestCreature(NPC_COWLEN, 50.0f, true))
@@ -408,7 +408,10 @@ public:
                         break;
                     case EVENT_START_ESCORT:
                         if (Player* player = ObjectAccessor::GetPlayer(*me, _player))
-                            EscortAI::Start(true, false, player->GetGUID());
+                        {
+                            LoadPath(PATH_ESCORT_MAGWIN);
+                            EscortAI::Start(true, player->GetGUID());
+                        }
                         _events.ScheduleEvent(EVENT_STAND, 2s);
                         break;
                     case EVENT_STAND: // Remove kneel standstate. Using a separate delayed event because it causes unwanted delay before starting waypoint movement.

--- a/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
+++ b/src/server/scripts/Kalimdor/zone_bloodmyst_isle.cpp
@@ -290,6 +290,8 @@ public:
 ## npc_demolitionist_legoso
 ######*/
 
+static constexpr uint32 PATH_ESCORT_LEGOSO = 143858;
+
 class npc_demolitionist_legoso : public CreatureScript
 {
 public:
@@ -307,7 +309,8 @@ public:
             if (quest->GetQuestId() == QUEST_ENDING_THEIR_WORLD)
             {
                 SetData(DATA_EVENT_STARTER_GUID, player->GetGUID().GetCounter());
-                Start(true, true, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_LEGOSO);
+                Start(true, player->GetGUID(), quest);
             }
         }
 

--- a/src/server/scripts/Kalimdor/zone_darkshore.cpp
+++ b/src/server/scripts/Kalimdor/zone_darkshore.cpp
@@ -196,6 +196,8 @@ enum Remtravel
     NPC_GRAVEL_GEO              = 2160
 };
 
+static constexpr uint32 PATH_ESCORT_PROSPECTOR_REMTRAVEL = 23338;
+
 class npc_prospector_remtravel : public CreatureScript
 {
 public:
@@ -284,7 +286,8 @@ public:
         {
             if (quest->GetQuestId() == QUEST_ABSENT_MINDED_PT2)
             {
-                Start(false, false, player->GetGUID());
+                LoadPath(PATH_ESCORT_PROSPECTOR_REMTRAVEL);
+                Start(false, player->GetGUID());
                 me->SetFaction(FACTION_ESCORTEE_A_NEUTRAL_PASSIVE);
             }
         }

--- a/src/server/scripts/Kalimdor/zone_moonglade.cpp
+++ b/src/server/scripts/Kalimdor/zone_moonglade.cpp
@@ -196,7 +196,7 @@ public:
                     AddWaypoint(i, Clintar_spirit_WP[i].X, Clintar_spirit_WP[i].Y, Clintar_spirit_WP[i].Z, Clintar_spirit_WP[i].O, Clintar_spirit_WP[i].waitTime);
                 }
                 PlayerGUID = player->GetGUID();
-                Start(true, false, PlayerGUID);
+                Start(true, player->GetGUID());
                 me->SetDisplayId(me->GetCreatureTemplate()->Modelid1);
                 me->RemoveUnitFlag(UNIT_FLAG_UNINTERACTIBLE);
             }

--- a/src/server/scripts/Kalimdor/zone_the_barrens.cpp
+++ b/src/server/scripts/Kalimdor/zone_the_barrens.cpp
@@ -59,6 +59,8 @@ enum Gilthares
     AREA_MERCHANT_COAST         = 391
 };
 
+static constexpr uint32 PATH_ESCORT_GILTHARES = 27722;
+
 class npc_gilthares : public CreatureScript
 {
 public:
@@ -122,7 +124,8 @@ public:
                 me->SetStandState(UNIT_STAND_STATE_STAND);
 
                 Talk(SAY_GIL_START, player);
-                Start(false, false, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_GILTHARES);
+                Start(false, player->GetGUID(), quest);
             }
         }
     };

--- a/src/server/scripts/Kalimdor/zone_winterspring.cpp
+++ b/src/server/scripts/Kalimdor/zone_winterspring.cpp
@@ -257,6 +257,8 @@ static Position wingThicketLocations[] =
 # npc_ranshalla
 #####*/
 
+static constexpr uint32 PATH_ESCORT_RANSHALLA = 82402;
+
 class npc_ranshalla : public CreatureScript
 {
 public:
@@ -545,7 +547,8 @@ public:
                 Talk(SAY_QUEST_START);
                 me->SetFaction(FACTION_ESCORTEE_A_NEUTRAL_PASSIVE);
 
-                Start(false, false, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_RANSHALLA);
+                Start(false, player->GetGUID(), quest);
             }
         }
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_argent_challenge.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_argent_challenge.cpp
@@ -548,13 +548,13 @@ public:
                     switch (uiType)
                     {
                         case 0:
-                            AddWaypoint(0, 712.14f, 628.42f, 411.88f);
+                            AddWaypoint(0, 712.14f, 628.42f, 411.88f, true);
                             break;
                         case 1:
-                            AddWaypoint(0, 742.44f, 650.29f, 411.79f);
+                            AddWaypoint(0, 742.44f, 650.29f, 411.79f, true);
                             break;
                         case 2:
-                            AddWaypoint(0, 783.33f, 615.29f, 411.84f);
+                            AddWaypoint(0, 783.33f, 615.29f, 411.84f, true);
                             break;
                     }
                     break;
@@ -562,13 +562,13 @@ public:
                     switch (uiType)
                     {
                         case 0:
-                            AddWaypoint(0, 713.12f, 632.97f, 411.90f);
+                            AddWaypoint(0, 713.12f, 632.97f, 411.90f, true);
                             break;
                         case 1:
-                            AddWaypoint(0, 746.73f, 650.24f, 411.56f);
+                            AddWaypoint(0, 746.73f, 650.24f, 411.56f, true);
                             break;
                         case 2:
-                            AddWaypoint(0, 781.32f, 610.54f, 411.82f);
+                            AddWaypoint(0, 781.32f, 610.54f, 411.82f, true);
                             break;
                     }
                     break;
@@ -576,19 +576,19 @@ public:
                     switch (uiType)
                     {
                         case 0:
-                            AddWaypoint(0, 715.06f, 637.07f, 411.91f);
+                            AddWaypoint(0, 715.06f, 637.07f, 411.91f, true);
                             break;
                         case 1:
-                            AddWaypoint(0, 750.72f, 650.20f, 411.77f);
+                            AddWaypoint(0, 750.72f, 650.20f, 411.77f, true);
                             break;
                         case 2:
-                            AddWaypoint(0, 779.77f, 607.03f, 411.81f);
+                            AddWaypoint(0, 779.77f, 607.03f, 411.81f, true);
                             break;
                     }
                     break;
             }
 
-            Start(false, true);
+            Start(false);
             uiWaypoint = uiType;
         }
 

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_black_knight.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_black_knight.cpp
@@ -351,6 +351,8 @@ public:
     }
 };
 
+static constexpr uint32 PATH_ESCORT_GRYPHON = 283930;
+
 class npc_black_knight_skeletal_gryphon : public CreatureScript
 {
 public:
@@ -360,7 +362,8 @@ public:
     {
         npc_black_knight_skeletal_gryphonAI(Creature* creature) : EscortAI(creature)
         {
-            Start(false, true);
+            LoadPath(PATH_ESCORT_GRYPHON);
+            Start(false);
         }
 
         void UpdateAI(uint32 uiDiff) override

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheChampion/boss_grand_champions.cpp
@@ -187,28 +187,28 @@ public:
             switch (uiType)
             {
                 case 1:
-                    AddWaypoint(0, 747.36f, 634.07f, 411.572f);
-                    AddWaypoint(1, 780.43f, 607.15f, 411.82f);
-                    AddWaypoint(2, 785.99f, 599.41f, 411.92f);
-                    AddWaypoint(3, 778.44f, 601.64f, 411.79f);
+                    AddWaypoint(0, 747.36f, 634.07f, 411.572f, true);
+                    AddWaypoint(1, 780.43f, 607.15f, 411.82f, true);
+                    AddWaypoint(2, 785.99f, 599.41f, 411.92f, true);
+                    AddWaypoint(3, 778.44f, 601.64f, 411.79f, true);
                     uiWaypointPath = 1;
                     break;
                 case 2:
-                    AddWaypoint(0, 747.35f, 634.07f, 411.57f);
-                    AddWaypoint(1, 768.72f, 581.01f, 411.92f);
-                    AddWaypoint(2, 763.55f, 590.52f, 411.71f);
+                    AddWaypoint(0, 747.35f, 634.07f, 411.57f, true);
+                    AddWaypoint(1, 768.72f, 581.01f, 411.92f, true);
+                    AddWaypoint(2, 763.55f, 590.52f, 411.71f, true);
                     uiWaypointPath = 2;
                     break;
                 case 3:
-                    AddWaypoint(0, 747.35f, 634.07f, 411.57f);
-                    AddWaypoint(1, 784.02f, 645.33f, 412.39f);
-                    AddWaypoint(2, 775.67f, 641.91f, 411.91f);
+                    AddWaypoint(0, 747.35f, 634.07f, 411.57f, true);
+                    AddWaypoint(1, 784.02f, 645.33f, 412.39f, true);
+                    AddWaypoint(2, 775.67f, 641.91f, 411.91f, true);
                     uiWaypointPath = 3;
                     break;
             }
 
             if (uiType <= 3)
-                Start(false, true);
+                Start(false);
         }
 
         void WaypointReached(uint32 waypointId, uint32 /*pathId*/) override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sister_svalna.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sister_svalna.cpp
@@ -514,6 +514,8 @@ private:
     bool _isEventInProgress;
 };
 
+static constexpr uint32 PATH_ESCORT_CROK_SCOURGEBANE = 297034;
+
 // 37129 - Crok Scourgebane
 struct npc_crok_scourgebane : public EscortAI
 {
@@ -749,7 +751,8 @@ struct npc_crok_scourgebane : public EscortAI
                     Talk(SAY_CROK_INTRO_3);
                     break;
                 case EVENT_START_PATHING:
-                    Start(true, true);
+                    LoadPath(PATH_ESCORT_CROK_SCOURGEBANE),
+                    Start(true);
                     break;
                 case EVENT_SCOURGE_STRIKE:
                     DoCastVictim(SPELL_SCOURGE_STRIKE);

--- a/src/server/scripts/Northrend/Ulduar/HallsOfStone/halls_of_stone.cpp
+++ b/src/server/scripts/Northrend/Ulduar/HallsOfStone/halls_of_stone.cpp
@@ -260,6 +260,8 @@ struct npc_tribuna_controller : public ScriptedAI
     }
 };
 
+static constexpr uint32 PATH_ESCORT_BRANN = 224562;
+
 struct npc_brann_hos : public EscortAI
 {
     npc_brann_hos(Creature* creature) : EscortAI(creature)
@@ -388,6 +390,7 @@ struct npc_brann_hos : public EscortAI
         me->RemoveNpcFlag(UNIT_NPC_FLAG_GOSSIP);
         SetEscortPaused(false);
         uiStep = 1;
+        LoadPath(PATH_ESCORT_BRANN);
         Start();
     }
 
@@ -416,7 +419,6 @@ struct npc_brann_hos : public EscortAI
                         return;
                     bIsBattle = false;
                     Talk(SAY_ESCORT_START);
-                    SetRun(true);
                     JumpToNextStep(0);
                     break;
                 case 3:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -997,6 +997,8 @@ class npc_thorims_hammer : public CreatureScript
         }
 };
 
+static constexpr uint32 PATH_ESCORT_MIMIRONS_INFERNO = 266962;
+
 class npc_mimirons_inferno : public CreatureScript
 {
 public:
@@ -1029,7 +1031,10 @@ public:
             EscortAI::UpdateAI(diff);
 
             if (!HasEscortState(STATE_ESCORT_ESCORTING))
-                Start(false, true, ObjectGuid::Empty, nullptr, false, true);
+            {
+                LoadPath(PATH_ESCORT_MIMIRONS_INFERNO);
+                Start(false, ObjectGuid::Empty, nullptr, false, true);
+            }
             else
             {
                 if (infernoTimer <= diff)

--- a/src/server/scripts/Northrend/VioletHold/violet_hold.cpp
+++ b/src/server/scripts/Northrend/VioletHold/violet_hold.cpp
@@ -885,11 +885,11 @@ struct violet_hold_trashAI : public EscortAI
             if (path)
             {
                 for (uint32 i = 0; i <= _lastWaypointId; i++)
-                    AddWaypoint(i, path[i].GetPositionX() + irand(-1, 1), path[i].GetPositionY() + irand(-1, 1), path[i].GetPositionZ(), 0);
+                    AddWaypoint(i, path[i].GetPositionX() + irand(-1, 1), path[i].GetPositionY() + irand(-1, 1), path[i].GetPositionZ(), 0, 0s, true);
                 me->SetHomePosition(path[_lastWaypointId].GetPositionX(), path[_lastWaypointId].GetPositionY(), path[_lastWaypointId].GetPositionZ(), float(M_PI));
             }
 
-            Start(true, true);
+            Start(true);
         }
     }
 

--- a/src/server/scripts/Northrend/zone_grizzly_hills.cpp
+++ b/src/server/scripts/Northrend/zone_grizzly_hills.cpp
@@ -54,7 +54,8 @@ enum Floppy
     TEXT_EMOTE_WP1              = 9, // Mr. Floppy revives
     TEXT_EMOTE_AGGRO            = 10, // The Ravenous Worg chomps down on Mr. Floppy
     SAY_QUEST_ACCEPT            = 11, // Are you ready, Mr. Floppy? Stay close to me and watch out for those wolves!
-    SAY_QUEST_COMPLETE          = 12  // Thank you for helping me get back to the camp. Go tell Walter that I'm safe now!
+    SAY_QUEST_COMPLETE          = 12, // Thank you for helping me get back to the camp. Go tell Walter that I'm safe now!
+    PATH_ESCORT_EMILY           = 212706
 };
 
 // emily
@@ -187,7 +188,8 @@ struct npc_emily : public EscortAI
             if (Creature* Mrfloppy = GetClosestCreatureWithEntry(me, NPC_MRFLOPPY, 180.0f))
                 Mrfloppy->GetMotionMaster()->MoveFollow(me, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
 
-            Start(true, false, player->GetGUID());
+            LoadPath(PATH_ESCORT_EMILY);
+            Start(true, player->GetGUID());
         }
     }
 

--- a/src/server/scripts/Northrend/zone_storm_peaks.cpp
+++ b/src/server/scripts/Northrend/zone_storm_peaks.cpp
@@ -202,6 +202,8 @@ struct npc_freed_protodrake : public VehicleAI
     }
 };
 
+static constexpr uint32 PATH_ESCORT_ICEFANG = 236818;
+
 struct npc_icefang : public EscortAI
 {
     npc_icefang(Creature* creature) : EscortAI(creature) { }
@@ -215,7 +217,10 @@ struct npc_icefang : public EscortAI
         if (who->GetTypeId() == TYPEID_PLAYER)
         {
             if (apply)
-                Start(false, true, who->GetGUID());
+            {
+                LoadPath(PATH_ESCORT_ICEFANG);
+                Start(false, who->GetGUID());
+            }
         }
     }
 

--- a/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_ambassador_hellmaw.cpp
+++ b/src/server/scripts/Outland/Auchindoun/ShadowLabyrinth/boss_ambassador_hellmaw.cpp
@@ -51,6 +51,8 @@ enum Events
     EVENT_BERSERK
 };
 
+static constexpr uint32 PATH_ESCORT_HELLMAW = 149850;
+
 struct boss_ambassador_hellmaw : public EscortAI
 {
     boss_ambassador_hellmaw(Creature* creature) : EscortAI(creature)
@@ -105,7 +107,8 @@ struct boss_ambassador_hellmaw : public EscortAI
             me->RemoveAurasDueToSpell(SPELL_BANISH);
 
         Talk(SAY_INTRO);
-        Start(true, false, ObjectGuid::Empty, nullptr, false, true);
+        LoadPath(PATH_ESCORT_HELLMAW);
+        Start(true, ObjectGuid::Empty, nullptr, false, true);
     }
 
     void JustEngagedWith(Unit* /*who*/) override

--- a/src/server/scripts/Outland/zone_nagrand.cpp
+++ b/src/server/scripts/Outland/zone_nagrand.cpp
@@ -61,7 +61,9 @@ enum MagharCaptive
     NPC_MURK_RAIDER             = 18203,
     NPC_MURK_BRUTE              = 18211,
     NPC_MURK_SCAVENGER          = 18207,
-    NPC_MURK_PUTRIFIER          = 18202
+    NPC_MURK_PUTRIFIER          = 18202,
+
+    PATH_ESCORT_MAGHAR_CAPTIVE  = 145682,
 };
 
 static float m_afAmbushA[]= {-1568.805786f, 8533.873047f, 1.958f};
@@ -131,8 +133,6 @@ public:
 
                     if (Player* player = GetPlayerForEscort())
                         player->GroupEventHappens(QUEST_TOTEM_KARDASH_H, me);
-
-                    SetRun();
                     break;
             }
         }
@@ -208,7 +208,8 @@ public:
             {
                 me->SetStandState(UNIT_STAND_STATE_STAND);
                 me->SetFaction(FACTION_ESCORTEE_H_NEUTRAL_ACTIVE);
-                Start(true, false, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_MAGHAR_CAPTIVE);
+                Start(true, player->GetGUID(), quest);
                 Talk(SAY_MAG_START);
 
                 me->SummonCreature(NPC_MURK_RAIDER, m_afAmbushA[0] + 2.5f, m_afAmbushA[1] - 2.5f, m_afAmbushA[2], 0.0f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25s);
@@ -250,6 +251,8 @@ enum KurenaiCaptive
     NPC_KUR_MURK_BRUTE              = 18211,
     NPC_KUR_MURK_SCAVENGER          = 18207,
     NPC_KUR_MURK_PUTRIFIER          = 18202,
+
+    PATH_ESCORT_KURENAI_CAPTIVE     = 145674,
 };
 
 static float kurenaiAmbushA[]= {-1568.805786f, 8533.873047f, 1.958f};
@@ -322,8 +325,6 @@ public:
 
                     if (Player* player = GetPlayerForEscort())
                         player->GroupEventHappens(QUEST_TOTEM_KARDASH_A, me);
-
-                    SetRun();
                     break;
                 }
             }
@@ -402,7 +403,8 @@ public:
             {
                 me->SetStandState(UNIT_STAND_STATE_STAND);
                 me->SetFaction(FACTION_ESCORTEE_A_NEUTRAL_ACTIVE);
-                Start(true, false, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_KURENAI_CAPTIVE);
+                Start(true, player->GetGUID(), quest);
                 Talk(SAY_KUR_START);
 
                 me->SummonCreature(NPC_KUR_MURK_RAIDER, kurenaiAmbushA[0] + 2.5f, kurenaiAmbushA[1] - 2.5f, kurenaiAmbushA[2], 0.0f, TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT, 25s);

--- a/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
+++ b/src/server/scripts/Outland/zone_shadowmoon_valley.cpp
@@ -491,7 +491,9 @@ enum Earthmender
     SPELL_HEALING_WAVE          = 12491,
 
     QUEST_ESCAPE_COILSCAR       = 10451,
-    NPC_COILSKAR_ASSASSIN       = 21044
+    NPC_COILSKAR_ASSASSIN       = 21044,
+
+    PATH_ESCORT_WILDA           = 168218,
 };
 
 class npc_earthmender_wilda : public CreatureScript
@@ -636,7 +638,8 @@ public:
                 Talk(SAY_WIL_START, player);
                 me->SetFaction(FACTION_EARTHEN_RING);
 
-                Start(false, false, player->GetGUID(), quest);
+                LoadPath(PATH_ESCORT_WILDA);
+                Start(false, player->GetGUID(), quest);
             }
         }
     };


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Port to 3.3.5: [Core/AI: Drop script_waypoints and move data to waypoint_data (https://github.com/TrinityCore/TrinityCore/pull/28879)

**Tests performed:**

Build, & Tested IG by checking all impacted scripts


**Note:**

- Core changes cherry-pick without any conflicts or changes
- Few scripts conflcits resolve in separate commits: dd348e244e3711e198d918ac33958622832f3633 and 27e437b59012fe16c0b38ffc7387462c75f821c3

I hope to didn't miss anything. Normally this PR is a bit less risky because changes in escort return a compilation error on all untreated paths.

**Todo:**
- need to investigate the use of IDs: 28912 and 26499

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
