### PR TITLE
DB/Conditions: Correct phase conditions for Lady Liadrin in capital cities

### DIFF
--- a/sql/updates/world/master/2026_XX_XX_XX_world.sql
+++ b/sql/updates/world/master/2026_XX_XX_XX_world.sql
@@ -1,0 +1,4 @@
+UPDATE `conditions` SET `ConditionValue1`=86852, `Comment`='Apply Phase 27731 If Quest 86852 is not rewarded' WHERE  `SourceTypeOrReferenceId`=26 AND `SourceGroup`=27731 AND `SourceEntry`=16079;
+UPDATE `conditions` SET `ConditionValue1`=86852, `Comment`='Apply Phase 27732 If Quest 86852 is not rewarded' WHERE  `SourceTypeOrReferenceId`=26 AND `SourceGroup`=27732 AND `SourceEntry`=5151;
+UPDATE `conditions` SET `ConditionValue1`=86852, `Comment`='Apply Phase 27733 If Quest 86852 is not rewarded' WHERE  `SourceTypeOrReferenceId`=26 AND `SourceGroup`=27733 AND `SourceEntry`=5170;
+UPDATE `conditions` SET `ConditionValue1`=86852, `Comment`='Apply Phase 27734 If Quest 86852 is not rewarded' WHERE  `SourceTypeOrReferenceId`=26 AND `SourceGroup`=27734 AND `SourceEntry`=15042;


### PR DESCRIPTION
**Changes proposed:**
- Updates the phase conditions introduced in d794fe4abbd55f8d7d4748a665e8dadaeb5c8a42 to correctly remove Liadrin's capital city phases after the quest "Light's Last Stand" (86852) is rewarded. This now matches retail behaviour.

**Issues addressed:**
none

**Tests performed:**
tested in game and the phases correctly removes when 86852 is rewarded


