### PR TITLE
Core/Movement: protect movement generator initialization or reset against early updates

### DIFF
--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -300,21 +300,27 @@ void MotionMaster::Update(uint32 diff)
 
     AddFlag(MOTIONMASTER_FLAG_UPDATE);
 
+    enum class InitState : uint8
+    {
+        Failed,
+        Success,
+        AlreadyInitialized
+    } initializationState = InitState::AlreadyInitialized;
+
     MovementGenerator* top = GetCurrentMovementGenerator();
-    bool initialized = false;
     if (HasFlag(MOTIONMASTER_FLAG_STATIC_INITIALIZATION_PENDING) && IsStatic(top))
     {
         RemoveFlag(MOTIONMASTER_FLAG_STATIC_INITIALIZATION_PENDING);
-        initialized = top->Initialize(_owner);
+        initializationState = top->Initialize(_owner) ? InitState::Success : InitState::Failed;
     }
     if (top->HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING))
-        initialized = top->Initialize(_owner);
+        initializationState = top->Initialize(_owner) ? InitState::Success : InitState::Failed;
     if (top->HasFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED))
-        initialized = top->Reset(_owner);
+        initializationState = top->Reset(_owner) ? InitState::Success : InitState::Failed;
 
     ASSERT(!top->HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED), "MotionMaster:Update: update called on an uninitialized top! (%s) (type: %u, flags: %u)", _owner->GetGUID().ToString().c_str(), top->GetMovementGeneratorType(), top->Flags);
 
-    if (!initialized && !top->Update(_owner, diff))
+    if (initializationState == InitState::Failed || !top->Update(_owner, initializationState == InitState::AlreadyInitialized ? diff : 0))
     {
         ASSERT(top == GetCurrentMovementGenerator(), "MotionMaster::Update: top was modified while updating! (%s)", _owner->GetGUID().ToString().c_str());
 

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -301,19 +301,20 @@ void MotionMaster::Update(uint32 diff)
     AddFlag(MOTIONMASTER_FLAG_UPDATE);
 
     MovementGenerator* top = GetCurrentMovementGenerator();
+    bool initialized = false;
     if (HasFlag(MOTIONMASTER_FLAG_STATIC_INITIALIZATION_PENDING) && IsStatic(top))
     {
         RemoveFlag(MOTIONMASTER_FLAG_STATIC_INITIALIZATION_PENDING);
-        top->Initialize(_owner);
+        initialized = top->Initialize(_owner);
     }
     if (top->HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING))
-        top->Initialize(_owner);
+        initialized = top->Initialize(_owner);
     if (top->HasFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED))
-        top->Reset(_owner);
+        initialized = top->Reset(_owner);
 
     ASSERT(!top->HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED), "MotionMaster:Update: update called on an uninitialized top! (%s) (type: %u, flags: %u)", _owner->GetGUID().ToString().c_str(), top->GetMovementGeneratorType(), top->Flags);
 
-    if (!top->Update(_owner, diff))
+    if (!initialized && !top->Update(_owner, diff))
     {
         ASSERT(top == GetCurrentMovementGenerator(), "MotionMaster::Update: top was modified while updating! (%s)", _owner->GetGUID().ToString().c_str());
 

--- a/src/server/game/Movement/MovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerator.h
@@ -51,9 +51,9 @@ class TC_GAME_API MovementGenerator
         virtual ~MovementGenerator();
 
         // on top first update
-        virtual void Initialize(Unit*) = 0;
+        virtual bool Initialize(Unit*) = 0;
         // on top reassign
-        virtual void Reset(Unit*) = 0;
+        virtual bool Reset(Unit*) = 0;
         // on top on MotionMaster::Update
         virtual bool Update(Unit*, uint32 diff) = 0;
         // on current top if another movement replaces
@@ -86,14 +86,14 @@ template<class T, class D>
 class MovementGeneratorMedium : public MovementGenerator
 {
     public:
-        void Initialize(Unit* owner) override
+        bool Initialize(Unit* owner) override
         {
-            (static_cast<D*>(this))->DoInitialize(static_cast<T*>(owner));
+            return (static_cast<D*>(this))->DoInitialize(static_cast<T*>(owner));
         }
 
-        void Reset(Unit* owner) override
+        bool Reset(Unit* owner) override
         {
-            (static_cast<D*>(this))->DoReset(static_cast<T*>(owner));
+            return (static_cast<D*>(this))->DoReset(static_cast<T*>(owner));
         }
 
         bool Update(Unit* owner, uint32 diff) override

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -75,20 +75,21 @@ ChaseMovementGenerator::ChaseMovementGenerator(Unit *target, Optional<ChaseRange
 }
 ChaseMovementGenerator::~ChaseMovementGenerator() = default;
 
-void ChaseMovementGenerator::Initialize(Unit* /*owner*/)
+bool ChaseMovementGenerator::Initialize(Unit* /*owner*/)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
 
     _path = nullptr;
     _lastTargetPosition.reset();
+    return true;
 }
 
-void ChaseMovementGenerator::Reset(Unit* owner)
+bool ChaseMovementGenerator::Reset(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    Initialize(owner);
+    return Initialize(owner);
 }
 
 bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -82,7 +82,7 @@ bool ChaseMovementGenerator::Initialize(Unit* /*owner*/)
 
     _path = nullptr;
     _lastTargetPosition.reset();
-    return true;
+    return false;
 }
 
 bool ChaseMovementGenerator::Reset(Unit* owner)

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -82,7 +82,7 @@ bool ChaseMovementGenerator::Initialize(Unit* /*owner*/)
 
     _path = nullptr;
     _lastTargetPosition.reset();
