### PR TITLE
Build: fix gcc build

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -39,6 +39,7 @@
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include <algorithm>
 
 void AddItemsSetItem(Player* player, Item* item)
 {


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  fix a gcc build configuration

**Issues addressed:**

I don't know it doesn't appear on the current TrinityCore rev, but by merging the recent CI/Github commits I encounter a build error with gcc for a missing header. I've create a full clean branch with the lastest rev to be sure that was not related to my personal project, and I got the same thing.

Here the logs: https://gist.github.com/Thelsen/0f235f8fa9ce5fd93c73bade5057871d

TrinityCore rev. 6282471


**Tests performed:**

Build only


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
