### PR TITLE
fix(DB/SAI): Remove Lash of Pain from Succubus Minion.

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_03_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_03_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 10928 AND `source_type` = 0;
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 10928;


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/22890 by @heyitsbench
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31522

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/e757e8979d618d3672fcdcdd00411a1f632c6298 before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.