### PR TITLE
Core/Player: fix druid shapeshifting display ids retrieval

### DIFF
--- a/src/server/game/Achievements/CriteriaHandler.cpp
+++ b/src/server/game/Achievements/CriteriaHandler.cpp
@@ -3688,7 +3688,7 @@ bool CriteriaHandler::ModifierSatisfied(ModifierTreeEntry const* modifier, uint6
             return false;
         case ModifierTreeType::PlayerSpellShapeshiftFormCreatureDisplayInfoSelection: // 308
         {
-            ShapeshiftFormModelData const* formModelData = sDB2Manager.GetShapeshiftFormModelData(referencePlayer->GetRace(), referencePlayer->GetNativeGender(), secondaryAsset);
+            ShapeshiftFormModelData const* formModelData = sDB2Manager.GetShapeshiftFormModelData(secondaryAsset);
             if (!formModelData)
                 return false;
             uint32 formChoice = referencePlayer->GetCustomizationChoice(formModelData->OptionID);

--- a/src/server/game/DataStores/DB2Stores.cpp
+++ b/src/server/game/DataStores/DB2Stores.cpp
@@ -498,7 +498,7 @@ namespace
     std::array<ClassPowerData, MAX_CLASSES> _powersByClass;
     std::unordered_map<uint32 /*chrCustomizationOptionId*/, std::vector<ChrCustomizationChoiceEntry const*>> _chrCustomizationChoicesByOption;
     std::unordered_map<std::pair<uint8, uint8>, ChrModelEntry const*> _chrModelsByRaceAndGender;
-    std::map<std::tuple<uint8 /*race*/, uint8/*gender*/, uint8/*shapeshift*/>, ShapeshiftFormModelData> _chrCustomizationChoicesForShapeshifts;
+    std::unordered_map<uint8 /*shapeshift form*/, ShapeshiftFormModelData> _chrCustomizationChoicesForShapeshifts;
     std::unordered_map<std::pair<uint8 /*race*/, uint8/*gender*/>, std::vector<ChrCustomizationOptionEntry const*>> _chrCustomizationOptionsByRaceAndGender;
     std::unordered_map<uint32 /*chrCustomizationReqId*/, std::vector<std::pair<uint32 /*chrCustomizationOptionId*/, std::vector<uint32>>>> _chrCustomizationRequiredChoices;
     ChrSpecializationByIndexContainer _chrSpecializationsByIndex;
@@ -1246,20 +1246,30 @@ void DB2Manager::IndexLoadedStores()
                     parentRaceOptions.insert(parentRaceOptions.end(), customizationOptionsForModel->begin(), customizationOptionsForModel->end());
                 }
             }
+        }
+    }
 
-            // link shapeshift displays to race/gender/form
-            for (std::pair<uint32 const, std::pair<uint32, uint8>> const& shapeshiftOptionsForModel : Trinity::Containers::MapEqualRange(shapeshiftFormByModel, model->ID))
-            {
-                ShapeshiftFormModelData& data = _chrCustomizationChoicesForShapeshifts[{ uint8(raceModel->ChrRacesID), uint8(raceModel->Sex), shapeshiftOptionsForModel.second.second }];
-                data.OptionID = shapeshiftOptionsForModel.second.first;
-                data.Choices = Trinity::Containers::MapGetValuePtr(_chrCustomizationChoicesByOption, shapeshiftOptionsForModel.second.first);
-                if (data.Choices)
-                {
-                    data.Displays.resize(data.Choices->size());
-                    for (std::size_t i = 0; i < data.Choices->size(); ++i)
-                        data.Displays[i] = Trinity::Containers::MapGetValuePtr(displayInfoByCustomizationChoice, (*data.Choices)[i]->ID);
-                }
-            }
+    // link shapeshift displays to form (form-specific ChrModelIDs are not in ChrRaceXChrModel)
+    std::unordered_set<uint8> processedForms;
+    for (std::pair<uint32 const, std::pair<uint32, uint8>> const& shapeshiftEntry : shapeshiftFormByModel)
+    {
+        uint8 formId = shapeshiftEntry.second.second;
+        if (formId == 0)
+            continue;
+
+        // each form has one OptionID; only process first occurrence
+        if (!processedForms.insert(formId).second)
+            continue;
+
+        uint32 optionId = shapeshiftEntry.second.first;
+        ShapeshiftFormModelData& data = _chrCustomizationChoicesForShapeshifts[formId];
+        data.OptionID = optionId;
+        data.Choices = Trinity::Containers::MapGetValuePtr(_chrCustomizationChoicesByOption, optionId);
+        if (data.Choices)
+        {
+            data.Displays.resize(data.Choices->size());
+            for (std::size_t i = 0; i < data.Choices->size(); ++i)
+                data.Displays[i] = Trinity::Containers::MapGetValuePtr(displayInfoByCustomizationChoice, (*data.Choices)[i]->ID);
         }
     }
 