-    return false;
+    return true;
 }
 
 bool ChaseMovementGenerator::Reset(Unit* owner)

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.h
@@ -34,8 +34,8 @@ class ChaseMovementGenerator : public MovementGenerator, public AbstractFollower
         explicit ChaseMovementGenerator(Unit* target, Optional<ChaseRange> range = {}, Optional<ChaseAngle> angle = {});
         ~ChaseMovementGenerator();
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override;
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -54,7 +54,7 @@ bool ConfusedMovementGenerator<T>::DoInitialize(T* owner)
     _timer.Reset(0);
     owner->GetPosition(_x, _y, _z);
     _path = nullptr;
-    return false;
+    return true;
 }
 
 template<class T>

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -50,12 +50,11 @@ bool ConfusedMovementGenerator<T>::DoInitialize(T* owner)
 
     // TODO: UNIT_FIELD_FLAGS should not be handled by generators
     owner->SetUnitFlag(UNIT_FLAG_CONFUSED);
-    owner->StopMoving();
 
     _timer.Reset(0);
     owner->GetPosition(_x, _y, _z);
     _path = nullptr;
-    return true;
+    return false;
 }
 
 template<class T>

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -40,13 +40,13 @@ MovementGeneratorType ConfusedMovementGenerator<T>::GetMovementGeneratorType() c
 }
 
 template<class T>
-void ConfusedMovementGenerator<T>::DoInitialize(T* owner)
+bool ConfusedMovementGenerator<T>::DoInitialize(T* owner)
 {
     MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     MovementGenerator::AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
     if (!owner || !owner->IsAlive())
-        return;
+        return false;
 
     // TODO: UNIT_FIELD_FLAGS should not be handled by generators
     owner->SetUnitFlag(UNIT_FLAG_CONFUSED);
@@ -55,14 +55,15 @@ void ConfusedMovementGenerator<T>::DoInitialize(T* owner)
     _timer.Reset(0);
     owner->GetPosition(_x, _y, _z);
     _path = nullptr;
+    return true;
 }
 
 template<class T>
-void ConfusedMovementGenerator<T>::DoReset(T* owner)
+bool ConfusedMovementGenerator<T>::DoReset(T* owner)
 {
     MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    DoInitialize(owner);
+    return DoInitialize(owner);
 }
 
 template<class T>
@@ -167,10 +168,10 @@ template ConfusedMovementGenerator<Player>::ConfusedMovementGenerator();
 template ConfusedMovementGenerator<Creature>::ConfusedMovementGenerator();
 template MovementGeneratorType ConfusedMovementGenerator<Player>::GetMovementGeneratorType() const;
 template MovementGeneratorType ConfusedMovementGenerator<Creature>::GetMovementGeneratorType() const;
-template void ConfusedMovementGenerator<Player>::DoInitialize(Player*);
-template void ConfusedMovementGenerator<Creature>::DoInitialize(Creature*);
-template void ConfusedMovementGenerator<Player>::DoReset(Player*);
-template void ConfusedMovementGenerator<Creature>::DoReset(Creature*);
+template bool ConfusedMovementGenerator<Player>::DoInitialize(Player*);
+template bool ConfusedMovementGenerator<Creature>::DoInitialize(Creature*);
+template bool ConfusedMovementGenerator<Player>::DoReset(Player*);
+template bool ConfusedMovementGenerator<Creature>::DoReset(Creature*);
 template bool ConfusedMovementGenerator<Player>::DoUpdate(Player*, uint32);
 template bool ConfusedMovementGenerator<Creature>::DoUpdate(Creature*, uint32);
 template void ConfusedMovementGenerator<Player>::DoDeactivate(Player*);

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.h
@@ -31,8 +31,8 @@ class ConfusedMovementGenerator : public MovementGeneratorMedium<T, ConfusedMove
 
         MovementGeneratorType GetMovementGeneratorType() const override;
 
-        void DoInitialize(T*);
-        void DoReset(T*);
+        bool DoInitialize(T*);
+        bool DoReset(T*);
         bool DoUpdate(T*, uint32);
         void DoDeactivate(T*);
         void DoFinalize(T*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.cpp
@@ -45,27 +45,28 @@ MovementGeneratorType FleeingMovementGenerator<T>::GetMovementGeneratorType() co
 }
 
 template<class T>
