### PR TITLE
fix(DB/Gameobject): Correct Area 52 Mailbox faction.

### DIFF
--- a/sql/updates/world/3.3.5/2025_12_15_10_world.sql
+++ b/sql/updates/world/3.3.5/2025_12_15_10_world.sql
@@ -1,0 +1,1 @@
+UPDATE `gameobject_template_addon` SET `faction` = 35 WHERE `entry` = 184085;


### PR DESCRIPTION
Cherry-picked from: https://github.com/azerothcore/azerothcore-wotlk/pull/22319 by @heyitsbench
From this issue: https://github.com/TrinityCore/TrinityCore/issues/31551

This needs to reverted: https://github.com/TrinityCore/TrinityCore/commit/69f25ba643ca38990378f5c28b676f8459bb2c6d before merging this PR

This PR is not tested, it has the original AC changes with the proper co-author.

As agreed with @meji46 cherry-picked or based AzerothCore PRs will be reverted and properly co-authored.