### PR TITLE
wip: Update db2 defs to match 11.2.7.64797

### DIFF
--- a/src/server/game/DataStores/DB2LoadInfo.h
+++ b/src/server/game/DataStores/DB2LoadInfo.h
@@ -2463,7 +2463,7 @@ struct GlyphRequiredSpecLoadInfo
 
 struct GossipNpcOptionLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[17] =
+    static constexpr DB2FieldMeta Fields[18] =
     {
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "GossipNpcOption" },
@@ -2482,9 +2482,10 @@ struct GossipNpcOptionLoadInfo
         { .IsSigned = true, .Type = FT_INT, .Name = "ProfessionID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "Unknown_1002_14" },
         { .IsSigned = true, .Type = FT_INT, .Name = "SkillLineID" },
+        { .IsSigned = true, .Type = FT_INT, .Name = "NeighborhoodMapID" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 17, &GossipNPCOptionMeta::Instance, HOTFIX_SEL_GOSSIP_NPC_OPTION };
+    static constexpr DB2LoadInfo Instance{ Fields, 18, &GossipNPCOptionMeta::Instance, HOTFIX_SEL_GOSSIP_NPC_OPTION };
 };
 
 struct GuildColorBackgroundLoadInfo
@@ -2681,7 +2682,7 @@ struct ImportPriceWeaponLoadInfo
 
 struct ItemLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[12] =
+    static constexpr DB2FieldMeta Fields[13] =
     {
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "ClassID" },
@@ -2695,9 +2696,10 @@ struct ItemLoadInfo
         { .IsSigned = true, .Type = FT_INT, .Name = "ContentTuningID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "ModifiedCraftingReagentItemID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "CraftingQualityID" },
+        { .IsSigned = true, .Type = FT_INT, .Name = "Unknown1127" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 12, &ItemMeta::Instance, HOTFIX_SEL_ITEM };
+    static constexpr DB2LoadInfo Instance{ Fields, 13, &ItemMeta::Instance, HOTFIX_SEL_ITEM };
 };
 
 struct ItemAppearanceLoadInfo
@@ -3031,7 +3033,7 @@ struct ItemDisenchantLootLoadInfo
 
 struct ItemEffectLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[9] =
+    static constexpr DB2FieldMeta Fields[10] =
     {
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = false, .Type = FT_BYTE, .Name = "LegacySlotIndex" },
@@ -3042,9 +3044,10 @@ struct ItemEffectLoadInfo
         { .IsSigned = false, .Type = FT_SHORT, .Name = "SpellCategoryID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "SpellID" },
         { .IsSigned = false, .Type = FT_SHORT, .Name = "ChrSpecializationID" },
+        {.IsSigned = true, .Type = FT_INT, .Name = "PlayerConditionID" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 9, &ItemEffectMeta::Instance, HOTFIX_SEL_ITEM_EFFECT };
+    static constexpr DB2LoadInfo Instance{ Fields, 10, &ItemEffectMeta::Instance, HOTFIX_SEL_ITEM_EFFECT };
 };
 
 struct ItemExtendedCostLoadInfo
@@ -3217,16 +3220,17 @@ struct ItemPriceBaseLoadInfo
 
 struct ItemScalingConfigLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[5] =
+    static constexpr DB2FieldMeta Fields[6] =
     {
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "ItemOffsetCurveID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "ItemLevel" },
         { .IsSigned = true, .Type = FT_INT, .Name = "RequiredLevel" },
+        { .IsSigned = true, .Type = FT_INT, .Name = "Unknown1200" },
         { .IsSigned = true, .Type = FT_INT, .Name = "Unknown1125" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 5, &ItemScalingConfigMeta::Instance, HOTFIX_SEL_ITEM_SCALING_CONFIG };
+    static constexpr DB2LoadInfo Instance{ Fields, 6, &ItemScalingConfigMeta::Instance, HOTFIX_SEL_ITEM_SCALING_CONFIG };
 };
 
 struct ItemSearchNameLoadInfo
