### PR TITLE
Core/Items: Add durability sell penalty when selling damaged items to…

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -749,7 +749,7 @@ bool Item::CanBeTraded(bool mail, bool trade) const
     return true;
 }
 
-uint32 Item::CalculateDurabilityRepairCost(float discount) const
+uint32 Item::CalculateDurabilityRepairCost(float discount, bool useRateConfig /*= true*/) const
 {
     uint32 maxDurability = GetUInt32Value(ITEM_FIELD_MAXDURABILITY);
     if (!maxDurability)
@@ -788,12 +788,17 @@ uint32 Item::CalculateDurabilityRepairCost(float discount) const
     }
 
     uint32 cost = static_cast<uint32>(std::round(lostDurability * dmultiplier * double(durabilityQualityEntry->Data)));
-    cost = uint32(cost * discount * sWorld->getRate(RATE_REPAIRCOST));
+    cost = uint32(cost * discount * (useRateConfig ? sWorld->getRate(RATE_REPAIRCOST) : 1));
 
     if (cost == 0) // Fix for ITEM_QUALITY_ARTIFACT
         cost = 1;
 
     return cost;
+}
+
+uint32 Item::CalculateDurabilitySellPenalty() const
+{
+    return CalculateDurabilityRepairCost(1.0f, false);
 }
 
 bool Item::HasEnchantRequiredSkill(Player const* player) const

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -109,7 +109,8 @@ class TC_GAME_API Item : public Object
         void SetInTrade(bool b = true) { mb_in_trade = b; }
         bool IsInTrade() const { return mb_in_trade; }
 
-        uint32 CalculateDurabilityRepairCost(float discount) const;
+        uint32 CalculateDurabilityRepairCost(float discount, bool useRateConfig = true) const;
+        uint32 CalculateDurabilitySellPenalty() const;
 
         bool HasEnchantRequiredSkill(Player const* player) const;
         uint32 GetEnchantRequiredLevel() const;

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -422,6 +422,16 @@ void WorldSession::HandleSellItemOpcode(WorldPackets::Item::SellItem& packet)
             if (pProto->GetSellPrice() > 0)
             {
                 uint32 money = pProto->GetSellPrice() * packet.Amount;
+                uint32 durabilityPenalty = pItem->CalculateDurabilitySellPenalty();
+
+                if (durabilityPenalty)
+                {
+                    if (durabilityPenalty > money)
+                        money = 1;
+                    else
+                        money -= durabilityPenalty;
+                }
+
                 if (_player->GetMoney() >= MAX_MONEY_AMOUNT - money)               // prevent exceeding gold limit
                 {
                     _player->SendEquipError(EQUIP_ERR_TOO_MUCH_GOLD, nullptr, nullptr);


### PR DESCRIPTION
… vendors

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Selling a damaged item to a vendor now properly reduces the gold received based on lost durability, matching what the client already displays.

**Issues addressed:**

none

**Tests performed:**

builds, tested in-game

before:

https://github.com/user-attachments/assets/994f4bc1-abda-4415-b28e-1931dcc9e8b9

after:

https://github.com/user-attachments/assets/abaaf542-47ed-481d-9503-0529ae649f2d


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
