### PR TITLE
Spells/Warrior: Implement Warlord's Torment

### DIFF
--- a/sql/updates/world/master/9999_99_99_99_world_warlords_torment.sql
+++ b/sql/updates/world/master/9999_99_99_99_world_warlords_torment.sql
@@ -1,0 +1,7 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`='spell_warr_warlords_torment';
+INSERT INTO `spell_script_names` (`spell_id`,`ScriptName`) VALUES
+(390140,'spell_warr_warlords_torment');
+
+DELETE FROM `spell_proc` WHERE `SpellId` IN (390140);
+INSERT INTO `spell_proc` (`SpellId`,`SchoolMask`,`SpellFamilyName`,`SpellFamilyMask0`,`SpellFamilyMask1`,`SpellFamilyMask2`,`SpellFamilyMask3`,`ProcFlags`,`ProcFlags2`,`SpellTypeMask`,`SpellPhaseMask`,`HitMask`,`AttributesMask`,`DisableEffectsMask`,`ProcsPerMinute`,`Chance`,`Cooldown`,`Charges`) VALUES
+(390140,0x00,4,0x00000000,0x00000000,0x00000000,0x00000000,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0,0,0,0); -- Warlord's Torment

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -258,6 +258,31 @@ class spell_warr_avatar : public SpellScript
     }
 };
 
+// 107574 - Avatar
+// 390140 - Warlord's Torment
+class spell_warr_warlords_torment : public AuraScript
+{
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_WARRIOR_RECKLESSNESS });
+    }
+
+    void HandleProc(ProcEventInfo& /*eventInfo*/)
+    {
+        Unit* caster = GetCaster();
+        int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(caster);
+
+        CastSpellExtraArgs args(TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);
+        args.SpellValueOverrides.emplace_back(SPELLVALUE_DURATION, durationMs);
+        caster->CastSpell(caster, SPELL_WARRIOR_RECKLESSNESS, args);
+    }
+
+    void Register() override
+    {
+        OnProc += AuraProcFn(spell_warr_warlords_torment::HandleProc);
+    }
+};
+
 // 23881 - Bloodthirst
 // 335096 - Bloodbath
 class spell_warr_bloodthirst : public SpellScript
@@ -1677,4 +1702,5 @@ void AddSC_warrior_spell_scripts()
     RegisterSpellScript(spell_warr_vicious_contempt);
     RegisterSpellScript(spell_warr_victorious_state);
     RegisterSpellScript(spell_warr_victory_rush);
+    RegisterSpellScript(spell_warr_warlords_torment);
 }

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -269,12 +269,12 @@ class spell_warr_warlords_torment : public AuraScript
 
     void HandleProc(ProcEventInfo& /*eventInfo*/)
     {
-        Unit* caster = GetCaster();
-        int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(caster);
+        Unit* target = GetTarget();
+        int32 durationMs = GetEffectInfo(EFFECT_0).CalcValue(target);
 
         CastSpellExtraArgs args(TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_DONT_REPORT_CAST_ERROR);
-        args.SpellValueOverrides.emplace_back(SPELLVALUE_DURATION, durationMs);
-        caster->CastSpell(caster, SPELL_WARRIOR_RECKLESSNESS, args);
+        args.AddSpellMod(SPELLVALUE_DURATION, durationMs);
+        target->CastSpell(target, SPELL_WARRIOR_RECKLESSNESS, args);
     }
 
     void Register() override


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fixes the proc for Recklessness being applied to caster if Avatar is cast when Warlords's Torment is talented
-  Implements the Recklessness aura with 6 seconds being applied when Avatar is cast

**Tests performed:**
Builds, Recklessness  is applied when Avatar is cast

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
