### PR TITLE
fix(DB/npc_vendor) Adjusted Wood frog box restock value from 2.5 hours to 30 mins

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_02_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_02_world.sql
@@ -1,0 +1,2 @@
+-- Changed restock value from 2.5 hours (9000) to 30 mins (1800)
+UPDATE `npc_vendor` SET `incrtime` = 1800 WHERE `entry` = 14860 AND `item` = 11027;


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/22936 by @chauusie
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31561 

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/2618f64dd8a32c3046973741ae97099ceec8cef2 before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.