-void FleeingMovementGenerator<T>::DoInitialize(T* owner)
+bool FleeingMovementGenerator<T>::DoInitialize(T* owner)
 {
     MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     MovementGenerator::AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
     if (!owner || !owner->IsAlive())
-        return;
+        return false;
 
     // TODO: UNIT_FIELD_FLAGS should not be handled by generators
     owner->SetUnitFlag(UNIT_FLAG_FLEEING);
 
     _path = nullptr;
     SetTargetLocation(owner);
+    return true;
 }
 
 template<class T>
-void FleeingMovementGenerator<T>::DoReset(T* owner)
+bool FleeingMovementGenerator<T>::DoReset(T* owner)
 {
     MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    DoInitialize(owner);
+    return DoInitialize(owner);
 }
 
 template<class T>
@@ -223,10 +224,10 @@ template FleeingMovementGenerator<Player>::FleeingMovementGenerator(ObjectGuid);
 template FleeingMovementGenerator<Creature>::FleeingMovementGenerator(ObjectGuid);
 template MovementGeneratorType FleeingMovementGenerator<Player>::GetMovementGeneratorType() const;
 template MovementGeneratorType FleeingMovementGenerator<Creature>::GetMovementGeneratorType() const;
-template void FleeingMovementGenerator<Player>::DoInitialize(Player*);
-template void FleeingMovementGenerator<Creature>::DoInitialize(Creature*);
-template void FleeingMovementGenerator<Player>::DoReset(Player*);
-template void FleeingMovementGenerator<Creature>::DoReset(Creature*);
+template bool FleeingMovementGenerator<Player>::DoInitialize(Player*);
+template bool FleeingMovementGenerator<Creature>::DoInitialize(Creature*);
+template bool FleeingMovementGenerator<Player>::DoReset(Player*);
+template bool FleeingMovementGenerator<Creature>::DoReset(Creature*);
 template bool FleeingMovementGenerator<Player>::DoUpdate(Player*, uint32);
 template bool FleeingMovementGenerator<Creature>::DoUpdate(Creature*, uint32);
 template void FleeingMovementGenerator<Player>::DoDeactivate(Player*);

--- a/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/FleeingMovementGenerator.h
@@ -34,8 +34,8 @@ class FleeingMovementGenerator : public MovementGeneratorMedium<T, FleeingMoveme
 
         MovementGeneratorType GetMovementGeneratorType() const override;
 
-        void DoInitialize(T*);
-        void DoReset(T*);
+        bool DoInitialize(T*);
+        bool DoReset(T*);
         bool DoUpdate(T*, uint32);
         void DoDeactivate(T*);
         void DoFinalize(T*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.cpp
@@ -58,16 +58,17 @@ bool FlightPathMovementGenerator::GetResetPosition(Unit* /*owner*/, float& x, fl
     return true;
 }
 
-void FlightPathMovementGenerator::DoInitialize(Player* owner)
+bool FlightPathMovementGenerator::DoInitialize(Player* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
-    DoReset(owner);
+    bool returnValue = DoReset(owner);
     InitEndGridInfo();
+    return returnValue;
 }
 
-void FlightPathMovementGenerator::DoReset(Player* owner)
+bool FlightPathMovementGenerator::DoReset(Player* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
@@ -80,7 +81,7 @@ void FlightPathMovementGenerator::DoReset(Player* owner)
     if (currentNodeId == end)
     {
         TC_LOG_DEBUG("movement.flightpath", "FlightPathMovementGenerator::DoReset: trying to start a flypath from the end point. {}", owner->GetDebugInfo());
-        return;
+        return false;
     }
 
     Movement::MoveSplineInit init(owner);
@@ -95,6 +96,7 @@ void FlightPathMovementGenerator::DoReset(Player* owner)
     init.SetFly();
     init.SetVelocity(PLAYER_FLIGHT_SPEED);
     init.Launch();
+    return true;
 }
 
 bool FlightPathMovementGenerator::DoUpdate(Player* owner, uint32 /*diff*/)

--- a/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/FlightPathMovementGenerator.h
@@ -37,8 +37,8 @@ class FlightPathMovementGenerator : public MovementGeneratorMedium<Player, Fligh
         MovementGeneratorType GetMovementGeneratorType() const override;
         bool GetResetPosition(Unit* owner, float& x, float& y, float& z) override;
 
-        void DoInitialize(Player*);
-        void DoReset(Player*);
+        bool DoInitialize(Player*);
+        bool DoReset(Player*);
         bool DoUpdate(Player*, uint32);
         void DoDeactivate(Player*);
         void DoFinalize(Player*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -60,7 +60,7 @@ bool FollowMovementGenerator::Initialize(Unit* owner)
     UpdatePetSpeed(owner);
     _path = nullptr;
     _lastTargetPosition.reset();
-    return false;
+    return true;
 }
 
 bool FollowMovementGenerator::Reset(Unit* owner)

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -52,7 +52,7 @@ static bool PositionOkay(Unit* owner, Unit* target, float range, Optional<ChaseA
     return !angle || angle->IsAngleOkay(target->GetRelativeAngle(owner));
 }
 
-void FollowMovementGenerator::Initialize(Unit* owner)
+bool FollowMovementGenerator::Initialize(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
@@ -61,13 +61,14 @@ void FollowMovementGenerator::Initialize(Unit* owner)
     UpdatePetSpeed(owner);
     _path = nullptr;
     _lastTargetPosition.reset();
+    return true;
 }
 
-void FollowMovementGenerator::Reset(Unit* owner)
+bool FollowMovementGenerator::Reset(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    Initialize(owner);
+    return Initialize(owner);
 }
 
 bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -57,11 +57,10 @@ bool FollowMovementGenerator::Initialize(Unit* owner)
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED | MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
 
-    owner->StopMoving();
     UpdatePetSpeed(owner);
     _path = nullptr;
     _lastTargetPosition.reset();
-    return true;
+    return false;
 }
 
 bool FollowMovementGenerator::Reset(Unit* owner)

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.h
@@ -36,8 +36,8 @@ class FollowMovementGenerator : public MovementGenerator, public AbstractFollowe
         explicit FollowMovementGenerator(Unit* target, float range, ChaseAngle angle);
         ~FollowMovementGenerator();
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override;
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;

