### PR TITLE
[WIP] Spells/Priest: Implement Idol of C'Thun

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world_idol_of_cthun.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_idol_of_cthun.sql
@@ -1,0 +1,10 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_pri_idol_of_cthun');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(377349, 'spell_pri_idol_of_cthun');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (377349);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(377349,0x00,6,0x00000000,0x00080000,0x00000040,0x00000000,0x0,0x0,0x0,0x2,0x0,0x0,0x0,0,0,0,0); -- Idol of C'Thun
+
+UPDATE `creature_template` SET `ScriptName` = 'npc_pet_pri_void_tendril' WHERE `entry` = 192337;
+UPDATE `creature_template` SET `ScriptName` = 'npc_pet_pri_void_lasher' WHERE `entry` = 198757;

--- a/sql/updates/world/master/9999_99_99_99_world_idol_of_cthun.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_idol_of_cthun.sql
@@ -1,10 +1,14 @@
-DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_pri_idol_of_cthun');
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_pri_idol_of_cthun', 'spell_pri_idol_of_cthun_trigger', 'spell_pri_idol_of_cthun_periodic_aura');
 INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
-(377349, 'spell_pri_idol_of_cthun');
+(377349, 'spell_pri_idol_of_cthun'),
+(263165, 'spell_pri_idol_of_cthun_trigger'),
+(1240401, 'spell_pri_idol_of_cthun_trigger'),
+(466316, 'spell_pri_idol_of_cthun_periodic_aura'),
+(466317, 'spell_pri_idol_of_cthun_periodic_aura');
 
 DELETE FROM `spell_proc` WHERE `SpellId` IN (377349);
 INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
-(377349,0x00,6,0x00000000,0x00080000,0x00000040,0x00000000,0x0,0x0,0x0,0x2,0x0,0x0,0x0,0,0,0,0); -- Idol of C'Thun
+(377349,0x00,6,0x00000000,0x00000000,0x00000040,0x00000000,0x0,0x0,0x0,0x2,0x0,0x0,0x0,0,0,0,0); -- Idol of C'Thun
 
 UPDATE `creature_template` SET `ScriptName` = 'npc_pet_pri_void_tendril' WHERE `entry` = 192337;
 UPDATE `creature_template` SET `ScriptName` = 'npc_pet_pri_void_lasher' WHERE `entry` = 198757;

--- a/src/server/scripts/Pet/pet_priest.cpp
+++ b/src/server/scripts/Pet/pet_priest.cpp
@@ -32,7 +32,9 @@ enum PriestSpells
     SPELL_PRIEST_ATONEMENT_PASSIVE          = 195178,
     SPELL_PRIEST_DIVINE_IMAGE_SPELL_CHECK   = 405216,
     SPELL_PRIEST_INVOKE_THE_NAARU           = 196687,
-    SPELL_PRIEST_LIGHTWELL_CHARGES          = 59907
+    SPELL_PRIEST_LIGHTWELL_CHARGES          = 59907,
+    SPELL_PRIEST_MIND_FLAY_PERMANENT        = 466316,
+    SPELL_PRIEST_MIND_SEAR_PERMANENT        = 466317
 };
 
 // 198236 - Divine Image
@@ -91,9 +93,43 @@ struct npc_pet_pri_shadowfiend_mindbender : public PetAI
     }
 };
 
+// 192337 - Void Tendril
+struct npc_pet_pri_void_tendril : public PassiveAI
+{
+    npc_pet_pri_void_tendril(Creature* creature) : PassiveAI(creature) {}
+
+    void IsSummonedBy(WorldObject* summonerWO) override
+    {
+        Unit* summoner = summonerWO->ToUnit();
+        if (!summoner)
+            return;
+
+        me->SetControlled(true, UNIT_STATE_ROOT);
+        DoCastSelf(SPELL_PRIEST_MIND_FLAY_PERMANENT, TRIGGERED_FULL_MASK);
+    }
+};
+
+// 198757 - Void Lasher
+struct npc_pet_pri_void_lasher : public PassiveAI
+{
+    npc_pet_pri_void_lasher(Creature* creature) : PassiveAI(creature) {}
+
+    void IsSummonedBy(WorldObject* summonerWO) override
+    {
+        Unit* summoner = summonerWO->ToUnit();
+        if (!summoner)
+            return;
+
+        me->SetControlled(true, UNIT_STATE_ROOT);
+        DoCastSelf(SPELL_PRIEST_MIND_SEAR_PERMANENT, TRIGGERED_FULL_MASK);
+    }
+};
+
 void AddSC_priest_pet_scripts()
 {
     RegisterCreatureAI(npc_pet_pri_divine_image);
     RegisterCreatureAI(npc_pet_pri_lightwell);
     RegisterCreatureAI(npc_pet_pri_shadowfiend_mindbender);
+    RegisterCreatureAI(npc_pet_pri_void_tendril);
+    RegisterCreatureAI(npc_pet_pri_void_lasher);
 }

