### PR TITLE
Worldstate: Naming Awakened Raids for Dragonflight

### DIFF
--- a/sql/updates/world/2026_05_15_00_world_df_awakened_raid.sql
+++ b/sql/updates/world/2026_05_15_00_world_df_awakened_raid.sql
@@ -1,0 +1,4 @@
+-- Worldstate for Awakened raids in Dragonflight
+DELETE FROM `world_state` WHERE `ID` = 25589;
+INSERT INTO `world_state` (`ID`, `DefaultValue`, `MapIDs`, `AreaIDs`, `ScriptName`, `Comment`) VALUES
+(25589, 0, NULL, NULL, '', 'Dragonflight - Awakened raids');

--- a/sql/updates/world/master/2026_05_17_00_world.sql
+++ b/sql/updates/world/master/2026_05_17_00_world.sql
@@ -1,4 +1,4 @@
 -- Worldstate for Awakened raids in Dragonflight
 DELETE FROM `world_state` WHERE `ID` = 25589;
 INSERT INTO `world_state` (`ID`, `DefaultValue`, `MapIDs`, `AreaIDs`, `ScriptName`, `Comment`) VALUES
-(25589, 0, NULL, NULL, '', 'Dragonflight - Awakened raids');
+(25589, 0, NULL, NULL, '', 'Dragonflight - Active Awakened raid');


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Names the worldstate for Dragonflights past Awakened Raids

**Tests performed:**
Builds and applies like it should

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