@@ -3304,7 +3308,7 @@ struct ItemSetSpellLoadInfo
 
 struct ItemSparseLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[101] =
+    static constexpr DB2FieldMeta Fields[102] =
     {
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = true, .Type = FT_LONG, .Name = "AllowableRace" },
@@ -3372,6 +3376,7 @@ struct ItemSparseLoadInfo
         { .IsSigned = true, .Type = FT_INT, .Name = "PlayerLevelToItemLevelCurveID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "ItemLevelOffsetCurveID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "ItemLevelOffsetItemLevel" },
+        { .IsSigned = true, .Type = FT_INT, .Name = "Unknown1200" },
         { .IsSigned = false, .Type = FT_SHORT, .Name = "ItemNameDescriptionID" },
         { .IsSigned = false, .Type = FT_SHORT, .Name = "RequiredTransmogHoliday" },
         { .IsSigned = false, .Type = FT_SHORT, .Name = "RequiredHoliday" },
@@ -3409,7 +3414,7 @@ struct ItemSparseLoadInfo
         { .IsSigned = true, .Type = FT_BYTE, .Name = "OverallQualityID" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 101, &ItemSparseMeta::Instance, HOTFIX_SEL_ITEM_SPARSE };
+    static constexpr DB2LoadInfo Instance{ Fields, 102, &ItemSparseMeta::Instance, HOTFIX_SEL_ITEM_SPARSE };
 };
 
 struct ItemSpecLoadInfo
@@ -3869,17 +3874,20 @@ struct MapLoadInfo
 
 struct MapChallengeModeLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[21] =
+    static constexpr DB2FieldMeta Fields[24] =
     {
         { .IsSigned = false, .Type = FT_STRING, .Name = "Name" },
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = false, .Type = FT_SHORT, .Name = "MapID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "Flags" },
+        { .IsSigned = true, .Type = FT_INT, .Name = "Unknown1200" },
         { .IsSigned = false, .Type = FT_INT, .Name = "ExpansionLevel" },
         { .IsSigned = true, .Type = FT_INT, .Name = "RequiredWorldStateID" },
         { .IsSigned = true, .Type = FT_SHORT, .Name = "CriteriaCount1" },
         { .IsSigned = true, .Type = FT_SHORT, .Name = "CriteriaCount2" },
         { .IsSigned = true, .Type = FT_SHORT, .Name = "CriteriaCount3" },
+        { .IsSigned = true, .Type = FT_SHORT, .Name = "CriteriaCount4" },
+        { .IsSigned = true, .Type = FT_SHORT, .Name = "CriteriaCount5" },
         { .IsSigned = true, .Type = FT_INT, .Name = "FirstRewardQuestID1" },
         { .IsSigned = true, .Type = FT_INT, .Name = "FirstRewardQuestID2" },
         { .IsSigned = true, .Type = FT_INT, .Name = "FirstRewardQuestID3" },
@@ -3894,7 +3902,7 @@ struct MapChallengeModeLoadInfo
         { .IsSigned = true, .Type = FT_INT, .Name = "RewardQuestID6" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 21, &MapChallengeModeMeta::Instance, HOTFIX_SEL_MAP_CHALLENGE_MODE };
+    static constexpr DB2LoadInfo Instance{ Fields, 24, &MapChallengeModeMeta::Instance, HOTFIX_SEL_MAP_CHALLENGE_MODE };
 };
 
 struct MapDifficultyLoadInfo
