### PR TITLE
Spells/Warrior: Implement Blademaster's Torment

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world_blademasters_torment.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_blademasters_torment.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_warr_bladesmasters_torment';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(390138,'spell_warr_bladesmasters_torment');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (390138);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(390138,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0,0,0,0); -- Blademaster's Torment

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -270,14 +270,14 @@ class spell_warr_bladesmasters_torment : public AuraScript
 
     void HandleProc(ProcEventInfo& /*eventInfo*/)
     {
-        Unit* caster = GetCaster();
+        Unit* target = GetTarget();
 
         // Get BasePoints and set as duration for Sweeping Strikes
-        int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(caster);
+        int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(target);
 
         CastSpellExtraArgs args(TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);
-        args.SpellValueOverrides.emplace_back(SPELLVALUE_DURATION, durationMs);
-        caster->CastSpell(caster, SPELL_WARRIOR_SWEEPING_STRIKES, args);
+        args.AddSpellMod(SPELLVALUE_DURATION, durationMs);
+        target->CastSpell(target, SPELL_WARRIOR_SWEEPING_STRIKES, args);
     }
 
     void Register() override

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -271,8 +271,6 @@ class spell_warr_bladesmasters_torment : public AuraScript
     void HandleProc(ProcEventInfo& /*eventInfo*/)
     {
         Unit* target = GetTarget();
-
-        // Get BasePoints and set as duration for Sweeping Strikes
         int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(target);
 
         CastSpellExtraArgs args(TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -97,6 +97,7 @@ enum WarriorSpells
     SPELL_WARRIOR_STRATEGIST                        = 384041,
     SPELL_WARRIOR_SUDDEN_DEATH                      = 280721,
     SPELL_WARRIOR_SUDDEN_DEATH_BUFF                 = 280776,
+    SPELL_WARRIOR_SWEEPING_STRIKES                  = 260708,
     SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1   = 12723,
     SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_2   = 26654,
     SPELL_WARRIOR_TAUNT                             = 355,
@@ -255,6 +256,33 @@ class spell_warr_avatar : public SpellScript
     void Register() override
     {
         OnEffectHitTarget += SpellEffectFn(spell_warr_avatar::HandleRemoveImpairingAuras, EFFECT_5, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
+// 107574 - Avatar
+// 390138 - Blademaster's Torment
+class spell_warr_bladesmasters_torment : public AuraScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARRIOR_SWEEPING_STRIKES });
+    }
+
+    void HandleProc(ProcEventInfo& /*eventInfo*/)
+    {
+        Unit* caster = GetCaster();
+
+        // Get BasePoints and set as duration for Sweeping Strikes
+        int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(caster);
+
+        CastSpellExtraArgs args(TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);
+        args.SpellValueOverrides.emplace_back(SPELLVALUE_DURATION, durationMs);
+        caster->CastSpell(caster, SPELL_WARRIOR_SWEEPING_STRIKES, args);
+    }
+
+    void Register() override
+    {
+        OnProc += AuraProcFn(spell_warr_bladesmasters_torment::HandleProc);
     }
 };
 
@@ -1677,4 +1705,5 @@ void AddSC_warrior_spell_scripts()
     RegisterSpellScript(spell_warr_vicious_contempt);
     RegisterSpellScript(spell_warr_victorious_state);
     RegisterSpellScript(spell_warr_victory_rush);
+    RegisterSpellScript(spell_warr_bladesmasters_torment);
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixes the proc for Sweeping Strikes being applied to caster if Avatar is cast when Blademaster's Torment is talented
-  Implements the Sweeping Strikes aura with 8 seconds being applied when Avatar is cast

**Tests performed:**
Builds, Sweeping Strikes is applied when Avatar is cast

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
