### PR TITLE
Core/Unit: Forward proc events from controlled units to owner

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2292,6 +2292,7 @@ SpellCastResult WorldObject::CastSpell(CastSpellTargetArg const& targets, uint32
     }
 
     spell->m_customArg = args.CustomArg;
+    spell->m_extraProcFlags = args.ExtraProcFlags;
     spell->m_scriptResult = args.ScriptResult;
     spell->m_scriptWaitsForSpellHit = args.ScriptWaitsForSpellHit;
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10574,18 +10574,49 @@ void Unit::TriggerAurasProcOnEvent(AuraApplicationList* myProcAuras, AuraApplica
     {
         GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, myProcAuras, myProcEventInfo);
 
-        // needed for example for Cobra Strikes, pet does the attack, but aura is on owner
         if (Player* modOwner = GetSpellModOwner())
         {
-            if (modOwner != this && spell)
+            if (modOwner != this)
             {
-                AuraApplicationList modAuras;
-                for (auto itr = modOwner->GetAppliedAuras().begin(); itr != modOwner->GetAppliedAuras().end(); ++itr)
+                // Needed for examples like Cobra Strikes: pet does the attack, but aura is on owner.
+                if (spell)
                 {
-                    if (spell->m_appliedMods.count(itr->second->GetBase()) != 0)
-                        modAuras.push_front(itr->second);
+                    AuraApplicationList modAuras;
+
+                    for (auto itr = modOwner->GetAppliedAuras().begin(); itr != modOwner->GetAppliedAuras().end(); ++itr)
+                    {
+                        if (spell->m_appliedMods.count(itr->second->GetBase()) != 0)
+                            modAuras.push_front(itr->second);
+                    }
+
+                    if (!modAuras.empty())
+                        modOwner->GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, &modAuras, myProcEventInfo);
                 }
-                modOwner->GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, &modAuras, myProcEventInfo);
+
+                SpellInfo const* eventSpellInfo = myProcEventInfo.GetSpellInfo();
+
+                if (eventSpellInfo && GetTypeId() == TYPEID_UNIT && IsControlledByPlayer())
+                {
+                    AuraApplicationList ownerAuras;
+
+                    for (auto itr = modOwner->GetAppliedAuras().begin(); itr != modOwner->GetAppliedAuras().end(); ++itr)
+                    {
+                        Aura* ownerAura = itr->second->GetBase();
+
+                        // Already covered by spellmod-specific owner handling above.
+                        if (spell && spell->m_appliedMods.count(ownerAura) != 0)
+                            continue;
+
+                        // Keep forwarding to class-family auras to avoid generic item procs from controlled-unit events.
+                        if (ownerAura->GetSpellInfo()->SpellFamilyName == SPELLFAMILY_GENERIC)
+                            continue;
+
+                        ownerAuras.push_front(itr->second);
+                    }
+
+                    if (!ownerAuras.empty())
+                        modOwner->GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, &ownerAuras, myProcEventInfo);
+                }
             }
         }
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -273,7 +273,7 @@ ProcEventInfo::ProcEventInfo(Unit* actor, Unit* actionTarget, Unit* procTarget,
                              Spell* spell, DamageInfo* damageInfo,
                              HealInfo* healInfo) :
     _actor(actor), _actionTarget(actionTarget), _procTarget(procTarget),
-    _typeMask(typeMask), _spellTypeMask(spellTypeMask),
+    _typeMask(typeMask), _extraProcFlags(spell ? spell->GetExtraProcFlags() : PROC_EXTRA_FLAG_NONE), _spellTypeMask(spellTypeMask),
     _spellPhaseMask(spellPhaseMask), _hitMask(hitMask), _spell(spell),
     _damageInfo(damageInfo), _healInfo(healInfo)
 { }