@@ -5803,7 +5811,7 @@ struct SpellTotemsLoadInfo
 
 struct SpellVisualLoadInfo
 {
-    static constexpr DB2FieldMeta Fields[21] =
+    static constexpr DB2FieldMeta Fields[22] =
     {
         { .IsSigned = false, .Type = FT_INT, .Name = "ID" },
         { .IsSigned = false, .Type = FT_FLOAT, .Name = "MissileCastOffset1" },
@@ -5812,6 +5820,7 @@ struct SpellVisualLoadInfo
         { .IsSigned = false, .Type = FT_FLOAT, .Name = "MissileImpactOffset1" },
         { .IsSigned = false, .Type = FT_FLOAT, .Name = "MissileImpactOffset2" },
         { .IsSigned = false, .Type = FT_FLOAT, .Name = "MissileImpactOffset3" },
+        { .IsSigned = true, .Type = FT_INT, .Name = "Unknown1200" },
         { .IsSigned = false, .Type = FT_INT, .Name = "AnimEventSoundID" },
         { .IsSigned = true, .Type = FT_INT, .Name = "Flags" },
         { .IsSigned = true, .Type = FT_BYTE, .Name = "MissileAttachment" },
@@ -5828,7 +5837,7 @@ struct SpellVisualLoadInfo
         { .IsSigned = true, .Type = FT_INT, .Name = "ReducedUnexpectedCameraMovementSpellVisualID" },
     };
 
-    static constexpr DB2LoadInfo Instance{ Fields, 21, &SpellVisualMeta::Instance, HOTFIX_SEL_SPELL_VISUAL };
+    static constexpr DB2LoadInfo Instance{ Fields, 22, &SpellVisualMeta::Instance, HOTFIX_SEL_SPELL_VISUAL };
 };
 
 struct SpellVisualEffectNameLoadInfo

--- a/src/server/game/DataStores/DB2Metadata.h
+++ b/src/server/game/DataStores/DB2Metadata.h
@@ -4882,7 +4882,7 @@ struct ConditionalContentTuningMeta
         .ParentIndexField   = 3,
         .FieldCount         = 4,
         .FileFieldCount     = 3,
-        .LayoutHash         = 0x15616FBC,
+        .LayoutHash         = 0xB4A236C9,
         .Fields             = Fields
     };
 };
@@ -9456,12 +9456,13 @@ struct GlyphRequiredSpecMeta
 
 struct GossipNPCOptionMeta
 {
-    static constexpr DB2MetaField Fields[16] =
+    static constexpr DB2MetaField Fields[17] =
     {
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_BYTE,                 .ArraySize =  1, .IsSigned =  true },
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
@@ -9481,9 +9482,9 @@ struct GossipNPCOptionMeta
         .FileDataId         = 4278503,
         .IndexField         = -1,
         .ParentIndexField   = -1,
-        .FieldCount         = 16,
-        .FileFieldCount     = 16,
-        .LayoutHash         = 0x29CC1EF1,
+        .FieldCount         = 17,
+        .FileFieldCount     = 17,
+        .LayoutHash         = 0x5679719D,
         .Fields             = Fields
     };
 };
@@ -10330,7 +10331,7 @@ struct InvasionClientDataMeta
 
 struct ItemMeta
 {
-    static constexpr DB2MetaField Fields[11] =
+    static constexpr DB2MetaField Fields[12] =
     {
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_BYTE,                 .ArraySize =  1, .IsSigned = false },
@@ -10343,6 +10344,7 @@ struct ItemMeta
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
     };
 
     static constexpr DB2Meta Instance =
@@ -10350,9 +10352,9 @@ struct ItemMeta
         .FileDataId         = 841626,
         .IndexField         = -1,
         .ParentIndexField   = -1,
-        .FieldCount         = 11,
-        .FileFieldCount     = 11,
-        .LayoutHash         = 0xE39A209A,
+        .FieldCount         = 12,
+        .FileFieldCount     = 12,
+        .LayoutHash         = 0x6D1DD0CE,
         .Fields             = Fields
     };
 };
