### PR TITLE
Core/Spells: Fix 79528 Potion of Shrouding

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3551,6 +3551,19 @@ void SpellMgr::LoadSpellInfoCorrections()
         });
     });
 
+    // Potion of Shrouding
+    ApplySpellFix({ 79528 }, [](SpellInfo* spellInfo)
+        {
+            spellInfo->ExplicitTargetMask = TARGET_FLAG_UNIT_ALLY;
+            spellInfo->RequiredExplicitTargetMask = TARGET_FLAG_UNIT_ALLY;
+
+            ApplySpellEffectFix(spellInfo, EFFECT_0, [](SpellEffectInfo* spellEffectInfo)
+                {
+                    spellEffectInfo->TargetA = SpellImplicitTargetInfo(TARGET_UNIT_CASTER);
+                    spellEffectInfo->TargetB = SpellImplicitTargetInfo();
+                });
+        });
+
     ApplySpellFix({
         56690, // Thrust Spear
         60586, // Mighty Spear Thrust


### PR DESCRIPTION
**Changes proposed:**

Fixes Potion of Shrouding (79528) which currently is requiring the player to manually target themselves before using the item.

The spell has implicit target NONE (0) in DB2, causing item use without a selected target to fail with invalid target.

This updates the spell fix to:
- Use the caster as implicit target
- Set explicit target masks to allied unit so item use can resolve the caster as fallback target

Tested:
- Using Potion of Shrouding from item without targeting self works
- Cooldown behavior remains handled by normal item spell path

**Tests performed:**
Builds and tests ingame