--- a/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
@@ -38,7 +38,7 @@ MovementGeneratorType FormationMovementGenerator::GetMovementGeneratorType() con
     return FORMATION_MOTION_TYPE;
 }
 
-void FormationMovementGenerator::DoInitialize(Creature* owner)
+bool FormationMovementGenerator::DoInitialize(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
@@ -47,17 +47,18 @@ void FormationMovementGenerator::DoInitialize(Creature* owner)
     {
         AddFlag(MOVEMENTGENERATOR_FLAG_INTERRUPTED);
         owner->StopMoving();
-        return;
+        return true;
     }
 
     _nextMoveTimer.Reset(0);
+    return true;
 }
 
-void FormationMovementGenerator::DoReset(Creature* owner)
+bool FormationMovementGenerator::DoReset(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    DoInitialize(owner);
+    return DoInitialize(owner);
 }
 
 bool FormationMovementGenerator::DoUpdate(Creature* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
@@ -51,7 +51,7 @@ bool FormationMovementGenerator::DoInitialize(Creature* owner)
     }
 
     _nextMoveTimer.Reset(0);
-    return false;
+    return true;
 }
 
 bool FormationMovementGenerator::DoReset(Creature* owner)

--- a/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.cpp
@@ -51,7 +51,7 @@ bool FormationMovementGenerator::DoInitialize(Creature* owner)
     }
 
     _nextMoveTimer.Reset(0);
-    return true;
+    return false;
 }
 
 bool FormationMovementGenerator::DoReset(Creature* owner)

--- a/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/FormationMovementGenerator.h
@@ -32,8 +32,8 @@ class FormationMovementGenerator : public MovementGeneratorMedium<Creature, Form
 
         MovementGeneratorType GetMovementGeneratorType() const override;
 
-        void DoInitialize(Creature*);
-        void DoReset(Creature*);
+        bool DoInitialize(Creature*);
+        bool DoReset(Creature*);
         bool DoUpdate(Creature*, uint32);
         void DoDeactivate(Creature*);
         void DoFinalize(Creature*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
@@ -36,7 +36,7 @@ bool GenericMovementGenerator::Initialize(Unit* owner)
     {
         RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
         AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
-        return false;
+        return true;
     }
 
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
@@ -30,13 +30,13 @@ GenericMovementGenerator::GenericMovementGenerator(std::function<void(Movement::
     BaseUnitState = UNIT_STATE_ROAMING;
 }
 
-void GenericMovementGenerator::Initialize(Unit* owner)
+bool GenericMovementGenerator::Initialize(Unit* owner)
 {
     if (HasFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED) && !HasFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING)) // Resume spline is not supported
     {
         RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
         AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
-        return;
+        return false;
     }
 
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
@@ -45,11 +45,12 @@ void GenericMovementGenerator::Initialize(Unit* owner)
     Movement::MoveSplineInit init(owner);
     _splineInit(init);
     _duration.Reset(init.Launch());
+    return true;
 }
 
-void GenericMovementGenerator::Reset(Unit* owner)
+bool GenericMovementGenerator::Reset(Unit* owner)
 {
-    Initialize(owner);
+    return Initialize(owner);
 }
 
 bool GenericMovementGenerator::Update(Unit* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
@@ -36,7 +36,7 @@ bool GenericMovementGenerator::Initialize(Unit* owner)
     {
         RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
         AddFlag(MOVEMENTGENERATOR_FLAG_FINALIZED);
-        return true;
+        return false;
     }
 
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
@@ -45,7 +45,7 @@ bool GenericMovementGenerator::Initialize(Unit* owner)
     Movement::MoveSplineInit init(owner);
     _splineInit(init);
     _duration.Reset(init.Launch());
-    return true;
+    return _duration.GetExpiry() > 0ms;
 }
 
 bool GenericMovementGenerator::Reset(Unit* owner)

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.h
@@ -32,8 +32,8 @@ class GenericMovementGenerator : public MovementGenerator
     public:
         explicit GenericMovementGenerator(std::function<void(Movement::MoveSplineInit& init)>&& initializer, MovementGeneratorType type, uint32 id);
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override;
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;