@@ -11184,7 +11186,7 @@ struct ItemDisplayInfoModelMatResMeta
 
 struct ItemEffectMeta
 {
-    static constexpr DB2MetaField Fields[8] =
+    static constexpr DB2MetaField Fields[9] =
     {
         { .Type = FT_BYTE,                 .ArraySize =  1, .IsSigned = false },
         { .Type = FT_BYTE,                 .ArraySize =  1, .IsSigned =  true },
@@ -11194,6 +11196,7 @@ struct ItemEffectMeta
         { .Type = FT_SHORT,                .ArraySize =  1, .IsSigned = false },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_SHORT,                .ArraySize =  1, .IsSigned = false },
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
     };
 
     static constexpr DB2Meta Instance =
@@ -11201,9 +11204,9 @@ struct ItemEffectMeta
         .FileDataId         = 969941,
         .IndexField         = -1,
         .ParentIndexField   = -1,
-        .FieldCount         = 8,
-        .FileFieldCount     = 8,
-        .LayoutHash         = 0x2CEB026E,
+        .FieldCount         = 9,
+        .FileFieldCount     = 9,
+        .LayoutHash         = 0xDA85CB08,
         .Fields             = Fields
     };
 };
@@ -11746,8 +11749,9 @@ struct ItemSalvageLootMeta
 
 struct ItemScalingConfigMeta
 {
-    static constexpr DB2MetaField Fields[4] =
+    static constexpr DB2MetaField Fields[5] =
     {
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
@@ -11759,9 +11763,9 @@ struct ItemScalingConfigMeta
         .FileDataId         = 7322705,
         .IndexField         = -1,
         .ParentIndexField   = -1,
-        .FieldCount         = 4,
-        .FileFieldCount     = 4,
-        .LayoutHash         = 0x2A1E702E,
+        .FieldCount         = 5,
+        .FileFieldCount     = 5,
+        .LayoutHash         = 0x7BEABE68,
         .Fields             = Fields
     };
 };
@@ -11845,7 +11849,7 @@ struct ItemSetSpellMeta
 
 struct ItemSparseMeta
 {
-    static constexpr DB2MetaField Fields[66] =
+    static constexpr DB2MetaField Fields[67] =
     {
         { .Type = FT_LONG,                 .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_STRING,               .ArraySize =  1, .IsSigned =  true },
@@ -11875,6 +11879,7 @@ struct ItemSparseMeta
         { .Type = FT_FLOAT,                .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_FLOAT,                .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  5, .IsSigned =  true },
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
@@ -11920,9 +11925,9 @@ struct ItemSparseMeta
         .FileDataId         = 1572924,
         .IndexField         = -1,
         .ParentIndexField   = -1,
-        .FieldCount         = 66,
-        .FileFieldCount     = 66,
-        .LayoutHash         = 0x2928311F,
+        .FieldCount         = 67,
+        .FileFieldCount     = 67,
+        .LayoutHash         = 0xABF517CD,
         .Fields             = Fields
     };
 };
@@ -13540,15 +13545,16 @@ struct MapCelestialBodyMeta
 
 struct MapChallengeModeMeta
 {
-    static constexpr DB2MetaField Fields[9] =
+    static constexpr DB2MetaField Fields[10] =
     {
         { .Type = FT_STRING,               .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned = false },
         { .Type = FT_SHORT,                .ArraySize =  1, .IsSigned = false },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned = false },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
-        { .Type = FT_SHORT,                .ArraySize =  3, .IsSigned =  true },
+        { .Type = FT_SHORT,                .ArraySize =  5, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  6, .IsSigned =  true },
         { .Type = FT_INT,                  .ArraySize =  6, .IsSigned =  true },
     };
@@ -13558,9 +13564,9 @@ struct MapChallengeModeMeta
         .FileDataId         = 801709,
         .IndexField         = 1,
         .ParentIndexField   = 2,
-        .FieldCount         = 9,
-        .FileFieldCount     = 9,
-        .LayoutHash         = 0x531A0D41,
+        .FieldCount         = 10,
+        .FileFieldCount     = 10,
+        .LayoutHash         = 0xAAC13A73,
         .Fields             = Fields
     };
 };
