### PR TITLE
Core/Movement: Immediately launch new spline on ConfusedMovementGener…

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -52,7 +52,9 @@ bool ConfusedMovementGenerator<T>::DoInitialize(T* owner)
 
     _timer.Reset(0);
     owner->GetPosition(_x, _y, _z);
+
     _path = nullptr;
+    SetTargetLocation(owner);
     return true;
 }
 
@@ -85,42 +87,7 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* owner, uint32 diff)
     if ((MovementGenerator::HasFlag(MOVEMENTGENERATOR_FLAG_SPEED_UPDATE_PENDING) && !owner->movespline->Finalized()) || (_timer.Passed() && owner->movespline->Finalized()))
     {
         MovementGenerator::RemoveFlag(MOVEMENTGENERATOR_FLAG_TRANSITORY);
-
-        Position destination(_x, _y, _z);
-        float distance = 4.0f * frand(0.0f, 1.0f) - 2.0f;
-        float angle = frand(0.0f, 1.0f) * float(M_PI) * 2.0f;
-        owner->MovePositionToFirstCollision(destination, distance, angle);
-
-        // Check if the destination is in LOS
-        if (!owner->IsWithinLOS(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ()))
-        {
-            // Retry later on
-            _timer.Reset(200);
-            return true;
-        }
-
-        if (!_path)
-        {
-            _path = std::make_unique<PathGenerator>(owner);
-            _path->SetPathLengthLimit(30.0f);
-        }
-
-        bool result = _path->CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
-        if (!result || (_path->GetPathType() & PATHFIND_NOPATH)
-                    || (_path->GetPathType() & PATHFIND_SHORTCUT)
-                    || (_path->GetPathType() & PATHFIND_FARFROMPOLY))
-        {
-            _timer.Reset(100);
-            return true;
-        }
-
-        owner->AddUnitState(UNIT_STATE_CONFUSED_MOVE);
-
-        Movement::MoveSplineInit init(owner);
-        init.MovebyPath(_path->GetPath());
-        init.SetWalk(true);
-        int32 traveltime = init.Launch();
-        _timer.Reset(traveltime + urand(800, 1500));
+        SetTargetLocation(owner);
     }
 
     return true;
@@ -160,6 +127,49 @@ void ConfusedMovementGenerator<Creature>::DoFinalize(Creature* owner, bool activ
         if (owner->GetVictim())
             owner->SetTarget(owner->EnsureVictim()->GetGUID());
     }
+}
+
+template<class T>
+void ConfusedMovementGenerator<T>::SetTargetLocation(T* owner)
+{
+    if (!owner)
+        return;
+
+    Position destination(_x, _y, _z);
+    float distance = 4.0f * frand(0.0f, 1.0f) - 2.0f;
+    float angle = frand(0.0f, 1.0f) * float(M_PI) * 2.0f;
+    owner->MovePositionToFirstCollision(destination, distance, angle);
+
+    // Check if the destination is in LOS
+    if (!owner->IsWithinLOS(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ()))
+    {
+        // Retry later on
+        _timer.Reset(200);
+        return;
+    }
+
+    if (!_path)
+    {
+        _path = std::make_unique<PathGenerator>(owner);
+        _path->SetPathLengthLimit(30.0f);
+    }
+
+    bool result = _path->CalculatePath(destination.GetPositionX(), destination.GetPositionY(), destination.GetPositionZ());
+    if (!result || (_path->GetPathType() & PATHFIND_NOPATH)
+        || (_path->GetPathType() & PATHFIND_SHORTCUT)
+        || (_path->GetPathType() & PATHFIND_FARFROMPOLY))
+    {
+        _timer.Reset(100);
+        return;
+    }
+
+    owner->AddUnitState(UNIT_STATE_CONFUSED_MOVE);
+
+    Movement::MoveSplineInit init(owner);
+    init.MovebyPath(_path->GetPath());
+    init.SetWalk(true);
+    int32 traveltime = init.Launch();
+    _timer.Reset(traveltime + urand(800, 1500));
 }
 
 template ConfusedMovementGenerator<Player>::ConfusedMovementGenerator();

--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.h
@@ -40,6 +40,8 @@ class ConfusedMovementGenerator : public MovementGeneratorMedium<T, ConfusedMove
         void UnitSpeedChanged() override { ConfusedMovementGenerator<T>::AddFlag(MOVEMENTGENERATOR_FLAG_SPEED_UPDATE_PENDING); }
 
     private:
+        void SetTargetLocation(T*);
+
         std::unique_ptr<PathGenerator> _path;
         TimeTracker _timer;
         float _x, _y, _z;


### PR DESCRIPTION
…ator initialization

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Immediately launch a new spline on `ConfusedMovementGenerator` initialization, matching the behavior of `FleeingMovementGenerator`
- Fixes a bug where casting Polymorph on a creature that is actively chasing a target does not begin confused movement until the current chase spline finishes.

**Issues addressed:**

none

**Tests performed:**

builds, tested in-game


https://github.com/user-attachments/assets/48887ad6-e9a1-4f44-9ff9-727eacafeafe


https://github.com/user-attachments/assets/ceb420b1-2f4b-419a-b063-c2d11691815b



<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
