### PR TITLE
Core/PacketIO: drop MovementPacketBuilder

### DIFF
--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -173,17 +173,17 @@ namespace Movement
         move_spline.onTransport = transport;
         move_spline.Initialize(args);
 
-        WorldPacket data(SMSG_MONSTER_MOVE, 64);
-        data << unit->GetPackGUID();
+        WorldPackets::Movement::MonsterMove packet;
+        packet.MoverGUID = unit->GetGUID();
+        packet.SplineData.ID = move_spline.GetId();
+        packet.SplineData.Destination = G3D::Vector3(loc.x, loc.y, loc.z);
+        packet.SplineData.Move.Face = MONSTER_MOVE_STOP;
         if (transport)
         {
-            data.SetOpcode(SMSG_MONSTER_MOVE_TRANSPORT);
-            data << unit->GetTransGUID().WriteAsPacked();
-            data << int8(unit->GetTransSeat());
+            packet.SplineData.TransportGUID = unit->GetTransGUID();
+            packet.SplineData.VehicleSeat = unit->GetTransSeat();
         }
-
-        PacketBuilder::WriteStopMovement(loc, args.splineId, data);
-        unit->SendMessageToSet(&data, true);
+        unit->SendMessageToSet(packet.Write(), true);
     }
 
     MoveSplineInit::MoveSplineInit(Unit* m) : unit(m)

--- a/src/server/game/Movement/Spline/MoveSplineInit.cpp
+++ b/src/server/game/Movement/Spline/MoveSplineInit.cpp
@@ -18,6 +18,7 @@
 #include "MoveSplineInit.h"
 #include "Creature.h"
 #include "MoveSpline.h"
+#include "MovementPackets.h"
 #include "MovementPacketBuilder.h"
 #include "Unit.h"
 #include "PathGenerator.h"
@@ -128,17 +129,15 @@ namespace Movement
         unit->m_movementInfo.SetMovementFlags(moveFlags);
         move_spline.Initialize(args);
 
-        WorldPacket data(SMSG_MONSTER_MOVE, 64);
-        data << unit->GetPackGUID();
+        WorldPackets::Movement::MonsterMove packet;
+        packet.MoverGUID = unit->GetGUID();
         if (transport)
         {
-            data.SetOpcode(SMSG_MONSTER_MOVE_TRANSPORT);
-            data << unit->GetTransGUID().WriteAsPacked();
-            data << int8(unit->GetTransSeat());
+            packet.SplineData.TransportGUID = unit->GetTransGUID();
+            packet.SplineData.VehicleSeat = unit->GetTransSeat();
         }
-
-        PacketBuilder::WriteMonsterMove(move_spline, data);
-        unit->SendMessageToSet(&data, true);
+        PacketBuilder::WriteMonsterMove(move_spline, packet.SplineData);
+        unit->SendMessageToSet(packet.Write(), true);
 
         return move_spline.Duration();
     }

--- a/src/server/game/Movement/Spline/MovementPacketBuilder.cpp
+++ b/src/server/game/Movement/Spline/MovementPacketBuilder.cpp
@@ -19,129 +19,100 @@
 #include "ByteBuffer.h"
 #include "MoveSpline.h"
 #include "Position.h"
