### PR TITLE
fix(DB/Quests): Fix Sleep Giants quest requirements 

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_04_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_04_world.sql
@@ -1,0 +1,2 @@
+-- PrevQuestID 11239 to 11231, make Of Keys and Cages the prerequisite, not In Service to the Light
+UPDATE `quest_template_addon` SET `PrevQuestID` = 11231 WHERE (`ID` = 11432);


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/24070 by @rorshan
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31562

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/b3b09068e53c9ed4a9c904befd378ee16be1bae3 before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.