### PR TITLE
Core/Creatures: recompute combat stats when a summon is level-scaled …

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -244,6 +244,18 @@ void TempSummon::InitStats(WorldObject* summoner, Milliseconds duration)
             int32 maxLevel = m_unitData->ScalingLevelMax + m_unitData->ScalingLevelDelta;
             uint8 level = std::clamp<int32>(unitSummoner->GetLevel(), minLevel, maxLevel);
             SetLevel(level);
+            // Recompute combat stats for the newly assigned (summoner-matched) level. SetLevel()
+            // only updates the Level field; without this a scalable creature summoned at a lower
+            // level than its ContentTuning keeps the weapon damage, health and attack power that
+            // were computed at its original (higher) level. Because such a creature is level-
+            // matched to its target, GetDamageMultiplierForTarget() returns 1.0 (no scaling), so
+            // the stale high stats are applied in full - e.g. a summoned creature scaled down to a
+            // starting-zone player one-shots it. UpdateLevelDependantStats() fixes weapon damage
+            // and health and sets the base attack power; UpdateAttackPowerAndDamage() is needed to
+            // propagate that base into the live attack power that drives most of the melee hit.
+            UpdateLevelDependantStats();
+            UpdateAttackPowerAndDamage();
+            UpdateAttackPowerAndDamage(true);
         }
     }
 

--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -244,18 +244,12 @@ void TempSummon::InitStats(WorldObject* summoner, Milliseconds duration)
             int32 maxLevel = m_unitData->ScalingLevelMax + m_unitData->ScalingLevelDelta;
             uint8 level = std::clamp<int32>(unitSummoner->GetLevel(), minLevel, maxLevel);
             SetLevel(level);
-            // Recompute combat stats for the newly assigned (summoner-matched) level. SetLevel()
-            // only updates the Level field; without this a scalable creature summoned at a lower
-            // level than its ContentTuning keeps the weapon damage, health and attack power that
-            // were computed at its original (higher) level. Because such a creature is level-
-            // matched to its target, GetDamageMultiplierForTarget() returns 1.0 (no scaling), so
-            // the stale high stats are applied in full - e.g. a summoned creature scaled down to a
-            // starting-zone player one-shots it. UpdateLevelDependantStats() fixes weapon damage
-            // and health and sets the base attack power; UpdateAttackPowerAndDamage() is needed to
-            // propagate that base into the live attack power that drives most of the melee hit.
-            UpdateLevelDependantStats();
-            UpdateAttackPowerAndDamage();
-            UpdateAttackPowerAndDamage(true);
+            if (!IsGuardian())
+            {
+                UpdateLevelDependantStats();
+                UpdateAttackPowerAndDamage(false);
+                UpdateAttackPowerAndDamage(true);
+            }
         }
     }
 


### PR DESCRIPTION
### Changes proposed
`TempSummon::InitStats` sets a scalable summon's level to its summoner's level but does not recompute the creature's level-dependent combat stats afterwards. This adds a recompute of weapon damage, health and attack power immediately after the summon-level `SetLevel()`.

### Why / bug fixed
A scalable creature summoned *below* its ContentTuning level keeps the weapon damage, health and attack power computed at its original (higher) level, because `SetLevel()` only updates the Level field. Since the creature is then level-matched to its target, `Creature::GetDamageMultiplierForTarget()` returns `1.0` (no scaling correction), so the stale higher stats are dealt in full. The summon shows the correct low level but has the health and damage of a much higher-level creature, one-shotting the player it was scaled to.

### Reproduction (current master)
1. Create a fresh Worgen character and play the Gilneas starting-zone intro.
2. Accept the quest **"Evacuate the Merchant Square"** (quest ID 14098). It has you open doors to free trapped Frightened Citizens who then flee.
3. When a door is opened, a **Rampaging Worgen (entry 35660)** can spawn behind the fleeing citizens and attack. This worgen is *summoned* (it has no world spawns) and level-scaled to the player.
4. It displays the player's level but has ~2000 HP and hits for ~170–213, one-shotting the level 2–3 character. Its world-spawn counterpart (entry 34884) behaves correctly.

### Tests performed (level-2 player)
| | melee hit | max HP |
|---|---|---|
| before | 170–213 (one-shot) | ~2000 |
| after  | 10–15 | ~86 |

After the fix the summoned worgen is statistically identical to the correctly-behaving world-spawn worgen. The fix is in the shared summon path, so it covers any scalable creature summoned below its ContentTuning level. 