### PR TITLE
[Low Priority] Fix typo in worldserver.conf.dist

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -1396,7 +1396,7 @@ BirthdayTime = 1222964635
 #
 #
 
- CacheDataQueries = 1
+CacheDataQueries = 1
 
 #
 #   FeatureSystem.CharacterUndelete.Enabled


### PR DESCRIPTION
Very low priority. OCD Edit.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix a leading space for a setting to match all other entries in the default config.


**Issues addressed:**

-  Consistency in formatting I suppose you'd call it.


**Tests performed:**

No test needed.


**Known issues and TODO list:** (add/remove lines as needed)

None


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
