### PR TITLE
Core/PetAI: Charmed units will properly return near owner after target death

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -363,7 +363,7 @@ void PetAI::HandleReturnMovement()
 
     // Prevent activating movement when under control of spells
     // such as "Eyes of the Beast"
-    if (me->IsCharmed())
+    if (me->isPossessed())
         return;
 
     if (!me->GetCharmInfo())


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix the case where charmed unit "forget" to turn back near owner after target died (it remain stuck nearby).

**Issues addressed:**

To be combined with https://github.com/TrinityCore/TrinityCore/pull/31747.

Updates https://github.com/TrinityCore/TrinityCore/issues/30169


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ None as I know. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
