### PR TITLE
Fix encounter check for Dungeon entry conditions

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -3870,7 +3870,7 @@ Map::EnterState InstanceMap::CannotEnter(Player* player)
     }
 
     // cannot enter while an encounter is in progress (unless this is a relog, in which case it is permitted)
-    if (!player->IsLoading() && IsRaid() && GetInstanceScript() && GetInstanceScript()->IsEncounterInProgress())
+    if (!player->IsLoading() && GetInstanceScript() && GetInstanceScript()->IsEncounterInProgress())
         return CANNOT_ENTER_ZONE_IN_COMBAT;
 
     // cannot enter if player is permanent saved to a different instance id


### PR DESCRIPTION
It shouldn't be possible to walk into a 5-man instance while a boss fight is in progress. That’s how it was in the 2009 original, too.
Removing this line causes not only raids but also dungeons to be checked.

Various archive forum posts confirm this.:

https://eu.forums.blizzard.com/en/wow/t/unable-to-zone-in-while-an-encounter-is-in-progess/21536
https://www.reddit.com/r/wow/comments/trtsbp/queue_pop_unable_to_enter_dungeon_due_to/
https://us.forums.blizzard.com/en/wow/t/lfr-cant-zone-me-in-encounter-in-progress/1090020/2

`"The restriction is definitely blizzlike for WotLK. In the original 3.3.5a client's GlobalStrings.lua, Blizzard hardcoded TRANSFER_ABORT_ZONE_IN_COMBAT = "You cannot enter the instance while an encounter is in progress.". Whenever the Dungeon Finder (RDF) auto-teleported a replacement player into a 5-man dungeon while the remaining party was in combat, the server sent TRANSFER_ABORT_ZONE_IN_COMBAT and aborted the loading screen. It's handled by the base Map class (MapEncounterInProgress), which applies to both InstanceMap (5-man) and RaidMap inside the engine."`

**Tests performed:**

Testet ingame and works