--- a/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.cpp
@@ -81,10 +81,10 @@ void HomeMovementGenerator<Creature>::SetTargetLocation(Creature* owner)
 }
 
 template<class T>
-void HomeMovementGenerator<T>::DoInitialize(T*) { }
+bool HomeMovementGenerator<T>::DoInitialize(T*) { }
 
 template<>
-void HomeMovementGenerator<Creature>::DoInitialize(Creature* owner)
+bool HomeMovementGenerator<Creature>::DoInitialize(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
@@ -92,17 +92,18 @@ void HomeMovementGenerator<Creature>::DoInitialize(Creature* owner)
     owner->SetNoSearchAssistance(false);
 
     SetTargetLocation(owner);
+    return true;
 }
 
 template<class T>
-void HomeMovementGenerator<T>::DoReset(T*) { }
+bool HomeMovementGenerator<T>::DoReset(T*) { }
 
 template<>
-void HomeMovementGenerator<Creature>::DoReset(Creature* owner)
+bool HomeMovementGenerator<Creature>::DoReset(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    DoInitialize(owner);
+    return DoInitialize(owner);
 }
 
 template<class T>

--- a/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.cpp
@@ -81,7 +81,7 @@ void HomeMovementGenerator<Creature>::SetTargetLocation(Creature* owner)
 }
 
 template<class T>
-bool HomeMovementGenerator<T>::DoInitialize(T*) { }
+bool HomeMovementGenerator<T>::DoInitialize(T*) { return false; }
 
 template<>
 bool HomeMovementGenerator<Creature>::DoInitialize(Creature* owner)
@@ -96,7 +96,7 @@ bool HomeMovementGenerator<Creature>::DoInitialize(Creature* owner)
 }
 
 template<class T>
-bool HomeMovementGenerator<T>::DoReset(T*) { }
+bool HomeMovementGenerator<T>::DoReset(T*) { return false; }
 
 template<>
 bool HomeMovementGenerator<Creature>::DoReset(Creature* owner)

--- a/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/HomeMovementGenerator.h
@@ -28,8 +28,8 @@ class HomeMovementGenerator : public MovementGeneratorMedium< T, HomeMovementGen
 
         MovementGeneratorType GetMovementGeneratorType() const override;
 
-        void DoInitialize(T*);
-        void DoReset(T*);
+        bool DoInitialize(T*);
+        bool DoReset(T*);
         bool DoUpdate(T*, uint32);
         void DoDeactivate(T*);
         void DoFinalize(T*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
@@ -77,8 +77,7 @@ bool RotateMovementGenerator::Initialize(Unit* owner)
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
-    owner->StopMoving();
-    return true;
+    return false;
     /*
      *  TODO: This code should be handled somewhere else, like MovementInform
      *

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
@@ -36,14 +36,16 @@ IdleMovementGenerator::IdleMovementGenerator()
  *  TODO: "if (!owner->IsStopped())" is useless, each generator cleans their own STATE_MOVE, the result is that StopMoving is almost never called
  *  Old comment: "StopMoving is needed to make unit stop if its last movement generator expires but it should not be sent otherwise there are many redundent packets"
  */
-void IdleMovementGenerator::Initialize(Unit* owner)
+bool IdleMovementGenerator::Initialize(Unit* owner)
 {
     owner->StopMoving();
+    return true;
 }
 
-void IdleMovementGenerator::Reset(Unit* owner)
+bool IdleMovementGenerator::Reset(Unit* owner)
 {
     owner->StopMoving();
+    return true;
 }
 
 void IdleMovementGenerator::Deactivate(Unit* /*owner*/)
@@ -70,13 +72,13 @@ RotateMovementGenerator::RotateMovementGenerator(uint32 id, uint32 time, RotateD
     BaseUnitState = UNIT_STATE_ROTATING;
 }
 
-void RotateMovementGenerator::Initialize(Unit* owner)
+bool RotateMovementGenerator::Initialize(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
     owner->StopMoving();
-
+    return true;
     /*
      *  TODO: This code should be handled somewhere else, like MovementInform
      *
@@ -87,11 +89,11 @@ void RotateMovementGenerator::Initialize(Unit* owner)
      */
 }
 
-void RotateMovementGenerator::Reset(Unit* owner)
+bool RotateMovementGenerator::Reset(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    Initialize(owner);
+    return Initialize(owner);
 }
 
 bool RotateMovementGenerator::Update(Unit* owner, uint32 diff)
@@ -148,7 +150,7 @@ DistractMovementGenerator::DistractMovementGenerator(uint32 timer, float orienta
     BaseUnitState = UNIT_STATE_DISTRACTED;
 }
 
-void DistractMovementGenerator::Initialize(Unit* owner)
+bool DistractMovementGenerator::Initialize(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
@@ -165,13 +167,14 @@ void DistractMovementGenerator::Initialize(Unit* owner)
         init.DisableTransportPathTransformations();
     init.SetFacing(_orientation);
     init.Launch();
+    return true;
 }
 
-void DistractMovementGenerator::Reset(Unit* owner)
+bool DistractMovementGenerator::Reset(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    Initialize(owner);
+    return Initialize(owner);
 }
 
 bool DistractMovementGenerator::Update(Unit* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
@@ -77,7 +77,7 @@ bool RotateMovementGenerator::Initialize(Unit* /*owner*/)
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
-    return false;
+    return true;
     /*
      *  TODO: This code should be handled somewhere else, like MovementInform
      *

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.cpp
@@ -72,7 +72,7 @@ RotateMovementGenerator::RotateMovementGenerator(uint32 id, uint32 time, RotateD
     BaseUnitState = UNIT_STATE_ROTATING;
 }
 
-bool RotateMovementGenerator::Initialize(Unit* owner)
+bool RotateMovementGenerator::Initialize(Unit* /*owner*/)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);

