### PR TITLE
Core/GameObject: Mage Portals and Refreshment Tables should be usable when the creating Mage is on another map or offline as long as you remain in group

### DIFF
--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2034,11 +2034,18 @@ void GameObject::Use(Unit* user)
 
             if (info->spellcaster.partyOnly)
             {
-                Unit* caster = GetOwner();
-                if (!caster || caster->GetTypeId() != TYPEID_PLAYER)
+                ObjectGuid ownerGuid = GetOwnerGUID();
+                if (!ownerGuid)
                     return;
 
-                if (user->GetTypeId() != TYPEID_PLAYER || !user->ToPlayer()->IsInSameRaidWith(caster->ToPlayer()))
+                if (user->GetTypeId() != TYPEID_PLAYER)
+                    return;
+
+                Group* group = user->ToPlayer()->GetGroup();
+                if (!group)
+                    return;
+
+                if (!group->IsMember(ownerGuid))
                     return;
             }
 

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2035,18 +2035,22 @@ void GameObject::Use(Unit* user)
             if (info->spellcaster.partyOnly)
             {
                 ObjectGuid ownerGuid = GetOwnerGUID();
-                if (!ownerGuid)
+                if (!ownerGuid || !ownerGuid.IsPlayer())
                     return;
 
                 if (user->GetTypeId() != TYPEID_PLAYER)
                     return;
 
-                Group* group = user->ToPlayer()->GetGroup();
-                if (!group)
-                    return;
-
-                if (!group->IsMember(ownerGuid))
-                    return;
+                if (Group* group = user->ToPlayer()->GetGroup())
+                {
+                    if (! group->IsMember(ownerGuid))
+                        return;
+                }
+                else
+                {
+                    if (ownerGuid != user->GetGUID())
+                        return;
+                }
             }
 
             user->RemoveAurasByType(SPELL_AURA_MOUNTED);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2043,7 +2043,7 @@ void GameObject::Use(Unit* user)
 
                 if (Group* group = user->ToPlayer()->GetGroup())
                 {
-                    if (! group->IsMember(ownerGuid))
+                    if (!group->IsMember(ownerGuid))
                         return;
                 }
                 else

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2035,20 +2035,20 @@ void GameObject::Use(Unit* user)
             if (info->spellcaster.partyOnly)
             {
                 ObjectGuid ownerGuid = GetOwnerGUID();
-                if (!ownerGuid || !ownerGuid.IsPlayer())
+                if (ownerGuid.IsEmpty())
                     return;
 
-                if (user->GetTypeId() != TYPEID_PLAYER)
-                    return;
-
-                if (Group* group = user->ToPlayer()->GetGroup())
+                if (ownerGuid != user->GetGUID())
                 {
-                    if (!group->IsMember(ownerGuid))
+                    if (Unit* owner = ObjectAccessor::GetUnit(*this, ownerGuid))
+                        ownerGuid = owner->GetCharmerOrOwnerOrOwnGUID();
+
+                    Player const* playerUser = user->GetCharmerOrOwnerPlayerOrPlayerItself();
+                    if (!playerUser)
                         return;
-                }
-                else
-                {
-                    if (ownerGuid != user->GetGUID())
+
+                    Group const* group = playerUser->GetGroup();
+                    if (!group || !group->IsMember(ownerGuid))
                         return;
                 }
             }


### PR DESCRIPTION
…p or offline so long as you remain in group

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Allow using Mage Portals and Refreshment Tables in the specified cases.

**Issues addressed:**

Found the following issue where I got the linked solution:

Closes https://github.com/TrinityCore/TrinityCore/issues/31527


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ No that I'm aware. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
