### PR TITLE
DB/SQL: Add transport Ogrimmar <-> Waking Shores

### DIFF
--- a/sql/updates/world/master/2026_01_15_00_world.sql
+++ b/sql/updates/world/master/2026_01_15_00_world.sql
@@ -1,0 +1,11 @@
+SET @CGUID := 11000000;
+
+-- Transport: The Defiant Dragonscale (Orgrimmar <-> Waking Shores)
+DELETE FROM `transports` WHERE `guid`=37;
+INSERT INTO `transports` (`guid`, `entry`, `name`, `phaseUseFlags`, `phaseid`, `phasegroup`, `ScriptName`) VALUES 
+(37, 375041, 'Orgrimmar and Waking Shores ("The Defiant Dragonscale")', 0, 0, 0, '');
+
+DELETE FROM `gameobject_template_addon` WHERE `entry`=375041;
+INSERT INTO `gameobject_template_addon` (`entry`, `faction`, `flags`, `mingold`, `maxgold`, `artkit0`, `artkit1`, `artkit2`, `artkit3`, `artkit4`, `WorldEffectID`, `AIAnimKitID`) VALUES 
+(375041, 0, 1048616, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Implements and enables The Defiant Dragonscale going from Ogrimmar to Waking Shores for Horde


Builds, and works like intended

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Spawn crew on the ship
- [ ] Add pathing to spawns

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
