### PR TITLE
Core/Spells: Prevent Polymorph from setting victim in combat when out…

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -8737,6 +8737,11 @@ void Unit::AtTargetAttacked(Unit* target, bool canInitialAggro)
 {
     if (!target->IsEngaged() && !canInitialAggro)
         return;
+    if (target->IsPolymorphed() && !IsWithinMeleeRange(target)) // Skipping aggro and tapping for ranged Polymorph
+    {
+        if (!target->IsEngaged())
+            return;
+    }
     target->EngageWithTarget(this);
     if (Unit* targetOwner = target->GetCharmerOrOwner())
         targetOwner->EngageWithTarget(this);


### PR DESCRIPTION
…side melee range (#31868)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Add distance and state check in `Unit::AtTargetAttacked` to bypass threat and tapping when mage poly is cast on unengaged target outside melee range.
-  prevent caster from entering combat state or forcing target lock on the victim when crowd-controlled from range

**Issues addressed:**

Closes #31868


**Tests performed:**

- [x] compiled cleanly with no errors
- [ ] test in game


**Known issues and TODO list:** (add/remove lines as needed)

- [x] Code compiled and clean
- [ ] Needs in-game verification on a running 3.3.5a client


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