@@ -2983,9 +2993,9 @@ std::vector<RewardPackXItemEntry const*> const* DB2Manager::GetRewardPackItemsBy
     return Trinity::Containers::MapGetValuePtr(_rewardPackItems, rewardPackID);
 }
 
-ShapeshiftFormModelData const* DB2Manager::GetShapeshiftFormModelData(uint8 race, uint8 gender, uint8 form) const
+ShapeshiftFormModelData const* DB2Manager::GetShapeshiftFormModelData(uint8 form) const
 {
-    return Trinity::Containers::MapGetValuePtr(_chrCustomizationChoicesForShapeshifts, { race, gender, form });
+    return Trinity::Containers::MapGetValuePtr(_chrCustomizationChoicesForShapeshifts, form);
 }
 
 std::vector<SkillLineEntry const*> const* DB2Manager::GetSkillLinesForParentSkill(uint32 parentSkillId) const

--- a/src/server/game/DataStores/DB2Stores.h
+++ b/src/server/game/DataStores/DB2Stores.h
@@ -547,7 +547,7 @@ public:
     uint32 GetQuestUniqueBitFlag(uint32 questId);
     std::vector<RewardPackXCurrencyTypeEntry const*> const* GetRewardPackCurrencyTypesByRewardID(uint32 rewardPackID) const;
     std::vector<RewardPackXItemEntry const*> const* GetRewardPackItemsByRewardID(uint32 rewardPackID) const;
-    ShapeshiftFormModelData const* GetShapeshiftFormModelData(uint8 race, uint8 gender, uint8 form) const;
+    ShapeshiftFormModelData const* GetShapeshiftFormModelData(uint8 form) const;
     std::vector<SkillLineEntry const*> const* GetSkillLinesForParentSkill(uint32 parentSkillId) const;
     std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skillId) const;
     SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, uint8 class_) const;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12654,7 +12654,8 @@ uint32 Unit::GetModelForForm(ShapeshiftForm form, uint32 spellId) const
                     if (ShapeshiftForm(artifactAppearance->OverrideShapeshiftFormID) == form)
                         return artifactAppearance->OverrideShapeshiftDisplayID;
 
-        if (ShapeshiftFormModelData const* formModelData = sDB2Manager.GetShapeshiftFormModelData(GetRace(), player->GetNativeGender(), form))
+        ShapeshiftFormModelData const* formModelData = sDB2Manager.GetShapeshiftFormModelData(form);
+        if (formModelData)
         {
             bool useRandom = false;
             switch (form)
@@ -12691,7 +12692,9 @@ uint32 Unit::GetModelForForm(ShapeshiftForm form, uint32 spellId) const
             }
             else
             {
-                if (uint32 formChoice = player->GetCustomizationChoice(formModelData->OptionID))
+                uint32 formChoice = player->GetCustomizationChoice(formModelData->OptionID);
+
+                if (formChoice)
                 {
                     auto choiceItr = std::find_if(formModelData->Choices->begin(), formModelData->Choices->end(), [formChoice](ChrCustomizationChoiceEntry const* choice)
                     {
@@ -12699,8 +12702,24 @@ uint32 Unit::GetModelForForm(ShapeshiftForm form, uint32 spellId) const
                     });
 
                     if (choiceItr != formModelData->Choices->end())
-                        if (ChrCustomizationDisplayInfoEntry const* displayInfo = formModelData->Displays[std::distance(formModelData->Choices->begin(), choiceItr)])
+                    {
+                        auto idx = std::distance(formModelData->Choices->begin(), choiceItr);
+                        if (ChrCustomizationDisplayInfoEntry const* displayInfo = formModelData->Displays[idx])
                             return displayInfo->DisplayID;
+                    }
+                }
+                else
+                {
+                    for (std::size_t i = 0; i < formModelData->Choices->size(); ++i)
+                    {
+                        ChrCustomizationReqEntry const* choiceReq = sChrCustomizationReqStore.LookupEntry((*formModelData->Choices)[i]->ChrCustomizationReqID);
+                        if (!choiceReq || player->GetSession()->MeetsChrCustomizationReq(choiceReq, Races(GetRace()), Classes(GetClass()), false,
+                            MakeChrCustomizationChoiceRange(player->m_playerData->Customizations)))
+                        {
+                            if (ChrCustomizationDisplayInfoEntry const* displayInfo = formModelData->Displays[i])
+                                return displayInfo->DisplayID;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Changes proposed:**

-  Modify the shapeshift form display retrieval to no longer use race and gender combo
-  Shapeshift forms are now per customization option
-  fixes fallback to the dummy/invisible display ids from SpellShapeshiftForm.db2 and use the correct customization display ids
- customization requirements are checked

**Issues addressed:**
- druid shapeshift forms are now working correctly

Closes #  (insert issue tracker number)
29664

**Tests performed:**
- builds
- tested ingame with multiple races/druid


**Known issues and TODO list:** (add/remove lines as needed)
None that i can think of
