### PR TITLE
Core/Spells: Send missing CastResult when a channeled spell with casting status is canceled if it has a cooldown that starts with an event

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3324,7 +3324,7 @@ void Spell::cancel(SpellCastResult result /*= SPELL_FAILED_INTERRUPTED*/, Option
             SendChannelUpdate(0);
 
             // Channeled spells with cooldown started on event should send cast result packet to client on cancel
-            if (m_spellInfo->IsCooldownStartedOnEvent() && m_spellInfo->IsChanneled())
+            if (m_spellInfo->IsCooldownStartedOnEvent())
                 SendCastResult(result);
 
             SendInterrupted(result, resultOther);

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3322,6 +3322,11 @@ void Spell::cancel(SpellCastResult result /*= SPELL_FAILED_INTERRUPTED*/, Option
                         unit->RemoveOwnedAura(m_spellInfo->Id, m_originalCasterGUID, 0, AURA_REMOVE_BY_CANCEL);
 
             SendChannelUpdate(0);
+
+            // Channeled spells with cooldown started on event should send cast result packet to client on cancel
+            if (m_spellInfo->IsCooldownStartedOnEvent() && m_spellInfo->IsChanneled())
+                SendCastResult(result);
+
             SendInterrupted(result, resultOther);
 
             m_appliedMods.clear();


### PR DESCRIPTION
**Changes proposed:**

-  Send missing CastResult when a channeled spell with casting status is canceled if it has a cooldown that starts with an event

After these commits:
63bc405faeb7afcf99de6f7531e4ea59065165f4
844efbfca84580f7b2bd700f40209515f2aaa959
b1c15cbfe61884664ed7615a34ca77ad0db3d95c

when you cast a channeled spell with IsCooldownStartedOnEvent() true like Ritual of Refreshment of Mage and you cancel it (move it during channeling by example), cooldown is not updated (visually).

Spells with these characteristics are:
- 3362, 18540, 29893, 39050, 41173, 43648, 43987, 48191, 49474, 58659, 58887, 59790, 71251

Relevant spells are:
- ID - 18540 Ritual of Doom (Warlock)
- ID - 29893 Ritual of Souls (Rank 1) (Warlock)
- ID - 43987 Ritual of Refreshment (Rank 1) (Mage)
- ID - 58659 Ritual of Refreshment (Rank 2) (Mage)
- ID - 58887 Ritual of Souls (Rank 2) (Warlock)

**Issues addressed:**

None


**Tests performed:**

<details>
  <summary> Test before PR:</summary>

- Ritual of Refreshment: https://imgur.com/a/85A1Qca
- Ritual of Doom: https://imgur.com/a/8wbW7Sf
- Ritual of Souls: https://imgur.com/a/qOWlaxg

</details>

<details>
  <summary> Test with PR:</summary>

- Ritual of Refreshment: https://imgur.com/a/5gd9hk1
- Ritual of Doom: https://imgur.com/a/BLNyuC0
- Ritual of Souls: https://imgur.com/a/MLHSHFJ

</details>

