### PR TITLE
fix(DB/Creature) Remove immunity to Disarm from Gal'darah.

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_05_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_05_world.sql
@@ -1,0 +1,2 @@
+-- Remove Disarm Immunity
+UPDATE `creature_template` SET `mechanic_immune_mask` = `mechanic_immune_mask` &~ 4 WHERE (`entry` IN (31368, 29306));


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/24070 by @Rorschach91
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31559

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/574cbb1c19c6d200118c190a452a8e7234fd3019 before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.