@@ -10585,7 +10585,7 @@ void Unit::TriggerAurasProcOnEvent(AuraApplicationList* myProcAuras, AuraApplica
 
                     for (auto itr = modOwner->GetAppliedAuras().begin(); itr != modOwner->GetAppliedAuras().end(); ++itr)
                     {
-                        if (spell->m_appliedMods.count(itr->second->GetBase()) != 0)
+                        if (spell->m_appliedMods.contains(itr->second->GetBase()))
                             modAuras.push_front(itr->second);
                     }
 
@@ -10593,9 +10593,7 @@ void Unit::TriggerAurasProcOnEvent(AuraApplicationList* myProcAuras, AuraApplica
                         modOwner->GetProcAurasTriggeredOnEvent(myAurasTriggeringProc, &modAuras, myProcEventInfo);
                 }
 
-                SpellInfo const* eventSpellInfo = myProcEventInfo.GetSpellInfo();
-
-                if (eventSpellInfo && GetTypeId() == TYPEID_UNIT && IsControlledByPlayer())
+                if ((myProcEventInfo.GetExtraProcFlags() & PROC_EXTRA_FLAG_ALLOW_OWNER_PROC_ON_PET_EVENT) && GetTypeId() == TYPEID_UNIT && IsControlledByPlayer())
                 {
                     AuraApplicationList ownerAuras;
 
@@ -10604,11 +10602,12 @@ void Unit::TriggerAurasProcOnEvent(AuraApplicationList* myProcAuras, AuraApplica
                         Aura* ownerAura = itr->second->GetBase();
 
                         // Already covered by spellmod-specific owner handling above.
-                        if (spell && spell->m_appliedMods.count(ownerAura) != 0)
+                        if (spell && spell->m_appliedMods.contains(ownerAura))
                             continue;
 
-                        // Keep forwarding to class-family auras to avoid generic item procs from controlled-unit events.
-                        if (ownerAura->GetSpellInfo()->SpellFamilyName == SPELLFAMILY_GENERIC)
+                        // Keep the controlled unit as the proc actor and only offer owner auras that explicitly opt in.
+                        SpellProcEntry const* ownerProcEntry = sSpellMgr->GetSpellProcEntry(ownerAura->GetSpellInfo());
+                        if (!ownerProcEntry || !(ownerProcEntry->AttributesMask & PROC_ATTR_ALLOW_OWNER_PROC_ON_PET_EVENT))
                             continue;
 
                         ownerAuras.push_front(itr->second);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -501,6 +501,7 @@ class TC_GAME_API ProcEventInfo
         Unit* GetProcTarget() const { return _procTarget; }
 
         ProcFlagsInit GetTypeMask() const { return _typeMask; }
+        ProcExtraFlags GetExtraProcFlags() const { return _extraProcFlags; }
         ProcFlagsSpellType GetSpellTypeMask() const { return _spellTypeMask; }
         ProcFlagsSpellPhase GetSpellPhaseMask() const { return _spellPhaseMask; }
         ProcFlagsHit GetHitMask() const { return _hitMask; }
@@ -518,6 +519,7 @@ class TC_GAME_API ProcEventInfo
         Unit* const _actionTarget;
         Unit* const _procTarget;
         ProcFlagsInit _typeMask;
+        ProcExtraFlags _extraProcFlags;
         ProcFlagsSpellType _spellTypeMask;
         ProcFlagsSpellPhase _spellPhaseMask;
         ProcFlagsHit _hitMask;

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -563,6 +563,7 @@ m_spellValue(new SpellValue(m_spellInfo, caster)), _spellEvent(nullptr)
     memset(m_misc.Raw.Data, 0, sizeof(m_misc.Raw.Data));
     m_SpellVisual.SpellXSpellVisualID = caster->GetCastSpellXSpellVisualId(m_spellInfo);
     m_triggeredByAuraSpell  = nullptr;
+    m_extraProcFlags = PROC_EXTRA_FLAG_NONE;
     m_procChainLength = caster->IsUnit() ? caster->ToUnit()->GetProcChainLength() : 0;
     _spellAura = nullptr;
     _dynObjAura = nullptr;

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -64,6 +64,7 @@ struct SummonPropertiesEntry;
 enum AuraType : uint32;
 enum CurrentSpellTypes : uint8;
 enum LootType : uint8;
+enum ProcExtraFlags : uint32;
 enum ProcFlagsHit : uint32;
 enum ProcFlagsSpellType : uint32;
 enum SpellTargetCheckTypes : uint8;
@@ -638,6 +639,9 @@ class TC_GAME_API Spell
             } Raw;
         } m_misc;
         std::any m_customArg;
+
+        ProcExtraFlags m_extraProcFlags;
+
         SpellCastVisual m_SpellVisual;
         SpellCastTargets m_targets;
         SpellCustomErrors m_customError;
@@ -666,6 +670,7 @@ class TC_GAME_API Spell
         bool CanReleaseEmpowerSpell() const;
 
         bool IsTriggeredByAura(SpellInfo const* auraSpellInfo) const { return (auraSpellInfo == m_triggeredByAuraSpell); }
+        ProcExtraFlags GetExtraProcFlags() const { return m_extraProcFlags; }
 
         int32 GetProcChainLength() const { return m_procChainLength; }
 

--- a/src/server/game/Spells/SpellDefines.h
+++ b/src/server/game/Spells/SpellDefines.h
@@ -306,6 +306,14 @@ enum TriggerCastFlags : uint32
 
 DEFINE_ENUM_FLAG(TriggerCastFlags);
 
+enum ProcExtraFlags : uint32
+{
+    PROC_EXTRA_FLAG_NONE                            = 0x00000000,
+    PROC_EXTRA_FLAG_ALLOW_OWNER_PROC_ON_PET_EVENT   = 0x00000001  // Allows a controlled pet spell event to evaluate explicitly marked owner auras
+};
+
+DEFINE_ENUM_FLAG(ProcExtraFlags);
+
 enum SpellCastTargetFlags : uint32
 {
     TARGET_FLAG_NONE            = 0x00000000,
@@ -480,6 +488,7 @@ struct TC_GAME_API CastSpellTargetArg
 struct CastSpellExtraArgsInit
 {
     TriggerCastFlags TriggerFlags = TRIGGERED_NONE;
+    ProcExtraFlags ExtraProcFlags = PROC_EXTRA_FLAG_NONE;
     Difficulty CastDifficulty = Difficulty(0);
     Item* CastItem = nullptr;
     Spell const* TriggeringSpell = nullptr;
@@ -527,6 +536,7 @@ struct TC_GAME_API CastSpellExtraArgs : public CastSpellExtraArgsInit
     ~CastSpellExtraArgs();
 
     CastSpellExtraArgs& SetTriggerFlags(TriggerCastFlags flag) { TriggerFlags = flag; return *this; }
+    CastSpellExtraArgs& SetExtraProcFlags(ProcExtraFlags flags) { ExtraProcFlags = flags; return *this; }
     CastSpellExtraArgs& SetCastItem(Item* item) { CastItem = item; return *this; }
     CastSpellExtraArgs& SetTriggeringSpell(Spell const* triggeringSpell);
     CastSpellExtraArgs& SetTriggeringAura(AuraEffect const* triggeringAura) { TriggeringAura = triggeringAura; return *this; }

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -254,26 +254,28 @@ DEFINE_ENUM_FLAG(ProcFlagsHit);
 
 enum ProcAttributes : uint32
 {
-    PROC_ATTR_NONE                      = 0x0000000,
-    PROC_ATTR_REQ_EXP_OR_HONOR          = 0x0000001, // requires proc target to give exp or honor for aura proc
-    PROC_ATTR_TRIGGERED_CAN_PROC        = 0x0000002, // aura can proc even with triggered spells
-    PROC_ATTR_REQ_POWER_COST            = 0x0000004, // requires triggering spell to have a power cost for aura proc
-    PROC_ATTR_REQ_SPELLMOD              = 0x0000008, // requires triggering spell to be affected by proccing aura to drop charges
-    PROC_ATTR_USE_STACKS_FOR_CHARGES    = 0x0000010, // consuming proc drops a stack from proccing aura instead of charge
+    PROC_ATTR_NONE                          = 0x0000000,
+    PROC_ATTR_REQ_EXP_OR_HONOR              = 0x0000001, // requires proc target to give exp or honor for aura proc
+    PROC_ATTR_TRIGGERED_CAN_PROC            = 0x0000002, // aura can proc even with triggered spells
+    PROC_ATTR_REQ_POWER_COST                = 0x0000004, // requires triggering spell to have a power cost for aura proc
+    PROC_ATTR_REQ_SPELLMOD                  = 0x0000008, // requires triggering spell to be affected by proccing aura to drop charges
+    PROC_ATTR_USE_STACKS_FOR_CHARGES        = 0x0000010, // consuming proc drops a stack from proccing aura instead of charge
 
-    PROC_ATTR_REDUCE_PROC_60            = 0x0000080, // aura should have a reduced chance to proc if level of proc Actor > 60
-    PROC_ATTR_CANT_PROC_FROM_ITEM_CAST  = 0x0000100, // do not allow aura proc if proc is caused by a spell casted by item
+    PROC_ATTR_REDUCE_PROC_60                = 0x0000080, // aura should have a reduced chance to proc if level of proc Actor > 60
+    PROC_ATTR_CANT_PROC_FROM_ITEM_CAST      = 0x0000100, // do not allow aura proc if proc is caused by a spell casted by item
+    PROC_ATTR_ALLOW_OWNER_PROC_ON_PET_EVENT = 0x0000200  // Allows this aura to be evaluated on the owner for pet-triggered events that explicitly opt in
 };
 
 DEFINE_ENUM_FLAG(ProcAttributes);
 
-#define PROC_ATTR_ALL_ALLOWED (PROC_ATTR_REQ_EXP_OR_HONOR       | \
-                               PROC_ATTR_TRIGGERED_CAN_PROC     | \
-                               PROC_ATTR_REQ_POWER_COST         | \
-                               PROC_ATTR_REQ_SPELLMOD           | \
-                               PROC_ATTR_USE_STACKS_FOR_CHARGES | \
-                               PROC_ATTR_REDUCE_PROC_60         | \
-                               PROC_ATTR_CANT_PROC_FROM_ITEM_CAST)
+#define PROC_ATTR_ALL_ALLOWED (PROC_ATTR_REQ_EXP_OR_HONOR               | \
+                               PROC_ATTR_TRIGGERED_CAN_PROC             | \
+                               PROC_ATTR_REQ_POWER_COST                 | \
+                               PROC_ATTR_REQ_SPELLMOD                   | \
+                               PROC_ATTR_USE_STACKS_FOR_CHARGES         | \
+                               PROC_ATTR_REDUCE_PROC_60                 | \
+                               PROC_ATTR_CANT_PROC_FROM_ITEM_CAST       | \
+                               PROC_ATTR_ALLOW_OWNER_PROC_ON_PET_EVENT)
 
 struct SpellProcEntry
 {


### PR DESCRIPTION
**Changes proposed:**

Extend proc forwarding for controlled units (pets/guardians).

When a controlled unit triggers a proc event, the event is now also
forwarded to the owner so relevant owner auras can react to it. TrinityCore
already forwarded spellmod-related auras (e.g. Cobra Strikes), but other
owner auras were not considered.

This change forwards additional owner class-family auras while avoiding
double processing of already handled spellmod auras and explicitly
excluding generic auras to prevent unintended item procs.


**Tests performed:**

Tested proc behavior with controlled units triggering events while relevant
auras were active on the owner (e.g. pet attacks causing owner auras to react).
Verified that owner auras correctly receive and process the forwarded proc
events and that spellmod-related auras continue to behave as before.

Testing was performed on a TCCP core.  
The change has not yet been tested against TrinityCore master.
