### PR TITLE
Core/Players: Reject logins flagged for rename earlier in Player::LoadFromDB

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -16931,6 +16931,14 @@ bool Player::LoadFromDB(ObjectGuid guid, CharacterDatabaseQueryHolder const& hol
         return false;
     }
 
+    m_atLoginFlags = fields[38].GetUInt16();
+
+    if (HasAtLoginFlag(AT_LOGIN_RENAME))
+    {
+        TC_LOG_ERROR("entities.player.cheat", "Player::LoadFromDB: Player ({}) tried to login while forced to rename, can't load.'", guid.ToString());
+        return false;
+    }
+
     Object::_Create(guid);
 
     m_name = fields[2].GetString();
@@ -17339,6 +17347,7 @@ bool Player::LoadFromDB(ObjectGuid guid, CharacterDatabaseQueryHolder const& hol
         }
     }
 
+    // no early return is allowed past this point, player will be deleted and still referenced by the map and battleground AddPlayer can apply auras also
     SetMap(map);
     UpdatePositionData();
 
@@ -17381,14 +17390,6 @@ bool Player::LoadFromDB(ObjectGuid guid, CharacterDatabaseQueryHolder const& hol
     uint32 extraflags = fields[36].GetUInt16();
 
     _LoadPetStable(fields[37].GetUInt8(), holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOAD_PET_SLOTS));
-
-    m_atLoginFlags = fields[38].GetUInt16();
-
-    if (HasAtLoginFlag(AT_LOGIN_RENAME))
-    {
-        TC_LOG_ERROR("entities.player.cheat", "Player::LoadFromDB: Player ({}) tried to login while forced to rename, can't load.'", GetGUID().ToString());
-        return false;
-    }
 
     // Honor system
     // Update Honor kills data


### PR DESCRIPTION
**Changes proposed:**

- Move Player::LoadFromDB AT_LOGIN_RENAME check before SetMap() and Battleground::AddPlayer()
- Add a comment to warn about early return issues after SetMap() and Battleground::AddPlayer().
- If the battleground applied an aura while adding the player (preparation aura), Unit destructor fails with
  ASSERT(m_appliedAuras.empty()) when AT_LOGIN_RENAME reject login of a player.

**Issues addressed:**

None

**Tests performed:**

- run .debug bg and enter in a battleground.
- logout and remain on char selection screen
- use the command .character rename name_of_bg_player in console or with another gm account
- alternative (if you don't want to use the command): update in characters db at_login_flag with 1 value
- enter with character to world, skipping first rename check of character screen and get assertion failed