### PR TITLE
Scripts/Gruul's Lair: Handle respawn of Maulgar's ogres with spawn groups

### DIFF
--- a/sql/updates/world/3.3.5/2026_08_230_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_08_230_00_world.sql
@@ -1,0 +1,14 @@
+--
+SET @SPAWN_GROUP_ID := 419; -- 4
+
+UPDATE `spawn_group` SET `groupId` = @SPAWN_GROUP_ID+0 WHERE `spawnId` = 81651 AND `spawnType` = 0;
+UPDATE `spawn_group` SET `groupId` = @SPAWN_GROUP_ID+1 WHERE `spawnId` = 81652 AND `spawnType` = 0;
+UPDATE `spawn_group` SET `groupId` = @SPAWN_GROUP_ID+2 WHERE `spawnId` = 81643 AND `spawnType` = 0;
+UPDATE `spawn_group` SET `groupId` = @SPAWN_GROUP_ID+3 WHERE `spawnId` = 48348 AND `spawnType` = 0;
+
+DELETE FROM `spawn_group_template` WHERE `groupId` BETWEEN @SPAWN_GROUP_ID+0 AND @SPAWN_GROUP_ID+3;
+INSERT INTO `spawn_group_template` (`groupId`, `groupName`, `groupFlags`) VALUES
+(@SPAWN_GROUP_ID+0,"Gruul's Lair - Krosh Firehand",4), -- 419
+(@SPAWN_GROUP_ID+1,"Gruul's Lair - Olm the Summoner",4), -- 420
+(@SPAWN_GROUP_ID+2,"Gruul's Lair - Kiggler the Crazed",4), -- 421
+(@SPAWN_GROUP_ID+3,"Gruul's Lair - Blindeye the Seer",4); -- 422

--- a/src/server/scripts/Outland/GruulsLair/boss_high_king_maulgar.cpp
+++ b/src/server/scripts/Outland/GruulsLair/boss_high_king_maulgar.cpp
@@ -73,12 +73,20 @@ enum MaulgarMisc
     ACTION_OGRE_DEATH           = 0
 };
 
-static constexpr std::array<uint32, 4> OgreData =
+enum MaulgarSpawnGroups
 {
-    DATA_KROSH_FIREHAND,
-    DATA_OLM_THE_SUMMONER,
-    DATA_KIGGLER_THE_CRAZED,
-    DATA_BLINDEYE_THE_SEER
+    SPAWN_GROUP_KROSH           = 419,
+    SPAWN_GROUP_OLM             = 420,
+    SPAWN_GROUP_KIGGLER         = 421,
+    SPAWN_GROUP_BLINDEYE        = 422
+};
+
+static constexpr std::array<uint32, 4> OgreSpawnGroupsData =
+{
+    SPAWN_GROUP_KROSH,
+    SPAWN_GROUP_OLM,
+    SPAWN_GROUP_KIGGLER,
+    SPAWN_GROUP_BLINDEYE
 };
 
 // 18831 - High King Maulgar
@@ -92,8 +100,8 @@ struct boss_high_king_maulgar : public BossAI
         _enraged = false;
         SetEquipmentSlots(true);
 
-        for (uint32 data : OgreData)
-            me->GetMap()->Respawn(SPAWN_TYPE_CREATURE, instance->GetData64(data));
+        for (uint32 group : OgreSpawnGroupsData)
+            me->GetMap()->SpawnGroupSpawn(group, true);
     }
 
     void JustEngagedWith(Unit* who) override

--- a/src/server/scripts/Outland/GruulsLair/gruuls_lair.h
+++ b/src/server/scripts/Outland/GruulsLair/gruuls_lair.h
@@ -31,21 +31,9 @@ enum GLEncounters
     DATA_GRUUL                  = 1
 };
 
-enum GLDataTypes
-{
-    DATA_KROSH_FIREHAND,
-    DATA_OLM_THE_SUMMONER,
-    DATA_KIGGLER_THE_CRAZED,
-    DATA_BLINDEYE_THE_SEER
-};
-
 enum GLCreatureIds
 {
-    NPC_MAULGAR                 = 18831,
-    NPC_KROSH_FIREHAND          = 18832,
-    NPC_OLM_THE_SUMMONER        = 18834,
-    NPC_KIGGLER_THE_CRAZED      = 18835,
-    NPC_BLINDEYE_THE_SEER       = 18836
+    NPC_MAULGAR                 = 18831
 };
 
 enum GLGameObjectIds

--- a/src/server/scripts/Outland/GruulsLair/instance_gruuls_lair.cpp
+++ b/src/server/scripts/Outland/GruulsLair/instance_gruuls_lair.cpp
@@ -47,51 +47,6 @@ class instance_gruuls_lair : public InstanceMapScript
                 LoadDoorData(doorData);
                 LoadObjectData(creatureData, nullptr);
             }
-
-            void OnCreatureCreate(Creature* creature) override
-            {
-                InstanceScript::OnCreatureCreate(creature);
-
-                switch (creature->GetEntry())
-                {
-                    case NPC_KROSH_FIREHAND:
-                        MaulgarOgreSpawnId[0] = creature->GetSpawnId();
-                        break;
-                    case NPC_OLM_THE_SUMMONER:
-                        MaulgarOgreSpawnId[1] = creature->GetSpawnId();
-                        break;
-                    case NPC_KIGGLER_THE_CRAZED:
-                        MaulgarOgreSpawnId[2] = creature->GetSpawnId();
-                        break;
-                    case NPC_BLINDEYE_THE_SEER:
-                        MaulgarOgreSpawnId[3] = creature->GetSpawnId();
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            uint64 GetData64(uint32 type) const override
-            {
-                switch (type)
-                {
-                    case DATA_KROSH_FIREHAND:
-                        return MaulgarOgreSpawnId[0];
-                    case DATA_OLM_THE_SUMMONER:
-                        return MaulgarOgreSpawnId[1];
-                    case DATA_KIGGLER_THE_CRAZED:
-                        return MaulgarOgreSpawnId[2];
-                    case DATA_BLINDEYE_THE_SEER:
-                        return MaulgarOgreSpawnId[3];
-                    default:
-                        break;
-                }
-
-                return InstanceScript::GetData64(type);
-            }
-
-        protected:
-            ObjectGuid::LowType MaulgarOgreSpawnId[4] = { };
         };
 
         InstanceScript* GetInstanceScript(InstanceMap* map) const override


### PR DESCRIPTION

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  With old handling if server is crashed when ogres are dead, ogres will not respawn after instance creation

**Issues addressed:**

none

**Tests performed:**

builds, tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