@@ -20572,10 +20578,11 @@ struct SpellTotemsMeta
 
 struct SpellVisualMeta
 {
-    static constexpr DB2MetaField Fields[16] =
+    static constexpr DB2MetaField Fields[17] =
     {
         { .Type = FT_FLOAT,                .ArraySize =  3, .IsSigned =  true },
         { .Type = FT_FLOAT,                .ArraySize =  3, .IsSigned =  true },
+        { .Type = FT_INT,                  .ArraySize =  1, .IsSigned = true },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned = false },
         { .Type = FT_INT,                  .ArraySize =  1, .IsSigned =  true },
         { .Type = FT_BYTE,                 .ArraySize =  1, .IsSigned =  true },
@@ -20597,9 +20604,9 @@ struct SpellVisualMeta
         .FileDataId         = 897952,
         .IndexField         = -1,
         .ParentIndexField   = -1,
-        .FieldCount         = 16,
-        .FileFieldCount     = 16,
-        .LayoutHash         = 0xFB411669,
+        .FieldCount         = 17,
+        .FileFieldCount     = 17,
+        .LayoutHash         = 0xE2F62C2F,
         .Fields             = Fields
     };
 };

--- a/src/server/game/DataStores/DB2Structure.h
+++ b/src/server/game/DataStores/DB2Structure.h
@@ -2086,6 +2086,7 @@ struct GossipNPCOptionEntry
     int32 ProfessionID;
     int32 Unknown_1002_14;
     int32 SkillLineID;
+    int32 NeighborhoodMapID;
 };
 
 struct GuildColorBackgroundEntry
@@ -2193,6 +2194,7 @@ struct ItemEntry
     int32 ContentTuningID;
     int32 ModifiedCraftingReagentItemID;
     int32 CraftingQualityID;
+    int32 Unknown1127;
 };
 
 struct ItemAppearanceEntry
@@ -2393,6 +2395,7 @@ struct ItemEffectEntry
     uint16 SpellCategoryID;
     int32 SpellID;
     uint16 ChrSpecializationID;
+    int32 PlayerConditionID;
 };
 
 #define MAX_ITEM_EXT_COST_ITEMS         5
@@ -2501,6 +2504,7 @@ struct ItemScalingConfigEntry
     int32 ItemOffsetCurveID;
     int32 ItemLevel;
     int32 RequiredLevel;
+    int32 Unknown1200;
     int32 Unknown1125;
 };
 
@@ -2581,6 +2585,7 @@ struct ItemSparseEntry
     int32 PlayerLevelToItemLevelCurveID;
     int32 ItemLevelOffsetCurveID;
     int32 ItemLevelOffsetItemLevel;
+    int32 Unknown1200; // added in 11.2.7.64797 ??
     uint16 ItemNameDescriptionID;
     uint16 RequiredTransmogHoliday;
     uint16 RequiredHoliday;
@@ -2938,9 +2943,10 @@ struct MapChallengeModeEntry
     uint32 ID;
     uint16 MapID;
     int32 Flags;
+    int32 Unknown1200;
     uint32 ExpansionLevel;
     int32 RequiredWorldStateID; // maybe?
-    std::array<int16, 3> CriteriaCount;
+    std::array<int16, 5> CriteriaCount;
     std::array<int32, 6> FirstRewardQuestID;
     std::array<int32, 6> RewardQuestID;
 };
@@ -4164,6 +4170,7 @@ struct SpellVisualEntry
     uint32 ID;
     std::array<float, 3> MissileCastOffset;
     std::array<float, 3> MissileImpactOffset;
+    int32 Unknown1200;
     uint32 AnimEventSoundID;
     int32 Flags;
     int8 MissileAttachment;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Update DB2 struct definitions to match 11.2.7.64797 build

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Critical Item Ids ( ITEM_ACCOUNT_BANK_TAB_BAG and ITEM_CHARACTER_BANK_TAB_BAG) are still missing from the ItemSparseStore
