### PR TITLE
Core/Objects: Use input position as pathfinding source in MovePositionToFirstCollision

### DIFF
--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -2850,7 +2850,7 @@ void WorldObject::MovePositionToFirstCollision(Position &pos, float dist, float 
     // Use a detour raycast to get our first collision point
     PathGenerator path(this);
     path.SetUseRaycast(true);
-    path.CalculatePath(destx, desty, destz, false);
+    path.CalculatePath(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), destx, desty, destz, false);
 
     // Check for valid path types before we proceed
     if (!(path.GetPathType() & PATHFIND_NOT_USING_PATH))


### PR DESCRIPTION
MovePositionToFirstCollision calculates its destination relative to the provided position and uses that position for collision checks, so the same position as the PathGenerator source has to be used so that all collision checks evaluate the same segment