--- a/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/IdleMovementGenerator.h
@@ -28,8 +28,8 @@ class IdleMovementGenerator : public MovementGenerator
     public:
         explicit IdleMovementGenerator();
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override { return true; }
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;
@@ -41,8 +41,8 @@ class RotateMovementGenerator : public MovementGenerator
     public:
         explicit RotateMovementGenerator(uint32 id, uint32 time, RotateDirection direction);
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override;
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;
@@ -58,8 +58,8 @@ class DistractMovementGenerator : public MovementGenerator
     public:
         explicit DistractMovementGenerator(uint32 timer, float orientation);
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override;
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.cpp
@@ -43,7 +43,7 @@ MovementGeneratorType PointMovementGenerator<T>::GetMovementGeneratorType() cons
 }
 
 template<class T>
-void PointMovementGenerator<T>::DoInitialize(T* owner)
+bool PointMovementGenerator<T>::DoInitialize(T* owner)
 {
     MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     MovementGenerator::AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
@@ -51,14 +51,14 @@ void PointMovementGenerator<T>::DoInitialize(T* owner)
     if (_movementId == EVENT_CHARGE_PREPATH)
     {
         owner->AddUnitState(UNIT_STATE_ROAMING_MOVE);
-        return;
+        return true;
     }
 
     if (owner->HasUnitState(UNIT_STATE_NOT_MOVE) || owner->IsMovementPreventedByCasting())
     {
         MovementGenerator::AddFlag(MOVEMENTGENERATOR_FLAG_INTERRUPTED);
         owner->StopMoving();
-        return;
+        return true;
     }
 
     owner->AddUnitState(UNIT_STATE_ROAMING_MOVE);
@@ -76,14 +76,15 @@ void PointMovementGenerator<T>::DoInitialize(T* owner)
     // Call for creature group update
     if (Creature* creature = owner->ToCreature())
         creature->SignalFormationMovement();
+    return true;
 }
 
 template<class T>
-void PointMovementGenerator<T>::DoReset(T* owner)
+bool PointMovementGenerator<T>::DoReset(T* owner)
 {
     MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    DoInitialize(owner);
+    return DoInitialize(owner);
 }
 
 template<class T>
