### PR TITLE
fix(DB/Conditions): Malister's Frost Wand should require Proto-Drake

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_01_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_01_world.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 40969) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 23689) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(17, 0, 40969, 0, 0, 31, 1, 3, 23689, 0, 0, 0, 0, '', 'Malister Frost Wand require Proto-Drake');

--- a/sql/updates/world/3.3.5/2025_12_15_01_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_01_world.sql
@@ -1,4 +1,4 @@
 --
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 17) AND (`SourceGroup` = 0) AND (`SourceEntry` = 40969) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 23689) AND (`ConditionValue3` = 0);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(17, 0, 40969, 0, 0, 31, 1, 3, 23689, 0, 0, 0, 0, '', 'Malister Frost Wand require Proto-Drake');
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=17 AND `SourceEntry`=40969;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `Comment`) VALUES 
+(17, 0, 40969, 0, 0, 31, 1, 3, 23689, 0, 0, "Malister's Frost Wand only hits Proto-Drake");


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/23569 by @Nyeriah 
In addition to the above: https://github.com/TrinityCore/TrinityCore/issues/31506 by @CraftedRO 

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/fce52746767c8530c671d225aaaeb3634d448e94 before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author and Crafted's changes.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.