### PR TITLE
Set CAST_FLAG_EX_DONT_CONSUME_CHARGES for spells ignoring cds

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -534,7 +534,7 @@ m_spellValue(new SpellValue(m_spellInfo, caster)), _spellEvent(nullptr)
     m_castFlagsEx = 0;
 
     if (IsIgnoringCooldowns())
-        m_castFlagsEx |= CAST_FLAG_EX_IGNORE_COOLDOWN;
+        m_castFlagsEx |= CAST_FLAG_EX_IGNORE_COOLDOWN | CAST_FLAG_EX_DONT_CONSUME_CHARGES;
 
     if (_triggeredCastFlags & TRIGGERED_SUPPRESS_CASTER_ANIM)
         m_castFlagsEx |= CAST_FLAG_EX_SUPPRESS_CASTER_ANIM;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -534,7 +534,11 @@ m_spellValue(new SpellValue(m_spellInfo, caster)), _spellEvent(nullptr)
     m_castFlagsEx = 0;
 
     if (IsIgnoringCooldowns())
-        m_castFlagsEx |= CAST_FLAG_EX_IGNORE_COOLDOWN | CAST_FLAG_EX_DONT_CONSUME_CHARGES;
+    {
+        m_castFlagsEx |= CAST_FLAG_EX_IGNORE_COOLDOWN;
+        if (m_spellInfo->ChargeCategoryId)
+            m_castFlagsEx |= CAST_FLAG_EX_DONT_CONSUME_CHARGES;
+    }
 
     if (_triggeredCastFlags & TRIGGERED_SUPPRESS_CASTER_ANIM)
         m_castFlagsEx |= CAST_FLAG_EX_SUPPRESS_CASTER_ANIM;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Spells cast with _TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD_ should skip charge consumption.
Required by priest [Evangelism](https://github.com/TrinityCore/TrinityCore/pull/31661).

**Issues addressed:**

**Tests performed:**
builds and tested in-game

**Known issues and TODO list:**

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
