### PR TITLE
Core/Movement: Resume chase for non-player units targeting victims

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11418,6 +11418,8 @@ void Unit::SetConfused(bool apply)
             GetMotionMaster()->Remove(CONFUSED_MOTION_TYPE);
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
+            if (!IsPlayer())
+                GetMotionMaster()->MoveChase(GetVictim());
         }
 
         // allow control to real player in control (eg charmer)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11417,12 +11417,9 @@ void Unit::SetConfused(bool apply)
         {
             GetMotionMaster()->Remove(CONFUSED_MOTION_TYPE);
             if (GetVictim())
-            {
                 SetTarget(EnsureVictim()->GetGUID());
-                // Re-issue chase for creatures — confuse leaves them standing still
-                if (!IsPlayer())
-                    GetMotionMaster()->MoveChase(GetVictim());
-            }
+            if (!IsPlayer())
+                GetMotionMaster()->MoveChase(GetVictim());
         }
 
         // allow control to real player in control (eg charmer)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11418,8 +11418,6 @@ void Unit::SetConfused(bool apply)
             GetMotionMaster()->Remove(CONFUSED_MOTION_TYPE);
             if (GetVictim())
                 SetTarget(EnsureVictim()->GetGUID());
-            if (!IsPlayer())
-                GetMotionMaster()->MoveChase(GetVictim());
         }
 
         // allow control to real player in control (eg charmer)

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11417,9 +11417,12 @@ void Unit::SetConfused(bool apply)
         {
             GetMotionMaster()->Remove(CONFUSED_MOTION_TYPE);
             if (GetVictim())
+            {
                 SetTarget(EnsureVictim()->GetGUID());
-            if (!IsPlayer())
-                GetMotionMaster()->MoveChase(GetVictim());
+                // Re-issue chase for creatures — confuse leaves them standing still
+                if (!IsPlayer())
+                    GetMotionMaster()->MoveChase(GetVictim());
+            }
         }
 
         // allow control to real player in control (eg charmer)

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -143,6 +143,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
     {
         RemoveFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
         _path = nullptr;
+        _lastTargetPosition.reset();
         if (Creature* cOwner = owner->ToCreature())
             cOwner->SetCannotReachTarget(false);
         owner->ClearUnitState(UNIT_STATE_CHASE_MOVE);

--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -143,7 +143,6 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
     {
         RemoveFlag(MOVEMENTGENERATOR_FLAG_INFORM_ENABLED);
         _path = nullptr;
-        _lastTargetPosition.reset();
         if (Creature* cOwner = owner->ToCreature())
             cOwner->SetCannotReachTarget(false);
         owner->ClearUnitState(UNIT_STATE_CHASE_MOVE);
@@ -152,7 +151,7 @@ bool ChaseMovementGenerator::Update(Unit* owner, uint32 diff)
     }
 
     // if the target moved, we have to consider whether to adjust
-    if (!_lastTargetPosition || target->GetPosition() != _lastTargetPosition.value() || mutualChase != _mutualChase)
+    if (!_path || !_lastTargetPosition || target->GetPosition() != _lastTargetPosition.value() || mutualChase != _mutualChase)
     {
         _lastTargetPosition = target->GetPosition();
         _mutualChase = mutualChase;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Attempt to fix cases like https://youtu.be/ramqDHHpMn4 when the enemy is standing in place "rooted" instead chase and then mele attack you at the end of confused effects.
-  When a chase spline completes, ChaseMovementGenerator clears _path but retains _lastTargetPosition. If the target has not moved, subsequent updates may not satisfy the repath condition, preventing a new chase spline from being generated. This can leave creatures stationary after movement interruptions such as polymorph/confuse effects. Resetting _lastTargetPosition together with _path ensures the next update performs a fresh chase path calculation.

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

Does it build, tested in-game, etc.


**Known issues and TODO list:** (add/remove lines as needed)

- [ None as I know. ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
