### PR TITLE
Core/Cinematic: Properly end re-triggered cinematic before starting a new one

### DIFF
--- a/src/server/game/Entities/Player/CinematicMgr.cpp
+++ b/src/server/game/Entities/Player/CinematicMgr.cpp
@@ -47,6 +47,13 @@ void CinematicMgr::BeginCinematic()
     if (m_activeCinematicCameraId == 0)
         return;
 
+    uint32 const activeCamera = m_activeCinematicCameraId;
+
+    if (!m_CinematicObjectGUID.IsEmpty())
+        EndCinematic();
+
+    m_activeCinematicCameraId = activeCamera;
+
     if (std::vector<FlyByCamera> const* flyByCameras = GetFlyByCameras(m_activeCinematicCameraId))
     {
         // Initialize diff, and set camera
@@ -90,6 +97,8 @@ void CinematicMgr::EndCinematic()
 
         if (WorldObject* cinematicObject = ObjectAccessor::GetWorldObject(*player, m_CinematicObjectGUID))
             cinematicObject->AddObjectToRemoveList();
+
+        m_CinematicObjectGUID.Clear();
     }
 }
 


### PR DESCRIPTION

**Changes proposed:**

- Call EndCinematic() before summoning a new camera object when one is already active
- Clear the stored cinematic object GUID in EndCinematic()

Starting a cinematic while another one is still in progress (clicking gameobject 187578 in Magister's Terrace more than once) summoned a new camera object without cleaning up the previous one.
The player stayed bound to the old camera and, once it despawned, the Unit destructor failed on ASSERT(m_sharedVision.empty()).


**Issues addressed:**

None


**Tests performed:**

tested in-game

