### PR TITLE
fix(DB/Quest): Fixes the prerequisite quest for "A Job Undone"

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_08_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_08_world.sql
@@ -1,0 +1,3 @@
+-- Fixes Zangarmarsh Quest "A Job Undone" invalid prerequisite quest
+-- closes https://github.com/azerothcore/azerothcore-wotlk/issues/21708
+UPDATE `quest_template_addon` SET `PrevQuestID` = 9773 WHERE (`ID` = 9899);

--- a/sql/updates/world/3.3.5/2025_12_15_08_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_08_world.sql
@@ -1,2 +1,3 @@
 -- Fixes Zangarmarsh Quest "A Job Undone" invalid prerequisite quest
+-- closes https://github.com/azerothcore/azerothcore-wotlk/issues/21708
 UPDATE `quest_template_addon` SET `PrevQuestID` = 9773 WHERE (`ID` = 9899);

--- a/sql/updates/world/3.3.5/2025_12_15_08_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_08_world.sql
@@ -1,3 +1,0 @@
--- Fixes Zangarmarsh Quest "A Job Undone" invalid prerequisite quest
--- closes https://github.com/azerothcore/azerothcore-wotlk/issues/21708
-UPDATE `quest_template_addon` SET `PrevQuestID` = 9773 WHERE (`ID` = 9899);

--- a/sql/updates/world/3.3.5/2025_12_15_08_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_08_world.sql
@@ -1,3 +1,2 @@
 -- Fixes Zangarmarsh Quest "A Job Undone" invalid prerequisite quest
--- closes https://github.com/azerothcore/azerothcore-wotlk/issues/21708
 UPDATE `quest_template_addon` SET `PrevQuestID` = 9773 WHERE (`ID` = 9899);


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/21714 by `No Longer a Github User`
[Co-authored-by: Pandeesh Groodanj <dark.dog5483@fastmail.com>](https://github.com/azerothcore/azerothcore-wotlk/commit/04b400447c7b4645067eb338c29ec4f0111b01f4)
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31554

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/dba354a33dec13c64edcd08e03542fcb096b0cc9 before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.