### PR TITLE
Core/Spells: Fixed pushback not applying during the cast time of channeled spells

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -945,17 +945,20 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel) cons
 
         if (damagetype != NODAMAGE && damagetype != DOT && damage)
         {
-            if (victim != attacker && victim->GetTypeId() == TYPEID_PLAYER && (!spellProto || !(spellProto->HasAttribute(SPELL_ATTR7_NO_PUSHBACK_ON_DAMAGE) || spellProto->HasAttribute(SPELL_ATTR3_TREAT_AS_PERIODIC))))
+            if (victim != attacker && victim->IsPlayer() && (!spellProto || !(spellProto->HasAttribute(SPELL_ATTR7_NO_PUSHBACK_ON_DAMAGE) || spellProto->HasAttribute(SPELL_ATTR3_TREAT_AS_PERIODIC))))
             {
-                if (Spell* spell = victim->m_currentSpells[CURRENT_GENERIC_SPELL])
+                for (uint32 i = CURRENT_GENERIC_SPELL; i <= CURRENT_CHANNELED_SPELL; ++i)
                 {
-                    if (spell->getState() == SPELL_STATE_PREPARING)
+                    if (Spell* spell = victim->m_currentSpells[i])
                     {
-                        uint32 interruptFlags = spell->m_spellInfo->InterruptFlags;
-                        if (interruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG)
-                            victim->InterruptNonMeleeSpells(false);
-                        else
-                            spell->Delayed();
+                        if (spell->getState() == SPELL_STATE_PREPARING)
+                        {
+                            uint32 interruptFlags = spell->m_spellInfo->InterruptFlags;
+                            if (interruptFlags & SPELL_INTERRUPT_FLAG_ABORT_ON_DMG)
+                                victim->InterruptNonMeleeSpells(false);
+                            else
+                                spell->Delayed();
+                        }
                     }
                 }
 


### PR DESCRIPTION

**Changes proposed:**

-  Check if channeled spell during the casting time phase should receive pushback

Relevant affected spells are:
```
ID - 126 Eye of Kilrogg (Summon)
ID - 605 Mind Control
ID - 1002 Eyes of the Beast
ID - 18540 Ritual of Doom
ID - 61994 Ritual of Summoning
```

https://warcraft.wiki.gg/wiki/Pushback
>Patch changes
>Wrath of the Lich King [Patch 3.0.2](https://warcraft.wiki.gg/wiki/Patch_3.0.2) (2008-10-14): Spell casting and spell channeling pushback has been changed to the following:
>- When casting a spell:
>    - The first and second hit will add .5 secs each to the cast time.
>    - All hits after the second will have no effect.
>- When channeling a spell:
>    - The first and second hit reduces current duration by 25% of total duration each.
>    - All hits after the second will have no effect.

This information may be ambiguous, because it doesn't clearly state whether it refers to the type of spell or the type of spell phase. So here is a video.
https://www.youtube.com/watch?v=LdbweF7iUC8
min 3:54 and min 7:08, priest cast Mind Control and get pushback in casting phase


**Issues addressed:**

None


**Tests performed:**

tested in-game

