### PR TITLE
Player/Inventory: Add 4 extra slots for secured account flag.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -472,7 +472,11 @@ bool Player::Create(ObjectGuid::LowType guidlow, WorldPackets::Character::Charac
     SetRestState(REST_TYPE_XP, (GetSession()->IsARecruiter() || GetSession()->GetRecruiterId() != 0) ? REST_STATE_RAF_LINKED : REST_STATE_NORMAL);
     SetRestState(REST_TYPE_HONOR, REST_STATE_NORMAL);
     SetNativeGender(Gender(createInfo->Sex));
-    SetInventorySlotCount(INVENTORY_DEFAULT_SIZE);
+
+    if (HasPlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED))
+        SetInventorySlotCount(INVENTORY_ACCOUNT_SECURED_SIZE);
+    else
+        SetInventorySlotCount(INVENTORY_DEFAULT_SIZE);
 
     // set starting level
     SetLevel(GetStartLevel(createInfo->Race, createInfo->Class, createInfo->TemplateSet), false);
@@ -20424,6 +20428,10 @@ void Player::SaveToDB(LoginDatabaseTransaction loginTransaction, CharacterDataba
         ScheduleDelayedOperation(DELAYED_SAVE_PLAYER);
         return;
     }
+
+    // adding extra inventory slots to existing characters
+    if (HasPlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED) && GetInventorySlotCount() == INVENTORY_DEFAULT_SIZE)
+        SetInventorySlotCount(INVENTORY_ACCOUNT_SECURED_SIZE);
 
     // first save/honor gain after midnight will also update the player's honor fields
     UpdateHonorFields();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -473,11 +473,6 @@ bool Player::Create(ObjectGuid::LowType guidlow, WorldPackets::Character::Charac
     SetRestState(REST_TYPE_HONOR, REST_STATE_NORMAL);
     SetNativeGender(Gender(createInfo->Sex));
 
-    if (HasPlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED))
-        SetInventorySlotCount(INVENTORY_ACCOUNT_SECURED_SIZE);
-    else
-        SetInventorySlotCount(INVENTORY_DEFAULT_SIZE);
-
     // set starting level
     SetLevel(GetStartLevel(createInfo->Race, createInfo->Class, createInfo->TemplateSet), false);
 
@@ -9858,6 +9853,18 @@ void Player::SetInventorySlotCount(uint8 slots)
     SetUpdateFieldValue(m_values.ModifyValue(&Player::m_activePlayerData).ModifyValue(&UF::ActivePlayerData::NumBackpackSlots), slots);
 }
 
+void Player::UpdateInventorySlotCount()
+{
+    uint8 slotCount = INVENTORY_DEFAULT_SIZE;
+    if (HasPlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED))
+        slotCount += INVENTORY_ACCOUNT_SECURED_BONUS_SIZE;
+
+    if (AuraEffect const* alpacaSaddlebags = GetAuraEffect(SPELL_ALPACA_SADDLEBAGS, EFFECT_0))
+        slotCount += alpacaSaddlebags->GetAmountAsInt();
+
+    SetInventorySlotCount(slotCount);
+}
+
 bool Player::HasItemCount(uint32 item, uint32 count, bool inBankAlso) const
 {
     ItemSearchLocation location = ItemSearchLocation::Equipment | ItemSearchLocation::Inventory | ItemSearchLocation::ReagentBank;
@@ -10087,6 +10094,8 @@ InventoryResult Player::CanStoreItem_InSpecificSlot(uint8 bag, uint8 slot, ItemP
             // prevent cheating
             if ((slot >= BUYBACK_SLOT_START && slot < BUYBACK_SLOT_END) || slot >= PLAYER_SLOT_END)
                 return EQUIP_ERR_WRONG_BAG_TYPE;
+            if (slot < INVENTORY_SLOT_ITEM_END && slot >= INVENTORY_SLOT_ITEM_START + GetInventorySlotCount())
+                return EQUIP_ERR_NO_SLOT_AVAILABLE;
         }
         else
         {
@@ -19194,6 +19203,8 @@ void Player::_LoadInventory(PreparedQueryResult result, PreparedQueryResult arti
     //NOTE2: the "order by `slot`" is needed because mainhand weapons are (wrongly?)
     //expected to be equipped before offhand items (@todo fixme)
 
+    UpdateInventorySlotCount();
+
     std::unordered_map<ObjectGuid::LowType, ItemAdditionalLoadInfo> additionalData;
     ItemAdditionalLoadInfo::Init(&additionalData, artifactsResult, azeriteResult, azeriteItemMilestonePowersResult,
         azeriteItemUnlockedEssencesResult, azeriteEmpoweredItemResult);
@@ -20428,10 +20439,6 @@ void Player::SaveToDB(LoginDatabaseTransaction loginTransaction, CharacterDataba
         ScheduleDelayedOperation(DELAYED_SAVE_PLAYER);
         return;
     }
-
-    // adding extra inventory slots to existing characters
-    if (HasPlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED) && GetInventorySlotCount() == INVENTORY_DEFAULT_SIZE)
-        SetInventorySlotCount(INVENTORY_ACCOUNT_SECURED_SIZE);
 
     // first save/honor gain after midnight will also update the player's honor fields
     UpdateHonorFields();
@@ -31072,6 +31079,16 @@ void Player::UpdateWarModeAuras()
             RemovePvpFlag(UNIT_BYTE2_FLAG_PVP);
         RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags2::WarModeLeave);
     }
