### PR TITLE
Core/Arena: Sync default Arena.ArenaStartPersonalRating value

### DIFF
--- a/src/server/game/World/World.cpp
+++ b/src/server/game/World/World.cpp
@@ -1246,7 +1246,7 @@ void World::LoadConfigSettings(bool reload)
     m_bool_configs[CONFIG_ARENA_QUEUE_ANNOUNCER_ENABLE]              = sConfigMgr->GetBoolDefault("Arena.QueueAnnouncer.Enable", false);
     m_int_configs[CONFIG_ARENA_SEASON_ID]                            = sConfigMgr->GetIntDefault ("Arena.ArenaSeason.ID", 1);
     m_int_configs[CONFIG_ARENA_START_RATING]                         = sConfigMgr->GetIntDefault ("Arena.ArenaStartRating", 0);
-    m_int_configs[CONFIG_ARENA_START_PERSONAL_RATING]                = sConfigMgr->GetIntDefault ("Arena.ArenaStartPersonalRating", 1000);
+    m_int_configs[CONFIG_ARENA_START_PERSONAL_RATING]                = sConfigMgr->GetIntDefault ("Arena.ArenaStartPersonalRating", 0);
     m_int_configs[CONFIG_ARENA_START_MATCHMAKER_RATING]              = sConfigMgr->GetIntDefault ("Arena.ArenaStartMatchmakerRating", 1500);
     m_bool_configs[CONFIG_ARENA_SEASON_IN_PROGRESS]                  = sConfigMgr->GetBoolDefault("Arena.ArenaSeason.InProgress", true);
     m_bool_configs[CONFIG_ARENA_LOG_EXTENDED_INFO]                   = sConfigMgr->GetBoolDefault("ArenaLog.ExtendedInfo", false);


### PR DESCRIPTION
**Changes proposed:**

-  Core/Arena: Sync default Arena.ArenaStartPersonalRating value

After this commit: https://github.com/TrinityCore/TrinityCore/commit/50a90522f9c6145e94d3c268e4355ea14c58061e#diff-d88fa29cc529859e675b29c15bcddddb5fe915116df44cac561a52773107d94cR1046
Arena.ArenaStartPersonalRating value in World.cpp was set in 1000, but in worldserver.conf file it remained at 0.
The appropriate default value is 0; 1000 already sets when the player joins if TR of the team is greater than 1000


**Tests performed:**

not necessary