@@ -167,10 +168,10 @@ template PointMovementGenerator<Player>::PointMovementGenerator(uint32, float, f
 template PointMovementGenerator<Creature>::PointMovementGenerator(uint32, float, float, float, bool, float, Optional<float>);
 template MovementGeneratorType PointMovementGenerator<Player>::GetMovementGeneratorType() const;
 template MovementGeneratorType PointMovementGenerator<Creature>::GetMovementGeneratorType() const;
-template void PointMovementGenerator<Player>::DoInitialize(Player*);
-template void PointMovementGenerator<Creature>::DoInitialize(Creature*);
-template void PointMovementGenerator<Player>::DoReset(Player*);
-template void PointMovementGenerator<Creature>::DoReset(Creature*);
+template bool PointMovementGenerator<Player>::DoInitialize(Player*);
+template bool PointMovementGenerator<Creature>::DoInitialize(Creature*);
+template bool PointMovementGenerator<Player>::DoReset(Player*);
+template bool PointMovementGenerator<Creature>::DoReset(Creature*);
 template bool PointMovementGenerator<Player>::DoUpdate(Player*, uint32);
 template bool PointMovementGenerator<Creature>::DoUpdate(Creature*, uint32);
 template void PointMovementGenerator<Player>::DoDeactivate(Player*);

--- a/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/PointMovementGenerator.h
@@ -31,8 +31,8 @@ class PointMovementGenerator : public MovementGeneratorMedium<T, PointMovementGe
 
         MovementGeneratorType GetMovementGeneratorType() const override;
 
-        void DoInitialize(T*);
-        void DoReset(T*);
+        bool DoInitialize(T*);
+        bool DoReset(T*);
         bool DoUpdate(T*, uint32);
         void DoDeactivate(T*);
         void DoFinalize(T*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -69,7 +69,7 @@ void RandomMovementGenerator<T>::Resume(uint32 overrideTimer /*= 0*/)
 template MovementGeneratorType RandomMovementGenerator<Creature>::GetMovementGeneratorType() const;
 
 template<class T>
-bool RandomMovementGenerator<T>::DoInitialize(T*) { }
+bool RandomMovementGenerator<T>::DoInitialize(T*) { return false; }
 
 template<>
 bool RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
@@ -81,7 +81,6 @@ bool RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
         return false;
 
     _reference = owner->GetPosition();
-    owner->StopMoving();
 
     if (_wanderDistance == 0.f)
         _wanderDistance = owner->GetWanderDistance();
@@ -91,11 +90,11 @@ bool RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
 
     _timer.Reset(0);
     _path = nullptr;
-    return true;
+    return false;
 }
 
 template<class T>
-bool RandomMovementGenerator<T>::DoReset(T*) { }
+bool RandomMovementGenerator<T>::DoReset(T*) { return false; }
 
 template<>
 bool RandomMovementGenerator<Creature>::DoReset(Creature* owner)

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -69,16 +69,16 @@ void RandomMovementGenerator<T>::Resume(uint32 overrideTimer /*= 0*/)
 template MovementGeneratorType RandomMovementGenerator<Creature>::GetMovementGeneratorType() const;
 
 template<class T>
-void RandomMovementGenerator<T>::DoInitialize(T*) { }
+bool RandomMovementGenerator<T>::DoInitialize(T*) { }
 
 template<>
-void RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
+bool RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED | MOVEMENTGENERATOR_FLAG_TIMED_PAUSED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
 
     if (!owner || !owner->IsAlive())
-        return;
+        return false;
 
     _reference = owner->GetPosition();
     owner->StopMoving();
@@ -91,17 +91,18 @@ void RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
 
     _timer.Reset(0);
     _path = nullptr;
+    return true;
 }
 
 template<class T>
-void RandomMovementGenerator<T>::DoReset(T*) { }
+bool RandomMovementGenerator<T>::DoReset(T*) { }
 
 template<>
-void RandomMovementGenerator<Creature>::DoReset(Creature* owner)
+bool RandomMovementGenerator<Creature>::DoReset(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
-    DoInitialize(owner);
+    return DoInitialize(owner);
 }
 
 template<class T>

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.cpp
@@ -90,7 +90,7 @@ bool RandomMovementGenerator<Creature>::DoInitialize(Creature* owner)
 
     _timer.Reset(0);
     _path = nullptr;
-    return false;
+    return true;
 }
 
 template<class T>

--- a/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/RandomMovementGenerator.h
@@ -35,8 +35,8 @@ class RandomMovementGenerator : public MovementGeneratorMedium<T, RandomMovement
         void Pause(uint32 timer = 0) override;
         void Resume(uint32 overrideTimer = 0) override;
 
-        void DoInitialize(T*);
-        void DoReset(T*);
+        bool DoInitialize(T*);
+        bool DoReset(T*);
         bool DoUpdate(T*, uint32);
         void DoDeactivate(T*);
         void DoFinalize(T*, bool, bool);

--- a/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
@@ -81,7 +81,7 @@ void SplineChainMovementGenerator::SendSplineFor(Unit* owner, uint32 index, uint
     }
 }
 
-void SplineChainMovementGenerator::Initialize(Unit* owner)
+bool SplineChainMovementGenerator::Initialize(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
     AddFlag(MOVEMENTGENERATOR_FLAG_INITIALIZED);
@@ -89,20 +89,20 @@ void SplineChainMovementGenerator::Initialize(Unit* owner)
     if (!_chainSize)
     {
         TC_LOG_ERROR("movement", "SplineChainMovementGenerator::Initialize: couldn't initialize generator, referenced spline is empty! ({})", owner->GetGUID().ToString());
-        return;
+        return false;
     }
 
     if (_nextIndex >= _chainSize)
     {
         TC_LOG_WARN("movement", "SplineChainMovementGenerator::Initialize: couldn't initialize generator, _nextIndex is >= _chainSize ({})", owner->GetGUID().ToString());
         _msToNext = 0;
-        return;
+        return true;
     }
 
     if (_nextFirstWP) // this is a resumed movegen that has to start with a partial spline
     {
         if (HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED))
-            return;
+            return true;
 
         SplineChainLink const& thisLink = _chain[_nextIndex];
         if (_nextFirstWP >= thisLink.Points.size())
@@ -133,14 +133,15 @@ void SplineChainMovementGenerator::Initialize(Unit* owner)
         if (_nextIndex >= _chainSize)
             _msToNext = 0;
     }