+}
+
+void Player::SetAccountSecured(bool secured)
+{
+    if (secured)
+        SetPlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED);
+    else
+        RemovePlayerLocalFlag(PLAYER_LOCAL_FLAG_ACCOUNT_SECURED);
+
+    UpdateInventorySlotCount();
 }
 
 void Player::AddUnlockedTransmogOutfits(std::span<int32 const> transmogOutfitIds)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -720,7 +720,9 @@ static_assert(UF::size<decltype(UF::ActivePlayerData::InvSlots)>() == PLAYER_SLO
 
 inline constexpr uint8 INVENTORY_SLOT_BAG_0 = 255;
 inline constexpr uint8 INVENTORY_DEFAULT_SIZE = 16;
-inline constexpr uint8 INVENTORY_ACCOUNT_SECURED_SIZE = INVENTORY_DEFAULT_SIZE + 4; // 4 slots are provided for having a secured account
+inline constexpr uint8 INVENTORY_ACCOUNT_SECURED_BONUS_SIZE = 4;
+
+inline constexpr uint32 SPELL_ALPACA_SADDLEBAGS = 317795;
 
 enum EquipmentSlots : uint8                                 // 19 slots
 {
@@ -1495,6 +1497,7 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         bool IsValidPos(uint8 bag, uint8 slot, bool explicit_pos) const;
         uint8 GetInventorySlotCount() const { return m_activePlayerData->NumBackpackSlots; }
         void SetInventorySlotCount(uint8 slots);
+        void UpdateInventorySlotCount();
         uint8 GetBankBagSlotCount() const { return m_activePlayerData->NumBankSlots; }
         void SetBankBagSlotCount(uint8 count) { SetUpdateFieldValue(m_values.ModifyValue(&Player::m_activePlayerData).ModifyValue(&UF::ActivePlayerData::NumBankSlots), count); }
         uint8 GetCharacterBankTabCount() const { return m_activePlayerData->NumCharacterBankTabs; }
@@ -3040,6 +3043,8 @@ class TC_GAME_API Player final : public Unit, public GridObject<Player>
         void SetWarModeLocal(bool enabled);
         bool CanEnableWarModeInArea() const;
         void UpdateWarModeAuras();
+
+        void SetAccountSecured(bool secured);
 
         void AddUnlockedTransmogOutfits(std::span<int32 const> transmogOutfitIds);
         void AddUnlockedTransmogOutfit(int32 transmogOutfitIds) { AddUnlockedTransmogOutfits(std::span(&transmogOutfitIds, 1)); }

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -718,8 +718,9 @@ enum PlayerSlots
 
 static_assert(UF::size<decltype(UF::ActivePlayerData::InvSlots)>() == PLAYER_SLOT_END);
 
-#define INVENTORY_SLOT_BAG_0    255
-#define INVENTORY_DEFAULT_SIZE  16
+inline constexpr uint8 INVENTORY_SLOT_BAG_0 = 255;
+inline constexpr uint8 INVENTORY_DEFAULT_SIZE = 16;
+inline constexpr uint8 INVENTORY_ACCOUNT_SECURED_SIZE = INVENTORY_DEFAULT_SIZE + 4; // 4 slots are provided for having a secured account
 
 enum EquipmentSlots : uint8                                 // 19 slots
 {


### PR DESCRIPTION
**Changes proposed:**

- Add the 4 extra slots for backpack inventory when player has the secured account flag 
- Update the inventory defines to constexpr

**Issues addressed:**
none that i know off


**Tests performed:**
builds and works ingame - if you add the required flag ofcourse


**Known issues and TODO list:** (add/remove lines as needed)
none

Original idea from @KamiliaBlow 