### PR TITLE
Core/Network: Enable Sell All Junk button at vendors

### DIFF
--- a/src/server/game/Handlers/AuthHandler.cpp
+++ b/src/server/game/Handlers/AuthHandler.cpp
@@ -145,6 +145,7 @@ void WorldSession::SendFeatureSystemStatusGlueScreen()
     WorldPackets::System::MirrorVarSingle vars[] =
     {
         { "raidLockoutExtendEnabled"sv, "1"sv },
+        { "sellAllJunkEnabled"sv, "1"sv },
         { "bypassItemLevelScalingCode"sv, "0"sv },
         { "shop2Enabled"sv, "0"sv },
         { "bpayStoreEnable"sv, "0"sv },


### PR DESCRIPTION
The Sell All Junk button in the merchant UI is gated by the client's
`C_MerchantFrame.IsSellAllJunkEnabled()` Lua API, which reads a
`sellAllJunkEnabled` CVar. That CVar's value is populated from
the MirrorVar overlay sent via `SMSG_MIRROR_VARS` during
authentication. Without this MirrorVar, the CVar defaults to 0
and the button never appears.

The server-side `CMSG_SELL_ALL_JUNK_ITEMS` handler
(`HandleSellAllJunkItems`) is already fully implemented and
functional — it iterates inventory for Poor quality items,
respects `ExcludeJunkSell` bag flags and the
`BackpackSellJunkDisabled` player setting, sells qualifying items,
and adds them to buyback.

This one-line change sends `sellAllJunkEnabled = "1"` in the
MirrorVars packet, enabling the button for all vendor interactions.