### PR TITLE
Scripts/Commands: Fix integer underflow in .pinfo ban time display

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1848,7 +1848,7 @@ public:
 
         // Output III. LANG_PINFO_BANNED if ban exists and is applied
         if (banTime >= 0)
-            handler->PSendSysMessage(LANG_PINFO_BANNED, banType.c_str(), banReason.c_str(), banTime > 0 ? secsToTimeString(banTime - GameTime::GetGameTime(), TimeFormat::ShortText).c_str() : handler->GetTrinityString(LANG_PERMANENTLY), bannedBy.c_str());
+            handler->PSendSysMessage(LANG_PINFO_BANNED, banType.c_str(), banReason.c_str(), banTime > 0 ? secsToTimeString(std::max<int64>(banTime - GameTime::GetGameTime(), 0), TimeFormat::ShortText).c_str() : handler->GetTrinityString(LANG_PERMANENTLY), bannedBy.c_str());
 
         // Output IV. LANG_PINFO_MUTED if mute is applied
         if (muteTime > 0)


### PR DESCRIPTION
**Changes proposed:**

-  Fix integer underflow in .pinfo ban time

- When you ban a character (or account), you can see the remaining time of active ban (if not permanent) with .pinfo command.
If no player enter in the character selection within that time frame, CHAR_DEL_EXPIRED_BANS is not executed.

- When this happens, checking .pinfo calculates a negative remaining ban time, which causes an integer underflow when formatting the output string. This change sets the remaining time to 0 instead.

**Issues addressed:**

None


**Tests performed:**

Tested in-game

Test before fix:
1. use command .ban character name_of_player 10s "test1"
2. use .pinfo name_of_player
3. see duration until end, with result:
```
- Banned: (Type: Character, Reason: "test1", Time: 213503982334601d6h59m49s, By: Jildor)
```

Test after fix:
1. use command .ban character name_of_player 10s "test2"
2. use .pinfo name_of_player
3. see duration until end, with result:
```
- Banned: (Type: Character, Reason: "test2", Time: 0s, By: Jildor)
```
