### PR TITLE
Core/Misc: Update account names max length

### DIFF
--- a/sql/updates/world/3.3.5/2026_XX_XX_XX_world.sql
+++ b/sql/updates/world/3.3.5/2026_XX_XX_XX_world.sql
@@ -1,0 +1,4 @@
+-- Replace LANG_ACCOUNT_NAME_TOO_LONG
+DELETE FROM `trinity_string` WHERE `entry`=1005;
+INSERT INTO `trinity_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`) VALUES
+(1005, "Your account name can't be longer than 17 characters (client limit), account wasn't created!", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/server/game/Accounts/AccountMgr.h
+++ b/src/server/game/Accounts/AccountMgr.h
@@ -39,7 +39,7 @@ enum PasswordChangeSecurity
 };
 
 #define MAX_PASS_STR 16
-#define MAX_ACCOUNT_STR 16
+#define MAX_ACCOUNT_STR 17
 #define MAX_EMAIL_STR 64
 
 namespace rbac


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  While updating some cms stuffs I found out that account names does works up to a maximum 17 characters length limit, so I decided to create a PR after I tested the 17 length characters account and was able to login.

**Issues addressed:**

Closes: None


**Tests performed:**

(Not yet tested.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ None ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
