### PR TITLE
Core/Battleground: Remove dead code in HandleBattleFieldPortOpcode related with leave arena queue

### DIFF
--- a/src/server/game/Handlers/BattleGroundHandler.cpp
+++ b/src/server/game/Handlers/BattleGroundHandler.cpp
@@ -417,20 +417,9 @@ void WorldSession::HandleBattleFieldPortOpcode(WorldPackets::Battleground::Battl
     }
     else // leave queue
     {
+        // leaving arena queue is not allowed if you have already been called to enter (it was presumably a hotfix before Cataclysm expansion)
         if (bg->isArena() && bg->GetStatus() > STATUS_WAIT_QUEUE)
             return;
-
-        // if player leaves rated arena match before match start, it is counted as he played but he lost
-        if (ginfo.IsRated && ginfo.IsInvitedToBGInstanceGUID)
-        {
-            ArenaTeam* at = sArenaTeamMgr->GetArenaTeamById(ginfo.Team);
-            if (at)
-            {
-                TC_LOG_DEBUG("bg.battleground", "UPDATING memberLost's personal arena rating for {} by opponents rating: {}, because he has left queue!", _player->GetGUID().ToString(), ginfo.OpponentsTeamRating);
-                at->MemberLost(_player, ginfo.OpponentsMatchmakerRating);
-                at->SaveToDB();
-            }
-        }
 
         WorldPackets::Battleground::BattlefieldStatusNone battlefieldStatus;
         BattlegroundMgr::BuildBattlegroundStatusNone(&battlefieldStatus, queueSlot);


### PR DESCRIPTION
**Changes proposed:**

- Remove wrong and dead code in HandleBattleFieldPortOpcode. The early return above (`bg->isArena() && bg->GetStatus() > STATUS_WAIT_QUEUE`) blocks that code execution, and BattlegroundQueue::RemovePlayer already handles the penalty correctly.
- Keep the early return for arena queue leave with a descriptive comment.

Initially this PR was a correction to:
```c++
ArenaTeam* at = sArenaTeamMgr->GetArenaTeamById(ginfo.Team);
```
due to wrong teamId, team is (ALLIANCE=469 / HORDE=67) instead of using ginfo.ArenaTeamId.
but then I realized that the previous check prevents that code from being executed.
```c++
         if (bg->isArena() && bg->GetStatus() > STATUS_WAIT_QUEUE)
             return;
```

- Research:

In this commit, the wrong team ID was added (Dec 19, 2008):  https://github.com/TrinityCore/TrinityCore/commit/400f7b859693eef1043a75a18c369dd871ffb721#diff-ab51b545ea247ba8c3317e7371d03d19084cda2722b66b4d035aae5a6ef27446R465-R477

Subsequently, the following commit is applied (Mar 10, 2009): https://github.com/TrinityCore/TrinityCore/commit/c708eba7131a19ea25065fd8f05b5c556c2a25e2#diff-a3eb55a1364899925853e22b333154aa465371e99842880974bfaa233bf71bf8

Added to BattleGroundQueue::RemovePlayer MemberLost/OfflineMemberLost in case of player leave arena queue when is calling to enter (or doesn't enter after 60 seconds)

Subsequently, the following commits are applied (Sep 4, 2012, Sep 5, 2012, Sep 17, 2012): 
https://github.com/TrinityCore/TrinityCore/commit/cf711ffbe5235a62e40c2a40a1769901afcb8d8e
https://github.com/TrinityCore/TrinityCore/commit/b8d55cc019f8ce3a936f9d805e6d762c60d28c5d
https://github.com/TrinityCore/TrinityCore/commit/639f1b67885c7bd3d1a42bf6a408f66366aca481

Prevents leaving the arena queue when called, because once called in, bg status is greater than STATUS_WAIT_QUEUE.
Therefore, the wrong code that attempted to locate the arena team to cause them to lose their member by searching for "Team" instead of "ArenaTeamId" was not executed, and with that return, it no longer allows you to leave the queue once called in.

These latest changes are due to the following issue: TrinityCore/TrinityCore#7633
which indicates that with the macro you can leave queue:
```
/script AcceptBattlefieldPort(1.0)
```

Info about that for wotlk expansion was: https://web.archive.org/web/20140704065924/http://www.blizzhackers.cc/viewtopic.php?f=179&t=389760&start=15
It's about joining a BG queue and leaving it. It also indicates that it was hotfixed.

Later in cataclysm API went protected:
https://www.bluetracker.gg/wow/topic/gb-en/1999564311-cant-leave-bg-queue-with-acceptbattlefieldport1-0/
https://wowpedia.fandom.com/wiki/API_AcceptBattlefieldPort
>[Patch 4.1.0](https://wowpedia.fandom.com/wiki/Patch_4.1.0/API_changes) (2011-04-26): Protected; requires a hardware event.

Because the client has the "leave queue" button disabled when calling in to enter the arena queue, and given the mention of hotfixes and the fact that API was moved to protected in Cataclysm, it seems most reasonable to keep the check and prevent players from explicitly leaving the arena queue once they've called in.

- Therefore, I've added a comment to the check and removed the dead code.

**Tests performed:**

tested in-game

