### PR TITLE
Allow dynamic tile building for M2 models.

### DIFF
--- a/src/server/game/Maps/DynamicMMapTileBuilder.cpp
+++ b/src/server/game/Maps/DynamicMMapTileBuilder.cpp
@@ -137,11 +137,11 @@ struct TileCache
     {
         MMAP::CreateVMapManager = &CreateVMapManager;
 
-        // init timer
-        OnCacheCleanupTimerTick({});
-
         // start the worker
         _builderThread = std::thread([this] { _taskContext.run(); });
+
+        // init timer
+        OnCacheCleanupTimerTick({});
     }
 
     TileCache(TileCache const&) = delete;
@@ -276,7 +276,7 @@ std::weak_ptr<DynamicTileBuilder::AsyncTileResult> DynamicTileBuilder::BuildTile
     std::vector<std::shared_ptr<GameObjectModel const>> gameObjectModelReferences; // hold strong refs to models
     for (GameObjectModel const* gameObjectModel : m_map->GetGameObjectModelsInGrid(tileX, tileY))
     {
-        if (!gameObjectModel->IsMapObject() || !gameObjectModel->IsIncludedInNavMesh())
+        if (!gameObjectModel->IsIncludedInNavMesh())
             continue;
 
         std::shared_ptr<VMAP::WorldModel const> worldModel = gameObjectModel->GetWorldModel();


### PR DESCRIPTION
**Changes proposed:**

- Fixed the initialization order in the `TileCache` constructor  
- Enabled dynamic tile building for M2 models  

**Tests performed:**

- Project builds successfully  
- Verified dynamic tile building with M2 models in-game  
