### PR TITLE
Core/Unit: Normalize charmed units speed and also drop unneeded combat check

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8625,12 +8625,12 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
 
     if (Creature* creature = ToCreature())
     {
-        if (creature->HasUnitTypeMask(UNIT_MASK_MINION) || creature->IsCharmed())
+        if (creature->HasUnitTypeMask(UNIT_MASK_MINION))
         {
             if (GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
             {
                 Unit* followed = ASSERT_NOTNULL(dynamic_cast<AbstractFollower*>(GetMotionMaster()->GetCurrentMovementGenerator()))->GetTarget();
-                if (followed && followed->GetGUID() == GetCharmerOrOwnerGUID())
+                if (followed && followed->GetGUID() == GetOwnerGUID())
                 {
                     float ownerSpeed = followed->GetSpeedRate(mtype);
                     if (speed < ownerSpeed || creature->IsWithinDist3d(followed, 10.0f))

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8625,12 +8625,12 @@ void Unit::UpdateSpeed(UnitMoveType mtype)
 
     if (Creature* creature = ToCreature())
     {
-        if (creature->HasUnitTypeMask(UNIT_MASK_MINION) && !creature->IsInCombat())
+        if (creature->HasUnitTypeMask(UNIT_MASK_MINION) || creature->IsCharmed())
         {
             if (GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
             {
                 Unit* followed = ASSERT_NOTNULL(dynamic_cast<AbstractFollower*>(GetMotionMaster()->GetCurrentMovementGenerator()))->GetTarget();
-                if (followed && followed->GetGUID() == GetOwnerGUID() && !followed->IsInCombat())
+                if (followed && followed->GetGUID() == GetCharmerOrOwnerGUID())
                 {
                     float ownerSpeed = followed->GetSpeedRate(mtype);
                     if (speed < ownerSpeed || creature->IsWithinDist3d(followed, 10.0f))

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -160,6 +160,24 @@ bool FollowMovementGenerator::Update(Unit* owner, uint32 diff)
             init.MovebyPath(_path->GetPath());
             init.SetWalk(target->IsWalking());
             init.SetFacing(target->GetOrientation());
+
+            // For units following their owner/charmer, dynamically scale spline speed
+            if (Creature* cOwner = owner->ToCreature())
+            {
+                if (cOwner->IsCharmed() && !cOwner->ToPet())
+                {
+                    Unit* followed = GetTarget();
+                    if (followed && followed->GetGUID() == owner->GetCharmerOrOwnerGUID())
+                    {
+                        float dist = owner->GetDistance(followed);
+                        float ownerSpeed = followed->GetSpeed(MOVE_RUN);
+                        float catchupSpeed = ownerSpeed * std::min(std::max(1.0f, 0.75f + (dist - PET_FOLLOW_DIST) * 0.05f), 1.3f);
+                        if (catchupSpeed > owner->GetSpeed(MOVE_RUN))
+                            init.SetVelocity(catchupSpeed);
+                    }
+                }
+            }
+
             init.Launch();
         }
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Now charmed units have same speed like pets.
-  Pets should inherit player speed even if the player is in combat.

**Issues addressed:**

Closes https://github.com/TrinityCore/TrinityCore/issues/26754
Updates https://github.com/TrinityCore/TrinityCore/issues/30169


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ None as I'm aware ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
