### PR TITLE
Scripts/Zul'Aman: A couple changes for Malacrass

### DIFF
--- a/sql/updates/world/3.3.5/2026_08_232_00_world.sql
+++ b/sql/updates/world/3.3.5/2026_08_232_00_world.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `spell_script_names` SET `ScriptName` = 'spell_malacrass_lifebloom' WHERE `ScriptName` = 'spell_hexlord_lifebloom';

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_hexlord.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_hexlord.cpp
@@ -18,7 +18,6 @@
 /*
  * SAY_BERSERK is NYI, is it used?
  * Combat timers requires to be revisited, mainly player class abilities, half of timers are guessed
- * Move spell script of spell 43421 to this file
  * Currently we generate random companions after every wipe, doubt it is correct
  * We interrupt Siphon Soul instantly to allow casting player class abilities, that's a hack
  */
@@ -133,6 +132,7 @@ enum MalacrassSpells
     SPELL_COLD_STARE              = 43593,
 
     // Scripts
+    SPELL_LIFEBLOOM_FINAL_HEAL    = 43422,
     SPELL_UNSTABLE_AFFL_DISPEL    = 43523,
     SPELL_SIPHON_SOUL_EFFECT      = 43501,
     SPELL_MARK_OF_BLOOD_HEAL      = 61607
@@ -804,6 +804,30 @@ struct boss_koragg : public MalacrassCompanionBaseAI
     }
 };
 
+// 43421 - Lifebloom
+class spell_malacrass_lifebloom : public AuraScript
+{
+    PrepareAuraScript(spell_malacrass_lifebloom);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_LIFEBLOOM_FINAL_HEAL });
+    }
+
+    void AfterRemove(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        if (GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_EXPIRE && GetTargetApplication()->GetRemoveMode() != AURA_REMOVE_BY_ENEMY_SPELL)
+            return;
+
+        GetTarget()->CastSpell(nullptr, SPELL_LIFEBLOOM_FINAL_HEAL, { aurEff, GetCasterGUID() });
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_malacrass_lifebloom::AfterRemove, EFFECT_0, SPELL_AURA_PERIODIC_HEAL, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 // 43498 - Siphon Soul
 class spell_malacrass_siphon_soul : public SpellScript
 {
@@ -816,13 +840,20 @@ class spell_malacrass_siphon_soul : public SpellScript
 
     void FilterTargets(std::list<WorldObject*>& targets)
     {
-        // This is wrong, full list of targets is sent to client
-        Trinity::Containers::RandomResize(targets, 1);
+        if (targets.empty())
+            return;
+
+        WorldObject* target = Trinity::Containers::SelectRandomContainerElement(targets);
+
+        _selectedTargetGuid = target->GetGUID();
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
         Unit* target = GetHitUnit();
+
+        if (target->GetGUID() != _selectedTargetGuid)
+            return;
 
         if (Creature* caster = GetCaster()->ToCreature())
         {
@@ -836,6 +867,9 @@ class spell_malacrass_siphon_soul : public SpellScript
         OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_malacrass_siphon_soul::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
         OnEffectHitTarget += SpellEffectFn(spell_malacrass_siphon_soul::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
     }
+
+private:
+    ObjectGuid _selectedTargetGuid;
 };
 
 // 43522 - Unstable Affliction
@@ -910,6 +944,7 @@ void AddSC_boss_hex_lord_malacrass()
     RegisterZulAmanCreatureAI(boss_fenstalker);
     RegisterZulAmanCreatureAI(boss_darkheart);
     RegisterZulAmanCreatureAI(boss_koragg);
+    RegisterSpellScript(spell_malacrass_lifebloom);
     RegisterSpellScript(spell_malacrass_siphon_soul);
     RegisterSpellScript(spell_malacrass_unstable_affliction);
     RegisterSpellScript(spell_malacrass_mind_control);

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -2211,7 +2211,6 @@ class spell_gen_lifeblood_aura : public AuraScript
 
 enum GenericLifebloom
 {
-    SPELL_HEXLORD_MALACRASS_LIFEBLOOM_FINAL_HEAL        = 43422,
     SPELL_TUR_RAGEPAW_LIFEBLOOM_FINAL_HEAL              = 52552,
     SPELL_CENARION_SCOUT_LIFEBLOOM_FINAL_HEAL           = 53692,
     SPELL_TWISTED_VISAGE_LIFEBLOOM_FINAL_HEAL           = 57763,
@@ -4776,7 +4775,6 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScriptWithArgs(spell_gen_knock_away_threat_reduction, "spell_gen_knock_away_threat_reduction_50", 50);     // 18670, 18945
     RegisterSpellScriptWithArgs(spell_gen_knock_away_threat_reduction, "spell_gen_knock_away_threat_reduction_25", 25);     // 18813, 25778
     RegisterSpellAndAuraScriptPair(spell_gen_lifeblood, spell_gen_lifeblood_aura);
-    RegisterSpellScriptWithArgs(spell_gen_lifebloom, "spell_hexlord_lifebloom", SPELL_HEXLORD_MALACRASS_LIFEBLOOM_FINAL_HEAL);
     RegisterSpellScriptWithArgs(spell_gen_lifebloom, "spell_tur_ragepaw_lifebloom", SPELL_TUR_RAGEPAW_LIFEBLOOM_FINAL_HEAL);
     RegisterSpellScriptWithArgs(spell_gen_lifebloom, "spell_cenarion_scout_lifebloom", SPELL_CENARION_SCOUT_LIFEBLOOM_FINAL_HEAL);
     RegisterSpellScriptWithArgs(spell_gen_lifebloom, "spell_twisted_visage_lifebloom", SPELL_TWISTED_VISAGE_LIFEBLOOM_FINAL_HEAL);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Move spell script of Lifebloom to Malacrass' file
-  Change Siphon Soul script so it no longer resizes target list to 1 (full list of targets is supposed to be sent to client)

**Issues addressed:**

none

**Tests performed:**

builds, tested in-game


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
