### PR TITLE
Core/Scripts: Allow using Soulwells even when creating Warlock is on another map or offline as long as you remain in group

### DIFF
--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -35,8 +35,10 @@ EndContentData */
 #include "GameObject.h"
 #include "GameObjectAI.h"
 #include "GameTime.h"
+#include "Group.h"
 #include "Log.h"
 #include "MotionMaster.h"
+#include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
@@ -462,12 +464,23 @@ class go_soulwell : public GameObjectScript
 
             bool OnGossipHello(Player* player) override
             {
-                Unit* owner = me->GetOwner();
                 if (_stoneSpell == 0 || _stoneId == 0)
                     return true;
 
-                if (!owner || owner->GetTypeId() != TYPEID_PLAYER || !player->IsInSameRaidWith(owner->ToPlayer()))
+                ObjectGuid ownerGuid = me->GetOwnerGUID();
+                if (!ownerGuid || !ownerGuid.IsPlayer())
                     return true;
+
+                if (Group* group = player->GetGroup())
+                {
+                    if (!group->IsMember(ownerGuid))
+                        return true;
+                }
+                else
+                {
+                    if (ownerGuid != player->GetGUID())
+                        return true;
+                }
 
                 // Don't try to add a stone if we already have one.
                 if (player->HasItemCount(_stoneId))
@@ -477,7 +490,7 @@ class go_soulwell : public GameObjectScript
                     return true;
                 }
 
-                owner->CastSpell(player, _stoneSpell, true);
+                me->CastSpell(player, _stoneSpell, true);
                 // Item has to actually be created to remove a charge on the well.
                 if (player->HasItemCount(_stoneId))
                     me->AddUse();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Mirror #31730 checks but this time for Soulwells

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ ~Sometimes the SPELL_FAILED_TOO_MANY_OF_ITEM error pop even at first click, need further investigation if related to this PR or it happened before too.~ seems not related ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