+#include "MovementPackets.h"
 
 namespace Movement
 {
-    inline void operator<<(ByteBuffer& b, Vector3 const& v)
-    {
-        b << v.x << v.y << v.z;
-    }
-
-    inline void operator>>(ByteBuffer& b, Vector3& v)
-    {
-        b >> v.x >> v.y >> v.z;
-    }
-
-    enum MonsterMoveType
-    {
-        MonsterMoveNormal       = 0,
-        MonsterMoveStop         = 1,
-        MonsterMoveFacingSpot   = 2,
-        MonsterMoveFacingTarget = 3,
-        MonsterMoveFacingAngle  = 4
-    };
-
-    void PacketBuilder::WriteCommonMonsterMovePart(MoveSpline const& move_spline, ByteBuffer& data)
-    {
-        MoveSplineFlag splineflags = move_spline.splineflags;
-
-        data << uint8(0);                                       // sets/unsets MOVEMENTFLAG2_UNK7 (0x40)
-        data << move_spline.spline.getPoint(move_spline.spline.first());
-        data << move_spline.GetId();
-
-        switch (splineflags & MoveSplineFlag::Mask_Final_Facing)
-        {
-            case MoveSplineFlag::Final_Target:
-                data << uint8(MonsterMoveFacingTarget);
-                data << move_spline.facing.target;
-                break;
-            case MoveSplineFlag::Final_Angle:
-                data << uint8(MonsterMoveFacingAngle);
-                data << move_spline.facing.angle;
-                break;
-            case MoveSplineFlag::Final_Point:
-                data << uint8(MonsterMoveFacingSpot);
-                data << move_spline.facing.f.x << move_spline.facing.f.y << move_spline.facing.f.z;
-                break;
-            default:
-                data << uint8(MonsterMoveNormal);
-                break;
-        }
-
-        data << uint32(splineflags & uint32(~MoveSplineFlag::Mask_No_Monster_Move));
-
-        if (splineflags.animation)
-        {
-            data << splineflags.animTier;
-            data << move_spline.effect_start_time;
-        }
-
-        data << move_spline.Duration();
-
-        if (splineflags.parabolic)
-        {
-            data << move_spline.vertical_acceleration;
-            data << move_spline.effect_start_time;
-        }
-    }
-
     void PacketBuilder::WriteStopMovement(G3D::Vector3 const& pos, uint32 splineId, ByteBuffer& data)
     {
         data << uint8(0);                                       // sets/unsets MOVEMENTFLAG2_UNK7 (0x40)
         data << pos;
         data << splineId;
-        data << uint8(MonsterMoveStop);
+        data << uint8(MONSTER_MOVE_STOP);
     }
 
-    void WriteLinearPath(Spline<int32> const& spline, ByteBuffer& data)
+    void PacketBuilder::WriteMonsterMove(MoveSpline const& move_spline, WorldPackets::Movement::MovementMonsterSpline& movementMonsterSpline)
     {
-        uint32 last_idx = spline.getPointCount() - 3;
-        G3D::Vector3 const* real_path = &spline.getPoint(1);
+        movementMonsterSpline.ID = move_spline.m_Id;
+        WorldPackets::Movement::MovementSpline& movementSpline = movementMonsterSpline.Move;
 
-        data << last_idx;
-        data << real_path[last_idx];   // destination
-        if (last_idx > 1)
-        {
-            G3D::Vector3 middle = (real_path[0] + real_path[last_idx]) / 2.f;
-            G3D::Vector3 offset;
-            // first and last points already appended
-            for (uint32 i = 1; i < last_idx; ++i)
-            {
-                offset = middle - real_path[i];
-                data << TaggedPosition<Position::PackedXYZ>(offset.x, offset.y, offset.z);
-            }
-        }
-    }
-
-    void WriteCatmullRomPath(Spline<int32> const& spline, ByteBuffer& data)
-    {
-        uint32 count = spline.getPointCount() - 3;
-        data << count;
-        data.append<G3D::Vector3>(&spline.getPoint(2), count);
-    }
-
-    void WriteCatmullRomCyclicPath(Spline<int32> const& spline, ByteBuffer& data)
-    {
-        uint32 count = spline.getPointCount() - 4;
-        data << count;
-        data.append<Vector3>(&spline.getPoint(2), count);
-    }
-
-    void PacketBuilder::WriteMonsterMove(MoveSpline const& move_spline, ByteBuffer& data)
-    {
-        WriteCommonMonsterMovePart(move_spline, data);
-
-        const Spline<int32>& spline = move_spline.spline;
         MoveSplineFlag splineflags = move_spline.splineflags;
+        movementSpline.Flags = uint32(splineflags & uint32(~MoveSplineFlag::Mask_No_Monster_Move));
+ 
+        movementMonsterSpline.Destination = move_spline.spline.getPoint(move_spline.spline.first());
+
+        switch (splineflags & MoveSplineFlag::Mask_Final_Facing)
+        {
+            case MoveSplineFlag::Final_Point:
+                movementSpline.Face = MONSTER_MOVE_FACING_SPOT;
+                movementSpline.FaceSpot = Vector3(move_spline.facing.f.x, move_spline.facing.f.y, move_spline.facing.f.z);
+                break;
+            case MoveSplineFlag::Final_Target:
+                movementSpline.Face = MONSTER_MOVE_FACING_TARGET;
+                movementSpline.FaceGUID = move_spline.facing.target;
+                break;
+            case MoveSplineFlag::Final_Angle:
+                movementSpline.Face = MONSTER_MOVE_FACING_ANGLE;
+                movementSpline.FaceDirection = move_spline.facing.angle;
+                break;
+            default:
+                movementSpline.Face = MONSTER_MOVE_NORMAL;
+                break;
+        }
+
+        if (splineflags.animation)
+        {
+            movementSpline.AnimTier = splineflags.animTier;
+            movementSpline.TierTransStartTime = move_spline.effect_start_time;
+        }
+
+        movementSpline.MoveTime = move_spline.Duration();
+
+        if (splineflags.parabolic)
+        {
+            movementSpline.JumpGravity = move_spline.vertical_acceleration;
+            movementSpline.SpecialTime = move_spline.effect_start_time;
+        }
+
+        Spline<int32> const& spline = move_spline.spline;
+        std::vector<Vector3> const& array = spline.getPoints();
+
         if (splineflags & MoveSplineFlag::Mask_CatmullRom)
         {
-            if (splineflags.cyclic)
-                WriteCatmullRomCyclicPath(spline, data);
+            if (!splineflags.cyclic)
+            {
+                uint32 count = spline.getPointCount() - 3;
+                movementSpline.Points.reserve(count);
+                for (uint32 i = 0; i < count; ++i)
+                    movementSpline.Points.push_back(array[i + 2]);
+            }
             else
-                WriteCatmullRomPath(spline, data);
+            {
+                uint32 count = spline.getPointCount() - 4;
+                movementSpline.Points.reserve(count);
+                for (uint32 i = 0; i < count; ++i)
+                    movementSpline.Points.push_back(array[i + 2]);
+            }
         }
         else
-            WriteLinearPath(spline, data);
+        {
+            uint32 last_idx = spline.getPointCount() - 3;
+            Vector3 const* real_path = &spline.getPoint(1);
+
+            movementSpline.Points.push_back(real_path[last_idx]);
+
+            if (last_idx > 1)
+            {
+                Vector3 middle = (real_path[0] + real_path[last_idx]) / 2.f;
+                Vector3 offset;
+                // first and last points already appended
+                for (uint32 i = 1; i < last_idx; ++i)
+                {
+                    offset = middle - real_path[i];
+                    movementSpline.PackedDeltas.push_back(offset);
+                }
+            }
+        }
     }
 
     void PacketBuilder::WriteCreate(MoveSpline const& move_spline, ByteBuffer& data)

--- a/src/server/game/Movement/Spline/MovementPacketBuilder.cpp
+++ b/src/server/game/Movement/Spline/MovementPacketBuilder.cpp
@@ -23,14 +23,6 @@
 
 namespace Movement
 {
-    void PacketBuilder::WriteStopMovement(G3D::Vector3 const& pos, uint32 splineId, ByteBuffer& data)
-    {
-        data << uint8(0);                                       // sets/unsets MOVEMENTFLAG2_UNK7 (0x40)
-        data << pos;
-        data << splineId;
-        data << uint8(MONSTER_MOVE_STOP);
-    }
-
     void PacketBuilder::WriteMonsterMove(MoveSpline const& move_spline, WorldPackets::Movement::MovementMonsterSpline& movementMonsterSpline)
     {
         movementMonsterSpline.ID = move_spline.m_Id;

--- a/src/server/game/Movement/Spline/MovementPacketBuilder.h
+++ b/src/server/game/Movement/Spline/MovementPacketBuilder.h
@@ -19,22 +19,21 @@
 #define TRINITYSERVER_PACKET_BUILDER_H
 
 #include "Define.h"
+#include "G3D/Vector3.h"
+#include "MovementPackets.h"
+using G3D::Vector3;
 
 class ByteBuffer;
-namespace G3D
-{
-    class Vector3;
-}
+class WorldPacket;
 
 namespace Movement
 {
     class MoveSpline;
     class PacketBuilder
     {
-        static void WriteCommonMonsterMovePart(MoveSpline const& mov, ByteBuffer& data);
     public:
 
-        static void WriteMonsterMove(MoveSpline const& mov, ByteBuffer& data);
+        static void WriteMonsterMove(MoveSpline const& mov, WorldPackets::Movement::MovementMonsterSpline& movementMonsterSpline);
         static void WriteStopMovement(G3D::Vector3 const& loc, uint32 splineId, ByteBuffer& data);
         static void WriteCreate(MoveSpline const& mov, ByteBuffer& data);
         static void WriteSplineSync(MoveSpline const& mov, ByteBuffer& data);

--- a/src/server/game/Movement/Spline/MovementPacketBuilder.h
+++ b/src/server/game/Movement/Spline/MovementPacketBuilder.h
@@ -34,7 +34,6 @@ namespace Movement
     public:
 
         static void WriteMonsterMove(MoveSpline const& mov, WorldPackets::Movement::MovementMonsterSpline& movementMonsterSpline);
-        static void WriteStopMovement(G3D::Vector3 const& loc, uint32 splineId, ByteBuffer& data);
         static void WriteCreate(MoveSpline const& mov, ByteBuffer& data);
         static void WriteSplineSync(MoveSpline const& mov, ByteBuffer& data);
     };

--- a/src/server/game/Movement/Spline/MovementTypedefs.h
+++ b/src/server/game/Movement/Spline/MovementTypedefs.h
@@ -20,6 +20,15 @@
 
 #include "Common.h"
 
+enum MonsterMoveType
+{
+    MONSTER_MOVE_NORMAL        = 0,
+    MONSTER_MOVE_STOP          = 1,
+    MONSTER_MOVE_FACING_SPOT   = 2,
+    MONSTER_MOVE_FACING_TARGET = 3,
+    MONSTER_MOVE_FACING_ANGLE  = 4
+};
+
 namespace G3D
 {
     class Vector3;

--- a/src/server/game/Server/Packets/MovementPackets.cpp
+++ b/src/server/game/Server/Packets/MovementPackets.cpp
@@ -112,6 +112,10 @@ ByteBuffer& operator>>(ByteBuffer& data, MovementInfo& movementInfo)
 ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Movement::MovementSpline const& movementSpline)
 {
     data << uint8(movementSpline.Face);
+
+    if (movementSpline.Face == MONSTER_MOVE_STOP)
+        return data;
+
     switch (movementSpline.Face)
     {
         case MONSTER_MOVE_FACING_SPOT:

--- a/src/server/game/Server/Packets/MovementPackets.cpp
+++ b/src/server/game/Server/Packets/MovementPackets.cpp
@@ -16,7 +16,24 @@
  */
 
 #include "MovementPackets.h"
+#include "MovementPacketBuilder.h"
+#include "MoveSpline.h"
+#include "MoveSplineFlag.h"
+#include "MovementTypedefs.h"
+#include "Position.h"
 #include "UnitDefines.h"
+
+ByteBuffer& operator << (ByteBuffer& data, const G3D::Vector3& v)
+{
+    data << v.x << v.y << v.z;
+    return data;
+}
+
+ByteBuffer& operator >> (ByteBuffer& data, G3D::Vector3& v)
+{
+    data >> v.x >> v.y >> v.z;
+    return data;
+}
 
 ByteBuffer& operator<<(ByteBuffer& data, MovementInfo const& movementInfo)
 {
@@ -92,12 +109,93 @@ ByteBuffer& operator>>(ByteBuffer& data, MovementInfo& movementInfo)
     return data;
 }
 
+ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Movement::MovementSpline const& movementSpline)
+{
+    data << uint8(movementSpline.Face);
+    switch (movementSpline.Face)
+    {
+        case MONSTER_MOVE_FACING_SPOT:
+            data << movementSpline.FaceSpot;
+            break;
+        case MONSTER_MOVE_FACING_TARGET:
+            data << movementSpline.FaceGUID;
+            break;
+        case MONSTER_MOVE_FACING_ANGLE:
+            data << float(movementSpline.FaceDirection);
+            break;
+        default:
+            break;
+    }
+
+    data << uint32(movementSpline.Flags);
+
+    if (movementSpline.Flags & ::Movement::MoveSplineFlag::Animation)
+    {
+        data << uint8(movementSpline.AnimTier);
+        data << uint32(movementSpline.TierTransStartTime);
+    }
+
+    data << uint32(movementSpline.MoveTime);
+
+    if (movementSpline.Flags & ::Movement::MoveSplineFlag::Parabolic)
+    {
+        data << float(movementSpline.JumpGravity);
+        data << uint32(movementSpline.SpecialTime);
+    }
+
+    if (movementSpline.Flags & ::Movement::MoveSplineFlag::Mask_CatmullRom)
+    {
+        data << uint32(movementSpline.Points.size());
+        for (G3D::Vector3 const& point : movementSpline.Points)
+            data << point;
+    }
+    else
+    {
+        // Linear path: Points[0] = destination, PackedDeltas = intermediate offsets
+        uint32 lastIdx = uint32(movementSpline.PackedDeltas.size()) + 1;
+        data << uint32(lastIdx);
+        if (!movementSpline.Points.empty())
+            data << movementSpline.Points.front();
+        for (G3D::Vector3 const& offset : movementSpline.PackedDeltas)
+            data << TaggedPosition<Position::PackedXYZ>(offset.x, offset.y, offset.z);
+    }
+
+    return data;
+}
+
+ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Movement::MovementMonsterSpline const& movementMonsterSpline)
+{
+    if (!movementMonsterSpline.TransportGUID.IsEmpty())
+    {
+        data << movementMonsterSpline.TransportGUID.WriteAsPacked();
+        data << int8(movementMonsterSpline.VehicleSeat);
+    }
+
+    data << uint8(0);                                       // sets/unsets MOVEMENTFLAG2_UNK7 (0x40)
+    data << movementMonsterSpline.Destination;
+    data << uint32(movementMonsterSpline.ID);
+    data << movementMonsterSpline.Move;
+    return data;
+}
+
 namespace WorldPackets::Movement
 {
 void ClientPlayerMovement::Read()
 {
     _worldPacket >> Status.guid.ReadAsPacked();
     _worldPacket >> Status;
+}
+
+WorldPacket const* MonsterMove::Write()
+{
+    _worldPacket << MoverGUID.WriteAsPacked();
+
+    if (!SplineData.TransportGUID.IsEmpty())
+        _worldPacket.SetOpcode(SMSG_MONSTER_MOVE_TRANSPORT);
+
+    _worldPacket << SplineData;
+
+    return &_worldPacket;
 }
 
 WorldPacket const* MoveUpdate::Write()

--- a/src/server/game/Server/Packets/MovementPackets.h
+++ b/src/server/game/Server/Packets/MovementPackets.h
@@ -20,7 +20,9 @@
 
 #include "Packet.h"
 #include "MovementInfo.h"
+#include "MoveSpline.h"
 #include "ObjectGuid.h"
+#include <G3D/Vector3.h>
 
 namespace WorldPackets
 {
@@ -34,6 +36,42 @@ namespace WorldPackets
             void Read() override;
 
             MovementInfo Status;
+        };
+
+        struct MovementSpline
+        {
+            uint32 Flags                = 0;        // Spline flags (see MoveSplineFlag)
+            uint8 Face                  = 0;        // Movement direction (see MonsterMoveType)
+            uint8 AnimTier              = 0;
+            uint32 TierTransStartTime   = 0;
+            uint32 MoveTime             = 0;
+            float JumpGravity           = 0.0f;
+            uint32 SpecialTime          = 0;
+            std::vector<G3D::Vector3> Points;       // Spline path (CatmullRom) or single destination point (Linear)
+            std::vector<G3D::Vector3> PackedDeltas; // Linear path offsets (encoded as PackedXYZ on the wire)
+            float FaceDirection         = 0.0f;
+            ObjectGuid FaceGUID;
+            G3D::Vector3 FaceSpot;
+        };
+
+        struct MovementMonsterSpline
+        {
+            uint32 ID = 0;
+            ObjectGuid TransportGUID;
+            int8 VehicleSeat = -1;
+            G3D::Vector3 Destination;
+            MovementSpline Move;
+        };
+
+        class MonsterMove final : public ServerPacket
+        {
+        public:
+            MonsterMove() : ServerPacket(SMSG_MONSTER_MOVE) { }
+
+            WorldPacket const* Write() override;
+
+            ObjectGuid MoverGUID;
+            MovementMonsterSpline SplineData;
         };
 
         class TC_GAME_API MoveUpdate final : public ServerPacket
@@ -59,7 +97,11 @@ namespace WorldPackets
     }
 }
 
+ByteBuffer& operator<<(ByteBuffer& data, const G3D::Vector3& v);
+ByteBuffer& operator>>(ByteBuffer& data, G3D::Vector3& v);
 ByteBuffer& operator<<(ByteBuffer& data, MovementInfo const& movementInfo);
 ByteBuffer& operator>>(ByteBuffer& data, MovementInfo& movementInfo);
+ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Movement::MovementSpline const& movementSpline);
+ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Movement::MovementMonsterSpline const& movementMonsterSpline);
 
 #endif // TRINITYCORE_MOVEMENT_PACKETS_H


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Move Monster to WorldPacket class
-  Adapt the split of the spline structure from master branch to 3.3.5
- **WIP**: drop MovementPacketBuilder

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)

- Build
- Random traval IG
- City fly
- Multiple instance (ICC, Ulduar...)
- Combat (with mobs kitting)


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