--- a/src/server/scripts/Pet/pet_priest.cpp
+++ b/src/server/scripts/Pet/pet_priest.cpp
@@ -105,6 +105,11 @@ struct npc_pet_pri_void_tendril : public PassiveAI
             return;
 
         me->SetControlled(true, UNIT_STATE_ROOT);
+        me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+
+        if (me->ToTempSummon()->IsGuardian())
+            static_cast<Guardian*>(me)->SetBonusDamage(summoner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_SHADOW));
+
         DoCastSelf(SPELL_PRIEST_MIND_FLAY_PERIODIC, TRIGGERED_FULL_MASK);
     }
 };
@@ -121,6 +126,11 @@ struct npc_pet_pri_void_lasher : public PassiveAI
             return;
 
         me->SetControlled(true, UNIT_STATE_ROOT);
+        me->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+
+        if (me->ToTempSummon()->IsGuardian())
+            static_cast<Guardian*>(me)->SetBonusDamage(summoner->SpellBaseDamageBonusDone(SPELL_SCHOOL_MASK_SHADOW));
+
         DoCastSelf(SPELL_PRIEST_MIND_SEAR_PERIODIC, TRIGGERED_FULL_MASK);
     }
 };

--- a/src/server/scripts/Pet/pet_priest.cpp
+++ b/src/server/scripts/Pet/pet_priest.cpp
@@ -33,8 +33,8 @@ enum PriestSpells
     SPELL_PRIEST_DIVINE_IMAGE_SPELL_CHECK   = 405216,
     SPELL_PRIEST_INVOKE_THE_NAARU           = 196687,
     SPELL_PRIEST_LIGHTWELL_CHARGES          = 59907,
-    SPELL_PRIEST_MIND_FLAY_PERMANENT        = 466316,
-    SPELL_PRIEST_MIND_SEAR_PERMANENT        = 466317
+    SPELL_PRIEST_MIND_FLAY_PERIODIC         = 466316,
+    SPELL_PRIEST_MIND_SEAR_PERIODIC         = 466317
 };
 
 // 198236 - Divine Image
@@ -105,7 +105,7 @@ struct npc_pet_pri_void_tendril : public PassiveAI
             return;
 
         me->SetControlled(true, UNIT_STATE_ROOT);
-        DoCastSelf(SPELL_PRIEST_MIND_FLAY_PERMANENT, TRIGGERED_FULL_MASK);
+        DoCastSelf(SPELL_PRIEST_MIND_FLAY_PERIODIC, TRIGGERED_FULL_MASK);
     }
 };
 
@@ -121,7 +121,7 @@ struct npc_pet_pri_void_lasher : public PassiveAI
             return;
 
         me->SetControlled(true, UNIT_STATE_ROOT);
-        DoCastSelf(SPELL_PRIEST_MIND_SEAR_PERMANENT, TRIGGERED_FULL_MASK);
+        DoCastSelf(SPELL_PRIEST_MIND_SEAR_PERIODIC, TRIGGERED_FULL_MASK);
     }
 };
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implement [Idol of C'Thun](https://www.wowhead.com/spell=377349/idol-of-cthun) talent.

**Issues addressed:**
None.

Closes #  nothing yet

**Tests performed:**
Builds and tested in-game.


**Known issues and TODO list:**
- [ ] Mind Flay casted by the summoned creature fails to hit the target (SPELL_FAILED_LINE_OF_SIGHT).


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
