### PR TITLE
fix(DB/Creature): Ahn'kahar Watcher will no longer spawn in normal mode.

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_09_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_09_world.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature` SET `spawnMask` = `spawnMask`&~(1) WHERE `guid` IN (68283,68284) AND `id1` = 31104;

--- a/sql/updates/world/3.3.5/2025_12_15_09_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_09_world.sql
@@ -1,2 +1,2 @@
 --
-UPDATE `creature` SET `spawnMask` = `spawnMask`&~(1) WHERE `guid` IN (68283,68284) AND `id1` = 31104;
+UPDATE `creature` SET `spawnMask` = `spawnMask`&~(1) WHERE `guid` IN (68283,68284) AND `id` = 31104;


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/22083 by @avarishd
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31552

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/6a05a9857a87d6471ad283277cf68ca1b54658ea before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.