### PR TITLE
Core/Spells: Make SpellHistory::IsReady return an enum with the reason instead of bool, removing HasCooldownOnHold

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -129,7 +129,7 @@ void PetAI::UpdateAI(uint32 diff)
                 continue;
 
             // check spell cooldown
-            if (!me->GetSpellHistory()->IsReady(spellInfo))
+            if (me->GetSpellHistory()->IsReady(spellInfo) != SpellHistory::ReadyStatus::Ready)
                 continue;
 
             if (spellInfo->IsPositive())

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -5169,12 +5169,16 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* param1 /*= nullptr*/, uint
                 return SPELL_FAILED_NOT_READY;
         }
 
-        if (m_caster->ToUnit() && !m_caster->ToUnit()->GetSpellHistory()->IsReady(m_spellInfo, m_castItemEntry, IsIgnoringCooldowns()))
+        if (Unit* unitCaster = m_caster->ToUnit())
         {
-            if (m_triggeredByAuraSpell || (m_spellInfo->IsCooldownStartedOnEvent() && !m_caster->ToUnit()->GetSpellHistory()->HasCooldownOnHold(m_spellInfo->Id)))
-                return SPELL_FAILED_DONT_REPORT;
+            SpellHistory::ReadyStatus readyStatus = unitCaster->GetSpellHistory()->IsReady(m_spellInfo, m_castItemEntry, IsIgnoringCooldowns());
+            if (readyStatus != SpellHistory::ReadyStatus::Ready)
+            {
+                if (m_triggeredByAuraSpell || (m_spellInfo->IsCooldownStartedOnEvent() && readyStatus != SpellHistory::ReadyStatus::NotReadyOnHold))
+                    return SPELL_FAILED_DONT_REPORT;
 
-            return SPELL_FAILED_NOT_READY;
+                return SPELL_FAILED_NOT_READY;
+            }
         }
     }
 
@@ -6190,7 +6194,7 @@ SpellCastResult Spell::CheckPetCast(Unit* target)
 
     // check cooldown
     if (Creature* creatureCaster = m_caster->ToCreature())
-        if (!creatureCaster->GetSpellHistory()->IsReady(m_spellInfo))
+        if (creatureCaster->GetSpellHistory()->IsReady(m_spellInfo) != SpellHistory::ReadyStatus::Ready)
             return SPELL_FAILED_NOT_READY;
 
     // Check if spell is affected by GCD

--- a/src/server/game/Spells/SpellHistory.cpp
+++ b/src/server/game/Spells/SpellHistory.cpp
@@ -188,16 +188,23 @@ void SpellHistory::HandleCooldowns(SpellInfo const* spellInfo, uint32 itemID, Sp
     StartCooldown(spellInfo, itemID, spell);
 }
 
-bool SpellHistory::IsReady(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, bool ignoreCategoryCooldown /*= false*/) const
+SpellHistory::ReadyStatus SpellHistory::IsReady(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, bool ignoreCategoryCooldown /*= false*/) const
 {
+    // check cooldowns first so an on hold cooldown takes priority over school locks
+    if (HasCooldown(spellInfo->Id, itemId, ignoreCategoryCooldown))
+    {
+        auto itr = _spellCooldowns.find(spellInfo->Id);
+        if (itr != _spellCooldowns.end() && itr->second.OnHold)
+            return ReadyStatus::NotReadyOnHold;
+
+        return ReadyStatus::NotReady;
+    }
+
     if (spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE)
         if (IsSchoolLocked(spellInfo->GetSchoolMask()))
-            return false;
+            return ReadyStatus::SchoolLocked;
 
-    if (HasCooldown(spellInfo->Id, itemId, ignoreCategoryCooldown))
-        return false;
-
-    return true;
+    return ReadyStatus::Ready;
 }
 
 template<>
@@ -477,13 +484,6 @@ bool SpellHistory::HasCooldown(SpellInfo const* spellInfo, uint32 itemId /*= 0*/
 bool SpellHistory::HasCooldown(uint32 spellId, uint32 itemId /*= 0*/, bool ignoreCategoryCooldown /*= false*/) const
 {
     return HasCooldown(sSpellMgr->AssertSpellInfo(spellId), itemId, ignoreCategoryCooldown);
-}
-
-bool SpellHistory::HasCooldownOnHold(uint32 spellId) const
-{
-    // TODO: Delete this function and make SpellHistory::IsReady return enum with reason instead of bool
-    auto itr = _spellCooldowns.find(spellId);
-    return itr != _spellCooldowns.end() && itr->second.OnHold;
 }
 
 uint32 SpellHistory::GetRemainingCooldown(SpellInfo const* spellInfo) const

--- a/src/server/game/Spells/SpellHistory.h
+++ b/src/server/game/Spells/SpellHistory.h
@@ -64,6 +64,14 @@ public:
     typedef std::unordered_map<uint32 /*categoryId*/, CooldownEntry*> CategoryCooldownStorageType;
     typedef std::unordered_map<uint32 /*categoryId*/, Clock::time_point> GlobalCooldownStorageType;
 
+    enum class ReadyStatus : uint8
+    {
+        Ready,
+        NotReady,
+        NotReadyOnHold,
+        SchoolLocked
+    };
+
     explicit SpellHistory(Unit* owner) : _owner(owner), _schoolLockouts() { }
 
     template<class OwnerType>
@@ -76,7 +84,8 @@ public:
 
     void HandleCooldowns(SpellInfo const* spellInfo, Item const* item, Spell* spell = nullptr);
     void HandleCooldowns(SpellInfo const* spellInfo, uint32 itemID, Spell* spell = nullptr);
-    bool IsReady(SpellInfo const* spellInfo, uint32 itemId = 0, bool ignoreCategoryCooldown = false) const;
+
+    ReadyStatus IsReady(SpellInfo const* spellInfo, uint32 itemId = 0, bool ignoreCategoryCooldown = false) const;
     template<class OwnerType>
     void WritePacket(WorldPacket& packet) const;
     void WritePacket(WorldPackets::Spells::InitialSpells* initialSpells) const;
@@ -122,7 +131,6 @@ public:
     void ResetAllCooldowns();
     bool HasCooldown(SpellInfo const* spellInfo, uint32 itemId = 0, bool ignoreCategoryCooldown = false) const;
     bool HasCooldown(uint32 spellId, uint32 itemId = 0, bool ignoreCategoryCooldown = false) const;
-    bool HasCooldownOnHold(uint32 spellId) const;
     uint32 GetRemainingCooldown(SpellInfo const* spellInfo) const;
 
     // School lockouts


### PR DESCRIPTION
**Changes proposed:**

- Make `SpellHistory::IsReady` return an enum (`ReadyStatus`) with the reason the spell is not ready, instead of a bool
- Remove `SpellHistory::HasCooldownOnHold` (TODO added in #31887)

**Issues addressed:**

None

**Tests performed:**

tested in-game