+    return true;
 }
 
-void SplineChainMovementGenerator::Reset(Unit* owner)
+bool SplineChainMovementGenerator::Reset(Unit* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
     owner->StopMoving();
-    Initialize(owner);
+    return Initialize(owner);
 }
 
 bool SplineChainMovementGenerator::Update(Unit* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.cpp
@@ -96,13 +96,13 @@ bool SplineChainMovementGenerator::Initialize(Unit* owner)
     {
         TC_LOG_WARN("movement", "SplineChainMovementGenerator::Initialize: couldn't initialize generator, _nextIndex is >= _chainSize ({})", owner->GetGUID().ToString());
         _msToNext = 0;
-        return true;
+        return false;
     }
 
     if (_nextFirstWP) // this is a resumed movegen that has to start with a partial spline
     {
         if (HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED))
-            return true;
+            return false;
 
         SplineChainLink const& thisLink = _chain[_nextIndex];
         if (_nextFirstWP >= thisLink.Points.size())
@@ -126,6 +126,7 @@ bool SplineChainMovementGenerator::Initialize(Unit* owner)
     }
     else
     {
+        owner->AddUnitState(UNIT_STATE_ROAMING_MOVE);
         _msToNext = std::max(_chain[_nextIndex].TimeToNext, 1u);
         SendSplineFor(owner, _nextIndex, _msToNext);
 
@@ -146,7 +147,7 @@ bool SplineChainMovementGenerator::Reset(Unit* owner)
 
 bool SplineChainMovementGenerator::Update(Unit* owner, uint32 diff)
 {
-    if (!owner || HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED))
+    if (!owner || !_chainSize || HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED))
         return false;
 
     // _msToNext being zero here means we're on the final spline

--- a/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/SplineChainMovementGenerator.h
@@ -31,8 +31,8 @@ class TC_GAME_API SplineChainMovementGenerator : public MovementGenerator
         explicit SplineChainMovementGenerator(uint32 id, std::vector<SplineChainLink> const& chain, bool walk = false);
         explicit SplineChainMovementGenerator(SplineChainResumeInfo const& info);
 
-        void Initialize(Unit*) override;
-        void Reset(Unit*) override;
+        bool Initialize(Unit*) override;
+        bool Reset(Unit*) override;
         bool Update(Unit*, uint32) override;
         void Deactivate(Unit*) override;
         void Finalize(Unit*, bool, bool) override;

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -97,7 +97,7 @@ bool WaypointMovementGenerator<Creature>::GetResetPosition(Unit* /*owner*/, floa
     return true;
 }
 
-void WaypointMovementGenerator<Creature>::DoInitialize(Creature* owner)
+bool WaypointMovementGenerator<Creature>::DoInitialize(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_INITIALIZATION_PENDING | MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
@@ -112,15 +112,16 @@ void WaypointMovementGenerator<Creature>::DoInitialize(Creature* owner)
     if (!_path)
     {
         TC_LOG_ERROR("sql.sql", "WaypointMovementGenerator::DoInitialize: couldn't load path for creature ({}) (_pathId: {})", owner->GetGUID().ToString(), _pathId);
-        return;
+        return false;
     }
 
     owner->StopMoving();
 
     _nextMoveTime.Reset(1000);
+    return true;
 }
 
-void WaypointMovementGenerator<Creature>::DoReset(Creature* owner)
+bool WaypointMovementGenerator<Creature>::DoReset(Creature* owner)
 {
     RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY | MOVEMENTGENERATOR_FLAG_DEACTIVATED);
 
@@ -128,6 +129,7 @@ void WaypointMovementGenerator<Creature>::DoReset(Creature* owner)
 
     if (!HasFlag(MOVEMENTGENERATOR_FLAG_FINALIZED) && _nextMoveTime.Passed())
         _nextMoveTime.Reset(1); // Needed so that Update does not behave as if node was reached
+    return true;
 }
 
 bool WaypointMovementGenerator<Creature>::DoUpdate(Creature* owner, uint32 diff)

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.h
@@ -44,8 +44,8 @@ class WaypointMovementGenerator<Creature> : public MovementGeneratorMedium<Creat
         void Resume(uint32 overrideTimer = 0) override;
         bool GetResetPosition(Unit*, float& x, float& y, float& z) override;
 
-        void DoInitialize(Creature*);
-        void DoReset(Creature*);
+        bool DoInitialize(Creature*);
+        bool DoReset(Creature*);
         bool DoUpdate(Creature*, uint32);
         void DoDeactivate(Creature*);
         void DoFinalize(Creature*, bool, bool);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

Fixes edge cases (very, very edge cases) in which any given movement might send splines with duration 0 on initialize/reset, and their own update may process the spline as done too early (since the actual handling/processing of the spline happens on the unit's next update tick on UpdateMovementSpline), as generator update is called within the same MotionMaster::Update stack.


**Tests performed:**

Tested, will review each return value on the generator further


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
