### PR TITLE
Core/Movement: Stop forcing steady flight on login

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -19103,8 +19103,6 @@ void Player::_LoadAuras(PreparedQueryResult auraResult, PreparedQueryResult effe
         while (auraResult->NextRow());
     }
 
-    // TODO: finish dragonriding - this forces old flight mode
-    AddAura(404468, this);
 }
 
 void Player::_LoadGlyphAuras()

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -5214,12 +5214,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx4 |= SPELL_ATTR4_AURA_IS_BUFF;
     });
 
-    // TODO: temporary, remove with dragonriding
-    ApplySpellFix({ 404468 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->AttributesCu |= SPELL_ATTR0_CU_AURA_CANNOT_BE_SAVED;
-    });
-
     // Sigil of Flame
     ApplySpellFix({ 204598 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
**Changes proposed:**

- Stop forcing Steady Flight aura 404468 on every player login.
- Remove the matching temporary non-saveable spell correction so the client-data-driven flight-style aura can persist normally.
- Let 12.0.7 MountCapability, FlightCapability, and aura data select Skyriding versus Steady Flight instead of overriding it in Player::_LoadAuras.

**Why this is intentionally small:**

Current 12.0.7 client data already prioritizes the advanced-flight capability for supported mounts and Druid travel forms. It also carries the native periodic Vigor chain. The login-time AddAura(404468, this) bypasses that data and forces every character back to Steady Flight. Older patches that hard-code capability IDs, teach spells, bypass area conditions, or add custom impulse handling are therefore not included.

**Tests performed:**

- Full Windows Release build of the worldserver target on master commit 9464ec742bf56a83923b8cf14af258df30953b95.
- git diff --check.
- Audited the 12.0.7 MountCapability, FlightCapability, shapeshift, and aura paths against the existing generic handlers.

**Runtime verification still required:**

- Supported Skyriding mount after login.
- Druid Flight Form / Travel Form.
- Switch Flight Style in both directions.
- Relog persistence for the selected style.

Related to #30199 and #31725.